### PR TITLE
fix(feishu): bound onboarding response reads

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -254,6 +254,8 @@ _ONBOARD_OPEN_URLS = {
 }
 _REGISTRATION_PATH = "/oauth/v1/app/registration"
 _ONBOARD_REQUEST_TIMEOUT_S = 10
+_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES = 1024 * 1024
+_FEISHU_ONBOARD_ERROR_BODY_MAX_BYTES = 64 * 1024
 
 # ---------------------------------------------------------------------------
 # Fallback display strings
@@ -4965,6 +4967,22 @@ def _onboard_open_base_url(domain: str) -> str:
     return _ONBOARD_OPEN_URLS.get(domain, _ONBOARD_OPEN_URLS["feishu"])
 
 
+class _FeishuOnboardResponseTooLarge(ValueError):
+    """Raised when a Feishu onboarding HTTP response exceeds its read cap."""
+
+
+def _read_onboard_response_body(resp: Any, limit: int, *, label: str) -> bytes:
+    body = resp.read(limit + 1)
+    if len(body) > limit:
+        raise _FeishuOnboardResponseTooLarge(f"{label} exceeded {limit} bytes")
+    return body
+
+
+def _read_onboard_json_response(resp: Any, *, limit: int, label: str) -> dict:
+    body = _read_onboard_response_body(resp, limit, label=label)
+    return json.loads(body.decode("utf-8"))
+
+
 def _post_registration(base_url: str, body: Dict[str, str]) -> dict:
     """POST form-encoded data to the registration endpoint, return parsed JSON.
 
@@ -4977,9 +4995,20 @@ def _post_registration(base_url: str, body: Dict[str, str]) -> dict:
     req = Request(url, data=data, headers={"Content-Type": "application/x-www-form-urlencoded"})
     try:
         with urlopen(req, timeout=_ONBOARD_REQUEST_TIMEOUT_S) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+            return _read_onboard_json_response(
+                resp,
+                limit=_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES,
+                label="Feishu registration response body",
+            )
     except HTTPError as exc:
-        body_bytes = exc.read()
+        try:
+            body_bytes = _read_onboard_response_body(
+                exc,
+                _FEISHU_ONBOARD_ERROR_BODY_MAX_BYTES,
+                label="Feishu registration error response body",
+            )
+        except _FeishuOnboardResponseTooLarge:
+            raise exc from None
         if body_bytes:
             try:
                 return json.loads(body_bytes.decode("utf-8"))
@@ -5054,7 +5083,7 @@ def _poll_registration(
                 "device_code": device_code,
                 "tp": "ob_app",
             })
-        except (URLError, OSError, json.JSONDecodeError):
+        except (URLError, OSError, json.JSONDecodeError, _FeishuOnboardResponseTooLarge):
             time.sleep(interval)
             continue
 
@@ -5190,7 +5219,11 @@ def _probe_bot_http(app_id: str, app_secret: str, domain: str) -> Optional[dict]
             headers={"Content-Type": "application/json"},
         )
         with urlopen(token_req, timeout=_ONBOARD_REQUEST_TIMEOUT_S) as resp:
-            token_res = json.loads(resp.read().decode("utf-8"))
+            token_res = _read_onboard_json_response(
+                resp,
+                limit=_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES,
+                label="Feishu tenant token response body",
+            )
 
         access_token = token_res.get("tenant_access_token")
         if not access_token:
@@ -5204,10 +5237,14 @@ def _probe_bot_http(app_id: str, app_secret: str, domain: str) -> Optional[dict]
             },
         )
         with urlopen(bot_req, timeout=_ONBOARD_REQUEST_TIMEOUT_S) as resp:
-            bot_res = json.loads(resp.read().decode("utf-8"))
+            bot_res = _read_onboard_json_response(
+                resp,
+                limit=_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES,
+                label="Feishu bot info response body",
+            )
 
         return _parse_bot_response(bot_res)
-    except (URLError, OSError, KeyError, json.JSONDecodeError) as exc:
+    except (URLError, OSError, KeyError, json.JSONDecodeError, _FeishuOnboardResponseTooLarge) as exc:
         logger.debug("[Feishu onboard] HTTP probe failed: %s", exc)
         return None
 
@@ -5235,7 +5272,13 @@ def qr_register(
     """
     try:
         return _qr_register_inner(initial_domain=initial_domain, timeout_seconds=timeout_seconds)
