### PR TITLE
fix: respect disabled Home Assistant gateway config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1485,11 +1485,17 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if hass_token:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
+        ha_config = config.platforms[Platform.HOMEASSISTANT]
+        ha_explicitly_disabled = (
+            not ha_config.enabled
+            and bool((ha_config.extra or {}).get("_enabled_explicit", False))
+        )
+        if not ha_explicitly_disabled:
+            ha_config.enabled = True
+        ha_config.token = hass_token
         hass_url = os.getenv("HASS_URL")
         if hass_url:
-            config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
+            ha_config.extra["url"] = hass_url
 
     # Email
     email_addr = os.getenv("EMAIL_ADDRESS")

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -446,6 +446,53 @@ class TestConfigIntegration:
         config = load_gateway_config()
         assert Platform.HOMEASSISTANT not in config.platforms
 
+    def test_explicit_top_level_enabled_false_wins_over_env_token(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "homeassistant:\n"
+            "  enabled: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HASS_TOKEN", "env-token")
+        monkeypatch.setenv("HASS_URL", "http://10.0.0.5:8123")
+
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+
+        ha = config.platforms[Platform.HOMEASSISTANT]
+        assert ha.enabled is False
+        assert ha.token == "env-token"
+        assert ha.extra["url"] == "http://10.0.0.5:8123"
+
+    def test_explicit_platforms_enabled_false_wins_over_env_token(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  homeassistant:\n"
+            "    enabled: false\n"
+            "    extra:\n"
+            "      watch_entities:\n"
+            "        - sensor.example\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HASS_TOKEN", "env-token")
+        monkeypatch.setenv("HASS_URL", "http://10.0.0.5:8123")
+
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+
+        ha = config.platforms[Platform.HOMEASSISTANT]
+        assert ha.enabled is False
+        assert ha.token == "env-token"
+        assert ha.extra["url"] == "http://10.0.0.5:8123"
+        assert ha.extra["watch_entities"] == ["sensor.example"]
+
     def test_config_roundtrip_preserves_extra(self):
         config = GatewayConfig(
             platforms={


### PR DESCRIPTION
## Summary
- Respect explicit `homeassistant.enabled: false` even when `HASS_TOKEN` is present.
- Keep `HASS_TOKEN` / `HASS_URL` available on the platform config for standalone sends, without auto-enabling the gateway adapter.
- Add regression coverage for both top-level `homeassistant.enabled: false` and nested `platforms.homeassistant.enabled: false`.

## Test Plan
- `uv run --with pytest --with pyyaml --with pytest-asyncio --python /Users/stalingomez/.hermes/hermes-agent/venv/bin/python python -m pytest tests/gateway/test_homeassistant.py::TestConfigIntegration -q`
