### PR TITLE
docs: overnight documentation sweep

### DIFF
--- a/SECURITY.es.md
+++ b/SECURITY.es.md
@@ -173,9 +173,11 @@ modelo de autorización, pero las reglas a continuación se aplican uniformement
 
 **Superficies en Hermes Agent:**
 
-- **Adaptadores de plataforma del gateway.** Integraciones de mensajería en
-  `gateway/platforms/` (Telegram, Discord, Slack, email, SMS, etc.)
-  y adaptadores análogos incluidos como plugins.
+- **Adaptadores de plataforma del gateway.** Integraciones de mensajería —
+  principalmente `plugins/platforms/<name>/adapter.py`, más adaptadores legacy
+  directos y tipos compartidos en `gateway/platforms/` (Telegram, Discord,
+  Slack, email, SMS, etc. se distribuyen como plugins; `base.py` y algunas
+  rutas legacy permanecen en el árbol).
 - **Superficies HTTP expuestas en red.** El adaptador del servidor API, el
   plugin del dashboard, los endpoints HTTP del plugin kanban, y cualquier
   otro plugin que vincule un socket de escucha.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -177,9 +177,10 @@ authorization model, but the rules below apply uniformly.
 
 **Surfaces in Hermes Agent:**
 
-- **Gateway platform adapters.** Messaging integrations in
-  `gateway/platforms/` (Telegram, Discord, Slack, email, SMS, etc.)
-  and analogous adapters shipped as plugins.
+- **Gateway platform adapters.** Messaging integrations — mostly
+  `plugins/platforms/<name>/adapter.py`, plus legacy direct adapters and
+  shared types under `gateway/platforms/` (Telegram, Discord, Slack, email,
+  SMS, etc. ship as plugins; `base.py` and a few legacy paths remain in-tree).
 - **Network-exposed HTTP surfaces.** The API server adapter, the
   dashboard plugin, the kanban plugin's HTTP endpoints, and any
   other plugin that binds a listening socket.

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -21,7 +21,8 @@ The messaging gateway is the long-running process that connects Hermes to 20+ ex
 | `gateway/mirror.py` | Cross-session message mirroring for `send_message` |
 | `gateway/status.py` | Token lock management for profile-scoped gateway instances |
 | `gateway/builtin_hooks/` | Extension point for always-registered hooks (none shipped) |
-| `gateway/platforms/` | Platform adapters (one per messaging platform) |
+| `gateway/platform_registry.py` | Adapter registry; plugin platforms register deferred loaders so SDKs import only when needed |
+| `gateway/platforms/` | Shared `BasePlatformAdapter` (`base.py`) and legacy direct adapters (e.g. Signal); most chat platforms live under `plugins/platforms/` |
 
 ## Architecture Overview
 
@@ -143,7 +144,7 @@ Unlike the CLI (which uses `load_cli_config()` with hardcoded defaults), the gat
 
 ## Platform Adapters
 
