### PR TITLE
fix(providers): bound model-catalog response reads (#54735)

### DIFF
--- a/plugins/model-providers/anthropic/__init__.py
+++ b/plugins/model-providers/anthropic/__init__.py
@@ -1,11 +1,10 @@
 """Native Anthropic provider profile."""
 
-import json
 import logging
 import urllib.request
 
 from providers import register_provider
-from providers.base import ProviderProfile
+from providers.base import ProviderProfile, _read_json_capped
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +28,7 @@ class AnthropicProfile(ProviderProfile):
             req.add_header("anthropic-version", "2023-06-01")
             req.add_header("Accept", "application/json")
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                data = json.loads(resp.read().decode())
+                data = _read_json_capped(resp)
             return [
                 m["id"]
                 for m in data.get("data", [])

--- a/providers/base.py
+++ b/providers/base.py
@@ -20,6 +20,57 @@ logger = logging.getLogger(__name__)
 # Sentinel for "omit temperature entirely" (Kimi: server manages it)
 OMIT_TEMPERATURE = object()
 
+# Upper bound on a provider model-catalog response body (issue #54735).
+# Model lists are normally tens-to-hundreds of KB; 16 MiB is generous
+# headroom while still failing closed against a malicious / compromised /
+# misconfigured endpoint that streams an arbitrarily large body during model
+# discovery (model picker, provider probing, live-list refresh). Oversized
+# responses are rejected and callers fall back to the static model list.
+_MAX_MODELS_RESPONSE_BYTES = 16 * 1024 * 1024
+
+
+def _read_json_capped(resp, max_bytes: int | None = None):
+    """Read and JSON-parse an HTTP response body with a hard size cap.
+
+    Two-layer guard so a bad endpoint cannot exhaust memory:
+      1. Reject up front if the declared ``Content-Length`` exceeds the cap.
+      2. Read at most ``max_bytes + 1`` bytes and reject if the body actually
+         ran past the cap (covers a missing or lying Content-Length on a
+         streamed response).
+
+    Raises ``ValueError`` on oversize so the caller's existing
+    ``except Exception: return None`` path falls back to the static list.
+
+    ``max_bytes`` defaults to the module-level ``_MAX_MODELS_RESPONSE_BYTES``
+    (read at call time, so the cap can be lowered in tests).
+    """
+    import json
+
+    if max_bytes is None:
+        max_bytes = _MAX_MODELS_RESPONSE_BYTES
+
+    declared = resp.headers.get("Content-Length") if hasattr(resp, "headers") else None
+    if declared is not None:
+        try:
+            if int(declared) > max_bytes:
+                raise ValueError(
+                    f"model catalog response too large: Content-Length={declared} "
+                    f"> {max_bytes}"
+                )
+        except (TypeError, ValueError) as exc:
+            # A non-integer Content-Length is itself suspect — only re-raise
+            # our own oversize signal; ignore an unparseable header and fall
+            # through to the bounded read below.
+            if "too large" in str(exc):
+                raise
+
+    raw = resp.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise ValueError(
+            f"model catalog response too large: body exceeded {max_bytes} bytes"
+        )
+    return json.loads(raw.decode())
+
 
 def _profile_user_agent() -> str:
     """Return a ``hermes-cli/<version>`` UA string, with a stable fallback.
@@ -193,7 +244,6 @@ class ProviderProfile:
                 return None
             url = effective_base.rstrip("/") + "/models"
 
-        import json
         import urllib.request
 
         req = urllib.request.Request(url)
@@ -209,7 +259,7 @@ class ProviderProfile:
 
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                data = json.loads(resp.read().decode())
+                data = _read_json_capped(resp)
             items = data if isinstance(data, list) else data.get("data", [])
             return [m["id"] for m in items if isinstance(m, dict) and "id" in m]
         except Exception as exc:

--- a/tests/providers/test_fetch_models_bounded.py
+++ b/tests/providers/test_fetch_models_bounded.py
@@ -1,0 +1,171 @@
+"""Tests for bounded model-catalog reads in fetch_models (issue #54735).
+
+A malicious / compromised / misconfigured model endpoint must not be able to
+exhaust memory during model discovery. ``ProviderProfile.fetch_models`` should
+read at most a bounded body and fail closed (return ``None``, falling back to
+the static model list) on oversize responses.
+
+These assert the behavior contract (oversize -> None, normal -> list), not a
+snapshot of any particular model catalog.
+"""
+
+import json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from threading import Thread
+
+from providers.base import ProviderProfile, _read_json_capped
+
+
+class _OversizedContentLengthHandler(BaseHTTPRequestHandler):
+    """Declares a huge Content-Length without streaming the bytes."""
+
+    cap = 0
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        # Lie about the size: claim far more than the cap allows.
+        self.send_header("Content-Length", str(self.cap * 4))
+        self.end_headers()
+        # Body is irrelevant — the Content-Length guard should reject first.
+        self.wfile.write(b"{}")
+
+    def log_message(self, *args):
+        pass
+
+
+class _OversizedStreamedBodyHandler(BaseHTTPRequestHandler):
+    """Sends a body larger than the cap without an honest Content-Length."""
+
+    cap = 0
+
+    def do_GET(self):
+        # A valid-looking JSON object padded past the cap with whitespace
+        # inside the string value, so the body genuinely exceeds the limit.
+        filler = b" " * (self.cap + 1024)
+        body = b'{"data": [{"id": "m1"}], "_pad": "' + filler + b'"}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        # Deliberately omit Content-Length to force the streamed-read guard.
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+class _SmallBodyHandler(BaseHTTPRequestHandler):
+    """A normal, well-behaved /models response."""
+
+    def do_GET(self):
+        body = json.dumps({"data": [{"id": "ok-model-1"}, {"id": "ok-model-2"}]}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+def _serve(handler_cls):
+    server = HTTPServer(("127.0.0.1", 0), handler_cls)
+    port = server.server_address[1]
+    Thread(target=server.serve_forever, daemon=True).start()
+    return server, port
+
+
+class TestFetchModelsBounded:
+    def test_oversized_content_length_returns_none(self):
+        """A response declaring Content-Length > cap fails closed."""
+        _OversizedContentLengthHandler.cap = 4096
+        server, port = _serve(_OversizedContentLengthHandler)
+        try:
+            profile = ProviderProfile(name="t", base_url=f"http://127.0.0.1:{port}")
+            # Shrink the cap via the helper default by monkeypatching the module
+            # constant is unnecessary — the handler scales to its own `cap`.
+            import providers.base as pb
+            orig = pb._MAX_MODELS_RESPONSE_BYTES
+            pb._MAX_MODELS_RESPONSE_BYTES = 4096
+            try:
+                assert profile.fetch_models(api_key="k") is None
+            finally:
+                pb._MAX_MODELS_RESPONSE_BYTES = orig
+        finally:
+            server.shutdown()
+
+    def test_oversized_streamed_body_returns_none(self):
+        """A body that runs past the cap with no honest Content-Length fails closed."""
+        _OversizedStreamedBodyHandler.cap = 4096
+        server, port = _serve(_OversizedStreamedBodyHandler)
+        try:
+            profile = ProviderProfile(name="t", base_url=f"http://127.0.0.1:{port}")
+            import providers.base as pb
+            orig = pb._MAX_MODELS_RESPONSE_BYTES
+            pb._MAX_MODELS_RESPONSE_BYTES = 4096
+            try:
+                assert profile.fetch_models(api_key="k") is None
+            finally:
+                pb._MAX_MODELS_RESPONSE_BYTES = orig
+        finally:
+            server.shutdown()
+
+    def test_normal_small_body_still_works(self):
+        """A normal small catalog response is parsed correctly (no false reject)."""
+        server, port = _serve(_SmallBodyHandler)
+        try:
+            profile = ProviderProfile(name="t", base_url=f"http://127.0.0.1:{port}")
+            assert profile.fetch_models(api_key="k") == ["ok-model-1", "ok-model-2"]
+        finally:
+            server.shutdown()
+
+
+class _FakeResp:
+    """Minimal response stand-in to assert the read is bounded, not unbounded."""
+
+    def __init__(self, body: bytes, declared_len=None):
+        self._body = body
+        self.read_arg = None
+
+        class _H:
+            def __init__(self, v):
+                self._v = v
+
+            def get(self, _key):
+                return self._v
+
+        self.headers = _H(str(declared_len) if declared_len is not None else None)
+
+    def read(self, n=None):
+        self.read_arg = n
+        if n is None:
+            return self._body
+        return self._body[:n]
+
+
+class TestReadJsonCappedHelper:
+    def test_passes_bounded_size_to_read(self):
+        """_read_json_capped must call read(cap + 1), never an unbounded read()."""
+        body = json.dumps({"data": [{"id": "x"}]}).encode()
+        resp = _FakeResp(body)
+        _read_json_capped(resp, max_bytes=1024)
+        assert resp.read_arg == 1025  # cap + 1, i.e. bounded
+
+    def test_rejects_declared_oversize(self):
+        """A Content-Length over the cap is rejected before reading the body."""
+        resp = _FakeResp(b"{}", declared_len=10_000)
+        try:
+            _read_json_capped(resp, max_bytes=1024)
+            assert False, "expected ValueError for oversize Content-Length"
+        except ValueError:
+            pass
+
+    def test_rejects_streamed_oversize(self):
+        """A body exceeding the cap is rejected even without Content-Length."""
+        resp = _FakeResp(b"x" * 5000)
+        try:
+            _read_json_capped(resp, max_bytes=1024)
+            assert False, "expected ValueError for oversize streamed body"
+        except ValueError:
+            pass


### PR DESCRIPTION
## Summary

`ProviderProfile.fetch_models()` fetched the provider model catalog and parsed it with `json.loads(resp.read().decode())` — **no cap on the response body**. A malicious, compromised, or misconfigured model endpoint could return an arbitrarily large body and make Hermes allocate it while opening the model picker, probing providers, or refreshing live model lists.

The call already treats fetch failures as non-fatal and falls back to the static model list, so oversized responses should fail closed the same way. This PR makes them do exactly that.

## Change

Add a shared `_read_json_capped()` helper in `providers/base.py` with a two-layer guard:

1. **Reject up front** if the declared `Content-Length` exceeds the cap.
2. **Bounded read** of at most `cap + 1` bytes and reject if the body actually ran past the cap (covers a missing or lying `Content-Length` on a streamed response).

On oversize it raises `ValueError`, which the existing `except Exception: return None` path turns into the same fall-back to the static model list — the exact fail-closed behavior the issue asks for.

Applied to **both** unbounded sites so the whole bug class is closed:

- `providers/base.py` — generic `ProviderProfile.fetch_models()` (the openrouter plugin reuses this via `super().fetch_models(...)`).
- `plugins/model-providers/anthropic/__init__.py` — the sibling `AnthropicProfile.fetch_models()` override, which had the identical unbounded `resp.read()` shape. The issue's Scope note flagged provider-specific fetches for a separate sweep; this one is structurally identical to the base path, so it's folded in here.

Cap is **16 MiB** (`_MAX_MODELS_RESPONSE_BYTES`) — generous for real catalogs (tens-to-hundreds of KB) while bounding a malicious payload.

## Tests

New `tests/providers/test_fetch_models_bounded.py` asserts the **behavior contract** (not a model-name snapshot) against a real local `HTTPServer`:

- oversized `Content-Length` → `None`
- oversized streamed body (no honest `Content-Length`) → `None`
- normal small body → parsed model list (no false reject)
- helper-level checks that the read is bounded (`read(cap + 1)`, never an unbounded `read()`)

Verified with `scripts/run_tests.sh` (new file + regression on `test_fetch_models_base_url`, `test_provider_profiles`, `test_plugin_discovery`, anthropic picker/persistence) and `ruff`.

## Relation to #42930

#42930 (approved) bounds the read in `providers/base.py` only. This PR additionally covers the sibling `AnthropicProfile.fetch_models()` unbounded read, closing the bug class rather than the single reported site.

Closes #54735