### PR TITLE
fix(state): re-open SessionDB conn when a concurrent close() nulled it

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1051,6 +1051,34 @@ class SessionDB:
                 self._warn_fts5_unavailable(exc)
             return False
 
+    def _ensure_conn_locked(self) -> None:
+        """Re-open the connection if a concurrent close() nulled it. MUST be
+        called holding ``self._lock``.
+
+        ``close()`` (process shutdown / WAL-shrink / restart hooks) sets
+        ``self._conn = None``. A flush thread (e.g. run_agent's session-DB
+        mirror) that started before close but acquires the write lock after it
+        would otherwise call ``None.execute(...)`` → the bug surfaced as
+        repeated ``Session DB append_message failed: 'NoneType' object has no
+        attribute 'execute'`` warnings, dropping that message's DB mirror (the
+        JSON store still has it, so no user-visible data loss, but the searchable
+        copy diverges). Read-only handles never reconnect: they're SELECT-only
+        snapshots and silently re-opening would mask a real lifecycle bug.
+        """
+        if self._conn is not None:
+            return
+        if self.read_only:
+            raise sqlite3.ProgrammingError("Cannot operate on a closed read-only SessionDB")
+        self._conn = sqlite3.connect(
+            str(self.db_path),
+            check_same_thread=False,
+            timeout=1.0,
+            isolation_level=None,
+        )
+        self._conn.row_factory = sqlite3.Row
+        apply_wal_with_fallback(self._conn, db_label="state.db")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+
     def _execute_write(self, fn: Callable[[sqlite3.Connection], T]) -> T:
         """Execute a write transaction with BEGIN IMMEDIATE and jitter retry.
 
@@ -1070,6 +1098,7 @@ class SessionDB:
         for attempt in range(self._WRITE_MAX_RETRIES):
             try:
                 with self._lock:
+                    self._ensure_conn_locked()
                     self._conn.execute("BEGIN IMMEDIATE")
                     try:
                         result = fn(self._conn)

--- a/tests/hermes_state/test_conn_reopen_after_close.py
+++ b/tests/hermes_state/test_conn_reopen_after_close.py
@@ -1,0 +1,45 @@
+"""Regression: writes after a concurrent close() must not raise NoneType.
+
+Repro of the live bug seen on a very long WebUI session: ``close()`` (process
+shutdown / WAL-shrink / restart hook) sets ``self._conn = None``; a late flush
+thread (run_agent's session-DB mirror) then reached ``self._conn.execute(...)``
+and crashed with ``'NoneType' object has no attribute 'execute'``, dropping that
+message's DB mirror (the JSON store still had it — no user-visible loss — but the
+searchable DB copy diverged). The fix: ``_execute_write`` re-opens a nulled
+connection under the lock before BEGIN IMMEDIATE.
+"""
+
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _make_db(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", "test")
+    return db
+
+
+def test_append_after_close_reopens_and_persists(tmp_path):
+    db = _make_db(tmp_path)
+    db.append_message(session_id="s1", role="user", content="before")
+    db.close()
+    assert db._conn is None  # close nulled the handle
+
+    # Late flush after close must NOT raise; it should re-open and write.
+    mid = db.append_message(session_id="s1", role="assistant", content="after")
+    assert isinstance(mid, int) and mid > 0
+    assert db._conn is not None
+
+    rows = db.get_messages("s1")
+    assert [r["content"] for r in rows] == ["before", "after"]
+
+
+def test_readonly_db_does_not_silently_reopen(tmp_path):
+    SessionDB(db_path=tmp_path / "state.db").create_session("s1", "test")
+    ro = SessionDB(db_path=tmp_path / "state.db", read_only=True)
+    ro.close()
+    with pytest.raises(sqlite3.ProgrammingError):
+        ro._ensure_conn_locked()


### PR DESCRIPTION
## Problem

On long-lived / restarting WebUI sessions, the agent logged bursts of:

```
Session DB append_message failed: 'NoneType' object has no attribute 'execute'
```

`SessionDB.close()` (process shutdown, WAL-shrink, restart hooks) sets
`self._conn = None`. A late mirror flush from `run_agent` that started before
`close()` but acquires the write lock *after* it then runs
`self._conn.execute("BEGIN IMMEDIATE")` → `None.execute(...)`. The exception is
caught and warned, so there's **no user-visible data loss** (the JSON store still
has the message), but that message's row never lands in `state.db`, so the
searchable DB copy silently diverges from the JSON transcript.

## Fix

Add `_ensure_conn_locked()`, called under `self._lock` at the top of
`_execute_write`: if the writable connection was nulled by a concurrent
`close()`, re-open it (WAL + foreign_keys re-applied) before `BEGIN IMMEDIATE`.
Read-only handles raise `ProgrammingError` instead of silently reconnecting, so a
genuine read-only lifecycle bug isn't masked.

## Test

`tests/hermes_state/test_conn_reopen_after_close.py`:
- append-after-`close()` re-opens and persists; both rows read back in order
- read-only DB refuses to silently re-open

Built on latest `origin/main` (after #54442 touched this file). 329 tests green:
the new file + `test_hermes_state` + compression-locks + wal-fallback +
`test_13121_shutdown_inflight_transcript_flush`. 2 files, +74 lines, write-path
only.

@NousResearch maintainers — suggest `area:state` / `bug`.
