### PR TITLE
fix(cli): bound Azure detect response reads

### DIFF
--- a/hermes_cli/azure_detect.py
+++ b/hermes_cli/azure_detect.py
@@ -60,6 +60,8 @@ _AZURE_OPENAI_PROBE_API_VERSIONS = (
 # Default Azure Anthropic ``api-version``.  Matches the value used by
 # ``agent/anthropic_adapter.py`` when building the Anthropic client.
 _AZURE_ANTHROPIC_API_VERSION = "2025-04-15"
+_AZURE_DETECT_JSON_BODY_MAX_BYTES = 1024 * 1024
+_AZURE_DETECT_ERROR_BODY_MAX_BYTES = 64 * 1024
 
 
 @dataclass
@@ -145,6 +147,13 @@ def _apply_auth_headers(req: urllib_request.Request,
         req.add_header("Authorization", f"Bearer {token}")
 
 
+def _read_limited_response_body(resp: Any, limit: int, *, label: str) -> bytes:
+    body = resp.read(limit + 1)
+    if len(body) > limit:
+        raise ValueError(f"{label} exceeded {limit} bytes")
+    return body
+
+
 def _http_get_json(url: str,
                    api_key: Any,
                    timeout: float = 6.0,
@@ -159,8 +168,12 @@ def _http_get_json(url: str,
     req.add_header("User-Agent", "hermes-agent/azure-detect")
     try:
         with urllib_request.urlopen(req, timeout=timeout) as resp:
-            body = resp.read()
             try:
+                body = _read_limited_response_body(
+                    resp,
+                    _AZURE_DETECT_JSON_BODY_MAX_BYTES,
+                    label="Azure detection JSON response body",
+                )
                 return resp.status, json.loads(body.decode("utf-8", errors="replace"))
             except Exception:
                 return resp.status, None
@@ -276,7 +289,11 @@ def _probe_anthropic_messages(base_url: str,
     except HTTPError as exc:
         # 4xx with an Anthropic-shaped error body = Anthropic endpoint.
         try:
-            body = exc.read().decode("utf-8", errors="replace")
+            body = _read_limited_response_body(
+                exc,
+                _AZURE_DETECT_ERROR_BODY_MAX_BYTES,
+                label="Azure Anthropic probe error response body",
+            ).decode("utf-8", errors="replace")
             lowered = body.lower()
             if "anthropic" in lowered or '"type"' in lowered and '"error"' in lowered:
                 return True

--- a/tests/hermes_cli/test_azure_detect.py
+++ b/tests/hermes_cli/test_azure_detect.py
@@ -20,6 +20,7 @@ class _FakeHTTPResponse:
     def __init__(self, status: int, body: bytes):
         self.status = status
         self._body = body
+        self.read_calls: list[int] = []
 
     def __enter__(self):
         return self
@@ -27,8 +28,11 @@ class _FakeHTTPResponse:
     def __exit__(self, exc_type, exc, tb):
         return False
 
-    def read(self) -> bytes:
-        return self._body
+    def read(self, size: int = -1) -> bytes:
+        self.read_calls.append(size)
+        if size is None or size < 0:
+            return self._body
+        return self._body[:size]
 
 
 def _openai_models_body(*ids: str) -> bytes:
@@ -203,6 +207,36 @@ def test_http_get_json_on_http_error_returns_code_none():
         status, body = azure_detect._http_get_json("https://x/", "k")
     assert status == 403
     assert body is None
+
+
+def test_http_get_json_bounds_success_body(monkeypatch):
+    """Oversized model-list responses preserve status but skip JSON parsing."""
+    monkeypatch.setattr(azure_detect, "_AZURE_DETECT_JSON_BODY_MAX_BYTES", 8)
+    response = _FakeHTTPResponse(200, b"x" * 9)
+
+    with patch(
+        "hermes_cli.azure_detect.urllib_request.urlopen",
+        return_value=response,
+    ):
+        status, body = azure_detect._http_get_json("https://x/models", "k")
+
+    assert status == 200
+    assert body is None
+    assert response.read_calls == [9]
+
+
+def test_probe_anthropic_messages_bounds_error_body(monkeypatch):
+    """Oversized HTTP error bodies are not scanned to detect Anthropic mode."""
+    import urllib.error
+
+    monkeypatch.setattr(azure_detect, "_AZURE_DETECT_ERROR_BODY_MAX_BYTES", 8)
+    response = _FakeHTTPResponse(400, b"anthropic" + b"x")
+    err = urllib.error.HTTPError("https://x/", 400, "Bad Request", {}, response)
+
+    with patch("hermes_cli.azure_detect.urllib_request.urlopen", side_effect=err):
+        assert azure_detect._probe_anthropic_messages("https://x/", "k") is False
+
+    assert response.read_calls == [9]
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #54759. Supersedes the duplicate implementation in #55206.

Cap the two final response-body reads used by CLI Azure endpoint auto-detection:

- `/models` JSON responses: 1 MiB before decoding/parsing.
- Anthropic Messages probe error responses: 64 KiB before shape detection, with the HTTP error response explicitly closed after reading.

Oversized or unreadable responses retain the existing best-effort/manual-selection behavior. There is no unbounded fallback read. The current credential-aware request wrapper, authentication behavior, and September module decomposition are preserved.

## Scope

Only `hermes_cli/azure_detect.py` and its regression tests change. Redirect handling, authentication selection, other HTTP clients, and setup policy are not changed.

## Validation

Refreshed onto main at `6c27a289c3f57839a97f5709edb089b202ee6d82` on 2026-09-14.

- RED: two real local HTTP-server regressions fail with main's unbounded reads: oversized successful JSON is accepted, and oversized Anthropic error text still identifies a provider.
- GREEN: `bash scripts/run_tests.sh tests/hermes_cli/test_azure_detect.py tests/hermes_cli/test_urllib_security.py -j 1 -q` — **20 passed**.
- Ruff and `git diff --check` passed.
- Scoped Codex AutoReview: no actionable findings.

Tests use the real urllib response/credential-wrapper path with synthetic local-server data. No external credentials or live Azure account were used. The whole repository suite was not run.
