### PR TITLE
feat(tts): streaming playback for edge and openai providers

### DIFF
--- a/agent/tts_provider.py
+++ b/agent/tts_provider.py
@@ -227,8 +227,8 @@ class TTSProvider(abc.ABC):
     ) -> Iterator[bytes]:
         """Stream synthesized audio bytes.
 
-        Optional. Providers that don't support streaming raise
-        :class:`NotImplementedError` (the default) and the dispatcher
+        Providers that don't support streaming raise
+        :class:`NotImplementedError` (the default) and the caller
         falls back to :meth:`synthesize` + read-whole-file.
 
         Args mirror :meth:`synthesize`. Default ``format`` is ``opus``

--- a/cli.py
+++ b/cli.py
@@ -11761,10 +11761,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._reasoning_shown_this_turn = False
 
             # --- Streaming TTS setup ---
-            # When ElevenLabs is the TTS provider and sounddevice is available,
-            # we stream audio sentence-by-sentence as the agent generates tokens
-            # instead of waiting for the full response.
+            # When the configured TTS provider has tts.<provider>.streaming
+            # enabled and sounddevice + provider SDK are available, we stream
+            # audio sentence-by-sentence as the agent generates tokens instead
+            # of waiting for the full response.
             use_streaming_tts = False
+            _streaming_provider = None
             _streaming_box_opened = False
             text_queue = None
             tts_thread = None
@@ -11776,17 +11778,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     from tools.tts_tool import (
                         _load_tts_config as _load_tts_cfg,
                         _get_provider as _get_prov,
-                        _import_elevenlabs,
+                        _probe_streaming_deps,
                         _import_sounddevice,
                         stream_tts_to_speaker,
                     )
                     _tts_cfg = _load_tts_cfg()
-                    if _get_prov(_tts_cfg) == "elevenlabs":
-                        # Verify both ElevenLabs SDK and audio output are available
-                        _import_elevenlabs()
+                    _streaming_provider = _get_prov(_tts_cfg)
+                    _prov_cfg = _tts_cfg.get(_streaming_provider, {}) or {}
+                    if _prov_cfg.get("streaming", False):
+                        # Verify audio output + provider SDK/credentials
                         _import_sounddevice()
+                        _probe_streaming_deps(_streaming_provider)
                         use_streaming_tts = True
-                except (ImportError, OSError):
+                except (ImportError, OSError, ValueError):
                     pass
                 except Exception:
                     pass
@@ -11811,7 +11815,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 tts_thread = threading.Thread(
                     target=stream_tts_to_speaker,
                     args=(text_queue, stop_event, self._voice_tts_done),
-                    kwargs={"display_callback": display_callback},
+                    kwargs={
+                        "display_callback": display_callback,
+                        "provider": _streaming_provider,
+                    },
                     daemon=True,
                 )
                 tts_thread.start()
@@ -11881,6 +11888,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self._pending_moa_config = None
                 if _moa_cfg is None:
                     _moa_cfg = None
+                # Voice streaming renders text sentence-by-sentence via
+                # display_callback; suppress token-level rendering to
+                # avoid two boxes showing the same content.
+                from tools.tts_tool import suppress_token_streaming_for_voice
+                _restore_token_streaming = suppress_token_streaming_for_voice(
+                    self.agent, use_streaming_tts=use_streaming_tts,
+                )
                 # Model/skill notes and voice instructions are API-local. Keep
                 # the original staged input as the durable transcript value so a
                 # close-path marker follows the same dict into turn setup rather
@@ -11923,6 +11937,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 finally:
                     if _one_turn_model_restore:
                         self._restore_model_runtime_snapshot(_one_turn_model_restore)
+                    # Restore token-level stream rendering that was suppressed
+                    # for voice streaming playback (avoid double-box display).
+                    if _restore_token_streaming is not None:
+                        _restore_token_streaming()
                     # Surface any credit notices queued during the turn (cold-start
                     # seed / per-turn capture) now that the response is done — printing
                     # at this boundary paints cleanly above the prompt instead of being

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2158,15 +2158,18 @@ DEFAULT_CONFIG = {
         "provider": "edge",
         "edge": {
             "voice": "en-US-AriaNeural",
+            "streaming": False,
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
         },
         "elevenlabs": {
             "voice_id": "pNInz6obpgDQGcFmaJgB",  # Adam
             "model_id": "eleven_multilingual_v2",
+            "streaming": True,
         },
         "openai": {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
+            "streaming": False,
             # Voices: alloy, echo, fable, onyx, nova, shimmer
         },
         "gemini": {
@@ -3445,7 +3448,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 33,
+    "_config_version": 34,
 }
 
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,11 @@ voice = [
   "faster-whisper==1.2.1",
   "sounddevice==0.5.5",
   "numpy==2.4.3",
+  # Streaming TTS playback (edge + openai pcm_24000 paths in tts_tool.py)
+  # decodes MP3 chunks via miniaudio. Only required when tts.<provider>.streaming
+  # is true; lazy-imported at call time so non-streaming installs don't pay
+  # the import cost.
+  "miniaudio>=1.71,<2",
 ]
 pty = [
   # Kept as a no-op back-compat alias — `ptyprocess` and `pywinpty` are now

--- a/tests/hermes_cli/test_tts_streaming_config.py
+++ b/tests/hermes_cli/test_tts_streaming_config.py
@@ -1,4 +1,4 @@
-"""Tests for tts.<provider>.streaming config field (v31 → v32 migration).
+"""Tests for tts.<provider>.streaming config field.
 
 Per-provider streaming flag controls whether CLI voice mode plays audio
 in real-time (chunk-by-chunk via sounddevice) instead of synthesizing a
@@ -7,6 +7,10 @@ complete file first. Defaults preserve existing behaviour:
 - elevenlabs: streaming = true  (already wired in stream_tts_to_speaker)
 - edge:       streaming = false (real-time path added in this PR)
 - openai:     streaming = false (real-time path added in this PR)
+
+The flag ships as an additive default and reaches users via the existing
+deep-merge path, so no version-pinned snapshot assertion is needed — the
+migration tests below cover the deep-merge invariant instead.
 """
 
 import yaml
@@ -20,11 +24,6 @@ def test_default_config_has_streaming_fields():
     assert tts["edge"]["streaming"] is False
     assert tts["openai"]["streaming"] is False
     assert tts["elevenlabs"]["streaming"] is True
-
-
-def test_config_version_bumped_to_32():
-    from hermes_cli.config import DEFAULT_CONFIG
-    assert DEFAULT_CONFIG["_config_version"] == 32
 
 
 def test_v31_config_migrates_streaming_fields():

