### PR TITLE
feat(provider): add AnyRouter provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,14 @@
 # LLM_MODEL=anthropic/claude-opus-4.6
 
 # =============================================================================
+# LLM PROVIDER (AnyRouter)
+# =============================================================================
+# AnyRouter — OpenRouter-compatible unified gateway (vendor/model routing slugs)
+# Get your key at: https://anyrouter.dev
+# ANYROUTER_API_KEY=
+# ANYROUTER_BASE_URL=https://anyrouter.dev/api/v1  # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (NovitaAI)
 # =============================================================================
 # NovitaAI — 90+ models, pay-per-use

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -46,7 +46,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "anyrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -54,6 +54,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="OPENROUTER_BASE_URL",
     ),
+    "anyrouter": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("ANYROUTER_API_KEY",),
+        base_url_override="https://anyrouter.dev/api/v1",
+        base_url_env_var="ANYROUTER_BASE_URL",
+    ),
     "nous": HermesOverlay(
         transport="openai_chat",
         auth_type="oauth_device_code",

--- a/plugins/model-providers/anyrouter/__init__.py
+++ b/plugins/model-providers/anyrouter/__init__.py
@@ -1,0 +1,88 @@
+"""AnyRouter provider profile.
+
+AnyRouter (https://anyrouter.dev) is a unified model gateway with an
+OpenAI-style ``/v1`` surface and ``vendor/model`` routing slugs. This profile
+wires the request-shaping that AnyRouter's API actually documents and accepts:
+
+  - ``extra_body.session_id`` — sticky-session id grouping related requests in
+    the Request Logs dashboard (body wins over the ``x-session-id`` header).
+  - ``extra_body.provider`` — request-level routing preferences (only / ignore
+    / order / sort / allow_fallbacks / max_price …).
+  - ``extra_body.reasoning`` — reasoning effort passthrough; AnyRouter
+    translates it to each upstream's native thinking control.
+  - App-attribution headers (``HTTP-Referer`` / ``X-AnyRouter-Title`` /
+    ``X-AnyRouter-Source`` / ``X-AnyRouter-Categories``) so Hermes traffic is
+    credited to the agent in AnyRouter's public app rankings.
+
+See: https://anyrouter.dev/docs/api-reference/chat-completions and
+https://anyrouter.dev/docs/features/app-attribution
+"""
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class AnyRouterProfile(ProviderProfile):
+    """AnyRouter gateway — session, routing-preference, reasoning passthrough."""
+
+    def build_extra_body(
+        self, *, session_id: str | None = None, **context: Any
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if session_id:
+            body["session_id"] = session_id
+        prefs = context.get("provider_preferences")
+        if prefs:
+            body["provider"] = prefs
+        return body
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        supports_reasoning: bool = False,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Forward the reasoning config as ``extra_body.reasoning``.
+
+        AnyRouter accepts the OpenAI-style ``reasoning`` object natively
+        (``effort`` / ``enabled`` / ``exclude`` / ``max_tokens``) and owns the
+        translation to each upstream's thinking control, so the profile simply
+        passes the caller's intent through.
+        """
+        extra_body: dict[str, Any] = {}
+        if supports_reasoning:
+            if reasoning_config is not None:
+                extra_body["reasoning"] = dict(reasoning_config)
+            else:
+                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+        return extra_body, {}
+
+
+anyrouter = AnyRouterProfile(
+    name="anyrouter",
+    env_vars=("ANYROUTER_API_KEY", "ANYROUTER_BASE_URL"),
+    display_name="AnyRouter",
+    description="AnyRouter — OpenRouter-compatible unified model gateway",
+    signup_url="https://anyrouter.dev",
+    base_url="https://anyrouter.dev/api/v1",
+    models_url="https://anyrouter.dev/api/v1/models",
+    # App attribution — credits Hermes traffic in AnyRouter's app rankings.
+    default_headers={
+        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+        "X-AnyRouter-Title": "Hermes Agent",
+        "X-AnyRouter-Source": "cli-agent",
+        "X-AnyRouter-Categories": "cli-agent",
+    },
+    fallback_models=(
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.4",
+        "deepseek/deepseek-chat",
+        "google/gemini-3-flash-preview",
+        "qwen/qwen3-plus",
+    ),
+)
+
+register_provider(anyrouter)

--- a/plugins/model-providers/anyrouter/plugin.yaml
+++ b/plugins/model-providers/anyrouter/plugin.yaml
@@ -1,0 +1,5 @@
+name: anyrouter-provider
+kind: model-provider
+version: 1.0.0
+description: AnyRouter OpenRouter-compatible unified model gateway
+author: AnyRouter

--- a/tests/hermes_cli/test_anyrouter_provider.py
+++ b/tests/hermes_cli/test_anyrouter_provider.py
@@ -1,0 +1,237 @@
+"""Tests for AnyRouter provider support — OpenRouter-compatible aggregator.
+
+AnyRouter is a routing aggregator (vendor/model slugs) registered via a
+provider profile plugin. It auto-wires into auth.py, config.py, models.py,
+and model_metadata.py from the registry, and carries an ``is_aggregator``
+overlay in hermes_cli.providers for routing-slug behavior.
+"""
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_provider,
+    get_api_key_provider_status,
+    resolve_api_key_provider_credentials,
+)
+
+
+_OTHER_PROVIDER_KEYS = (
+    "OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+    "DEEPSEEK_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
+    "NOVITA_API_KEY", "XAI_API_KEY", "GLM_API_KEY", "ZAI_API_KEY",
+)
+
+
+# =============================================================================
+# Provider profile
+# =============================================================================
+
+
+class TestAnyRouterProfile:
+    def test_profile_registered(self):
+        from providers import get_provider_profile
+        p = get_provider_profile("anyrouter")
+        assert p is not None
+        assert p.name == "anyrouter"
+
+    def test_base_url(self):
+        from providers import get_provider_profile
+        assert get_provider_profile("anyrouter").base_url == "https://anyrouter.dev/api/v1"
+
+    def test_models_url(self):
+        from providers import get_provider_profile
+        assert get_provider_profile("anyrouter").models_url == "https://anyrouter.dev/api/v1/models"
+
+    def test_env_vars(self):
+        from providers import get_provider_profile
+        assert get_provider_profile("anyrouter").env_vars == (
+            "ANYROUTER_API_KEY", "ANYROUTER_BASE_URL",
+        )
+
+
+# =============================================================================
+# Aggregator routing
+# =============================================================================
+
+
+class TestAnyRouterAggregator:
+    def test_overlay_is_aggregator(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert "anyrouter" in HERMES_OVERLAYS
+        overlay = HERMES_OVERLAYS["anyrouter"]
+        assert overlay.is_aggregator
+        assert overlay.transport == "openai_chat"
+        assert overlay.base_url_override == "https://anyrouter.dev/api/v1"
+        assert overlay.base_url_env_var == "ANYROUTER_BASE_URL"
+
+    def test_is_aggregator_helpers(self):
+        from hermes_cli.providers import is_aggregator, is_routing_aggregator
+        assert is_aggregator("anyrouter")
+        # Routing aggregator: selecting a model re-routes to other vendors'
+        # endpoints, so the picker must treat it like OpenRouter (not a
+        # flat-namespace reseller).
+        assert is_routing_aggregator("anyrouter")
+
+    def test_get_provider(self):
+        from hermes_cli.providers import get_provider
+        pd = get_provider("anyrouter")
+        assert pd is not None
+        assert pd.id == "anyrouter"
+        assert pd.is_aggregator
+        assert pd.base_url == "https://anyrouter.dev/api/v1"
+        assert pd.api_key_env_vars == ("ANYROUTER_API_KEY",)
+
+
+# =============================================================================
+# Aliases / normalization
+# =============================================================================
+
+
+class TestAnyRouterNormalization:
+    def test_normalize_providers_py(self):
+        from hermes_cli.providers import normalize_provider
+        assert normalize_provider("anyrouter") == "anyrouter"
+
+    def test_normalize_models_py(self):
+        from hermes_cli.models import normalize_provider
+        assert normalize_provider("anyrouter") == "anyrouter"
+
+
+# =============================================================================
+# Registry auto-wiring
+# =============================================================================
+
+
+class TestAnyRouterRegistry:
+    def test_in_provider_registry(self):
+        assert "anyrouter" in PROVIDER_REGISTRY
+        cfg = PROVIDER_REGISTRY["anyrouter"]
+        assert cfg.auth_type == "api_key"
+        assert cfg.inference_base_url == "https://anyrouter.dev/api/v1"
+        assert cfg.api_key_env_vars == ("ANYROUTER_API_KEY",)
+        assert cfg.base_url_env_var == "ANYROUTER_BASE_URL"
+
+    def test_canonical_provider_entry(self):
+        from hermes_cli.models import CANONICAL_PROVIDERS
+        assert "anyrouter" in [p.slug for p in CANONICAL_PROVIDERS]
+
+    def test_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["anyrouter"] == "AnyRouter"
+
+    def test_env_vars_surfaced_in_config(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+        assert "ANYROUTER_API_KEY" in OPTIONAL_ENV_VARS
+        assert "ANYROUTER_BASE_URL" in OPTIONAL_ENV_VARS
+
+    def test_prefix_recognized(self):
+        from agent.model_metadata import _PROVIDER_PREFIXES
+        assert "anyrouter" in _PROVIDER_PREFIXES
+
+    def test_url_to_provider(self):
+        from agent.model_metadata import _URL_TO_PROVIDER
+        assert _URL_TO_PROVIDER.get("anyrouter.dev") == "anyrouter"
+
+
+# =============================================================================
+# Credentials
+# =============================================================================
+
+
+class TestAnyRouterCredentials:
+    def test_status_configured(self, monkeypatch):
+        monkeypatch.setenv("ANYROUTER_API_KEY", "ar-test")
+        assert get_api_key_provider_status("anyrouter")["configured"]
+
+    def test_status_not_configured(self, monkeypatch):
+        monkeypatch.delenv("ANYROUTER_API_KEY", raising=False)
+        assert not get_api_key_provider_status("anyrouter")["configured"]
+
+    def test_openrouter_key_does_not_configure_anyrouter(self, monkeypatch):
+        """An OpenRouter key must NOT make AnyRouter look configured."""
+        monkeypatch.delenv("ANYROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        assert not get_api_key_provider_status("anyrouter")["configured"]
+
+    def test_resolve_credentials(self, monkeypatch):
+        monkeypatch.setenv("ANYROUTER_API_KEY", "ar-direct-key")
+        monkeypatch.delenv("ANYROUTER_BASE_URL", raising=False)
+        creds = resolve_api_key_provider_credentials("anyrouter")
+        assert creds["api_key"] == "ar-direct-key"
+        assert creds["base_url"] == "https://anyrouter.dev/api/v1"
+
+    def test_custom_base_url_override(self, monkeypatch):
+        monkeypatch.setenv("ANYROUTER_API_KEY", "ar-x")
+        monkeypatch.setenv("ANYROUTER_BASE_URL", "https://proxy.anyrouter.example/v1")
+        creds = resolve_api_key_provider_credentials("anyrouter")
+        assert creds["base_url"] == "https://proxy.anyrouter.example/v1"
+
+    def test_resolve_provider_with_key(self, monkeypatch):
+        for key in _OTHER_PROVIDER_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("ANYROUTER_API_KEY", "ar-test-12345")
+        assert resolve_provider("anyrouter") == "anyrouter"
+
+
+# =============================================================================
+# Request building — OpenRouter-compatible passthrough
+# =============================================================================
+
+
+class TestAnyRouterRequestBuilding:
+    def _profile(self):
+        from providers import get_provider_profile
+        return get_provider_profile("anyrouter")
+
+    def test_session_id_passthrough(self):
+        """session_id is AnyRouter's sticky-session id (body wins over header)."""
+        body = self._profile().build_extra_body(session_id="s1")
+        assert body["session_id"] == "s1"
+
+    def test_provider_preferences_passthrough(self):
+        body = self._profile().build_extra_body(
+            session_id="s1", provider_preferences={"sort": "ttft"}
+        )
+        assert body["session_id"] == "s1"
+        assert body["provider"] == {"sort": "ttft"}
+
+    def test_no_session_no_prefs(self):
+        assert self._profile().build_extra_body() == {}
+
+    def test_reasoning_passthrough(self):
+        """AnyRouter accepts the reasoning object natively — pass it through."""
+        extra_body, top = self._profile().build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            supports_reasoning=True,
+            model="anthropic/claude-sonnet-4.6",
+        )
+        assert extra_body["reasoning"] == {"enabled": True, "effort": "high"}
+        assert top == {}
+
+    def test_reasoning_default_when_enabled_without_config(self):
+        extra_body, _ = self._profile().build_api_kwargs_extras(
+            reasoning_config=None, supports_reasoning=True, model="openai/gpt-5.4"
+        )
+        assert extra_body["reasoning"] == {"enabled": True, "effort": "medium"}
+
+    def test_reasoning_omitted_when_unsupported(self):
+        extra_body, top = self._profile().build_api_kwargs_extras(
+            reasoning_config={"effort": "high"}, supports_reasoning=False,
+        )
+        assert extra_body == {}
+        assert top == {}
+
+
+# =============================================================================
+# App attribution
+# =============================================================================
+
+
+class TestAnyRouterAppAttribution:
+    def test_attribution_headers(self):
+        """Hermes traffic is credited in AnyRouter's app rankings."""
+        from providers import get_provider_profile
+        headers = get_provider_profile("anyrouter").default_headers
+        assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
+        assert headers["X-AnyRouter-Title"] == "Hermes Agent"
+        assert headers["X-AnyRouter-Source"] == "cli-agent"
+        assert headers["X-AnyRouter-Categories"] == "cli-agent"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -20,6 +20,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
+| **AnyRouter** | `ANYROUTER_API_KEY` in `~/.hermes/.env` (provider: `anyrouter`; OpenRouter-compatible gateway, `vendor/model` routing slugs) |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -16,6 +16,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `OPENROUTER_BASE_URL` | Override the OpenRouter-compatible base URL |
 | `HERMES_OPENROUTER_CACHE` | Enable OpenRouter response caching (`1`/`true`/`yes`/`on`). Overrides `openrouter.response_cache` in config.yaml. See [Response Caching](https://openrouter.ai/docs/guides/features/response-caching). |
 | `HERMES_OPENROUTER_CACHE_TTL` | Cache TTL in seconds (1-86400). Overrides `openrouter.response_cache_ttl` in config.yaml. |
+| `ANYROUTER_API_KEY` | AnyRouter API key — OpenRouter-compatible unified gateway ([anyrouter.dev](https://anyrouter.dev)) |
+| `ANYROUTER_BASE_URL` | Override AnyRouter base URL (default: `https://anyrouter.dev/api/v1`) |
 | `NOUS_BASE_URL` | Override Nous Portal base URL (rarely needed; development/testing only) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference endpoint directly |
 | `OPENAI_API_KEY` | API key for custom OpenAI-compatible endpoints (used with `OPENAI_BASE_URL`) |


### PR DESCRIPTION
## What & why

Adds **AnyRouter** (https://anyrouter.dev) as a first-class inference provider — a unified model gateway with an OpenAI-style `/v1` surface and `vendor/model` routing slugs, so Claude / GPT / DeepSeek / Qwen models route through it from a single key.

Configure with `ANYROUTER_API_KEY` in `~/.hermes/.env` (base URL `https://anyrouter.dev/api/v1`, overridable via `ANYROUTER_BASE_URL`).

## How it's wired

Built on the `plugins/model-providers/` profile system, so most of the integration auto-wires from the registry (`auth.py`, `config.py`, `models.py`, `model_metadata.py`) with no edits to those files.

The profile's request shaping is grounded in AnyRouter's documented API contract (`/docs/api-reference/chat-completions`, `/docs/features/app-attribution`):

- **`extra_body.session_id`** — sticky-session id grouping related requests in the Request Logs dashboard.
- **`extra_body.provider`** — request-level routing preferences (`only` / `ignore` / `order` / `sort` / `allow_fallbacks` / `max_price`).
- **`extra_body.reasoning`** — reasoning effort passthrough; AnyRouter accepts the OpenAI-style `reasoning` object natively and translates it to each upstream's thinking control, so the profile forwards the caller's intent rather than reimplementing per-upstream workarounds.
- **App-attribution headers** (`HTTP-Referer` / `X-AnyRouter-Title` / `X-AnyRouter-Source` / `X-AnyRouter-Categories`) via `default_headers`, so Hermes traffic is credited to the agent in AnyRouter's public app rankings.

Plus:
- **`hermes_cli/providers.py`** — `HERMES_OVERLAYS` entry flagging `is_aggregator=True` (routing-slug behavior; the profile dataclass has no aggregator field).
- **`agent/model_metadata.py`** — recognizes the `anyrouter` provider prefix.
- **`.env.example`** + website provider / environment-variable reference docs.

## Tests

`tests/hermes_cli/test_anyrouter_provider.py` — 28 tests covering the profile, aggregator routing, registry auto-wiring (PROVIDER_REGISTRY, canonical list, labels, config env vars, URL→provider, prefixes), credential resolution, request building (session id, routing preferences, reasoning passthrough), and app attribution headers.

```
28 passed
```

## Platforms

Pure-Python registry/config change, no OS-specific code paths. Tested on macOS.