### PR TITLE
fix(ci): ignore arm64 cache-to errors on fork PRs (#54674)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -191,7 +191,15 @@ jobs:
           build-args: |
             HERMES_GIT_SHA=${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64
-          cache-to: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64,mode=max
+          # ignore-error: fork PRs get a read-only GITHUB_TOKEN regardless of
+          # the workflow's `permissions: packages: write` declaration, so the
+          # cache-to export to ghcr.io is denied and — without ignore-error —
+          # fails the whole job even though the image build and tests succeed.
+          # The github.repository == 'NousResearch/hermes-agent' guard on this
+          # job doesn't help: a fork→upstream PR runs in the upstream repo's
+          # context, so the guard passes. Same-repo events still write the
+          # cache normally; fork PRs simply skip the cache write.
+          cache-to: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64,mode=max,ignore-error=true
 
       - name: Install uv for docker tests
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0


### PR DESCRIPTION
## What Problem This Solves

Closes #54674.

Every PR opened from a fork currently shows a red ❌ on the `Build&Test Docker image / build-arm64` check, even though the image build and integration tests both succeed. The job dies on the last action — writing the build cache to `ghcr.io` — because GitHub issues a **read-only** `GITHUB_TOKEN` to fork PRs, regardless of the `permissions: packages: write` declaration at the top of the workflow:

```
#52 exporting cache to registry
#52 ERROR: error writing layer blob: denied: installation not allowed to Write organization package
```

The job's existing `if: github.repository == 'NousResearch/hermes-agent'` guard does not help: a fork→upstream PR runs in the upstream repo's context, so `github.repository` is `NousResearch/hermes-agent` and the job runs anyway. The same-repo `build-amd64` job is unaffected because it uses the `gha` cache backend, which works with a read-only token.

Impact: every external contributor's PR shows a failing `build-arm64` check, and maintainers have to manually explain "this one's expected" on each one (e.g. #54645).

## Why This Change Was Made

Add `ignore-error=true` to the **build step's** `cache-to` line so the registry cache export failure becomes non-fatal. This is option 1 from the issue report — smallest bounded fix that respects the existing cache design.

- Same-repo events (push to main, release, same-repo PRs) keep full read/write on the registry cache — no behavior change.
- Fork PRs skip the cache write but the image build and `tests/docker/` suite still run to completion.
- The push-by-digest step (line 237) is untouched because it's already gated to push/release events where the token has write permission.

The other options from the issue (conditional cache-to gated on `github.event.pull_request.head.repo.full_name`, or skipping the whole job for fork PRs) are more surgical but require new expression branches. `ignore-error=true` is a one-line change with the same effective behavior: the build/tests complete, the cache just isn't written from forks.

## User Impact

External contributors see a green `build-arm64` check on their PRs instead of a confusing red ❌ on a job they didn't touch. Maintainers no longer need to manually explain the failure on each fork PR. The arm64 registry cache continues to be populated by same-repo events (push to main, release) and read by all events — the existing cold-build-cache-outliving-SAS-token protection is preserved.

## Evidence

- Reproducer: the workflow run linked from #54674 (fork PR #54645) shows the cache export denial ending with "installation not allowed to Write organization package" on the `Build image (arm64, cached publish)` step, with the GITHUB_TOKEN scoped to `Packages: read`.
- YAML validated locally via `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker.yml'))"`.
- Diff is one logical line (the `cache-to` value) plus an inline comment explaining the failure mode for future readers; no other workflow changes.

The diagnosis and fix shape were originally proposed by @PRATHAMESH75 in #54674 — credit to them.