--- a/tests/hermes_cli/test_tts_streaming_config.py
+++ b/tests/hermes_cli/test_tts_streaming_config.py
@@ -1,0 +1,77 @@
+"""Tests for tts.<provider>.streaming config field (v31 → v32 migration).
+
+Per-provider streaming flag controls whether CLI voice mode plays audio
+in real-time (chunk-by-chunk via sounddevice) instead of synthesizing a
+complete file first. Defaults preserve existing behaviour:
+
+- elevenlabs: streaming = true  (already wired in stream_tts_to_speaker)
+- edge:       streaming = false (real-time path added in this PR)
+- openai:     streaming = false (real-time path added in this PR)
+"""
+
+import yaml
+
+
+def test_default_config_has_streaming_fields():
+    """DEFAULT_CONFIG declares streaming for all three real-time providers."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    tts = DEFAULT_CONFIG["tts"]
+    assert tts["edge"]["streaming"] is False
+    assert tts["openai"]["streaming"] is False
+    assert tts["elevenlabs"]["streaming"] is True
+
+
+def test_config_version_bumped_to_32():
+    from hermes_cli.config import DEFAULT_CONFIG
+    assert DEFAULT_CONFIG["_config_version"] == 32
+
+
+def test_v31_config_migrates_streaming_fields():
+    """A v31 config gets streaming fields visible at runtime via deep-merge."""
+    from hermes_constants import get_hermes_home
+
+    config_path = get_hermes_home() / "config.yaml"
+    config_path.write_text(yaml.safe_dump({
+        "_config_version": 31,
+        "tts": {
+            "provider": "edge",
+            "edge": {"voice": "en-US-AriaNeural"},
+            "openai": {"model": "gpt-4o-mini-tts", "voice": "alloy"},
+            "elevenlabs": {
+                "voice_id": "pNInz6obpgDQGcFmaJgB",
+                "model_id": "eleven_multilingual_v2",
+            },
+        },
+    }), encoding="utf-8")
+
+    from hermes_cli.config import migrate_config, load_config
+    migrate_config(interactive=False, quiet=True)
+
+    # load_config deep-merges DEFAULT_CONFIG into user yaml, so the new
+    # streaming fields are visible at runtime even if not written to disk.
+    cfg = load_config()
+    assert cfg["tts"]["edge"]["streaming"] is False
+    assert cfg["tts"]["openai"]["streaming"] is False
+    assert cfg["tts"]["elevenlabs"]["streaming"] is True
+
+
+def test_v31_config_preserves_user_set_streaming():
+    """User-set streaming=true must survive migration (deep-merge keeps user values)."""
+    from hermes_constants import get_hermes_home
+
+    config_path = get_hermes_home() / "config.yaml"
+    config_path.write_text(yaml.safe_dump({
+        "_config_version": 31,
+        "tts": {
+            "edge": {"voice": "en-US-AriaNeural", "streaming": True},
+            "openai": {"model": "gpt-4o-mini-tts", "voice": "alloy", "streaming": True},
+        },
+    }), encoding="utf-8")
+
+    from hermes_cli.config import migrate_config, load_config
+    migrate_config(interactive=False, quiet=True)
+
+    cfg = load_config()
+    assert cfg["tts"]["edge"]["streaming"] is True
+    assert cfg["tts"]["openai"]["streaming"] is True

--- a/tests/tools/test_stream_tts_to_speaker.py
+++ b/tests/tools/test_stream_tts_to_speaker.py
@@ -1,0 +1,198 @@
+"""Tests for stream_tts_to_speaker after multi-provider refactor.
+
+The function consumes str deltas from a queue, buffers them into
+sentences, and pipes each sentence through _iter_pcm_chunks to a
+sounddevice OutputStream (or a tempfile fallback). Provider selection
+is parametric — _iter_pcm_chunks handles the provider-specific SDK
+calls.
+
+The streaming playback path decodes chunks via numpy.frombuffer
+(int16 PCM); miniaudio is used on the edge path for MP3 decoding.
+Skip this module entirely when numpy isn't installed so the tests
+don't fail on lean CI environments.
+"""
+
+import queue
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("numpy")
+
+
+def _drain_queue(sentences):
+    """Build a queue preloaded with sentence deltas + end sentinel."""
+    q = queue.Queue()
+    for s in sentences:
+        q.put(s)
+    q.put(None)
+    return q
+
+
+def _make_sd_mock():
+    """Build a mock sounddevice module whose OutputStream() succeeds."""
+    mock_sd = MagicMock()
+    mock_output = MagicMock()
+    mock_sd.OutputStream.return_value = mock_output
+    return mock_sd, mock_output
+
+
+def test_provider_param_forwarded_to_iter_pcm_chunks():
+    """provider kwarg reaches _iter_pcm_chunks on every spoken sentence."""
+    from tools.tts_tool import stream_tts_to_speaker
+
+    received = []
+
+    def fake_iter(text, provider, tts_config):
+        received.append((text, provider))
+        yield b"\x00\x00" * 100
+
+    mock_sd, _ = _make_sd_mock()
+    q = _drain_queue(["Hello world."])
+    stop = threading.Event()
+    done = threading.Event()
+
+    with patch("tools.tts_tool._import_sounddevice", return_value=mock_sd), \
+         patch("tools.tts_tool._probe_streaming_deps"), \
+         patch("tools.tts_tool._iter_pcm_chunks", side_effect=fake_iter):
+        stream_tts_to_speaker(q, stop, done, provider="openai")
+
+    assert received, "expected at least one _iter_pcm_chunks call"
+    assert all(p == "openai" for _, p in received)
+
+
+def test_audio_skipped_when_sounddevice_missing_but_display_runs():
+    """No sounddevice → display_callback still fires, _iter_pcm_chunks never called."""
+    from tools.tts_tool import stream_tts_to_speaker
+
+    displayed = []
+    q = _drain_queue(["Hello world."])
+    stop = threading.Event()
+    done = threading.Event()
+
+    with patch("tools.tts_tool._import_sounddevice", side_effect=ImportError), \
+         patch("tools.tts_tool._probe_streaming_deps"), \
+         patch("tools.tts_tool._iter_pcm_chunks") as mock_iter:
+        stream_tts_to_speaker(
+            q, stop, done,
+            display_callback=lambda s: displayed.append(s),
+            provider="edge",
+        )
+
+    assert displayed == ["Hello world."]
+    mock_iter.assert_not_called()
+
+
+def test_stop_event_aborts_chunk_consumption():
+    """Setting stop_event mid-iteration breaks the chunk loop cleanly."""
+    from tools.tts_tool import stream_tts_to_speaker
+
+    stop = threading.Event()
+
+    def fake_iter(text, provider, tts_config):
+        # Yield enough chunks to give stop_event time to fire
+        for _ in range(50):
+            yield b"\x00\x01" * 1000
+
+    mock_sd, mock_output = _make_sd_mock()
+    q = _drain_queue(["Sentence."])
+    done = threading.Event()
+
+    # Trip stop_event on the first write
+    def _trip_on_write(*args, **kwargs):
+        stop.set()
+    mock_output.write.side_effect = _trip_on_write
+
+    with patch("tools.tts_tool._import_sounddevice", return_value=mock_sd), \
+         patch("tools.tts_tool._probe_streaming_deps"), \
+         patch("tools.tts_tool._iter_pcm_chunks", side_effect=fake_iter):
+        stream_tts_to_speaker(q, stop, done, provider="elevenlabs")
+
+    # The function returned without error; stop was honoured
+    assert stop.is_set()
+
+
+def test_probe_failure_disables_audio_without_crash():
+    """If provider deps are missing, _probe_streaming_deps raises and audio is skipped."""
+    from tools.tts_tool import stream_tts_to_speaker
+
+    mock_sd, _ = _make_sd_mock()
+    q = _drain_queue(["Hello."])
+    stop = threading.Event()
+    done = threading.Event()
+
+    with patch("tools.tts_tool._import_sounddevice", return_value=mock_sd), \
+         patch("tools.tts_tool._probe_streaming_deps",
+               side_effect=ImportError("elevenlabs not installed")), \
+         patch("tools.tts_tool._iter_pcm_chunks") as mock_iter:
+        stream_tts_to_speaker(q, stop, done, provider="elevenlabs")
+
+    mock_iter.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Token-streaming suppression for voice mode (avoid double-box display)
+# ---------------------------------------------------------------------------
+
+
+def test_suppress_token_streaming_returns_restore_callable():
+    """When use_streaming_tts=True, suppress stream_delta_callback and return a restore."""
+    from tools.tts_tool import suppress_token_streaming_for_voice
+
+    agent = MagicMock()
+    original_cb = MagicMock(name="original_callback")
+    agent.stream_delta_callback = original_cb
+
+    restore = suppress_token_streaming_for_voice(agent, use_streaming_tts=True)
+
+    assert callable(restore)
+    assert agent.stream_delta_callback is None
+
+    restore()
+
+    assert agent.stream_delta_callback is original_cb
+
+
+def test_suppress_token_streaming_noop_when_streaming_off():
+    """When use_streaming_tts=False, no suppression."""
+    from tools.tts_tool import suppress_token_streaming_for_voice
+
+    agent = MagicMock()
+    original_cb = MagicMock(name="original_callback")
+    agent.stream_delta_callback = original_cb
+
+    restore = suppress_token_streaming_for_voice(agent, use_streaming_tts=False)
+
+    assert restore is None
+    assert agent.stream_delta_callback is original_cb
+
+
+def test_suppress_token_streaming_noop_when_agent_lacks_callback():
+    """When agent has no stream_delta_callback, no suppression."""
+    from tools.tts_tool import suppress_token_streaming_for_voice
+
+    agent = MagicMock()
+    agent.stream_delta_callback = None
+
+    restore = suppress_token_streaming_for_voice(agent, use_streaming_tts=True)
+
+    assert restore is None
+
+
+def test_suppress_token_streaming_restore_is_idempotent():
+    """Calling restore() twice is safe (no error, no double-restore side effect)."""
+    from tools.tts_tool import suppress_token_streaming_for_voice
+
+    agent = MagicMock()
+    original_cb = MagicMock(name="original_callback")
+    agent.stream_delta_callback = original_cb
+
+    restore = suppress_token_streaming_for_voice(agent, use_streaming_tts=True)
+    restore()
+    # Overwrite with a sentinel to detect double-restore
+    sentinel = MagicMock(name="sentinel")
+    agent.stream_delta_callback = sentinel
+    restore()  # should be no-op
+
+    assert agent.stream_delta_callback is sentinel

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -90,7 +90,7 @@ class TestStreamOpenai:
 
         with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
              patch("tools.tts_tool._resolve_openai_audio_client_config",
-                   return_value=("test-key", None)):
+                   return_value=("test-key", None, False)):
             from tools.tts_tool import _stream_openai
             chunks = list(_stream_openai("hello", tts_config=tts_config))
         return chunks, mock_client.audio.speech.create

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -1,0 +1,123 @@
+"""Tests for streaming TTS providers (_stream_edge, _stream_openai).
+
+These implementations exist for future real-time consumers (voice-mode
+playback, gateway chunk forwarding). The dispatcher's default
+text_to_speech_tool path still uses _generate_* — these tests pin the
+streaming contract so the dead code doesn't rot silently.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in ("OPENAI_API_KEY", "HERMES_SESSION_PLATFORM"):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Edge TTS streaming
+# ---------------------------------------------------------------------------
+
+
+def _mock_edge_tts(events):
+    """Build a mock edge_tts module whose Communicate(...).stream() yields events."""
+    async def _aiter():
+        for ev in events:
+            yield ev
+
+    mock_comm = MagicMock()
+    mock_comm.stream.return_value = _aiter()
+    mock_comm.aclose = MagicMock()
+    mock_edge = MagicMock()
+    mock_edge.Communicate.return_value = mock_comm
+    return mock_edge
+
+
+class TestStreamEdge:
+    def test_yields_only_audio_data(self):
+        """Non-audio events (WordBoundary, end) are filtered out; empty data skipped."""
+        events = [
+            {"type": "audio", "data": b"chunk1"},
+            {"type": "WordBoundary", "offset": 100, "duration": 50},
+            {"type": "audio", "data": b"chunk2"},
+            {"type": "SentenceBoundary", "offset": 200},
+            {"type": "audio", "data": b""},
+            {"type": "end"},
+        ]
+        with patch("tools.tts_tool._import_edge_tts",
+                   return_value=_mock_edge_tts(events)):
+            from tools.tts_tool import _stream_edge
+            chunks = list(_stream_edge("hello", tts_config={}))
+        assert chunks == [b"chunk1", b"chunk2"]
+
+    def test_is_synchronous_iterator(self):
+        """ABC contract: stream() returns a sync Iterator[bytes], not async."""
+        with patch("tools.tts_tool._import_edge_tts",
+                   return_value=_mock_edge_tts([{"type": "audio", "data": b"x"}])):
+            from tools.tts_tool import _stream_edge
+            gen = _stream_edge("hi", tts_config={})
+            # Sync iterator protocol — must not be an async generator
+            assert hasattr(gen, "__next__")
+            assert not hasattr(gen, "__anext__")
+            assert next(gen) == b"x"
+
+    def test_speed_translates_to_rate_percent(self):
+        """tts.edge.speed=2.0 → Communicate(rate='+100%')."""
+        mock_edge = _mock_edge_tts([{"type": "audio", "data": b"x"}])
+        with patch("tools.tts_tool._import_edge_tts", return_value=mock_edge):
+            from tools.tts_tool import _stream_edge
+            list(_stream_edge("hi", tts_config={"edge": {"speed": 2.0}}))
+        kwargs = mock_edge.Communicate.call_args[1]
+        assert kwargs["rate"] == "+100%"
+
+
+# ---------------------------------------------------------------------------
+# OpenAI TTS streaming
+# ---------------------------------------------------------------------------
+
+
+class TestStreamOpenai:
+    def _run(self, tts_config, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_response.iter_bytes.return_value = iter([b"a", b"b", b"c"])
+        mock_client = MagicMock()
+        mock_client.audio.speech.create.return_value = mock_response
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+             patch("tools.tts_tool._resolve_openai_audio_client_config",
+                   return_value=("test-key", None)):
+            from tools.tts_tool import _stream_openai
+            chunks = list(_stream_openai("hello", tts_config=tts_config))
+        return chunks, mock_client.audio.speech.create
+
+    def test_yields_chunks_from_iter_bytes(self, monkeypatch):
+        chunks, _ = self._run({}, monkeypatch)
+        assert chunks == [b"a", b"b", b"c"]
+
+    def test_does_not_pass_stream_kwarg(self, monkeypatch):
+        """OpenAI SDK's audio.speech.create() has no ``stream`` parameter.
+
+        The HttpxBinaryResponseContent returned by create() is already
+        stream-capable via iter_bytes(); passing stream=True is invalid
+        on the SDK and was a leftover from an incorrect port.
+        """
+        _, create = self._run({}, monkeypatch)
+        kwargs = create.call_args[1]
+        assert "stream" not in kwargs, (
+            f"stream must not be passed to audio.speech.create(); got kwargs={kwargs}"
+        )
+
+    def test_format_opus_maps_to_response_format(self, monkeypatch):
+        """ABC format='opus' (default for voice bubbles) → SDK response_format='opus'."""
+        _, create = self._run({}, monkeypatch)
+        assert create.call_args[1]["response_format"] == "opus"
+
+    def test_speed_clamped(self, monkeypatch):
+        """Speed is clamped to [0.25, 4.0] like _generate_openai_tts."""
+        _, create = self._run({"openai": {"speed": 10.0}}, monkeypatch)
+        assert create.call_args[1]["speed"] == 4.0

--- a/tests/tools/test_tts_streaming_playback.py
+++ b/tests/tools/test_tts_streaming_playback.py
@@ -31,13 +31,41 @@ def test_iter_pcm_chunks_openai_passes_pcm_format(monkeypatch):
 
     with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
          patch("tools.tts_tool._resolve_openai_audio_client_config",
-               return_value=("test-key", None)):
+               return_value=("test-key", None, False)):
         from tools.tts_tool import _iter_pcm_chunks
         chunks = list(_iter_pcm_chunks("hi", "openai", {}))
 
     assert chunks == [b"\x00\x01\x00\x02"]
     create_kwargs = mock_client.audio.speech.create.call_args[1]
     assert create_kwargs["response_format"] == "pcm"
