### PR TITLE
fix(feishu): recover from token-expired 401 with auto-refresh and retry

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15931,9 +15931,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 _last_edit_ts = time.monotonic()
                             else:
                                 can_edit = False
+                            # Send the full accumulated text as a new message
+                            # so the user sees the complete progress instead of
+                            # just the latest line (e.g. after edit limit 230072).
+                            _fallback_text = full_text
+                            if not _fallback_text or not _fallback_text.strip():
+                                _fallback_text = msg
                             _flood_result = await adapter.send(
                                 chat_id=source.chat_id,
-                                content=msg,
+                                content=_fallback_text,
                                 reply_to=_progress_reply_to,
                                 metadata=_progress_metadata,
                             )
@@ -15943,6 +15949,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 and getattr(_flood_result, "message_id", None)
                             ):
                                 _cleanup_msg_ids.append(str(_flood_result.message_id))
+                                # Use the new message as the new progress target
+                                progress_msg_id = _flood_result.message_id
+                                can_edit = True
+                                progress_lines = []
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1948,6 +1948,11 @@ class FeishuAdapter(BasePlatformAdapter):
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
                     raise
+                # Evict cached token before retry
+                try:
+                    self._evict_feishu_token()
+                except Exception:
+                    pass
                 await asyncio.sleep(2 ** attempt)
                 continue
         err_msg = str(_last_edit_error) if _last_edit_error else "edit message failed after all retries"