-    except (RuntimeError, URLError, OSError, json.JSONDecodeError) as exc:
+    except (
+        RuntimeError,
+        URLError,
+        OSError,
+        json.JSONDecodeError,
+        _FeishuOnboardResponseTooLarge,
+    ) as exc:
         logger.warning("[Feishu onboard] Registration failed: %s", exc)
         return None
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -294,6 +294,8 @@ _ONBOARD_OPEN_URLS = {
 }
 _REGISTRATION_PATH = "/oauth/v1/app/registration"
 _ONBOARD_REQUEST_TIMEOUT_S = 10
+_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES = 1024 * 1024
+_FEISHU_ONBOARD_ERROR_BODY_MAX_BYTES = 64 * 1024
 
 # ---------------------------------------------------------------------------
 # Fallback display strings
@@ -5270,6 +5272,22 @@ def _onboard_open_base_url(domain: str) -> str:
     return _ONBOARD_OPEN_URLS.get(domain, _ONBOARD_OPEN_URLS["feishu"])
 
 
+class _FeishuOnboardResponseTooLarge(ValueError):
+    """Raised when a Feishu onboarding HTTP response exceeds its read cap."""
+
+
+def _read_onboard_response_body(resp: Any, limit: int, *, label: str) -> bytes:
+    body = resp.read(limit + 1)
+    if len(body) > limit:
+        raise _FeishuOnboardResponseTooLarge(f"{label} exceeded {limit} bytes")
+    return body
+
+
+def _read_onboard_json_response(resp: Any, *, limit: int, label: str) -> dict:
+    body = _read_onboard_response_body(resp, limit, label=label)
+    return json.loads(body.decode("utf-8"))
+
+
 def _post_registration(base_url: str, body: Dict[str, str]) -> dict:
     """POST form-encoded data to the registration endpoint, return parsed JSON.
 
@@ -5282,9 +5300,20 @@ def _post_registration(base_url: str, body: Dict[str, str]) -> dict:
     req = Request(url, data=data, headers={"Content-Type": "application/x-www-form-urlencoded"})
     try:
         with urlopen(req, timeout=_ONBOARD_REQUEST_TIMEOUT_S) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+            return _read_onboard_json_response(
+                resp,
+                limit=_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES,
+                label="Feishu registration response body",
+            )
     except HTTPError as exc:
-        body_bytes = exc.read()
+        try:
+            body_bytes = _read_onboard_response_body(
+                exc,
+                _FEISHU_ONBOARD_ERROR_BODY_MAX_BYTES,
+                label="Feishu registration error response body",
+            )
+        except _FeishuOnboardResponseTooLarge:
+            raise exc from None
         if body_bytes:
             try:
                 return json.loads(body_bytes.decode("utf-8"))
@@ -5359,7 +5388,7 @@ def _poll_registration(
                 "device_code": device_code,
                 "tp": "ob_app",
             })
-        except (URLError, OSError, json.JSONDecodeError):
+        except (URLError, OSError, json.JSONDecodeError, _FeishuOnboardResponseTooLarge):
             time.sleep(interval)
             continue
 
@@ -5498,7 +5527,11 @@ def _probe_bot_http(app_id: str, app_secret: str, domain: str) -> Optional[dict]
             headers={"Content-Type": "application/json"},
         )
         with urlopen(token_req, timeout=_ONBOARD_REQUEST_TIMEOUT_S) as resp:
-            token_res = json.loads(resp.read().decode("utf-8"))
+            token_res = _read_onboard_json_response(
+                resp,
+                limit=_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES,
+                label="Feishu tenant token response body",
+            )
 
         access_token = token_res.get("tenant_access_token")
         if not access_token:
@@ -5512,10 +5545,14 @@ def _probe_bot_http(app_id: str, app_secret: str, domain: str) -> Optional[dict]
             },
         )
         with urlopen(bot_req, timeout=_ONBOARD_REQUEST_TIMEOUT_S) as resp:
-            bot_res = json.loads(resp.read().decode("utf-8"))
+            bot_res = _read_onboard_json_response(
+                resp,
+                limit=_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES,
+                label="Feishu bot info response body",
+            )
 
         return _parse_bot_response(bot_res)
-    except (URLError, OSError, KeyError, json.JSONDecodeError) as exc:
+    except (URLError, OSError, KeyError, json.JSONDecodeError, _FeishuOnboardResponseTooLarge) as exc:
         logger.debug("[Feishu onboard] HTTP probe failed: %s", exc)
         return None
 
@@ -5543,7 +5580,13 @@ def qr_register(
     """
     try:
         return _qr_register_inner(initial_domain=initial_domain, timeout_seconds=timeout_seconds)