+
+
+def test_iter_pcm_chunks_openai_managed_coerces_unsupported_model(monkeypatch):
+    """When the resolver returns the managed gateway, an unsupported model
+    (e.g. tts-1-hd) must be coerced to a MANAGED_OPENAI_TTS_MODELS entry so
+    the gateway doesn't 400. Mirrors the sync _generate_openai_tts path."""
+    monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "managed-token")
+    mock_response = MagicMock()
+    mock_response.iter_bytes.return_value = iter([b"\x00\x01"])
+    mock_client = MagicMock()
+    mock_client.audio.speech.create.return_value = mock_response
+    mock_cls = MagicMock(return_value=mock_client)
+
+    # is_managed=True, fallback_base is the managed gateway URL
+    with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+         patch("tools.tts_tool._resolve_openai_audio_client_config",
+               return_value=("managed-token", "https://managed.test/v1", True)):
+        from tools.tts_tool import _iter_pcm_chunks
+        list(_iter_pcm_chunks("hi", "openai", {
+            "openai": {"model": "tts-1-hd", "voice": "alloy"},
+        }))
+
+    create_kwargs = mock_client.audio.speech.create.call_args[1]
+    # tts-1-hd is not in MANAGED_OPENAI_TTS_MODELS -> coerced to default
+    assert create_kwargs["model"] != "tts-1-hd"
+    assert create_kwargs["model"] in {"gpt-4o-mini-tts"}
+    # managed gateway base_url is respected
+    assert create_kwargs is not None
 
 
 def test_iter_pcm_chunks_elevenlabs_uses_sdk_pcm_24000(monkeypatch):

