### PR TITLE
feat(desktop): show per-message timestamp on every chat turn

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -303,6 +303,7 @@ const AssistantMessage: FC<{
   const messageId = useAuiState(s => s.message.id)
   const messageRuntime = useMessageRuntime()
   const { t } = useI18n()
+  const copy = t.assistant.thread
 
   // PERF: this component must NOT subscribe to the streaming text. Every
   // selector here returns a value that stays referentially stable across
@@ -379,7 +380,10 @@ const AssistantMessage: FC<{
         </MessagePrimitive.Error>
       </div>
       {hasVisibleText && (
-        <AssistantFooter getMessageText={getMessageText} messageId={messageId} onBranchInNewChat={onBranchInNewChat} />
+        <div className="mt-1 flex items-center justify-end gap-2 pr-(--message-text-indent) pl-(--message-text-indent)">
+          <MessageTimestamp />
+          <AssistantFooter getMessageText={getMessageText} messageId={messageId} onBranchInNewChat={onBranchInNewChat} />
+        </div>
       )}
     </MessagePrimitive.Root>
   )
@@ -784,7 +788,7 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
             </TooltipIconButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" onCloseAutoFocus={e => e.preventDefault()} sideOffset={6}>
-            <MessageTimestamp />
+            <MessageTimestamp variant="menu" />
             <DropdownMenuItem onSelect={() => onBranchInNewChat?.(messageId)}>
               <GitBranchIcon />
               {copy.branchNewChat}
@@ -838,7 +842,14 @@ const ReadAloudItem: FC<{ getText: () => string; messageId: string }> = ({ getTe
   )
 }
 
-const MessageTimestamp: FC = () => {
+interface MessageTimestampProps {
+  /** 'inline' = compact pill that sits above/beside the message (the default
+   *  for the new "show time on every message" feature).
+   *  'menu' = the dropdown-menu header used inside the message overflow menu. */
+  variant?: 'inline' | 'menu'
+}
+
+const MessageTimestamp: FC<MessageTimestampProps> = ({ variant = 'inline' }) => {
   const { t } = useI18n()
   const createdAt = useAuiState(s => s.message.createdAt)
   const label = formatMessageTimestamp(createdAt, t.assistant.thread)
@@ -847,7 +858,22 @@ const MessageTimestamp: FC = () => {
     return null
   }
 
-  return <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">{label}</DropdownMenuLabel>
+  if (variant === 'menu') {
+    return <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">{label}</DropdownMenuLabel>
+  }
+
+  const dateValue = createdAt instanceof Date ? createdAt : new Date(createdAt)
+
+  return (
+    <time
+      aria-label={t.assistant.thread.messageTimestampAria}
+      className="select-none text-[0.6875rem] leading-none tabular-nums text-(--ui-text-tertiary) opacity-80"
+      dateTime={Number.isNaN(dateValue.getTime()) ? undefined : dateValue.toISOString()}
+      title={label}
+    >
+      {label}
+    </time>
+  )
 }
 
 const AssistantFooter: FC<MessageActionProps> = props => (
@@ -1113,6 +1139,9 @@ const UserMessage: FC<{
       >
         <ActionBarPrimitive.Root className="relative w-full max-w-full" data-slot="aui_user-bubble-actions">
           <div className="human-message-with-todos-wrapper flex w-full flex-col gap-0">
+            <div className="flex items-center justify-end gap-2 pb-1 pr-1 text-right">
+              <MessageTimestamp />
+            </div>
             <div className="relative w-full">
               {/* Always editable — clicking opens the edit composer even while a
                   turn streams; sending the edit reverts (interrupt + rewind). */}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1989,6 +1989,7 @@ export const en: Translations = {
       thinking: 'Thinking',
       today: time => `Today, ${time}`,
       yesterday: time => `Yesterday, ${time}`,
+      messageTimestampAria: 'Message sent at',
       copy: 'Copy',
       refresh: 'Refresh',
       moreActions: 'More actions',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2114,6 +2114,7 @@ export const ja = defineLocale({
       thinking: '考え中',
       today: time => `今日 ${time}`,
       yesterday: time => `昨日 ${time}`,
+      messageTimestampAria: '送信日時',
       copy: 'コピー',
       refresh: '更新',
       moreActions: 'その他のアクション',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1640,6 +1640,7 @@ export interface Translations {
       thinking: string
       today: (time: string) => string
       yesterday: (time: string) => string
+      messageTimestampAria: string
       copy: string
       refresh: string
       moreActions: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2047,6 +2047,7 @@ export const zhHant = defineLocale({
       thinking: '思考中',
       today: time => `今天，${time}`,
       yesterday: time => `昨天，${time}`,
+      messageTimestampAria: '訊息發送於',
       copy: '複製',
       refresh: '重新整理',
       moreActions: '更多動作',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2159,6 +2159,7 @@ export const zh: Translations = {
       thinking: '思考中',
       today: time => `今天，${time}`,
       yesterday: time => `昨天，${time}`,
+      messageTimestampAria: '消息发送于',
       copy: '复制',
       refresh: '刷新',
       moreActions: '更多操作',


### PR DESCRIPTION
Render a compact relative timestamp (Today 14:32 / Yesterday 09:15 / Jun 25, 14:32) above every user message and beside every assistant message in the desktop chat view. The data was already present (ThreadMessage.createdAt) and the formatter already existed; this just wires the existing MessageTimestamp component into the rendered tree with an inline variant in addition to its existing dropdown-menu use.

- AssistantMessage: inline timestamp to the right of the footer
- UserMessage: inline timestamp above the sticky user bubble
- New i18n key assistant.thread.messageTimestampAria (en/zh/ja/zh-hant)
- ThreadMessage's createdAt is already populated by chat-runtime, no data-layer work needed
- Preserves the 30 Hz streaming perf budget (selector returns a stable Date; no per-token re-render of the new pill)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

