### PR TITLE
feat(config): add model routing tiers

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -165,6 +165,49 @@ model:
 #   # data_collection: "deny"
 
 # =============================================================================
+# Model Routing and Fallback Tiers (optional)
+# =============================================================================
+# Route simple chat and tool-heavy turns to different model/provider pairs.
+# Automatic chat/tool_use classification only turns on when both routing.chat
+# and routing.tool_use are configured. You can pin a context with
+# routing.context: "chat" or "tool_use".
+#
+# routing:
+#   chat:
+#     provider: "openrouter"
+#     model: "meta-llama/llama-3.3-8b-instruct"
+#     tier: "cheap"
+#   tool_use:
+#     provider: "anthropic"
+#     model: "claude-sonnet-4.6"
+#     tier: "mid"
+#
+# Select a tier for the whole profile/session without task routing:
+#
+# model:
+#   tier: "mid"
+#
+# fallback_tiers replace the top-level fallback_providers chain when the
+# selected route or model profile names a tier.
+#
+# fallback_tiers:
+#   cheap:
+#     - provider: "openrouter"
+#       model: "openai/gpt-5-nano"
+#     - provider: "anthropic"
+#       model: "claude-haiku-4.5"
+#   mid:
+#     - provider: "anthropic"
+#       model: "claude-sonnet-4.6"
+#     - provider: "openai-codex"
+#       model: "gpt-5"
+#   hard:
+#     - provider: "anthropic"
+#       model: "claude-opus-4.6"
+#     - provider: "openai-codex"
+#       model: "gpt-5"
+
+# =============================================================================
 # OpenRouter Response Caching (only applies when using OpenRouter)
 # =============================================================================
 # Cache identical API responses at the OpenRouter edge for free instant replays.

--- a/cli.py
+++ b/cli.py
@@ -12117,6 +12117,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             model_override=turn_route["model"],
             runtime_override=turn_route["runtime"],
             request_overrides=turn_route.get("request_overrides"),
+            fallback_model_override=turn_route.get("fallback_model"),
         ):
             return None
         
