### PR TITLE
fix(dingtalk): bound registration response reads

### DIFF
--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -17,6 +17,7 @@ import os
 import sys
 import time
 import logging
+import json
 from typing import Optional, Tuple
 
 import requests
@@ -30,6 +31,7 @@ REGISTRATION_BASE_URL = os.environ.get(
 ).rstrip("/")
 
 REGISTRATION_SOURCE = os.environ.get("DINGTALK_REGISTRATION_SOURCE", "openClaw")
+REGISTRATION_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
 
 
 # ── API helpers ────────────────────────────────────────────────────────────
@@ -38,15 +40,37 @@ class RegistrationError(Exception):
     """Raised when a DingTalk registration API call fails."""
 
 
+class RegistrationResponseTooLarge(ValueError):
+    """Raised when a DingTalk registration response exceeds its read cap."""
+
+
+def _read_limited_json_response(resp: requests.Response) -> dict:
+    body = resp.raw.read(
+        REGISTRATION_RESPONSE_BODY_MAX_BYTES + 1,
+        decode_content=True,
+    )
+    if len(body) > REGISTRATION_RESPONSE_BODY_MAX_BYTES:
+        raise RegistrationResponseTooLarge(
+            f"registration response body exceeded {REGISTRATION_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    return json.loads(body.decode("utf-8"))
+
+
 def _api_post(path: str, payload: dict) -> dict:
     """POST to the registration API and return the parsed JSON body."""
     url = f"{REGISTRATION_BASE_URL}{path}"
+    resp: Optional[requests.Response] = None
     try:
-        resp = requests.post(url, json=payload, timeout=15)
+        resp = requests.post(url, json=payload, timeout=15, stream=True)
         resp.raise_for_status()
-        data = resp.json()
+        data = _read_limited_json_response(resp)
     except requests.RequestException as exc:
         raise RegistrationError(f"Network error calling {url}: {exc}") from exc
+    except RegistrationResponseTooLarge as exc:
+        raise RegistrationError(f"Response too large calling {url}: {exc}") from exc
+    finally:
+        if resp is not None:
+            resp.close()
 
     errcode = data.get("errcode", -1)
     if errcode != 0:

--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -20,6 +20,7 @@ import logging
 from typing import Optional, Tuple
 
 import requests
+from urllib3.exceptions import HTTPError as Urllib3HTTPError
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ REGISTRATION_BASE_URL = os.environ.get(
 ).rstrip("/")
 
 REGISTRATION_SOURCE = os.environ.get("DINGTALK_REGISTRATION_SOURCE", "openClaw")
+REGISTRATION_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
 
 
 # ── API helpers ────────────────────────────────────────────────────────────
@@ -38,15 +40,40 @@ class RegistrationError(Exception):
     """Raised when a DingTalk registration API call fails."""
 
 
+class RegistrationResponseTooLarge(ValueError):
+    """Raised when a DingTalk registration response exceeds its read cap."""
+
+
+def _read_limited_json_response(resp: requests.Response) -> dict:
+    body = resp.raw.read(
+        REGISTRATION_RESPONSE_BODY_MAX_BYTES + 1,
+        decode_content=True,
+    )
+    if len(body) > REGISTRATION_RESPONSE_BODY_MAX_BYTES:
+        raise RegistrationResponseTooLarge(
+            f"registration response body exceeded {REGISTRATION_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    bounded = requests.Response()
+    bounded._content = body
+    bounded.encoding = resp.encoding
+    return bounded.json()
+
+
 def _api_post(path: str, payload: dict) -> dict:
     """POST to the registration API and return the parsed JSON body."""
     url = f"{REGISTRATION_BASE_URL}{path}"
+    resp: Optional[requests.Response] = None
     try:
-        resp = requests.post(url, json=payload, timeout=15)
+        resp = requests.post(url, json=payload, timeout=15, stream=True)
         resp.raise_for_status()
-        data = resp.json()
-    except requests.RequestException as exc:
+        data = _read_limited_json_response(resp)
+    except (requests.RequestException, Urllib3HTTPError) as exc:
         raise RegistrationError(f"Network error calling {url}: {exc}") from exc
+    except RegistrationResponseTooLarge as exc:
+        raise RegistrationError(f"Response too large calling {url}: {exc}") from exc
+    finally:
+        if resp is not None:
+            resp.close()
 
     errcode = data.get("errcode", -1)
     if errcode != 0:

--- a/tests/hermes_cli/test_dingtalk_auth.py
+++ b/tests/hermes_cli/test_dingtalk_auth.py
@@ -1,10 +1,19 @@
 """Unit tests for hermes_cli/dingtalk_auth.py (QR device-flow registration)."""
 from __future__ import annotations
 
+import json
 import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def _mock_response(payload: dict) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.raw.read.return_value = json.dumps(payload).encode("utf-8")
+    mock_resp.close = MagicMock()
+    return mock_resp
 
 
 # ---------------------------------------------------------------------------
@@ -26,9 +35,7 @@ class TestApiPost:
     def test_raises_on_nonzero_errcode(self):
         from hermes_cli.dingtalk_auth import _api_post, RegistrationError
 
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = {"errcode": 42, "errmsg": "boom"}
+        mock_resp = _mock_response({"errcode": 42, "errmsg": "boom"})
 
         with patch("hermes_cli.dingtalk_auth.requests.post", return_value=mock_resp):
             with pytest.raises(RegistrationError, match=r"boom \(errcode=42\)"):
@@ -37,13 +44,34 @@ class TestApiPost:
     def test_returns_data_on_success(self):
         from hermes_cli.dingtalk_auth import _api_post
 
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = {"errcode": 0, "nonce": "abc"}
+        mock_resp = _mock_response({"errcode": 0, "nonce": "abc"})
 
-        with patch("hermes_cli.dingtalk_auth.requests.post", return_value=mock_resp):
+        with patch("hermes_cli.dingtalk_auth.requests.post", return_value=mock_resp) as mock_post:
             result = _api_post("/app/registration/init", {"source": "hermes"})
             assert result["nonce"] == "abc"
+
+        assert mock_post.call_args.kwargs["stream"] is True
+        mock_resp.raw.read.assert_called_once_with(
+            1024 * 1024 + 1,
+            decode_content=True,
+        )
+        mock_resp.close.assert_called_once()
+
+    def test_bounds_response_body(self, monkeypatch):
+        from hermes_cli import dingtalk_auth
+
+        monkeypatch.setattr(dingtalk_auth, "REGISTRATION_RESPONSE_BODY_MAX_BYTES", 8)
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.raw.read.return_value = b"x" * 9
+        mock_resp.close = MagicMock()
+
+        with patch("hermes_cli.dingtalk_auth.requests.post", return_value=mock_resp):
+            with pytest.raises(dingtalk_auth.RegistrationError, match="Response too large"):
+                dingtalk_auth._api_post("/app/registration/init", {"source": "hermes"})
+
+        mock_resp.raw.read.assert_called_once_with(9, decode_content=True)
+        mock_resp.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dingtalk_auth.py
+++ b/tests/hermes_cli/test_dingtalk_auth.py
@@ -1,10 +1,20 @@
 """Unit tests for hermes_cli/dingtalk_auth.py (QR device-flow registration)."""
 from __future__ import annotations
 
+import json
 import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
+from urllib3.exceptions import DecodeError
+
+
+def _mock_response(payload: dict) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.encoding = None
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.raw.read.return_value = json.dumps(payload).encode("utf-16")
+    return mock_resp
 
 
 # ---------------------------------------------------------------------------
@@ -26,14 +36,57 @@ class TestApiPost:
     def test_raises_on_nonzero_errcode(self):
         from hermes_cli.dingtalk_auth import _api_post, RegistrationError
 
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = {"errcode": 42, "errmsg": "boom"}
+        mock_resp = _mock_response({"errcode": 42, "errmsg": "boom"})
 
         with patch("hermes_cli.dingtalk_auth.requests.post", return_value=mock_resp):
             with pytest.raises(RegistrationError, match=r"boom \(errcode=42\)"):
                 _api_post("/app/registration/init", {"source": "hermes"})
 
+    def test_returns_data_on_success(self):
+        from hermes_cli.dingtalk_auth import _api_post
+
+        mock_resp = _mock_response({"errcode": 0, "nonce": "abc"})
+
+        with patch("hermes_cli.dingtalk_auth.requests.post", return_value=mock_resp) as mock_post:
+            result = _api_post("/app/registration/init", {"source": "hermes"})
+            assert result["nonce"] == "abc"
+
+        assert mock_post.call_args.kwargs["stream"] is True
+        mock_resp.raw.read.assert_called_once_with(
+            1024 * 1024 + 1,
+            decode_content=True,
+        )
+        mock_resp.close.assert_called_once()
+
+    def test_bounds_response_body(self, monkeypatch):
+        from hermes_cli import dingtalk_auth
+
+        monkeypatch.setattr(dingtalk_auth, "REGISTRATION_RESPONSE_BODY_MAX_BYTES", 8)
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.raw.read.return_value = b"x" * 9
+        mock_resp.close = MagicMock()
+
+        with patch("hermes_cli.dingtalk_auth.requests.post", return_value=mock_resp):
+            with pytest.raises(dingtalk_auth.RegistrationError, match="Response too large"):
+                dingtalk_auth._api_post("/app/registration/init", {"source": "hermes"})
+
+        mock_resp.raw.read.assert_called_once_with(9, decode_content=True)
+        mock_resp.close.assert_called_once()
+
+    @pytest.mark.parametrize("body", [b"\xffnot-json", DecodeError("bad gzip")])
+    def test_maps_malformed_body_to_registration_error(self, body):
+        from hermes_cli.dingtalk_auth import _api_post, RegistrationError
+
+        mock_resp = MagicMock()
+        mock_resp.encoding = None
+        mock_resp.raw.read.side_effect = [body]
+
+        with patch("hermes_cli.dingtalk_auth.requests.post", return_value=mock_resp):
+            with pytest.raises(RegistrationError):
+                _api_post("/app/registration/init", {"source": "hermes"})
+
+        mock_resp.close.assert_called_once()
 
 # ---------------------------------------------------------------------------
 # begin_registration — 2-step nonce → device_code chain


### PR DESCRIPTION
﻿Fixes #54771

## Summary

- stream DingTalk QR registration API responses instead of using eager `Response.json()`
- cap registration JSON bodies at 1 MiB before decoding
- close streamed responses and route oversize bodies through the existing `RegistrationError` path

## Tests

- `python -m pytest tests\hermes_cli\test_dingtalk_auth.py -q --basetemp .pytest-tmp-dingtalk-auth` (`15 passed, 1 skipped`)
- `git diff --check`
