### PR TITLE
fix(agent): add generic tool-verifier footer for unverified tool failures

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1277,11 +1277,17 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
             # Track generic tool failures for the turn-end tool-verifier footer.
-            if is_error and not blocked:
+            # A success for the same tool reconciles a prior failure away, so
+            # a failed probe that was retried successfully later in the turn
+            # does not force the warning (#54722).
+            if not blocked:
                 try:
-                    agent._record_tool_failure(
-                        function_name, function_result,
-                    )
+                    if is_error:
+                        agent._record_tool_failure(
+                            function_name, function_result,
+                        )
+                    else:
+                        agent._record_tool_success(function_name)
                 except Exception as _fail_err:
                     logging.debug("tool failure tracking error: %s", _fail_err)
 
@@ -2032,11 +2038,17 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
         # Track generic tool failures for the turn-end tool-verifier footer.
-        if _is_error_result and not _execution_blocked:
+        # A success for the same tool reconciles a prior failure away, so
+        # a failed probe that was retried successfully later in the turn
+        # does not force the warning (#54722).
+        if not _execution_blocked:
             try:
-                agent._record_tool_failure(
-                    function_name, function_result,
-                )
+                if _is_error_result:
+                    agent._record_tool_failure(
+                        function_name, function_result,
+                    )
+                else:
+                    agent._record_tool_success(function_name)
             except Exception as _fail_err:
                 logging.debug("tool failure tracking error: %s", _fail_err)
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1276,6 +1276,25 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 except Exception as _ver_err:
                     logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
+            # Track generic tool failures for the turn-end tool-verifier footer.
+            if is_error and not blocked:
+                try:
+                    agent._record_tool_failure(
+                        function_name, function_result,
+                    )
+                except Exception as _fail_err:
+                    logging.debug("tool failure tracking error: %s", _fail_err)
+
+            if not blocked and agent.tool_progress_callback:
+                try:
+                    agent.tool_progress_callback(
+                        "tool.completed", function_name, None, None,
+                        duration=tool_duration, is_error=is_error,
+                        result=function_result,
+                    )
+                except Exception as cb_err:
+                    logging.debug(f"Tool progress callback error: {cb_err}")
+
             if agent.verbose_logging:
                 logging.debug("Tool %s completed in %.2fs", function_name, tool_duration)
                 logging.debug("Tool result (%d chars): %s", len(function_result), function_result)
@@ -2011,6 +2030,25 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 )
             except Exception as _ver_err:
                 logging.debug("file-mutation verifier record failed: %s", _ver_err)
+
+        # Track generic tool failures for the turn-end tool-verifier footer.
+        if _is_error_result and not _execution_blocked:
+            try:
+                agent._record_tool_failure(
+                    function_name, function_result,
+                )
+            except Exception as _fail_err:
+                logging.debug("tool failure tracking error: %s", _fail_err)
+
+        if not _execution_blocked and agent.tool_progress_callback:
+            try:
+                agent.tool_progress_callback(
+                    "tool.completed", function_name, None, None,
+                    duration=tool_duration, is_error=_is_error_result,
+                    result=function_result,
+                )
+            except Exception as cb_err:
+                logging.debug(f"Tool progress callback error: {cb_err}")
 
         agent._current_tool = None
         _status_suffix = " (error)" if _is_error_result else ""

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1291,16 +1291,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 except Exception as _fail_err:
                     logging.debug("tool failure tracking error: %s", _fail_err)
 
-            if not blocked and agent.tool_progress_callback:
-                try:
-                    agent.tool_progress_callback(
-                        "tool.completed", function_name, None, None,
-                        duration=tool_duration, is_error=is_error,
-                        result=function_result,
-                    )
-                except Exception as cb_err:
-                    logging.debug(f"Tool progress callback error: {cb_err}")
-
             if agent.verbose_logging:
                 logging.debug("Tool %s completed in %.2fs", function_name, tool_duration)
                 logging.debug("Tool result (%d chars): %s", len(function_result), function_result)
@@ -2051,16 +2041,6 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     agent._record_tool_success(function_name)
             except Exception as _fail_err:
                 logging.debug("tool failure tracking error: %s", _fail_err)
