### PR TITLE
fix(file-tools): anchor docker cold-start paths in container

### DIFF
--- a/tests/tools/test_file_tools_docker_coldstart.py
+++ b/tests/tools/test_file_tools_docker_coldstart.py
@@ -1,0 +1,65 @@
+"""Regression tests for Docker cold-start relative-path resolution.
+
+The bug (#54354): on a container backend (docker/singularity/modal/daytona),
+the very first relative file-tool path — before any terminal command has run,
+so the live cwd registry is still empty and no TERMINAL_CWD/last-known anchor
+exists — fell back to the HOST process cwd. That anchored container-bound
+writes on the host filesystem.
+
+Fix: when there is no authoritative workspace root AND the backend is a
+container, anchor on the sanitized container cwd (e.g. ``/root``) from
+``terminal_tool._get_env_config()`` instead of the host getcwd. Local/ssh keep
+host getcwd. No Docker daemon required — only the path-resolution math runs.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+import tools.file_tools as ft
+import tools.terminal_tool as terminal_tool
+
+
+@pytest.fixture
+def _coldstart(tmp_path, monkeypatch):
+    """Cold-start state: empty registries, no anchors, host cwd = decoy."""
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    (decoy / "file.py").write_text("HOST_DECOY\n")
+    monkeypatch.chdir(decoy)
+    # No live tracking, no overrides, no last-known, no configured TERMINAL_CWD.
+    monkeypatch.setattr(ft, "_get_live_tracking_cwd", lambda task_id="default": None)
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(ft, "_last_known_cwd", {})
+    monkeypatch.setattr(ft, "_file_ops_cache", {})
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    return decoy
+
+
+def test_docker_coldstart_resolves_in_container_not_host(_coldstart, monkeypatch):
+    """First relative path on docker cold start anchors at /root, not host."""
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    resolved = ft._resolve_path_for_task("file.py", task_id="default")
+
+    assert resolved == Path("/root/file.py")
+    assert not str(resolved).startswith(str(_coldstart))
+
+
+def test_local_coldstart_resolves_under_host_cwd(_coldstart, monkeypatch):
+    """Local backend keeps host-cwd anchoring (unchanged behavior)."""
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    resolved = ft._resolve_path_for_task("file.py", task_id="default")
+
+    assert resolved == (_coldstart / "file.py").resolve()
+
+
+def test_local_explicit_coldstart_resolves_under_host_cwd(_coldstart, monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    resolved = ft._resolve_path_for_task("file.py", task_id="default")
+
+    assert resolved == (_coldstart / "file.py").resolve()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -266,6 +266,33 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
     return _configured_terminal_cwd()
 
 
+def _container_default_base() -> str | None:
+    """Sanitized container cwd to anchor relative paths during cold start.
+
+    On a container backend (docker/singularity/modal/daytona) the agent's
+    relative writes target the CONTAINER filesystem, not the host. Before any
+    terminal command has populated the live cwd registry, returns the sanitized
+    container cwd from ``terminal_tool._get_env_config()`` (already guarded to
+    ``/root``/``/workspace`` etc.) so a first relative file-tool path resolves
+    inside the container rather than the host cwd. Returns ``None`` for
+    local/ssh, a non-absolute cwd, or on any failure (degrade to host getcwd).
+    """
+    try:
+        # Lazy import to avoid an import cycle with terminal_tool (matches the
+        # in-function imports used elsewhere in this module).
+        from tools.terminal_tool import _CONTAINER_BACKENDS, _get_env_config
+
+        env_type = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+        if env_type not in _CONTAINER_BACKENDS:
+            return None
+        cwd = _get_env_config().get("cwd")
+        if cwd and os.path.isabs(cwd):
+            return cwd
+    except Exception:
+        return None
+    return None
+
+
 def _resolve_base_dir(task_id: str = "default") -> Path:
     """Return the ABSOLUTE base directory for resolving relative paths.
 
@@ -277,7 +304,10 @@ def _resolve_base_dir(task_id: str = "default") -> Path:
       3. A sentinel-free, absolute ``$TERMINAL_CWD`` (the worktree path set by
          ``cli.py``/``main.py`` for ``-w`` sessions). Used even before any
          terminal command has populated the live cwd registry.
-      4. The process cwd.
+      4. For container backends only, the sanitized container cwd (e.g.
+         ``/root``) so a first relative path on cold start anchors inside the
+         container rather than the host. Local/ssh skip this step.
+      5. The process cwd.
 
     The returned base is ALWAYS absolute. This is the core invariant that
     prevents the worktree-cwd divergence bug: a relative or sentinel
@@ -293,7 +323,9 @@ def _resolve_base_dir(task_id: str = "default") -> Path:
     if root:
         base = Path(_expand_tilde(root))
     else:
-        base = Path(os.getcwd())
+        # Cold-start container fallback: a relative write before any command has
+        # run targets the container fs, not the host cwd. Local/ssh keep host.
+        base = Path(_container_default_base() or os.getcwd())
     if not base.is_absolute():
         # Last-resort anchoring: a live cwd should already be absolute, but if a
         # terminal backend ever reports a relative cwd, anchor it to the process


### PR DESCRIPTION
## What does this PR do?

Fixes the Docker cold-start path-resolution case from #54354. Before the lazy terminal environment has been built, relative file-tool paths had no live cwd or TERMINAL_CWD anchor and fell back to the host process cwd. For container backends, this PR anchors that first relative path to the sanitized container cwd from the terminal env config, typically /root, so the first call resolves the same way as later calls.

This is scoped to container backends only; local and ssh behavior is unchanged. It is distinct from #54616, which fixed override sanitization reaching docker run -w. #54408 was closed in favor of that PR, with follow-up invited for this separate cold-start repro.

## Related Issue

Fixes #54354

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a container-only cold-start fallback in tools/file_tools.py that uses the sanitized container cwd instead of host getcwd().
- Added a regression test covering Docker cold start plus unchanged local behavior in tests/tools/test_file_tools_docker_coldstart.py.

## How to Test

1. python3 -m pytest tests/tools/test_file_tools_docker_coldstart.py -q

Tested on Linux. The regression test exercises the path-resolution math directly and does not require a Docker daemon.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

3 passed in 0.83s