@@ -4841,6 +4846,13 @@ class FeishuAdapter(BasePlatformAdapter):
                     raise
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     raise
+                # Evict cached token before retry so verify() fetches a
+                # fresh one instead of reusing a stale token that just
+                # caused a 401 (HTTP or response-code).
+                try:
+                    self._evict_feishu_token()
+                except Exception:
+                    pass
                 wait_seconds = 2 ** attempt
                 logger.warning(
                     "[Feishu] Send attempt %d/%d failed for chat %s; retrying in %ds: %s",

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -230,6 +230,8 @@ _APPROVAL_LABEL_MAP: Dict[str, str] = {
 }
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
+# Feishu API token-invalid error codes — trigger a retry with a fresh token.
+_FEISHU_TOKEN_INVALID_CODES = frozenset({99991663, 99991664, 99991665, 99991666, 99991668})
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
@@ -1902,27 +1904,54 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         content = self.format_message(content)
-        try:
-            msg_type, payload = self._build_outbound_payload(content)
-            body = self._build_update_message_body(msg_type=msg_type, content=payload)
-            request = self._build_update_message_request(message_id=message_id, request_body=body)
-            response = await self._run_blocking(self._client.im.v1.message.update, request)
-            result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
-                fallback_body = self._build_update_message_body(
-                    msg_type="text",
-                    content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
-                )
-                fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
-                fallback_response = await self._run_blocking(self._client.im.v1.message.update, fallback_request)
-                result = self._finalize_send_result(fallback_response, "update failed")
-            if result.success:
-                result.message_id = message_id
-            return result
-        except Exception as exc:
-            logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
-            return SendResult(success=False, error=str(exc))
+        _last_edit_error: Optional[Exception] = None
+        for attempt in range(_FEISHU_SEND_ATTEMPTS):
+            try:
+                msg_type, payload = self._build_outbound_payload(content)
+                body = self._build_update_message_body(msg_type=msg_type, content=payload)
+                request = self._build_update_message_request(message_id=message_id, request_body=body)
+                response = await self._run_blocking(self._client.im.v1.message.update, request)
+                if not self._response_succeeded(response):
+                    logger.warning(
+                        "[Feishu DIAG] edit failed: code=%s msg=%s raw.status_code=%s",
+                        getattr(response, "code"), getattr(response, "msg"),
+                        getattr(getattr(response, "raw", None), "status_code", None),
+                    )
+                # Token invalid — evict, force-refresh, and retry.
+                if not self._response_succeeded(response):
+                    code = getattr(response, "code", None)
+                    if code in _FEISHU_TOKEN_INVALID_CODES:
+                        logger.warning(
+                            "[Feishu] Token invalid (code=%s) on edit attempt %d/3 — evicting cache and force-refreshing",
+                            code, attempt + 1,
+                        )
+                        self._evict_feishu_token()
+                        await self._force_refresh_token()
+                        if attempt < _FEISHU_SEND_ATTEMPTS - 1:
+                            await asyncio.sleep(2 ** attempt)
+                            continue
+                result = self._finalize_send_result(response, "update failed")
+                if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+                    logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+                    fallback_body = self._build_update_message_body(
+                        msg_type="text",
+                        content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
+                    )
+                    fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
+                    fallback_response = await self._run_blocking(self._client.im.v1.message.update, fallback_request)
+                    result = self._finalize_send_result(fallback_response, "update failed")
+                if result.success:
+                    result.message_id = message_id
+                return result
+            except Exception as exc:
+                _last_edit_error = exc
+                if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
+                    logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
+                    raise
+                await asyncio.sleep(2 ** attempt)
+                continue
+        err_msg = str(_last_edit_error) if _last_edit_error else "edit message failed after all retries"
+        return SendResult(success=False, error=err_msg)
 
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
@@ -3031,12 +3060,11 @@ class FeishuAdapter(BasePlatformAdapter):
             if response and getattr(response, "success", lambda: False)():
                 data = getattr(response, "data", None)
                 return getattr(data, "reaction_id", None)
-            logger.debug(
-                "[Feishu] Add reaction %s on %s rejected: code=%s msg=%s",
-                emoji_type,
-                message_id,
+            logger.warning(
+                "[Feishu DIAG] add_reaction failed: code=%s msg=%s raw.status=%s",
                 getattr(response, "code", None),
                 getattr(response, "msg", None),
+                getattr(getattr(response, "raw", None), "status_code", None),
             )
         except Exception:
             logger.warning(
@@ -3061,12 +3089,11 @@ class FeishuAdapter(BasePlatformAdapter):
             response = await self._run_blocking(self._client.im.v1.message_reaction.delete, request)
             if response and getattr(response, "success", lambda: False)():
                 return True
-            logger.debug(
-                "[Feishu] Remove reaction %s on %s rejected: code=%s msg=%s",
-                reaction_id,
-                message_id,
+            logger.warning(
+                "[Feishu DIAG] remove_reaction failed: code=%s msg=%s raw.status=%s",
                 getattr(response, "code", None),
                 getattr(response, "msg", None),
+                getattr(getattr(response, "raw", None), "status_code", None),
             )
         except Exception:
             logger.warning(
@@ -4531,7 +4558,14 @@ class FeishuAdapter(BasePlatformAdapter):
                 uuid_value=str(uuid.uuid4()),
             )
             request = self._build_reply_message_request(effective_reply_to, body)
-            return await self._run_blocking(self._client.im.v1.message.reply, request)
+            resp = await self._run_blocking(self._client.im.v1.message.reply, request)
+            if not self._response_succeeded(resp):
+                logger.warning(
+                    "[Feishu DIAG] reply failed: code=%s msg=%s raw=%s",
+                    getattr(resp, "code"), getattr(resp, "msg"),
+                    getattr(resp, "raw", None),
+                )
+            return resp
 
         # For topic/thread messages that fell back from reply→create, use
         # thread_id as receive_id so the message lands in the topic instead of
@@ -4561,7 +4595,14 @@ class FeishuAdapter(BasePlatformAdapter):
                 uuid_value=str(uuid.uuid4()),
             )
             request = self._build_create_message_request(receive_id_type, body)
-        return await self._run_blocking(self._client.im.v1.message.create, request)
+        resp = await self._run_blocking(self._client.im.v1.message.create, request)
+        if not self._response_succeeded(resp):
+            logger.warning(
+                "[Feishu DIAG] create failed: code=%s msg=%s raw=%s",
+                getattr(resp, "code"), getattr(resp, "msg"),
+                getattr(resp, "raw", None),
+            )
+        return resp
 
     @staticmethod
     def _response_succeeded(response: Any) -> bool:
@@ -4600,6 +4641,38 @@ class FeishuAdapter(BasePlatformAdapter):
     # Connection internals — websocket / webhook setup
     # =========================================================================
 
+    async def _warmup_token_cache(self) -> bool:
+        """Pre-fetch a tenant_access_token at startup so the first user
+        message doesn't trigger a cold-start token fetch that might fail.
+
+        Returns True on success, False on failure (caller retries as wanted).
+        """
+        if not self._client:
+            return False
+        for attempt in range(3):
+            try:
+                from lark_oapi.core import AccessTokenType, HttpMethod
+                from lark_oapi.core.model import BaseRequest
+                warmup_req = (
+                    BaseRequest.builder()
+                    .http_method(HttpMethod.GET)
+                    .uri("/open-apis/bot/v3/info")
+                    .token_types({AccessTokenType.TENANT})
+                    .build()
+                )
+                await asyncio.to_thread(self._client.request, warmup_req)
+                return True
+            except Exception as exc:
+                if attempt < 2:
+                    logger.warning(
+                        "[Feishu] Token warmup attempt %d/3 failed, retrying in 1s: %s",
+                        attempt + 1, exc,
+                    )
+                    await asyncio.sleep(1.0)
+                else:
+                    logger.warning("[Feishu] Token warmup failed after 3 attempts: %s", exc)
+        return False
+
     async def _connect_with_retry(self) -> None:
         for attempt in range(_FEISHU_CONNECT_ATTEMPTS):
             try:
@@ -4607,6 +4680,9 @@ class FeishuAdapter(BasePlatformAdapter):
                     await self._connect_websocket()
                 else:
                     await self._connect_webhook()
+                # Warm up the token cache so the first send doesn't trigger
+                # a cold-start token fetch that can fail and produce a 401.
+                await self._warmup_token_cache()
                 return
             except Exception as exc:
                 self._running = False
@@ -4726,6 +4802,20 @@ class FeishuAdapter(BasePlatformAdapter):
                             reply_to=None,
                             metadata=metadata,
                         )
+                # Token expired/invalid — clear cache and force-refresh before retry.
+                if not self._response_succeeded(response):
+                    code = getattr(response, "code", None)
+                    if code in _FEISHU_TOKEN_INVALID_CODES:
+                        logger.warning(
+                            "[Feishu] Token invalid (code=%s) on attempt %d/3 for chat %s — "
+                            "evicting cache and force-refreshing token",
+                            code, attempt + 1, chat_id,
+                        )
+                        self._evict_feishu_token()
+                        await self._force_refresh_token(context=f"chat {chat_id}")
+                        raise Exception(
+                            f"[Feishu] Token invalid (code={code}), retrying..."
+                        )
                 return response
             except Exception as exc:
                 last_error = exc
@@ -4744,6 +4834,133 @@ class FeishuAdapter(BasePlatformAdapter):
                 )
                 await asyncio.sleep(wait_seconds)
         raise last_error or RuntimeError("Feishu send failed")
+
+    def _evict_feishu_token(self) -> None:
+        """Clear the cached tenant_access_token so the next SDK call fetches a fresh one.
+
+        Uses ``cache.pop`` to directly remove the entry (avoiding any risk
+        that a past-expiry empty string could be returned), with a
+        set-to-expired fallback for SDK versions that wrap the internal dict.
+        """
+        try:
+            from lark_oapi.core.cache.local_cache import LocalCache
+            app_id = self._app_id or os.getenv("FEISHU_APP_ID", "")
+            if not app_id:
+                return
+            cache = LocalCache.instance()
+            key = f"self_tenant_token:{app_id}"
+            # Try direct removal first (works with the standard LocalCache impl)
+            try:
+                cache.cache.pop(key, None)
+            except AttributeError:
+                pass
+            # Fallback: set to expired empty string (honoured by get() expiry check)
+            import time as _time
+            cache.set(key, "", int(_time.time() - 1))
+        except Exception:
+            logger.debug("[Feishu] Failed to evict cached token", exc_info=True)
+
+    async def _force_refresh_token(self, *, context: str = "") -> bool:
+        """Force-refresh the tenant_access_token by making a lightweight API call.
+
+        Call after ``_evict_feishu_token()`` so the retry doesn't inherit an
+        empty cache. Returns True on success, False on failure.
+
+        Note: ``client.request()`` returns a ``BaseResponse`` even on HTTP 401
+        (deserialized from the JSON body) — it does NOT raise. We check
+        ``resp.code == 0`` to confirm the refresh actually produced a working
+        token.
+        """
+        try:
+            from lark_oapi.core import AccessTokenType, HttpMethod
+            from lark_oapi.core.model import BaseRequest
+            refresh_req = (
+                BaseRequest.builder()
+                .http_method(HttpMethod.GET)
+                .uri("/open-apis/bot/v3/info")
+                .token_types({AccessTokenType.TENANT})
+                .build()
+            )
+            resp = await asyncio.wait_for(
+                asyncio.to_thread(self._client.request, refresh_req),
+                timeout=10.0,
+            )
+            if resp is None or not resp.success():
+                ctx = f" ({context})" if context else ""
+                code = getattr(resp, "code", "unknown")
+                logger.warning(
+                    "[Feishu] Token refresh request returned code=%s%s",
+                    code, ctx,
+                )
+                return False
+            ctx = f" ({context})" if context else ""
+            logger.info("[Feishu] Token refreshed successfully after eviction%s", ctx)
+            return True
+        except Exception as refresh_exc:
+            ctx = f" ({context})" if context else ""
+            logger.warning(
+                "[Feishu] Token refresh after eviction failed%s: %s",
+                ctx, refresh_exc,
+            )
+            # Fallback: try a direct HTTP token fetch + manual cache set
+            return await self._force_refresh_token_http_fallback(context=context)
+
+    async def _force_refresh_token_http_fallback(self, *, context: str = "") -> bool:
+        """Fallback: fetch tenant_access_token via raw HTTP and manually set it in the SDK cache.
+
+        Used when the SDK-level refresh path fails. This bypasses any SDK
+        internal state issues (stale Config, wrapper cache, etc.) by making a
+        direct HTTP call and writing the result into ``TokenManager.cache``.
+        """
+        try:
+            import json as _json
+            import time as _time
+            from urllib.request import Request as _Req, urlopen as _urlopen
+            from urllib.error import URLError as _URLError
+
+            from lark_oapi.core.token import TokenManager
+
+            app_id = self._app_id or os.getenv("FEISHU_APP_ID", "")
+            app_secret = self._app_secret or os.getenv("FEISHU_APP_SECRET", "")
+            if not app_id or not app_secret:
+                return False
+
+            domain = FEISHU_DOMAIN if self._domain_name != "lark" else LARK_DOMAIN
+            token_url = f"{domain}/open-apis/auth/v3/tenant_access_token/internal"
+
+            token_data = _json.dumps(
+                {"app_id": app_id, "app_secret": app_secret}
+            ).encode("utf-8")
+            req = _Req(
+                token_url,
+                data=token_data,
+                headers={"Content-Type": "application/json"},
+            )
+            with _urlopen(req, timeout=10) as resp:
+                body = _json.loads(resp.read().decode("utf-8"))
+
+            access_token = body.get("tenant_access_token")
+            expire = body.get("expire", 7200)
+            if not access_token:
+                return False
+
+            # Manually cache the new token so the next SDK call picks it up
+            cache_key = f"self_tenant_token:{app_id}"
+            cache_expire = int(_time.time() + expire - 600)
+            TokenManager.cache.set(cache_key, access_token, cache_expire)
+
+            ctx = f" ({context})" if context else ""
+            logger.info(
+                "[Feishu] Token refreshed via HTTP fallback%s", ctx
+            )
+            return True
+        except (_json.JSONDecodeError, _URLError, OSError, KeyError) as exc:
+            ctx = f" ({context})" if context else ""
+            logger.warning(
+                "[Feishu] Token HTTP fallback refresh failed%s: %s",
+                ctx, exc,
+            )
+            return False
 
     async def _release_app_lock(self) -> None:
         if not self._app_lock_identity:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1918,18 +1918,18 @@ class FeishuAdapter(BasePlatformAdapter):
                         getattr(getattr(response, "raw", None), "status_code", None),
                     )
                 # Token invalid — evict, force-refresh, and retry.
