### PR TITLE
feat: add anysearch plugin, LongCat/DashScope providers, gateway channel-model overrides

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -378,8 +378,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = _API_KEY_PROVIDER_AUX_MODELS_FALL
 # differs from their main chat model, map it here.  The vision auto-detect
 # "exotic provider" branch checks this before falling back to the main model.
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
-    "xiaomi": "mimo-v2.5",
-    "zai": "glm-5v-turbo",
+    "sensenova": "sensenova-6.7-flash-lite",
 }
 
 # Providers whose endpoint does not accept image input, even though the
@@ -1563,6 +1562,44 @@ def _read_codex_access_token() -> Optional[str]:
     except Exception as exc:
         logger.debug("Could not read Codex auth for auxiliary client: %s", exc)
         return None
+
+
+def _resolve_key_from_matching_named_provider(base_url: str) -> str:
+    """Resolve an API key by matching the given base_url against named providers in config.yaml.
+
+    When an auxiliary task sets a ``base_url`` that coincides with a named
+    provider (e.g. ``longcat``), the custom endpoint route previously had no
+    way to discover the provider's ``key_env``.  This function bridges that
+    gap by scanning ``providers`` config for a matching ``base_url`` and
+    returning the value of its ``key_env`` environment variable.
+
+    Returns the resolved key string, or empty string if no match found.
+    """
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+    except Exception:
+        return ""
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    if not isinstance(providers, dict):
+        return ""
+
+    normalized_target = base_url.rstrip("/")
+    for _name, entry in providers.items():
+        if not isinstance(entry, dict):
+            continue
+        entry_base = str(entry.get("base_url", "") or "").strip().rstrip("/")
+        if entry_base and entry_base == normalized_target:
+            key_env = str(entry.get("key_env", "") or "").strip()
+            if key_env:
+                resolved = os.getenv(key_env, "").strip()
+                if resolved:
+                    logger.debug(
+                        "Custom route: resolved key from named provider %r via %s",
+                        _name, key_env,
+                    )
+                    return resolved
+    return ""
 
 
 def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
@@ -4077,6 +4114,7 @@ def resolve_provider_client(
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()
+                or _resolve_key_from_matching_named_provider(custom_base)
                 or "no-key-required"  # local servers don't need auth
             )
             if not custom_base:

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -451,6 +451,9 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
     """Look up full capability metadata from models.dev cache.
 
     Uses the existing fetch_models_dev() and PROVIDER_TO_MODELS_DEV mapping.
+    If not found in models.dev, falls back to reading supports_vision from
+    the user config (config.yaml) for providers/models not in the registry.
+
     Returns None if model not found.
 
     Extracts from model entry fields:
@@ -462,50 +465,75 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
       - family     (str)   → model_family
     """
     models = _get_provider_models(provider)
-    if models is None:
-        return None
+    entry = None
+    if models is not None:
+        entry = _find_model_entry(models, model)
 
-    entry = _find_model_entry(models, model)
-    if entry is None:
-        return None
+    # If models.dev has the entry, use it
+    if entry is not None:
+        # Extract capability flags (default to False if missing)
+        supports_tools = bool(entry.get("tool_call", False))
+        # Vision: prefer explicit `modalities.input` when models.dev provides it.
+        # The older `attachment` flag can be stale or too broad for image routing;
+        # fall back to it only when the input modalities are absent/invalid.
+        input_mods = entry.get("modalities", {})
+        if isinstance(input_mods, dict):
+            input_mods = input_mods.get("input")
+        else:
+            input_mods = None
+        if isinstance(input_mods, list):
+            supports_vision = "image" in input_mods
+        else:
+            supports_vision = bool(entry.get("attachment", False))
+        supports_reasoning = bool(entry.get("reasoning", False))
 
-    # Extract capability flags (default to False if missing)
-    supports_tools = bool(entry.get("tool_call", False))
-    # Vision: prefer explicit `modalities.input` when models.dev provides it.
-    # The older `attachment` flag can be stale or too broad for image routing;
-    # fall back to it only when the input modalities are absent/invalid.
-    input_mods = entry.get("modalities", {})
-    if isinstance(input_mods, dict):
-        input_mods = input_mods.get("input")
-    else:
-        input_mods = None
-    if isinstance(input_mods, list):
-        supports_vision = "image" in input_mods
-    else:
-        supports_vision = bool(entry.get("attachment", False))
-    supports_reasoning = bool(entry.get("reasoning", False))
+        # Extract limits
+        limit = entry.get("limit", {})
+        if not isinstance(limit, dict):
+            limit = {}
 
-    # Extract limits
-    limit = entry.get("limit", {})
-    if not isinstance(limit, dict):
-        limit = {}
+        ctx = limit.get("context")
+        context_window = int(ctx) if isinstance(ctx, (int, float)) and ctx > 0 else 200000
 
-    ctx = limit.get("context")
-    context_window = int(ctx) if isinstance(ctx, (int, float)) and ctx > 0 else 200000
+        out = limit.get("output")
+        max_output_tokens = int(out) if isinstance(out, (int, float)) and out > 0 else 8192
 
-    out = limit.get("output")
-    max_output_tokens = int(out) if isinstance(out, (int, float)) and out > 0 else 8192
+        model_family = entry.get("family", "") or ""
 
-    model_family = entry.get("family", "") or ""
+        return ModelCapabilities(
+            supports_tools=supports_tools,
+            supports_vision=supports_vision,
+            supports_reasoning=supports_reasoning,
+            context_window=context_window,
+            max_output_tokens=max_output_tokens,
+            model_family=model_family,
+        )
 
-    return ModelCapabilities(
-        supports_tools=supports_tools,
-        supports_vision=supports_vision,
-        supports_reasoning=supports_reasoning,
-        context_window=context_window,
-        max_output_tokens=max_output_tokens,
-        model_family=model_family,
-    )
+    # Fallback: check user config.yaml for supports_vision flag
+    # This handles providers/models not in models.dev registry (e.g. sensenova)
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        providers = cfg.get("providers", {})
+        provider_cfg = providers.get(provider, {})
+        provider_models = provider_cfg.get("models", [])
+        for m in provider_models:
+            if m.get("id") == model or m.get("name") == model:
+                if m.get("supports_vision"):
+                    # Use defaults for other fields when only vision is specified
+                    return ModelCapabilities(
+                        supports_tools=True,
+                        supports_vision=True,
+                        supports_reasoning=False,
+                        context_window=m.get("context_window", 200000),
+                        max_output_tokens=m.get("max_tokens", 8192),
+                        model_family="",
+                    )
+                break
+    except Exception as e:
+        logger.debug("Config fallback for %s/%s failed: %s", provider, model, e)
+
+    return None
 
 
 def list_provider_models(provider: str) -> List[str]:

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -120,6 +120,7 @@ def _read_config_key(*path: str) -> Optional[str]:
 # a free tier on upgrade). Filtered by ``is_available()`` at walk time so
 # we don't surface a provider the user has no credentials for.
 _LEGACY_PREFERENCE = (
+    "anysearch",
     "firecrawl",
     "parallel",
     "tavily",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3510,6 +3510,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 resolved_session_key or "", model, override_model,
             )
         else:
+            # Per-channel/topic model override from config.yaml
+            if source:
+                platform = source.platform.value
+                platform_cfg = (user_config.get("platforms") or {}).get(platform) or (user_config.get(platform) or {})
+                extra = platform_cfg.get("extra") or {}
+                channel_models = extra.get("channel_models") or {}
+                channel_key = f"{source.chat_id}:{source.thread_id}" if source.thread_id else str(source.chat_id)
+                channel_cfg = channel_models.get(channel_key)
+                if channel_cfg:
+                    ch_model = channel_cfg.get("model")
+                    ch_provider = channel_cfg.get("provider")
+                    if ch_model:
+                        model = ch_model
+                    if ch_provider:
+                        providers_cfg = user_config.get("providers", {})
+                        prov_cfg = providers_cfg.get(ch_provider, {})
+                        if prov_cfg:
+                            key_env = prov_cfg.get("key_env")
+                            runtime_kwargs = {
+                                "provider": ch_provider,
+                                "base_url": prov_cfg.get("base_url"),
+                                "api_key": os.getenv(key_env, "") if key_env else "",
+                                "api_mode": prov_cfg.get("api", "openai-completions"),
+                            }
+                            if not runtime_kwargs["api_key"]:
+                                runtime_kwargs["api_key"] = os.getenv("OPENAI_API_KEY", "")
+                            return model, runtime_kwargs
             logger.debug(
                 "No session model override: session=%s config_model=%s override_keys=%s",
                 resolved_session_key or "", model,
@@ -11242,7 +11269,309 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         args = (event.get_command_args() or "").strip()
         source = event.source
-        origin = None
+        session_key = self._session_key_for_source(source)
+        override = self._session_model_overrides.get(session_key, {})
+        if override:
+            current_model = override.get("model", current_model)
+            current_provider = override.get("provider", current_provider)
+            current_base_url = override.get("base_url", current_base_url)
+            current_api_key = override.get("api_key", current_api_key)
+
+        # Per-channel/topic model override from config.yaml
+        if source:
+            platform = source.platform.value
+            platform_cfg = (cfg.get("platforms") or {}).get(platform) or (cfg.get(platform) or {})
+            extra = platform_cfg.get("extra") or {}
+            channel_models = extra.get("channel_models") or {}
+            channel_key = f"{source.chat_id}:{source.thread_id}" if source.thread_id else str(source.chat_id)
+            channel_cfg = channel_models.get(channel_key)
+            if channel_cfg:
+                ch_model = channel_cfg.get("model")
+                ch_provider = channel_cfg.get("provider")
+                if ch_model:
+                    current_model = ch_model
+                if ch_provider:
+                    current_provider = ch_provider
+                    provs = cfg.get("providers", {})
+                    prov_cfg = provs.get(ch_provider, {})
+                    if prov_cfg:
+                        key_env = prov_cfg.get("key_env")
+                        if key_env:
+                            import os
+                            current_api_key = os.getenv(key_env, "")
+                        current_base_url = prov_cfg.get("base_url", current_base_url)
+
+        # No args: show interactive picker (Telegram/Discord) or text list
+        if not model_input and not explicit_provider:
+            # Try interactive picker if the platform supports it
+            adapter = self.adapters.get(source.platform)
+            has_picker = (
+                adapter is not None
+                and getattr(type(adapter), "send_model_picker", None) is not None
+            )
+
+            if has_picker:
+                try:
+                    providers = list_picker_providers(
+                        current_provider=current_provider,
+                        current_base_url=current_base_url,
+                        current_model=current_model,
+                        user_providers=user_provs,
+                        custom_providers=custom_provs,
+                        max_models=50,
+                    )
+                except Exception:
+                    providers = []
+
+                if providers:
+                    # Build a callback closure for when the user picks a model.
+                    # Captures self + locals needed for the switch logic.
+                    _self = self
+                    _session_key = session_key
+                    _cur_model = current_model
+                    _cur_provider = current_provider
+                    _cur_base_url = current_base_url
+                    _cur_api_key = current_api_key
+
+                    async def _on_model_selected(
+                        _chat_id: str, model_id: str, provider_slug: str
+                    ) -> str:
+                        """Perform the model switch and return confirmation text."""
+                        result = _switch_model(
+                            raw_input=model_id,
+                            current_provider=_cur_provider,
+                            current_model=_cur_model,
+                            current_base_url=_cur_base_url,
+                            current_api_key=_cur_api_key,
+                            is_global=False,
+                            explicit_provider=provider_slug,
+                            user_providers=user_provs,
+                            custom_providers=custom_provs,
+                        )
+                        if not result.success:
+                            return t("gateway.model.error_prefix", error=result.error_message)
+
+                        # Update cached agent in-place
+                        cached_entry = None
+                        _cache_lock = getattr(_self, "_agent_cache_lock", None)
+                        _cache = getattr(_self, "_agent_cache", None)
+                        if _cache_lock and _cache is not None:
+                            with _cache_lock:
+                                cached_entry = _cache.get(_session_key)
+                        if cached_entry and cached_entry[0] is not None:
+                            try:
+                                cached_entry[0].switch_model(
+                                    new_model=result.new_model,
+                                    new_provider=result.target_provider,
+                                    api_key=result.api_key,
+                                    base_url=result.base_url,
+                                    api_mode=result.api_mode,
+                                )
+                            except Exception as exc:
+                                logger.warning("Picker model switch failed for cached agent: %s", exc)
+
+                        # Store model note + session override
+                        if not hasattr(_self, "_pending_model_notes"):
+                            _self._pending_model_notes = {}
+                        _self._pending_model_notes[_session_key] = (
+                            f"[Note: model was just switched from {_cur_model} to {result.new_model} "
+                            f"via {result.provider_label or result.target_provider}. "
+                            f"Adjust your self-identification accordingly.]"
+                        )
+                        _self._session_model_overrides[_session_key] = {
+                            "model": result.new_model,
+                            "provider": result.target_provider,
+                            "api_key": result.api_key,
+                            "base_url": result.base_url,
+                            "api_mode": result.api_mode,
+                        }
+
+                        # Evict cached agent so the next turn creates a fresh
+                        # agent from the override rather than relying on the
+                        # stale cache signature to trigger a rebuild.
+                        _self._evict_cached_agent(_session_key)
+
+                        # Build confirmation text
+                        plabel = result.provider_label or result.target_provider
+                        lines = [t("gateway.model.switched", model=result.new_model)]
+                        lines.append(t("gateway.model.provider_label", provider=plabel))
+                        mi = result.model_info
+                        from hermes_cli.model_switch import resolve_display_context_length
+                        _sw_config_ctx = None
+                        try:
+                            _sw_cfg = _load_gateway_config()
+                            _sw_model_cfg = _sw_cfg.get("model", {})
+                            if isinstance(_sw_model_cfg, dict):
+                                _sw_raw = _sw_model_cfg.get("context_length")
+                                if _sw_raw is not None:
+                                    _sw_config_ctx = int(_sw_raw)
+                        except Exception:
+                            pass
+                        ctx = resolve_display_context_length(
+                            result.new_model,
+                            result.target_provider,
+                            base_url=result.base_url or current_base_url or "",
+                            api_key=result.api_key or current_api_key or "",
+                            model_info=mi,
+                            custom_providers=custom_provs,
+                            config_context_length=_sw_config_ctx,
+                        )
+                        if ctx:
+                            lines.append(t("gateway.model.context_label", tokens=f"{ctx:,}"))
+                        if mi:
+                            if mi.max_output:
+                                lines.append(t("gateway.model.max_output_label", tokens=f"{mi.max_output:,}"))
+                            if mi.has_cost_data():
+                                lines.append(t("gateway.model.cost_label", cost=mi.format_cost()))
+                            lines.append(t("gateway.model.capabilities_label", capabilities=mi.format_capabilities()))
+                        lines.append(t("gateway.model.session_only_hint"))
+                        return "\n".join(lines)
+
+                    metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+                    result = await adapter.send_model_picker(
+                        chat_id=source.chat_id,
+                        providers=providers,
+                        current_model=current_model,
+                        current_provider=current_provider,
+                        session_key=session_key,
+                        on_model_selected=_on_model_selected,
+                        metadata=metadata,
+                    )
+                    if result.success:
+                        return None  # Picker sent — adapter handles the response
+
+            # Fallback: text list (for platforms without picker or if picker failed)
+            provider_label = get_label(current_provider)
+            lines = [t("gateway.model.current_label", model=current_model or "unknown", provider=provider_label), ""]
+
+            try:
+                providers = list_authenticated_providers(
+                    current_provider=current_provider,
+                    current_base_url=current_base_url,
+                    current_model=current_model,
+                    user_providers=user_provs,
+                    custom_providers=custom_provs,
+                    max_models=5,
+                )
+                for p in providers:
+                    tag = t("gateway.model.current_tag") if p["is_current"] else ""
+                    lines.append(f"**{p['name']}** `--provider {p['slug']}`{tag}:")
+                    if p["models"]:
+                        model_strs = ", ".join(f"`{m}`" for m in p["models"])
+                        extra = t("gateway.model.more_models_suffix", count=p["total_models"] - len(p["models"])) if p["total_models"] > len(p["models"]) else ""
+                        lines.append(f"  {model_strs}{extra}")
+                    elif p.get("api_url"):
+                        lines.append(f"  `{p['api_url']}`")
+                    lines.append("")
+            except Exception:
+                pass
+
+            lines.append(t("gateway.model.usage_switch_model"))
+            lines.append(t("gateway.model.usage_switch_provider"))
+            lines.append(t("gateway.model.usage_persist"))
+            return "\n".join(lines)
+
+        # Perform the switch
+        result = _switch_model(
+            raw_input=model_input,
+            current_provider=current_provider,
+            current_model=current_model,
+            current_base_url=current_base_url,
+            current_api_key=current_api_key,
+            is_global=persist_global,
+            explicit_provider=explicit_provider,
+            user_providers=user_provs,
+            custom_providers=custom_provs,
+        )
+
+        if not result.success:
+            return t("gateway.model.error_prefix", error=result.error_message)
+
+        # If there's a cached agent, update it in-place
+        cached_entry = None
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if _cache_lock and _cache is not None:
+            with _cache_lock:
+                cached_entry = _cache.get(session_key)
+
+        if cached_entry and cached_entry[0] is not None:
+            try:
+                cached_entry[0].switch_model(
+                    new_model=result.new_model,
+                    new_provider=result.target_provider,
+                    api_key=result.api_key,
+                    base_url=result.base_url,
+                    api_mode=result.api_mode,
+                )
+            except Exception as exc:
+                logger.warning("In-place model switch failed for cached agent: %s", exc)
+
+        # Store a note to prepend to the next user message so the model
+        # knows about the switch (avoids system messages mid-history).
+        if not hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes = {}
+        self._pending_model_notes[session_key] = (
+            f"[Note: model was just switched from {current_model} to {result.new_model} "
+            f"via {result.provider_label or result.target_provider}. "
+            f"Adjust your self-identification accordingly.]"
+        )
+
+        # Store session override so next agent creation uses the new model
+        self._session_model_overrides[session_key] = {
+            "model": result.new_model,
+            "provider": result.target_provider,
+            "api_key": result.api_key,
+            "base_url": result.base_url,
+            "api_mode": result.api_mode,
+        }
+
+        # Evict cached agent so the next turn creates a fresh agent from the
+        # override rather than relying on cache signature mismatch detection.
+        self._evict_cached_agent(session_key)
+
+        # Persist to config if --global
+        if persist_global:
+            try:
+                if config_path.exists():
+                    with open(config_path, encoding="utf-8") as f:
+                        cfg = yaml.safe_load(f) or {}
+                else:
+                    cfg = {}
+                # Coerce scalar/None ``model:`` into a dict before mutation —
+                # otherwise ``cfg.setdefault("model", {})`` returns the existing
+                # scalar and the next assignment raises
+                # ``TypeError: 'str' object does not support item assignment``.
+                # Reproduces when ``config.yaml`` has ``model: <name>`` (flat
+                # string) instead of the proper nested ``model: {default: ...}``.
+                raw_model = cfg.get("model")
+                if isinstance(raw_model, dict):
+                    model_cfg = raw_model
+                elif isinstance(raw_model, str) and raw_model.strip():
+                    model_cfg = {"default": raw_model.strip()}
+                    cfg["model"] = model_cfg
+                else:
+                    model_cfg = {}
+                    cfg["model"] = model_cfg
+                model_cfg["default"] = result.new_model
+                model_cfg["provider"] = result.target_provider
+                if result.base_url:
+                    model_cfg["base_url"] = result.base_url
+                from hermes_cli.config import save_config
+                save_config(cfg)
+            except Exception as e:
+                logger.warning("Failed to persist model switch: %s", e)
+
+        # Build confirmation message with full metadata
+        provider_label = result.provider_label or result.target_provider
+        lines = [t("gateway.model.switched", model=result.new_model)]
+        lines.append(t("gateway.model.provider_label", provider=provider_label))
+
+        # Context: always resolve via the provider-aware chain so Codex OAuth,
+        # Copilot, and Nous-enforced caps win over the raw models.dev entry.
+        mi = result.model_info
+        from hermes_cli.model_switch import resolve_display_context_length
+        _sw2_config_ctx = None
         try:
             platform = getattr(source.platform, "value", None) or str(getattr(source, "platform", "") or "")
             chat_id = getattr(source, "chat_id", None)
@@ -12163,6 +12492,408 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+        # Display toggle (per-platform)
+        platform_key = _platform_config_key(event.source.platform)
+        if args in {"show", "on"}:
+            self._show_reasoning = True
+            _save_config_key(f"display.platforms.{platform_key}.show_reasoning", True)
+            return t("gateway.reasoning.display_set_on", platform=platform_key)
+
+        if args in {"hide", "off"}:
+            self._show_reasoning = False
+            _save_config_key(f"display.platforms.{platform_key}.show_reasoning", False)
+            return t("gateway.reasoning.display_set_off", platform=platform_key)
+
+        # Effort level change
+        effort = args.strip()
+        if effort == "reset":
+            if persist_global:
+                return t("gateway.reasoning.reset_global_unsupported")
+            self._set_session_reasoning_override(session_key, None)
+            self._reasoning_config = self._load_reasoning_config()
+            self._evict_cached_agent(session_key)
+            return t("gateway.reasoning.reset_done")
+        if effort == "none":
+            parsed = {"enabled": False}
+        elif effort in {"minimal", "low", "medium", "high", "xhigh"}:
+            parsed = {"enabled": True, "effort": effort}
+        else:
+            return t(
+                "gateway.reasoning.unknown_arg",
+                arg=effort or raw_args.lower(),
+            )
+
+        self._reasoning_config = parsed
+        if persist_global:
+            if _save_config_key("agent.reasoning_effort", effort):
+                self._set_session_reasoning_override(session_key, None)
+                self._evict_cached_agent(session_key)
+                return t("gateway.reasoning.set_global", effort=effort)
+            self._set_session_reasoning_override(session_key, parsed)
+            self._evict_cached_agent(session_key)
+            return t("gateway.reasoning.set_global_save_failed", effort=effort)
+
+        self._set_session_reasoning_override(session_key, parsed)
+        self._evict_cached_agent(session_key)
+        return t("gateway.reasoning.set_session", effort=effort)
+
+    async def _handle_fast_command(self, event: MessageEvent) -> str:
+        """Handle /fast — mirror the CLI Priority Processing toggle in gateway chats."""
+        import yaml
+        from hermes_cli.models import model_supports_fast_mode
+
+        args = event.get_command_args().strip().lower()
+        config_path = _hermes_home / "config.yaml"
+        self._service_tier = self._load_service_tier()
+
+        user_config = _load_gateway_config()
+        model = _resolve_gateway_model(user_config)
+        if not model_supports_fast_mode(model):
+            return t("gateway.fast.not_supported")
+
+        def _save_config_key(key_path: str, value):
+            """Save a dot-separated key to config.yaml."""
+            try:
+                user_config = {}
+                if config_path.exists():
+                    with open(config_path, encoding="utf-8") as f:
+                        user_config = yaml.safe_load(f) or {}
+                keys = key_path.split(".")
+                current = user_config
+                for k in keys[:-1]:
+                    if k not in current or not isinstance(current[k], dict):
+                        current[k] = {}
+                    current = current[k]
+                current[keys[-1]] = value
+                atomic_yaml_write(config_path, user_config)
+                return True
+            except Exception as e:
+                logger.error("Failed to save config key %s: %s", key_path, e)
+                return False
+
+        if not args or args == "status":
+            status = t("gateway.fast.status_fast") if self._service_tier == "priority" else t("gateway.fast.status_normal")
+            return t("gateway.fast.status", mode=status)
+
+        if args in {"fast", "on"}:
+            self._service_tier = "priority"
+            saved_value = "fast"
+            label = t("gateway.fast.label_fast")
+        elif args in {"normal", "off"}:
+            self._service_tier = None
+            saved_value = "normal"
+            label = t("gateway.fast.label_normal")
+        else:
+            return t("gateway.fast.unknown_arg", arg=args)
+
+        if _save_config_key("agent.service_tier", saved_value):
+            return t("gateway.fast.saved", label=label)
+        return t("gateway.fast.session_only", label=label)
+
+    async def _handle_yolo_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
+        """Handle /yolo — toggle dangerous command approval bypass for this session only."""
+        from tools.approval import (
+            disable_session_yolo,
+            enable_session_yolo,
+            is_session_yolo_enabled,
+        )
+
+        session_key = self._session_key_for_source(event.source)
+        current = is_session_yolo_enabled(session_key)
+        if current:
+            disable_session_yolo(session_key)
+            return EphemeralReply(t("gateway.yolo.disabled"))
+        else:
+            enable_session_yolo(session_key)
+            return EphemeralReply(t("gateway.yolo.enabled"))
+
+    async def _handle_verbose_command(self, event: MessageEvent) -> str:
+        """Handle /verbose command — cycle tool progress display mode.
+
+        Gated by ``display.tool_progress_command`` in config.yaml (default off).
+        When enabled, cycles the tool progress mode through off → new → all →
+        verbose → off for the *current platform*.  The setting is saved to
+        ``display.platforms.<platform>.tool_progress`` so each channel can
+        have its own verbosity level independently.
+        """
+
+        config_path = _hermes_home / "config.yaml"
+        platform_key = _platform_config_key(event.source.platform)
+
+        # --- check config gate ------------------------------------------------
+        try:
+            user_config = _load_gateway_config()
+            gate_enabled = is_truthy_value(
+                cfg_get(user_config, "display", "tool_progress_command"),
+                default=False,
+            )
+        except Exception:
+            gate_enabled = False
+
+        if not gate_enabled:
+            return t("gateway.verbose.not_enabled")
+
+        # --- cycle mode (per-platform) ----------------------------------------
+        cycle = ["off", "new", "all", "verbose"]
+        descriptions = {
+            "off": t("gateway.verbose.mode_off"),
+            "new": t("gateway.verbose.mode_new"),
+            "all": t("gateway.verbose.mode_all"),
+            "verbose": t("gateway.verbose.mode_verbose"),
+        }
+
+        # Read current effective mode for this platform via the resolver
+        from gateway.display_config import resolve_display_setting
+        current = resolve_display_setting(user_config, platform_key, "tool_progress", "all")
+        if current not in cycle:
+            current = "all"
+        idx = (cycle.index(current) + 1) % len(cycle)
+        new_mode = cycle[idx]
+
+        # Save to display.platforms.<platform>.tool_progress
+        try:
+            if "display" not in user_config or not isinstance(user_config.get("display"), dict):
+                user_config["display"] = {}
+            display = user_config["display"]
+            if "platforms" not in display or not isinstance(display.get("platforms"), dict):
+                display["platforms"] = {}
+            if platform_key not in display["platforms"] or not isinstance(display["platforms"].get(platform_key), dict):
+                display["platforms"][platform_key] = {}
+            display["platforms"][platform_key]["tool_progress"] = new_mode
+            atomic_yaml_write(config_path, user_config)
+            return (
+                f"{descriptions[new_mode]}\n"
+                + t("gateway.verbose.saved_suffix", platform=platform_key)
+            )
+        except Exception as e:
+            logger.warning("Failed to save tool_progress mode: %s", e)
+            return f"{descriptions[new_mode]}\n" + t("gateway.verbose.save_failed", error=e)
+
+    async def _handle_footer_command(self, event: MessageEvent) -> str:
+        """Handle /footer command — toggle the runtime-metadata footer.
+
+        Usage:
+            /footer           → toggle on/off
+            /footer on        → enable globally
+            /footer off       → disable globally
+            /footer status    → show current state + fields
+
+        The footer is saved to ``display.runtime_footer.enabled`` (global).
+        Per-platform overrides under ``display.platforms.<platform>.runtime_footer``
+        are respected but not modified here — edit config.yaml directly for
+        per-platform control.
+        """
+        from gateway.runtime_footer import resolve_footer_config
+
+        config_path = _hermes_home / "config.yaml"
+        platform_key = _platform_config_key(event.source.platform)
+
+        # --- parse argument -------------------------------------------------
+        arg = ""
+        try:
+            text = (getattr(event, "message", None) or "").strip()
+            if text.startswith("/"):
+                parts = text.split(None, 1)
+                if len(parts) > 1:
+                    arg = parts[1].strip().lower()
+        except Exception:
+            arg = ""
+
+        # --- load config ----------------------------------------------------
+        try:
+            user_config: dict = _load_gateway_config()
+        except Exception as e:
+            return t("gateway.config_read_failed", error=e)
+
+        effective = resolve_footer_config(user_config, platform_key)
+
+        if arg in {"status", "?"}:
+            state = t("gateway.footer.state_on") if effective["enabled"] else t("gateway.footer.state_off")
+            fields = ", ".join(effective.get("fields") or [])
+            return t(
+                "gateway.footer.status",
+                state=state,
+                fields=fields,
+                platform=platform_key,
+            )
+
+        if arg in {"on", "enable", "true", "1"}:
+            new_state = True
+        elif arg in {"off", "disable", "false", "0"}:
+            new_state = False
+        elif arg == "":
+            new_state = not effective["enabled"]
+        else:
+            return t("gateway.footer.usage")
+
+        # --- write global flag ---------------------------------------------
+        try:
+            if not isinstance(user_config.get("display"), dict):
+                user_config["display"] = {}
+            display = user_config["display"]
+            if not isinstance(display.get("runtime_footer"), dict):
+                display["runtime_footer"] = {}
+            display["runtime_footer"]["enabled"] = new_state
+            atomic_yaml_write(config_path, user_config)
+        except Exception as e:
+            logger.warning("Failed to save runtime_footer.enabled: %s", e)
+            return t("gateway.config_save_failed", error=e)
+
+        state = t("gateway.footer.state_on") if new_state else t("gateway.footer.state_off")
+        example = ""
+        if new_state:
+            # Show a preview using current agent state if available.
+            from gateway.runtime_footer import format_runtime_footer
+            preview = format_runtime_footer(
+                model=_resolve_gateway_model(user_config) or None,
+                context_tokens=0,
+                context_length=None,
+                fields=effective.get("fields") or ["model", "context_pct", "cwd"],
+            )
+            if preview:
+                example = t("gateway.footer.example_line", preview=preview)
+        return t("gateway.footer.saved", state=state, example=example)
+
+    async def _handle_compress_command(self, event: MessageEvent) -> str:
+        """Handle /compress command -- manually compress conversation context.
+
+        Accepts an optional focus topic: ``/compress <focus>`` guides the
+        summariser to preserve information related to *focus* while being
+        more aggressive about discarding everything else.
+        """
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+        history = self.session_store.load_transcript(session_entry.session_id)
+
+        if not history or len(history) < 4:
+            return t("gateway.compress.not_enough")
+
+        # Extract optional focus topic from command args
+        focus_topic = (event.get_command_args() or "").strip() or None
+
+        try:
+            from run_agent import AIAgent
+            from agent.manual_compression_feedback import summarize_manual_compression
+            from agent.model_metadata import estimate_request_tokens_rough
+
+            session_key = self._session_key_for_source(source)
+            user_config = _load_gateway_config()
+            model, runtime_kwargs = self._resolve_session_agent_runtime(
+                source=source,
+                session_key=session_key,
+                user_config=user_config,
+            )
+            if not runtime_kwargs.get("api_key"):
+                return t("gateway.compress.no_provider")
+
+            msgs = [
+                {"role": m.get("role"), "content": m.get("content")}
+                for m in history
+                if m.get("role") in {"user", "assistant"} and m.get("content")
+            ]
+
+            tmp_agent = AIAgent(
+                **runtime_kwargs,
+                model=model,
+                max_iterations=4,
+                quiet_mode=True,
+                skip_memory=True,
+                enabled_toolsets=["memory"],
+                session_id=session_entry.session_id,
+            )
+            try:
+                tmp_agent._print_fn = lambda *a, **kw: None
+
+                # Estimate with system prompt + tool schemas included so the
+                # figure reflects real request pressure, not a transcript-only
+                # underestimate (#6217). Must be computed after tmp_agent is
+                # built so _cached_system_prompt/tools are populated.
+                _sys_prompt = getattr(tmp_agent, "_cached_system_prompt", "") or ""
+                _tools = getattr(tmp_agent, "tools", None) or None
+                approx_tokens = estimate_request_tokens_rough(
+                    msgs, system_prompt=_sys_prompt, tools=_tools
+                )
+
+                compressor = tmp_agent.context_compressor
+                if not compressor.has_content_to_compress(msgs):
+                    return t("gateway.compress.nothing_to_do")
+
+                loop = asyncio.get_running_loop()
+                compressed, _ = await loop.run_in_executor(
+                    None,
+                    lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic, force=True)
+                )
+
+                # _compress_context already calls end_session() on the old session
+                # (preserving its full transcript in SQLite) and creates a new
+                # session_id for the continuation.  Write the compressed messages
+                # into the NEW session so the original history stays searchable.
+                new_session_id = tmp_agent.session_id
+                if new_session_id != session_entry.session_id:
+                    session_entry.session_id = new_session_id
+                    self.session_store._save()
+                    self._sync_telegram_topic_binding(
+                        source, session_entry, reason="compress-command",
+                    )
+
+                self.session_store.rewrite_transcript(new_session_id, compressed)
+                # Reset stored token count — transcript changed, old value is stale
+                self.session_store.update_session(
+                    session_entry.session_key, last_prompt_tokens=0
+                )
+                new_tokens = estimate_request_tokens_rough(
+                    compressed, system_prompt=_sys_prompt, tools=_tools
+                )
+                summary = summarize_manual_compression(
+                    msgs,
+                    compressed,
+                    approx_tokens,
+                    new_tokens,
+                )
+                # Detect summary-generation failure so we can surface a
+                # visible warning to the user even on the manual /compress
+                # path (otherwise the failure is silently logged).
+                # _last_compress_aborted means the aux LLM returned no
+                # usable summary and the compressor preserved messages
+                # unchanged (no drop, no placeholder).  force=True was
+                # passed above so any active cooldown is bypassed.
+                _summary_aborted = bool(getattr(compressor, "_last_compress_aborted", False))
+                _summary_err = getattr(compressor, "_last_summary_error", None)
+                # Separately: did the user's CONFIGURED aux model fail
+                # and we recovered via main?  Surface that as an info
+                # note so they can fix their config.
+                _aux_fail_model = getattr(compressor, "_last_aux_model_failure_model", None)
+                _aux_fail_err = getattr(compressor, "_last_aux_model_failure_error", None)
+            finally:
+                # Evict cached agent so next turn rebuilds system prompt
+                # from current files (SOUL.md, memory, etc.).
+                self._evict_cached_agent(session_key)
+                self._cleanup_agent_resources(tmp_agent)
+            lines = [f"🗜️ {summary['headline']}"]
+            if focus_topic:
+                lines.append(t("gateway.compress.focus_line", topic=focus_topic))
+            lines.append(summary["token_line"])
+            if summary["note"]:
+                lines.append(summary["note"])
+            if _summary_aborted:
+                lines.append(
+                    t(
+                        "gateway.compress.aborted",
+                        error=(_summary_err or "unknown error"),
+                    )
+                )
+            elif _aux_fail_model:
+                lines.append(
+                    t(
+                        "gateway.compress.aux_failed",
+                        model=_aux_fail_model,
+                        error=(_aux_fail_err or "unknown error"),
+                    )
+                )
+            return "\n".join(lines)
+        except Exception as e:
+            logger.warning("Manual compress failed: %s", e)
+            return t("gateway.compress.failed", error=e)
 
     async def _get_telegram_topic_capabilities(self, source: SessionSource) -> dict:
         """Read Telegram private-topic capability flags via Bot API getMe."""

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4371,12 +4371,22 @@ def _normalize_custom_provider_entry(
         normalized["models"] = models
     elif isinstance(models, list) and models:
         # Hand-edited configs (and older Hermes versions) write ``models`` as
-        # a plain list of model ids. Preserve them by converting to the dict
-        # shape downstream code expects; otherwise normalize silently drops
-        # the list and /model shows the provider with (0) models.
-        normalized["models"] = {
-            str(m): {} for m in models if isinstance(m, str) and m.strip()
-        }
+        # a list of dicts with id/name/context_window. Convert to the dict
+        # shape downstream code expects, preserving full metadata.
+        model_dict: Dict[str, Any] = {}
+        for m in models:
+            if isinstance(m, dict):
+                model_id = m.get("id") or m.get("name") or ""
+                if model_id:
+                    entry = dict(m)
+                    # Map context_window → context_length so
+                    # get_custom_provider_context_length can find it.
+                    if "context_window" in entry and "context_length" not in entry:
+                        entry["context_length"] = entry["context_window"]
+                    model_dict[str(model_id)] = entry
+            elif isinstance(m, str) and m.strip():
+                model_dict[m.strip()] = {}
+        normalized["models"] = model_dict
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2770,6 +2770,49 @@ def select_provider_and_model(args=None):
         config_provider or os.getenv("HERMES_INFERENCE_PROVIDER") or "auto"
     )
     compatible_custom_providers = get_compatible_custom_providers(config)
