### PR TITLE
feat(delegate): add skills parameter to delegate_task

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6256,6 +6256,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            skills=function_args.get("skills"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate_skills.py
+++ b/tests/tools/test_delegate_skills.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Tests for the delegate_task skills parameter.
+
+Covers: _merge_skills, _load_delegate_skills (cron pipeline), prompt
+injection, _build_child_agent AIAgent constructor capture, schema,
+and end-to-end integration through delegate_task().
+
+Run:  python -m pytest tests/tools/test_delegate_skills.py -v
+"""
+
+import json
+import unittest
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _merge_skills,
+    _load_delegate_skills,
+    _build_child_system_prompt,
+    _build_child_agent,
+    delegate_task,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _patch_load_pipeline(stack, *, skill_view_side_effect=None,
+                          skill_view_return=None, scan_passthrough=True,
+                          bundle_key_return=None):
+    """Patch the cron resolution pipeline used by _load_delegate_skills.
+
+    Returns the mock objects for further assertions.
+    """
+    mocks = {}
+    mocks["view"] = stack.enter_context(patch("tools.skills_tool.skill_view"))
+    if skill_view_side_effect is not None:
+        mocks["view"].side_effect = skill_view_side_effect
+    elif skill_view_return is not None:
+        mocks["view"].return_value = skill_view_return
+    mocks["bump"] = stack.enter_context(patch("tools.skill_usage.bump_use"))
+    mocks["bundle"] = stack.enter_context(
+        patch("agent.skill_bundles.resolve_bundle_command_key",
+              return_value=bundle_key_return)
+    )
+    mocks["norm"] = stack.enter_context(
+        patch("agent.skill_utils.normalize_skill_lookup_name", side_effect=lambda x: x)
+    )
+    mocks["scan"] = stack.enter_context(
+        patch("tools.cronjob_tools._scan_cron_skill_assembled")
+    )
+    if scan_passthrough:
+        mocks["scan"].side_effect = lambda assembled: (assembled, "")
+    return mocks
+
+
+def _patch_child_agent_env(stack):
+    """Patch _build_child_agent's external dependencies."""
+    stack.enter_context(patch("tools.delegate_tool._load_config", return_value={}))
+    stack.enter_context(patch("tools.delegate_tool._resolve_delegation_credentials", return_value={
+        "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "model": None, "request_overrides": None,
+        "max_output_tokens": None, "command": None, "args": None,
+    }))
+    stack.enter_context(patch("tools.delegate_tool._get_max_spawn_depth", return_value=2))
+    stack.enter_context(patch("tools.delegate_tool._get_orchestrator_enabled", return_value=True))
+    stack.enter_context(patch("tools.delegate_tool._resolve_workspace_hint", return_value=None))
+    stack.enter_context(patch("tools.delegate_tool._strip_blocked_tools", return_value=set()))
+    mock_agent = stack.enter_context(patch("run_agent.AIAgent"))
+    return mock_agent
+
+
+def _make_mock_parent():
+    parent = MagicMock()
+    parent.api_key = "test-key"
+    parent.model = "test-model"
+    parent.enabled_toolsets = None
+    parent.valid_tool_names = []
+    parent._delegate_depth = 0
+    parent._subagent_id = None
+    parent._delegate_spinner = None
+    parent.tool_progress_callback = None
+    parent._client_kwargs = {}
+    return parent
+
+
+def _capture_init(captured):
+    """Return a side_effect for AIAgent that captures kwargs into *captured*."""
+    def _init(*args, **kwargs):
+        captured.update(kwargs)
+        inst = MagicMock()
+        inst.tool_progress_callback = kwargs.get("tool_progress_callback")
+        inst._delegate_depth = kwargs.get("_delegate_depth", 0)
+        return inst
+    return _init
+
+
+# ---------------------------------------------------------------------------
+# _merge_skills
+# ---------------------------------------------------------------------------
+
+class TestMergeSkills(unittest.TestCase):
+    """_merge_skills: top-level + per-task merge with dedup."""
+
+    def test_none_and_empty(self):
+        self.assertIsNone(_merge_skills(None, None))
+        self.assertIsNone(_merge_skills([], []))
+        self.assertIsNone(_merge_skills(None, []))
+        self.assertIsNone(_merge_skills([], None))
+
+    def test_top_level_only(self):
+        self.assertEqual(_merge_skills(["a", "b"], None), ["a", "b"])
+        self.assertEqual(_merge_skills(["x"], []), ["x"])
+
+    def test_per_task_only(self):
+        self.assertEqual(_merge_skills(None, ["x", "y"]), ["x", "y"])
+        self.assertEqual(_merge_skills([], ["z"]), ["z"])
+
+    def test_merge_per_task_first(self):
+        self.assertEqual(_merge_skills(["a", "b"], ["x", "y"]), ["x", "y", "a", "b"])
+
+    def test_dedup_preserves_order(self):
+        result = _merge_skills(["a", "b", "c"], ["b", "d"])
+        self.assertEqual(result, ["b", "d", "a", "c"])
+        # Per-task instance wins: "b" from per-task is at index 0, not index 2
+        self.assertEqual(result[0], "b")
+
+
+# ---------------------------------------------------------------------------
+# _load_delegate_skills
+# ---------------------------------------------------------------------------
+
+class TestLoadDelegateSkills(unittest.TestCase):
+    """_load_delegate_skills: cron-compatible resolution pipeline."""
+
+    def test_empty(self):
+        self.assertEqual(_load_delegate_skills(None), "")
+        self.assertEqual(_load_delegate_skills([]), "")
+
+    def test_successful_load(self):
+        with ExitStack() as s:
+            m = _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": True, "content": "# My Skill\nDo things efficiently.",
+            }))
+            result = _load_delegate_skills(["my-skill"])
+        self.assertIn("my-skill", result)
+        self.assertIn("# My Skill", result)
+        self.assertIn("Do things efficiently.", result)
+        m["bump"].assert_called_once_with("my-skill")
+
+    def test_skill_not_found(self):
+        with ExitStack() as s:
+            _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": False, "error": "Skill not found",
+            }))
+            result = _load_delegate_skills(["missing-skill"])
+        self.assertIn("missing-skill", result)
+        self.assertIn("skipped", result)
+
+    def test_invalid_json(self):
+        with ExitStack() as s:
+            _patch_load_pipeline(s, skill_view_return="not json")
+            result = _load_delegate_skills(["bad-skill"])
+        self.assertIn("bad-skill", result)
+        self.assertIn("skipped", result)
+
+    def test_security_scan_returns_blocked_notice(self):
+        """When scan blocks content, a notice is returned (not empty string)
+        so the child agent can surface the block to the user."""
+        with ExitStack() as s:
+            m = _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": True, "content": "malicious content",
+            }), scan_passthrough=False)
+            m["scan"].return_value = ("cleaned", "Blocked: injection.")
+            result = _load_delegate_skills(["malicious-skill"])
+        self.assertNotEqual(result, "")
+        self.assertIn("malicious-skill", result)
+        self.assertIn("blocked", result.lower())
+        self.assertIn("security scanner", result.lower())
+
+    def test_multiple_skills(self):
+        with ExitStack() as s:
+            _patch_load_pipeline(s, skill_view_side_effect=[
+                json.dumps({"success": True, "content": "# Skill A"}),
+                json.dumps({"success": True, "content": "# Skill B"}),
+            ])
+            result = _load_delegate_skills(["skill-a", "skill-b"])
+        self.assertIn("skill-a", result)
+        self.assertIn("skill-b", result)
+        self.assertIn("# Skill A", result)
+        self.assertIn("# Skill B", result)
+
+    def test_bundle_resolution(self):
+        """When a skill name matches a bundle, the bundle is expanded."""
+        with ExitStack() as s:
+            _patch_load_pipeline(s, bundle_key_return="/my-bundle")
+            s.enter_context(patch(
+                "agent.skill_bundles.build_bundle_invocation_message",
+                return_value=("Bundle content", [], []),
+            ))
+            with patch("tools.skills_tool.skill_view") as mock_view:
+                result = _load_delegate_skills(["my-bundle"])
+        self.assertIn("Bundle content", result)
+        mock_view.assert_not_called()
+
+    # --- Edge cases (P2 gaps from review) ---
+
+    def test_scan_returns_sanitized_content(self):
+        """When scan strips invisible unicode, the SANITIZED string is
+        returned — not the raw assembled input."""
+        with ExitStack() as s:
+            m = _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": True, "content": "# Clean Skill",
+            }), scan_passthrough=False)
+            # Simulate sanitization: scan returns a modified string
+            m["scan"].return_value = ("SANITIZED_OUTPUT", "")
+            result = _load_delegate_skills(["clean-skill"])
+        self.assertEqual(result, "SANITIZED_OUTPUT")
+        self.assertNotIn("# Clean Skill", result)
+
+    def test_bump_use_failure_does_not_block_load(self):
+        """bump_use is best-effort — failure must not prevent skill loading."""
+        with ExitStack() as s:
+            m = _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": True, "content": "# Resilient Skill",
+            }))
+            m["bump"].side_effect = RuntimeError("DB locked")
+            result = _load_delegate_skills(["resilient-skill"])
+        self.assertIn("# Resilient Skill", result)
+        self.assertIn("resilient-skill", result)
+
+    def test_empty_skill_content_still_injects_frame(self):
+        """When skill_view returns success but empty content, the activation
+        header is still injected so the child knows the skill was requested."""
+        with ExitStack() as s:
+            _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": True, "content": "",
+            }))
+            result = _load_delegate_skills(["empty-skill"])
+        self.assertIn("empty-skill", result)
+        self.assertIn("IMPORTANT", result)
+
+    def test_mixed_success_and_failure(self):
+        """A list with one successful + one missing skill produces both
+        the successful content AND the skipped notice."""
+        with ExitStack() as s:
+            _patch_load_pipeline(s, skill_view_side_effect=[
+                json.dumps({"success": True, "content": "# Good Skill"}),
+                json.dumps({"success": False, "error": "Not found"}),
+            ])
+            result = _load_delegate_skills(["good-skill", "bad-skill"])
+        self.assertIn("# Good Skill", result)
+        self.assertIn("bad-skill", result)
+        self.assertIn("skipped", result)
+
+    def test_normalize_skill_lookup_name_is_called(self):
+        """normalize_skill_lookup_name must be invoked for each skill."""
+        with ExitStack() as s:
+            m = _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": True, "content": "# Skill",
+            }))
+            _load_delegate_skills(["my-skill"])
+        m["norm"].assert_called_once_with("my-skill")
+
+    def test_resolve_bundle_command_key_is_called(self):
+        """resolve_bundle_command_key must be invoked for each skill name."""
+        with ExitStack() as s:
+            m = _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": True, "content": "# Skill",
+            }))
+            _load_delegate_skills(["my-skill"])
+        m["bundle"].assert_called_once_with("my-skill")
+
+
+# ---------------------------------------------------------------------------
+# _build_child_system_prompt
+# ---------------------------------------------------------------------------
+
+class TestBuildChildSystemPromptWithSkills(unittest.TestCase):
+    """_build_child_system_prompt with skills_content injection."""
+
+    def test_no_skills_content(self):
+        prompt = _build_child_system_prompt("Do something")
+        self.assertIn("YOUR TASK:\nDo something", prompt)
+        self.assertIn("Complete this task", prompt)
+
+    def test_with_skills_content(self):
+        prompt = _build_child_system_prompt(
+            "Do something",
+            skills_content='[IMPORTANT: The "test-skill" skill.]\n# Test Skill\nFollow this.',
+        )
+        self.assertIn("test-skill", prompt)
+        self.assertIn("# Test Skill", prompt)
+        self.assertIn("Follow this.", prompt)
+
+    def test_empty_or_whitespace_skills_ignored(self):
+        for empty in ["", "   ", "\n\n  "]:
+            prompt = _build_child_system_prompt("Do something", skills_content=empty)
+            self.assertNotIn("IMPORTANT", prompt, f"failed for skills_content={empty!r}")
+
+    def test_skills_before_completion(self):
+        prompt = _build_child_system_prompt(
+            "Do something", skills_content="[IMPORTANT: SKILL CONTENT HERE]",
+        )
+        self.assertGreater(prompt.find("SKILL CONTENT HERE"), 0)
+        self.assertGreater(
+            prompt.find("Complete this task"),
+            prompt.find("SKILL CONTENT HERE"),
+        )
+
+    def test_skills_after_workspace_path(self):
+        """skills_content should come after WORKSPACE PATH block."""
+        prompt = _build_child_system_prompt(
+            "Do something",
+            workspace_path="/tmp/project",
+            skills_content="[IMPORTANT: SKILL HERE]",
+        )
+        ws_pos = prompt.find("WORKSPACE PATH")
+        skill_pos = prompt.find("SKILL HERE")
+        self.assertGreater(ws_pos, 0)
+        self.assertGreater(skill_pos, ws_pos,
+                           "skills should come after workspace path")
+
+    def test_skills_with_orchestrator_role(self):
+        """skills_content composes correctly with orchestrator role block."""
+        prompt = _build_child_system_prompt(
+            "Orchestrate work", role="orchestrator", child_depth=1, max_spawn_depth=3,
+            skills_content="[IMPORTANT: SKILL FOR ORCHESTRATOR]",
+        )
+        self.assertIn("SKILL FOR ORCHESTRATOR", prompt)
+        self.assertIn("Subagent Spawning", prompt)
+
+
+# ---------------------------------------------------------------------------
+# _build_child_agent
+# ---------------------------------------------------------------------------
+
+class TestBuildChildAgentWithSkills(unittest.TestCase):
+    """_build_child_agent with skills: capture AIAgent constructor, assert
+    ephemeral_system_prompt contains loaded skill content (teknium1 #3)."""
+
+    def test_skills_content_in_child_prompt(self):
+        """Child's ephemeral_system_prompt MUST contain skill content."""
+        captured = {}
+        with ExitStack() as s:
+            _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": True, "content": "# Test Skill\nThis is the skill body.",
+            }))
+            mock_agent = _patch_child_agent_env(s)
+            mock_agent.side_effect = _capture_init(captured)
+
+            _build_child_agent(
+                task_index=0, goal="Test the feature", context=None,
+                toolsets=None, model=None, max_iterations=50,
+                task_count=1, parent_agent=_make_mock_parent(),
+                skills=["test-skill"],
+            )
+
+        prompt = captured["ephemeral_system_prompt"]
+        self.assertIn("Test the feature", prompt)
+        self.assertIn("# Test Skill", prompt)
+        self.assertIn("This is the skill body.", prompt)
+
+    def test_no_skills_no_skill_block(self):
+        """Without skills, no skill invocation block in prompt."""
+        captured = {}
+        with ExitStack() as s:
+            mock_agent = _patch_child_agent_env(s)
+            mock_agent.side_effect = _capture_init(captured)
+
+            _build_child_agent(
+                task_index=0, goal="Test the feature", context=None,
+                toolsets=None, model=None, max_iterations=50,
+                task_count=1, parent_agent=_make_mock_parent(),
+                skills=None,
+            )
+
+        prompt = captured.get("ephemeral_system_prompt", "")
+        self.assertIn("Test the feature", prompt)
+        self.assertNotIn("IMPORTANT: The user has invoked", prompt)
+
+    def test_blocked_skill_notice_in_child_prompt(self):
+        """When scan blocks skill content, the blocked notice reaches the
+        child prompt so the child can surface it to the user."""
+        captured = {}
+        with ExitStack() as s:
+            m = _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": True, "content": "malicious",
+            }), scan_passthrough=False)
+            m["scan"].return_value = ("cleaned", "Blocked: injection.")
+            mock_agent = _patch_child_agent_env(s)
+            mock_agent.side_effect = _capture_init(captured)
+
+            _build_child_agent(
+                task_index=0, goal="Do work", context=None,
+                toolsets=None, model=None, max_iterations=50,
+                task_count=1, parent_agent=_make_mock_parent(),
+                skills=["bad-skill"],
+            )
+
+        prompt = captured.get("ephemeral_system_prompt", "")
+        self.assertIn("bad-skill", prompt)
+        self.assertIn("blocked", prompt.lower())
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+class TestSchemaValidation(unittest.TestCase):
+    """Schema includes skills property with correct semantics."""
+
+    def test_top_level_has_skills(self):
+        p = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["skills"]
+        self.assertEqual(p["type"], "array")
+        self.assertEqual(p["items"]["type"], "string")
+
+    def test_per_task_has_skills(self):
+        p = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]["skills"]
+        self.assertEqual(p["type"], "array")
+        self.assertEqual(p["items"]["type"], "string")
+
+    def test_descriptions_say_merge_not_replace(self):
+        top = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["skills"]["description"].lower()
+        per = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]["skills"]["description"].lower()
+        for desc, label in [(top, "top-level"), (per, "per-task")]:
+            self.assertIn("merge", desc, f"{label} must say 'merge'")
+            self.assertNotIn("replace", desc, f"{label} must NOT say 'replace'")
+
+    def test_top_level_mentions_security_pipeline(self):
+        desc = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["skills"]["description"].lower()
+        self.assertIn("resolution pipeline", desc)
+        self.assertIn("security scan", desc)
+
+
+# ---------------------------------------------------------------------------
+# Integration: delegate_task end-to-end
+# ---------------------------------------------------------------------------
+
+class TestDelegateTaskIntegrationWithSkills(unittest.TestCase):
+    """End-to-end test: delegate_task(goal=..., skills=[...]) threads skills
+    through the full path: schema → registry handler → delegate_task →
+    _build_child_agent → _load_delegate_skills → _build_child_system_prompt.
+    """
+
+    def _patch_delegate_env(self, stack):
+        """Patch delegate_task's runtime environment for integration tests."""
+        stack.enter_context(patch("tools.delegate_tool.is_spawn_paused", return_value=False))
+        stack.enter_context(patch("tools.delegate_tool._get_max_concurrent_children", return_value=3))
+        stack.enter_context(patch("tools.delegation_live_log.create_live_transcripts", return_value=(None, [], [])))
+        stack.enter_context(patch("tools.delegation_live_log.update_manifest_statuses"))
+        stack.enter_context(patch("tools.delegation_live_log.wrap_progress_callback", side_effect=lambda cb, w: cb))
+        import model_tools
+        stack.enter_context(patch.object(model_tools, "_last_resolved_tool_names", []))
+        # _run_single_child returns a result dict — patch it to avoid running
+        # the child agent's full conversation loop.
+        stack.enter_context(patch("tools.delegate_tool._run_single_child", return_value={
+            "status": "completed", "summary": "mock result", "output": "mock output",
+        }))
+
+    def test_single_task_with_skills(self):
+        """delegate_task with skills= produces a child whose prompt contains
+        the skill content."""
+        captured = {}
+        with ExitStack() as s:
+            _patch_load_pipeline(s, skill_view_return=json.dumps({
+                "success": True, "content": "# Integration Skill",
+            }))
+            mock_agent = _patch_child_agent_env(s)
+            mock_agent.side_effect = _capture_init(captured)
+            self._patch_delegate_env(s)
+
+            result = delegate_task(
+                goal="Do the work",
+                skills=["integration-skill"],
+                parent_agent=_make_mock_parent(),
+            )
+
+        result_data = json.loads(result)
+        self.assertTrue(result_data.get("results"))
+        prompt = captured.get("ephemeral_system_prompt", "")
+        self.assertIn("Do the work", prompt)
+        self.assertIn("# Integration Skill", prompt)
+        self.assertIn("integration-skill", prompt)
+
+    def test_single_task_without_skills_backward_compat(self):
+        """delegate_task without skills= still works (backward compat)."""
+        captured = {}
+        with ExitStack() as s:
+            mock_agent = _patch_child_agent_env(s)
+            mock_agent.side_effect = _capture_init(captured)
+            self._patch_delegate_env(s)
+
+            result = delegate_task(
+                goal="Simple task",
+                parent_agent=_make_mock_parent(),
+            )
+
+        result_data = json.loads(result)
+        self.assertTrue(result_data.get("results"))
+        prompt = captured.get("ephemeral_system_prompt", "")
+        self.assertIn("Simple task", prompt)
+        self.assertNotIn("IMPORTANT: The user has invoked", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -659,6 +659,162 @@ def check_delegate_requirements() -> bool:
     return True
 
 
+def _merge_skills(
+    top_level: Optional[List[str]],
+    per_task: Optional[List[str]],
+) -> Optional[List[str]]:
+    """Merge top-level and per-task skills lists.
+
+    Per-task skills are placed first (preserving order), followed by any
+    top-level skills not already present.  This lets a batch task extend
+    the parent's skill set.  Returns None when both inputs are empty/None,
+    so _load_delegate_skills can skip work entirely.
+    """
+    if not per_task and not top_level:
+        return None
+    seen: set[str] = set()
+    merged: list[str] = []
+    for name in (per_task or []):
+        if name not in seen:
+            seen.add(name)
+            merged.append(name)
+    for name in (top_level or []):
+        if name not in seen:
+            seen.add(name)
+            merged.append(name)
+    return merged or None
+
+
+def _load_delegate_skills(skills: Optional[List[str]]) -> str:
+    """Load skill content for injection into a child agent's system prompt.
+
+    Reuses the **identical** cron resolution pipeline so delegate_task
+    subagents get the same safety guarantees as cron jobs:
+
+    * Bundle resolution (``resolve_bundle_command_key``) — slash-command
+      bundles expand their members.
+    * Name normalization (``normalize_skill_lookup_name``) — handles
+      ``plugin:skill`` qualified names and trusted absolute paths.
+    * ``skill_view`` + ``bump_use`` — content loading and usage tracking.
+    * Runtime security scan (``_scan_cron_skill_assembled``) — sanitizes
+      invisible unicode and blocks injection directives (closes the
+      #3968 gap for subagent prompts).
+
+    Returns the assembled (and scanned) skill content string, or an
+    empty string if no skills were provided or all failed to load.
+    """
+    if not skills:
+        return ""
+
+    from tools.skills_tool import skill_view
+    from tools.skill_usage import bump_use
+    from agent.skill_bundles import (
+        build_bundle_invocation_message,
+        resolve_bundle_command_key,
+    )
+    from agent.skill_utils import normalize_skill_lookup_name
+    from tools.cronjob_tools import _scan_cron_skill_assembled
+
+    parts: list[str] = []
+    skipped: list[str] = []
+
+    for skill_name in skills:
+        # Mirror cron's bundle resolution so `skills: ["my-bundle"]`
+        # expands bundle members instead of being treated as a missing skill.
+        bundle_key = resolve_bundle_command_key(skill_name.lstrip("/"))
+        if bundle_key:
+            bundle_payload = build_bundle_invocation_message(
+                bundle_key,
+                user_instruction="",
+                task_id=None,
+            )
+            if bundle_payload:
+                bundle_message, _loaded, _missing = bundle_payload
+                if parts:
+                    parts.append("")
+                parts.append(bundle_message)
+                continue
+            logger.warning(
+                "delegate_task: bundle '%s' could not load any skills, skipping",
+                skill_name,
+            )
+            skipped.append(skill_name)
+            continue
+
+        try:
+            loaded = json.loads(
+                skill_view(normalize_skill_lookup_name(skill_name))
+            )
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "delegate_task: skill '%s' returned invalid JSON, skipping",
+                skill_name,
+            )
+            skipped.append(skill_name)
+            continue
+
+        if not loaded.get("success"):
+            error = loaded.get("error") or f"Failed to load skill '{skill_name}'"
+            logger.warning(
+                "delegate_task: skill '%s' not found, skipping — %s",
+                skill_name,
+                error,
+            )
+            skipped.append(skill_name)
+            continue
+
+        # Bump usage so the curator sees this skill as actively used.
+        try:
+            bump_use(skill_name)
+        except Exception:
+            logger.debug(
+                "delegate_task: failed to bump skill usage for '%s'",
+                skill_name,
+                exc_info=True,
+            )
+
+        content = str(loaded.get("content") or "").strip()
+        if parts:
+            parts.append("")
+        parts.extend([
+            f'[IMPORTANT: The user has invoked the "{skill_name}" skill, indicating they want you to follow its instructions. The full skill content is loaded below.]',
+            "",
+            content,
+        ])
+
+    if skipped:
+        notice = (
+            f"[IMPORTANT: The following skill(s) were listed for this job but could not be found "
+            f"and were skipped: {', '.join(skipped)}. "
+            f"Start your response with a brief notice so the user is aware, e.g.: "
+            f"'⚠️ Skill(s) not found and skipped: {', '.join(skipped)}']"
+        )
+        parts.insert(0, notice)
+
+    assembled = "\n".join(parts)
+
+    # Runtime security scan — same as cron's _scan_assembled_cron_prompt.
+    # Sanitizes invisible unicode and blocks injection directives in
+    # vetted skill content (closes #3968 for subagent prompts).
+    cleaned, scan_error = _scan_cron_skill_assembled(assembled)
+    if scan_error:
+        logger.warning(
+            "delegate_task: assembled skill content blocked by injection scanner — %s",
+            scan_error,
+        )
+        # Return a notice so the child agent can surface the block to the
+        # user, rather than silently degrading.  Matches the skipped-skill
+        # notice pattern above for consistent UX.
+        blocked_names = ", ".join(skills)
+        return (
+            f"[IMPORTANT: Skill content for '{blocked_names}' was blocked by "
+            f"the security scanner and omitted. Start your response with a "
+            f"brief notice so the user is aware, e.g.: "
+            f"'⚠️ Skill content blocked by security scanner: {blocked_names}']"
+        )
+    return cleaned
+
+
 def _build_child_system_prompt(
     goal: str,
     context: Optional[str] = None,
@@ -667,6 +823,7 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    skills_content: str = "",
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -675,6 +832,10 @@ def _build_child_system_prompt(
     inspiration/openclaw/src/agents/subagent-system-prompt.ts:63-95).
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
+
+    When skills_content is non-empty, it is injected between the task
+    context and the completion instructions, following the same pattern
+    as cron job skill loading.
     """
     parts = [
         "You are a focused subagent working on a specific delegated task.",
@@ -689,6 +850,8 @@ def _build_child_system_prompt(
             f"{workspace_path}\n"
             "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise."
         )
+    if skills_content and skills_content.strip():
+        parts.append(f"\n{skills_content}")
     parts.append(
         "\nComplete this task using the tools available to you. "
         "When finished, provide a clear, concise summary of:\n"
@@ -1086,6 +1249,9 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Skills to auto-load into the child's system prompt before execution.
+    # Each skill's content is injected verbatim, mirroring cron job behavior.
+    skills: Optional[List[str]] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1188,6 +1354,7 @@ def _build_child_agent(
         child_toolsets.append("delegation")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
+    skills_content = _load_delegate_skills(skills)
     child_prompt = _build_child_system_prompt(
         goal,
         context,
@@ -1195,6 +1362,7 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        skills_content=skills_content,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -2430,19 +2598,25 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    skills: Optional[List[str]] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context and role)
-      - Batch:  provide tasks array [{goal, context, role}, ...]
+      - Single: provide goal (+ optional context, role, skills)
+      - Batch:  provide tasks array [{goal, context, role, skills}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The 'skills' parameter auto-loads named skills into each child's
+    system prompt before execution, mirroring the cron job skills
+    parameter.  Per-task skills are merged with (and take precedence
+    over) top-level skills.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2532,7 +2706,7 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "role": top_role}]
+        task_list = [{"goal": goal, "context": context, "role": top_role, "skills": skills}]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -2606,6 +2780,9 @@ def delegate_task(
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
                 role=effective_role,
+                # Merge per-task skills with top-level skills (per-task takes
+                # precedence; deduplicate while preserving order).
+                skills=_merge_skills(skills, t.get("skills")),
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -3563,6 +3740,17 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "skills": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Per-task skills to load into this child's "
+                                "prompt before execution. Merged with top-level "
+                                "'skills' (per-task takes precedence; duplicates "
+                                "removed). Each skill's content is loaded via "
+                                "the same resolution pipeline as cron jobs."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3586,6 +3774,21 @@ DELEGATE_TASK_SCHEMA = {
                     "the work finishes; just continue working in the meantime. "
                     "Setting this has no effect; the parameter remains only for "
                     "backward compatibility."
+                ),
+            },
+            "skills": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional ordered list of skill names to load into each "
+                    "child agent's prompt before execution, mirroring the cron "
+                    "job 'skills' parameter. The child receives each skill's "
+                    "full content as part of its system prompt via the same "
+                    "resolution pipeline (bundle resolution, name normalization, "
+                    "runtime security scan). Per-task 'skills' in the tasks "
+                    "array are merged with this list (per-task takes precedence, "
+                    "duplicates removed). Pass an empty array to explicitly opt "
+                    "out of skill loading."
                 ),
             },
         },
@@ -3648,6 +3851,7 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
+        skills=args.get("skills"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## What does this PR do?

Adds an optional `skills` parameter to `delegate_task`, mirroring the existing `skills` parameter on `cronjob`. When specified, skill content is automatically loaded and injected into the child agent's system prompt — eliminating the need to write "Load the skill 'X' first with skill_view(name='X')" in every goal/context string.

### Why

Currently, `cronjob` supports `skills: ["odoo-testing", "agent-team"]` to auto-load skills before running a prompt. `delegate_task` has no equivalent — every subagent that needs a skill must be told in the `goal` or `context` string to load it manually. This is:
- **Verbose** — repetitive instructions in every task goal
- **Error-prone** — easy to forget, especially in batch mode with many tasks
- **Inconsistent** — `cronjob` has it, `delegate_task` doesn't

### Design

The implementation follows the same pattern as `cronjob`'s skill loading:
- **Top-level `skills`**: applied to all tasks (single or batch)
- **Per-task `skills`**: in `tasks[]` array, overrides/augments top-level
- **Merge**: `_merge_skills()` deduplicates while preserving order (per-task takes precedence)
- **Loading**: `_load_skills_content()` calls `skill_view()` + `bump_use()`, gracefully handles missing skills
- **Injection**: skills content is injected into the child system prompt before the completion instructions section

### Usage examples

**Single task with skills:**
```python
delegate_task(
    goal="Test the Odoo addon",
    skills=["odoo-testing", "systematic-debugging"]
)
```

**Batch with per-task skills:**
```python
delegate_task(
    skills=["agent-team"],  # all tasks get this
    tasks=[
        {"goal": "Research X", "skills": ["arxiv"]},  # gets agent-team + arxiv
        {"goal": "Build Y", "skills": ["tdd"]},        # gets agent-team + tdd
    ]
)
```

**No skills (backward compatible):**
```python
delegate_task(goal="Summarize this text")  # works exactly as before
```

## Related Issue

No existing issue — discovered during internal usage.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/delegate_tool.py`:
  - Added `_merge_skills()` helper (top-level + per-task merge with dedup)
  - Added `_load_skills_content()` helper (mirrors cron scheduler pattern)
  - Added `skills` parameter to `delegate_task()` and `_build_child_agent()`
  - Threaded `skills` through `_build_child_system_prompt()` as `skills_content`
  - Added `skills` property to top-level and per-task JSON schemas
  - Updated registry handler lambda to forward `skills` from tool args
- `run_agent.py`:
  - Forward `skills` in `_dispatch_delegate_task()`
- `tests/tools/test_delegate_skills.py`:
  - 26 new tests covering `_merge_skills`, `_load_skills_content`, prompt injection, `_build_child_agent`, and schema validation

## How to Test

1. Run the new test suite:
   ```bash
   python -m pytest tests/tools/test_delegate_skills.py -v
   ```
2. Run the existing delegate tests to verify no regressions:
   ```bash
   python -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py tests/tools/test_delegate_composite_toolsets.py tests/tools/test_async_delegation.py -v
   ```
3. Test end-to-end: invoke `delegate_task` with `skills=["agent-team"]` and verify the child agent has the skill content in its system prompt.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope):`)
- [x] I searched for existing PRs — no duplicates found
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/tools/test_delegate*.py -q` and all 199 tests pass (26 new + 173 existing)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04

### Documentation & Housekeeping

- [x] I've updated tool descriptions/schemas — `skills` property added to both top-level and per-task schemas
- [x] I've updated relevant docstrings — N/A (no separate docs, schema is self-documenting)
- [x] I've considered cross-platform impact — N/A (pure Python, no OS-specific code)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture changes)
