### PR TITLE
fix(gateway): preserve indentation when splitting long messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5316,7 +5316,11 @@ class BasePlatformAdapter(ABC):
                         split_at = safe_split
 
             chunk_body = remaining[:split_at]
-            remaining = remaining[split_at:].lstrip()
+            # Strip only the boundary newline(s), not leading whitespace.
+            # Using bare .lstrip() would also remove the indentation of the
+            # next line, which breaks whitespace-sensitive content like
+            # Python code blocks.  See #54579.
+            remaining = remaining[split_at:].lstrip("\n")
 
             full_chunk = prefix + chunk_body
 


### PR DESCRIPTION
## Problem

When an outbound reply is longer than a platform's per-message limit, `BasePlatformAdapter.truncate_message` splits it into chunks. It already preserves code fences (closes/reopens triple backticks). But when advancing to the next chunk it calls `.lstrip()` on the remainder, which removes not just the boundary newline but also the leading indentation of the next line. The first code line of every continuation chunk arrives de-indented.

This affects Telegram, Discord, WhatsApp, Signal, BlueBubbles, WeChat, QQ, yuanbao, and the streaming consumer's fallback send.

## Root Cause

`gateway/platforms/base.py:5319`:
```python
remaining = remaining[split_at:].lstrip()
```

`split_at` lands on the boundary newline. `.lstrip()` strips that newline together with the next line's indentation.

## Fix

Change `.lstrip()` to `.lstrip("\n")` to only strip boundary newlines, matching the behavior of the sibling splitter `_split_text_chunks` in `gateway/stream_consumer.py`.

**Changes:** 1 file, 5 lines (1 changed + 4 comment).

Fixes #54579