+    active = None
+    if effective_provider != "auto":
+        active_def = resolve_provider_full(
+            effective_provider,
+            config.get("providers"),
+            compatible_custom_providers,
+        )
+        if active_def is not None:
+            active = active_def.id
+        else:
+            warning = (
+                f"Unknown provider '{effective_provider}'. Check 'hermes model' for "
+                "available providers, or run 'hermes doctor' to diagnose config "
+                "issues."
+            )
+            print(f"Warning: {warning} Falling back to auto provider detection.")
+    if active is None:
+        try:
+            active = resolve_provider("auto")
+        except AuthError as exc:
+            if effective_provider == "auto":
+                warning = format_auth_error(exc)
+                print(f"Warning: {warning} Falling back to auto provider detection.")
+            active = None  # no provider yet; default to first in list
+
+    # Detect custom endpoint
+    if active == "openrouter" and get_env_value("OPENAI_BASE_URL"):
+        active = "custom"
+
+    from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_LABELS
+
+    provider_labels = dict(_PROVIDER_LABELS)  # derive from canonical list
+    active_label = provider_labels.get(active, active) if active else "none"
+
+    print()
+    print(f"  Current model:    {current_model}")
+    print(f"  Active provider:  {active_label}")
+    print()
+
+    # Step 1: Provider selection — ONLY show user-defined custom providers
+    # (Built-in CANONICAL_PROVIDERS are hidden per user preference)
+    all_providers = []
+
     def _named_custom_provider_map(cfg) -> dict[str, dict[str, str]]:
         from hermes_cli.config import read_raw_config
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1958,8 +1958,13 @@ def list_authenticated_providers(
                         models_list.append(m)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                    if isinstance(m, dict):
+                        # Extract model ID string from dict object
+                        model_id = m.get("id", "") or m.get("name", "")
+                    else:
+                        model_id = str(m) if m else ""
+                    if model_id and model_id not in models_list:
+                        models_list.append(model_id)
 
             # Official OpenAI API rows in providers: often have base_url but no
             # explicit models: dict — avoid a misleading zero count in /model.
@@ -2011,6 +2016,10 @@ def list_authenticated_providers(
             })
             seen_slugs.add(ep_name.lower())
             seen_slugs.add(custom_provider_slug(display_name).lower())
