### PR TITLE
feat(gateway): /platform reload — hot-reload messaging platform adapters (#54681)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4265,6 +4265,176 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         logger.info("%s resumed — retrying on next watcher tick", platform.value)
         return True
 
+    def _queue_failed_platform(self, platform, platform_config) -> None:
+        """Queue a platform for the reconnect watcher, mirroring the startup
+        path's retry entry so an adapter that failed to connect during a
+        reload self-heals once the underlying problem is fixed.
+        """
+        self._failed_platforms[platform] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() + 30,
+        }
+
+    async def _bring_up_platform_adapter(self, platform, platform_config) -> bool:
+        """Create, wire and connect a single platform adapter, installing it on
+        ``self.adapters`` on success.  Mirrors the startup connect path: on a
+        retryable failure the platform is queued for the reconnect watcher.
+        Returns True only when the adapter connected.
+        """
+        adapter = self._create_adapter(platform, platform_config)
+        if not adapter:
+            logger.warning("Platform reload: no adapter available for %s", platform.value)
+            return False
+
+        adapter.set_message_handler(self._handle_message)
+        adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+        adapter.set_session_store(self.session_store)
+        adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+        adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
+        adapter._busy_text_mode = self._busy_text_mode
+
+        self._update_platform_runtime_status(
+            platform.value, platform_state="connecting",
+            error_code=None, error_message=None,
+        )
+        try:
+            success = await self._connect_adapter_with_timeout(adapter, platform)
+        except Exception as e:
+            logger.error("Platform reload: %s connect error: %s", platform.value, e)
+            await self._safe_adapter_disconnect(adapter, platform)
+            self._queue_failed_platform(platform, platform_config)
+            self._update_platform_runtime_status(
+                platform.value, platform_state="retrying",
+                error_code=None, error_message=str(e),
+            )
+            return False
+
+        if success:
+            self.adapters[platform] = adapter
+            self._sync_voice_mode_state_to_adapter(adapter)
+            self._failed_platforms.pop(platform, None)
+            self._update_platform_runtime_status(
+                platform.value, platform_state="connected",
+                error_code=None, error_message=None,
+            )
+            logger.info("✓ %s connected via reload", platform.value)
+            return True
+
+        # connect() returned False — clean up partial resources, then either
+        # drop a non-retryable failure or queue a retryable one.
+        await self._safe_adapter_disconnect(adapter, platform)
+        if adapter.has_fatal_error and not adapter.fatal_error_retryable:
+            self._update_platform_runtime_status(
+                platform.value, platform_state="fatal",
+                error_code=adapter.fatal_error_code,
+                error_message=adapter.fatal_error_message,
+            )
+        else:
+            self._queue_failed_platform(platform, platform_config)
+            self._update_platform_runtime_status(
+                platform.value, platform_state="retrying",
+                error_code=adapter.fatal_error_code if adapter.has_fatal_error else None,
+                error_message=(
+                    adapter.fatal_error_message
+                    if adapter.has_fatal_error
+                    else "failed to connect"
+                ),
+            )
+        logger.warning("✗ %s failed to connect via reload", platform.value)
+        return False
+
+    async def _reload_platforms_from_config(self) -> Dict[str, List[str]]:
+        """Re-read platform config and apply the diff against running adapters
+        without restarting the gateway.
+
+        Newly-enabled platforms are connected, platforms that were disabled or
+        removed are disconnected, and platforms whose ``PlatformConfig`` changed
+        are reconnected with the new settings.  Unchanged connected platforms
+        are left untouched, so in-flight agent turns on them are never
+        interrupted.  ``delivery_router.adapters`` and the channel directory are
+        refreshed once after the diff is applied.
+
+        Returns a report dict with ``connected``/``reconnected``/
+        ``disconnected``/``unchanged``/``failed`` lists of platform value
+        strings for the caller to surface to the operator.
+        """
+        from gateway.config import load_gateway_config
+
+        report: Dict[str, List[str]] = {
+            "connected": [],
+            "reconnected": [],
+            "disconnected": [],
+            "unchanged": [],
+            "failed": [],
+        }
+
+        try:
+            new_config = load_gateway_config()
+        except Exception as e:
+            logger.error("Platform reload: failed to re-read config: %s", e)
+            report["failed"].append(f"config: {e}")
+            return report
+
+        desired = {
+            platform: cfg
+            for platform, cfg in new_config.platforms.items()
+            if cfg.enabled
+        }
+
+        # Disconnect platforms that are no longer enabled (disabled or removed).
+        for platform in list(self.adapters.keys()):
+            if platform not in desired:
+                adapter = self.adapters.pop(platform, None)
+                if adapter is not None:
+                    await self._safe_adapter_disconnect(adapter, platform)
+                self._update_platform_runtime_status(
+                    platform.value, platform_state="disconnected",
+                    error_code=None, error_message=None,
+                )
+                report["disconnected"].append(platform.value)
+        # Drop disabled platforms from the retry queue too, so the reconnect
+        # watcher stops trying to bring them back.
+        for platform in list(getattr(self, "_failed_platforms", {}).keys()):
+            if platform not in desired:
+                self._failed_platforms.pop(platform, None)
+                if platform.value not in report["disconnected"]:
+                    report["disconnected"].append(platform.value)
+
+        # Connect newly-enabled platforms and reconnect those whose config
+        # changed.  Leave unchanged connected platforms alone.
+        for platform, platform_config in desired.items():
+            existing = self.adapters.get(platform)
+            if existing is not None:
+                if existing.config == platform_config:
+                    report["unchanged"].append(platform.value)
+                    continue
+                # Config changed — drop the old adapter before reconnecting.
+                self.adapters.pop(platform, None)
+                await self._safe_adapter_disconnect(existing, platform)
+                outcome = "reconnected"
+            else:
+                outcome = "connected"
+
+            if await self._bring_up_platform_adapter(platform, platform_config):
+                report[outcome].append(platform.value)
+            else:
+                report["failed"].append(platform.value)
+
+        # Refresh runtime routing + channel directory once after the diff.
+        # Update the platforms map in place so the shared config object (also
+        # held by delivery_router) reflects the reloaded platform config
+        # without disturbing unrelated runtime config.
+        self.config.platforms = new_config.platforms
+        self.delivery_router.adapters = self.adapters
+        try:
+            from gateway.channel_directory import build_channel_directory
+            await build_channel_directory(self.adapters)
+        except Exception as e:
+            logger.debug("Platform reload: channel directory rebuild failed: %s", e)
+
+        return report
+
     @staticmethod
     def _load_prefill_messages() -> List[Dict[str, Any]]:
         """Load ephemeral prefill messages from config or env var.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9346,6 +9346,176 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         logger.info("%s resumed — retrying on next watcher tick", platform.value)
         return True
 
+    def _queue_failed_platform(self, platform, platform_config) -> None:
+        """Queue a platform for the reconnect watcher, mirroring the startup
+        path's retry entry so an adapter that failed to connect during a
+        reload self-heals once the underlying problem is fixed.
+        """
+        self._failed_platforms[platform] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() + 30,
+        }
+
+    async def _bring_up_platform_adapter(self, platform, platform_config) -> bool:
+        """Create, wire and connect a single platform adapter, installing it on
+        ``self.adapters`` on success.  Mirrors the startup connect path: on a
+        retryable failure the platform is queued for the reconnect watcher.
+        Returns True only when the adapter connected.
+        """
+        adapter = self._create_adapter(platform, platform_config)
+        if not adapter:
+            logger.warning("Platform reload: no adapter available for %s", platform.value)
+            return False
+
+        adapter.set_message_handler(self._handle_message)
+        adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+        adapter.set_session_store(self.session_store)
+        adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+        adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
+        adapter._busy_text_mode = self._busy_text_mode
+
+        self._update_platform_runtime_status(
+            platform.value, platform_state="connecting",
+            error_code=None, error_message=None,
+        )
+        try:
+            success = await self._connect_adapter_with_timeout(adapter, platform)
+        except Exception as e:
+            logger.error("Platform reload: %s connect error: %s", platform.value, e)
+            await self._safe_adapter_disconnect(adapter, platform)
+            self._queue_failed_platform(platform, platform_config)
+            self._update_platform_runtime_status(
+                platform.value, platform_state="retrying",
+                error_code=None, error_message=str(e),
+            )
+            return False
+
+        if success:
+            self.adapters[platform] = adapter
+            self._sync_voice_mode_state_to_adapter(adapter)
+            self._failed_platforms.pop(platform, None)
+            self._update_platform_runtime_status(
+                platform.value, platform_state="connected",
+                error_code=None, error_message=None,
+            )
+            logger.info("✓ %s connected via reload", platform.value)
+            return True
+
+        # connect() returned False — clean up partial resources, then either
+        # drop a non-retryable failure or queue a retryable one.
+        await self._safe_adapter_disconnect(adapter, platform)
+        if adapter.has_fatal_error and not adapter.fatal_error_retryable:
+            self._update_platform_runtime_status(
+                platform.value, platform_state="fatal",
+                error_code=adapter.fatal_error_code,
+                error_message=adapter.fatal_error_message,
+            )
+        else:
+            self._queue_failed_platform(platform, platform_config)
+            self._update_platform_runtime_status(
+                platform.value, platform_state="retrying",
+                error_code=adapter.fatal_error_code if adapter.has_fatal_error else None,
+                error_message=(
+                    adapter.fatal_error_message
+                    if adapter.has_fatal_error
+                    else "failed to connect"
+                ),
+            )
+        logger.warning("✗ %s failed to connect via reload", platform.value)
+        return False
+
+    async def _reload_platforms_from_config(self) -> Dict[str, List[str]]:
+        """Re-read platform config and apply the diff against running adapters
+        without restarting the gateway.
+
+        Newly-enabled platforms are connected, platforms that were disabled or
+        removed are disconnected, and platforms whose ``PlatformConfig`` changed
+        are reconnected with the new settings.  Unchanged connected platforms
+        are left untouched, so in-flight agent turns on them are never
+        interrupted.  ``delivery_router.adapters`` and the channel directory are
+        refreshed once after the diff is applied.
+
+        Returns a report dict with ``connected``/``reconnected``/
+        ``disconnected``/``unchanged``/``failed`` lists of platform value
+        strings for the caller to surface to the operator.
+        """
+        from gateway.config import load_gateway_config
+
+        report: Dict[str, List[str]] = {
+            "connected": [],
+            "reconnected": [],
+            "disconnected": [],
+            "unchanged": [],
+            "failed": [],
+        }
+
+        try:
+            new_config = load_gateway_config()
+        except Exception as e:
+            logger.error("Platform reload: failed to re-read config: %s", e)
+            report["failed"].append(f"config: {e}")
+            return report
+
+        desired = {
+            platform: cfg
+            for platform, cfg in new_config.platforms.items()
+            if cfg.enabled
+        }
+
+        # Disconnect platforms that are no longer enabled (disabled or removed).
+        for platform in list(self.adapters.keys()):
+            if platform not in desired:
+                adapter = self.adapters.pop(platform, None)
+                if adapter is not None:
+                    await self._safe_adapter_disconnect(adapter, platform)
+                self._update_platform_runtime_status(
+                    platform.value, platform_state="disconnected",
+                    error_code=None, error_message=None,
+                )
+                report["disconnected"].append(platform.value)
+        # Drop disabled platforms from the retry queue too, so the reconnect
+        # watcher stops trying to bring them back.
+        for platform in list(getattr(self, "_failed_platforms", {}).keys()):
+            if platform not in desired:
+                self._failed_platforms.pop(platform, None)
+                if platform.value not in report["disconnected"]:
+                    report["disconnected"].append(platform.value)
+
+        # Connect newly-enabled platforms and reconnect those whose config
+        # changed.  Leave unchanged connected platforms alone.
+        for platform, platform_config in desired.items():
+            existing = self.adapters.get(platform)
+            if existing is not None:
+                if existing.config == platform_config:
+                    report["unchanged"].append(platform.value)
+                    continue
+                # Config changed — drop the old adapter before reconnecting.
+                self.adapters.pop(platform, None)
+                await self._safe_adapter_disconnect(existing, platform)
+                outcome = "reconnected"
+            else:
+                outcome = "connected"
+
+            if await self._bring_up_platform_adapter(platform, platform_config):
+                report[outcome].append(platform.value)
+            else:
+                report["failed"].append(platform.value)
+
+        # Refresh runtime routing + channel directory once after the diff.
+        # Update the platforms map in place so the shared config object (also
+        # held by delivery_router) reflects the reloaded platform config
+        # without disturbing unrelated runtime config.
+        self.config.platforms = new_config.platforms
+        self.delivery_router.adapters = self.adapters
+        try:
+            from gateway.channel_directory import build_channel_directory
+            await build_channel_directory(self.adapters)
+        except Exception as e:
+            logger.debug("Platform reload: channel directory rebuild failed: %s", e)
+
+        return report
+
     @staticmethod
     def _load_prefill_messages() -> List[Dict[str, Any]]:
         """Load ephemeral prefill messages from config or env var.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -819,11 +819,12 @@ class GatewaySlashCommandsMixin:
         return t("gateway.stop.no_active")
 
     async def _handle_platform_command(self, event: MessageEvent) -> str:
