### PR TITLE
fix(gateway): detect unloaded launchd service by diagnostic text

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3517,8 +3517,27 @@ _LAUNCHCTL_DOMAIN_UNSUPPORTED_CODES = frozenset({5, 125})
 
 
 def _launchd_error_indicates_unloaded(exc: subprocess.CalledProcessError) -> bool:
-    """True when launchctl failed because the job isn't loaded (retry bootstrap)."""
-    return exc.returncode in _LAUNCHD_JOB_UNLOADED_EXIT_CODES
+    """True when launchctl failed because the job isn't loaded (retry bootstrap).
+
+    launchctl exit codes vary across macOS versions and domains.  Prefer the
+    known numeric codes, but also accept the stable human-readable diagnostics
+    emitted for the same condition so an unrecognized code does not bypass the
+    bootstrap recovery path.
+    """
+    if exc.returncode in _LAUNCHD_JOB_UNLOADED_EXIT_CODES:
+        return True
+    output = "\n".join(
+        str(part or "")
+        for part in (getattr(exc, "stdout", ""), getattr(exc, "stderr", ""))
+    ).lower()
+    return any(
+        marker in output
+        for marker in (
+            "could not find service",
+            "service is not loaded",
+            "no such process",
+        )
+    )
 
 
 def _launchctl_domain_unsupported(returncode: int) -> bool:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -790,6 +790,38 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
+    def test_launchd_start_reloads_on_unloaded_stderr_even_with_unknown_code(
+        self, tmp_path, monkeypatch
+    ):
+        """launchctl diagnostics should trigger bootstrap even if the code changes."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+
+        calls = []
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{label}"
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", target] and calls.count(cmd) == 1:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    78, cmd, stderr='Could not find service "ai.hermes.gateway"'
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_start()
+
+        assert calls == [
+            ["launchctl", "kickstart", target],
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "kickstart", target],
+        ]
+
     def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch, capsys):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"


### PR DESCRIPTION
Summary
- Harden macOS launchd unloaded-service detection by checking launchctl diagnostic text in addition to known exit codes.
- Keeps bootstrap recovery active when launchctl returns an unexpected code with the stable "Could not find service" / unloaded-service message.
- Adds a regression test for the unknown-exit-code + unloaded-service diagnostic path.

Why
- macOS launchctl return codes vary by version/domain. A valid plist can exist while launchd has unloaded the service; kickstart then fails with a diagnostic like "Could not find service".
- Existing recovery handles known codes. This closes the gap where the text clearly says the job is unloaded but the numeric code is not one of the known values.

Tests
- PASS: ./scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -k 'launchd_start_reloads_on_unloaded_stderr_even_with_unknown_code or launchd_start_reloads_unloaded_job_and_retries or launchd_start_reloads_on_kickstart_exit_code_113 or launchd_restart_boots_out_stale_registration_before_bootstrap' -q
- PASS: python3 -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py
- PASS: git diff --check
- NOTE: ./scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py currently fails 6 unrelated systemd tests on this macOS host because user systemd preflight raises UserSystemdUnavailableError before mocked systemctl paths run; launchd-focused tests pass.

Risk
- Low. macOS launchd path only. No systemd or gateway runtime behavior changes unless launchctl already failed and emitted an unloaded-service diagnostic.