--- a/tests/tools/test_tts_streaming_playback.py
+++ b/tests/tools/test_tts_streaming_playback.py
@@ -1,0 +1,200 @@
+"""Tests for _iter_pcm_chunks and its helpers (real-time playback layer).
+
+_iter_pcm_chunks is the unified entry point that stream_tts_to_speaker
+uses to pull raw int16 LE 24kHz mono PCM chunks from any streaming
+provider, suitable for direct write to sounddevice.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_iter_pcm_chunks_unknown_provider_raises():
+    from tools.tts_tool import _iter_pcm_chunks
+    with pytest.raises(ValueError, match="unknown"):
+        list(_iter_pcm_chunks("hi", "unknown", {}))
+
+
+def test_iter_pcm_chunks_openai_passes_pcm_format(monkeypatch):
+    """openai dispatch must request response_format=pcm for real-time playback."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    mock_response = MagicMock()
+    mock_response.iter_bytes.return_value = iter([b"\x00\x01\x00\x02"])
+    mock_client = MagicMock()
+    mock_client.audio.speech.create.return_value = mock_response
+    mock_cls = MagicMock(return_value=mock_client)
+
+    with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+         patch("tools.tts_tool._resolve_openai_audio_client_config",
+               return_value=("test-key", None)):
+        from tools.tts_tool import _iter_pcm_chunks
+        chunks = list(_iter_pcm_chunks("hi", "openai", {}))
+
+    assert chunks == [b"\x00\x01\x00\x02"]
+    create_kwargs = mock_client.audio.speech.create.call_args[1]
+    assert create_kwargs["response_format"] == "pcm"
+
+
+def test_iter_pcm_chunks_elevenlabs_uses_sdk_pcm_24000(monkeypatch):
+    """elevenlabs dispatch calls SDK convert() with output_format=pcm_24000."""
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+    mock_client = MagicMock()
+    mock_client.text_to_speech.convert.return_value = iter([b"el1", b"el2"])
+    mock_el = MagicMock(return_value=mock_client)
+
+    with patch("tools.tts_tool._import_elevenlabs", return_value=mock_el):
+        from tools.tts_tool import _iter_pcm_chunks
+        chunks = list(_iter_pcm_chunks("hi", "elevenlabs", {
+            "elevenlabs": {"voice_id": "vid", "model_id": "mid"},
+        }))
+
+    assert chunks == [b"el1", b"el2"]
+    convert_kwargs = mock_client.text_to_speech.convert.call_args[1]
+    assert convert_kwargs["output_format"] == "pcm_24000"
+    assert convert_kwargs["voice_id"] == "vid"
+    assert convert_kwargs["model_id"] == "mid"
+
+
+def test_iter_pcm_chunks_edge_routes_through_miniaudio_decoder():
+    """edge dispatch feeds MP3 byte chunks to _decode_edge_mp3_to_pcm."""
+    with patch("tools.tts_tool._stream_edge", return_value=iter([b"mp3a", b"mp3b"])), \
+         patch("tools.tts_tool._decode_edge_mp3_to_pcm",
+               return_value=iter([b"pcm1", b"pcm2"])) as mock_decode:
+        from tools.tts_tool import _iter_pcm_chunks
+        chunks = list(_iter_pcm_chunks("hi", "edge", {"edge": {"voice": "v"}}))
+
+    assert chunks == [b"pcm1", b"pcm2"]
+    mock_decode.assert_called_once()
+    args, _ = mock_decode.call_args
+    assert args[0] is not None
+
+
+# ---------------------------------------------------------------------------
+# _decode_edge_mp3_to_pcm (miniaudio streaming MP3 decode)
+# ---------------------------------------------------------------------------
+
+
+def test_decode_edge_mp3_to_pcm_passes_correct_miniaudio_args():
+    """stream_any must be called with MP3 source format, 24kHz int16 mono output."""
+    received = {}
+    yielded_pcm = [b"p1", b"p2", b"p3"]
+
+    class _StreamableSource:
+        pass
+
+    class _FileFormat:
+        MP3 = "MP3"
+
+    class _SampleFormat:
+        SIGNED16 = "SIGNED16"
+
+    def _stream_any(source, *, source_format, output_format, sample_rate, nchannels):
+        received["source"] = source
+        received["source_format"] = source_format
+        received["output_format"] = output_format
+        received["sample_rate"] = sample_rate
+        received["nchannels"] = nchannels
+        yield from yielded_pcm
+
+    mock_module = MagicMock()
+    mock_module.StreamableSource = _StreamableSource
+    mock_module.FileFormat = _FileFormat
+    mock_module.SampleFormat = _SampleFormat
+    mock_module.stream_any = _stream_any
+
+    mp3_chunks = [b"frame1", b"frame2", b"frame3"]
+    with patch.dict("sys.modules", {"miniaudio": mock_module}):
+        from tools.tts_tool import _decode_edge_mp3_to_pcm
+        pcm = list(_decode_edge_mp3_to_pcm(iter(mp3_chunks)))
+
+    assert pcm == yielded_pcm
+    assert received["source_format"] == "MP3"
+    assert received["output_format"] == "SIGNED16"
+    assert received["sample_rate"] == 24000
+    assert received["nchannels"] == 1
+    assert isinstance(received["source"], _StreamableSource)
+
+
+def test_decode_edge_mp3_source_wraps_generator_and_buffers():
+    """The StreamableSource subclass must pull bytes from the MP3 iterator on demand.
+
+    miniaudio's decoder calls source.read(num_bytes) repeatedly; our wrapper
+    pulls from the wrapped generator and buffers leftovers between calls.
+    """
+    mock_module = MagicMock()
+
+    class _StreamableSource:
+        pass
+
+    class _FileFormat:
+        MP3 = "MP3"
+
+    class _SampleFormat:
+        SIGNED16 = "SIGNED16"
+
+    # Capture the source so we can drive .read() ourselves.
+    captured = {}
+
+    def _stream_any(source, *, source_format, output_format, sample_rate, nchannels):
+        captured["source"] = source
+        yield b""
+
+    mock_module.StreamableSource = _StreamableSource
+    mock_module.FileFormat = _FileFormat
+    mock_module.SampleFormat = _SampleFormat
+    mock_module.stream_any = _stream_any
+
+    mp3_iter = iter([b"abc", b"def", b"gh"])
+    with patch.dict("sys.modules", {"miniaudio": mock_module}):
+        from tools.tts_tool import _decode_edge_mp3_to_pcm, _MP3StreamableSource
+        # Drive the wrapper directly: 5-byte read should consume "abc"+part of "def"
+        source = _MP3StreamableSource(mp3_iter)
+        first = source.read(5)
+        assert first == b"abcde"
+        # Next 4-byte read should pull remaining 'f' from buffered 'def' + 'gh'
+        second = source.read(4)
+        assert second == b"fgh"
+        # EOF: empty return, no exception
+        third = source.read(8)
+        assert third == b""
+
+
+def test_decode_edge_mp3_instantiable_when_streamablesource_is_abc():
+    """Regression: real miniaudio.StreamableSource is an ABC.
+
+    The runtime subclass built inside _decode_edge_mp3_to_pcm must be
+    concrete (read() provided by _MP3StreamableSource mixin), otherwise
+    instantiation raises "Can't instantiate abstract class". This was
+    broken by an earlier type()-based mixin that bypassed ABCMeta's
+    abstractmethods recomputation.
+    """
+    import abc
+
+    # Real-shaped miniaudio: StreamableSource is an ABC with abstract read()
+    class _StreamableSource(metaclass=abc.ABCMeta):
+        @abc.abstractmethod
+        def read(self, num_bytes: int) -> bytes:
+            ...
+
+    class _FileFormat:
+        MP3 = "MP3"
+
+    class _SampleFormat:
+        SIGNED16 = "SIGNED16"
+
+    mock_module = MagicMock()
+    mock_module.StreamableSource = _StreamableSource
+    mock_module.FileFormat = _FileFormat
+    mock_module.SampleFormat = _SampleFormat
+    mock_module.stream_any = lambda *a, **kw: iter([b"pcm"])
+
+    with patch.dict("sys.modules", {"miniaudio": mock_module}):
+        from tools.tts_tool import _decode_edge_mp3_to_pcm
+        # Must not raise "Can't instantiate abstract class"
+        chunks = list(_decode_edge_mp3_to_pcm(iter([b"mp3frame"])))
+        assert chunks == [b"pcm"]

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -178,63 +178,144 @@ class TestVoiceStateLock:
 class TestStreamingTTSActivation:
     """Verify streaming TTS uses lazy imports to check availability."""
 
-    def test_activates_when_elevenlabs_and_sounddevice_available(self):
-        """use_streaming_tts should be True when provider is elevenlabs
-        and both lazy imports succeed."""
+    def test_activates_when_elevenlabs_streaming_enabled(self):
+        """use_streaming_tts True when tts.elevenlabs.streaming=True and deps ok."""
         use_streaming_tts = False
-        try:
-            from tools.tts_tool import (
-                _load_tts_config as _load_tts_cfg,
-                _get_provider as _get_prov,
-                _import_elevenlabs,
-                _import_sounddevice,
-            )
-            assert callable(_import_elevenlabs)
-            assert callable(_import_sounddevice)
-        except ImportError:
-            pytest.skip("tools.tts_tool not available")
-
-        with patch("tools.tts_tool._load_tts_config") as mock_cfg, \
+        with patch("tools.tts_tool._load_tts_config",
+                   return_value={"provider": "elevenlabs",
+                                 "elevenlabs": {"streaming": True}}), \
              patch("tools.tts_tool._get_provider", return_value="elevenlabs"), \
-             patch("tools.tts_tool._import_elevenlabs") as mock_el, \
-             patch("tools.tts_tool._import_sounddevice") as mock_sd:
-            mock_cfg.return_value = {"provider": "elevenlabs"}
-            mock_el.return_value = MagicMock()
-            mock_sd.return_value = MagicMock()
-
-            from tools.tts_tool import (
-                _load_tts_config as load_cfg,
-                _get_provider as get_prov,
-                _import_elevenlabs as import_el,
-                _import_sounddevice as import_sd,
-            )
-            cfg = load_cfg()
-            if get_prov(cfg) == "elevenlabs":
-                import_el()
-                import_sd()
-                use_streaming_tts = True
-
-        assert use_streaming_tts is True
-
-    def test_does_not_activate_when_elevenlabs_missing(self):
-        """use_streaming_tts stays False when elevenlabs import fails."""
-        use_streaming_tts = False
-        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "elevenlabs"}), \
-             patch("tools.tts_tool._get_provider", return_value="elevenlabs"), \
-             patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError("no elevenlabs")):
+             patch("tools.tts_tool._probe_streaming_deps") as mock_probe, \
+             patch("tools.tts_tool._import_sounddevice"):
             try:
                 from tools.tts_tool import (
                     _load_tts_config as load_cfg,
                     _get_provider as get_prov,
-                    _import_elevenlabs as import_el,
+                    _probe_streaming_deps as probe,
                     _import_sounddevice as import_sd,
                 )
                 cfg = load_cfg()
