### PR TITLE
fix(providers): resolve plugin-registered providers in resolve_provider_full()

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -762,4 +762,36 @@ def resolve_provider_full(
     except Exception:
         pass
 
+    # 4. Plugin-registered providers (providers/ module registry).
+    #    Providers registered via register_provider() in
+    #    plugins/model-providers/<name>/__init__.py live in the runtime
+    #    registry but not in models.dev or config.yaml.  This step bridges
+    #    the gap so /model, doctor, and --provider all recognise them.
+    try:
+        from providers import get_provider_profile as _get_plugin_profile
+        for _candidate in (canonical, raw):
+            plugin_profile = _get_plugin_profile(_candidate)
+            if plugin_profile is not None:
+                _api_key_vars = tuple(
+                    v for v in plugin_profile.env_vars
+                    if not v.endswith("_BASE_URL") and not v.endswith("_URL")
+                )
+                _base_url_var = next(
+                    (v for v in plugin_profile.env_vars
+                     if v.endswith("_BASE_URL") or v.endswith("_URL")),
+                    None,
+                )
+                return ProviderDef(
+                    id=plugin_profile.name,
+                    name=plugin_profile.display_name or plugin_profile.name,
+                    transport="openai_chat",
+                    api_key_env_vars=_api_key_vars or plugin_profile.env_vars,
+                    base_url=plugin_profile.base_url,
+                    base_url_env_var=_base_url_var or "",
+                    auth_type=plugin_profile.auth_type,
+                    source="plugin",
+                )
+    except Exception:
+        pass
+
     return None


### PR DESCRIPTION
## Problem

`resolve_provider_full()` checks user config, built-in aliases, and models.dev — but **not** the `providers/` module registry where `plugins/model-providers/<name>/` register themselves via `register_provider()`.

This causes two symptoms for any plugin-registered provider (e.g. `abc`):

1. **`/model` picker fails after selection**: the provider appears in the picker list (because `CANONICAL_PROVIDERS` is auto-extended from the same registry), but saving the selection errors with `Unknown provider 'abc'. Check 'hermes model' for available providers, or define it in config.yaml under 'providers:'.` — because `model_switch.py` calls `resolve_provider_full()` and errors on `None`.

2. **`hermes doctor` false positive**: reports `model.provider 'abc' is not a recognised provider` even though the provider appears in the "known" list (because `doctor.py` calls `resolve_provider_full()` and flags `None` as unknown).

Runtime is unaffected — `PROVIDER_REGISTRY` in `auth.py` is auto-extended from the same registry, so `hermes status` and actual inference work fine. The gap is only in `resolve_provider_full()`'s resolution chain.

## Fix

Add step 4 to `resolve_provider_full()` that checks `get_provider_profile()` from the `providers` module and converts the `ProviderProfile` to a `ProviderDef`, mirroring the env-var splitting already done in `auth.py`'s auto-extend block (lines 448–476).

## Verification

```python
# Before fix:
>>> resolve_provider_full("abc", None, None)
None

# After fix:
>>> resolve_provider_full("abc", None, None)
ProviderDef(id='abc', name='ABC AI Gateway', transport='openai_chat',
            api_key_env_vars=('ABC_API_KEY',),
            base_url='http://xxx.com',
            auth_type='api_key', source='plugin')

# Truly unknown providers still return None:
>>> resolve_provider_full("nonexistent-provider-xyz", None, None)
None
```

- `hermes doctor` no longer reports false positive for plugin providers
- `hermes model` / `/model` saves selection successfully
- All 63 existing doctor tests pass (1 pre-existing failure unrelated to this change)