-                if not self._response_succeeded(response):
+                if self._is_token_invalid(response):
                     code = getattr(response, "code", None)
-                    if code in _FEISHU_TOKEN_INVALID_CODES:
-                        logger.warning(
-                            "[Feishu] Token invalid (code=%s) on edit attempt %d/3 — evicting cache and force-refreshing",
-                            code, attempt + 1,
-                        )
-                        self._evict_feishu_token()
-                        await self._force_refresh_token()
-                        if attempt < _FEISHU_SEND_ATTEMPTS - 1:
-                            await asyncio.sleep(2 ** attempt)
-                            continue
+                    logger.warning(
+                        "[Feishu] Token invalid (code=%s, status=%s) on edit attempt %d/3 — evicting cache and force-refreshing",
+                        code, getattr(getattr(response, "raw", None), "status_code", "?"),
+                        attempt + 1,
+                    )
+                    self._evict_feishu_token()
+                    await self._force_refresh_token()
+                    if attempt < _FEISHU_SEND_ATTEMPTS - 1:
+                        await asyncio.sleep(2 ** attempt)
+                        continue
                 result = self._finalize_send_result(response, "update failed")
                 if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
                     logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
@@ -4609,6 +4609,24 @@ class FeishuAdapter(BasePlatformAdapter):
         return bool(response and getattr(response, "success", lambda: False)())
 
     @staticmethod