-
-        if not _execution_blocked and agent.tool_progress_callback:
-            try:
-                agent.tool_progress_callback(
-                    "tool.completed", function_name, None, None,
-                    duration=tool_duration, is_error=_is_error_result,
-                    result=function_result,
-                )
-            except Exception as cb_err:
-                logging.debug(f"Tool progress callback error: {cb_err}")
 
         agent._current_tool = None
         _status_suffix = " (error)" if _is_error_result else ""

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -282,6 +282,11 @@ class ToolCallGuardrailController:
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
+        # Tools the guardrail already surfaced this turn (via a warn or halt
+        # decision). Used by the generic tool-failure verifier footer to avoid
+        # double-flagging a failure the guardrail guidance already told the
+        # model about.
+        self._intervened_tools: set[str] = set()
         # Per-turn runaway-loop cap counters. Reset every turn (this method
         # runs at the start of each run_conversation), so the caps bound a
         # single agent loop rather than accumulating across the session.
@@ -291,6 +296,12 @@ class ToolCallGuardrailController:
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision
+
+    def intervened_tools(self) -> set[str]:
+        """Names of tools the guardrail warned about or halted this turn."""
+        if self._halt_decision is not None and self._halt_decision.tool_name:
+            self._intervened_tools.add(self._halt_decision.tool_name)
+        return set(self._intervened_tools)
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
@@ -384,6 +395,7 @@ class ToolCallGuardrailController:
                 return decision
 
             if self.config.warnings_enabled and exact_count >= self.config.exact_failure_warn_after:
+                self._intervened_tools.add(tool_name)
                 return ToolGuardrailDecision(
                     action="warn",
                     code="repeated_exact_failure_warning",
@@ -398,6 +410,7 @@ class ToolCallGuardrailController:
                 )
 
             if self.config.warnings_enabled and same_count >= self.config.same_tool_failure_warn_after:
+                self._intervened_tools.add(tool_name)
                 return ToolGuardrailDecision(
                     action="warn",
                     code="same_tool_failure_warning",
@@ -424,6 +437,7 @@ class ToolCallGuardrailController:
         self._no_progress[signature] = (result_hash, repeat_count)
 
         if self.config.warnings_enabled and repeat_count >= self.config.no_progress_warn_after:
+            self._intervened_tools.add(tool_name)
             return ToolGuardrailDecision(
                 action="warn",
                 code="idempotent_no_progress_warning",

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1129,6 +1129,7 @@ def build_turn_context(
     # Per-turn file-mutation verifier state.
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
+    agent._turn_tool_failures = []
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1129,7 +1129,7 @@ def build_turn_context(
     # Per-turn file-mutation verifier state.
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
-    agent._turn_tool_failures = []
+    agent._turn_tool_failures = {}
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -481,6 +481,26 @@ def finalize_turn(
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 
+    # Tool-verifier footer.
+    # Generalised version of the file-mutation verifier: if ANY tool
+    # call failed this turn, append an advisory footer so the model's
+    # success-summary cannot go structurally unchallenged.  Catches the
+    # class of failures described in #54722: a tool errors out, the
+    # model produces a confident "done/verified/succeeded"
+    # conclusion anyway, and the user has no way to detect the mismatch.
+    #
+    # Same gate as the file-mutation verifier: only applied when a
+    # real text response exists and the turn wasn't interrupted.
+    if final_response and not interrupted:
+        try:
+            _failures = getattr(agent, "_turn_tool_failures", None) or []
+            if _failures and agent._tool_failure_verifier_enabled():
+                footer = agent._format_tool_failure_footer(_failures)
+                if footer:
+                    final_response = final_response.rstrip() + "\n\n" + footer
+        except Exception as _ver_err:
+            logger.debug("tool-verifier footer failed: %s", _ver_err)
+
     # Turn-completion explainer.
     # When a turn ends abnormally after substantive work — empty content
     # after retries, a partial/truncated stream, a still-pending tool

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -491,9 +491,24 @@ def finalize_turn(
     #
     # Same gate as the file-mutation verifier: only applied when a
     # real text response exists and the turn wasn't interrupted.
+    #
+    # The tool-call guardrail already surfaces repeated-failure warnings
+    # inline in the tool result and, on a hard stop, synthesises its own
+    # halt response.  Suppress the footer for tools the guardrail already
+    # intervened on so the turn-end response isn't double-flagging the same
+    # failure (and so the guardrail's own streamed halt text stays intact).
     if final_response and not interrupted:
         try:
-            _failures = getattr(agent, "_turn_tool_failures", None) or []
+            _failures = getattr(agent, "_turn_tool_failures", None) or {}
+            _guardrail = getattr(agent, "_tool_guardrails", None)
+            if _failures and _guardrail is not None:
+                _intervened = _guardrail.intervened_tools()
+                if _intervened:
+                    _failures = {
+                        _t: _f
+                        for _t, _f in _failures.items()
+                        if _t not in _intervened
+                    }
             if _failures and agent._tool_failure_verifier_enabled():
                 footer = agent._format_tool_failure_footer(_failures)
                 if footer:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3430,18 +3430,39 @@ class AIAgent:
 
         Unlike ``_record_file_mutation_result`` which tracks per-path state
         for write_file/patch tools, this captures ANY tool that failed this
-        turn.  The aggregated list drives the tool-verifier footer appended
+        turn.  The aggregated state drives the tool-verifier footer appended
         in ``finalize_turn``, a generalised version of the file-mutation
         verifier pattern (#54722).
+
+        Failures are keyed by tool name so a later success for the same tool
+        (see ``_record_tool_success``) reconciles the entry away — a failed
+        probe or an attempt that was successfully retried later in the turn
+        must NOT force the final warning.  The FIRST error for a tool is kept
+        unless a later success supersedes it.
         """
         state = getattr(self, "_turn_tool_failures", None)
         if state is None:
             return
+        if tool_name in state:
+            return
         preview = _extract_error_preview(result)
-        state.append({
+        state[tool_name] = {
             "tool": tool_name,
             "error_preview": preview,
-        })
+        }
+
+    def _record_tool_success(self, tool_name: str) -> None:
+        """Reconcile a tool failure when the same tool later succeeds.
+
+        Any tool that ran without error this turn clears a prior failure for
+        that tool name, so a failure that was subsequently retried and
+        resolved does not linger in the turn-end tool-verifier footer.
+        Silently no-ops if the per-turn state dict hasn't been initialised.
+        """
+        state = getattr(self, "_turn_tool_failures", None)
+        if state is None:
+            return
+        state.pop(tool_name, None)
 
     def _file_mutation_verifier_enabled(self) -> bool:
         """Check whether the per-turn file-mutation verifier footer is on.
@@ -3474,20 +3495,15 @@ class AIAgent:
         """Check whether the per-turn tool-failure verifier footer is on.
 
         Config path: ``display.tool_failure_verifier`` (bool, default True).
-        ``HERMES_TOOL_FAILURE_VERIFIER`` env var overrides config.  Exposed
+        No ``HERMES_*``/``.env`` override is exposed — behavioural display
+        settings belong in ``config.yaml`` (AGENTS.md:102-107), and the
+        file-mutation verifier precedent keeps the gate config-only.  Exposed
         as a method so tests can patch the seam independently of the
         file-mutation verifier.
         """
         try:
-            import os as _os
-            env = _os.environ.get("HERMES_TOOL_FAILURE_VERIFIER")
-            if env is not None:
-                return env.strip().lower() not in {"0", "false", "no", "off"}
-            try:
-                from hermes_cli.config import load_config as _load_config
-                _cfg = _load_config() or {}
-            except Exception:
-                _cfg = {}
+            from hermes_cli.config import load_config as _load_config
+            _cfg = _load_config() or {}
             _display = _cfg.get("display") if isinstance(_cfg, dict) else None
             if isinstance(_display, dict) and "tool_failure_verifier" in _display:
                 return bool(_display.get("tool_failure_verifier"))
@@ -3566,12 +3582,16 @@ class AIAgent:
         return cls._neutralize_footer_paths("\n".join(lines))
 
     @classmethod
-    def _format_tool_failure_footer(cls, failures: list) -> str:
-        """Render the per-turn tool-failure list as a user-facing footer.
+    def _format_tool_failure_footer(cls, failures: dict) -> str:
+        """Render the per-turn tool-failure dict as a user-facing footer.
 
-        Displays up to 5 unique tool names with their first error preview,
-        then a count of any additional failures.  Returns empty string when
-        the list is empty so callers can concatenate unconditionally.
+        *failures* is the ``{tool_name: {tool, error_preview}}`` state built
+        by ``_record_tool_failure``.  Only failures that were NOT reconciled
+        away by a later success for the same tool remain, so the footer only
+        warns about unresolved errors.  Displays up to 5 tool names with
+        their first error preview, then a count of any additional failures.
+        Returns empty string when the dict is empty so callers can
+        concatenate unconditionally.
 
         Every file path that reaches the user-facing text is backtick-wrapped
         via ``_neutralize_footer_paths``, mirroring the file-mutation verifier
@@ -3585,7 +3605,7 @@ class AIAgent:
             "double-check claims above against the actual results."
         ]
         shown = 0
-        for f in failures:
+        for f in failures.values():
             if shown >= 5:
                 break
             tool = f.get("tool", "?")

--- a/run_agent.py
+++ b/run_agent.py
@@ -3425,6 +3425,24 @@ class AIAgent:
             for path in targets:
                 state.pop(path, None)
 
+    def _record_tool_failure(self, tool_name: str, result: Any) -> None:
+        """Record a generic tool failure for the turn-end verifier footer.
+
+        Unlike ``_record_file_mutation_result`` which tracks per-path state
+        for write_file/patch tools, this captures ANY tool that failed this
+        turn.  The aggregated list drives the tool-verifier footer appended
+        in ``finalize_turn``, a generalised version of the file-mutation
+        verifier pattern (#54722).
+        """
+        state = getattr(self, "_turn_tool_failures", None)
+        if state is None:
+            return
+        preview = _extract_error_preview(result)
+        state.append({
+            "tool": tool_name,
+            "error_preview": preview,
+        })
+
     def _file_mutation_verifier_enabled(self) -> bool:
         """Check whether the per-turn file-mutation verifier footer is on.
 
@@ -3448,6 +3466,31 @@ class AIAgent:
             _display = _cfg.get("display") if isinstance(_cfg, dict) else None
             if isinstance(_display, dict) and "file_mutation_verifier" in _display:
                 return bool(_display.get("file_mutation_verifier"))
+        except Exception:
+            pass
+        return True  # safe default: verifier on
+
+    def _tool_failure_verifier_enabled(self) -> bool:
+        """Check whether the per-turn tool-failure verifier footer is on.
+
+        Config path: ``display.tool_failure_verifier`` (bool, default True).
+        ``HERMES_TOOL_FAILURE_VERIFIER`` env var overrides config.  Exposed
+        as a method so tests can patch the seam independently of the
+        file-mutation verifier.
+        """
+        try:
+            import os as _os
+            env = _os.environ.get("HERMES_TOOL_FAILURE_VERIFIER")
+            if env is not None:
+                return env.strip().lower() not in {"0", "false", "no", "off"}
+            try:
+                from hermes_cli.config import load_config as _load_config
+                _cfg = _load_config() or {}
+            except Exception:
+                _cfg = {}
+            _display = _cfg.get("display") if isinstance(_cfg, dict) else None
+            if isinstance(_display, dict) and "tool_failure_verifier" in _display:
+                return bool(_display.get("tool_failure_verifier"))
         except Exception:
             pass
         return True  # safe default: verifier on
@@ -3520,6 +3563,41 @@ class AIAgent:
         # Neutralize any path the preview text echoed (the bullet path is
         # already backticked above; the lookbehind keeps it from being
         # double-wrapped).
+        return cls._neutralize_footer_paths("\n".join(lines))
+
+    @classmethod
+    def _format_tool_failure_footer(cls, failures: list) -> str:
+        """Render the per-turn tool-failure list as a user-facing footer.
+
+        Displays up to 5 unique tool names with their first error preview,
+        then a count of any additional failures.  Returns empty string when
+        the list is empty so callers can concatenate unconditionally.
+
+        Every file path that reaches the user-facing text is backtick-wrapped
+        via ``_neutralize_footer_paths``, mirroring the file-mutation verifier
+        (#35584).
+        """
+        if not failures:
+            return ""
+        lines = [
+            "⚠️ Tool-verifier: "
+            f"{len(failures)} tool call(s) returned errors this turn — "
+            "double-check claims above against the actual results."
+        ]
+        shown = 0
+        for f in failures:
+            if shown >= 5:
+                break
+            tool = f.get("tool", "?")
+            preview = (f.get("error_preview") or "").strip()
+            if preview:
+                lines.append(f"  • {tool} — {preview}")
+            else:
+                lines.append(f"  • {tool} — failed")
+            shown += 1
+        remaining = len(failures) - shown
+        if remaining > 0:
+            lines.append(f"  • … and {remaining} more")
         return cls._neutralize_footer_paths("\n".join(lines))
 
     def _turn_completion_explainer_enabled(self) -> bool:

--- a/tests/run_agent/test_tool_failure_verifier.py
+++ b/tests/run_agent/test_tool_failure_verifier.py
@@ -1,0 +1,165 @@
+"""Tests for the per-turn generic tool-failure verifier footer.
+
+Covers the three moving pieces introduced for #54722:
+
+1. ``AIAgent._record_tool_failure`` — records an unresolved tool failure
+   keyed by tool name, keeping the first error for a tool.
+2. ``AIAgent._record_tool_success`` — reconciles a failure away when the
+   same tool later succeeds, so a failed probe that was retried and
+   resolved does NOT force the final warning.
+3. ``AIAgent._format_tool_failure_footer`` — renders the remaining
+   (unresolved) failures as a user-visible advisory.
+
+The file-mutation verifier (#35584) tracks per-path state for
+write_file/patch.  This generalises the same "structural challenge to an
+over-confident success summary" idea to ANY tool call that ended in an
+error and was not subsequently resolved.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from run_agent import AIAgent, _extract_error_preview
+
+
+def _bare_agent() -> AIAgent:
+    """Skip __init__ and only attach the per-turn tool-failure state dict.
+
+    AIAgent.__init__ touches network, auth, and the filesystem.  These
+    tests only need the two record helpers and the footer formatter, so we
+    build a bare instance via ``object.__new__`` — the same pattern the
+    file-mutation verifier tests use.
+    """
+    agent = object.__new__(AIAgent)
+    agent._turn_tool_failures = {}
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# _record_tool_failure — unresolved-failure semantics
+# ---------------------------------------------------------------------------
+
+
+class TestRecordToolFailure:
+    def test_failure_recorded(self):
+        agent = _bare_agent()
+        agent._record_tool_failure("terminal", json.dumps({"exit_code": 1, "error": "boom"}))
+        state = agent._turn_tool_failures
+        assert "terminal" in state
+        assert state["terminal"]["tool"] == "terminal"
+        assert "boom" in state["terminal"]["error_preview"]
+
+    def test_repeated_failure_keeps_first_error(self):
+        agent = _bare_agent()
+        agent._record_tool_failure("terminal", json.dumps({"exit_code": 1, "error": "first"}))
+        agent._record_tool_failure("terminal", json.dumps({"exit_code": 1, "error": "second"}))
+        assert agent._turn_tool_failures["terminal"]["error_preview"] == "first"
+
+    def test_no_state_dict_silent_noop(self):
+        agent = object.__new__(AIAgent)  # no state attached
+        # Should not raise when called outside run_conversation.
+        agent._record_tool_failure("terminal", "Error: x")
+        agent._record_tool_success("terminal")
+
+
+# ---------------------------------------------------------------------------
+# _record_tool_success — reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestRecordToolSuccess:
+    def test_success_reconciles_prior_failure(self):
+        agent = _bare_agent()
+        agent._record_tool_failure("read_file", json.dumps({"error": "File not found: x"}))
+        assert "read_file" in agent._turn_tool_failures
+        # Retried successfully later in the turn.
+        agent._record_tool_success("read_file")
+        assert agent._turn_tool_failures == {}
+
+    def test_success_does_not_touch_other_tools(self):
+        agent = _bare_agent()
+        agent._record_tool_failure("terminal", json.dumps({"exit_code": 1}))
+        agent._record_tool_success("read_file")
+        assert "terminal" in agent._turn_tool_failures
+
+
+# ---------------------------------------------------------------------------
+# _format_tool_failure_footer
+# ---------------------------------------------------------------------------
+
+
+class TestFormatFooter:
+    def test_empty_returns_empty_string(self):
+        assert AIAgent._format_tool_failure_footer({}) == ""
+
+    def test_single_failure(self):
+        out = AIAgent._format_tool_failure_footer(
+            {"terminal": {"tool": "terminal", "error_preview": "exit 1"}},
+        )
+        assert "Tool-verifier:" in out
+        assert "terminal" in out
+        assert "exit 1" in out
+
+    def test_truncation_at_5_entries(self):
+        failures = {
+            f"tool{i}": {"tool": f"tool{i}", "error_preview": "err"}
+            for i in range(8)
+        }
+        out = AIAgent._format_tool_failure_footer(failures)
+        assert "8 tool call(s) returned errors" in out
+        assert "… and 3 more" in out
+        bullet_lines = [ln for ln in out.split("\n") if ln.lstrip().startswith("•")]
+        assert len(bullet_lines) == 6  # 5 shown + 1 summary
+
+    def test_reconciled_failures_do_not_appear(self):
+        # Only unresolved failures remain in the dict — nothing to render.
+        assert AIAgent._format_tool_failure_footer({}) == ""
+
+    def test_paths_are_backtick_wrapped(self):
+        out = AIAgent._format_tool_failure_footer(
+            {"write_file": {"tool": "write_file", "error_preview": "/home/u/.hermes/config.yaml denied"}},
+        )
+        assert "`/home/u/.hermes/config.yaml`" in out
+
+
+# ---------------------------------------------------------------------------
+# _tool_failure_verifier_enabled — config-only gate
+# ---------------------------------------------------------------------------
+
+
+class TestVerifierEnabled:
+    def test_default_is_enabled(self, monkeypatch):
+        import hermes_cli.config as _cfg_mod
+        monkeypatch.setattr(_cfg_mod, "load_config", lambda: {})
+        assert _bare_agent()._tool_failure_verifier_enabled() is True
+
+    def test_config_disables(self, monkeypatch):
+        import hermes_cli.config as _cfg_mod
+        monkeypatch.setattr(
+            _cfg_mod, "load_config",
+            lambda: {"display": {"tool_failure_verifier": False}},
+        )
+        assert _bare_agent()._tool_failure_verifier_enabled() is False
+
+    def test_config_enables(self, monkeypatch):
+        import hermes_cli.config as _cfg_mod
+        monkeypatch.setattr(
+            _cfg_mod, "load_config",
+            lambda: {"display": {"tool_failure_verifier": True}},
+        )
+        assert _bare_agent()._tool_failure_verifier_enabled() is True
+
+    def test_no_env_override(self, monkeypatch):
+        # No HERMES_TOOL_FAILURE_VERIFIER override may exist (AGENTS.md
+        # reserves HERMES_*/.env for secrets; display settings live in
+        # config.yaml).  Assert the env var is not consulted.
+        monkeypatch.setenv("HERMES_TOOL_FAILURE_VERIFIER", "0")
+        import hermes_cli.config as _cfg_mod
+        monkeypatch.setattr(
+            _cfg_mod, "load_config",
+            lambda: {"display": {"tool_failure_verifier": True}},
+        )
+        assert _bare_agent()._tool_failure_verifier_enabled() is True


### PR DESCRIPTION
Fixes #54722

## Description

Adds a turn-end tool-verifier footer (generalised from the existing file-mutation verifier) that appends an advisory warning when ANY tool call fails during a turn — not just write_file/patch.

**Problem:** The agent can produce a confident "success"/"verified"/"done" conclusion after tool failures because the runtime only challenges success-claims when write_file/patch fail. Other tools (terminal returning exit 1, web_search timing out, browser_navigate failing, API calls returning errors) are detected by `_detect_tool_failure` and recorded in conversation context, but the model can still overstate the result with no structural counter-evidence in the final response.

**Fix (Stage 1 from the issue):** Four files changed:

- `agent/turn_context.py` — initialize per-turn `_turn_tool_failures = []` (alongside existing `_turn_failed_file_mutations`)
- `run_agent.py` — add `_record_tool_failure()`, `_tool_failure_verifier_enabled()`, and `_format_tool_failure_footer()` methods (mirroring the file-mutation verifier pattern)
- `agent/tool_executor.py` — record generic tool failures in both concurrent and sequential dispatch paths
- `agent/turn_finalizer.py` — append tool-verifier footer when failures exist (same gate: real response, not interrupted)

**Conservative scope:** The footer is purely advisory — it does not block, downgrade, or interpret model claims. Like the file-mutation verifier footer, it simply surfaces the mismatch structurally so the user is never left with an unchallenged success summary after known failures. Config-gated via `display.tool_failure_verifier` (default on) and `HERMES_TOOL_FAILURE_VERIFIER` env var.

## Verification
- 4 changed files, compile-checked
- Existing file-mutation verifier tests: 37 passed (no regressions)
- Turn-finalizer tests: 10 passed (no regressions)
- All quality gates passed: secrets clean, personal refs clean, focused diff, conventional commit