### PR TITLE
test(windows): harden pid-scan no-window assertion against captured-call leakage

### DIFF
--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -168,7 +168,21 @@ def test_gateway_pid_scan_hides_wmic_and_powershell_windows(monkeypatch):
     monkeypatch.setattr(gateway.subprocess, "run", fake_run)
 
     assert gateway._scan_gateway_pids(set()) == [123]
-    assert [kwargs["creationflags"] for _, kwargs in captured] == [
+    # The wmic probe and the PowerShell fallback are the two console spawns
+    # this scan makes on Windows; both must hide the window via
+    # ``creationflags``. Filter to those two commands (rather than indexing a
+    # positional list) so the contract — "every Windows pid-scan spawn is
+    # windowless" — is asserted directly and can't be tripped by an unrelated
+    # captured call leaking in from prior module-state churn in the same
+    # process. ``.get`` keeps a stray non-windowed call from masking the real
+    # assertion behind a bare KeyError.
+    scan_spawns = [
+        kwargs
+        for cmd, kwargs in captured
+        if cmd and cmd[0] in {"wmic", "powershell", "pwsh"}
+    ]
+    assert len(scan_spawns) == 2, captured
+    assert [kwargs.get("creationflags") for kwargs in scan_spawns] == [
         _CREATE_NO_WINDOW,
         _CREATE_NO_WINDOW,
     ]


### PR DESCRIPTION
## Infographic

![windows-pidscan-flake-hardened](https://v3b.fal.media/files/b/0aa03636/MOlTdKB3WKuVKVZ8Awaep_sXqdZgjv.png)

## Summary

Hardens `test_gateway_pid_scan_hides_wmic_and_powershell_windows` so an intermittent CI flake can't recur as a cryptic `KeyError`.

The test asserts both Windows pid-scan console spawns (the `wmic` probe and the PowerShell fallback) hide their window via `creationflags`. It flaked once in CI (slice 7/8) with `KeyError: 'creationflags'` while passing 15/15 under exact CI-parity locally — the failing run took 2.99s vs ~0.23s, consistent with a loaded runner / stray captured call rather than a code defect.

## Root cause

The assertion indexed the captured `subprocess.run` calls positionally:

```python
[kwargs["creationflags"] for _, kwargs in captured]
```

If anything causes an extra `subprocess.run` to be captured (module-state churn earlier in the same per-file pytest process), the `["creationflags"]` indexing raises a bare `KeyError` that masks the real contract instead of reporting what actually happened.

## Fix

- Filter `captured` to the two intended Windows console commands (`wmic`, `powershell`/`pwsh`).
- Assert exactly two such spawns (`len == 2`, with the full `captured` list in the assertion message).
- Read the flag via `.get("creationflags")` so a stray non-windowed call surfaces as a readable value mismatch, not a `KeyError`.

The behavior contract — *every Windows pid-scan spawn is windowless* — is asserted more directly, not weakened.

## Scope

Test-only. No production code touched. This is a **pre-existing flake on `main`, unrelated** to the Slack group-DM PR (#54663) it surfaced under; shipped as its own PR off `main` per the separate-fix rule.

## Validation

| | Result |
|---|---|
| `tests/test_windows_subprocess_no_window_flags.py` | 15/15 pass |
| Production code | unchanged |
| Change-detector risk | none — asserts a contract, not a snapshot |
