### PR TITLE
fix(mcp): allow generous timeout for interactive OAuth reauth probe

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -694,8 +694,12 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
     _info(f"Starting OAuth flow for '{name}'...")
 
     # Probe triggers the OAuth flow (browser redirect + callback capture).
+    # The whole interactive browser authorization happens INSIDE this probe
+    # call, so it needs a generous timeout — the default 40s is not enough for
+    # a human to open the URL, approve, and paste the redirect back. Allow up
+    # to ~5 min (matches the OAuth provider's own 300s callback wait).
     try:
-        tools = _probe_single_server(name, server_config)
+        tools = _probe_single_server(name, server_config, connect_timeout=300)
         # A clean probe is NOT proof of authentication. Some MCP servers
         # (notably Google's official Drive server) serve initialize +
         # tools/list WITHOUT auth, so the probe lists tools even when the

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -716,7 +716,7 @@ class TestMcpLogin:
         # Probe returns tools even though auth never completed.
         monkeypatch.setattr(
             "hermes_cli.mcp_config._probe_single_server",
-            lambda name, cfg: [("search_files", "d"), ("read_file_content", "d")],
+            lambda name, cfg, **kw: [("search_files", "d"), ("read_file_content", "d")],
         )
         # No token file is created → _oauth_tokens_present() returns False.
         from hermes_cli.mcp_config import cmd_mcp_login
@@ -738,7 +738,7 @@ class TestMcpLogin:
         # cmd_mcp_login wipes tokens before probing, then the real OAuth flow
         # writes a fresh token during the probe. Simulate that: the mocked
         # probe drops a token file, mirroring a successful authorization.
-        def mock_probe(name, cfg):
+        def mock_probe(name, cfg, **kw):
             token_dir.mkdir(exist_ok=True)
             (token_dir / "realserver.json").write_text('{"access_token": "x"}')
             return [("a", "d"), ("b", "d"), ("c", "d")]


### PR DESCRIPTION
Closes #54692.

## What

Raise the OAuth probe timeout on the **interactive reauth path** to 300s (`_probe_single_server(..., connect_timeout=300)`), matching the OAuth provider's own callback wait.

## Why

`hermes mcp reauth` drives the entire browser authorization (open URL, approve, capture redirect) inside the probe call. The default ~40s connect timeout isn't enough for a human to finish — especially with MFA/org login — so reauth fails spuriously.

## Why this is better

- Stops reauth failing for the common case of a human taking >40s to log in.
- 300s is not arbitrary: it matches the provider's callback wait window, so we never wait longer than the flow can succeed.
- Only the explicitly-interactive reauth path is affected; background probes keep their tight timeout.

## Test

- `python -m py_compile hermes_cli/mcp_config.py` passes.
- Manual: `hermes mcp reauth <server>` with a slow/MFA login now completes instead of timing out at ~40s.