+            # Also register the `custom:` slug variant to prevent
+            # duplicate entries in Section 4 (get_compatible_custom_providers
+            # converts the same `providers:` dict into custom_providers format
+            # with `custom:<name>` slugs — #10629)
             _pair = (
                 str(display_name).strip().lower(),
                 str(api_url).strip().rstrip("/").lower(),

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1045,11 +1045,12 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("arcee",          "Arcee AI",                 "Arcee AI (Trinity models, direct API)"),
     ProviderEntry("gmi",            "GMI Cloud",                "GMI Cloud (Multi-model direct API)"),
     ProviderEntry("kilocode",       "Kilo Code",                "Kilo Code (Kilo Gateway API)"),
-    ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (Curated models, pay-as-you-go)"),
-    ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (Open models subscription)"),
-    ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek; IAM or API key)"),
-    ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint, your Azure AI deployment)"),
-    ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
+    ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (35+ curated models, pay-as-you-go)"),
+    ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (open models, $10/month subscription)"),
+    ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek — IAM or API key)"),
+    ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint — your Azure AI deployment)"),
+    ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (reuses local Qwen CLI login)"),
+    ProviderEntry("longcat",        "LongCat AI",               "LongCat AI (LongCat-Flash-Thinking, LongCat-Flash-Lite — free tier)"),
 ]
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
@@ -1074,6 +1075,7 @@ except Exception:
 # Derived dicts — used throughout the codebase
 _PROVIDER_LABELS = {p.slug: p.label for p in CANONICAL_PROVIDERS}
 _PROVIDER_LABELS["custom"] = "Custom endpoint"  # special case: not a named provider