-        """Handle ``/platform list|pause|resume [name]`` — surface and
-        manually control failed/paused gateway adapters.
+        """Handle ``/platform list|reload|pause|resume [name]`` — surface and
+        manually control gateway adapters.
 
         Examples:
             ``/platform list``           — show connected + failed/paused platforms
+            ``/platform reload``         — apply config.yaml platform changes without a restart
             ``/platform pause whatsapp`` — stop the reconnect watcher hammering whatsapp
             ``/platform resume whatsapp`` — re-queue a paused platform for retry
         """
@@ -869,6 +870,27 @@ class GatewaySlashCommandsMixin:
                 lines.append("Failed/paused: (none)")
             return "\n".join(lines)
 
+        if action == "reload":
+            report = await self._reload_platforms_from_config()
+            lines = ["**Platform reload**"]
+            labels = [
+                ("connected", "Connected"),
+                ("reconnected", "Reconnected (config changed)"),
+                ("disconnected", "Disconnected"),
+                ("failed", "Failed"),
+                ("unchanged", "Unchanged"),
+            ]
+            for key, label in labels:
+                vals = report.get(key) or []
+                if vals:
+                    lines.append(f"{label}: " + ", ".join(sorted(vals)))
+            if not any(report.get(k) for k in ("connected", "reconnected", "disconnected", "failed")):
+                if report.get("unchanged"):
+                    lines.append("No changes — all enabled platforms already up to date.")
+                else:
+                    lines.append("No messaging platforms enabled.")
+            return "\n".join(lines)
+
         if action in {"pause", "resume"}:
             if not target:
                 return f"Usage: /platform {action} <name>"
@@ -905,8 +927,9 @@ class GatewaySlashCommandsMixin:
             return f"✓ {platform.value} resumed — retrying on next watcher tick."
 
         return (
-            "Usage: /platform <list|pause|resume> [name]\n"
+            "Usage: /platform <list|reload|pause|resume> [name]\n"
             "  /platform list — show platform status\n"
+            "  /platform reload — apply config.yaml platform changes without a restart\n"
             "  /platform pause <name> — stop retrying a failing platform\n"
             "  /platform resume <name> — re-queue a paused platform"
         )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1507,11 +1507,12 @@ class GatewaySlashCommandsMixin:
         return t("gateway.stop.no_active")
 
     async def _handle_platform_command(self, event: MessageEvent) -> str:
-        """Handle ``/platform list|pause|resume [name]`` — surface and
-        manually control failed/paused gateway adapters.
+        """Handle ``/platform list|reload|pause|resume [name]`` — surface and
+        manually control gateway adapters.
 
         Examples:
             ``/platform list``           — show connected + failed/paused platforms
+            ``/platform reload``         — apply config.yaml platform changes without a restart
             ``/platform pause whatsapp`` — stop the reconnect watcher hammering whatsapp
             ``/platform resume whatsapp`` — re-queue a paused platform for retry
         """
