### PR TITLE
fix(acp): handle missing check dependencies

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -152,11 +152,17 @@ def _print_version() -> None:
     print(hermes_version)
 
 
-def _run_check() -> None:
-    import acp  # noqa: F401
-    from acp_adapter.server import HermesACPAgent  # noqa: F401
+def _run_check() -> int:
+    try:
+        import acp  # noqa: F401
+        from acp_adapter.server import HermesACPAgent  # noqa: F401
+    except ImportError:
+        print("ACP dependencies not installed.", file=sys.stderr)
+        print("Install them with:  pip install -e '.[acp]'", file=sys.stderr)
+        return 1
 
     print("Hermes ACP check OK")
+    return 0
 
 
 def _run_setup() -> None:
@@ -221,7 +227,9 @@ def main(argv: list[str] | None = None) -> None:
         _print_version()
         return
     if args.check:
-        _run_check()
+        rc = _run_check()
+        if rc != 0:
+            sys.exit(rc)
         return
     if args.setup:
         _run_setup()

--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -155,11 +155,17 @@ def _print_version() -> None:
     print(hermes_version)
 
 
-def _run_check() -> None:
-    import acp  # noqa: F401
-    from acp_adapter.server import HermesACPAgent  # noqa: F401
+def _run_check() -> int:
+    try:
+        import acp  # noqa: F401
+        from acp_adapter.server import HermesACPAgent  # noqa: F401
+    except ImportError:
+        print("ACP dependencies not installed.", file=sys.stderr)
+        print("Install them with:  pip install -e '.[acp]'", file=sys.stderr)
+        return 1
 
     print("Hermes ACP check OK")
+    return 0
 
 
 def _run_setup() -> None:
@@ -224,7 +230,9 @@ def main(argv: list[str] | None = None) -> None:
         _print_version()
         return
     if args.check:
-        _run_check()
+        rc = _run_check()
+        if rc != 0:
+            sys.exit(rc)
         return
     if args.setup:
         _run_setup()

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -1,5 +1,6 @@
 """Tests for acp_adapter.entry startup wiring."""
 
+import builtins
 import sys
 
 import acp
@@ -39,6 +40,26 @@ def test_main_check_prints_ok_without_starting_server(monkeypatch, capsys):
     entry.main(["--check"])
 
     assert capsys.readouterr().out.strip() == "Hermes ACP check OK"
+
+
+def test_main_check_reports_missing_acp_dependency(monkeypatch, capsys):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "acp":
+            raise ModuleNotFoundError("No module named 'acp'", name="acp")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(SystemExit) as excinfo:
+        entry.main(["--check"])
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "ACP dependencies not installed." in captured.err
+    assert "pip install -e '.[acp]'" in captured.err
 
 
 def test_main_setup_runs_model_configuration(monkeypatch):

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -1,5 +1,6 @@
 """Tests for acp_adapter.entry startup wiring."""
 
+import builtins
 import sys
 
 import acp
@@ -45,6 +46,24 @@ def test_main_skips_configured_mcp_discovery_when_requested(monkeypatch):
 
 
 
+def test_main_check_reports_missing_acp_dependency(monkeypatch, capsys):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "acp":
+            raise ModuleNotFoundError("No module named 'acp'", name="acp")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(SystemExit) as excinfo:
+        entry.main(["--check"])
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "ACP dependencies not installed." in captured.err
+    assert "pip install -e '.[acp]'" in captured.err
 
 
 


### PR DESCRIPTION
﻿## What does this PR do?

Fixes the standalone `hermes-acp --check` console script so a missing ACP optional dependency reports the same friendly install hint as `hermes acp --check`, instead of crashing with a Python traceback.

Without the `acp` extra installed, the standalone console script currently reaches `_run_check()`, imports `acp`, and raises `ModuleNotFoundError: No module named 'acp'`. That is especially rough because `--check` is the diagnostic command users run to understand ACP setup.

## Related Issue

Fixes #54672

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `acp_adapter/entry.py`: catch `ImportError` in `_run_check()`, print the ACP install hint to stderr, and return exit code 1.
- `tests/acp/test_entry.py`: add regression coverage for the missing-`acp` dependency path.

## How to Test

Reproduced before the fix on Windows from a dev-only environment:

```powershell
uv run --extra dev hermes-acp --check
```

Before: exited 1 with traceback ending in `ModuleNotFoundError: No module named 'acp'`.

After:

```text
ACP dependencies not installed.
Install them with:  pip install -e '.[acp]'
```

Validated with:

```powershell
uv run --extra dev hermes-acp --check
# exit 1, friendly missing-dependency message, no traceback

uv run --extra dev --extra acp python -m pytest tests/acp/test_entry.py -q
# 11 passed

uv run --extra dev --extra acp ruff check acp_adapter/entry.py tests/acp/test_entry.py
# All checks passed

uv run --extra dev --extra acp hermes-acp --check
# Hermes ACP check OK

git diff --check
# passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide / repo guidance
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 Pro 10.0.22631, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) - console script behavior is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

No screenshots. The before/after terminal output is included above.