+_PROVIDER_LABELS["longcat"] = "LongCat AI"
 
 
 # ---------------------------------------------------------------------------
@@ -4021,6 +4023,53 @@ def validate_requested_model(
                 f"model listing.  Many Anthropic-compatible proxies do not "
                 f"implement GET /v1/models.  The model name has been accepted "
                 f"without verification."
+            ),
+        }
+
+    # LongCat AI doesn't expose /v1/models — validate against known model IDs
+    if normalized == "longcat":
+        known_models = {"LongCat-Flash-Thinking", "LongCat-Flash-Thinking-2601", "LongCat-Flash-Lite", "LongCat-Flash-Omni", "LongCat-2.0-Preview"}
+        if requested_for_lookup in known_models or requested_for_lookup.lower().startswith("longcat"):
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
+        suggestions = get_close_matches(requested, list(known_models), n=3, cutoff=0.5)
+        suggestion_text = "\n  Known LongCat models: " + ", ".join(f"`{s}`" for s in suggestions) if suggestions else ""
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": False,
+            "message": (
+                f"Note: `{requested}` is not a known LongCat model ID."
+                f"{suggestion_text}"
+            ),
+        }
+    # DashScope coding endpoint doesn't expose /v1/models — validate against known model IDs
+    if normalized == "bailian":
+        known_models = {
+            "qwen3.6-plus", "qwen-plus", "qwen-turbo", "qwen-max", "qwen-max-latest",
+            "qwen-coder-plus", "qwen-coder-turbo", "qwen-coder-plus-latest",
+            "qwen3-coder-plus", "qwen3-coder",
+            "qwen2.5-coder-32b-instruct", "qwen2.5-coder-7b-instruct",
+        }
+        if requested_for_lookup in known_models:
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
+        # Accept unknown models too — DashScope has many models not listed here
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": False,
+            "message": (
+                f"Note: `{requested}` is not a known DashScope coding model ID. "
+                f"It may still work if the model is available on the coding endpoint."
             ),
         }
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -594,7 +594,8 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
     # Extract fields
     display_name = entry.get("name", "") or name
     api_url = entry.get("api", "") or entry.get("url", "") or entry.get("base_url", "") or ""