@@ -1557,6 +1558,27 @@ class GatewaySlashCommandsMixin:
                 lines.append("Failed/paused: (none)")
             return "\n".join(lines)
 
+        if action == "reload":
+            report = await self._reload_platforms_from_config()
+            lines = ["**Platform reload**"]
+            labels = [
+                ("connected", "Connected"),
+                ("reconnected", "Reconnected (config changed)"),
+                ("disconnected", "Disconnected"),
+                ("failed", "Failed"),
+                ("unchanged", "Unchanged"),
+            ]
+            for key, label in labels:
+                vals = report.get(key) or []
+                if vals:
+                    lines.append(f"{label}: " + ", ".join(sorted(vals)))
+            if not any(report.get(k) for k in ("connected", "reconnected", "disconnected", "failed")):
+                if report.get("unchanged"):
+                    lines.append("No changes — all enabled platforms already up to date.")
+                else:
+                    lines.append("No messaging platforms enabled.")
+            return "\n".join(lines)
+
         if action in {"pause", "resume"}:
             if not target:
                 return f"Usage: /platform {action} <name>"
@@ -1593,8 +1615,9 @@ class GatewaySlashCommandsMixin:
             return f"✓ {platform.value} resumed — retrying on next watcher tick."
 
         return (
-            "Usage: /platform <list|pause|resume> [name]\n"
+            "Usage: /platform <list|reload|pause|resume> [name]\n"
             "  /platform list — show platform status\n"
+            "  /platform reload — apply config.yaml platform changes without a restart\n"
             "  /platform pause <name> — stop retrying a failing platform\n"
             "  /platform resume <name> — re-queue a paused platform"
         )

