### PR TITLE
fix(teams): don't block the Bot Framework ack on the agent turn

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -975,7 +975,22 @@ class TeamsAdapter(BasePlatformAdapter):
             media_types=media_types,
             message_id=msg_id,
         )
-        await self.handle_message(event)
+
+        # Fire-and-forget: do NOT block the inbound HTTP request on the agent
+        # turn. A turn can take 30-90s, but the Bot Framework expects the webhook
+        # to be acknowledged within ~15s; exceeding that opens its circuit breaker
+        # and delivery can stall for a long time. Acknowledge immediately and run
+        # the (potentially long) turn in a tracked background task.
+        async def _bg_handle() -> None:
+            try:
+                await self.handle_message(event)
+            except Exception:  # noqa: BLE001 — background turn must not crash the loop
+                logger.exception("[teams] background handle_message failed")
+
+        task = asyncio.create_task(_bg_handle())
+        self._bg_tasks = getattr(self, "_bg_tasks", set())
+        self._bg_tasks.add(task)
+        task.add_done_callback(self._bg_tasks.discard)
 
     async def _send_card(self, chat_id: str, card: "AdaptiveCard") -> "Any":
         """Send an AdaptiveCard, using a stored ConversationReference when available."""

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+import asyncio
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -605,6 +606,18 @@ class TestTeamsSummaryWriter:
 # Tests: Message Handling
 # ---------------------------------------------------------------------------
 
+async def _drain_bg(adapter):
+    """Drain the fire-and-forget background handle_message task(s).
+
+    `_on_message` acknowledges the inbound webhook immediately and runs the
+    (potentially long) agent turn in a tracked background task so the Bot
+    Framework ack window isn't blocked. In tests we await those tasks so the
+    handler's effect is observable deterministically.
+    """
+    for task in list(getattr(adapter, "_bg_tasks", set())):
+        await task
+
+
 class TestTeamsMessageHandling:
     def _make_activity(
         self,
@@ -650,6 +663,7 @@ class TestTeamsMessageHandling:
 
         activity = self._make_activity(conversation_type="personal")
         await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         adapter.handle_message.assert_awaited_once()
         event = adapter.handle_message.call_args[0][0]
@@ -666,6 +680,7 @@ class TestTeamsMessageHandling:
 
         activity = self._make_activity(conversation_type="groupChat")
         await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         event = adapter.handle_message.call_args[0][0]
         assert event.source.chat_type == "group"
@@ -681,6 +696,7 @@ class TestTeamsMessageHandling:
 
         activity = self._make_activity(conversation_type="channel")
         await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         event = adapter.handle_message.call_args[0][0]
         assert event.source.chat_type == "channel"
@@ -696,6 +712,7 @@ class TestTeamsMessageHandling:
 
         activity = self._make_activity(from_aad_id="aad-stable-id", from_id="teams-id")
         await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         event = adapter.handle_message.call_args[0][0]
         assert event.source.user_id == "aad-stable-id"
@@ -711,6 +728,7 @@ class TestTeamsMessageHandling:
 
         activity = self._make_activity(from_id="bot-id")
         await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         adapter.handle_message.assert_not_awaited()
 
@@ -728,6 +746,7 @@ class TestTeamsMessageHandling:
             from_id="user-id",
         )
         await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         event = adapter.handle_message.call_args[0][0]
         assert event.text == "what is the weather?"
@@ -746,6 +765,7 @@ class TestTeamsMessageHandling:
 
         await adapter._on_message(ctx)
         await adapter._on_message(ctx)
+        await _drain_bg(adapter)
 
         assert adapter.handle_message.await_count == 1
 
@@ -820,6 +840,7 @@ class TestTeamsAttachmentClassification:
 
         activity = self._make_activity([self._file_download_attachment()])
         await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.DOCUMENT, (
@@ -846,6 +867,7 @@ class TestTeamsAttachmentClassification:
                 self._file_download_attachment(),
             ])
             await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.DOCUMENT
@@ -858,6 +880,7 @@ class TestTeamsAttachmentClassification:
         adapter = self._make_adapter()
         activity = self._make_activity([self._html_body_attachment()])
         await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.TEXT
@@ -876,6 +899,7 @@ class TestTeamsAttachmentClassification:
             mp.setattr(_teams_mod, "cache_image_from_url", fake_cache_image)
             activity = self._make_activity([self._image_attachment()])
             await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.PHOTO
@@ -890,6 +914,7 @@ class TestTeamsAttachmentClassification:
 
         activity = self._make_activity([self._file_download_attachment()])
         await adapter._on_message(self._make_ctx(activity))
+        await _drain_bg(adapter)
 
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.TEXT


### PR DESCRIPTION
Closes #54694.

## What

Stop awaiting the full agent turn inside the Teams inbound webhook handler. Acknowledge the request immediately and run the turn in a tracked background task.

## Why

A turn can take 30-90s, but the Bot Framework expects the activity webhook to be acked within ~15s. Blocking on the turn trips the Bot Framework circuit breaker and can stall delivery for minutes, making the bot look dead while it's actually working.

## Why this is better

- Eliminates ack-timeout stalls under normal (long) turns.
- Standard fire-and-forget pattern: ack fast, process async.
- Background errors are logged and isolated; the task handle is retained in a set (and discarded on completion) so in-flight tasks aren't GC'd mid-run.

## Test

- `python -m py_compile plugins/platforms/teams/adapter.py` passes.
- Manual: send a Teams message that triggers a long (>15s) turn; the bot keeps receiving subsequent messages instead of going silent.