@@ -16158,6 +16159,7 @@ def main(
                         model_override=turn_route["model"],
                         runtime_override=turn_route["runtime"],
                         request_overrides=turn_route.get("request_overrides"),
+                        fallback_model_override=turn_route.get("fallback_model"),
                     ):
                         cli.agent.quiet_mode = True
                         cli.agent.suppress_status_output = True

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -58,6 +58,11 @@ from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.model_routing import (
+    classify_task_context,
+    fallback_chain_signature,
+    get_route_override,
+)
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -3891,12 +3896,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         """Build the effective model/runtime config for a single turn.
 
-        Always uses the session's primary model/provider.  If `/fast` is
-        enabled and the model supports Priority Processing / Anthropic fast
-        mode, attach `request_overrides` so the API call is marked
-        accordingly.
+        Uses the session's primary model/provider unless config.yaml
+        ``routing.<context>`` selects a task-specific provider/model. If
+        `/fast` is enabled and the model supports Priority Processing /
+        Anthropic fast mode, attach `request_overrides` so the API call is
+        marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.runtime_provider import resolve_runtime_provider
 
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
@@ -3908,6 +3915,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "credential_pool": runtime_kwargs.get("credential_pool"),
             "max_tokens": runtime_kwargs.get("max_tokens"),
         }
+        config = _load_gateway_config()
+        task_context = classify_task_context(config, user_message)
+        route_override = get_route_override(config, task_context)
+        if route_override:
+            model = route_override.get("model") or model
+            provider = route_override.get("provider") or runtime["provider"]
+            if (
+                provider != runtime["provider"]
+                or route_override.get("model")
+                or route_override.get("base_url")
+                or route_override.get("api_key")
+            ):
+                resolved = resolve_runtime_provider(
+                    requested=provider,
+                    target_model=model or None,
+                    explicit_base_url=route_override.get("base_url"),
+                    explicit_api_key=route_override.get("api_key"),
+                )
+                runtime.update(
+                    {
+                        "api_key": resolved.get("api_key"),
+                        "base_url": resolved.get("base_url"),
+                        "provider": resolved.get("provider"),
+                        "api_mode": resolved.get("api_mode"),
+                        "command": resolved.get("command"),
+                        "args": list(resolved.get("args") or []),
+                        "credential_pool": resolved.get("credential_pool"),
+                    }
+                )
+        fallback_model = get_fallback_chain(config, task_context=task_context) or None
         route = {
             "model": model,
             "runtime": runtime,
@@ -3918,7 +3955,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 runtime["api_mode"],
                 runtime["command"],
                 tuple(runtime["args"]),
+                fallback_chain_signature(fallback_model),
             ),
+            "fallback_model": fallback_model,
         }
 
         service_tier = getattr(self, "_service_tier", None)
@@ -13361,9 +13400,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
                     session_db=getattr(self._session_db, "_db", self._session_db),
-                    # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
                 )
+                if turn_route.get("fallback_model"):
+                    self._apply_fallback_chain_to_agent(
+                        agent, turn_route["fallback_model"],
+                    )
                 try:
                     return agent.run_conversation(
                         user_message=enriched_prompt,
@@ -18084,12 +18126,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
             # schemas for prompt cache hits.
+            _cache_keys = dict(self._extract_cache_busting_config(user_config) or ())
+            _cache_keys["model_routing.fallback_chain"] = fallback_chain_signature(
+                turn_route.get("fallback_model")
+            )
             _sig = self._agent_config_signature(
                 turn_route["model"],
                 turn_route["runtime"],
                 enabled_toolsets,
                 combined_ephemeral,
-                cache_keys=self._extract_cache_busting_config(user_config),
+                cache_keys=_cache_keys,
                 user_id=getattr(source, "user_id", None),
                 user_id_alt=getattr(source, "user_id_alt", None),
             )
@@ -18193,7 +18239,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # serialization (_running_agents) keeps this safe post-lock.
             if reused_cached_agent and agent is not None:
                 self._apply_fallback_chain_to_agent(
-                    agent, self._refresh_fallback_model(),
+                    agent,
+                    turn_route.get("fallback_model") or self._refresh_fallback_model(),
                 )
 
             # Lock released — now schedule cleanup of any cross-process-evicted
@@ -18248,9 +18295,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_id=source.thread_id,
                     gateway_session_key=session_key,
                     session_db=getattr(self._session_db, "_db", self._session_db),
-                    # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
                 )
+                if turn_route.get("fallback_model"):
+                    self._apply_fallback_chain_to_agent(
+                        agent, turn_route["fallback_model"],
+                    )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
                         # Record the session_id the snapshot was taken for

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -174,12 +174,21 @@ class CLIAgentSetupMixin:
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
         """Build the effective model/runtime config for a single user turn.
 
-        Always uses the session's primary model/provider.  If the user has
-        toggled `/fast` on and the current model supports Priority
+        Uses the session's primary model/provider unless config.yaml
+        ``routing.<context>`` selects a task-specific provider/model. If the
+        user has toggled `/fast` on and the current model supports Priority
         Processing / Anthropic fast mode, attach `request_overrides` so the
         API call is marked accordingly.
         """
+        from cli import CLI_CONFIG
+        from hermes_cli.fallback_config import get_fallback_chain
+        from hermes_cli.model_routing import (
+            classify_task_context,
+            fallback_chain_signature,
+            get_route_override,
+        )
         from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.runtime_provider import resolve_runtime_provider
 
         runtime = {
             "api_key": self.api_key,
@@ -190,17 +199,54 @@ class CLIAgentSetupMixin:
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
         }
+        model = self.model
+        task_context = classify_task_context(CLI_CONFIG, user_message)
+        route_override = get_route_override(CLI_CONFIG, task_context)
+        if route_override:
+            model = route_override.get("model") or model
+            provider = route_override.get("provider") or runtime["provider"]
+            if (
+                provider != runtime["provider"]
+                or route_override.get("model")
+                or route_override.get("base_url")
+                or route_override.get("api_key")
+            ):
+                resolved = resolve_runtime_provider(
+                    requested=provider,
+                    target_model=model or None,
+                    explicit_base_url=route_override.get("base_url"),
+                    explicit_api_key=route_override.get("api_key"),
+                )
+                runtime.update(
+                    {
+                        "api_key": resolved.get("api_key"),
+                        "base_url": resolved.get("base_url"),
+                        "provider": resolved.get("provider"),
+                        "api_mode": resolved.get("api_mode"),
+                        "command": resolved.get("command"),
+                        "args": list(resolved.get("args") or []),
+                        "credential_pool": resolved.get("credential_pool"),
+                    }
+                )
+
+        fallback_model = get_fallback_chain(
+            CLI_CONFIG,
+            task_context=task_context,
+        ) or None
+        fallback_sig = fallback_chain_signature(fallback_model)
         route = {
-            "model": self.model,
+            "model": model,
             "runtime": runtime,
             "signature": (
-                self.model,
+                model,
                 runtime["provider"],
                 runtime["base_url"],
                 runtime["api_mode"],
                 runtime["command"],
                 tuple(runtime["args"]),
+                fallback_sig,
             ),
+            "fallback_model": fallback_model,
         }
 
         service_tier = getattr(self, "service_tier", None)
@@ -215,7 +261,7 @@ class CLIAgentSetupMixin:
         route["request_overrides"] = overrides
         return route
 
-    def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None) -> bool:
+    def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None, fallback_model_override=None) -> bool:
         """
         Initialize the agent on first use.
         When resuming a session, restores conversation history from SQLite.