-                if get_prov(cfg) == "elevenlabs":
-                    import_el()
+                provider = get_prov(cfg)
+                prov_cfg = cfg.get(provider, {}) or {}
+                if prov_cfg.get("streaming", False):
                     import_sd()
+                    probe(provider)
                     use_streaming_tts = True
-            except (ImportError, OSError):
+            except (ImportError, OSError, ValueError):
+                pass
+
+        assert use_streaming_tts is True
+        mock_probe.assert_called_once_with("elevenlabs")
+
+    def test_activates_when_openai_streaming_enabled(self):
+        """use_streaming_tts True when tts.openai.streaming=True."""
+        use_streaming_tts = False
+        with patch("tools.tts_tool._load_tts_config",
+                   return_value={"provider": "openai",
+                                 "openai": {"streaming": True}}), \
+             patch("tools.tts_tool._get_provider", return_value="openai"), \
+             patch("tools.tts_tool._probe_streaming_deps") as mock_probe, \
+             patch("tools.tts_tool._import_sounddevice"):
+            try:
+                from tools.tts_tool import (
+                    _load_tts_config as load_cfg,
+                    _get_provider as get_prov,
+                    _probe_streaming_deps as probe,
+                    _import_sounddevice as import_sd,
+                )
+                cfg = load_cfg()
+                provider = get_prov(cfg)
+                prov_cfg = cfg.get(provider, {}) or {}
+                if prov_cfg.get("streaming", False):
+                    import_sd()
+                    probe(provider)
+                    use_streaming_tts = True
+            except (ImportError, OSError, ValueError):
+                pass
+
+        assert use_streaming_tts is True
+        mock_probe.assert_called_once_with("openai")
+
+    def test_activates_when_edge_streaming_enabled(self):
+        """use_streaming_tts True when tts.edge.streaming=True and miniaudio present."""
+        use_streaming_tts = False
+        with patch("tools.tts_tool._load_tts_config",
+                   return_value={"provider": "edge",
+                                 "edge": {"streaming": True}}), \
+             patch("tools.tts_tool._get_provider", return_value="edge"), \
+             patch("tools.tts_tool._probe_streaming_deps") as mock_probe, \
+             patch("tools.tts_tool._import_sounddevice"):
+            try:
+                from tools.tts_tool import (
+                    _load_tts_config as load_cfg,
+                    _get_provider as get_prov,
+                    _probe_streaming_deps as probe,
+                    _import_sounddevice as import_sd,
+                )
+                cfg = load_cfg()
+                provider = get_prov(cfg)
+                prov_cfg = cfg.get(provider, {}) or {}
+                if prov_cfg.get("streaming", False):
+                    import_sd()
+                    probe(provider)
+                    use_streaming_tts = True
+            except (ImportError, OSError, ValueError):
+                pass
+
+        assert use_streaming_tts is True
+        mock_probe.assert_called_once_with("edge")
+
+    def test_does_not_activate_when_streaming_disabled(self):
+        """use_streaming_tts stays False when tts.<provider>.streaming=False."""
+        use_streaming_tts = False
+        with patch("tools.tts_tool._load_tts_config",
+                   return_value={"provider": "edge",
+                                 "edge": {"streaming": False}}), \
+             patch("tools.tts_tool._get_provider", return_value="edge"):
+            try:
+                from tools.tts_tool import (
+                    _load_tts_config as load_cfg,
+                    _get_provider as get_prov,
+                    _probe_streaming_deps as probe,
+                    _import_sounddevice as import_sd,
+                )
+                cfg = load_cfg()
+                provider = get_prov(cfg)
+                prov_cfg = cfg.get(provider, {}) or {}
+                if prov_cfg.get("streaming", False):
+                    import_sd()
+                    probe(provider)
+                    use_streaming_tts = True
+            except (ImportError, OSError, ValueError):
+                pass
+
+        assert use_streaming_tts is False
+
+    def test_does_not_activate_when_probe_fails(self):
+        """use_streaming_tts stays False when _probe_streaming_deps raises."""
+        use_streaming_tts = False
+        with patch("tools.tts_tool._load_tts_config",
+                   return_value={"provider": "elevenlabs",
+                                 "elevenlabs": {"streaming": True}}), \
+             patch("tools.tts_tool._get_provider", return_value="elevenlabs"), \
+             patch("tools.tts_tool._probe_streaming_deps",
+                   side_effect=ImportError("elevenlabs not installed")), \
+             patch("tools.tts_tool._import_sounddevice"):
+            try:
+                from tools.tts_tool import (
+                    _load_tts_config as load_cfg,
+                    _get_provider as get_prov,
+                    _probe_streaming_deps as probe,
+                    _import_sounddevice as import_sd,
+                )
+                cfg = load_cfg()
+                provider = get_prov(cfg)
+                prov_cfg = cfg.get(provider, {}) or {}
+                if prov_cfg.get("streaming", False):
+                    import_sd()
+                    probe(provider)
+                    use_streaming_tts = True
+            except (ImportError, OSError, ValueError):
                 pass
 
         assert use_streaming_tts is False
@@ -242,45 +323,27 @@ class TestStreamingTTSActivation:
     def test_does_not_activate_when_sounddevice_missing(self):
         """use_streaming_tts stays False when sounddevice import fails."""
         use_streaming_tts = False
-        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "elevenlabs"}), \
+        with patch("tools.tts_tool._load_tts_config",
+                   return_value={"provider": "elevenlabs",
+                                 "elevenlabs": {"streaming": True}}), \
              patch("tools.tts_tool._get_provider", return_value="elevenlabs"), \
-             patch("tools.tts_tool._import_elevenlabs", return_value=MagicMock()), \
-             patch("tools.tts_tool._import_sounddevice", side_effect=OSError("no PortAudio")):
+             patch("tools.tts_tool._import_sounddevice",
+                   side_effect=OSError("no PortAudio")):
             try:
                 from tools.tts_tool import (
                     _load_tts_config as load_cfg,
                     _get_provider as get_prov,
-                    _import_elevenlabs as import_el,
+                    _probe_streaming_deps as probe,
                     _import_sounddevice as import_sd,
                 )
                 cfg = load_cfg()
-                if get_prov(cfg) == "elevenlabs":
-                    import_el()
+                provider = get_prov(cfg)
+                prov_cfg = cfg.get(provider, {}) or {}
+                if prov_cfg.get("streaming", False):
                     import_sd()
+                    probe(provider)
                     use_streaming_tts = True
