### PR TITLE
fix(cli): bound enrollment response reads

### DIFF
--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -449,6 +449,8 @@ def _post_provision(
     import urllib.error
     import urllib.request
 
+    from hermes_cli import _http_response_limits as http_response_limits
+
     body: dict = {
         "gatewayId": gateway_id,
         "platform": platform,
@@ -482,11 +484,23 @@ def _post_provision(
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
+            payload = http_response_limits.read_limited_json_response(
+                resp,
+                label="relay provision response body",
+            )
     except urllib.error.HTTPError as exc:
         detail = ""
         try:
-            detail = (json.loads(exc.read().decode()) or {}).get("error", "")
+            detail = (
+                http_response_limits.read_limited_json_response(
+                    exc,
+                    limit=http_response_limits.ERROR_RESPONSE_BODY_MAX_BYTES,
+                    label="relay provision error response body",
+                )
+                or {}
+            ).get("error", "")
+        except http_response_limits.ResponseBodyTooLarge as read_exc:
+            detail = str(read_exc)
         except Exception:
             pass
         raise RuntimeError(

--- a/hermes_cli/_http_response_limits.py
+++ b/hermes_cli/_http_response_limits.py
@@ -1,0 +1,33 @@
+"""Small helpers for bounded urllib response reads."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+JSON_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+ERROR_RESPONSE_BODY_MAX_BYTES = 64 * 1024
+
+
+class ResponseBodyTooLarge(ValueError):
+    """Raised when a response body exceeds its configured read cap."""
+
+
+def read_limited_response_body(resp: Any, limit: int, *, label: str) -> bytes:
+    body = resp.read(limit + 1)
+    if len(body) > limit:
+        raise ResponseBodyTooLarge(f"{label} exceeded {limit} bytes")
+    return body
+
+
+def read_limited_json_response(
+    resp: Any,
+    *,
+    limit: int | None = None,
+    label: str = "JSON response body",
+) -> Any:
+    if limit is None:
+        limit = JSON_RESPONSE_BODY_MAX_BYTES
+    body = read_limited_response_body(resp, limit, label=label)
+    return json.loads(body.decode("utf-8"))
+

--- a/hermes_cli/_http_response_limits.py
+++ b/hermes_cli/_http_response_limits.py
@@ -1,0 +1,32 @@
+"""Small helpers for bounded urllib response reads."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+JSON_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+ERROR_RESPONSE_BODY_MAX_BYTES = 64 * 1024
+
+
+class ResponseBodyTooLarge(RuntimeError):
+    """Raised when a response body exceeds its configured read cap."""
+
+
+def read_limited_response_body(resp: Any, limit: int, *, label: str) -> bytes:
+    body = resp.read(limit + 1)
+    if len(body) > limit:
+        raise ResponseBodyTooLarge(f"{label} exceeded {limit} bytes")
+    return body
+
+
+def read_limited_json_response(
+    resp: Any,
+    *,
+    limit: int | None = None,
+    label: str = "JSON response body",
+) -> Any:
+    if limit is None:
+        limit = JSON_RESPONSE_BODY_MAX_BYTES
+    body = read_limited_response_body(resp, limit, label=label)
+    return json.loads(body.decode("utf-8"))

--- a/hermes_cli/dashboard_register.py
+++ b/hermes_cli/dashboard_register.py
@@ -32,6 +32,8 @@ import urllib.error
 import urllib.request
 from typing import Optional
 
+from hermes_cli import _http_response_limits as http_response_limits
+
 
 # Docker-style name generator. Same vibe as Docker's adjective_surname, but
 # adjective_noun with a space-free underscore join so it drops cleanly into a
@@ -139,17 +141,26 @@ def _register_self_hosted_client(
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
+            payload = http_response_limits.read_limited_json_response(
+                resp,
+                label="dashboard registration response body",
+            )
     except urllib.error.HTTPError as exc:
         # The endpoint returns structured JSON errors ({error, error_description}).
         detail = ""
         try:
-            err_body = json.loads(exc.read().decode())
+            err_body = http_response_limits.read_limited_json_response(
+                exc,
+                limit=http_response_limits.ERROR_RESPONSE_BODY_MAX_BYTES,
+                label="dashboard registration error response body",
+            )
             detail = (
                 err_body.get("error_description")
                 or err_body.get("error")
                 or ""
             )
+        except http_response_limits.ResponseBodyTooLarge as read_exc:
+            detail = str(read_exc)
         except Exception:
             pass
         if exc.code == 401:

--- a/hermes_cli/dashboard_register.py
+++ b/hermes_cli/dashboard_register.py
@@ -32,6 +32,8 @@ import urllib.error
 import urllib.request
 from typing import Optional
 
+from hermes_cli import _http_response_limits as http_response_limits
+
 
 # Docker-style name generator. Same vibe as Docker's adjective_surname, but
 # adjective_noun with a space-free underscore join so it drops cleanly into a
@@ -139,17 +141,26 @@ def _register_self_hosted_client(
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
+            payload = http_response_limits.read_limited_json_response(
+                resp,
+                label="dashboard registration response body",
+            )
     except urllib.error.HTTPError as exc:
         # The endpoint returns structured JSON errors ({error, error_description}).
         detail = ""
         try:
-            err_body = json.loads(exc.read().decode())
+            err_body = http_response_limits.read_limited_json_response(
+                exc,
+                limit=http_response_limits.ERROR_RESPONSE_BODY_MAX_BYTES,
+                label="dashboard registration error response body",
+            )
             detail = (
                 err_body.get("error_description")
                 or err_body.get("error")
                 or ""
             )
+        except http_response_limits.ResponseBodyTooLarge as read_exc:
+            raise read_exc from exc
         except Exception:
             pass
         if exc.code == 401:

--- a/hermes_cli/gateway_enroll.py
+++ b/hermes_cli/gateway_enroll.py
@@ -38,6 +38,8 @@ import urllib.error
 import urllib.request
 from typing import Optional
 
+from hermes_cli import _http_response_limits as http_response_limits
+
 
 def _default_gateway_id() -> str:
     """A stable-ish default gateway instance id: ``<hostname>-<pid-free slug>``.
@@ -113,11 +115,23 @@ def _post_enroll(
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
+            payload = http_response_limits.read_limited_json_response(
+                resp,
+                label="gateway enrollment response body",
+            )
     except urllib.error.HTTPError as exc:
         detail = ""
         try:
-            detail = (json.loads(exc.read().decode()) or {}).get("error", "")
+            detail = (
+                http_response_limits.read_limited_json_response(
+                    exc,
+                    limit=http_response_limits.ERROR_RESPONSE_BODY_MAX_BYTES,
+                    label="gateway enrollment error response body",
+                )
+                or {}
+            ).get("error", "")
+        except http_response_limits.ResponseBodyTooLarge as read_exc:
+            detail = str(read_exc)
         except Exception:
             pass
         if exc.code == 401:

--- a/hermes_cli/gateway_enroll.py
+++ b/hermes_cli/gateway_enroll.py
@@ -39,6 +39,8 @@ import urllib.parse
 import urllib.request
 from typing import Optional
 
+from hermes_cli import _http_response_limits as http_response_limits
+
 
 def _default_gateway_id() -> str:
     """A stable-ish default gateway instance id: ``<hostname>-<pid-free slug>``.
@@ -128,11 +130,23 @@ def _post_enroll(
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
+            payload = http_response_limits.read_limited_json_response(
+                resp,
+                label="gateway enrollment response body",
+            )
     except urllib.error.HTTPError as exc:
         detail = ""
         try:
-            detail = (json.loads(exc.read().decode()) or {}).get("error", "")
+            detail = (
+                http_response_limits.read_limited_json_response(
+                    exc,
+                    limit=http_response_limits.ERROR_RESPONSE_BODY_MAX_BYTES,
+                    label="gateway enrollment error response body",
+                )
+                or {}
+            ).get("error", "")
+        except http_response_limits.ResponseBodyTooLarge as read_exc:
+            raise read_exc from exc
         except Exception:
             pass
         if exc.code == 401:

--- a/tests/gateway/relay/test_self_provision.py
+++ b/tests/gateway/relay/test_self_provision.py
@@ -13,6 +13,7 @@ managed, which is False on a NAS-hosted Fly agent). The real gate is
 from __future__ import annotations
 
 import os
+import urllib.error
 
 import pytest
 
@@ -161,8 +162,9 @@ def test_post_provision_body_includes_instanceId_only_when_set(monkeypatch):
         def __exit__(self, *a):
             return False
 
-        def read(self):
-            return json.dumps({"secret": "a" * 64, "deliveryKey": "b" * 64, "tenant": "t", "gatewayId": "gw-1"}).encode()
+        def read(self, size=-1):
+            body = json.dumps({"secret": "a" * 64, "deliveryKey": "b" * 64, "tenant": "t", "gatewayId": "gw-1"}).encode()
+            return body if size < 0 else body[:size]
 
     def _fake_urlopen(req, timeout=None):  # noqa: ANN001
         sent["body"] = json.loads(req.data.decode())
@@ -194,6 +196,67 @@ def test_post_provision_body_includes_instanceId_only_when_set(monkeypatch):
         route_keys=[],
     )
     assert "instanceId" not in sent["body"]
+
+
+@pytest.mark.parametrize("status", [None, 403])
+def test_post_provision_bounds_success_and_error_bodies(monkeypatch, status):
+    import json
+
+    from hermes_cli import _http_response_limits as limits
+
+    monkeypatch.setattr(limits, "JSON_RESPONSE_BODY_MAX_BYTES", 8)
+    monkeypatch.setattr(limits, "ERROR_RESPONSE_BODY_MAX_BYTES", 8)
+    body = b'x' * 9
+
+    class _Resp:
+        def __init__(self):
+            self.read_calls = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self, size=-1):
+            self.read_calls.append(size)
+            return body if size < 0 else body[:size]
+
+    response = _Resp()
+    result = (
+        urllib.error.HTTPError(
+            "https://connector.example/relay/provision",
+            status,
+            "Forbidden",
+            {},
+            response,
+        )
+        if status
+        else response
+    )
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(result)
+        if status
+        else result,
+    )
+
+    label = "error " if status else ""
+    with pytest.raises(
+        RuntimeError,
+        match=rf"relay provision {label}response body exceeded 8 bytes",
+    ):
+        relay._post_provision(
+            provision_url="https://connector.example/relay/provision",
+            access_token="token",
+            gateway_id="gw",
+            platform="discord",
+            bot_id="bot",
+            gateway_endpoint=None,
+            route_keys=[],
+        )
+
+    assert response.read_calls == [9]
 
 
 # ─────────────────── wake-url forwarding (Phase 5 Unit C) ───────────────────

--- a/tests/hermes_cli/test_cli_response_limits.py
+++ b/tests/hermes_cli/test_cli_response_limits.py
@@ -1,0 +1,153 @@
+"""Tests for bounded CLI urllib response reads."""
+
+from __future__ import annotations
+
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_calls: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_calls.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_read_limited_json_response_rejects_oversized_body():
+    from hermes_cli._http_response_limits import read_limited_json_response
+
+    response = _FakeResponse(b"x" * 9)
+
+    with pytest.raises(ValueError, match="test response exceeded 8 bytes"):
+        read_limited_json_response(response, limit=8, label="test response")
+
+    assert response.read_calls == [9]
+
+
+def test_dashboard_register_bounds_success_response(monkeypatch):
+    from hermes_cli.dashboard_register import _register_self_hosted_client
+
+    monkeypatch.setattr(
+        "hermes_cli._http_response_limits.JSON_RESPONSE_BODY_MAX_BYTES",
+        8,
+    )
+    response = _FakeResponse(b"x" * 9)
+
+    with patch(
+        "hermes_cli.dashboard_register.urllib.request.urlopen",
+        return_value=response,
+    ):
+        with pytest.raises(
+            ValueError,
+            match="dashboard registration response body exceeded 8 bytes",
+        ):
+            _register_self_hosted_client(
+                access_token="token",
+                portal_base_url="https://portal.example",
+                name="local",
+                custom_redirect_uri=None,
+            )
+
+    assert response.read_calls == [9]
+
+
+def test_gateway_enroll_bounds_success_response(monkeypatch):
+    from hermes_cli.gateway_enroll import _post_enroll
+
+    monkeypatch.setattr(
+        "hermes_cli._http_response_limits.JSON_RESPONSE_BODY_MAX_BYTES",
+        8,
+    )
+    response = _FakeResponse(b"x" * 9)
+
+    with patch(
+        "hermes_cli.gateway_enroll.urllib.request.urlopen",
+        return_value=response,
+    ):
+        with pytest.raises(
+            ValueError,
+            match="gateway enrollment response body exceeded 8 bytes",
+        ):
+            _post_enroll(
+                connector_base_url="https://connector.example",
+                access_token="token",
+                enrollment_token="enroll",
+                gateway_id="gw-test",
+            )
+
+    assert response.read_calls == [9]
+
+
+def test_dashboard_register_bounds_http_error_body(monkeypatch):
+    from hermes_cli.dashboard_register import _register_self_hosted_client
+
+    monkeypatch.setattr(
+        "hermes_cli._http_response_limits.ERROR_RESPONSE_BODY_MAX_BYTES",
+        8,
+    )
+    response = _FakeResponse(b"x" * 9)
+    http_error = urllib.error.HTTPError(
+        url="https://portal.example/api/oauth/self-hosted-client",
+        code=403,
+        msg="Forbidden",
+        hdrs={},
+        fp=response,
+    )
+
+    with patch(
+        "hermes_cli.dashboard_register.urllib.request.urlopen",
+        side_effect=http_error,
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="dashboard registration error response body exceeded 8 bytes",
+        ):
+            _register_self_hosted_client(
+                access_token="token",
+                portal_base_url="https://portal.example",
+                name="local",
+                custom_redirect_uri=None,
+            )
+
+    assert response.read_calls == [9]
+
+
+def test_dashboard_register_preserves_generic_message_for_bad_error_json():
+    from hermes_cli.dashboard_register import _register_self_hosted_client
+
+    response = _FakeResponse(b"not json")
+    http_error = urllib.error.HTTPError(
+        url="https://portal.example/api/oauth/self-hosted-client",
+        code=403,
+        msg="Forbidden",
+        hdrs={},
+        fp=response,
+    )
+
+    with patch(
+        "hermes_cli.dashboard_register.urllib.request.urlopen",
+        side_effect=http_error,
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="Your account is not permitted to register a self-hosted dashboard",
+        ):
+            _register_self_hosted_client(
+                access_token="token",
+                portal_base_url="https://portal.example",
+                name="local",
+                custom_redirect_uri=None,
+            )

--- a/tests/hermes_cli/test_cli_response_limits.py
+++ b/tests/hermes_cli/test_cli_response_limits.py
@@ -1,0 +1,236 @@
+"""Tests for bounded CLI urllib response reads."""
+
+from __future__ import annotations
+
+import urllib.error
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_calls: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_calls.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_read_limited_json_response_rejects_oversized_body():
+    from hermes_cli._http_response_limits import read_limited_json_response
+
+    response = _FakeResponse(b"x" * 9)
+
+    with pytest.raises(RuntimeError, match="test response exceeded 8 bytes"):
+        read_limited_json_response(response, limit=8, label="test response")
+
+    assert response.read_calls == [9]
+
+
+def test_dashboard_register_bounds_success_response(monkeypatch):
+    from hermes_cli.dashboard_register import _register_self_hosted_client
+
+    monkeypatch.setattr(
+        "hermes_cli._http_response_limits.JSON_RESPONSE_BODY_MAX_BYTES",
+        8,
+    )
+    response = _FakeResponse(b"x" * 9)
+
+    with patch(
+        "hermes_cli.dashboard_register.urllib.request.urlopen",
+        return_value=response,
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="dashboard registration response body exceeded 8 bytes",
+        ):
+            _register_self_hosted_client(
+                access_token="token",
+                portal_base_url="https://portal.example",
+                name="local",
+                custom_redirect_uri=None,
+            )
+
+    assert response.read_calls == [9]
+
+
+def test_gateway_enroll_bounds_success_response(monkeypatch):
+    from hermes_cli.gateway_enroll import _post_enroll
+
+    monkeypatch.setattr(
+        "hermes_cli._http_response_limits.JSON_RESPONSE_BODY_MAX_BYTES",
+        8,
+    )
+    response = _FakeResponse(b"x" * 9)
+
+    with patch(
+        "hermes_cli.gateway_enroll.urllib.request.urlopen",
+        return_value=response,
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="gateway enrollment response body exceeded 8 bytes",
+        ):
+            _post_enroll(
+                connector_base_url="https://connector.example",
+                access_token="token",
+                enrollment_token="enroll",
+                gateway_id="gw-test",
+            )
+
+    assert response.read_calls == [9]
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_dashboard_register_bounds_http_error_body(monkeypatch, status):
+    from hermes_cli.dashboard_register import _register_self_hosted_client
+
+    monkeypatch.setattr(
+        "hermes_cli._http_response_limits.ERROR_RESPONSE_BODY_MAX_BYTES",
+        8,
+    )
+    response = _FakeResponse(b"x" * 9)
+    http_error = urllib.error.HTTPError(
+        url="https://portal.example/api/oauth/self-hosted-client",
+        code=status,
+        msg="Forbidden",
+        hdrs={},
+        fp=response,
+    )
+
+    with patch(
+        "hermes_cli.dashboard_register.urllib.request.urlopen",
+        side_effect=http_error,
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="dashboard registration error response body exceeded 8 bytes",
+        ):
+            _register_self_hosted_client(
+                access_token="token",
+                portal_base_url="https://portal.example",
+                name="local",
+                custom_redirect_uri=None,
+            )
+
+    assert response.read_calls == [9]
+
+
+def test_gateway_enroll_reports_oversized_unauthorized_body(monkeypatch):
+    from hermes_cli.gateway_enroll import _post_enroll
+
+    monkeypatch.setattr(
+        "hermes_cli._http_response_limits.ERROR_RESPONSE_BODY_MAX_BYTES",
+        8,
+    )
+    response = _FakeResponse(b"x" * 9)
+    http_error = urllib.error.HTTPError(
+        url="https://connector.example/relay/enroll",
+        code=401,
+        msg="Unauthorized",
+        hdrs={},
+        fp=response,
+    )
+
+    with patch(
+        "hermes_cli.gateway_enroll.urllib.request.urlopen",
+        side_effect=http_error,
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="gateway enrollment error response body exceeded 8 bytes",
+        ):
+            _post_enroll(
+                connector_base_url="https://connector.example",
+                access_token="token",
+                enrollment_token="enroll",
+                gateway_id="gw-test",
+            )
+
+    assert response.read_calls == [9]
+
+
+def test_dashboard_register_preserves_generic_message_for_bad_error_json():
+    from hermes_cli.dashboard_register import _register_self_hosted_client
+
+    response = _FakeResponse(b"not json")
+    http_error = urllib.error.HTTPError(
+        url="https://portal.example/api/oauth/self-hosted-client",
+        code=403,
+        msg="Forbidden",
+        hdrs={},
+        fp=response,
+    )
+
+    with patch(
+        "hermes_cli.dashboard_register.urllib.request.urlopen",
+        side_effect=http_error,
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="Your account is not permitted to register a self-hosted dashboard",
+        ):
+            _register_self_hosted_client(
+                access_token="token",
+                portal_base_url="https://portal.example",
+                name="local",
+                custom_redirect_uri=None,
+            )
+
+
+@pytest.mark.parametrize("command", ["dashboard", "gateway"])
+def test_cli_commands_report_oversized_success_responses(monkeypatch, capsys, command):
+    from hermes_cli import dashboard_register, gateway_enroll
+    from hermes_cli._http_response_limits import ResponseBodyTooLarge
+
+    monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+    if command == "dashboard":
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_nous_access_token", lambda: "token"
+        )
+        monkeypatch.setattr("hermes_cli.config.get_env_value", lambda _key: None)
+        monkeypatch.setattr(
+            dashboard_register,
+            "_register_self_hosted_client",
+            lambda **_kwargs: (_ for _ in ()).throw(
+                ResponseBodyTooLarge("dashboard response exceeded 8 bytes")
+            ),
+        )
+        invoke = lambda: dashboard_register.cmd_dashboard_register(
+            SimpleNamespace(portal_url=None, name="local", redirect_uri=None)
+        )
+        expected = "Registration failed: dashboard response exceeded 8 bytes"
+    else:
+        monkeypatch.setattr(gateway_enroll, "_resolve_identity_token", lambda: "token")
+        monkeypatch.setattr(
+            gateway_enroll,
+            "_post_enroll",
+            lambda **_kwargs: (_ for _ in ()).throw(
+                ResponseBodyTooLarge("enrollment response exceeded 8 bytes")
+            ),
+        )
+        invoke = lambda: gateway_enroll.cmd_gateway_enroll(
+            SimpleNamespace(
+                token="enroll",
+                connector_url="https://connector.example",
+                gateway_id="gw-test",
+                wake_url=None,
+            )
+        )
+        expected = "Enrollment failed: enrollment response exceeded 8 bytes"
+
+    with pytest.raises(SystemExit, match="1"):
+        invoke()
+
+    assert expected in capsys.readouterr().out


### PR DESCRIPTION
Fixes #54757

## Summary

- add a small shared urllib response helper for bounded CLI response reads
- cap dashboard registration and gateway enrollment success JSON bodies at 1 MiB
- cap structured error JSON bodies at 64 KiB while preserving existing generic handling for malformed small error JSON

## Tests

- `python -m pytest tests\hermes_cli\test_cli_response_limits.py tests\hermes_cli\test_dashboard_register.py -q --basetemp .pytest-tmp-cli-limits` (`42 passed`)
- `git diff --check`