### PR TITLE
fix(mem0): preserve custom_instructions param after backend restructure

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -203,6 +203,9 @@ class OSSBackend(Mem0Backend):
             "embedder": _provider_block("embedder"),
             "version": "v1.1",
         }
+        # Pass custom_instructions if present in oss_config (set via mem0.json "oss.custom_instructions")
+        if oss_config.get("custom_instructions"):
+            config["custom_instructions"] = oss_config["custom_instructions"]
         self._memory = Memory.from_config(config)
 
     @staticmethod

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -229,6 +229,9 @@ class OSSBackend(Mem0Backend):
             "embedder": _provider_block("embedder"),
             "version": "v1.1",
         }
+# Pass custom_instructions if present in oss_config (set via mem0.json "oss.custom_instructions")
+        if oss_config.get("custom_instructions"):
+            config["custom_instructions"] = oss_config["custom_instructions"]
         if str(config["llm"].get("provider") or "").strip().lower() == "openai":
             # mem0 validates LlmConfig.provider before its factory lookup, so
             # first build the supported OpenAI config and only then swap the

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -231,6 +231,163 @@ class TestOSSBackend:
         assert "api_base" not in captured["embedder"]["config"]
         assert raw == before
 
+    # ── regression: custom_instructions forwarding (PR #54739) ──────────
+
+    def test_constructor_forwards_custom_instructions(self, monkeypatch):
+        """When custom_instructions is present in oss_config, it must be
+        passed through to Memory.from_config()."""
+        import sys
+        import types
+
+        captured_config: dict = {}
+
+        class StubMemory:
+            @staticmethod
+            def from_config(config):
+                captured_config.update(config)
+                return FakeOSSMemory()
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = StubMemory
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+
+        # Inject a KNOWN_DIMS stub so the dims lookup doesn't fail.
+        stub_providers = types.ModuleType("plugins.memory.mem0._oss_providers")
+        stub_providers.KNOWN_DIMS = {"nomic-embed-text": 768}  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "plugins.memory.mem0._oss_providers", stub_providers
+        )
+
+        raw = {
+            "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
+            "embedder": {
+                "provider": "ollama",
+                "config": {"model": "nomic-embed-text"},
+            },
+            "vector_store": {"provider": "qdrant", "config": {}},
+            "custom_instructions": "Remember: the user prefers pasta.",
+        }
+
+        OSSBackend(raw)
+
+        assert (
+            captured_config.get("custom_instructions")
+            == "Remember: the user prefers pasta."
+        )
+
+    def test_constructor_omits_custom_instructions_when_absent(self, monkeypatch):
+        """When custom_instructions is NOT in oss_config, the key must be
+        absent from the config passed to Memory.from_config()."""
+        import sys
+        import types
+
+        captured_config: dict = {}
+
+        class StubMemory:
+            @staticmethod
+            def from_config(config):
+                captured_config.update(config)
+                return FakeOSSMemory()
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = StubMemory
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+
+        stub_providers = types.ModuleType("plugins.memory.mem0._oss_providers")
+        stub_providers.KNOWN_DIMS = {"nomic-embed-text": 768}  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "plugins.memory.mem0._oss_providers", stub_providers
+        )
+
+        raw = {
+            "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
+            "embedder": {
+                "provider": "ollama",
+                "config": {"model": "nomic-embed-text"},
+            },
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }
+
+        OSSBackend(raw)
+
+        assert "custom_instructions" not in captured_config
+
+    def test_constructor_omits_custom_instructions_when_none(self, monkeypatch):
+        """custom_instructions=None must be treated as absent — not forwarded."""
+        import sys
+        import types
+
+        captured_config: dict = {}
+
+        class StubMemory:
+            @staticmethod
+            def from_config(config):
+                captured_config.update(config)
+                return FakeOSSMemory()
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = StubMemory
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+
+        stub_providers = types.ModuleType("plugins.memory.mem0._oss_providers")
+        stub_providers.KNOWN_DIMS = {"nomic-embed-text": 768}  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "plugins.memory.mem0._oss_providers", stub_providers
+        )
+
+        raw = {
+            "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
+            "embedder": {
+                "provider": "ollama",
+                "config": {"model": "nomic-embed-text"},
+            },
+            "vector_store": {"provider": "qdrant", "config": {}},
+            "custom_instructions": None,
+        }
+
+        OSSBackend(raw)
+
+        assert "custom_instructions" not in captured_config
+
+    def test_constructor_omits_custom_instructions_when_empty_string(
+        self, monkeypatch
+    ):
+        """custom_instructions='' must be treated as absent — not forwarded."""
+        import sys
+        import types
+
+        captured_config: dict = {}
+
+        class StubMemory:
+            @staticmethod
+            def from_config(config):
+                captured_config.update(config)
+                return FakeOSSMemory()
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = StubMemory
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+
+        stub_providers = types.ModuleType("plugins.memory.mem0._oss_providers")
+        stub_providers.KNOWN_DIMS = {"nomic-embed-text": 768}  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "plugins.memory.mem0._oss_providers", stub_providers
+        )
+
+        raw = {
+            "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
+            "embedder": {
+                "provider": "ollama",
+                "config": {"model": "nomic-embed-text"},
+            },
+            "vector_store": {"provider": "qdrant", "config": {}},
+            "custom_instructions": "",
+        }
+
+        OSSBackend(raw)
+
+        assert "custom_instructions" not in captured_config
+
 
 httpx = pytest.importorskip("httpx")
 

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -18,6 +18,10 @@ from plugins.memory.mem0._backend import (
     SelfHostedBackend,
 )
 
