### PR TITLE
fix(copilot): bound auth JSON response reads

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -43,6 +43,17 @@ COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 # Polling constants
 _DEVICE_CODE_POLL_INTERVAL = 5  # seconds
 _DEVICE_CODE_POLL_SAFETY_MARGIN = 3  # seconds
+_COPILOT_AUTH_JSON_BODY_MAX_BYTES = 1024 * 1024
+
+
+def _read_copilot_json_response(resp, *, label: str) -> dict:
+    body = resp.read(_COPILOT_AUTH_JSON_BODY_MAX_BYTES + 1)
+    if len(body) > _COPILOT_AUTH_JSON_BODY_MAX_BYTES:
+        raise ValueError(
+            f"Copilot {label} response exceeded "
+            f"{_COPILOT_AUTH_JSON_BODY_MAX_BYTES} bytes"
+        )
+    return json.loads(body.decode())
 
 
 def validate_copilot_token(token: str) -> tuple[bool, str]:
@@ -193,7 +204,7 @@ def copilot_device_code_login(
 
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
-            device_data = json.loads(resp.read().decode())
+            device_data = _read_copilot_json_response(resp, label="device code")
     except Exception as exc:
         logger.error("Failed to initiate device authorization: %s", exc)
         print(f"  ✗ Failed to start device authorization: {exc}")
@@ -239,7 +250,7 @@ def copilot_device_code_login(
 
         try:
             with urllib.request.urlopen(poll_req, timeout=10) as resp:
-                result = json.loads(resp.read().decode())
+                result = _read_copilot_json_response(resp, label="device code poll")
         except Exception:
             print(".", end="", flush=True)
             continue
@@ -334,7 +345,7 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            data = json.loads(resp.read().decode())
+            data = _read_copilot_json_response(resp, label="token exchange")
     except Exception as exc:
         raise ValueError(f"Copilot token exchange failed: {exc}") from exc
 

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -49,6 +49,21 @@ COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 # Polling constants
 _DEVICE_CODE_POLL_INTERVAL = 5  # seconds
 _DEVICE_CODE_POLL_SAFETY_MARGIN = 3  # seconds
+_COPILOT_AUTH_JSON_BODY_MAX_BYTES = 1024 * 1024
+
+
+class _CopilotAuthResponseTooLarge(ValueError):
+    """A Copilot auth control response exceeded its byte cap."""
+
+
+def _read_copilot_json_response(resp, *, label: str) -> dict:
+    body = resp.read(_COPILOT_AUTH_JSON_BODY_MAX_BYTES + 1)
+    if len(body) > _COPILOT_AUTH_JSON_BODY_MAX_BYTES:
+        raise _CopilotAuthResponseTooLarge(
+            f"Copilot {label} response exceeded "
+            f"{_COPILOT_AUTH_JSON_BODY_MAX_BYTES} bytes"
+        )
+    return json.loads(body.decode())
 
 
 def validate_copilot_token(token: str) -> tuple[bool, str]:
@@ -217,7 +232,7 @@ def copilot_device_code_login(
 
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
-            device_data = json.loads(resp.read().decode())
+            device_data = _read_copilot_json_response(resp, label="device code")
     except Exception as exc:
         logger.error("Failed to initiate device authorization: %s", exc)
         print(f"  ✗ Failed to start device authorization: {exc}")
@@ -263,7 +278,10 @@ def copilot_device_code_login(
 
         try:
             with urllib.request.urlopen(poll_req, timeout=10) as resp:
-                result = json.loads(resp.read().decode())
+                result = _read_copilot_json_response(resp, label="device code poll")
+        except _CopilotAuthResponseTooLarge as exc:
+            print(f"\n  ✗ {exc}")
+            return None
         except Exception:
             print(".", end="", flush=True)
             continue
@@ -551,7 +569,7 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
     for attempt in range(_EXCHANGE_MAX_ATTEMPTS):
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                data = json.loads(resp.read().decode())
+                data = _read_copilot_json_response(resp, label="token exchange")
             break
         except Exception as exc:  # noqa: BLE001 — retry all, re-raise below
             last_exc = exc

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -1,7 +1,7 @@
 """Tests for hermes_cli.copilot_auth — Copilot token validation and resolution."""
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 class TestTokenValidation:
@@ -105,6 +105,29 @@ class TestResolveToken:
             token, source = resolve_copilot_token()
         assert token == ""
         assert source == ""
+
+
+class TestDeviceCodeLogin:
+    """Copilot OAuth device-code login."""
+
+    @patch("urllib.request.urlopen")
+    def test_device_code_response_size_limit(self, mock_urlopen, monkeypatch, capsys):
+        from hermes_cli.copilot_auth import copilot_device_code_login
+
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth._COPILOT_AUTH_JSON_BODY_MAX_BYTES",
+            8,
+        )
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"x" * 9
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert copilot_device_code_login(timeout_seconds=0) is None
+
+        mock_resp.read.assert_called_once_with(9)
+        assert "response exceeded 8 bytes" in capsys.readouterr().out
 
 
 class TestRequestHeaders:

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -1,7 +1,7 @@
 """Tests for hermes_cli.copilot_auth — Copilot token validation and resolution."""
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 class TestTokenValidation:
@@ -70,6 +70,53 @@ class TestResolveToken:
         assert token == ""
         assert source == ""
         mock_cli.assert_not_called()
+
+
+class TestDeviceCodeLogin:
+    """Copilot OAuth device-code login."""
+
+    @patch("urllib.request.urlopen")
+    def test_device_code_response_size_limit(self, mock_urlopen, monkeypatch, capsys):
+        from hermes_cli.copilot_auth import copilot_device_code_login
+
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth._COPILOT_AUTH_JSON_BODY_MAX_BYTES",
+            8,
+        )
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"x" * 9
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert copilot_device_code_login(timeout_seconds=0) is None
+
+        mock_resp.read.assert_called_once_with(9)
+        assert "response exceeded 8 bytes" in capsys.readouterr().out
+
+    @patch("time.sleep")
+    @patch("time.monotonic", side_effect=[0, 0, 2])
+    @patch("urllib.request.urlopen")
+    def test_poll_response_size_limit(
+        self, mock_urlopen, _mock_monotonic, _mock_sleep, monkeypatch, capsys
+    ):
+        from hermes_cli.copilot_auth import copilot_device_code_login
+
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth._COPILOT_AUTH_JSON_BODY_MAX_BYTES", 64
+        )
+        responses = [MagicMock(), MagicMock()]
+        responses[0].read.return_value = (
+            b'{"device_code":"d","user_code":"u","interval":1}'
+        )
+        responses[1].read.return_value = b"x" * 65
+        for response in responses:
+            response.__enter__.return_value = response
+        mock_urlopen.side_effect = responses
+
+        assert copilot_device_code_login(timeout_seconds=1) is None
+        assert "poll response exceeded 64 bytes" in capsys.readouterr().out
+        assert mock_urlopen.call_count == 2
 
 
 class TestRequestHeaders:

--- a/tests/hermes_cli/test_copilot_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_token_exchange.py
@@ -97,6 +97,25 @@ class TestExchangeCopilotToken:
         with pytest.raises(ValueError, match="network error"):
             exchange_copilot_token("gho_test123")
 
+    @patch("urllib.request.urlopen")
+    def test_response_body_size_limit(self, mock_urlopen, monkeypatch):
+        from hermes_cli.copilot_auth import exchange_copilot_token
+
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth._COPILOT_AUTH_JSON_BODY_MAX_BYTES",
+            8,
+        )
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"x" * 9
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        with pytest.raises(ValueError, match="token exchange response exceeded 8 bytes"):
+            exchange_copilot_token("gho_test123")
+
+        mock_resp.read.assert_called_once_with(9)
+
 
 class TestGetCopilotApiToken:
     """Tests for get_copilot_api_token() — the fallback wrapper."""

