### PR TITLE
fix(whatsapp): strip device-id suffix in JID normalization

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -122,8 +122,10 @@ class WhatsAppBehaviorMixin:
         if not value:
             return ""
         normalized = str(value).strip()
-        if ":" in normalized and "@" in normalized:
-            normalized = normalized.replace(":", "@", 1)
+        # Strip the :device-id segment (e.g. "123:38@lid" -> "123@lid") instead
+        # of turning the first ":" into "@", which produced the invalid
+        # "123@38@lid". Mirrors normalizeWhatsAppIdentifier() in allowlist.js.
+        normalized = re.sub(r":.*@", "@", normalized)
         return normalized
 
     @staticmethod

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -156,7 +156,10 @@ function trackSentMessageId(sent) {
 
 function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  // Strip the :device-id segment (e.g. "123:38@lid" -> "123@lid") instead of
+  // turning the first ':' into '@', which produced the invalid "123@38@lid".
+  // Mirrors normalizeWhatsAppIdentifier() in allowlist.js.
+  return String(value).replace(/:.*@/, '@');
 }
 
 function getMessageContent(msg) {


### PR DESCRIPTION
Two JID normalizers mangle identifiers carrying a device-id suffix (e.g. "123:38@lid"):

  - gateway/platforms/whatsapp_common.py _normalize_whatsapp_id: str.replace(":", "@", 1)  ->  "123@38@lid"
  - scripts/whatsapp-bridge/bridge.js normalizeWhatsAppId: String(value).replace(":", "@")  ->  "123@38@lid"

The second "@" yields an invalid JID, so config-provided JIDs (with the device suffix) no longer match bridge output (stripped), breaking allowlist/policy gating and self-chat detection.

The repo's own scripts/whatsapp-bridge/allowlist.js normalizeWhatsAppIdentifier already strips this correctly via .replace(/:.*@/, '@') (covered by allowlist.test.mjs). Align both stragglers with that behavior so "123:38@lid" -> "123@lid" and suffix-free JIDs pass through unchanged.

Verified: allowlist.test.mjs passes 5/5; both functions return the expected normalized JID on the device-suffix cases.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

