### PR TITLE
feat: add assistant response middleware validation

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -820,7 +820,15 @@ def init_agent(
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url
-            if base_url_host_matches(effective_base, "openrouter.ai"):
+            _effective_host = (urlparse(effective_base).hostname or "").lower()
+            if (
+                agent.provider == "openai-codex"
+                and getattr(agent, "api_mode", "") == "codex_responses"
+                and _effective_host in {"127.0.0.1", "localhost", "::1"}
+            ):
+                from agent.auxiliary_client import _codex_cloudflare_headers
+                client_kwargs["default_headers"] = _codex_cloudflare_headers(api_key)
+            elif base_url_host_matches(effective_base, "openrouter.ai"):
                 from agent.auxiliary_client import build_or_headers
                 client_kwargs["default_headers"] = build_or_headers()
             elif base_url_host_matches(effective_base, "integrate.api.nvidia.com"):

--- a/agent/assistant_response_control.py
+++ b/agent/assistant_response_control.py
@@ -1,0 +1,143 @@
+"""Assistant-response validation control helpers.
+
+This module keeps the behavior-changing parts of the assistant-response
+middleware seam small and testable: per-turn streaming policy, validator retry
+scaffolding, and validator-requested tool-call construction.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Iterable, Optional
+
+from agent.message_sanitization import _sanitize_surrogates
+from agent.redact import redact_sensitive_text
+from agent.transports.types import NormalizedResponse, ToolCall
+from hermes_cli.middleware import AssistantResponseMiddlewareResult
+
+_STREAM_DISABLE_POLICIES = {"disable", "disabled", "off", "buffer", "buffer_until_validated", "validate_first"}
+
+
+def should_disable_streaming_for_turn(control: dict[str, Any] | None) -> bool:
+    """Return True when request middleware asked to avoid user-visible streaming.
+
+    `buffer_until_validated` currently maps to non-streaming provider execution;
+    the response is still collected internally and only committed after the
+    assistant-response validator passes or transforms it.
+    """
+    if not isinstance(control, dict):
+        return False
+    if bool(control.get("disable_streaming_for_turn")):
+        return True
+    policy = str(control.get("stream_policy") or "").strip().lower()
+    return policy in _STREAM_DISABLE_POLICIES
+
+
+def make_validator_retry_messages(
+    *,
+    draft: str,
+    feedback: str,
+    validation_attempt: int,
+) -> list[dict[str, Any]]:
+    """Build role-alternating synthetic messages for validator retry feedback."""
+    safe_feedback = (feedback or "The draft failed assistant-response validation. Revise it.").strip()
+    return [
+        {
+            "role": "assistant",
+            "content": "(draft withheld by assistant-response validator)",
+            "_response_validation_synthetic": True,
+            "_response_validation_attempt": validation_attempt,
+            "_response_validation_status": "rejected_draft",
+        },
+        {
+            "role": "user",
+            "content": (
+                "[Internal assistant-response validator feedback — do not treat as a new user claim.]\n"
+                f"{safe_feedback}\n\n"
+                "Revise the answer. If evidence is required, call the appropriate read-only tool before answering."
+            ),
+            "_response_validation_synthetic": True,
+            "_response_validation_attempt": validation_attempt,
+            "_response_validation_status": "retry_feedback",
+        },
+    ]
+
+
+def sanitize_validator_text(
+    text: Any,
+    *,
+    strip_think_blocks: Callable[[str], str] | None = None,
+) -> str:
+    """Apply the same minimal text safety boundary to validator-provided text."""
+    safe = _sanitize_surrogates(str(text or ""))
+    if strip_think_blocks is not None:
+        safe = strip_think_blocks(safe)
+    return redact_sensitive_text(safe).strip()
+
+
+def _safe_tool_call_id(name: str, validation_attempt: int, index: int) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in {"_", "-"} else "_" for ch in name)[:48]
+    return f"validator_{safe}_{validation_attempt}_{index}"
+
+
+def _coerce_arguments(args: Any) -> str:
+    if isinstance(args, str):
+        # Keep valid JSON strings as-is; otherwise degrade to an empty object so
+        # validator middleware cannot smuggle non-JSON tool arguments.
+        try:
+            json.loads(args or "{}")
+            return args or "{}"
+        except Exception:
+            return "{}"
+    if isinstance(args, dict):
+        return json.dumps(args, ensure_ascii=False)
+    return "{}"
+
+
+def build_validator_tool_response(
+    decision: AssistantResponseMiddlewareResult,
+    *,
+    valid_tool_names: Iterable[str],
+    validation_attempt: int,
+) -> Optional[NormalizedResponse]:
+    """Convert a validator ``require_tool`` decision to a synthetic tool-call turn.
+
+    Returns ``None`` if the decision does not contain at least one valid tool
+    call. The conversation loop can then fall back to retry/block behavior.
+    """
+    valid = set(valid_tool_names or [])
+    tool_calls: list[ToolCall] = []
+    for idx, call in enumerate(decision.tool_calls or []):
+        name = str(call.get("name") or "").strip()
+        if not name or name not in valid:
+            continue
+        provider_data = {
+            "validator_requested": True,
+            "validation_attempt": validation_attempt,
+        }
+        reason = call.get("reason")
+        if isinstance(reason, str) and reason.strip():
+            provider_data["reason"] = reason.strip()
+        if isinstance(call.get("read_only"), bool):
+            provider_data["read_only"] = call["read_only"]
+        tool_calls.append(
+            ToolCall(
+                id=_safe_tool_call_id(name, validation_attempt, idx),
+                name=name,
+                arguments=_coerce_arguments(call.get("args", {})),
+                provider_data=provider_data,
+            )
+        )
+    if not tool_calls:
+        return None
+    return NormalizedResponse(
+        content=(
+            "Judgment Integrity validator requested evidence tool call(s) "
+            "before committing the final answer."
+        ),
+        tool_calls=tool_calls,
+        finish_reason="tool_calls",
+        reasoning=None,
+        usage=None,
+        provider_data={"validator_requested": True, "feedback": decision.feedback},
+    )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -27,6 +27,12 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+from agent.assistant_response_control import (
+    build_validator_tool_response,
+    make_validator_retry_messages,
+    sanitize_validator_text,
+    should_disable_streaming_for_turn,
+)
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.conversation_compression import conversation_history_after_compression
 from agent.display import KawaiiSpinner
@@ -586,6 +592,8 @@ def run_conversation(
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
+    response_validation_attempts = 0
+    setattr(agent, "_assistant_response_validated", False)
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
 
     # Per-turn tally of consecutive successful credential-pool token refreshes,
@@ -1073,9 +1081,11 @@ def run_conversation(
                     api_kwargs = _llm_request_mw.payload
                     _original_api_kwargs = _llm_request_mw.original_payload
                     _llm_middleware_trace = _llm_request_mw.trace
+                    _llm_middleware_control = getattr(_llm_request_mw, "control", {}) or {}
                 except Exception:
                     _original_api_kwargs = dict(api_kwargs)
                     _llm_middleware_trace = []
+                    _llm_middleware_control = {}
 
                 try:
                     from hermes_cli.plugins import (
@@ -1161,6 +1171,8 @@ def run_conversation(
                 # attempt — switch to non-streaming for the rest of this
                 # session instead of re-failing every retry.
                 if getattr(agent, "_disable_streaming", False):
+                    _use_streaming = False
+                elif should_disable_streaming_for_turn(_llm_middleware_control):
                     _use_streaming = False
                 # CopilotACPClient communicates via subprocess stdio and
                 # returns a plain SimpleNamespace — not an iterable
@@ -4751,6 +4763,118 @@ def run_conversation(
                 final_response = agent._strip_think_blocks(final_response).strip()
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+
+                try:
+                    from hermes_cli.middleware import apply_assistant_response_middleware
+
+                    validation_decision = apply_assistant_response_middleware(
+                        final_response,
+                        messages=list(messages),
+                        response_message=dict(final_msg),
+                        session_id=agent.session_id or "",
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        platform=agent.platform or "",
+                        model=agent.model,
+                        provider=agent.provider,
+                        base_url=agent.base_url,
+                        api_mode=agent.api_mode,
+                        api_call_count=api_call_count,
+                        validation_attempt=response_validation_attempts,
+                        tools=list(agent.tools or []),
+                        valid_tool_names=sorted(getattr(agent, "valid_tool_names", set())),
+                    )
+                except Exception as _validation_exc:
+                    logger.warning("assistant_response middleware failed: %s", _validation_exc)
+                    validation_decision = None
+
+                if validation_decision is not None and getattr(validation_decision, "trace", None):
+                    setattr(agent, "_assistant_response_validated", True)
+                    try:
+                        _max_validation_attempts = int(
+                            os.getenv("HERMES_ASSISTANT_RESPONSE_VALIDATION_MAX_ATTEMPTS", "2")
+                        )
+                    except Exception:
+                        _max_validation_attempts = 2
+                    if validation_decision.max_retries is not None:
+                        _max_validation_attempts = max(0, validation_decision.max_retries)
+                    _validation_action = validation_decision.action
+
+                    if _validation_action == "rewrite":
+                        final_response = sanitize_validator_text(
+                            validation_decision.response_text
+                            or validation_decision.message
+                            or final_response,
+                            strip_think_blocks=agent._strip_think_blocks,
+                        )
+                        final_msg["content"] = final_response
+                        final_msg["_response_validation_decision"] = "rewrite"
+                    elif _validation_action == "block":
+                        final_response = sanitize_validator_text(
+                            validation_decision.message
+                            or validation_decision.response_text
+                            or "[Assistant Response Validator] The draft was blocked before delivery.",
+                            strip_think_blocks=agent._strip_think_blocks,
+                        )
+                        final_msg["content"] = final_response
+                        final_msg["_response_validation_decision"] = "block"
+                    elif _validation_action in {"retry_with_feedback", "require_tool"}:
+                        rejected_draft = final_response
+                        final_response = None
+                        if response_validation_attempts < _max_validation_attempts:
+                            if _validation_action == "require_tool":
+                                validator_tool_response = build_validator_tool_response(
+                                    validation_decision,
+                                    valid_tool_names=getattr(agent, "valid_tool_names", set()),
+                                    validation_attempt=response_validation_attempts,
+                                )
+                                if validator_tool_response is not None:
+                                    validator_assistant_msg = agent._build_assistant_message(
+                                        validator_tool_response,
+                                        "tool_calls",
+                                    )
+                                    validator_assistant_msg["_response_validation_synthetic"] = True
+                                    validator_assistant_msg["_response_validation_decision"] = "require_tool"
+                                    messages.append(validator_assistant_msg)
+                                    agent._emit_interim_assistant_message(validator_assistant_msg)
+                                    if agent.stream_delta_callback:
+                                        try:
+                                            agent.stream_delta_callback(None)
+                                        except Exception:
+                                            pass
+                                    response_validation_attempts += 1
+                                    agent._execute_tool_calls(
+                                        validator_tool_response,
+                                        messages,
+                                        effective_task_id,
+                                        api_call_count,
+                                    )
+                                    if agent._tool_guardrail_halt_decision is not None:
+                                        decision = agent._tool_guardrail_halt_decision
+                                        _turn_exit_reason = "guardrail_halt"
+                                        final_response = agent._toolguard_controlled_halt_response(decision)
+                                        messages.append({"role": "assistant", "content": final_response})
+                                        break
+                                    agent._session_messages = messages
+                                    continue
+
+                            messages.extend(make_validator_retry_messages(
+                                draft=rejected_draft,
+                                feedback=validation_decision.feedback,
+                                validation_attempt=response_validation_attempts,
+                            ))
+                            response_validation_attempts += 1
+                            agent._session_messages = messages
+                            continue
+
+                        final_response = sanitize_validator_text(
+                            validation_decision.message
+                            or validation_decision.response_text
+                            or "[Assistant Response Validator] The draft could not be validated within the retry limit.",
+                            strip_think_blocks=agent._strip_think_blocks,
+                        )
+                        final_msg["content"] = final_response
+                        final_msg["_response_validation_decision"] = "retry_limit_block"
 
                 # Pop thinking-only prefill and empty-response retry
                 # scaffolding before appending either a final response or a

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -329,7 +329,11 @@ def finalize_turn(
                 response_text=final_response,
                 session_id=agent.session_id or "",
                 model=agent.model,
+                provider=agent.provider,
+                base_url=agent.base_url,
+                api_mode=getattr(agent, "api_mode", ""),
                 platform=getattr(agent, "platform", None) or "",
+                assistant_response_validated=bool(getattr(agent, "_assistant_response_validated", False)),
             )
             for _hook_result in _transform_results:
                 if isinstance(_hook_result, str) and _hook_result:

--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -19,6 +19,8 @@ With middleware enabled, plugins can:
   streaming, interrupt, and hook behavior.
 - Wrap the actual tool execution callback while preserving Hermes guardrails,
   approval, post-tool hooks, and tool-result transformation.
+- Validate a final assistant draft before it is committed, with structured
+  control over pass, rewrite, retry, evidence-tool execution, or block.
 
 ## Contract
 
@@ -28,6 +30,7 @@ Plugins register middleware from `register(ctx)`:
 def register(ctx):
     ctx.register_middleware("llm_request", on_llm_request)
     ctx.register_middleware("llm_execution", on_llm_execution)
+    ctx.register_middleware("assistant_response", on_assistant_response)
     ctx.register_middleware("tool_request", on_tool_request)
     ctx.register_middleware("tool_execution", on_tool_execution)
 ```
@@ -44,10 +47,11 @@ Supported middleware kinds:
 
 | Kind | Payload | Return shape | Purpose |
 | --- | --- | --- | --- |
-| `llm_request` | `request`, `original_request` | `{"request": {...}}` | Replace effective provider kwargs before provider execution. |
+| `llm_request` | `request`, `original_request` | `{"request": {...}}`, optional `{"control": {...}}` | Replace effective provider kwargs before provider execution and optionally set per-turn runtime controls. |
 | `tool_request` | `tool_name`, `args`, `original_args` | `{"args": {...}}` | Replace effective tool args before hooks, guardrails, approvals, and execution. |
 | `llm_execution` | `request`, `original_request`, `next_call` | Any provider response | Wrap or replace the actual provider call. |
 | `tool_execution` | `tool_name`, `args`, `original_args`, `next_call` | Any tool result | Wrap or replace the actual tool call. |
+| `assistant_response` | `response_text`, `messages`, `response_message` | `{"action": "pass|rewrite|retry_with_feedback|require_tool|block", ...}` | Validate the final assistant draft before persistence and final delivery. |
 
 Request middleware can return optional trace fields:
 
@@ -61,6 +65,21 @@ return {
 
 Hermes stores those trace entries in later observer hook payloads as
 `middleware_trace`.
+
+`llm_request` middleware may also return per-turn `control`. Currently Hermes
+recognizes `stream_policy: "buffer_until_validated"` (aliases: `buffer`,
+`validate_first`, `disable`, `off`) and disables user-visible streaming for
+that provider attempt so a later `assistant_response` validator can approve or
+transform the draft before final delivery:
+
+```python
+return {
+    "request": updated_request,
+    "control": {"stream_policy": "buffer_until_validated"},
+    "source": "judgment-integrity",
+    "reason": "risky-turn",
+}
+```
 
 Execution middleware receives a `next_call` callback. Call it to continue the
 chain:
@@ -92,6 +111,51 @@ Request middleware sees the full provider kwargs, including `messages` or
 Responses API `input`, model settings, tool definitions, stream options, and
 provider-specific options. Execution middleware receives the same effective
 request plus `next_call`.
+
+### Assistant Final Drafts
+
+When the model produces a text final answer rather than tool calls, Hermes
+builds the assistant draft and then applies `assistant_response` middleware
+before the draft is appended to durable conversation history or returned as the
+turn's final answer.
+
+The first decisive non-`pass` decision wins. Supported decisions are:
+
+| Action | Required fields | Runtime effect |
+| --- | --- | --- |
+| `pass` | none | Commit the original draft. |
+| `rewrite` | `response_text` or `message` | Replace the final assistant text before commit. |
+| `block` | `message` or `response_text` | Replace the final assistant text with a visible block explanation. |
+| `retry_with_feedback` | `feedback` | Append internal validator feedback and re-enter the provider loop in the same user turn, capped by `HERMES_ASSISTANT_RESPONSE_VALIDATION_MAX_ATTEMPTS` or decision `max_retries`. |
+| `require_tool` | `tool_calls` | Convert concrete tool calls into a normalized assistant tool-call turn, execute them through Hermes' normal tool path, append tool results, and re-enter the provider loop in the same user turn. |
+
+Example:
+
+```python
+def on_assistant_response(**kwargs):
+    draft = kwargs["response_text"]
+    if "I checked" in draft and not has_recorded_evidence(kwargs):
+        return {
+            "action": "require_tool",
+            "tool_calls": [
+                {
+                    "name": "read_file",
+                    "args": {"path": "README.md"},
+                    "reason": "verify source before reversing",
+                    "read_only": True,
+                }
+            ],
+            "feedback": "Gather actual evidence before changing the answer.",
+            "max_retries": 1,
+            "source": "judgment-integrity",
+        }
+    return {"action": "pass", "source": "judgment-integrity"}
+```
+
+Validator-requested tools do not bypass existing tool policy. They still flow
+through tool availability checks, `tool_request` middleware, `pre_tool_call`,
+guardrails, approvals, execution middleware, `post_tool_call`, and
+`transform_tool_result` before their result is appended back to context.
 
 ### Tool Calls
 
@@ -242,6 +306,9 @@ For NeMo Relay adaptive execution middleware, see
   routing to a dynamic external system.
 - Request middleware should return complete replacement payloads, not partial
   patches.
+- `assistant_response` middleware should be bounded. Use `max_retries` and
+  concrete, read-only `tool_calls` for evidence acquisition; do not synthesize
+  broad or destructive tool calls from validator output.
 - Execution middleware should call `next_call(...)` exactly once unless it is
   intentionally short-circuiting execution.
 - If execution middleware raises before calling `next_call(...)`, Hermes treats

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -53,10 +53,13 @@ behavior-affecting hooks:
 | `pre_llm_call` | May return a string or `{"context": "..."}` to inject ephemeral context into the current user message. |
 | `pre_tool_call` | May return `{"action": "block", "message": "..."}` to block a tool before execution. |
 | `transform_tool_result` | May return a replacement tool result string after `post_tool_call`. |
-| `transform_llm_output` | May return a replacement final assistant text string. |
+| `transform_llm_output` | May return a replacement final assistant text string. Legacy post-loop compatibility hook; it cannot retry the model or execute tools in the same turn. |
 
 Telemetry plugins should treat these behavior-affecting returns as optional
-compatibility features, not as observability requirements.
+compatibility features, not as observability requirements. New behavior-changing
+final-draft validation should use `assistant_response` middleware instead of an
+observer hook when it needs structured `pass`, `rewrite`, `retry_with_feedback`,
+`require_tool`, or `block` control flow.
 
 ## Correlation IDs
 

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -21,6 +21,7 @@ TOOL_REQUEST_MIDDLEWARE = "tool_request"
 TOOL_EXECUTION_MIDDLEWARE = "tool_execution"
 LLM_REQUEST_MIDDLEWARE = "llm_request"
 LLM_EXECUTION_MIDDLEWARE = "llm_execution"
+ASSISTANT_RESPONSE_MIDDLEWARE = "assistant_response"
 
 # Back-compat aliases for older PoC branches that used API terminology.
 API_REQUEST_MIDDLEWARE = LLM_REQUEST_MIDDLEWARE
@@ -31,6 +32,7 @@ VALID_MIDDLEWARE: set[str] = {
     TOOL_EXECUTION_MIDDLEWARE,
     LLM_REQUEST_MIDDLEWARE,
     LLM_EXECUTION_MIDDLEWARE,
+    ASSISTANT_RESPONSE_MIDDLEWARE,
 }
 
 
@@ -42,6 +44,21 @@ class RequestMiddlewareResult:
     original_payload: Any
     changed: bool = False
     trace: List[Dict[str, Any]] = field(default_factory=list)
+    control: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AssistantResponseMiddlewareResult:
+    """Structured decision from assistant-response validation middleware."""
+
+    action: str = "pass"
+    response_text: str = ""
+    message: str = ""
+    feedback: str = ""
+    tool_calls: List[Dict[str, Any]] = field(default_factory=list)
+    max_retries: Optional[int] = None
+    trace: List[Dict[str, Any]] = field(default_factory=list)
+    raw_decision: Dict[str, Any] = field(default_factory=dict)
 
 
 def observer_payload(**kwargs: Any) -> Dict[str, Any]:
@@ -89,11 +106,13 @@ def apply_llm_request_middleware(
             original_payload=request,
             changed=False,
             trace=[],
+            control={},
         )
 
     original_request = _safe_copy(request)
     current_request = _safe_copy(original_request)
     trace: List[Dict[str, Any]] = []
+    control: Dict[str, Any] = {}
 
     for result in _invoke_middleware(
         LLM_REQUEST_MIDDLEWARE,
@@ -104,16 +123,20 @@ def apply_llm_request_middleware(
         if not isinstance(result, dict):
             continue
         next_request = result.get("request")
-        if not isinstance(next_request, dict):
-            continue
-        current_request = _safe_copy(next_request)
-        trace.append(_trace_entry(result))
+        if isinstance(next_request, dict):
+            current_request = _safe_copy(next_request)
+        next_control = result.get("control")
+        if isinstance(next_control, dict):
+            control.update(_safe_copy(next_control))
+        if isinstance(next_request, dict) or isinstance(next_control, dict):
+            trace.append(_trace_entry(result))
 
     return RequestMiddlewareResult(
         payload=current_request,
         original_payload=original_request,
         changed=bool(trace),
         trace=trace,
+        control=control,
     )
 
 
@@ -170,6 +193,46 @@ def apply_api_request_middleware(
     return apply_llm_request_middleware(request, **context)
 
 
+def apply_assistant_response_middleware(
+    response_text: str,
+    **context: Any,
+) -> AssistantResponseMiddlewareResult:
+    """Apply final-draft assistant response validation middleware.
+
+    Middleware may return a structured decision dict with action:
+    ``pass``, ``rewrite``, ``retry_with_feedback``, ``require_tool``, or
+    ``block``. The first decisive non-pass action wins; pass decisions are
+    traced and evaluation continues so multiple validators can observe.
+    """
+    original_text = response_text or ""
+    if not _has_middleware(ASSISTANT_RESPONSE_MIDDLEWARE):
+        return AssistantResponseMiddlewareResult(
+            action="pass",
+            response_text=original_text,
+            trace=[],
+        )
+
+    trace: List[Dict[str, Any]] = []
+    for result in _invoke_middleware(
+        ASSISTANT_RESPONSE_MIDDLEWARE,
+        response_text=original_text,
+        **context,
+    ):
+        if not isinstance(result, dict):
+            continue
+        decision = _normalize_assistant_response_decision(result, original_text)
+        trace.append(_trace_entry(result))
+        decision.trace = list(trace)
+        if decision.action != "pass":
+            return decision
+
+    return AssistantResponseMiddlewareResult(
+        action="pass",
+        response_text=original_text,
+        trace=trace,
+    )
+
+
 def run_llm_execution_middleware(
     request: Dict[str, Any],
     next_call: Callable[[Dict[str, Any]], Any],
@@ -217,6 +280,84 @@ def run_api_execution_middleware(
 ) -> Any:
     """Compatibility wrapper for older ``api_execution`` naming."""
     return run_llm_execution_middleware(request, next_call, **context)
+
+
+def _normalize_tool_call(value: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(value, dict):
+        return None
+    name = value.get("name") or value.get("tool_name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    raw_args = value.get("args", value.get("arguments", {}))
+    if not isinstance(raw_args, dict):
+        raw_args = {}
+    normalized: Dict[str, Any] = {
+        "name": name.strip(),
+        "args": _safe_copy(raw_args),
+    }
+    reason = value.get("reason")
+    if isinstance(reason, str) and reason.strip():
+        normalized["reason"] = reason.strip()
+    read_only = value.get("read_only")
+    if isinstance(read_only, bool):
+        normalized["read_only"] = read_only
+    return normalized
+
+
+def _normalize_tool_calls(value: Any) -> List[Dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    calls: List[Dict[str, Any]] = []
+    for item in value:
+        call = _normalize_tool_call(item)
+        if call is not None:
+            calls.append(call)
+    return calls
+
+
+def _normalize_assistant_response_decision(
+    result: Dict[str, Any],
+    original_text: str,
+) -> AssistantResponseMiddlewareResult:
+    action = str(result.get("action") or result.get("verdict") or "pass").strip().lower()
+    aliases = {
+        "allow": "pass",
+        "ok": "pass",
+        "revise": "rewrite",
+        "retry": "retry_with_feedback",
+        "retry_with_feedback": "retry_with_feedback",
+        "require_evidence": "require_tool",
+        "evidence_required": "require_tool",
+        "tool": "require_tool",
+        "deny": "block",
+    }
+    action = aliases.get(action, action)
+    if action not in {"pass", "rewrite", "retry_with_feedback", "require_tool", "block"}:
+        action = "block"
+
+    message = result.get("message", "")
+    replacement = result.get("response_text", result.get("revised_response"))
+    if replacement is None and action == "rewrite":
+        replacement = message or original_text
+    elif replacement is None:
+        replacement = original_text
+    response_text = str(replacement) if replacement is not None else original_text
+    feedback = result.get("feedback", "")
+    try:
+        max_retries = result.get("max_retries")
+        max_retries = int(max_retries) if max_retries is not None else None
+    except Exception:
+        max_retries = None
+
+    return AssistantResponseMiddlewareResult(
+        action=action,
+        response_text=response_text,
+        message=str(message or ""),
+        feedback=str(feedback or ""),
+        tool_calls=_normalize_tool_calls(result.get("tool_calls")),
+        max_retries=max_retries,
+        raw_decision=_safe_copy(result),
+    )
 
 
 def _invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -360,6 +360,9 @@ def _resolve_runtime_from_pool_entry(
     api_mode = "chat_completions"
     if provider == "openai-codex":
         api_mode = "codex_responses"
+        env_base_url = _getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        if env_base_url:
+            base_url = env_base_url
         base_url = base_url or DEFAULT_CODEX_BASE_URL
     elif provider == "xai-oauth":
         api_mode = "codex_responses"

--- a/run_agent.py
+++ b/run_agent.py
@@ -4046,7 +4046,16 @@ class AIAgent:
             build_or_headers,
         )
 
-        if base_url_host_matches(base_url, "openrouter.ai"):
+        if (
+            self.provider == "openai-codex"
+            and getattr(self, "api_mode", None) == "codex_responses"
+            and base_url_hostname(base_url) in {"127.0.0.1", "localhost", "::1"}
+        ):
+            from agent.auxiliary_client import _codex_cloudflare_headers
+            self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
+                self._client_kwargs.get("api_key", "")
+            )
+        elif base_url_host_matches(base_url, "openrouter.ai"):
             self._client_kwargs["default_headers"] = build_or_headers()
         elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
             self._client_kwargs["default_headers"] = build_nvidia_nim_headers(base_url)

--- a/tests/agent/test_assistant_response_control.py
+++ b/tests/agent/test_assistant_response_control.py
@@ -1,0 +1,89 @@
+"""Tests for assistant-response validation control helpers."""
+
+import json
+
+from hermes_cli.middleware import AssistantResponseMiddlewareResult
+
+from agent.assistant_response_control import (
+    build_validator_tool_response,
+    make_validator_retry_messages,
+    sanitize_validator_text,
+    should_disable_streaming_for_turn,
+)
+
+
+def test_stream_policy_can_disable_streaming_for_one_turn():
+    assert should_disable_streaming_for_turn({"stream_policy": "buffer_until_validated"}) is True
+    assert should_disable_streaming_for_turn({"disable_streaming_for_turn": True}) is True
+    assert should_disable_streaming_for_turn({}) is False
+
+
+def test_build_validator_tool_response_preserves_provenance_and_json_args():
+    decision = AssistantResponseMiddlewareResult(
+        action="require_tool",
+        feedback="Read README before reversing.",
+        tool_calls=[
+            {
+                "name": "read_file",
+                "args": {"path": "README.md"},
+                "reason": "verify source file",
+                "read_only": True,
+            }
+        ],
+    )
+
+    response = build_validator_tool_response(
+        decision,
+        valid_tool_names={"read_file"},
+        validation_attempt=0,
+    )
+
+    assert response.content.startswith("Judgment Integrity validator requested")
+    assert response.finish_reason == "tool_calls"
+    assert len(response.tool_calls) == 1
+    call = response.tool_calls[0]
+    assert call.id == "validator_read_file_0_0"
+    assert call.name == "read_file"
+    assert json.loads(call.arguments) == {"path": "README.md"}
+    assert call.provider_data["validator_requested"] is True
+    assert call.provider_data["reason"] == "verify source file"
+
+
+def test_build_validator_tool_response_rejects_missing_or_unknown_tools():
+    missing = AssistantResponseMiddlewareResult(action="require_tool", tool_calls=[])
+    assert build_validator_tool_response(missing, valid_tool_names={"read_file"}, validation_attempt=0) is None
+
+    unknown = AssistantResponseMiddlewareResult(
+        action="require_tool",
+        tool_calls=[{"name": "rm_everything", "args": {}, "read_only": True}],
+    )
+    assert build_validator_tool_response(unknown, valid_tool_names={"read_file"}, validation_attempt=0) is None
+
+
+def test_validator_retry_messages_preserve_role_alternation_and_mark_synthetic():
+    messages = make_validator_retry_messages(
+        draft="맞습니다. 제가 틀렸습니다. sk-secretsecretsecret",
+        feedback="Do not reverse without evidence.",
+        validation_attempt=0,
+    )
+
+    assert [m["role"] for m in messages] == ["assistant", "user"]
+    assert messages[0]["_response_validation_synthetic"] is True
+    assert messages[1]["_response_validation_synthetic"] is True
+    assert "제가 틀렸습니다" not in messages[0]["content"]
+    assert "sk-secretsecretsecret" not in messages[0]["content"]
+    assert "Do not reverse without evidence." in messages[1]["content"]
+
+
+def test_sanitize_validator_text_redacts_and_strips_reasoning():
+    text = "<think>private reasoning</think>Use sk-secretsecretsecret safely\ud800"
+
+    sanitized = sanitize_validator_text(
+        text,
+        strip_think_blocks=lambda value: value.replace("<think>private reasoning</think>", ""),
+    )
+
+    assert "private reasoning" not in sanitized
+    assert "sk-secretsecretsecret" not in sanitized
+    assert "\ud800" not in sanitized
+    assert "Use" in sanitized

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -23,6 +23,7 @@ from hermes_cli.plugins import (
 )
 from hermes_cli.middleware import (
     VALID_MIDDLEWARE,
+    apply_assistant_response_middleware,
     apply_llm_request_middleware,
     apply_tool_request_middleware,
     run_tool_execution_middleware,
@@ -158,17 +159,134 @@ class TestPluginDiscovery:
 
         llm_result = apply_llm_request_middleware(request)
         tool_result = apply_tool_request_middleware("read_file", args)
+        assistant_result = apply_assistant_response_middleware("final draft")
 
         assert llm_result.payload is request
         assert llm_result.original_payload is request
         assert llm_result.changed is False
         assert llm_result.trace == []
+        assert llm_result.control == {}
         assert tool_result.payload is args
         assert tool_result.original_payload is args
         assert tool_result.changed is False
         assert tool_result.trace == []
+        assert assistant_result.action == "pass"
+        assert assistant_result.response_text == "final draft"
+        assert assistant_result.trace == []
         assert run_tool_execution_middleware("terminal", args, lambda payload: payload) is args
         assert has_middleware("tool_request") is False
+
+    def test_llm_request_middleware_can_return_turn_control(self, monkeypatch):
+        def middleware(**kwargs):
+            return {
+                "request": {**kwargs["request"], "guarded": True},
+                "control": {"stream_policy": "buffer_until_validated"},
+                "source": "test-plugin",
+                "reason": "risky-turn",
+            }
+
+        manager = types.SimpleNamespace(
+            _middleware={"llm_request": [middleware]},
+            invoke_middleware=lambda kind, **kwargs: [middleware(**kwargs)],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        result = apply_llm_request_middleware({"messages": []})
+
+        assert result.payload == {"messages": [], "guarded": True}
+        assert result.control == {"stream_policy": "buffer_until_validated"}
+        assert result.trace == [{"source": "test-plugin", "reason": "risky-turn"}]
+
+    def test_assistant_response_middleware_first_decisive_action_wins(self, monkeypatch):
+        def pass_middleware(**kwargs):
+            return {"action": "pass", "source": "pass-plugin"}
+
+        def rewrite_middleware(**kwargs):
+            return {
+                "action": "rewrite",
+                "response_text": "safe replacement",
+                "source": "rewrite-plugin",
+                "reason": "validator-rewrite",
+            }
+
+        def block_middleware(**kwargs):
+            return {"action": "block", "message": "too late"}
+
+        callbacks = [pass_middleware, rewrite_middleware, block_middleware]
+        manager = types.SimpleNamespace(
+            _middleware={"assistant_response": callbacks},
+            invoke_middleware=lambda kind, **kwargs: [cb(**kwargs) for cb in callbacks],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        result = apply_assistant_response_middleware(
+            "unsafe draft",
+            session_id="s1",
+            model="m",
+            validation_attempt=0,
+        )
+
+        assert "assistant_response" in VALID_MIDDLEWARE
+        assert result.action == "rewrite"
+        assert result.response_text == "safe replacement"
+        assert result.trace == [
+            {"source": "pass-plugin"},
+            {"source": "rewrite-plugin", "reason": "validator-rewrite"},
+        ]
+
+    def test_assistant_response_middleware_normalizes_require_tool_calls(self, monkeypatch):
+        def require_tool(**kwargs):
+            return {
+                "action": "require_tool",
+                "tool_calls": [
+                    {
+                        "name": "read_file",
+                        "args": {"path": "README.md"},
+                        "reason": "verify file before reversing",
+                        "read_only": True,
+                    }
+                ],
+                "feedback": "Read the file before changing the answer.",
+                "source": "validator",
+            }
+
+        manager = types.SimpleNamespace(
+            _middleware={"assistant_response": [require_tool]},
+            invoke_middleware=lambda kind, **kwargs: [require_tool(**kwargs)],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        result = apply_assistant_response_middleware("draft")
+
+        assert result.action == "require_tool"
+        assert result.feedback == "Read the file before changing the answer."
+        assert result.tool_calls == [
+            {
+                "name": "read_file",
+                "args": {"path": "README.md"},
+                "reason": "verify file before reversing",
+                "read_only": True,
+            }
+        ]
+
+    def test_assistant_response_rewrite_can_use_message_as_replacement(self, monkeypatch):
+        def rewrite_with_message(**kwargs):
+            return {
+                "action": "rewrite",
+                "message": "replacement from message",
+                "source": "validator",
+            }
+
+        manager = types.SimpleNamespace(
+            _middleware={"assistant_response": [rewrite_with_message]},
+            invoke_middleware=lambda kind, **kwargs: [rewrite_with_message(**kwargs)],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        result = apply_assistant_response_middleware("unsafe draft")
+
+        assert result.action == "rewrite"
+        assert result.response_text == "replacement from message"
 
     def test_request_middleware_changed_tracks_trace_not_deep_equality(self, monkeypatch):
         def same_payload_middleware(**kwargs):

--- a/tests/run_agent/test_assistant_response_middleware_loop.py
+++ b/tests/run_agent/test_assistant_response_middleware_loop.py
@@ -1,0 +1,289 @@
+"""Integration tests for assistant_response middleware inside run_conversation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+ASSISTANT_RESPONSE = "assistant_response"
+LLM_REQUEST = "llm_request"
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"Mock {name}",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_assistant_msg(content="Hello", tool_calls=None):
+    return SimpleNamespace(content=content, tool_calls=tool_calls)
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = _mock_assistant_msg(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("read_file", "search_files", "web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.tool_delay = 0
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+def _run(agent: AIAgent, prompt: str = "hello"):
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=False),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(prompt)
+
+
+def _install_middleware(monkeypatch, *, assistant_decisions, llm_request_decisions=None):
+    assistant_decisions = list(assistant_decisions)
+    llm_request_decisions = list(llm_request_decisions or [])
+    calls: list[tuple[str, dict]] = []
+
+    def has_middleware(kind: str) -> bool:
+        return kind in {ASSISTANT_RESPONSE, LLM_REQUEST}
+
+    def invoke_middleware(kind: str, **kwargs):
+        calls.append((kind, kwargs))
+        if kind == ASSISTANT_RESPONSE:
+            if assistant_decisions:
+                decision = assistant_decisions.pop(0)
+                if callable(decision):
+                    decision = decision(**kwargs)
+                return [decision]
+            return [{"action": "pass", "source": "test-validator"}]
+        if kind == LLM_REQUEST:
+            if llm_request_decisions:
+                decision = llm_request_decisions.pop(0)
+                if callable(decision):
+                    decision = decision(**kwargs)
+                return [decision]
+            return []
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.has_middleware", has_middleware)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_middleware", invoke_middleware)
+    return calls
+
+
+def test_assistant_response_rewrite_replaces_final_before_commit(agent, monkeypatch):
+    agent.client.chat.completions.create.return_value = _mock_response("unsafe draft")
+    _install_middleware(
+        monkeypatch,
+        assistant_decisions=[
+            {
+                "action": "rewrite",
+                "response_text": "safe replacement",
+                "source": "test-validator",
+            }
+        ],
+    )
+
+    result = _run(agent)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "safe replacement"
+    assert result["messages"][-1]["content"] == "safe replacement"
+    assert result["messages"][-1]["_response_validation_decision"] == "rewrite"
+
+
+def test_assistant_response_block_replaces_final_before_commit(agent, monkeypatch):
+    agent.client.chat.completions.create.return_value = _mock_response("unsafe draft")
+    _install_middleware(
+        monkeypatch,
+        assistant_decisions=[
+            {
+                "action": "block",
+                "message": "blocked before delivery",
+                "source": "test-validator",
+            }
+        ],
+    )
+
+    result = _run(agent)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "blocked before delivery"
+    assert result["messages"][-1]["content"] == "blocked before delivery"
+    assert result["messages"][-1]["_response_validation_decision"] == "block"
+
+
+def test_assistant_response_retry_with_feedback_reenters_provider_loop(agent, monkeypatch):
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response("unsupported reversal"),
+        _mock_response("validated answer after retry"),
+    ]
+    _install_middleware(
+        monkeypatch,
+        assistant_decisions=[
+            {
+                "action": "retry_with_feedback",
+                "feedback": "Do not reverse without evidence.",
+                "max_retries": 1,
+                "source": "test-validator",
+            },
+            {"action": "pass", "source": "test-validator"},
+        ],
+    )
+
+    result = _run(agent)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "validated answer after retry"
+    assert result["api_calls"] == 2
+    second_request_messages = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+    assert any(
+        "Do not reverse without evidence." in msg.get("content", "")
+        for msg in second_request_messages
+    )
+    assert not any(
+        "unsupported reversal" in msg.get("content", "")
+        for msg in second_request_messages
+    )
+
+
+def test_assistant_response_retry_exhaustion_does_not_return_rejected_draft(agent, monkeypatch):
+    agent.max_iterations = 1
+    agent.client.chat.completions.create.return_value = _mock_response("unsupported reversal")
+    agent._handle_max_iterations = MagicMock(return_value="budget exhausted summary")
+    _install_middleware(
+        monkeypatch,
+        assistant_decisions=[
+            {
+                "action": "retry_with_feedback",
+                "feedback": "Do not reverse without evidence.",
+                "max_retries": 1,
+                "source": "test-validator",
+            }
+        ],
+    )
+
+    result = _run(agent)
+
+    assert result["completed"] is False
+    assert "budget exhausted summary" in result["final_response"]
+    assert result["final_response"] != "unsupported reversal"
+    assert "unsupported reversal" not in result["final_response"]
+    agent._handle_max_iterations.assert_called_once()
+
+
+def test_assistant_response_require_tool_executes_tool_path_then_reenters(agent, monkeypatch):
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response("unsupported reversal"),
+        _mock_response("validated answer after evidence"),
+    ]
+    _install_middleware(
+        monkeypatch,
+        assistant_decisions=[
+            {
+                "action": "require_tool",
+                "feedback": "Read README.md before reversing.",
+                "tool_calls": [
+                    {
+                        "name": "read_file",
+                        "args": {"path": "README.md"},
+                        "reason": "verify source",
+                        "read_only": True,
+                    }
+                ],
+                "max_retries": 1,
+                "source": "test-validator",
+            },
+            {"action": "pass", "source": "test-validator"},
+        ],
+    )
+
+    with patch("run_agent.handle_function_call", return_value="README evidence") as handle_function_call:
+        result = _run(agent)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "validated answer after evidence"
+    assert result["api_calls"] == 2
+    handle_function_call.assert_called_once()
+    assert handle_function_call.call_args.args[:2] == (
+        "read_file",
+        {"path": "README.md"},
+    )
+    assert isinstance(handle_function_call.call_args.args[2], str)
+    assert handle_function_call.call_args.args[2]
+    second_request_messages = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+    assert any(
+        msg.get("role") == "assistant"
+        and msg.get("tool_calls")
+        and msg["tool_calls"][0]["function"]["name"] == "read_file"
+        for msg in second_request_messages
+    )
+    assert any(
+        msg.get("role") == "tool" and "README evidence" in msg.get("content", "")
+        for msg in second_request_messages
+    )
+
+
+def test_llm_request_stream_policy_uses_non_streaming_before_validation(agent, monkeypatch):
+    non_streaming_response = _mock_response("validated non-streaming response")
+    agent.stream_delta_callback = lambda _delta: None
+    agent._interruptible_api_call = MagicMock(return_value=non_streaming_response)
+    agent._interruptible_streaming_api_call = MagicMock(
+        side_effect=AssertionError("streaming must be disabled before validator-controlled turns")
+    )
+
+    def llm_request_decision(**kwargs):
+        return {
+            "request": kwargs["request"],
+            "control": {"stream_policy": "buffer_until_validated"},
+            "source": "test-guard",
+            "reason": "risky-turn",
+        }
+
+    _install_middleware(
+        monkeypatch,
+        assistant_decisions=[{"action": "pass", "source": "test-validator"}],
+        llm_request_decisions=[llm_request_decision],
+    )
+
+    result = _run(agent)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "validated non-streaming response"
+    agent._interruptible_api_call.assert_called_once()
+    agent._interruptible_streaming_api_call.assert_not_called()


### PR DESCRIPTION
## Summary

Adds an `assistant_response` middleware seam that lets plugins validate, rewrite, retry, require tool evidence, or block a draft before it is committed to the user.

This is used by the Judgment Integrity plugin to catch unsupported reversals after weak user challenges, including Codex/Headroom Responses-style request payloads.

## What changed

- Add assistant-response middleware result normalization and runtime plumbing.
- Add core loop support for actions: `pass`, `rewrite`, `retry_with_feedback`, `require_tool`, and `block`.
- Add per-turn streaming buffering control so risky drafts are not streamed before validation.
- Route validator-requested tool calls through the existing tool execution path.
- Prevent rejected drafts from being replayed into retry context.
- Sanitize validator-provided replacement/block text before final delivery.
- Document the new middleware seam and observability behavior.

## Verification

- `8 passed` targeted post-review leak/fallback tests
- `105 passed` assistant-response/core focused tests
- `14 passed` Judgment Integrity plugin tests
- deterministic Judgment Integrity heavy smoke: `85/85`
- `py_compile`: passed
- `git diff --check`: clean
- static diff scan for obvious secret/shell/eval/deserialization/SQL hazards: no new hits