-Most messaging platforms ship as plugin adapters under `plugins/platforms/<name>/adapter.py`; a few legacy adapters still live directly in `gateway/platforms/`. All extend `BasePlatformAdapter` from `gateway/platforms/base.py`:
+Most messaging platforms ship as plugin adapters under `plugins/platforms/<name>/adapter.py`; a few legacy adapters still live directly in `gateway/platforms/`. All extend `BasePlatformAdapter` from `gateway/platforms/base.py`. At plugin discovery time, bundled platform plugins register **deferred loaders** in `gateway/platform_registry.py` so heavy SDK imports run only when a platform is actually started, used for delivery, or listed in setup/status — plain `hermes chat` does not eagerly import every adapter.
 
 ```text
 plugins/platforms/                  # plugin-packaged adapters (one dir each)

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -72,7 +72,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/personality` | Set a predefined personality |
 | `/verbose` | Cycle tool progress display: off → new → all → verbose. Can be [enabled for messaging](#notes) via config. |
 | `/fast [normal\|fast\|status]` | Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode. Options: `normal`, `fast`, `status`. |
-| `/reasoning` | Manage reasoning effort and display (usage: /reasoning [level\|show\|hide]) |
+| `/reasoning` | Manage reasoning effort and display (usage: /reasoning [level\|show\|hide\|full\|clamp]). Levels include `none`, `minimal`, `low`, `medium`, `high`, `xhigh`. `full` shows complete reasoning blocks when the model returns them; `clamp` trims long reasoning for display. |
 | `/skin` | Show or change the display skin/theme |
 | `/statusbar` (alias: `/sb`) | Toggle the context/model status bar on or off |
 | `/voice [on\|off\|tts\|status]` | Toggle CLI voice mode and spoken playback. Recording uses `voice.record_key` (default: `Ctrl+B`). |
@@ -223,7 +223,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/usage` | Show token usage, estimated cost breakdown (input/output), context window state, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits pulled live from the provider's API. |
 | `/credits` | Show your Nous credit balance and a top-up link that opens the portal billing page in a browser. |
 | `/insights [days]` | Show usage analytics. |
-| `/reasoning [level\|show\|hide]` | Change reasoning effort or toggle reasoning display. |
+| `/reasoning [level\|show\|hide\|full\|clamp]` | Change reasoning effort or toggle reasoning display (`full` / `clamp` control how much reasoning text is shown). |
 | `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | Control spoken replies in chat. `join`/`channel`/`leave` manage Discord voice-channel mode. |
 | `/rollback [number]` | List or restore filesystem checkpoints. |
 | `/background <prompt>` | Run a prompt in a separate background session. Results are delivered back to the same chat when the task finishes. See [Messaging Background Sessions](/user-guide/messaging/#background-sessions). |
@@ -251,7 +251,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 
 ## Notes
 
-- `/skin`, `/snapshot`, `/reload`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/platforms`, `/paste`, `/image`, `/statusbar`, `/plugins`, `/busy`, `/indicator`, `/redraw`, `/clear`, `/history`, `/save`, `/copy`, `/handoff`, `/billing`, and `/quit` are **CLI-only** commands.
+- `/skin`, `/snapshot`, `/reload`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/platforms`, `/paste`, `/image`, `/statusbar`, `/plugins`, `/busy`, `/indicator`, `/redraw`, `/clear`, `/history`, `/save`, `/copy`, `/handoff`, `/billing`, `/prompt` (alias `/compose`), `/timestamps` (alias `/ts`), and `/quit` are **CLI-only** commands.
 - `/skills` is **CLI-only for search/browse/install**; its write-approval review subcommands (`pending`, `approve`, `reject`, `diff`, `approval`) also work on messaging platforms when `skills.write_approval` is on. `/memory` works on **both** surfaces.
 - `/verbose` is **CLI-only by default**, but can be enabled for messaging platforms by setting `display.tool_progress_command: true` in `config.yaml`. When enabled, it cycles the `display.tool_progress` mode and saves to config.
 - `/sethome`, `/update`, `/restart`, `/approve`, `/deny`, `/topic`, `/platform`, and `/commands` are **messaging-only** commands.

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -40,6 +40,10 @@ By default the curator only **prunes** — the deterministic inactivity pass mar
 
 Pinned skills are off-limits to both the curator's auto-transitions and the agent's own `skill_manage` tool. See [Pinning a skill](#pinning-a-skill) below.
 
+**Cron-referenced skills** are treated like pinned for automatic transitions: if any cron job (including paused or disabled jobs) lists a skill in its invocation, the curator will not mark it stale or archive it — resuming or the next fire must still find the skill on disk. When consolidation merges a skill into an umbrella, the curator rewrites cron job skill references to follow the new name.
+
+**Never-used skills** (`use_count == 0`) are not archived until they are at least `stale_after_days` old. Zero uses means absence of evidence, not proof the skill is obsolete — a recently created skill may simply not have matched its trigger yet.
+
 ## Configuration
 
 All settings live in `config.yaml` under `curator:` (not `.env` — this isn't a secret). Defaults:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/gateway-internals.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/gateway-internals.md
@@ -21,7 +21,8 @@ description: "消息 gateway 如何启动、授权用户、路由会话以及投
 | `gateway/mirror.py` | 为 `send_message` 提供跨会话消息镜像 |
 | `gateway/status.py` | 面向 profile 范围的 gateway 实例的 token 锁管理 |
 | `gateway/builtin_hooks/` | 始终注册的 hook 扩展点（当前未内置任何 hook） |
-| `gateway/platforms/` | 平台适配器（每个消息平台一个） |
+| `gateway/platform_registry.py` | 适配器注册表；插件平台注册延迟加载器，仅在需要时才导入 SDK |
+| `gateway/platforms/` | 共享的 `BasePlatformAdapter`（`base.py`）与少量 legacy 直接适配器；多数聊天平台位于 `plugins/platforms/` |
 
 ## 架构概览
 


### PR DESCRIPTION
## Summary
- Reviewed the full codebase for documentation drift against `origin/main` (local main was 308 commits behind; branch created from `origin/main`).
- Updated documentation to match current implementation (plugin platform adapters, deferred registry loading, slash-command registry, curator invariants).
- Saved run progress in `/tmp/overnight-docs-sweep.md`.

## Sweep window
- From: `2026-06-28 00:00`
- To: `2026-06-29 00:00` (host local TZ)

## Recent changes reviewed
- `27f03243a` fix(dashboard): stop ElevenLabs voice-list 401 log spam
- `95f2919f9` perf(startup): lazy-load gateway platform adapters (#54448)
- `4c2961c51` fix(curator): never archive cron-referenced skills + floor use=0 pruning (#54443)
- `b31b0b9d9` docs: reconcile docs with code across last 3 releases (#54254)
- Plus ~35 additional commits in the window (desktop remote picker, Windows console fixes, gateway session persistence, etc.)

## Documentation checked
- `hermes_cli/commands.py` ↔ `website/docs/reference/slash-commands.md`
- `gateway/platform_registry.py`, `plugins/platforms/` ↔ `website/docs/developer-guide/gateway-internals.md`, `SECURITY.md`, `SECURITY.es.md`
- `agent/curator.py` ↔ `website/docs/user-guide/features/curator.md`
- Drift checklist: `skills/.../overnight-docs-sweep/references/hermes-agent-drift-checklist.md`

## Documentation updated
- `website/docs/developer-guide/gateway-internals.md` — Key Files table + deferred platform loader behavior
- `website/i18n/zh-Hans/.../gateway-internals.md` — Key Files table (en sync)
- `SECURITY.md`, `SECURITY.es.md` — gateway external-surface adapter paths
- `website/docs/reference/slash-commands.md` — `/reasoning` `full`/`clamp`; CLI-only `/prompt`, `/timestamps`
- `website/docs/user-guide/features/curator.md` — cron-referenced skills + `use_count == 0` grace

## Verification
- `git diff --check` — passed
- `npm run docs:build` — skipped: script not configured
- `npm run build` (website/) — failed: `docusaurus: not found` (node_modules not installed in this environment)

## Open questions / risks
- Operator machine had unrelated dirty `apps/desktop/electron/main.cjs` — stashed before branching; pop stash on `main` after sweep.
- zh-Hans gateway-internals Platform Adapters prose not fully re-translated (Key Files table only).

## Autoreview
- Docs-only diff; no secrets or `/tmp` paths committed.
- Claims grounded in `commands.py`, `platform_registry.py`, `curator.py`, and existing gateway-internals Platform Adapters section.