--- a/tests/hermes_cli/test_copilot_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_token_exchange.py
@@ -67,6 +67,26 @@ class TestExchangeCopilotToken:
         with pytest.raises(ValueError, match="empty token"):
             exchange_copilot_token("gho_test123")
 
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_response_body_size_limit(self, mock_urlopen, _mock_sleep, monkeypatch):
+        from hermes_cli.copilot_auth import exchange_copilot_token, _EXCHANGE_MAX_ATTEMPTS
+
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth._COPILOT_AUTH_JSON_BODY_MAX_BYTES",
+            8,
+        )
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"x" * 9
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        with pytest.raises(ValueError, match="token exchange response exceeded 8 bytes"):
+            exchange_copilot_token("gho_test123")
+
+        assert mock_resp.read.call_count == _EXCHANGE_MAX_ATTEMPTS
+        mock_resp.read.assert_called_with(9)
 
 class TestGetCopilotApiToken:
     """Tests for get_copilot_api_token() — the fallback wrapper."""


### PR DESCRIPTION
## Summary

Fixes #54749.

This bounds Copilot auth JSON response reads in `hermes_cli.copilot_auth`:

- device-code creation responses now use a limited JSON reader
- device-code polling responses now use the same limited reader
- Copilot token exchange responses now use the same limited reader
- oversized JSON responses fail with a clear diagnostic instead of buffering the whole body

The cap is 1 MiB, which is far above the expected size of these OAuth/token JSON payloads while still protecting the process from malformed upstream or proxy responses.

## Testing

- `C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-openclaw-pattern-scan\.venv\Scripts\python.exe -m pytest tests\hermes_cli\test_copilot_auth.py tests\hermes_cli\test_copilot_token_exchange.py -q --basetemp .pytest-tmp-copilot-auth` (`39 passed`)
- `git diff --check`