@@ -224,6 +270,7 @@ class CLIAgentSetupMixin:
             bool: True if successful, False otherwise
         """
         from cli import AIAgent, ChatConsole, _DIM, _RST, _accent_hex, _cprint, _prepare_deferred_agent_startup, logger
+        from hermes_cli.model_routing import fallback_chain_signature
         if self.agent is not None:
             return True
 
@@ -374,7 +421,7 @@ class CLIAgentSetupMixin:
                 clarify_callback=self._clarify_callback,
                 reasoning_callback=self._current_reasoning_callback(),
 
-                fallback_model=self._fallback_model,
+                fallback_model=fallback_model_override if fallback_model_override is not None else self._fallback_model,
                 thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,
@@ -423,6 +470,9 @@ class CLIAgentSetupMixin:
                 runtime.get("api_mode"),
                 runtime.get("command"),
                 tuple(runtime.get("args") or ()),
+                fallback_chain_signature(
+                    fallback_model_override if fallback_model_override is not None else self._fallback_model
+                ),
             )
 
             # Force-create DB row on /title intent, then apply title.

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1659,7 +1659,7 @@ class CLICommandsMixin:
                     provider_require_parameters=self._provider_require_params,
                     provider_data_collection=self._provider_data_collection,
                     openrouter_min_coding_score=self._openrouter_min_coding_score,
-                    fallback_model=self._fallback_model,
+                    fallback_model=turn_route.get("fallback_model") or self._fallback_model,
                 )
                 # Silence raw spinner; route thinking through TUI widget when no foreground agent is active.
                 bg_agent._print_fn = lambda *_a, **_kw: None

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -48,16 +48,71 @@ def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
     )
 
 
-def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
+def _configured_tier(config: dict[str, Any], explicit_tier: str | None = None) -> str:
+    if explicit_tier:
+        return explicit_tier.strip()
+
+    model_cfg = config.get("model") or {}
+    if isinstance(model_cfg, dict):
+        tier = str(model_cfg.get("tier") or "").strip()
+        if tier:
+            return tier
+
+    agent_cfg = config.get("agent") or {}
+    if isinstance(agent_cfg, dict):
+        tier = str(agent_cfg.get("tier") or "").strip()
+        if tier:
+            return tier
+
+    return ""
+
+
+def _routing_entry(config: dict[str, Any], task_context: str | None) -> dict[str, Any]:
+    if not task_context:
+        return {}
+    routing = config.get("routing") or {}
+    if not isinstance(routing, dict):
+        return {}
+    entry = routing.get(task_context) or {}
+    return entry if isinstance(entry, dict) else {}
+
+
+def get_fallback_chain(
+    config: dict[str, Any] | None,
+    *,
+    tier: str | None = None,
+    task_context: str | None = None,
+) -> list[dict[str, Any]]:
     """Return the effective fallback chain merged across old and new config keys.
 
     ``fallback_providers`` remains the primary source of truth and keeps its
     order. Legacy ``fallback_model`` entries are appended afterwards unless
     they target the same provider/model/base_url route as an earlier entry.