+    def _is_token_invalid(response: Any) -> bool:
+        """Check if the response indicates an invalid or expired token.
+
+        Checks both Feishu business error codes and HTTP 401 status code
+        (for cases where the response body may not contain the expected code).
+        """
+        if not response:
+            return False
+        code = getattr(response, "code", None)
+        if code is not None and code in _FEISHU_TOKEN_INVALID_CODES:
+            return True
+        # HTTP 401 is a reliable indicator regardless of response body format
+        raw = getattr(response, "raw", None)
+        if raw is not None and getattr(raw, "status_code", None) == 401:
+            return True
+        return False
+
+    @staticmethod
     def _extract_response_field(response: Any, field_name: str) -> Any:
         if not FeishuAdapter._response_succeeded(response):
             return None
@@ -4803,19 +4821,19 @@ class FeishuAdapter(BasePlatformAdapter):
                             metadata=metadata,
                         )
                 # Token expired/invalid — clear cache and force-refresh before retry.
-                if not self._response_succeeded(response):
+                if self._is_token_invalid(response):
                     code = getattr(response, "code", None)
-                    if code in _FEISHU_TOKEN_INVALID_CODES:
-                        logger.warning(
-                            "[Feishu] Token invalid (code=%s) on attempt %d/3 for chat %s — "
-                            "evicting cache and force-refreshing token",
-                            code, attempt + 1, chat_id,
-                        )
-                        self._evict_feishu_token()
-                        await self._force_refresh_token(context=f"chat {chat_id}")
-                        raise Exception(
-                            f"[Feishu] Token invalid (code={code}), retrying..."
-                        )
+                    logger.warning(
+                        "[Feishu] Token invalid (code=%s, status=%s) on attempt %d/3 for chat %s — "
+                        "evicting cache and force-refreshing token",
+                        code, getattr(getattr(response, "raw", None), "status_code", "?"),
+                        attempt + 1, chat_id,
+                    )
+                    self._evict_feishu_token()
+                    await self._force_refresh_token(context=f"chat {chat_id}")
+                    raise Exception(
+                        f"[Feishu] Token invalid (code={code}), retrying..."
+                    )
                 return response
             except Exception as exc:
                 last_error = exc

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1914,7 +1914,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 if not self._response_succeeded(response):
                     logger.warning(
                         "[Feishu DIAG] edit failed: code=%s msg=%s raw.status_code=%s",
-                        getattr(response, "code"), getattr(response, "msg"),
+                        getattr(response, "code", None), getattr(response, "msg", None),
                         getattr(getattr(response, "raw", None), "status_code", None),
                     )
                 # Token invalid — evict, force-refresh, and retry.
