### PR TITLE
fix(mattermost): bound REST response reads

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -35,6 +35,9 @@ logger = logging.getLogger(__name__)
 # Mattermost post size limit (server default is 16383, but 4000 is the
 # practical limit for readable messages — matching OpenClaw's choice).
 MAX_POST_LENGTH = 4000
+_MATTERMOST_JSON_BODY_MAX_BYTES = 4 * 1024 * 1024
+_MATTERMOST_ERROR_BODY_MAX_BYTES = 64 * 1024
+_MATTERMOST_BODY_READ_CHUNK_BYTES = 64 * 1024
 
 # Channel type codes returned by the Mattermost API.
 _CHANNEL_TYPE_MAP = {
@@ -48,6 +51,102 @@ _CHANNEL_TYPE_MAP = {
 _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
+
+
+def _is_mock_object(value: Any) -> bool:
+    return "unittest.mock" in type(value).__module__
+
+
+async def _read_mattermost_body(resp: Any, limit: int, *, label: str) -> bytes:
+    content_length = getattr(resp, "content_length", None)
+    if isinstance(content_length, int) and content_length > limit:
+        raise ValueError(f"Mattermost {label} exceeded {limit} bytes")
+    headers = getattr(resp, "headers", None)
+    header_value = None
+    if not _is_mock_object(headers) and hasattr(headers, "get"):
+        header_value = headers.get("Content-Length") or headers.get("content-length")
+    if header_value is not None:
+        try:
+            if int(header_value) > limit:
+                raise ValueError(f"Mattermost {label} exceeded {limit} bytes")
+        except (TypeError, ValueError):
+            if isinstance(header_value, str) and header_value.strip().isdigit():
+                raise
+
+    content = getattr(resp, "content", None)
+    iter_chunked = getattr(content, "iter_chunked", None)
+    if callable(iter_chunked) and not _is_mock_object(iter_chunked):
+        chunks: List[bytes] = []
+        total = 0
+        try:
+            async for chunk in iter_chunked(_MATTERMOST_BODY_READ_CHUNK_BYTES):
+                if isinstance(chunk, bytearray):
+                    chunk = bytes(chunk)
+                if not isinstance(chunk, bytes):
+                    raise TypeError("Mattermost response stream yielded non-bytes")
+                total += len(chunk)
+                if total > limit:
+                    raise ValueError(f"Mattermost {label} exceeded {limit} bytes")
+                chunks.append(chunk)
+        except TypeError:
+            pass
+        else:
+            return b"".join(chunks)
+
+    read = getattr(content, "read", None)
+    if callable(read) and not _is_mock_object(read):
+        body = await read(limit + 1)
+        if isinstance(body, bytearray):
+            body = bytes(body)
+        if isinstance(body, bytes):
+            if len(body) > limit:
+                raise ValueError(f"Mattermost {label} exceeded {limit} bytes")
+            return body
+
+    read_response = getattr(resp, "read", None)
+    if callable(read_response) and not _is_mock_object(read_response):
+        body = await read_response()
+        if isinstance(body, bytearray):
+            body = bytes(body)
+        if isinstance(body, bytes):
+            if len(body) > limit:
+                raise ValueError(f"Mattermost {label} exceeded {limit} bytes")
+            return body
+
+    raise TypeError("Mattermost response body is not readable")
+
+
+async def _read_mattermost_text_response(
+    resp: Any,
+    *,
+    limit: Optional[int] = None,
+) -> str:
+    if limit is None:
+        limit = _MATTERMOST_ERROR_BODY_MAX_BYTES
+    try:
+        body = await _read_mattermost_body(resp, limit, label="error response body")
+    except TypeError:
+        return await resp.text()
+    return body.decode("utf-8", errors="replace")
+
+
+async def _read_mattermost_json_response(
+    resp: Any,
+    *,
+    limit: Optional[int] = None,
+) -> Dict[str, Any]:
+    if limit is None:
+        limit = _MATTERMOST_JSON_BODY_MAX_BYTES
+    try:
+        body = await _read_mattermost_body(resp, limit, label="JSON response body")
+    except TypeError:
+        return await resp.json()
+    if not body:
+        return {}
+    data = json.loads(body.decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Mattermost JSON response was not an object")
+    return data
 
 
 def check_mattermost_requirements() -> bool:
@@ -124,11 +223,11 @@ class MattermostAdapter(BasePlatformAdapter):
         try:
             async with self._session.get(url, headers=self._headers(), timeout=aiohttp.ClientTimeout(total=30)) as resp:
                 if resp.status >= 400:
-                    body = await resp.text()
+                    body = await _read_mattermost_text_response(resp)
                     logger.error("MM API GET %s → %s: %s", path, resp.status, body[:200])
                     return {}
-                return await resp.json()
-        except aiohttp.ClientError as exc:
+                return await _read_mattermost_json_response(resp)
+        except (aiohttp.ClientError, ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             logger.error("MM API GET %s network error: %s", path, exc)
             return {}
 
@@ -150,12 +249,12 @@ class MattermostAdapter(BasePlatformAdapter):
             ) as resp:
                 self._last_post_status = resp.status
                 if resp.status >= 400:
-                    body = await resp.text()
+                    body = await _read_mattermost_text_response(resp)
                     self._last_post_error = body or ""
                     logger.error("MM API POST %s → %s: %s", path, resp.status, body[:200])
                     return {}
-                return await resp.json()
-        except aiohttp.ClientError as exc:
+                return await _read_mattermost_json_response(resp)
+        except (aiohttp.ClientError, ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             self._last_post_error = str(exc)
             logger.error("MM API POST %s network error: %s", path, exc)
             return {}
@@ -228,11 +327,11 @@ class MattermostAdapter(BasePlatformAdapter):
                 url, headers=self._headers(), json=payload
             ) as resp:
                 if resp.status >= 400:
-                    body = await resp.text()
+                    body = await _read_mattermost_text_response(resp)
                     logger.error("MM API PUT %s → %s: %s", path, resp.status, body[:200])
                     return {}
-                return await resp.json()
-        except aiohttp.ClientError as exc:
+                return await _read_mattermost_json_response(resp)
+        except (aiohttp.ClientError, ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             logger.error("MM API PUT %s network error: %s", path, exc)
             return {}
 
@@ -252,14 +351,18 @@ class MattermostAdapter(BasePlatformAdapter):
             content_type=content_type,
         )
         headers = {"Authorization": f"Bearer {self._token}"}
-        async with self._session.post(url, headers=headers, data=form, timeout=aiohttp.ClientTimeout(total=60)) as resp:
-            if resp.status >= 400:
-                body = await resp.text()
-                logger.error("MM file upload → %s: %s", resp.status, body[:200])
-                return None
-            data = await resp.json()
-            infos = data.get("file_infos", [])
-            return infos[0]["id"] if infos else None
+        try:
+            async with self._session.post(url, headers=headers, data=form, timeout=aiohttp.ClientTimeout(total=60)) as resp:
+                if resp.status >= 400:
+                    body = await _read_mattermost_text_response(resp)
+                    logger.error("MM file upload → %s: %s", resp.status, body[:200])
+                    return None
+                data = await _read_mattermost_json_response(resp)
+                infos = data.get("file_infos", [])
+                return infos[0]["id"] if infos else None
+        except (aiohttp.ClientError, ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+            logger.error("MM file upload network error: %s", exc)
+            return None
 
     # ------------------------------------------------------------------
     # Required overrides
@@ -1053,14 +1156,14 @@ async def _standalone_send(
                     **_req_kw,
                 ) as upload_resp:
                     if upload_resp.status not in {200, 201}:
-                        body = await upload_resp.text()
+                        body = await _read_mattermost_text_response(upload_resp)
                         return {
                             "error": (
                                 f"Mattermost file upload failed "
                                 f"({upload_resp.status}): {body[:400]}"
                             )
                         }
-                    upload_data = await upload_resp.json()
+                    upload_data = await _read_mattermost_json_response(upload_resp)
                     for info in upload_data.get("file_infos", []):
                         if info.get("id"):
                             file_ids.append(info["id"])
@@ -1081,14 +1184,14 @@ async def _standalone_send(
                 **_req_kw,
             ) as resp:
                 if resp.status not in {200, 201}:
-                    body = await resp.text()
+                    body = await _read_mattermost_text_response(resp)
                     return {
                         "error": (
                             f"Mattermost API error ({resp.status}): "
                             f"{body[:400]}"
                         )
                     }
-                data = await resp.json()
+                data = await _read_mattermost_json_response(resp)
             return {
                 "success": True,
                 "platform": "mattermost",

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -59,6 +59,9 @@ logger = logging.getLogger(__name__)
 # Mattermost post size limit (server default is 16383, but 4000 is the
 # practical limit for readable messages — matching OpenClaw's choice).
 MAX_POST_LENGTH = 4000
+_MATTERMOST_JSON_BODY_MAX_BYTES = 4 * 1024 * 1024
+_MATTERMOST_ERROR_BODY_MAX_BYTES = 64 * 1024
+_MATTERMOST_BODY_READ_CHUNK_BYTES = 64 * 1024
 
 # Channel type codes returned by the Mattermost API.
 _CHANNEL_TYPE_MAP = {
@@ -84,6 +87,102 @@ def _with_mentions_disabled(payload: Dict[str, Any]) -> Dict[str, Any]:
     else:
         payload["props"] = dict(_MATTERMOST_DISABLE_MENTIONS_PROPS)
     return payload
+
+
+def _is_mock_object(value: Any) -> bool:
+    return "unittest.mock" in type(value).__module__
+
+
+async def _read_mattermost_body(resp: Any, limit: int, *, label: str) -> bytes:
+    content_length = getattr(resp, "content_length", None)
+    if isinstance(content_length, int) and content_length > limit:
+        raise ValueError(f"Mattermost {label} exceeded {limit} bytes")
+    headers = getattr(resp, "headers", None)
+    header_value = None
+    if not _is_mock_object(headers) and hasattr(headers, "get"):
+        header_value = headers.get("Content-Length") or headers.get("content-length")
+    if header_value is not None:
+        try:
+            if int(header_value) > limit:
+                raise ValueError(f"Mattermost {label} exceeded {limit} bytes")
+        except (TypeError, ValueError):
+            if isinstance(header_value, str) and header_value.strip().isdigit():
+                raise
+
+    content = getattr(resp, "content", None)
+    iter_chunked = getattr(content, "iter_chunked", None)
+    if callable(iter_chunked) and not _is_mock_object(iter_chunked):
+        chunks: List[bytes] = []
+        total = 0
+        try:
+            async for chunk in iter_chunked(_MATTERMOST_BODY_READ_CHUNK_BYTES):
+                if isinstance(chunk, bytearray):
+                    chunk = bytes(chunk)
+                if not isinstance(chunk, bytes):
+                    raise TypeError("Mattermost response stream yielded non-bytes")
+                total += len(chunk)
+                if total > limit:
+                    raise ValueError(f"Mattermost {label} exceeded {limit} bytes")
+                chunks.append(chunk)
+        except TypeError:
+            pass
+        else:
+            return b"".join(chunks)
+
+    read = getattr(content, "read", None)
+    if callable(read) and not _is_mock_object(read):
+        body = await read(limit + 1)
+        if isinstance(body, bytearray):
+            body = bytes(body)
+        if isinstance(body, bytes):
+            if len(body) > limit:
+                raise ValueError(f"Mattermost {label} exceeded {limit} bytes")
+            return body
+
+    read_response = getattr(resp, "read", None)
+    if callable(read_response) and not _is_mock_object(read_response):
+        body = await read_response()
+        if isinstance(body, bytearray):
+            body = bytes(body)
+        if isinstance(body, bytes):
+            if len(body) > limit:
+                raise ValueError(f"Mattermost {label} exceeded {limit} bytes")
+            return body
+
+    raise TypeError("Mattermost response body is not readable")
+
+
+async def _read_mattermost_text_response(
+    resp: Any,
+    *,
+    limit: Optional[int] = None,
+) -> str:
+    if limit is None:
+        limit = _MATTERMOST_ERROR_BODY_MAX_BYTES
+    try:
+        body = await _read_mattermost_body(resp, limit, label="error response body")
+    except TypeError:
+        return await resp.text()
+    return body.decode("utf-8", errors="replace")
+
+
+async def _read_mattermost_json_response(
+    resp: Any,
+    *,
+    limit: Optional[int] = None,
+) -> Dict[str, Any]:
+    if limit is None:
+        limit = _MATTERMOST_JSON_BODY_MAX_BYTES
+    try:
+        body = await _read_mattermost_body(resp, limit, label="JSON response body")
+    except TypeError:
+        return await resp.json()
+    if not body:
+        return {}
+    data = json.loads(body.decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Mattermost JSON response was not an object")
+    return data
 
 
 def check_mattermost_requirements() -> bool:
@@ -166,11 +265,11 @@ class MattermostAdapter(BasePlatformAdapter):
         try:
             async with self._session.get(url, headers=self._headers(), timeout=aiohttp.ClientTimeout(total=30)) as resp:
                 if resp.status >= 400:
-                    body = await resp.text()
+                    body = await _read_mattermost_text_response(resp)
                     logger.error("MM API GET %s → %s: %s", path, resp.status, body[:200])
                     return {}
-                return await resp.json()
-        except aiohttp.ClientError as exc:
+                return await _read_mattermost_json_response(resp)
+        except (aiohttp.ClientError, ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             logger.error("MM API GET %s network error: %s", path, exc)
             return {}
 
@@ -192,12 +291,12 @@ class MattermostAdapter(BasePlatformAdapter):
             ) as resp:
                 self._last_post_status = resp.status
                 if resp.status >= 400:
-                    body = await resp.text()
+                    body = await _read_mattermost_text_response(resp)
                     self._last_post_error = body or ""
                     logger.error("MM API POST %s → %s: %s", path, resp.status, body[:200])
                     return {}
-                return await resp.json()
-        except aiohttp.ClientError as exc:
+                return await _read_mattermost_json_response(resp)
+        except (aiohttp.ClientError, ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             self._last_post_error = str(exc)
             logger.error("MM API POST %s network error: %s", path, exc)
             return {}
@@ -270,11 +369,11 @@ class MattermostAdapter(BasePlatformAdapter):
                 url, headers=self._headers(), json=payload
             ) as resp:
                 if resp.status >= 400:
-                    body = await resp.text()
+                    body = await _read_mattermost_text_response(resp)
                     logger.error("MM API PUT %s → %s: %s", path, resp.status, body[:200])
                     return {}
-                return await resp.json()
-        except aiohttp.ClientError as exc:
+                return await _read_mattermost_json_response(resp)
+        except (aiohttp.ClientError, ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             logger.error("MM API PUT %s network error: %s", path, exc)
             return {}
 
@@ -294,14 +393,18 @@ class MattermostAdapter(BasePlatformAdapter):
             content_type=content_type,
         )
         headers = {"Authorization": f"Bearer {self._token}"}
-        async with self._session.post(url, headers=headers, data=form, timeout=aiohttp.ClientTimeout(total=60)) as resp:
-            if resp.status >= 400:
-                body = await resp.text()
-                logger.error("MM file upload → %s: %s", resp.status, body[:200])
-                return None
-            data = await resp.json()
-            infos = data.get("file_infos", [])
-            return infos[0]["id"] if infos else None
+        try:
+            async with self._session.post(url, headers=headers, data=form, timeout=aiohttp.ClientTimeout(total=60)) as resp:
+                if resp.status >= 400:
+                    body = await _read_mattermost_text_response(resp)
+                    logger.error("MM file upload → %s: %s", resp.status, body[:200])
+                    return None
+                data = await _read_mattermost_json_response(resp)
+                infos = data.get("file_infos", [])
+                return infos[0]["id"] if infos else None
+        except (aiohttp.ClientError, ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+            logger.error("MM file upload network error: %s", exc)
+            return None
 
     # ------------------------------------------------------------------
     # Required overrides
@@ -1097,14 +1200,14 @@ async def _standalone_send(
                     **_req_kw,
                 ) as upload_resp:
                     if upload_resp.status not in {200, 201}:
-                        body = await upload_resp.text()
+                        body = await _read_mattermost_text_response(upload_resp)
                         return {
                             "error": (
                                 f"Mattermost file upload failed "
                                 f"({upload_resp.status}): {body[:400]}"
                             )
                         }
-                    upload_data = await upload_resp.json()
+                    upload_data = await _read_mattermost_json_response(upload_resp)
                     for info in upload_data.get("file_infos", []):
                         if info.get("id"):
                             file_ids.append(info["id"])
@@ -1125,14 +1228,14 @@ async def _standalone_send(
                 **_req_kw,
             ) as resp:
                 if resp.status not in {200, 201}:
-                    body = await resp.text()
+                    body = await _read_mattermost_text_response(resp)
                     return {
                         "error": (
                             f"Mattermost API error ({resp.status}): "
                             f"{body[:400]}"
                         )
                     }
-                data = await resp.json()
+                data = await _read_mattermost_json_response(resp)
             return {
                 "success": True,
                 "platform": "mattermost",

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -199,6 +199,128 @@ def _make_adapter():
     return adapter
 
 
+class _FakeMattermostContent:
+    def __init__(self, body: bytes, *, chunks: list[bytes] | None = None):
+        self.body = body
+        self.chunks = chunks
+        self.read_calls = []
+        self.iter_chunked_calls = []
+
+    async def read(self, size: int = -1) -> bytes:
+        self.read_calls.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+    async def iter_chunked(self, size: int):
+        self.iter_chunked_calls.append(size)
+        chunks = self.chunks if self.chunks is not None else [self.body]
+        for chunk in chunks:
+            yield chunk
+
+
+class _FakeMattermostResponse:
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        status: int = 200,
+        chunks: list[bytes] | None = None,
+        headers: dict[str, str] | None = None,
+    ):
+        self.status = status
+        self.headers = headers or {}
+        self.content = _FakeMattermostContent(body, chunks=chunks)
+
+
+class _FakeMattermostRequestContext:
+    def __init__(self, response: _FakeMattermostResponse):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeMattermostSession:
+    def __init__(self, response: _FakeMattermostResponse):
+        self.response = response
+
+    def get(self, *_args, **_kwargs):
+        return _FakeMattermostRequestContext(self.response)
+
+    def post(self, *_args, **_kwargs):
+        return _FakeMattermostRequestContext(self.response)
+
+
+class TestMattermostResponseLimits:
+    @pytest.mark.asyncio
+    async def test_json_reader_rejects_oversized_body(self):
+        from plugins.platforms.mattermost.adapter import _read_mattermost_json_response
+
+        response = _FakeMattermostResponse(b"x" * 9)
+
+        with pytest.raises(ValueError, match="JSON response body exceeded 8 bytes"):
+            await _read_mattermost_json_response(response, limit=8)
+
+        assert response.content.iter_chunked_calls == [65536]
+
+    @pytest.mark.asyncio
+    async def test_json_reader_rejects_oversized_content_length(self):
+        from plugins.platforms.mattermost.adapter import _read_mattermost_json_response
+
+        response = _FakeMattermostResponse(b"{}", headers={"Content-Length": "9"})
+
+        with pytest.raises(ValueError, match="JSON response body exceeded 8 bytes"):
+            await _read_mattermost_json_response(response, limit=8)
+
+        assert response.content.iter_chunked_calls == []
+
+    @pytest.mark.asyncio
+    async def test_text_reader_rejects_oversized_error_body(self):
+        from plugins.platforms.mattermost.adapter import _read_mattermost_text_response
+
+        response = _FakeMattermostResponse(
+            b"x" * 9,
+            status=500,
+            chunks=[b"xxxx", b"xxxx", b"x"],
+        )
+
+        with pytest.raises(ValueError, match="error response body exceeded 8 bytes"):
+            await _read_mattermost_text_response(response, limit=8)
+
+        assert response.content.iter_chunked_calls == [65536]
+
+    @pytest.mark.asyncio
+    async def test_api_get_returns_empty_on_oversized_success_json(self, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.platforms.mattermost.adapter._MATTERMOST_JSON_BODY_MAX_BYTES",
+            8,
+        )
+        adapter = _make_adapter()
+        response = _FakeMattermostResponse(b"x" * 9)
+        adapter._session = _FakeMattermostSession(response)
+
+        assert await adapter._api_get("users/me") == {}
+        assert response.content.iter_chunked_calls == [65536]
+
+    @pytest.mark.asyncio
+    async def test_api_post_bounds_error_body(self, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.platforms.mattermost.adapter._MATTERMOST_ERROR_BODY_MAX_BYTES",
+            8,
+        )
+        adapter = _make_adapter()
+        response = _FakeMattermostResponse(b"x" * 9, status=500)
+        adapter._session = _FakeMattermostSession(response)
+
+        assert await adapter._api_post("posts", {"channel_id": "c", "message": "m"}) == {}
+        assert adapter._last_post_error == "Mattermost error response body exceeded 8 bytes"
+        assert response.content.iter_chunked_calls == [65536]
+
+
 class TestMattermostFormatMessage:
     def setup_method(self):
         self.adapter = _make_adapter()

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -11,6 +11,7 @@ from gateway.run import (
     _resolve_gateway_display_bool,
     _resolve_progress_thread_id,
 )
+from plugins.platforms.mattermost import adapter as mattermost_adapter
 
 
 class TestMattermostProgressThreadRouting:
@@ -96,6 +97,189 @@ def _make_adapter():
     )
     adapter = MattermostAdapter(config)
     return adapter
+
+
+class _FakeMattermostContent:
+    def __init__(self, body: bytes, *, chunks: list[bytes] | None = None):
+        self.body = body
+        self.chunks = chunks
+        self.read_calls = []
+        self.iter_chunked_calls = []
+
+    async def read(self, size: int = -1) -> bytes:
+        self.read_calls.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+    async def iter_chunked(self, size: int):
+        self.iter_chunked_calls.append(size)
+        chunks = self.chunks if self.chunks is not None else [self.body]
+        for chunk in chunks:
+            yield chunk
+
+
+class _FakeMattermostResponse:
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        status: int = 200,
+        chunks: list[bytes] | None = None,
+        headers: dict[str, str] | None = None,
+    ):
+        self.status = status
+        self.headers = headers or {}
+        self.content = _FakeMattermostContent(body, chunks=chunks)
+
+    async def json(self):
+        return json.loads(self.content.body)
+
+    async def text(self):
+        return self.content.body.decode("utf-8", errors="replace")
+
+
+class _FakeMattermostRequestContext:
+    def __init__(self, response: _FakeMattermostResponse):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeMattermostSession:
+    def __init__(self, response: _FakeMattermostResponse):
+        self.response = response
+
+    def get(self, *_args, **_kwargs):
+        return _FakeMattermostRequestContext(self.response)
+
+    def post(self, *_args, **_kwargs):
+        return _FakeMattermostRequestContext(self.response)
+
+    def put(self, *_args, **_kwargs):
+        return _FakeMattermostRequestContext(self.response)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class TestMattermostResponseLimits:
+    @pytest.mark.asyncio
+    async def test_json_reader_rejects_oversized_body(self):
+        from plugins.platforms.mattermost.adapter import _read_mattermost_json_response
+
+        response = _FakeMattermostResponse(b"x" * 9)
+
+        with pytest.raises(ValueError, match="JSON response body exceeded 8 bytes"):
+            await _read_mattermost_json_response(response, limit=8)
+
+        assert response.content.iter_chunked_calls == [65536]
+
+    @pytest.mark.asyncio
+    async def test_json_reader_rejects_oversized_content_length(self):
+        from plugins.platforms.mattermost.adapter import _read_mattermost_json_response
+
+        response = _FakeMattermostResponse(b"{}", headers={"Content-Length": "9"})
+
+        with pytest.raises(ValueError, match="JSON response body exceeded 8 bytes"):
+            await _read_mattermost_json_response(response, limit=8)
+
+        assert response.content.iter_chunked_calls == []
+
+    @pytest.mark.asyncio
+    async def test_text_reader_rejects_oversized_error_body(self):
+        from plugins.platforms.mattermost.adapter import _read_mattermost_text_response
+
+        response = _FakeMattermostResponse(
+            b"x" * 9,
+            status=500,
+            chunks=[b"xxxx", b"xxxx", b"x"],
+        )
+
+        with pytest.raises(ValueError, match="error response body exceeded 8 bytes"):
+            await _read_mattermost_text_response(response, limit=8)
+
+        assert response.content.iter_chunked_calls == [65536]
+
+    @pytest.mark.asyncio
+    async def test_api_get_returns_empty_on_oversized_success_json(self, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.platforms.mattermost.adapter._MATTERMOST_JSON_BODY_MAX_BYTES",
+            8,
+        )
+        adapter = _make_adapter()
+        response = _FakeMattermostResponse(b"x" * 9)
+        adapter._session = _FakeMattermostSession(response)
+
+        assert await adapter._api_get("users/me") == {}
+        assert response.content.iter_chunked_calls == [65536]
+
+    @pytest.mark.asyncio
+    async def test_api_post_bounds_error_body(self, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.platforms.mattermost.adapter._MATTERMOST_ERROR_BODY_MAX_BYTES",
+            8,
+        )
+        adapter = _make_adapter()
+        response = _FakeMattermostResponse(b"x" * 9, status=500)
+        adapter._session = _FakeMattermostSession(response)
+
+        assert await adapter._api_post("posts", {"channel_id": "c", "message": "m"}) == {}
+        assert adapter._last_post_error == "Mattermost error response body exceeded 8 bytes"
+        assert response.content.iter_chunked_calls == [65536]
+
+    @pytest.mark.asyncio
+    async def test_api_put_bounds_success_body(self, monkeypatch):
+        monkeypatch.setattr(mattermost_adapter, "_MATTERMOST_JSON_BODY_MAX_BYTES", 8)
+        response = _FakeMattermostResponse(b'{"id":"p"}')
+        adapter = _make_adapter()
+        adapter._session = _FakeMattermostSession(response)
+
+        assert await adapter._api_put("posts/p", {"message": "m"}) == {}
+        assert response.content.iter_chunked_calls == [65536]
+
+    @pytest.mark.asyncio
+    async def test_upload_file_bounds_error_body(self, monkeypatch):
+        monkeypatch.setattr(mattermost_adapter, "_MATTERMOST_ERROR_BODY_MAX_BYTES", 8)
+        response = _FakeMattermostResponse(b"x" * 9, status=500)
+        adapter = _make_adapter()
+        adapter._session = _FakeMattermostSession(response)
+
+        assert await adapter._upload_file("c", b"data", "x.bin") is None
+        assert response.content.iter_chunked_calls == [65536]
+
+    @pytest.mark.asyncio
+    async def test_standalone_post_bounds_success_body(self, monkeypatch):
+        monkeypatch.setattr(mattermost_adapter, "_MATTERMOST_JSON_BODY_MAX_BYTES", 8)
+        response = _FakeMattermostResponse(b'{"id":"p"}')
+        monkeypatch.setattr("aiohttp.ClientSession", lambda **_kwargs: _FakeMattermostSession(response))
+        config = MagicMock(token="t", extra={"url": "https://mm.example.com"})
+
+        result = await mattermost_adapter._standalone_send(config, "c", "hello")
+
+        assert result == {"error": "Mattermost send failed: Mattermost JSON response body exceeded 8 bytes"}
+        assert response.content.iter_chunked_calls == [65536]
+
+    @pytest.mark.asyncio
+    async def test_standalone_upload_bounds_error_body(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(mattermost_adapter, "_MATTERMOST_ERROR_BODY_MAX_BYTES", 8)
+        response = _FakeMattermostResponse(b"x" * 9, status=500)
+        monkeypatch.setattr("aiohttp.ClientSession", lambda **_kwargs: _FakeMattermostSession(response))
+        media = tmp_path / "x.bin"
+        media.write_bytes(b"data")
+        config = MagicMock(token="t", extra={"url": "https://mm.example.com"})
+
+        result = await mattermost_adapter._standalone_send(config, "c", "hello", media_files=[str(media)])
+
+        assert result == {"error": "Mattermost send failed: Mattermost error response body exceeded 8 bytes"}
+        assert response.content.iter_chunked_calls == [65536]
 
 
 class TestMattermostFormatMessage:


### PR DESCRIPTION
## Summary

Fixes #54753.

This bounds Mattermost REST response reads in `plugins.platforms.mattermost.adapter`:

- adds shared bounded text/JSON response readers
- rejects oversized `Content-Length` values before reading the body
- reads aiohttp response streams in bounded chunks instead of buffering with `resp.json()` / `resp.text()`
- caps successful REST JSON response bodies at 4 MiB
- caps retained REST error text bodies at 64 KiB
- routes `_api_get`, `_api_post`, `_api_put`, `_upload_file`, and standalone send through the bounded readers
- preserves existing mock/test behavior by falling back to `resp.json()` / `resp.text()` only when a test double does not expose an aiohttp-style content stream

Mattermost is often self-hosted and `MATTERMOST_URL` is operator-configured, so this prevents a bad server/proxy/API response from being buffered without a cap.

## Duplicate / OpenClaw audit

- Rechecked after openclaw/openclaw#97851 (`fix(mattermost): bound null-body error response reads`).
- Hermes does not have OpenClaw's exact `!res.body` JSON error special-case, but the affected class is already covered here: REST success JSON and REST error text reads now share bounded readers.
- No separate Mattermost null-body PR is needed; a duplicate would be lower quality than keeping this focused PR current.

## Testing

- `python -m pytest tests\gateway\test_mattermost.py tests\tools\test_send_message_missing_platforms.py -q` (`82 passed`, run with worktree-local TEMP/TMP on Windows)
- `ruff check plugins\platforms\mattermost\adapter.py tests\gateway\test_mattermost.py tests\tools\test_send_message_missing_platforms.py`
- `git diff --check`