+    When ``model.tier`` / ``agent.tier`` or an explicit ``tier`` is configured,
+    ``fallback_tiers.<tier>`` replaces the global chain. ``routing.<context>``
+    may also provide ``fallback_providers`` or ``tier`` for task-specific
+    routing.
     The returned list always contains fresh dict copies.
     """
 
     config = config or {}
+    route = _routing_entry(config, task_context)
+    route_chain = _iter_fallback_entries(
+        route.get("fallback_providers") or route.get("fallback_model")
+    )
+    if route_chain:
+        return route_chain
+
+    selected_tier = _configured_tier(
+        config,
+        explicit_tier=(tier or str(route.get("tier") or route.get("fallback_tier") or "")),
+    )
+    fallback_tiers = config.get("fallback_tiers") or {}
+    if selected_tier and isinstance(fallback_tiers, dict):
+        tier_chain = _iter_fallback_entries(fallback_tiers.get(selected_tier))
+        if tier_chain:
+            return tier_chain
+
     chain: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
 

--- a/hermes_cli/model_routing.py
+++ b/hermes_cli/model_routing.py
@@ -1,0 +1,99 @@
+"""Config-driven model route selection for agent turns.
+
+This module is deliberately pure: it reads config shapes and returns the
+requested route, while callers keep using their normal provider resolver for
+credentials and client setup.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+_TOOL_USE_HINT_RE = re.compile(
+    r"(?i)\b("
+    r"run|execute|test|pytest|npm|ruff|mypy|lint|build|commit|diff|patch|"
+    r"edit|write|modify|create|delete|rename|move|read|open|inspect|search|"
+    r"grep|rg|find|file|directory|repo|code|bug|debug|fix|implement|shell|"
+    r"terminal|command|browse|web|fetch|download"
+    r")\b|(?:^|\s)(?:\./|/|~\/|[A-Za-z]:\\)"
+)
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _configured_context(config: dict[str, Any]) -> str:
+    routing = _as_mapping(config.get("routing"))
+    value = str(routing.get("context") or routing.get("default_context") or "").strip()
+    return value
+
+
+def classify_task_context(config: dict[str, Any] | None, user_message: Any) -> str:
+    """Return the routing context for a turn.
+
+    ``routing.context`` can pin a context explicitly. Otherwise, only configs
+    that define both ``routing.chat`` and ``routing.tool_use`` get automatic
+    chat/tool-use classification; this keeps existing installs inert.
+    """
+
+    config = config or {}
+    explicit = _configured_context(config)
+    if explicit:
+        return explicit
+
+    routing = _as_mapping(config.get("routing"))
+    if "chat" not in routing or "tool_use" not in routing:
+        return ""
+
+    text = ""
+    if isinstance(user_message, str):
+        text = user_message
+    elif isinstance(user_message, list):
+        parts: list[str] = []
+        for part in user_message:
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                parts.append(part["text"])
+        text = "\n".join(parts)
+
+    return "tool_use" if _TOOL_USE_HINT_RE.search(text or "") else "chat"
+
+
+def get_route_override(
+    config: dict[str, Any] | None,
+    task_context: str,
+) -> dict[str, Any]:
+    """Return ``routing.<task_context>`` when it names a provider/model route."""
+
+    routing = _as_mapping((config or {}).get("routing"))
+    entry = _as_mapping(routing.get(task_context))
+    provider = str(entry.get("provider") or "").strip()
+    model = str(entry.get("model") or entry.get("default") or "").strip()
+    if not provider and not model:
+        return {}
+
+    route = dict(entry)
+    if provider:
+        route["provider"] = provider
+    if model:
+        route["model"] = model
+    return route
+
+
+def fallback_chain_signature(chain: Any) -> tuple[tuple[str, str, str], ...]:
+    """Stable identity for deciding whether a cached agent's fallback changed."""
+
+    if not isinstance(chain, list):
+        return ()
+    out: list[tuple[str, str, str]] = []
+    for entry in chain:
+        if not isinstance(entry, dict):
+            continue
+        out.append((
+            str(entry.get("provider") or "").strip().lower(),
+            str(entry.get("model") or "").strip(),
+            str(entry.get("base_url") or "").strip().rstrip("/").lower(),
+        ))
+    return tuple(out)

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -306,6 +306,7 @@ def _run_agent(
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
+    from hermes_cli.model_routing import classify_task_context, get_route_override
     from hermes_cli.models import detect_provider_for_model
     from hermes_cli.runtime_provider import resolve_runtime_provider
     from hermes_cli.tools_config import _get_platform_tools
@@ -366,10 +367,18 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
+    task_context = classify_task_context(cfg, prompt)
+    route_override = get_route_override(cfg, task_context)
+    if route_override:
+        effective_model = route_override.get("model") or effective_model
+        effective_provider = route_override.get("provider") or effective_provider
+        explicit_base_url_from_alias = route_override.get("base_url") or explicit_base_url_from_alias
+
     runtime = resolve_runtime_provider(
         requested=effective_provider,
         target_model=effective_model or None,
         explicit_base_url=explicit_base_url_from_alias,
+        explicit_api_key=route_override.get("api_key") if route_override else None,
     )
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user
@@ -382,7 +391,7 @@ def _run_agent(
     session_db = _create_session_db_for_oneshot()
     # Read the effective fallback chain from profile config so oneshot workers
     # honour the same merge semantics as interactive CLI and gateway sessions.
-    _fb = get_fallback_chain(cfg)
+    _fb = get_fallback_chain(cfg, task_context=task_context)
 
     agent = AIAgent(
         api_key=runtime.get("api_key"),

--- a/tests/hermes_cli/test_model_routing.py
+++ b/tests/hermes_cli/test_model_routing.py
@@ -1,0 +1,165 @@
+from types import SimpleNamespace
+
+
+def test_fallback_chain_uses_configured_model_tier():
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    cfg = {
+        "model": {"tier": "cheap"},
+        "fallback_providers": [{"provider": "anthropic", "model": "global"}],
+        "fallback_tiers": {
+            "cheap": [{"provider": "openai", "model": "gpt-5-nano"}],
+            "hard": [{"provider": "anthropic", "model": "claude-opus"}],
+        },
+    }
+
+    assert get_fallback_chain(cfg) == [{"provider": "openai", "model": "gpt-5-nano"}]
+
+
+def test_routing_context_can_select_different_fallback_tier():
+    from hermes_cli.fallback_config import get_fallback_chain
+    from hermes_cli.model_routing import classify_task_context, get_route_override
+
+    cfg = {
+        "routing": {
+            "chat": {"provider": "openrouter", "model": "small"},
+            "tool_use": {"provider": "anthropic", "model": "sonnet", "tier": "hard"},
+        },
+        "fallback_tiers": {
+            "hard": [{"provider": "anthropic", "model": "opus"}],
+        },
+    }
+
+    context = classify_task_context(cfg, "please edit the file and run tests")
+
+    assert context == "tool_use"
+    assert get_route_override(cfg, context)["model"] == "sonnet"
+    assert get_fallback_chain(cfg, task_context=context) == [
+        {"provider": "anthropic", "model": "opus"}
+    ]
+
+
+def test_cli_turn_route_applies_routing_override(monkeypatch):
+    import cli
+    from cli import HermesCLI
+    import hermes_cli.runtime_provider as runtime_provider
+
+    cfg = {
+        "routing": {
+            "chat": {"provider": "openrouter", "model": "small-chat"},
+            "tool_use": {"provider": "anthropic", "model": "claude-sonnet"},
+        },
+        "fallback_tiers": {
+            "hard": [{"provider": "anthropic", "model": "claude-opus"}],
+        },
+    }
+    cfg["routing"]["tool_use"]["tier"] = "hard"
+    monkeypatch.setattr(cli, "CLI_CONFIG", cfg)
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **kw: {
+            "api_key": "anthropic-key",
+            "base_url": "https://api.anthropic.com/v1/anthropic",
+            "provider": kw["requested"],
+            "api_mode": "anthropic_messages",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        },
+    )
+
+    shell = SimpleNamespace(
+        model="small-chat",
+        api_key="openrouter-key",
+        base_url="https://openrouter.ai/api/v1",
+        provider="openrouter",
+        api_mode="chat_completions",
+        acp_command=None,
+        acp_args=[],
+        _credential_pool=None,
+        service_tier=None,
+    )
+
+    route = HermesCLI._resolve_turn_agent_config(shell, "edit file.py")
+
+    assert route["model"] == "claude-sonnet"
+    assert route["runtime"]["provider"] == "anthropic"
+    assert route["fallback_model"] == [
+        {"provider": "anthropic", "model": "claude-opus"}
+    ]
+
+
+def test_gateway_turn_route_applies_routing_override(monkeypatch):
+    import gateway.run as gateway_run
+    import hermes_cli.runtime_provider as runtime_provider
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "routing": {
+                "chat": {"provider": "openrouter", "model": "small-chat"},
+                "tool_use": {"provider": "openai", "model": "gpt-5", "tier": "mid"},
+            },
+            "fallback_tiers": {
+                "mid": [{"provider": "openai", "model": "gpt-5-mini"}],
+            },
+        },
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **kw: {
+            "api_key": "openai-key",
+            "base_url": "https://api.openai.com/v1",
+            "provider": kw["requested"],
+            "api_mode": "codex_responses",
+            "command": None,
+            "args": [],
+            "credential_pool": "pool",
+        },
+    )
+    runner = SimpleNamespace(_service_tier=None)
+    runtime_kwargs = {
+        "api_key": "openrouter-key",
+        "base_url": "https://openrouter.ai/api/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "run pytest",
+        "small-chat",
+        runtime_kwargs,
+    )
+
+    assert route["model"] == "gpt-5"
+    assert route["runtime"]["provider"] == "openai"
+    assert route["runtime"]["credential_pool"] == "pool"
+    assert route["fallback_model"] == [{"provider": "openai", "model": "gpt-5-mini"}]
+
+
+def test_gateway_cached_agent_prefers_routed_fallback_chain():
+    import gateway.run as gateway_run
+
+    agent = SimpleNamespace(
+        _fallback_chain=[],
+        _fallback_model=None,
+        _fallback_activated=False,
+        _fallback_index=0,
+    )
+    routed_chain = [{"provider": "openai", "model": "gpt-5-mini"}]
+    global_chain = [{"provider": "anthropic", "model": "claude-haiku"}]
+
+    gateway_run.GatewayRunner._apply_fallback_chain_to_agent(
+        agent,
+        routed_chain or global_chain,
+    )
+
+    assert agent._fallback_chain == routed_chain
+    assert agent._fallback_model == routed_chain[0]


