### PR TITLE
fix(wecom): bound QR setup response reads

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1515,6 +1515,14 @@ _QR_QUERY_URL = "https://work.weixin.qq.com/ai/qc/query_result"
 _QR_CODE_PAGE = "https://work.weixin.qq.com/ai/qc/gen?source=hermes&scode="
 _QR_POLL_INTERVAL = 3  # seconds
 _QR_POLL_TIMEOUT = 300  # 5 minutes
+_QR_JSON_BODY_MAX_BYTES = 1024 * 1024
+
+
+def _read_qr_json_response(resp: Any, *, label: str) -> Dict[str, Any]:
+    body = resp.read(_QR_JSON_BODY_MAX_BYTES + 1)
+    if len(body) > _QR_JSON_BODY_MAX_BYTES:
+        raise ValueError(f"{label} exceeded {_QR_JSON_BODY_MAX_BYTES} bytes")
+    return json.loads(body.decode("utf-8"))
 
 
 def qr_scan_for_bot_info(
@@ -1548,7 +1556,7 @@ def qr_scan_for_bot_info(
     try:
         req = urllib.request.Request(generate_url, headers={"User-Agent": "HermesAgent/1.0"})
         with urllib.request.urlopen(req, timeout=15) as resp:
-            raw = json.loads(resp.read().decode("utf-8"))
+            raw = _read_qr_json_response(resp, label="WeCom QR generate response body")
     except Exception as exc:
         logger.error("WeCom QR: failed to fetch QR code: %s", exc)
         print(f" failed: {exc}")
@@ -1598,7 +1606,7 @@ def qr_scan_for_bot_info(
         try:
             req = urllib.request.Request(query_url, headers={"User-Agent": "HermesAgent/1.0"})
             with urllib.request.urlopen(req, timeout=10) as resp:
-                result = json.loads(resp.read().decode("utf-8"))
+                result = _read_qr_json_response(resp, label="WeCom QR poll response body")
         except Exception as exc:
             logger.debug("WeCom QR poll error: %s", exc)
             time.sleep(_QR_POLL_INTERVAL)

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1575,6 +1575,14 @@ _QR_QUERY_URL = "https://work.weixin.qq.com/ai/qc/query_result"
 _QR_CODE_PAGE = "https://work.weixin.qq.com/ai/qc/gen?source=hermes&scode="
 _QR_POLL_INTERVAL = 3  # seconds
 _QR_POLL_TIMEOUT = 300  # 5 minutes
+_QR_JSON_BODY_MAX_BYTES = 1024 * 1024
+
+
+def _read_qr_json_response(resp: Any, *, label: str) -> Dict[str, Any]:
+    body = resp.read(_QR_JSON_BODY_MAX_BYTES + 1)
+    if len(body) > _QR_JSON_BODY_MAX_BYTES:
+        raise ValueError(f"{label} exceeded {_QR_JSON_BODY_MAX_BYTES} bytes")
+    return json.loads(body.decode("utf-8"))
 
 
 def qr_scan_for_bot_info(
@@ -1608,7 +1616,7 @@ def qr_scan_for_bot_info(
     try:
         req = urllib.request.Request(generate_url, headers={"User-Agent": "HermesAgent/1.0"})
         with urllib.request.urlopen(req, timeout=15) as resp:
-            raw = json.loads(resp.read().decode("utf-8"))
+            raw = _read_qr_json_response(resp, label="WeCom QR generate response body")
     except Exception as exc:
         logger.error("WeCom QR: failed to fetch QR code: %s", exc)
         print(f" failed: {exc}")
@@ -1658,7 +1666,7 @@ def qr_scan_for_bot_info(
         try:
             req = urllib.request.Request(query_url, headers={"User-Agent": "HermesAgent/1.0"})
             with urllib.request.urlopen(req, timeout=10) as resp:
-                result = json.loads(resp.read().decode("utf-8"))
+                result = _read_qr_json_response(resp, label="WeCom QR poll response body")
         except Exception as exc:
             logger.debug("WeCom QR poll error: %s", exc)
             time.sleep(_QR_POLL_INTERVAL)

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -124,6 +124,57 @@ class TestWeComConnect:
 
 
 class TestWeComQrScan:
+    class _FakeHTTPResponse:
+        def __init__(self, body: bytes):
+            self.body = body
+            self.read_calls: list[int] = []
+
+        def read(self, size: int = -1) -> bytes:
+            self.read_calls.append(size)
+            if size is None or size < 0:
+                return self.body
+            return self.body[:size]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def test_qr_scan_bounds_generate_response(self, monkeypatch):
+        from plugins.platforms.wecom import adapter as wecom
+
+        monkeypatch.setattr(wecom, "_QR_JSON_BODY_MAX_BYTES", 8)
+        response = self._FakeHTTPResponse(b"x" * 9)
+        monkeypatch.setattr("urllib.request.urlopen", lambda *_args, **_kwargs: response)
+
+        with patch("builtins.print"):
+            result = wecom.qr_scan_for_bot_info(timeout_seconds=1)
+
+        assert result is None
+        assert response.read_calls == [9]
+
+    def test_qr_scan_bounds_poll_response(self, monkeypatch):
+        from plugins.platforms.wecom import adapter as wecom
+
+        generate_body = b'{"data":{"scode":"abc","auth_url":"https://example.com/qr"}}'
+        monkeypatch.setattr(wecom, "_QR_JSON_BODY_MAX_BYTES", len(generate_body))
+        generate_resp = self._FakeHTTPResponse(
+            generate_body
+        )
+        poll_resp = self._FakeHTTPResponse(b"x" * (len(generate_body) + 1))
+        responses = iter([generate_resp, poll_resp])
+        monkeypatch.setattr("urllib.request.urlopen", lambda *_args, **_kwargs: next(responses))
+        monkeypatch.setattr(wecom.time, "monotonic", MagicMock(side_effect=[1000, 1000.2, 1001.2]))
+        monkeypatch.setattr(wecom.time, "sleep", MagicMock())
+
+        with patch("builtins.print"), patch.dict("sys.modules", {"qrcode": None}):
+            result = wecom.qr_scan_for_bot_info(timeout_seconds=1)
+
+        assert result is None
+        assert generate_resp.read_calls == [len(generate_body) + 1]
+        assert poll_resp.read_calls == [len(generate_body) + 1]
+
     @patch("plugins.platforms.wecom.adapter.time")
     @patch("plugins.platforms.wecom.adapter.json.loads")
     @patch("plugins.platforms.wecom.adapter.logger")

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -63,6 +63,57 @@ class TestWeComConnect:
 
 
 class TestWeComQrScan:
+    class _FakeHTTPResponse:
+        def __init__(self, body: bytes):
+            self.body = body
+            self.read_calls: list[int] = []
+
+        def read(self, size: int = -1) -> bytes:
+            self.read_calls.append(size)
+            if size is None or size < 0:
+                return self.body
+            return self.body[:size]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def test_qr_scan_bounds_generate_response(self, monkeypatch):
+        from plugins.platforms.wecom import adapter as wecom
+
+        monkeypatch.setattr(wecom, "_QR_JSON_BODY_MAX_BYTES", 8)
+        response = self._FakeHTTPResponse(b"x" * 9)
+        monkeypatch.setattr("urllib.request.urlopen", lambda *_args, **_kwargs: response)
+
+        with patch("builtins.print"):
+            result = wecom.qr_scan_for_bot_info(timeout_seconds=1)
+
+        assert result is None
+        assert response.read_calls == [9]
+
+    def test_qr_scan_bounds_poll_response(self, monkeypatch):
+        from plugins.platforms.wecom import adapter as wecom
+
+        generate_body = b'{"data":{"scode":"abc","auth_url":"https://example.com/qr"}}'
+        monkeypatch.setattr(wecom, "_QR_JSON_BODY_MAX_BYTES", len(generate_body))
+        generate_resp = self._FakeHTTPResponse(
+            generate_body
+        )
+        poll_resp = self._FakeHTTPResponse(b"x" * (len(generate_body) + 1))
+        responses = iter([generate_resp, poll_resp])
+        monkeypatch.setattr("urllib.request.urlopen", lambda *_args, **_kwargs: next(responses))
+        monkeypatch.setattr(wecom.time, "monotonic", MagicMock(side_effect=[1000, 1000.2, 1001.2]))
+        monkeypatch.setattr(wecom.time, "sleep", MagicMock())
+
+        with patch("builtins.print"), patch.dict("sys.modules", {"qrcode": None}):
+            result = wecom.qr_scan_for_bot_info(timeout_seconds=1)
+
+        assert result is None
+        assert generate_resp.read_calls == [len(generate_body) + 1]
+        assert poll_resp.read_calls == [len(generate_body) + 1]
+
     @patch("plugins.platforms.wecom.adapter.time")
     @patch("plugins.platforms.wecom.adapter.json.loads")
     @patch("plugins.platforms.wecom.adapter.logger")


### PR DESCRIPTION
﻿Fixes #54768

## Summary

- add a bounded JSON response reader for WeCom QR setup
- cap QR generate and poll response bodies at 1 MiB before decoding
- keep existing setup behavior: generate failures return `None`; poll failures continue until timeout

## Tests

- `python -m pytest tests\gateway\test_wecom.py -q -k "WeComQrScan" --basetemp .pytest-tmp-wecom-qr` (`3 passed, 45 deselected`)
- `git diff --check`