--- a/tests/gateway/test_platform_reload.py
+++ b/tests/gateway/test_platform_reload.py
@@ -1,0 +1,193 @@
+"""Tests for the gateway ``/platform reload`` config-diff hot-reload."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.run import GatewayRunner
+
+
+class StubAdapter(BasePlatformAdapter):
+    """Minimal adapter whose connect() result can be controlled."""
+
+    def __init__(self, *, platform=Platform.TELEGRAM, config=None, succeed=True):
+        super().__init__(config or PlatformConfig(enabled=True, token="test"), platform)
+        self._succeed = succeed
+        self.disconnected = False
+
+    async def connect(self):
+        return self._succeed
+
+    async def disconnect(self):
+        self.disconnected = True
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="1")
+
+    async def send_typing(self, chat_id, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+def _make_runner(*, adapters=None, config=None):
+    """Build a GatewayRunner with just enough wiring for reload tests."""
+    runner = object.__new__(GatewayRunner)
+    runner.config = config or GatewayConfig(platforms={})
+    runner.adapters = adapters or {}
+    runner._failed_platforms = {}
+    runner.delivery_router = MagicMock()
+    runner.session_store = MagicMock()
+    runner._busy_text_mode = "default"
+    runner._handle_message = MagicMock()
+    runner._handle_adapter_fatal_error = MagicMock()
+    runner._handle_active_session_busy_message = MagicMock()
+    runner._recover_telegram_topic_thread_id = MagicMock()
+    runner._update_platform_runtime_status = MagicMock()
+    runner._sync_voice_mode_state_to_adapter = MagicMock()
+    async def _disconnect(adapter, platform):
+        await adapter.disconnect()
+
+    runner._safe_adapter_disconnect = AsyncMock(side_effect=_disconnect)
+    return runner
+
+
+def _config_with(platforms):
+    return GatewayConfig(platforms=platforms)
+
+
+@pytest.mark.asyncio
+async def test_reload_connects_newly_enabled_platform():
+    runner = _make_runner()
+    new_adapter = StubAdapter(platform=Platform.TELEGRAM, succeed=True)
+    runner._create_adapter = MagicMock(return_value=new_adapter)
+    runner._connect_adapter_with_timeout = AsyncMock(return_value=True)
+
+    new_cfg = _config_with({Platform.TELEGRAM: PlatformConfig(enabled=True, token="t")})
+    with patch("gateway.config.load_gateway_config", return_value=new_cfg):
+        with patch("gateway.channel_directory.build_channel_directory", new=AsyncMock()):
+            report = await runner._reload_platforms_from_config()
+
+    assert Platform.TELEGRAM in runner.adapters
+    assert report["connected"] == ["telegram"]
+    assert runner.delivery_router.adapters is runner.adapters
+
+
+@pytest.mark.asyncio
+async def test_reload_disconnects_disabled_platform():
+    existing = StubAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapters={Platform.TELEGRAM: existing})
+    runner._create_adapter = MagicMock()
+
+    # Telegram now disabled.
+    new_cfg = _config_with({Platform.TELEGRAM: PlatformConfig(enabled=False, token="t")})
+    with patch("gateway.config.load_gateway_config", return_value=new_cfg):
+        with patch("gateway.channel_directory.build_channel_directory", new=AsyncMock()):
+            report = await runner._reload_platforms_from_config()
+
+    assert Platform.TELEGRAM not in runner.adapters
+    assert existing.disconnected is True
+    assert report["disconnected"] == ["telegram"]
+    runner._create_adapter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reload_reconnects_changed_config():
+    old_cfg = PlatformConfig(enabled=True, token="old")
+    existing = StubAdapter(platform=Platform.TELEGRAM, config=old_cfg)
+    runner = _make_runner(adapters={Platform.TELEGRAM: existing})
+    fresh = StubAdapter(
+        platform=Platform.TELEGRAM,
+        config=PlatformConfig(enabled=True, token="new"),
+        succeed=True,
+    )
+    runner._create_adapter = MagicMock(return_value=fresh)
+    runner._connect_adapter_with_timeout = AsyncMock(return_value=True)
+
+    new_cfg = _config_with({Platform.TELEGRAM: PlatformConfig(enabled=True, token="new")})
+    with patch("gateway.config.load_gateway_config", return_value=new_cfg):
+        with patch("gateway.channel_directory.build_channel_directory", new=AsyncMock()):
+            report = await runner._reload_platforms_from_config()
+
+    assert existing.disconnected is True
+    assert runner.adapters[Platform.TELEGRAM] is fresh
+    assert report["reconnected"] == ["telegram"]
+
+
+@pytest.mark.asyncio
+async def test_reload_leaves_unchanged_platform_untouched():
+    cfg = PlatformConfig(enabled=True, token="same")
+    existing = StubAdapter(platform=Platform.TELEGRAM, config=cfg)
+    runner = _make_runner(adapters={Platform.TELEGRAM: existing})
+    runner._create_adapter = MagicMock()
+    runner._connect_adapter_with_timeout = AsyncMock()
+
+    new_cfg = _config_with({Platform.TELEGRAM: PlatformConfig(enabled=True, token="same")})
+    with patch("gateway.config.load_gateway_config", return_value=new_cfg):
+        with patch("gateway.channel_directory.build_channel_directory", new=AsyncMock()):
+            report = await runner._reload_platforms_from_config()
+
+    # Same adapter object stays connected; nothing recreated or disconnected.
+    assert runner.adapters[Platform.TELEGRAM] is existing
+    assert existing.disconnected is False
+    assert report["unchanged"] == ["telegram"]
+    runner._create_adapter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reload_queues_failed_connect_for_retry():
+    runner = _make_runner()
+    failing = StubAdapter(platform=Platform.TELEGRAM, succeed=False)
+    runner._create_adapter = MagicMock(return_value=failing)
+    runner._connect_adapter_with_timeout = AsyncMock(return_value=False)
+
+    new_cfg = _config_with({Platform.TELEGRAM: PlatformConfig(enabled=True, token="t")})
+    with patch("gateway.config.load_gateway_config", return_value=new_cfg):
+        with patch("gateway.channel_directory.build_channel_directory", new=AsyncMock()):
+            report = await runner._reload_platforms_from_config()
+
+    assert Platform.TELEGRAM not in runner.adapters
+    assert Platform.TELEGRAM in runner._failed_platforms
+    assert report["failed"] == ["telegram"]
+
+
+@pytest.mark.asyncio
+async def test_reload_drops_disabled_platform_from_retry_queue():
+    runner = _make_runner()
+    runner._failed_platforms = {
+        Platform.TELEGRAM: {"config": PlatformConfig(enabled=True), "attempts": 2}
+    }
+    runner._create_adapter = MagicMock()
+
+    new_cfg = _config_with({Platform.TELEGRAM: PlatformConfig(enabled=False)})
+    with patch("gateway.config.load_gateway_config", return_value=new_cfg):
+        with patch("gateway.channel_directory.build_channel_directory", new=AsyncMock()):
+            report = await runner._reload_platforms_from_config()
+
+    assert Platform.TELEGRAM not in runner._failed_platforms
+    assert report["disconnected"] == ["telegram"]
+
+
+@pytest.mark.asyncio
+async def test_platform_reload_command_formats_report():
+    runner = _make_runner()
+    runner._reload_platforms_from_config = AsyncMock(
+        return_value={
+            "connected": ["telegram"],
+            "reconnected": [],
+            "disconnected": ["slack"],
+            "unchanged": ["discord"],
+            "failed": [],
+        }
+    )
+    event = SimpleNamespace(content="/platform reload")
+    out = await runner._handle_platform_command(event)
+
+    assert "Connected: telegram" in out
+    assert "Disconnected: slack" in out
+    assert "Unchanged: discord" in out


### PR DESCRIPTION
## What does this PR do?

Adds a `/platform reload` gateway command that re-reads `config.yaml` and applies the messaging-platform diff against the **running** gateway, with no restart:

- **Newly-enabled** platforms are connected.
- **Disabled / removed** platforms are disconnected (and dropped from the reconnect retry queue).
- Platforms whose `PlatformConfig` **changed** (token, home_channel, reply mode, etc.) are reconnected with the new settings.
- **Unchanged** connected platforms are left completely untouched, so in-flight agent turns on them are never interrupted.

After the diff is applied, `delivery_router.adapters` and the channel directory are refreshed once so `send_message` name resolution stays correct.

This addresses the core of #54681 (apply add/enable/disable/update platform changes without taking unrelated platforms offline via a full `hermes gateway restart`). It deliberately reuses the existing startup connect path and extends the existing `/platform` command group rather than adding new CLI/signal surface (note: the separate open PR #48918 already proposes `hermes gateway reload` → `SIGUSR2` for MCP/skills; this change is scoped to messaging-platform adapters and stays clear of that surface).

## Related Issue

Fixes #54681

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run.py`:
  - `_reload_platforms_from_config()` — computes the enabled-platform diff vs. running adapters and applies connect / disconnect / reconnect, then refreshes `delivery_router.adapters` and the channel directory. Returns a structured report.
  - `_bring_up_platform_adapter()` — create → wire handlers → connect a single adapter, installing it on `self.adapters`; mirrors the startup path and queues retryable failures for the reconnect watcher.
  - `_queue_failed_platform()` — small helper that builds the reconnect-watcher retry entry (shared between the two failure paths).
- `gateway/slash_commands.py`: `_handle_platform_command` gains a `reload` action that runs the reload and formats a per-platform report; usage/help text and docstring updated to list `reload`.
- `tests/gateway/test_platform_reload.py`: new tests for connect / disconnect / reconnect-on-change / unchanged-no-op / failed-connect-queued / disabled-dropped-from-retry-queue, plus the command formatter.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_platform_reload.py
```

Result: **7 passed**. Also re-ran the adjacent suites with no regressions:

```bash
pytest tests/gateway/test_platform_reconnect.py tests/gateway/test_platform_registry.py \
       tests/gateway/test_pre_gateway_dispatch.py tests/gateway/test_gateway_command_help.py \
       tests/gateway/test_platform_connected_checkers.py -q
```

Result: **112 passed, 1 skipped**.

Manual: with a gateway running, edit `config.yaml` to enable/disable/change a platform, send `/platform reload`, and confirm the report reflects the change and unrelated platforms stay connected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the affected + adjacent gateway suites (see How to Test); did not run the entire repo suite -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings + `/platform` usage/help text updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure asyncio/dict logic, no OS-specific calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Example `/platform reload` report after enabling Slack and changing the Telegram token:

```
**Platform reload**
Connected: slack
Reconnected (config changed): telegram
Unchanged: discord
```