### PR DESCRIPTION
## What does this PR do?

Adds a config-driven model routing layer so Hermes can choose a provider/model and fallback chain from the current agent tier or task context before constructing the per-turn AIAgent.

## Related Issue

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `hermes_cli/model_routing.py` for inert-by-default chat/tool-use context classification and `routing.<context>` route selection.
- Extended `hermes_cli/fallback_config.py` so `model.tier`, `agent.tier`, or `routing.<context>.tier` can select `fallback_tiers.<tier>` instead of the global fallback chain.
- Wired CLI, CLI background tasks, oneshot mode, and gateway turns to pass route-specific fallback chains into `AIAgent` and rebuild cached agents when the effective fallback chain changes.
- Documented the new `routing` and `fallback_tiers` shapes in `cli-config.yaml.example`.
- Added focused coverage in `tests/hermes_cli/test_model_routing.py`.

## Shared root cause

- Hermes had per-turn setup hooks (`_resolve_turn_agent_config`) but they always returned the session primary provider/model and a single global fallback chain. That left both fleet-tier fallback selection and chat-vs-tool model routing without a shared config/runtime abstraction.
- The fix centralizes route-context selection and tiered fallback-chain resolution before `AIAgent` construction, preserving prompt-cache stability by rebuilding the agent only when the route signature changes.