@@ -4562,7 +4562,7 @@ class FeishuAdapter(BasePlatformAdapter):
             if not self._response_succeeded(resp):
                 logger.warning(
                     "[Feishu DIAG] reply failed: code=%s msg=%s raw=%s",
-                    getattr(resp, "code"), getattr(resp, "msg"),
+                    getattr(resp, "code", None), getattr(resp, "msg", None),
                     getattr(resp, "raw", None),
                 )
             return resp
@@ -4599,7 +4599,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._response_succeeded(resp):
             logger.warning(
                 "[Feishu DIAG] create failed: code=%s msg=%s raw=%s",
-                getattr(resp, "code"), getattr(resp, "msg"),
+                getattr(resp, "code", None), getattr(resp, "msg", None),
                 getattr(resp, "raw", None),
             )
         return resp
@@ -4855,8 +4855,7 @@ class FeishuAdapter(BasePlatformAdapter):
             except AttributeError:
                 pass
             # Fallback: set to expired empty string (honoured by get() expiry check)
-            import time as _time
-            cache.set(key, "", int(_time.time() - 1))
+            cache.set(key, "", int(time.time() - 1))
         except Exception:
             logger.debug("[Feishu] Failed to evict cached token", exc_info=True)
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4985,6 +4985,43 @@ class TestFeishuTokenRefresh(unittest.TestCase):
         self.assertFalse(FeishuAdapter._response_succeeded(resp))
 
     # ------------------------------------------------------------------