-    key_env = entry.get("key_env", "") or ""
+    # Support both "key_env" and "api_key_env" field names for consistency
+    key_env = entry.get("key_env", "") or entry.get("api_key_env", "") or ""
     transport = entry.get("transport", "openai_chat") or "openai_chat"
 
     env_vars: List[str] = []

--- a/plugins/web/anysearch/__init__.py
+++ b/plugins/web/anysearch/__init__.py
@@ -1,0 +1,9 @@
+"""AnySearch search plugin — bundled, auto-loaded."""
+from __future__ import annotations
+
+from plugins.web.anysearch.provider import AnySearchProvider
+
+
+def register(ctx) -> None:
+    """Register the AnySearch provider with the plugin context."""
+    ctx.register_web_search_provider(AnySearchProvider())

--- a/plugins/web/anysearch/plugin.yaml
+++ b/plugins/web/anysearch/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-anysearch
+version: 1.0.0
+description: "AnySearch — unified real-time search engine supporting general web, vertical domain search, and batch search. Requires ANYSEARCH_API_KEY."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - anysearch

--- a/plugins/web/anysearch/provider.py
+++ b/plugins/web/anysearch/provider.py
@@ -1,0 +1,120 @@
+"""AnySearch web provider.
+
+Unified real-time search engine supporting general web, vertical domain search,
+and batch search. Integrates with Hermes via the `web_search` tool.
+
+Config keys::
+
+    web:
+      search_backend: "anysearch"
+      backend: "searxng"  # fallback
+
+Env var::
+
+    ANYSEARCH_API_KEY=as_sk_...
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+class AnySearchProvider(WebSearchProvider):
+    """Search via AnySearch REST API (/v1/search)."""
+
+    @property
+    def name(self) -> str:
+        return "anysearch"
+
+    @property
+    def display_name(self) -> str:
+        return "AnySearch"
+
+    def is_available(self) -> bool:
+        return bool(os.getenv("ANYSEARCH_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False  # Extract via MCP is unreliable (403s)
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        api_key = os.getenv("ANYSEARCH_API_KEY", "").strip()
+        if not api_key:
+            return {"success": False, "error": "ANYSEARCH_API_KEY is not set"}
+
+        url = "https://api.anysearch.com/v1/search"
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "query": query,
+            "max_results": limit,
+            # Auto-detect CN zone for Chinese queries
+            "zone": "cn" if any("\u4e00" <= c <= "\u9fff" for c in query) else None,
+        }
+        # Remove zone key if None to avoid sending it
+        if payload["zone"] is None:
+            del payload["zone"]
+
+        try:
+            resp = httpx.post(url, json=payload, headers=headers, timeout=15)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("AnySearch HTTP error: %s", exc)
+            try:
+                detail = exc.response.json()
+                msg = detail.get("message", f"HTTP {exc.response.status_code}")
+            except Exception:
+                msg = f"HTTP {exc.response.status_code}"
+            return {"success": False, "error": f"AnySearch returned {msg}"}
+        except httpx.RequestError as exc:
+            return {"success": False, "error": f"Could not reach AnySearch API: {exc}"}
+
+        try:
+            data = resp.json()
+        except Exception as exc:
+            return {"success": False, "error": f"Could not parse AnySearch response: {exc}"}
+
+        if data.get("code") != 0:
+            return {"success": False, "error": f"API error: {data.get('message', 'unknown')}"}
+
+        results = data.get("data", {}).get("results", [])
+        web_results = [
+            {
+                "title": str(r.get("title", "")),
+                "url": str(r.get("url", "")),
+                "description": str(r.get("content", ""))[:500],  # Snippet
+                "position": i + 1,
+            }
+            for i, r in enumerate(results[:limit])
+        ]
+
+        logger.info(
+            "AnySearch '%s': %d results (limit %d)",
+            query, len(web_results), limit,
+        )
+        return {"success": True, "data": {"web": web_results}}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "AnySearch",
+            "badge": "real-time · 23 domains",
+            "tag": "Unified search with vertical domains (finance, academic, security, etc.).",
+            "env_vars": [
+                {
+                    "key": "ANYSEARCH_API_KEY",
+                    "prompt": "AnySearch API key",
+                    "url": "https://anysearch.com/console/api-keys",
+                },
+            ],
+        }

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -149,7 +149,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "anysearch"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -160,14 +160,17 @@ def _get_backend() -> str:
     # with "no subscription" and the tool returns an error to the agent
     # without falling back). Free-tier backends trail the paid ones.
     backend_candidates = (
-        ("tavily", _has_env("TAVILY_API_KEY")),
-        ("exa", _has_env("EXA_API_KEY")),
-        ("parallel", _has_env("PARALLEL_API_KEY")),
-        ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")),
-        ("firecrawl", _is_tool_gateway_ready()),
-        ("searxng", _has_env("SEARXNG_URL")),
-        ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
-        ("ddgs", _ddgs_package_importable()),
+        ( "anysearch", _has_env("ANYSEARCH_API_KEY")),
+        ( "firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
+        ( "parallel", _has_env("PARALLEL_API_KEY")),
+        ( "tavily", _has_env("TAVILY_API_KEY")),
+        ( "exa", _has_env("EXA_API_KEY")),
+        ( "parallel", _has_env("PARALLEL_API_KEY")),
+        ( "firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")),
+        ( "firecrawl", _is_tool_gateway_ready()),
+        ( "searxng", _has_env("SEARXNG_URL")),
+        ( "brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
+        ( "ddgs", _ddgs_package_importable()),
     )
     for backend, available in backend_candidates:
         if available:
@@ -224,6 +227,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "anysearch":
+        return _has_env("ANYSEARCH_API_KEY")
     if backend == "searxng":
         return _has_env("SEARXNG_URL")
     if backend == "brave-free":
@@ -850,13 +855,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             get_provider as _wsp_get_provider,
         )
 
-        backend = _get_search_backend()
-        provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
-            provider = get_active_search_provider()
+        provider = get_active_search_provider()
 
         if provider is None:
             response_data = {
@@ -1185,11 +1184,11 @@ async def web_extract_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "anysearch"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "anysearch")
     )
 
 
@@ -1225,6 +1224,8 @@ if __name__ == "__main__":
             print("   Using Parallel API (https://parallel.ai)")
         elif backend == "tavily":
             print("   Using Tavily API (https://tavily.com)")
+        elif backend == "anysearch":
+            print(f"   Using AnySearch (search): {os.getenv('ANYSEARCH_API_KEY', '')[:10]}...")
         elif backend == "searxng":
             print(f"   Using SearXNG (search only): {_env_value('SEARXNG_URL')}")
         elif backend == "brave-free":


### PR DESCRIPTION
## Summary

This PR adds several new features and improvements to Hermes Agent:

### New Plugin
- **AnySearch web search plugin** — unified real-time search engine supporting general web, vertical domain search, and batch search. Requires `ANYSEARCH_API_KEY`. Ships as a bundled plugin under `plugins/web/anysearch/`.

### New Providers
- **LongCat AI** — added as a canonical provider with known model-ID validation (LongCat-Flash-Thinking, LongCat-Flash-Lite, LongCat-Flash-Omni, LongCat-2.0-Preview, etc.)
- **DashScope (bailian) coding endpoint** — model validation for the Alibaba Cloud coding endpoint

### Gateway
- **Per-channel/topic model overrides** — support for `extra.channel_models` in `config.yaml` to set per-channel/provider overrides for different Telegram/Discord channels/topics
- **Improved /model command** — interactive picker for platforms that support it

### Auxiliary Client
- **`_resolve_key_from_matching_named_provider()`** — bridges custom endpoint `base_url` to named provider `key_env` so auxiliary tasks can discover API keys from config

### Model Capabilities
- **`get_model_capabilities()` fallback** — now falls back to user `config.yaml` for providers/models not in the models.dev registry

### Configuration
- **Custom provider model normalization** — accept dict-list format in `models` config, map `context_window` → `context_length`
- **`api_key_env` alias** — support `api_key_env` as an alias for `key_env` in provider config
- **`custom:` slug dedup fix** — prevent duplicate entries in model switch display

### CLI
- **Provider selection improvements** — show current model + provider at top, only show user-defined custom providers in the selection list

## Changes

| File | Lines |
|------|-------|
| plugins/web/anysearch/__init__.py | +9 |
| plugins/web/anysearch/plugin.yaml | +7 |
| plugins/web/anysearch/provider.py | +120 |
| gateway/run.py | +733 |
| agent/auxiliary_client.py | +42 |
| agent/models_dev.py | +114 |
| agent/web_search_registry.py | +1 |
| hermes_cli/config.py | +22 |
| hermes_cli/main.py | +43 |
| hermes_cli/model_switch.py | +13 |
| hermes_cli/models.py | +59 |
| hermes_cli/providers.py | +3 |
| tools/web_tools.py | +37 |
| **Total** | **+1,125 / −78** |