### PR TITLE
fix(qqbot): accept is_reconnect kwarg in QQAdapter.connect (closes #54679)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,16 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        ``is_reconnect`` matches the :meth:`PlatformAdapter.connect` contract so
+        the gateway can forward it on watcher-driven reconnects (#54679). QQ
+        manages its own session resume/replay inside the listen loop via op 6
+        Resume, so the flag is accepted for signature compatibility and does not
+        alter the cold-boot handshake here.
+        """
+        del is_reconnect  # accepted for PlatformAdapter.connect compatibility
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2220,3 +2220,35 @@ class TestReadEventsClosedWsGuard:
         adapter._ws = None
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
+
+
+class TestConnectAcceptsIsReconnect:
+    """Regression for #54679: the gateway's _connect_adapter_with_timeout
+    forwards ``is_reconnect`` to ``adapter.connect(is_reconnect=...)`` on a
+    watcher-driven reconnect. QQAdapter.connect() previously had the bare
+    signature ``async def connect(self)`` and raised
+    ``TypeError: connect() got an unexpected keyword argument 'is_reconnect'``,
+    so QQ never recovered after a disconnect. The signature must accept the
+    keyword to honor the PlatformAdapter.connect contract."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    def test_connect_signature_accepts_is_reconnect_keyword(self):
+        import inspect
+        from gateway.platforms.qqbot import QQAdapter
+        sig = inspect.signature(QQAdapter.connect)
+        assert "is_reconnect" in sig.parameters
+        param = sig.parameters["is_reconnect"]
+        # Matches the base contract: keyword-only with a False default.
+        assert param.kind == inspect.Parameter.KEYWORD_ONLY
+        assert param.default is False
+
+    def test_connect_does_not_raise_typeerror_on_is_reconnect(self):
+        # Missing deps short-circuit connect() to a graceful False return
+        # before any network I/O — but only if the kwarg is accepted at all.
+        adapter = self._make_adapter()
+        with mock.patch("gateway.platforms.qqbot.adapter.AIOHTTP_AVAILABLE", False):
+            result = asyncio.run(adapter.connect(is_reconnect=True))
+        assert result is False


### PR DESCRIPTION
Closes #54679.

## Root Cause

**Symptom** — After updating to v0.17.0, the QQ Bot never recovers after a disconnection. On the watcher-driven reconnect it crashes with `TypeError: connect() got an unexpected keyword argument 'is_reconnect'`.

**Root cause** — `gateway/run.py::_connect_adapter_with_timeout()` forwards `is_reconnect` to every adapter via `adapter.connect(is_reconnect=is_reconnect)` (lines 3194/3197), and `_PlatformAdapter.connect` declares the contract `async def connect(self, *, is_reconnect: bool = False)` (gateway/platforms/base.py:2675). `QQAdapter.connect` was the lone token-platform adapter still on the bare signature `async def connect(self)` (gateway/platforms/qqbot/adapter.py:281), so the forwarded keyword raised `TypeError` and the reconnect path aborted.

**Evidence** — `grep is_reconnect gateway/platforms/*.py` shows signal/weixin/whatsapp_cloud/bluebubbles/yuanbao/webhook/msgraph_webhook/api_server all accept the keyword; qqbot did not. The cold-boot first connect worked (the gateway only passes `is_reconnect=True` from the watcher at run.py:7009), which matches the reporter's "fails on reconnect" symptom exactly.

**Fix + why this level** — Align `QQAdapter.connect` with the `PlatformAdapter.connect` contract (`*, is_reconnect: bool = False`). QQ manages its own session resume/replay inside the listen loop via op 6 Resume (`_send_resume`, tracking `_session_id`/`_last_seq`), so the cold-boot handshake itself is unchanged; the flag is accepted for signature compatibility. Fixing at the adapter signature (rather than wrapping the call site in `try/except TypeError` in run.py) is correct because the base contract already mandates this signature for all adapters — the call site is right, the adapter was the outlier.

**Scope / risk** — One-line signature change plus a docstring note in qqbot/adapter.py. No behavioral change to the handshake; `is_reconnect` is intentionally not consumed because QQ resume is handled in the listen loop, not at connect. No other adapter touched.

## Tests

Added `TestConnectAcceptsIsReconnect` in `tests/gateway/test_qqbot.py`:
- `test_connect_signature_accepts_is_reconnect_keyword` — asserts the param exists, is keyword-only, defaults False.
- `test_connect_does_not_raise_typeerror_on_is_reconnect` — calls `connect(is_reconnect=True)` (deps short-circuited) and asserts a graceful `False`, not a `TypeError`.

Both FAIL without the fix (TypeError) and pass with it.

```
$ .venv/bin/python -m pytest tests/gateway/test_qqbot.py -q
163 passed, 4 warnings in 3.49s

# without fix (signature reverted to `async def connect(self)`):
FAILED tests/gateway/test_qqbot.py::TestConnectAcceptsIsReconnect::test_connect_signature_accepts_is_reconnect_keyword
FAILED tests/gateway/test_qqbot.py::TestConnectAcceptsIsReconnect::test_connect_does_not_raise_typeerror_on_is_reconnect
2 failed in 0.25s
```