+# Sentinel: distinguishes "custom_instructions key absent" from an explicit
+# None/"" (both of which must NOT be forwarded) in the OSSBackend constructor.
+_UNSET = object()
+
 
 class FakePlatformClient:
     """Fake MemoryClient for PlatformBackend tests."""
@@ -616,6 +620,65 @@ class TestOSSBackend:
         assert "hermes_openai" not in factory.provider_to_class
         assert state.clients == []
         assert raw == before
+
+    # ── regression: custom_instructions forwarding (PR #54739) ──────────
+
+    def _spy_from_config(self, monkeypatch):
+        """Install the shared fake mem0 and wrap Memory.from_config so tests
+        can assert exactly what config dict reaches it."""
+        state, Memory, _ = _install_fake_mem0(monkeypatch)
+        captured: dict = {}
+        original = Memory.from_config.__func__
+
+        def spy(cls, config):
+            captured.update(config)
+            return original(Memory, config)
+
+        monkeypatch.setattr(Memory, "from_config", classmethod(spy))
+        return captured
+
+    def _oss_raw(self, custom_instructions=_UNSET, *, provider="ollama"):
+        raw = {
+            "llm": {"provider": provider, "config": {"model": "llama3.1:8b"}},
+            "embedder": {"provider": "ollama", "config": {"model": "nomic-embed-text"}},
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }
+        if custom_instructions is not _UNSET:
+            raw["custom_instructions"] = custom_instructions
+        return raw
+
+    def test_constructor_forwards_custom_instructions(self, monkeypatch):
+        """When custom_instructions is present in oss_config, it must be
+        passed through to Memory.from_config()."""
+        captured = self._spy_from_config(monkeypatch)
+        OSSBackend(
+            self._oss_raw(custom_instructions="Remember: the user prefers pasta.")
+        )
+        assert (
+            captured.get("custom_instructions")
+            == "Remember: the user prefers pasta."
+        )
+
+    def test_constructor_omits_custom_instructions_when_absent(self, monkeypatch):
+        """When custom_instructions is NOT in oss_config, the key must be
+        absent from the config passed to Memory.from_config()."""
+        captured = self._spy_from_config(monkeypatch)
+        OSSBackend(self._oss_raw())
+        assert "custom_instructions" not in captured
+
+    def test_constructor_omits_custom_instructions_when_none(self, monkeypatch):
+        """custom_instructions=None must be treated as absent — not forwarded."""
+        captured = self._spy_from_config(monkeypatch)
+        OSSBackend(self._oss_raw(custom_instructions=None))
+        assert "custom_instructions" not in captured
+
+    def test_constructor_omits_custom_instructions_when_empty_string(
+        self, monkeypatch
+    ):
+        """custom_instructions='' must be treated as absent — not forwarded."""
+        captured = self._spy_from_config(monkeypatch)
+        OSSBackend(self._oss_raw(custom_instructions=""))
+        assert "custom_instructions" not in captured
 
 
 httpx = pytest.importorskip("httpx")


### PR DESCRIPTION
## Description

The upstream restructure (commit `2e779d11a`) moved the OSSBackend file to `plugins/memory/mem0/_backend.py` but **did not carry forward the fix** from PR #52586, which passes `custom_instructions` to `Memory.from_config()`.

Without this fix, custom_instructions configured via mem0.json (`"oss.custom_instructions"`) are silently ignored.

## Fix

3 lines in the new file path:
```python
# Pass custom_instructions if present in oss_config (set via mem0.json "oss.custom_instructions")
if oss_config.get("custom_instructions"):
    config["custom_instructions"] = oss_config["custom_instructions"]
```

## References
- Original PR: #52586 (already merged and approved)
- Restructure commit: `2e779d11a`

## Checklist
- [x] Fix already approved in original PR
- [x] Tested locally — working as expected
- [x] No additional dependencies