### PR TITLE
feat(webhook): verify native Asana webhook signatures (X-Hook-Signature)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -778,6 +778,15 @@ class WebhookAdapter(BasePlatformAdapter):
             ).hexdigest()
             return hmac.compare_digest(generic_sig, expected)
 
+        # Asana: X-Hook-Signature = <hex HMAC-SHA256 of raw body>
+        # Secret is established during the Asana webhook handshake (X-Hook-Secret).
+        asana_sig = request.headers.get("X-Hook-Signature", "")
+        if asana_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(asana_sig, expected)
+
         # No recognised signature header but secret is configured → reject
         logger.debug(
             "[webhook] Secret configured but no signature header found"


### PR DESCRIPTION
Closes #54693.

## What

Add native verification of Asana's `X-Hook-Signature` (hex HMAC-SHA256 over the raw body, keyed by the handshake secret) to the webhook adapter, with a constant-time compare.

## Why

The adapter recognised GitLab and a generic HMAC header but not Asana's scheme, so Asana deliveries couldn't be authenticated natively — integrators had to fall back to a generic header or disable verification.

## Why this is better

- First-class Asana webhook support out of the box.
- Constant-time compare (`hmac.compare_digest`) — no timing side channel.
- Purely additive; sits alongside the existing GitLab/generic/Svix branches and changes none of them.

## Test

- `python -m py_compile gateway/platforms/webhook.py` passes.
- Manual: an Asana webhook delivery with a valid `X-Hook-Signature` authenticates; an invalid one is rejected.