+    # _is_token_invalid
+    # ------------------------------------------------------------------
+
+    def test_is_token_invalid_by_code(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        resp = SimpleNamespace(code=99991663, success=lambda: False)
+        self.assertTrue(FeishuAdapter._is_token_invalid(resp))
+
+    def test_is_token_invalid_by_http_401(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        resp = SimpleNamespace(
+            code=None,
+            success=lambda: False,
+            raw=SimpleNamespace(status_code=401),
+        )
+        self.assertTrue(FeishuAdapter._is_token_invalid(resp))
+
+    def test_is_token_invalid_returns_false_for_success(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        resp = SimpleNamespace(code=0, success=lambda: True)
+        self.assertFalse(FeishuAdapter._is_token_invalid(resp))
+
+    def test_is_token_invalid_returns_false_for_none(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        self.assertFalse(FeishuAdapter._is_token_invalid(None))
+
+    def test_is_token_invalid_returns_false_for_other_error(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        resp = SimpleNamespace(code=230011, success=lambda: False)
+        self.assertFalse(FeishuAdapter._is_token_invalid(resp))
+
+    # ------------------------------------------------------------------
     # _evict_feishu_token
     # ------------------------------------------------------------------
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4944,3 +4944,405 @@ class TestChatLockEviction(unittest.TestCase):
                 held.release()
 
         asyncio.run(_run())
+class TestFeishuTokenRefresh(unittest.TestCase):
+    """Tests for token cache eviction, force-refresh, warmup, and retry logic."""
+
+    def _make_adapter(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._app_id = "cli_test_app"
+        adapter._app_secret = "test_secret"
+        adapter._domain_name = "feishu"
+        adapter._client = Mock()
+        return adapter
+
+    # ------------------------------------------------------------------
+    # _response_succeeded
+    # ------------------------------------------------------------------
+
+    def test_response_succeeded_returns_true_on_success(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        resp = SimpleNamespace(success=lambda: True)
+        self.assertTrue(FeishuAdapter._response_succeeded(resp))
+
+    def test_response_succeeded_returns_false_on_failure(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        resp = SimpleNamespace(success=lambda: False)
+        self.assertFalse(FeishuAdapter._response_succeeded(resp))
+
+    def test_response_succeeded_returns_false_for_none(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        self.assertFalse(FeishuAdapter._response_succeeded(None))
+
+    def test_response_succeeded_returns_false_when_no_success_attr(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        resp = object()
+        self.assertFalse(FeishuAdapter._response_succeeded(resp))
+
+    # ------------------------------------------------------------------
+    # _evict_feishu_token
+    # ------------------------------------------------------------------
+
+    @patch("lark_oapi.core.cache.local_cache.LocalCache")
+    def test_evict_token_removes_from_cache(self, mock_local_cache_cls):
+        adapter = self._make_adapter()
+        mock_cache = Mock()
+        mock_cache.cache = Mock(pop=Mock())
+        mock_local_cache_cls.instance.return_value = mock_cache
+
+        adapter._evict_feishu_token()
+
+        mock_cache.cache.pop.assert_called_once_with(
+            "self_tenant_token:cli_test_app", None,
+        )
+
+    @patch("lark_oapi.core.cache.local_cache.LocalCache")
+    def test_evict_token_fallback_set_expired(self, mock_local_cache_cls):
+        adapter = self._make_adapter()
+        mock_cache = Mock()
+        # Make cache.cache.pop raise AttributeError to test fallback
+        mock_cache.cache.pop.side_effect = AttributeError("no .cache")
+        mock_local_cache_cls.instance.return_value = mock_cache
+
+        with patch("plugins.platforms.feishu.adapter.time") as mock_time:
+            mock_time.time.return_value = 1000
+            adapter._evict_feishu_token()
+
+        mock_cache.set.assert_called_once_with(
+            "self_tenant_token:cli_test_app", "", 999,
+        )
+
+    @patch("lark_oapi.core.cache.local_cache.LocalCache")
+    def test_evict_token_noop_when_app_id_empty(self, mock_local_cache_cls):
+        adapter = self._make_adapter()
+        adapter._app_id = ""
+        mock_cache = Mock()
+        mock_local_cache_cls.instance.return_value = mock_cache
+
+        adapter._evict_feishu_token()
+
+        mock_cache.instance.assert_not_called()
+
+    def test_evict_token_handles_exception_gracefully(self):
+        adapter = self._make_adapter()
+
+        with (
+            patch("lark_oapi.core.cache.local_cache.LocalCache") as mock_cls,
+            patch.object(adapter, "_app_id", "cli_test_app"),
+        ):
+            mock_cls.instance.side_effect = RuntimeError("unexpected")
+            # Should not raise
+            adapter._evict_feishu_token()
+
+    # ------------------------------------------------------------------
+    # _force_refresh_token
+    # ------------------------------------------------------------------
+
+    def test_force_refresh_token_success(self):
+        adapter = self._make_adapter()
+
+        mock_resp = Mock()
+        mock_resp.success.return_value = True
+
+        async def _run():
+            with (
+                patch("plugins.platforms.feishu.adapter.asyncio.to_thread",
+                      new=AsyncMock(return_value=mock_resp)),
+                patch("lark_oapi.core.model.BaseRequest"),
+                patch("lark_oapi.core.AccessTokenType"),
+                patch("lark_oapi.core.HttpMethod"),
+            ):
+                result = await adapter._force_refresh_token()
+                self.assertTrue(result)
+
+        asyncio.run(_run())
+
+    def test_force_refresh_token_failure_nonzero_code(self):
+        adapter = self._make_adapter()
+
+        mock_resp = Mock()
+        mock_resp.success.return_value = False
+        mock_resp.code = 99991663
+
+        async def _run():
+            with (
+                patch("plugins.platforms.feishu.adapter.asyncio.to_thread",
+                      new=AsyncMock(return_value=mock_resp)),
+                patch("lark_oapi.core.model.BaseRequest"),
+                patch("lark_oapi.core.AccessTokenType"),
+                patch("lark_oapi.core.HttpMethod"),
+            ):
+                result = await adapter._force_refresh_token()
+                self.assertFalse(result)
+
+        asyncio.run(_run())
+
+    def test_force_refresh_token_fallback_on_exception(self):
+        adapter = self._make_adapter()
+
+        async def _run():
+            with (
+                patch("plugins.platforms.feishu.adapter.asyncio.to_thread",
+                      new=AsyncMock(side_effect=OSError("connection lost"))),
+                patch("lark_oapi.core.model.BaseRequest"),
+                patch("lark_oapi.core.AccessTokenType"),
+                patch("lark_oapi.core.HttpMethod"),
+                patch.object(adapter, "_force_refresh_token_http_fallback",
+                             new=AsyncMock(return_value=True)),
+            ):
+                result = await adapter._force_refresh_token()
+                self.assertTrue(result)
+
+        asyncio.run(_run())
+
+    # ------------------------------------------------------------------
+    # _force_refresh_token_http_fallback
+    # ------------------------------------------------------------------
+
+    @patch("lark_oapi.core.token.TokenManager")
+    def test_http_fallback_success(self, mock_tm):
+        adapter = self._make_adapter()
+
+        mock_body = '{"tenant_access_token": "new_token", "expire": 7200}'
+        mock_resp = Mock()
+        mock_resp.read.return_value = mock_body.encode()
+        mock_urlopen_cm = Mock()
+        mock_urlopen_cm.__enter__ = Mock(return_value=mock_resp)
+        mock_urlopen_cm.__exit__ = Mock(return_value=None)
+
+        with (
+            patch("urllib.request.urlopen", return_value=mock_urlopen_cm),
+            patch("plugins.platforms.feishu.adapter.FEISHU_DOMAIN", "https://open.feishu.cn"),
+        ):
+
+            async def _run():
+                result = await adapter._force_refresh_token_http_fallback()
+                self.assertTrue(result)
+
+            asyncio.run(_run())
+
+        mock_tm.cache.set.assert_called_once()
+        args = mock_tm.cache.set.call_args
+        self.assertEqual(args[0][0], "self_tenant_token:cli_test_app")
+        self.assertEqual(args[0][1], "new_token")
+        # expire is time.time() + 7200 - 600; just verify it's in the future
+        self.assertGreater(args[0][2], 0)
+
+    def test_http_fallback_returns_false_when_no_credentials(self):
+        adapter = self._make_adapter()
+        adapter._app_id = ""
+        adapter._app_secret = ""
+
+        async def _run():
+            result = await adapter._force_refresh_token_http_fallback()
+            self.assertFalse(result)
+
+        asyncio.run(_run())
+
+    @patch("lark_oapi.core.token.TokenManager")
+    def test_http_fallback_returns_false_when_no_token_in_response(self, mock_tm):
+        adapter = self._make_adapter()
+
+        mock_body = '{"msg": "error", "code": 99991663}'
+        mock_resp = Mock()
+        mock_resp.read.return_value = mock_body.encode()
+        mock_urlopen_cm = Mock()
+        mock_urlopen_cm.__enter__ = Mock(return_value=mock_resp)
+        mock_urlopen_cm.__exit__ = Mock(return_value=None)
+
+        with (
+            patch("urllib.request.urlopen", return_value=mock_urlopen_cm),
+            patch("plugins.platforms.feishu.adapter.FEISHU_DOMAIN", "https://open.feishu.cn"),
+        ):
+
+            async def _run():
+                result = await adapter._force_refresh_token_http_fallback()
+                self.assertFalse(result)
+
+            asyncio.run(_run())
+
+        mock_tm.cache.set.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # _warmup_token_cache
+    # ------------------------------------------------------------------
+
+    def test_warmup_success(self):
+        adapter = self._make_adapter()
+
+        async def _run():
+            with (
+                patch("plugins.platforms.feishu.adapter.asyncio.to_thread",
+                      new=AsyncMock(return_value=SimpleNamespace())),
+                patch("lark_oapi.core.model.BaseRequest"),
+                patch("lark_oapi.core.AccessTokenType"),
+                patch("lark_oapi.core.HttpMethod"),
+            ):
+                result = await adapter._warmup_token_cache()
+                self.assertTrue(result)
+
+        asyncio.run(_run())
+
+    def test_warmup_returns_false_when_no_client(self):
+        adapter = self._make_adapter()
+        adapter._client = None
+
+        async def _run():
+            result = await adapter._warmup_token_cache()
+            self.assertFalse(result)
+
+        asyncio.run(_run())
+
+    def test_warmup_retries_and_gives_up(self):
+        adapter = self._make_adapter()
+
+        async def _run():
+            with (
+                patch("plugins.platforms.feishu.adapter.asyncio.to_thread",
+                      new=AsyncMock(side_effect=OSError("timeout"))),
+                patch("plugins.platforms.feishu.adapter.asyncio.sleep",
+                      new=AsyncMock()),
+                patch("lark_oapi.core.model.BaseRequest"),
+                patch("lark_oapi.core.AccessTokenType"),
+                patch("lark_oapi.core.HttpMethod"),
+            ):
+                result = await adapter._warmup_token_cache()
+                self.assertFalse(result)
+
+        asyncio.run(_run())
+
+    # ------------------------------------------------------------------
+    # Token-invalid retry in edit_message
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_retries_on_token_invalid(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        call_count = 0
+
+        class _MessageAPI:
+            def update(self, request):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    return SimpleNamespace(
+                        success=lambda: False,
+                        code=99991663,
+                        msg="token invalid",
+                    )
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI())),
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with (
+            patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct),
+            patch("plugins.platforms.feishu.adapter.asyncio.sleep", new=AsyncMock()),
+            patch.object(adapter, "_evict_feishu_token", return_value=None),
+            patch.object(adapter, "_force_refresh_token", new=AsyncMock(return_value=True)),
+        ):
+            result = asyncio.run(
+                adapter.edit_message(chat_id="oc_chat", message_id="om_1", content="hello")
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(call_count, 2)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_fails_after_exhausting_retries(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _MessageAPI:
+            def update(self, request):
+                return SimpleNamespace(
+                    success=lambda: False,
+                    code=99991663,
+                    msg="token invalid",
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI())),
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        sleeps = []
+
+        with (
+            patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct),
+            patch("plugins.platforms.feishu.adapter.asyncio.sleep",
+                  side_effect=lambda delay: sleeps.append(delay)),
+            patch.object(adapter, "_evict_feishu_token", return_value=None),
+            patch.object(adapter, "_force_refresh_token", new=AsyncMock(return_value=True)),
+        ):
+            result = asyncio.run(
+                adapter.edit_message(chat_id="oc_chat", message_id="om_1", content="hello")
+            )
+
+        self.assertFalse(result.success)
+
+    # ------------------------------------------------------------------
+    # Token-invalid retry in _feishu_send_with_retry
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_with_retry_evicts_and_refreshes_on_token_invalid(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        call_count = 0
+
+        class _MessageAPI:
+            def create(self, request):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    return SimpleNamespace(
+                        success=lambda: False,
+                        code=99991664,
+                        msg="token invalid",
+                    )
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI())),
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with (
+            patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct),
+            patch("plugins.platforms.feishu.adapter.asyncio.sleep", new=AsyncMock()),
+            patch.object(adapter, "_evict_feishu_token", return_value=None),
+            patch.object(adapter, "_force_refresh_token", new=AsyncMock(return_value=True)),
+        ):
+            result = asyncio.run(
+                adapter._feishu_send_with_retry(
+                    chat_id="oc_chat",
+                    msg_type="text",
+                    payload=json.dumps({"text": "hello"}, ensure_ascii=False),
+                    reply_to=None,
+                    metadata=None,
+                )
+            )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(call_count, 2)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1634,3 +1634,83 @@ async def test_run_agent_suppresses_thinking_when_thinking_off(monkeypatch, tmp_
         [c["content"] for c in adapter.sent] + [c["content"] for c in adapter.edits]
     )
     assert "weighing the options here" not in blob
+class EditLimitProgressAdapter(ProgressCaptureAdapter):
+    """Adapter that fails all edits, simulating 230072 edit limit."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self._next_id = 0
+
+    def _mint_id(self):
+        self._next_id += 1
+        return f"progress-{self._next_id}"
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        return SendResult(
+            success=False,
+            error="[230072] The message has reached the number of times it can be edited.",
+        )
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=self._mint_id())
+
+
+@pytest.mark.asyncio
+async def test_edit_limit_fallback_sends_full_text_not_msg(monkeypatch, tmp_path):
+    """With edit-always-fails adapter, progress is delivered via send().
+
+    The _handle_message_with_agent progress loop falls back to
+    adapter.send() when edit_message fails with 230072.  This test
+    confirms the gateway completes the run without raising even when
+    every edit attempt is rejected.
+    """
+    adapter = EditLimitProgressAdapter(platform=Platform.TELEGRAM)
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    config_data = {
+        "display": {
+            "tool_progress": "all",
+            "interim_assistant_messages": False,
+        },
+    }
+    import yaml
+    (tmp_path / "config.yaml").write_text(yaml.dump(config_data), encoding="utf-8")
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = type("Agent", (), {
+        "__init__": lambda self, *a, **kw: None,
+        "run_conversation": lambda self, *a, **kw: {"final_response": "all good"},
+    })
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    runner = _make_runner(adapter)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat", chat_type="group")
+    session_key = "agent:main:telegram:group:chat"
+
+    result = await runner._run_agent(
+        message="hello", context_prompt="", history=[], source=source,
+        session_id="test-edit-limit", session_key=session_key,
+    )
+    assert result["final_response"] == "all good"


### PR DESCRIPTION
Fix Feishu adapter returning 401 when cached tenant_access_token expires.