-    except (RuntimeError, URLError, OSError, json.JSONDecodeError) as exc:
+    except (
+        RuntimeError,
+        URLError,
+        OSError,
+        json.JSONDecodeError,
+        _FeishuOnboardResponseTooLarge,
+    ) as exc:
         logger.warning("[Feishu onboard] Registration failed: %s", exc)
         return None
 

--- a/tests/gateway/test_setup_feishu.py
+++ b/tests/gateway/test_setup_feishu.py
@@ -5,7 +5,28 @@ Feishu adapter: credentials, connection mode, DM policy, and group policy.
 """
 
 import os
+import urllib.error
 from unittest.mock import patch
+
+import pytest
+
+
+class _FakeHTTPResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_calls: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_calls.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +84,51 @@ def _run_setup_feishu(
 
 class TestSetupFeishuQrPath:
     """Tests for the QR scan-to-create happy path."""
+
+    def test_post_registration_bounds_success_response(self, monkeypatch):
+        from plugins.platforms.feishu import adapter as feishu
+
+        monkeypatch.setattr(feishu, "_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES", 8)
+        response = _FakeHTTPResponse(b"x" * 9)
+
+        with patch("plugins.platforms.feishu.adapter.urlopen", return_value=response):
+            with pytest.raises(
+                feishu._FeishuOnboardResponseTooLarge,
+                match="Feishu registration response body exceeded 8 bytes",
+            ):
+                feishu._post_registration("https://accounts.example", {"action": "init"})
+
+        assert response.read_calls == [9]
+
+    def test_post_registration_bounds_http_error_response(self, monkeypatch):
+        from plugins.platforms.feishu import adapter as feishu
+
+        monkeypatch.setattr(feishu, "_FEISHU_ONBOARD_ERROR_BODY_MAX_BYTES", 8)
+        response = _FakeHTTPResponse(b"x" * 9)
+        http_error = urllib.error.HTTPError(
+            url="https://accounts.example/oauth/v1/app/registration",
+            code=400,
+            msg="Bad Request",
+            hdrs={},
+            fp=response,
+        )
+
+        with patch("plugins.platforms.feishu.adapter.urlopen", side_effect=http_error):
+            with pytest.raises(urllib.error.HTTPError):
+                feishu._post_registration("https://accounts.example", {"action": "poll"})
+
+        assert response.read_calls == [9]
+
+    def test_probe_bot_http_bounds_token_response(self, monkeypatch):
+        from plugins.platforms.feishu import adapter as feishu
+
+        monkeypatch.setattr(feishu, "_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES", 8)
+        response = _FakeHTTPResponse(b"x" * 9)
+
+        with patch("plugins.platforms.feishu.adapter.urlopen", return_value=response):
+            assert feishu._probe_bot_http("cli_test", "secret_test", "feishu") is None
+
+        assert response.read_calls == [9]
 
     def test_qr_success_saves_core_credentials(self):
         env = _run_setup_feishu(

--- a/tests/gateway/test_setup_feishu.py
+++ b/tests/gateway/test_setup_feishu.py
@@ -5,7 +5,28 @@ Feishu adapter: credentials, connection mode, DM policy, and group policy.
 """
 
 import os
+import urllib.error
 from unittest.mock import patch
