### PR TITLE
fix(telegram): gate active-session dispatch by mention rules

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2677,6 +2677,10 @@ class BasePlatformAdapter(ABC):
         thread replies without explicit mentions).
         """
         self._session_store = session_store
+
+    def _should_dispatch_message_event(self, event: MessageEvent) -> bool:
+        """Final platform gate before an event enters session dispatch."""
+        return True
     
     @abstractmethod
     async def connect(self, *, is_reconnect: bool = False) -> bool:
@@ -4385,6 +4389,10 @@ class BasePlatformAdapter(ABC):
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
+
+        if not self._should_dispatch_message_event(event):
+            logger.debug("[%s] Dropping message before session dispatch: platform gate rejected event", self.name)
+            return
 
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6662,6 +6662,15 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         return self._message_matches_mention_patterns(message)
 
+    def _should_dispatch_message_event(self, event: MessageEvent) -> bool:
+        """Re-apply Telegram trigger rules before active-session dispatch."""
+        if getattr(event, "internal", False):
+            return True
+        raw_message = getattr(event, "raw_message", None)
+        if raw_message is None:
+            return True
+        return self._should_process_message(raw_message, is_command=event.is_command())
+
     async def _ensure_forum_commands(self, message) -> None:
         """Lazy-register bot commands for forum supergroups.
 

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -4,8 +4,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
-from gateway.platforms.base import MessageType
-from gateway.session import SessionSource
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
 
 
 def _make_adapter(
@@ -148,6 +148,58 @@ def _bot_command_entity(text, command):
     """
     offset = text.index(command)
     return SimpleNamespace(type="bot_command", offset=offset, length=len(command))
+
+
+def _message_event_from_group_message(message):
+    return MessageEvent(
+        text=message.text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=str(message.chat.id),
+            chat_type="group",
+            user_id=str(message.from_user.id),
+            user_name=message.from_user.full_name,
+        ),
+        raw_message=message,
+        message_id=str(message.message_id),
+        reply_to_message_id=(
+            str(message.reply_to_message.message_id)
+            if message.reply_to_message is not None
+            else None
+        ),
+    )
+
+
+async def _dispatch_event_during_active_session(adapter, event):
+    adapter._busy_session_handler = None
+    adapter._busy_text_mode = "interrupt"
+    adapter._session_tasks = {}
+    adapter._background_tasks = set()
+    adapter._expected_cancelled_tasks = set()
+    adapter._topic_recovery_fn = None
+
+    session_key = build_session_key(
+        event.source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+
+    async def _active_run():
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(_active_run())
+    adapter._session_tasks[session_key] = task
+    adapter._active_sessions[session_key] = asyncio.Event()
+    try:
+        await adapter.handle_message(event)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    return session_key
 
 
 def test_group_messages_can_be_opened_via_config():
@@ -481,6 +533,58 @@ def test_explicit_multi_bot_mentions_route_only_to_named_bots():
     assert default_bot._should_process_message(_group_message(text, reply_to_bot=True, entities=entities)) is False
     assert research_bot._should_process_message(_group_message(text, entities=entities)) is True
     assert ops_bot._should_process_message(_group_message(text, entities=entities)) is True
+
+
+def test_unmentioned_bot_reply_dropped_during_active_session():
+    async def _run():
+        adapter = _make_adapter(require_mention=True, bot_username="dev_bot")
+
+        message = _group_message(
+            "default bot reply",
+            chat_id=-100,
+            from_user_id=8810308684,
+            from_user_name="Default Bot",
+        )
+        message.from_user.is_bot = True
+        message.reply_to_message = SimpleNamespace(
+            message_id=41,
+            from_user=SimpleNamespace(id=123, is_bot=False),
+            text="user message",
+            caption=None,
+        )
+        assert adapter._should_process_message(message) is False
+
+        event = _message_event_from_group_message(message)
+        session_key = await _dispatch_event_during_active_session(adapter, event)
+
+        adapter._message_handler.assert_not_awaited()
+        assert session_key not in adapter._pending_messages
+
+    asyncio.run(_run())
+
+
+def test_addressed_group_messages_still_queue_during_active_session():
+    async def _run():
+        reply_adapter = _make_adapter(require_mention=True, bot_username="dev_bot")
+        reply_message = _group_message("replying to dev", reply_to_bot=True)
+        assert reply_adapter._should_process_message(reply_message) is True
+        reply_key = await _dispatch_event_during_active_session(
+            reply_adapter,
+            _message_event_from_group_message(reply_message),
+        )
+        assert reply_key in reply_adapter._pending_messages
+
+        mention_adapter = _make_adapter(require_mention=True, bot_username="dev_bot")
+        text = "@dev_bot please continue"
+        mention_message = _group_message(text, entities=[_mention_entity(text, "@dev_bot")])
+        assert mention_adapter._should_process_message(mention_message) is True
+        mention_key = await _dispatch_event_during_active_session(
+            mention_adapter,
+            _message_event_from_group_message(mention_message),
+        )
+        assert mention_key in mention_adapter._pending_messages
+
+    asyncio.run(_run())
 
 
 def test_entityless_multi_bot_mentions_still_route_exclusively():


### PR DESCRIPTION
## Summary

- add a final platform dispatch gate in `BasePlatformAdapter` (default allow)
- have Telegram re-apply `_should_process_message(raw_message)` before an event can enter session dispatch
- cover the active-session regression where an unmentioned bot reply fails `require_mention` but was still queued as a follow-up turn

## Notes

This is intentionally narrower than #54374. It does not add a new `TELEGRAM_ALLOW_BOTS` mode; it keeps Telegram's existing `require_mention` / reply-to-bot / explicit mention / mention-pattern rules authoritative even after a `MessageEvent` has reached the active-session dispatch path.

Fixes #54370.

## Tests

- `TMPDIR=/tmp HERMES_HOME=/tmp/hermes-agent-test-home python3 -m pytest tests/gateway/test_telegram_group_gating.py::test_unmentioned_bot_reply_dropped_during_active_session tests/gateway/test_telegram_group_gating.py::test_addressed_group_messages_still_queue_during_active_session -q`
- `TMPDIR=/tmp HERMES_HOME=/tmp/hermes-agent-test-home python3 -m pytest tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_mention_boundaries.py tests/gateway/test_telegram_text_batching.py -q`
- `python3 -m ruff check gateway/platforms/base.py plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_group_gating.py`