## How this fixes each issue

- #25321: A profile or agent can set `model.tier` / `agent.tier`, or a route can set `tier`, and Hermes will use the matching `fallback_tiers.<tier>` chain instead of one global `fallback_providers` chain.
- #26027: `routing.chat` and `routing.tool_use` can select different provider/model pairs; when both are configured, Hermes classifies simple chat separately from tool-heavy prompts and resolves the matching route through the existing provider resolver.

## How to Test

1. `pytest tests/hermes_cli/test_model_routing.py tests/agent/test_credential_pool_routing.py tests/cli/test_fast_command.py tests/gateway/test_fast_command.py -q --timeout=60`
2. `ruff check` on changed Python files
3. `python scripts/check-windows-footguns.py cli.py gateway/run.py hermes_cli/cli_agent_setup_mixin.py hermes_cli/cli_commands_mixin.py hermes_cli/fallback_config.py hermes_cli/model_routing.py hermes_cli/oneshot.py tests/hermes_cli/test_model_routing.py cli-config.yaml.example`

Broad suite note: the required full command `pytest tests/ -q -x --timeout=60` was run and aborted during collection because this local environment lacks dashboard dependencies (`fastapi`/`uvicorn`) and lazy installation is blocked by Homebrew Python's externally-managed-environment/PEP 668 guard. The focused covering subset above passed.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched the source for existing model/fallback routing paths before implementing
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation / examples
- [x] I've updated `cli-config.yaml.example` because this adds config keys
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A

Refs #25321
Refs #26027

<!-- autocontrib:worker-id=pr-spanning-35c89ff8 kind=pr-open -->