### PR TITLE
fix: propagate custom_providers key_env into ProviderDef (salvage #14353)

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -639,7 +639,7 @@ def resolve_custom_provider(
     # from a prior model-switch bug), fall back to the first custom
     # provider entry so existing configs self-heal.  (GH #17478)
     bare_custom_fallback = requested == "custom"
-    first_valid = None
+    first_valid: Optional[Tuple[str, str, Tuple[str, ...]]] = None
 
     for entry in custom_providers:
         if not isinstance(entry, dict):
@@ -655,9 +655,14 @@ def resolve_custom_provider(
         if not display_name or not api_url:
             continue
 
+        key_env = (entry.get("key_env") or "").strip()
+        env_vars: List[str] = []
+        if key_env:
+            env_vars.append(key_env)
+
         # Stash the first valid entry for bare-"custom" fallback
         if first_valid is None:
-            first_valid = (display_name, api_url)
+            first_valid = (display_name, api_url, tuple(env_vars))
 
         slug = custom_provider_slug(display_name)
         if requested not in {display_name.lower(), slug}:
@@ -667,7 +672,7 @@ def resolve_custom_provider(
             id=slug,
             name=display_name,
             transport="openai_chat",
-            api_key_env_vars=(),
+            api_key_env_vars=tuple(env_vars),
             base_url=api_url,
             is_aggregator=False,
             auth_type="api_key",
@@ -676,13 +681,13 @@ def resolve_custom_provider(
 
     # Self-heal: bare "custom" matched nothing — return first valid entry
     if bare_custom_fallback and first_valid:
-        dname, aurl = first_valid
+        dname, aurl, denv = first_valid
         slug = custom_provider_slug(dname)
         return ProviderDef(
             id=slug,
             name=dname,
             transport="openai_chat",
-            api_key_env_vars=(),
+            api_key_env_vars=denv,
             base_url=aurl,
             is_aggregator=False,
             auth_type="api_key",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "telos@apex-z.com": "telos-oc",  # PR #14353 salvage (propagate custom_providers key_env into ProviderDef.api_key_env_vars; named + bare-custom self-heal paths)
     "256073454+Kolektori@users.noreply.github.com": "Kolektori",  # PR #6436 salvage (require approval for host-bound Docker commands; container guard fast-path)
     "41764686+LIC99@users.noreply.github.com": "LIC99",  # PR #4682 salvage (warn + default to manual on unknown approvals.mode; #4261)
     "carlosmcejas@gmail.com": "cmcejas",  # PR #41188 salvage (early Telegram auth gate before event build/observe; #40863)

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -337,6 +337,7 @@ def test_list_dedupes_dict_model_matching_singular_default(monkeypatch):
 
 
 
+
 # ─────────────────────────────────────────────────────────────────────────────
 # #9210: group custom_providers by (base_url, api_key) in /model picker
 # ─────────────────────────────────────────────────────────────────────────────
@@ -791,3 +792,52 @@ def test_custom_providers_discover_models_false_string_is_normalised(monkeypatch
     assert gateway_prov is not None
     assert calls == [], "string 'false' must disable live discovery"
     assert gateway_prov["models"] == ["only-model"]
+
+
+def test_resolve_custom_provider_passes_key_env():
+    """resolve_custom_provider should propagate key_env into api_key_env_vars.
+
+    Regression: previously api_key_env_vars was always (), silently dropping
+    the configured env var and causing 401s on every request.
+    """
+    from hermes_cli.providers import resolve_custom_provider
+
+    resolved = resolve_custom_provider(
+        "custom:token-plan",
+        custom_providers=[
+            {
+                "name": "token-plan",
+                "base_url": "https://token-plan-sgp.xiaomimimo.com/v1",
+                "key_env": "XIAOMI_MIMO_API_KEY",
+                "model": "mimo-v2-pro",
+            }
+        ],
+    )
+
+    assert resolved is not None
+    assert resolved.api_key_env_vars == ("XIAOMI_MIMO_API_KEY",)
+    assert resolved.base_url == "https://token-plan-sgp.xiaomimimo.com/v1"
+
+
+def test_resolve_custom_provider_bare_custom_self_heal_passes_key_env():
+    """The bare-'custom' self-heal path must also propagate key_env.
+
+    A corrupt stored provider of the bare string 'custom' falls back to the
+    first valid entry; that fallback previously hardcoded api_key_env_vars=(),
+    dropping the env var just like the named-match path did.
+    """
+    from hermes_cli.providers import resolve_custom_provider
+
+    resolved = resolve_custom_provider(
+        "custom",
+        custom_providers=[
+            {
+                "name": "token-plan",
+                "base_url": "https://token-plan-sgp.xiaomimimo.com/v1",
+                "key_env": "XIAOMI_MIMO_API_KEY",
+            }
+        ],
+    )
+
+    assert resolved is not None
+    assert resolved.api_key_env_vars == ("XIAOMI_MIMO_API_KEY",)


### PR DESCRIPTION
## Summary

`resolve_custom_provider()` now propagates a custom provider's configured `key_env` into `ProviderDef.api_key_env_vars` instead of hardcoding `()`, so config-driven readiness checks see the env var.

Root cause: the `custom_providers:`-list path dropped `key_env` while the parallel `providers:`-dict path (`resolve_user_provider`) read it correctly — an asymmetry. The dropped value made `hermes doctor`, `hermes setup` status, and the dashboard config view falsely report the key as missing. (Live runtime auth is resolved separately in `runtime_provider.py`, so this is a readiness/display bug, not a fresh 401 on every request.)

Salvage of #14353 by @telos-oc. The function moved from `model_switch.py` to `hermes_cli/providers.py` since the PR was opened; the fix translates directly.

## Changes
- `hermes_cli/providers.py`: read `key_env` and pass `tuple(env_vars)` to `ProviderDef` at the **named-match** return (@telos-oc's original fix) **and** at the **bare-`"custom"` self-heal** return (sibling site widened in this salvage — `first_valid` now stashes the env tuple).
- `tests/`: `test_resolve_custom_provider_passes_key_env` (named) + `test_resolve_custom_provider_bare_custom_self_heal_passes_key_env` (self-heal regression).
- `scripts/release.py`: AUTHOR_MAP entry for @telos-oc.

## Validation
| Path | Before | After |
|---|---|---|
| named match (`custom:token-plan`) | `()` | `("XIAOMI_MIMO_API_KEY",)` |
| bare-`custom` self-heal | `()` | `("XIAOMI_MIMO_API_KEY",)` |
| `resolve_provider_full` (doctor/setup) | `()` | `("XIAOMI_MIMO_API_KEY",)` |
| no `key_env` configured | `()` | `()` |

28/28 in `tests/hermes_cli/test_model_switch_custom_providers.py` pass; E2E verified with real imports across all three resolution paths.

## Infographic

![key_env propagation fixed](https://v3b.fal.media/files/b/0aa038bd/5Z27MFAl1QS--3Y7kvoYo_N0GCWkWC.png)

---
Nous Research