+
+import pytest
+
+
+class _FakeHTTPResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_calls: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_calls.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +97,70 @@ def _run_setup_feishu(
 class TestSetupFeishuQrPath:
     """Tests for the QR scan-to-create happy path."""
 
+    def test_post_registration_bounds_success_response(self, monkeypatch):
+        from plugins.platforms.feishu import adapter as feishu
+
+        monkeypatch.setattr(feishu, "_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES", 8)
+        response = _FakeHTTPResponse(b"x" * 9)
+
+        with patch("plugins.platforms.feishu.adapter.urlopen", return_value=response):
+            with pytest.raises(
+                feishu._FeishuOnboardResponseTooLarge,
+                match="Feishu registration response body exceeded 8 bytes",
+            ):
+                feishu._post_registration("https://accounts.example", {"action": "init"})
+
+        assert response.read_calls == [9]
+
+    def test_post_registration_bounds_http_error_response(self, monkeypatch):
+        from plugins.platforms.feishu import adapter as feishu
+
+        monkeypatch.setattr(feishu, "_FEISHU_ONBOARD_ERROR_BODY_MAX_BYTES", 8)
+        response = _FakeHTTPResponse(b"x" * 9)
+        http_error = urllib.error.HTTPError(
+            url="https://accounts.example/oauth/v1/app/registration",
+            code=400,
+            msg="Bad Request",
+            hdrs={},
+            fp=response,
+        )
+
+        with patch("plugins.platforms.feishu.adapter.urlopen", side_effect=http_error):
+            with pytest.raises(urllib.error.HTTPError):
+                feishu._post_registration("https://accounts.example", {"action": "poll"})
+
+        assert response.read_calls == [9]
+
+    def test_probe_bot_http_bounds_token_response(self, monkeypatch):
+        from plugins.platforms.feishu import adapter as feishu
+
+        monkeypatch.setattr(feishu, "_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES", 8)
+        response = _FakeHTTPResponse(b"x" * 9)
+
+        with patch("plugins.platforms.feishu.adapter.urlopen", return_value=response):
+            assert feishu._probe_bot_http("cli_test", "secret_test", "feishu") is None
+
+        assert response.read_calls == [9]
+
+    def test_probe_bot_http_bounds_bot_info_response(self, monkeypatch):
+        import json
+
+        from plugins.platforms.feishu import adapter as feishu
+
+        monkeypatch.setattr(feishu, "_FEISHU_ONBOARD_JSON_BODY_MAX_BYTES", 64)
+        token_response = _FakeHTTPResponse(
+            json.dumps({"tenant_access_token": "tenant-token"}).encode()
+        )
+        bot_response = _FakeHTTPResponse(b"x" * 65)
+
+        with patch(
+            "plugins.platforms.feishu.adapter.urlopen",
+            side_effect=[token_response, bot_response],
+        ):
+            assert feishu._probe_bot_http("cli_test", "secret_test", "feishu") is None
+
+        assert token_response.read_calls == [65]
+        assert bot_response.read_calls == [65]
 
     def test_qr_success_does_not_persist_bot_identity(self):
         """Bot identity is discovered at runtime by _hydrate_bot_identity — not persisted


### PR DESCRIPTION
Fixes #54761

## Summary

- add bounded raw-HTTP body readers for Feishu/Lark QR onboarding
- cap registration, tenant-token, and bot-info success JSON reads at 1 MiB
- cap structured registration error bodies at 64 KiB
- route oversized responses through the existing graceful setup failure paths

## Duplicate audit

- Checked live open PRs/issues for Feishu/Lark QR onboarding response-body cap coverage before opening this PR.
- This PR is scoped to the existing report in #54761.

## OpenClaw pattern

- Mirrors the same class of fix as openclaw/openclaw#97782: bound Feishu API JSON response reads instead of buffering arbitrary upstream/proxy bodies.

## Tests

- `python -m pytest tests\gateway\test_setup_feishu.py -q -k bounds --basetemp .pytest-tmp-feishu-onboard-response-cap` (`3 passed, 14 deselected`)
- `python -m pytest tests\gateway\test_feishu_onboard.py -q --basetemp .pytest-tmp-feishu-onboard-response-cap-2` (`27 passed`)
- `git diff --check`