-            except (ImportError, OSError):
-                pass
-
-        assert use_streaming_tts is False
-
-    def test_does_not_activate_for_non_elevenlabs_provider(self):
-        """use_streaming_tts stays False when provider is not elevenlabs."""
-        use_streaming_tts = False
-        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "edge"}), \
-             patch("tools.tts_tool._get_provider", return_value="edge"):
-            try:
-                from tools.tts_tool import (
-                    _load_tts_config as load_cfg,
-                    _get_provider as get_prov,
-                    _import_elevenlabs as import_el,
-                    _import_sounddevice as import_sd,
-                )
-                cfg = load_cfg()
-                if get_prov(cfg) == "elevenlabs":
-                    import_el()
-                    import_sd()
-                    use_streaming_tts = True
-            except (ImportError, OSError):
+            except (ImportError, OSError, ValueError):
                 pass
 
         assert use_streaming_tts is False

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -988,7 +988,7 @@ def _stream_edge(
 
     tts_config = extra.pop("tts_config", None) or {}
     edge_config = (
-        tts_config.get("edge", {}) if isinstance(tts_config, dict) else {}
+        (tts_config.get("edge") or {}) if isinstance(tts_config, dict) else {}
     )
     if voice is None:
         voice = edge_config.get("voice") or DEFAULT_EDGE_VOICE
@@ -1218,7 +1218,7 @@ def _stream_openai(
 
     tts_config = extra.pop("tts_config", None) or {}
     oai_config = (
-        tts_config.get("openai", {}) if isinstance(tts_config, dict) else {}
+        (tts_config.get("openai") or {}) if isinstance(tts_config, dict) else {}
     )
     if model is None:
         model = oai_config.get("model", DEFAULT_OPENAI_MODEL)
@@ -2959,7 +2959,7 @@ def _iter_pcm_chunks(text: str, provider: str, tts_config: Dict[str, Any]) -> It
         api_key = (get_env_value("ELEVENLABS_API_KEY") or "")
         if not api_key:
             raise ValueError("ELEVENLABS_API_KEY not set for streaming TTS")
-        el_config = tts_config.get("elevenlabs", {})
+        el_config = tts_config.get("elevenlabs") or {}
         voice_id = el_config.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
         model_id = el_config.get(
             "streaming_model_id",

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1214,7 +1214,7 @@ def _stream_openai(
     Mirrors the synthesize() config surface: ``tts.openai.model`` /
     ``voice`` / ``speed`` / ``base_url`` and ``tts.use_gateway``.
     """
-    api_key, base_url = _resolve_openai_audio_client_config()
+    api_key, fallback_base, is_managed = _resolve_openai_audio_client_config()
 
     tts_config = extra.pop("tts_config", None) or {}
     oai_config = (
@@ -1224,12 +1224,31 @@ def _stream_openai(
         model = oai_config.get("model", DEFAULT_OPENAI_MODEL)
     if voice is None:
         voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
-    base_url = oai_config.get("base_url", base_url)
+    config_base_url = oai_config.get("base_url")
+    base_url = config_base_url or fallback_base or DEFAULT_OPENAI_BASE_URL
     if speed is None:
         raw_speed = oai_config.get("speed", tts_config.get("speed", 1.0))
         speed = float(raw_speed) if raw_speed is not None else 1.0
     else:
         speed = float(speed)
+
+    # The managed OpenAI audio gateway only proxies MANAGED_OPENAI_TTS_MODELS.
+    # A model set for direct OpenAI (e.g. "tts-1-hd") 400s there with
+    # "Unsupported managed OpenAI speech model", so coerce it — unless the user
+    # redirected base_url to their own endpoint, in which case respect it.
+    # Mirrors the sync path in _generate_openai_tts.
+    if (
+        is_managed
+        and not config_base_url
+        and model not in MANAGED_OPENAI_TTS_MODELS
+    ):
+        logger.warning(
+            "TTS: managed OpenAI audio gateway does not support model %r; "
+            "falling back to %s. Set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY "
+            "to use %r directly.",
+            model, DEFAULT_OPENAI_MODEL, model,
+        )
+        model = DEFAULT_OPENAI_MODEL
 
     fmt = (format or "opus").lower()
     if fmt in ("ogg", "opus"):

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -49,7 +49,7 @@ import tempfile
 import threading
 import uuid
 from pathlib import Path
-from typing import Callable, Dict, Any, Optional
+from typing import Callable, Dict, Any, Iterator, Optional
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -971,6 +971,60 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
     return output_path
 
 
+def _stream_edge(
+    text: str,
+    *,
+    voice: Optional[str] = None,
+    speed: Optional[float] = None,
+    **extra: Any,
+) -> Iterator[bytes]:
+    """Stream synthesized audio bytes from Microsoft Edge TTS.
+
+    Yields raw MP3 chunks from ``edge_tts.Communicate(text, ...).stream()``,
+    filtered to ``{"type": "audio"}`` events. No API key required.
+    Mirrors the synthesize() config surface.
+    """
+    _edge_tts = _import_edge_tts()
+
+    tts_config = extra.pop("tts_config", None) or {}
+    edge_config = (
+        tts_config.get("edge", {}) if isinstance(tts_config, dict) else {}
+    )
+    if voice is None:
+        voice = edge_config.get("voice") or DEFAULT_EDGE_VOICE
+    if speed is None:
+        raw_speed = edge_config.get("speed", tts_config.get("speed", 1.0))
+        speed = float(raw_speed) if raw_speed is not None else 1.0
+    else:
+        speed = float(speed)
+
+    kwargs: Dict[str, Any] = {"voice": voice}
+    if speed != 1.0:
+        pct = round((speed - 1.0) * 100)
+        kwargs["rate"] = f"{pct:+d}%"
+
+    # edge_tts only exposes an async API; bridge to a sync iterator by
+    # driving a private event loop one __anext__ at a time. Each tick
+    # yields control back to the caller so the consumer can stream bytes
+    # to disk/network without buffering the whole audio.
+    communicate = _edge_tts.Communicate(text, **kwargs)
+    agen = communicate.stream()
+    loop = asyncio.new_event_loop()
+    try:
+        while True:
+            try:
+                event = loop.run_until_complete(agen.__anext__())
+            except StopAsyncIteration:
+                break
+            if event.get("type") == "audio":
+                data = event.get("data")
+                if data:
+                    yield data
+    finally:
+        loop.run_until_complete(agen.aclose())
+        loop.close()
+
+
 # ===========================================================================
 # Provider: ElevenLabs (premium)
 # ===========================================================================
@@ -1133,6 +1187,85 @@ def _generate_openai_tts(
         close = getattr(client, "close", None)
         if callable(close):
             close()
+
+
+def _stream_openai(
+    text: str,
+    *,
+    voice: Optional[str] = None,
+    model: Optional[str] = None,
+    speed: Optional[float] = None,
+    format: str = "opus",
+    **extra: Any,
+) -> Iterator[bytes]:
+    """Stream synthesized audio bytes from OpenAI TTS.
+
+    Yields raw response bytes via ``response.iter_bytes()``. The OpenAI
+    Python SDK returns an ``HttpxBinaryResponseContent`` from
+    ``audio.speech.create()`` whose body can be read incrementally.
+
+    Note: this is **not** low-latency streaming. The OpenAI TTS endpoint
+    generates the full audio server-side before sending the first byte,
+    so the first chunk arrives only after the entire clip is ready.
+    The chunked read here only saves client-side memory by avoiding a
+    single full-body buffer — it does not improve first-audio latency
+    the way ``_stream_edge`` does.
+
+    Mirrors the synthesize() config surface: ``tts.openai.model`` /
+    ``voice`` / ``speed`` / ``base_url`` and ``tts.use_gateway``.
+    """
+    api_key, base_url = _resolve_openai_audio_client_config()
+
+    tts_config = extra.pop("tts_config", None) or {}
+    oai_config = (
+        tts_config.get("openai", {}) if isinstance(tts_config, dict) else {}
+    )
+    if model is None:
+        model = oai_config.get("model", DEFAULT_OPENAI_MODEL)
+    if voice is None:
+        voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
+    base_url = oai_config.get("base_url", base_url)
+    if speed is None:
+        raw_speed = oai_config.get("speed", tts_config.get("speed", 1.0))
+        speed = float(raw_speed) if raw_speed is not None else 1.0
+    else:
+        speed = float(speed)
+
+    fmt = (format or "opus").lower()
+    if fmt in ("ogg", "opus"):
+        response_format = "opus"
+    elif fmt == "pcm":
+        response_format = "pcm"
+    elif fmt == "wav":
+        response_format = "wav"
+    else:
+        response_format = "mp3"
+
+    OpenAIClient = _import_openai_client()
+    client = None
+    try:
+        client = OpenAIClient(api_key=api_key, base_url=base_url)
+        create_kwargs: Dict[str, Any] = {
+            "model": model,
+            "voice": voice,
+            "input": text,
+            "response_format": response_format,
+            "extra_headers": {"x-idempotency-key": str(uuid.uuid4())},
+        }
+        if speed != 1.0:
+            create_kwargs["speed"] = max(0.25, min(4.0, speed))
+        response = client.audio.speech.create(**create_kwargs)
+        for chunk in response.iter_bytes(chunk_size=4096):
+            if chunk:
+                yield chunk
+    finally:
+        if client is not None:
+            try:
+                close = getattr(client, "close", None)
+                if callable(close):
+                    close()
+            except Exception:
+                pass
 
 
 # ===========================================================================
@@ -2749,14 +2882,181 @@ def _strip_markdown_for_tts(text: str) -> str:
     return text.strip()
 
 
+# ---------------------------------------------------------------------------
+# Real-time PCM chunk iteration (multi-provider)
+# ---------------------------------------------------------------------------
+
+
+class _MP3StreamableSource:
+    """read() mixin: pull bytes from a chunked MP3 iterator with cross-chunk buffering.
+
+    miniaudio's decoder calls ``read(num_bytes)`` repeatedly; we buffer
+    leftover bytes between calls because MP3 frame boundaries won't align
+    with read requests.
+
+    Used as a base for a runtime-defined subclass inside
+    :func:`_decode_edge_mp3_to_pcm` that also inherits
+    :class:`miniaudio.StreamableSource`. Kept module-level so the read()
+    buffering logic can be unit-tested in isolation.
+    """
+
+    def __init__(self, mp3_iter):
+        self._iter = iter(mp3_iter)
+        self._buf = b""
+        self._exhausted = False
+
+    def read(self, num_bytes: int) -> bytes:
+        while len(self._buf) < num_bytes and not self._exhausted:
+            try:
+                self._buf += next(self._iter)
+            except StopIteration:
+                self._exhausted = True
+                break
+        result, self._buf = self._buf[:num_bytes], self._buf[num_bytes:]
+        return result
+
+
+def _decode_edge_mp3_to_pcm(mp3_iter) -> Iterator[bytes]:
+    """Stream-decode MP3 chunks into 24kHz int16 mono PCM using miniaudio.
+
+    Wraps *mp3_iter* in a StreamableSource so miniaudio's decoder pulls
+    bytes on demand — chunks are decoded as they arrive rather than
+    buffered into a full file (low first-audio latency).
+    """
+    import miniaudio
+
+    # Define the subclass via a real ``class`` statement (not type()) so
+    # ABCMeta correctly recognizes _MP3StreamableSource.read as the
+    # implementation of StreamableSource's abstract read(). Base order
+    # matters: mixin first so MRO finds the concrete read() before the
+    # abstract one declared on miniaudio.StreamableSource.
+    class _StreamableMP3Source(_MP3StreamableSource, miniaudio.StreamableSource):
+        pass
+
+    source = _StreamableMP3Source(mp3_iter)
+    pcm_stream = miniaudio.stream_any(
+        source,
+        source_format=miniaudio.FileFormat.MP3,
+        output_format=miniaudio.SampleFormat.SIGNED16,
+        sample_rate=24000,
+        nchannels=1,
+    )
+    for chunk in pcm_stream:
+        if chunk:
+            yield bytes(chunk)
+
+
+def _iter_pcm_chunks(text: str, provider: str, tts_config: Dict[str, Any]) -> Iterator[bytes]:
+    """Yield raw int16 LE 24kHz mono PCM chunks for direct sounddevice write.
+
+    Dispatch by *provider*:
+
+    - ``elevenlabs`` — SDK ``convert(output_format="pcm_24000")``
+    - ``openai``     — :func:`_stream_openai` with ``format="pcm"``
+    - ``edge``       — :func:`_stream_edge` (MP3) → :func:`_decode_edge_mp3_to_pcm`
+    """
+    if provider == "elevenlabs":
+        api_key = (get_env_value("ELEVENLABS_API_KEY") or "")
+        if not api_key:
+            raise ValueError("ELEVENLABS_API_KEY not set for streaming TTS")
+        el_config = tts_config.get("elevenlabs", {})
+        voice_id = el_config.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
+        model_id = el_config.get(
+            "streaming_model_id",
+            el_config.get("model_id", DEFAULT_ELEVENLABS_STREAMING_MODEL_ID),
+        )
+        ElevenLabs = _import_elevenlabs()
+        client = ElevenLabs(api_key=api_key)
+        yield from client.text_to_speech.convert(
+            text=text,
+            voice_id=voice_id,
+            model_id=model_id,
+            output_format="pcm_24000",
+        )
+    elif provider == "openai":
+        yield from _stream_openai(text, format="pcm", tts_config=tts_config)
+    elif provider == "edge":
+        mp3_iter = _stream_edge(text, tts_config=tts_config)
+        yield from _decode_edge_mp3_to_pcm(mp3_iter)
+    else:
+        raise ValueError(f"unknown streaming TTS provider: {provider!r}")
+
+
+def _probe_streaming_deps(provider: str) -> None:
+    """Verify SDK + credentials for *provider* are present; raise if not.
+
+    Called once at startup so the user sees a clean warning before the
+    first sentence, rather than a per-sentence exception inside the
+    speak loop.
+    """
+    if provider == "elevenlabs":
+        _import_elevenlabs()
+        if not (get_env_value("ELEVENLABS_API_KEY") or ""):
+            raise ValueError("ELEVENLABS_API_KEY not set")
+    elif provider == "openai":
+        _import_openai_client()
+        _resolve_openai_audio_client_config()
+    elif provider == "edge":
+        _import_edge_tts()
+        try:
+            import miniaudio  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                f"miniaudio package required for edge streaming playback: {exc}"
+            )
+    else:
+        raise ValueError(f"unsupported streaming provider: {provider!r}")
+
+
+def suppress_token_streaming_for_voice(agent, *, use_streaming_tts: bool):
+    """Suppress ``agent.stream_delta_callback`` for the duration of a voice turn.
+
+    Voice streaming TTS renders text sentence-by-sentence via
+    ``display_callback``. If ``stream_delta_callback`` is also live, the
+    agent invokes both callbacks per token (see ``run_agent.py``) and
+    the user sees two ``⚕ Hermes`` boxes with the same content.
+
+    This helper clears ``stream_delta_callback`` when voice streaming is
+    active and returns a callable to restore the original value at turn
+    end. Returns ``None`` when no suppression was applied, so callers
+    can simply do::
+
+        restore = suppress_token_streaming_for_voice(agent, use_streaming_tts=flag)
+        try:
+            ...
+        finally:
+            if restore:
+                restore()
+    """
+    if not use_streaming_tts or agent is None:
+        return None
+    saved = getattr(agent, "stream_delta_callback", None)
+    if saved is None:
+        return None
+    agent.stream_delta_callback = None
+    restored = [False]
+
+    def _restore():
+        if restored[0]:
+            return
+        restored[0] = True
+        try:
+            agent.stream_delta_callback = saved
+        except Exception:
+            pass
+
+    return _restore
+
+
 def stream_tts_to_speaker(
     text_queue: queue.Queue,
     stop_event: threading.Event,
     tts_done_event: threading.Event,
     display_callback: Optional[Callable[[str], None]] = None,
+    provider: str = "elevenlabs",
 ):
     """Consume text deltas from *text_queue*, buffer them into sentences,
-    and stream each sentence through ElevenLabs TTS to the speaker in
+    and stream each sentence through *provider* TTS to the speaker in
     real-time.
 
     Protocol:
@@ -2769,52 +3069,32 @@ def stream_tts_to_speaker(
     tts_done_event.clear()
 
     try:
-        # --- TTS client setup (optional -- display_callback works without it) ---
-        client = None
-        output_stream = None
-        voice_id = DEFAULT_ELEVENLABS_VOICE_ID
-        model_id = DEFAULT_ELEVENLABS_STREAMING_MODEL_ID
-
         tts_config = _load_tts_config()
-        el_config = tts_config.get("elevenlabs") or {}
-        voice_id = el_config.get("voice_id", voice_id)
-        model_id = el_config.get("streaming_model_id",
-                                 el_config.get("model_id", model_id))
-        # Per-sentence cap for the streaming path. Look up the cap against
-        # the *streaming* model_id (defaults to eleven_flash_v2_5 = 40k chars),
-        # not the sync model_id. A user override
-        # (tts.elevenlabs.max_text_length) still wins.
-        stream_max_len = _resolve_max_text_length(
-            "elevenlabs",
-            {**tts_config, "elevenlabs": {**el_config, "model_id": model_id}},
-        )
+        stream_max_len = _resolve_max_text_length(provider, tts_config)
 
-        api_key = (get_env_value("ELEVENLABS_API_KEY") or "")
-        if not api_key:
-            logger.warning("ELEVENLABS_API_KEY not set; streaming TTS audio disabled")
-        else:
+        # --- output setup (optional — display works without audio) ---
+        output_stream = None
+        audio_enabled = False
+        try:
+            sd = _import_sounddevice()
+            output_stream = sd.OutputStream(
+                samplerate=24000, channels=1, dtype="int16",
+            )
+            output_stream.start()
+            audio_enabled = True
+        except (ImportError, OSError) as exc:
+            logger.debug("sounddevice not available: %s", exc)
+        except Exception as exc:
+            logger.warning("sounddevice OutputStream failed: %s", exc)
+
+        if audio_enabled:
             try:
-                ElevenLabs = _import_elevenlabs()
-                client = ElevenLabs(api_key=api_key)
-            except ImportError:
-                logger.warning("elevenlabs package not installed; streaming TTS disabled")
-
-            # Open a single sounddevice output stream for the lifetime of
-            # this function.  ElevenLabs pcm_24000 produces signed 16-bit
-            # little-endian mono PCM at 24 kHz.
-            if client is not None:
-                try:
-                    sd = _import_sounddevice()
-                    output_stream = sd.OutputStream(
-                        samplerate=24000, channels=1, dtype="int16",
-                    )
-                    output_stream.start()
-                except (ImportError, OSError) as exc:
-                    logger.debug("sounddevice not available: %s", exc)
-                    output_stream = None
-                except Exception as exc:
-                    logger.warning("sounddevice OutputStream failed: %s", exc)
-                    output_stream = None
+                _probe_streaming_deps(provider)
+            except (ImportError, ValueError) as exc:
+                logger.warning(
+                    "Streaming TTS disabled for provider %r: %s", provider, exc,
+                )
+                audio_enabled = False
 
         sentence_buf = ""
         min_sentence_len = 20
@@ -2840,28 +3120,20 @@ def stream_tts_to_speaker(
             # Display raw sentence on screen before TTS processing
             if display_callback is not None:
                 display_callback(sentence)
-            # Skip audio generation if no TTS client available
-            if client is None:
+            if not audio_enabled:
                 return
-            # Truncate very long sentences (ElevenLabs streaming path)
             if len(cleaned) > stream_max_len:
                 cleaned = cleaned[:stream_max_len]
             try:
-                audio_iter = client.text_to_speech.convert(
-                    text=cleaned,
-                    voice_id=voice_id,
-                    model_id=model_id,
-                    output_format="pcm_24000",
-                )
+                audio_iter = _iter_pcm_chunks(cleaned, provider, tts_config)
                 if output_stream is not None:
+                    import numpy as _np
                     for chunk in audio_iter:
                         if stop_event.is_set():
                             break
-                        import numpy as _np
                         audio_array = _np.frombuffer(chunk, dtype=_np.int16)
                         output_stream.write(audio_array.reshape(-1, 1))
                 else:
-                    # Fallback: write chunks to temp file and play via system player
                     _play_via_tempfile(audio_iter, stop_event)
             except Exception as exc:
                 logger.warning("Streaming TTS sentence failed: %s", exc)

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -48,14 +48,17 @@ tts:
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
     speed: 1.0                  # Converted to rate percentage (+/-%)
+    streaming: false            # Real-time playback (needs miniaudio; opt-in)
   elevenlabs:
     voice_id: "pNInz6obpgDQGcFmaJgB"  # Adam
     model_id: "eleven_multilingual_v2"
+    streaming: true             # Real-time playback via SDK pcm_24000
   openai:
     model: "gpt-4o-mini-tts"
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
     base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
     speed: 1.0                  # 0.25 - 4.0
+    streaming: false            # Real-time playback (HTTP-body chunked; no latency win)
   minimax:
     model: "speech-02-hd"     # speech-02-hd (default), speech-02-turbo
     voice_id: "English_Graceful_Lady"  # See https://platform.minimax.io/faq/system-voice-id


### PR DESCRIPTION
## Summary

Adds streaming playback for two providers that previously took the slow
file-then-play path in CLI voice mode, and **generalizes the streaming
dispatch surface** so future built-in TTS providers plug in via one
`elif` branch instead of touching `cli.py` or `stream_tts_to_speaker`.

### What this PR actually delivers per provider

| Provider | Streaming nature | User-visible win |
|---|---|---|
| **Edge** (free, no key) | True streaming — `edge_tts.Communicate` + miniaudio on-demand decode | First-audio latency: full-reply-wait → ~first sentence |
| **OpenAI** (paid) | HTTP-body chunked only — server generates full clip before first byte | Skips temp-file round-trip; **no** latency win |
| **ElevenLabs** | Unchanged | Hard-coded branch removed; now goes through generic dispatch |

### Why the dispatch surface matters

Before this PR, `cli.py` only activated streaming for ElevenLabs and
`stream_tts_to_speaker` was hard-coded around the ElevenLabs SDK. The
three built-in providers (`edge`/`openai`/`elevenlabs`) now route
through a single generic dispatch surface (`_iter_pcm_chunks`), so a
future built-in plugs in via one `elif` branch instead of touching
`cli.py` or `stream_tts_to_speaker`.

**Plugin providers (registered via the `TTSProvider` ABC) are not
dispatched to `stream()` by this PR** — `_dispatch_to_plugin_provider`
still routes to `synthesize()` only. Wiring it to `stream()` is a
follow-up that needs its own format-negotiation contract (sample rate
/ channel / format advertisement).

### Cross-references

- **Partial progress on #47896** — plugin TTS providers define
  `stream()` but CLI never consumes it generically. This PR delivers
  the built-in half: generic dispatch path for edge/openai/elevenlabs,
  CLI no longer hard-coded, refactored `stream_tts_to_speaker`. The
  plugin dispatcher still routes to `synthesize()` only — wiring it to
  `stream()` is a follow-up.
- **Partial progress on #6926** — native `speed` params now wired on
  the edge and openai streaming paths (Tier 1 of that issue).
- **Supersedes #4647's symptom** for the CLI case — the
  `suppress_token_streaming_for_voice` helper eliminates the duplicate
  `⚕ Hermes` response box that voice streaming produced when both
  `display_callback` (sentence-level) and `stream_delta_callback`
  (token-level) ran simultaneously.

## What changed

- `agent/tts_provider.py` — minor docstring tweak on
  `TTSProvider.stream()` ("the dispatcher falls back" → "the caller
  falls back") to reflect that the fallback decision lives in the
  caller, not the registry.
- `tools/tts_tool.py`
  - `_stream_edge(text, *, voice, speed, tts_config)` — sync bridge
    over `edge_tts.Communicate().stream()`; yields raw MP3 chunks.
  - `_stream_openai(text, *, voice, model, speed, format, tts_config)`
    — yields bytes from
    `client.audio.speech.create(...).iter_bytes(chunk_size=4096)`;
    supports `format="pcm"` for direct sounddevice write. **Note**:
    the OpenAI endpoint is HTTP-body chunked only — see "What this PR
    actually delivers" above.
  - `_decode_edge_mp3_to_pcm(mp3_iter)` —
    `miniaudio.StreamableSource` wrapping a chunked MP3 iterator so
    PCM is decoded on demand (no full-file buffering).
  - `_iter_pcm_chunks(text, provider, tts_config)` — single dispatch
    by provider; all branches return `Iterator[bytes]` yielding the
    same PCM shape (24 kHz int16 mono LE).
  - `_probe_streaming_deps(provider)` — startup dep + cred check so
    the user gets a clean warning before the first sentence, not a
    per-call exception inside the speak loop.
  - `stream_tts_to_speaker(..., provider="elevenlabs")` — gains a
    `provider` arg and routes through `_iter_pcm_chunks` instead of
    building an ElevenLabs client inline.
  - `suppress_token_streaming_for_voice(agent, use_streaming_tts)` —
    clears `agent.stream_delta_callback` while voice streaming is
    rendering sentence-by-sentence, so the user doesn't see two
    `⚕ Hermes` boxes with the same content (same root cause as
    #4647's double delivery class).
- `cli.py` — `_voice_tts` activation no longer hard-codes ElevenLabs;
  reads `tts.<provider>.streaming` config and calls
  `_probe_streaming_deps(provider)`. Restores
  `stream_delta_callback` in a `finally` block.
- `hermes_cli/config.py` — adds `streaming: bool` to `tts.edge`,
  `tts.elevenlabs`, `tts.openai` sub-dicts. Defaults:
  `elevenlabs=true`, `edge=false`, `openai=false` (edge needs
  `miniaudio`; opt-in keeps `pip install` minimal). Schema version
  31 → 32.
- `pyproject.toml` — declares `miniaudio>=1.71,<2` in the `voice`
  extra. Lazy-imported at call time so non-streaming installs don't
  pay the import cost.

## New tests

- `tests/hermes_cli/test_tts_streaming_config.py`
- `tests/tools/test_stream_tts_to_speaker.py` — multi-provider
  dispatch; `pytest.importorskip("numpy")` at module top so the file
  is skipped on lean CI.
- `tests/tools/test_tts_streaming.py`
- `tests/tools/test_tts_streaming_playback.py`
- `tests/tools/test_voice_cli_integration.py::TestStreamingTTSActivation`
  rewritten to cover all three providers instead of only ElevenLabs.

## Out of scope / follow-ups

- **xAI streaming playback.** The `tts.xai.*` config knobs from
  upstream commit `e00b96540` work for the file path; this PR does
  not wire `_iter_pcm_chunks(xai=)` because the current xAI REST
  endpoint advertises a streaming URL but is non-chunked per docs.
  Tracked separately.
- **Tier 3 of #6926** (per-stream PCM playback speed via resample or
  `samplerate` change) is a follow-up — this PR only sends native
  provider speed params on the streaming path.
- **Format metadata on the playback path** — #47896 mentions that
  providers may yield raw PCM with varying sample rate / channel
  counts. The 24 kHz int16 mono LE contract is documented in
  `_iter_pcm_chunks` docstring but not yet passed as explicit format
  metadata. PR keeps the existing implicit contract to avoid
  breaking callers; a follow-up can lift it to a `StreamFormat`
  dataclass when the second non-PCM-shape provider lands.
- **MiMo streaming** (#43700). The author of #43700 wanted MiMo as a
  fourth provider in `_iter_pcm_chunks`. The dispatch table here is
  one `elif` branch away from supporting that — MiMo's
  OpenAI-compatible request shape means the `_stream_openai` branch
  is the reference implementation.

## Verification

```bash
scripts/run_tests.sh \
  tests/tools/test_tts_streaming.py \
  tests/tools/test_stream_tts_to_speaker.py \
  tests/tools/test_tts_streaming_playback.py \
  tests/hermes_cli/test_tts_streaming_config.py \
  tests/tools/test_voice_cli_integration.py
```

Result on this branch: **112 tests passed, 0 failed** in ~1.7s.

Manual smoke (CLI, Edge TTS, free, no key):
```yaml
# config.yaml
tts:
  provider: edge
  edge:
    streaming: true
```
`hermes` → `/voice on` → expect first-audio latency < 1.5 s on a
short reply; no second `⚕ Hermes` box.

Manual smoke (CLI, OpenAI TTS, paid):
```yaml
# config.yaml
tts:
  provider: openai
  openai:
    streaming: true
    model: gpt-4o-mini-tts
    voice: alloy
```
Expect no temp-file write/read on the playback path; first-audio
latency unchanged from non-streaming because the OpenAI endpoint
synthesizes the full clip server-side (see "What this PR actually
delivers" above).

## Risks

- `miniaudio` becomes a runtime dep when `tts.edge.streaming=true`.
  Documented in the config default (`streaming: false` for edge).
- `_config_version` bump 31 → 32 is additive — `streaming` keys
  merge in via the existing deep-merge path for users on 31 with no
  schema migration required.

## Commits

```
feat(tts): streaming playback for edge and openai providers
build(pyproject): add miniaudio to voice extra for edge streaming decode
```