### PR TITLE
fix(agent): intercept --version/--help in run_agent.main()

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5467,6 +5467,28 @@ def main(
     Toolset Examples:
         - "research": Web search, extract, crawl + vision tools
     """
+    # Intercept --version / --help before initializing the agent.
+    # pyproject.toml maps the `hermes-agent` console script to this
+    # function, so `hermes-agent --version` must not start an agent run.
+    import sys as _sys
+    if len(_sys.argv) > 1:
+        _arg = _sys.argv[1]
+        if _arg in ("--version", "-V"):
+            try:
+                from hermes_cli import __release_date__, __version__
+                print(f"Hermes Agent v{__version__} ({__release_date__})")
+            except Exception:
+                print("Hermes Agent (version unavailable)")
+            return
+        if _arg in ("--help", "-h"):
+            print("Usage: hermes-agent [OPTIONS] [QUERY]")
+            print()
+            print("Options:")
+            print("  --version, -V    Show version and exit")
+            print("  --help, -h       Show this help and exit")
+            print()
+            print("For full CLI usage, run: hermes --help")
+            return
     print("🤖 AI Agent with Tool Calling")
     print("=" * 50)
     


### PR DESCRIPTION
## Problem

`pyproject.toml` maps the `hermes-agent` console script to `run_agent:main()`, which has no CLI argument parsing. Running `hermes-agent --version` or `hermes-agent --help` starts a real agent run (initializing AIAgent, attempting provider requests) instead of printing version/help text and exiting.

The primary `hermes --version` command works correctly, but the `hermes-agent` entry point does not.

## Fix

Add `sys.argv` check at the top of `run_agent.main()` to intercept `--version`/`-V` and `--help`/`-h` before the agent initializes. Mirrors the `hermes_cli/main.py` version output format.

**Changes:** 1 file (`run_agent.py`), 22 lines added.

Fixes #54648