### PR TITLE
fix(nous): bound billing response reads

### DIFF
--- a/hermes_cli/nous_billing.py
+++ b/hermes_cli/nous_billing.py
@@ -42,6 +42,12 @@ DEFAULT_TIMEOUT = 15.0
 # hermes_cli.auth.NOUS_BILLING_MANAGE_SCOPE (kept here too so this module has no
 # import-time dependency on the much heavier auth module).
 BILLING_MANAGE_SCOPE = "billing:manage"
+_BILLING_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+_BILLING_ERROR_BODY_MAX_BYTES = 64 * 1024
+
+
+class _BillingResponseTooLarge(ValueError):
+    pass
 
 
 # =============================================================================
@@ -295,8 +301,13 @@ def _request(
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            raw = resp.read().decode("utf-8")
+            raw = _read_billing_response_text(
+                resp,
+                max_bytes=_BILLING_RESPONSE_BODY_MAX_BYTES,
+            )
             return json.loads(raw) if raw.strip() else {}
+    except _BillingResponseTooLarge as exc:
+        raise BillingError(str(exc), error="response_too_large") from exc
     except urllib.error.HTTPError as exc:
         # A 401 on a cached token → drop the cache and retry once with a fresh
         # (refresh-aware) resolve before surfacing the auth error.
@@ -313,7 +324,16 @@ def _request(
             )
         raw = ""
         try:
-            raw = exc.read().decode("utf-8")
+            raw = _read_billing_response_text(
+                exc,
+                max_bytes=_BILLING_ERROR_BODY_MAX_BYTES,
+            )
+        except _BillingResponseTooLarge as read_exc:
+            payload = {
+                "error": "response_too_large",
+                "message": str(read_exc),
+            }
+            _raise_for_error(exc.code, payload, getattr(exc, "headers", None))
         except Exception:
             raw = ""
         try:
@@ -326,6 +346,15 @@ def _request(
         raise BillingError(
             f"Could not reach Nous Portal: {exc.reason}", error="network_error"
         ) from exc
+
+
+def _read_billing_response_text(resp: Any, *, max_bytes: int) -> str:
+    raw = resp.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise _BillingResponseTooLarge(
+            f"Billing response exceeded {max_bytes} bytes"
+        )
+    return raw.decode("utf-8")
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_billing_portal_url.py
+++ b/tests/hermes_cli/test_billing_portal_url.py
@@ -9,16 +9,70 @@ from __future__ import annotations
 
 import pytest
 
+import hermes_cli.nous_billing as billing
 from hermes_cli.nous_billing import (
     BillingError,
+    BillingRateLimited,
     _absolutize_portal_url,
     _raise_for_error,
 )
 
 
+class _FakeBillingResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> "_FakeBillingResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+
+class _FakeBillingHTTPError(billing.urllib.error.HTTPError):
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        code: int = 429,
+        headers: dict[str, str] | None = None,
+    ):
+        super().__init__(
+            "https://portal.example.test/api/billing/state",
+            code,
+            "error",
+            headers or {},
+            None,
+        )
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+
 @pytest.fixture
 def _preview(monkeypatch):
     monkeypatch.setenv("HERMES_PORTAL_BASE_URL", "https://nas-pr-412.nousresearch.wtf")
+
+
+@pytest.fixture
+def _billing_token(monkeypatch):
+    monkeypatch.setattr(
+        billing,
+        "_resolve_token_and_base",
+        lambda *, use_cache=True: ("portal-token", "https://portal.example.test"),
+    )
 
 
 def test_absolutize_resolves_relative(_preview):
@@ -51,3 +105,59 @@ def test_raise_for_error_attaches_absolute_portal_url(_preview):
         exc_info.value.portal_url
         == "https://nas-pr-412.nousresearch.wtf/billing?topup=open"
     )
+
+
+def test_request_bounds_success_response_read(monkeypatch, _billing_token):
+    response = _FakeBillingResponse(b'{"ok": true}')
+    captured = []
+
+    def _urlopen(req, timeout):
+        captured.append((req, timeout))
+        return response
+
+    monkeypatch.setattr(billing.urllib.request, "urlopen", _urlopen)
+
+    result = billing._request("GET", "/api/billing/state", timeout=1)
+
+    assert result == {"ok": True}
+    assert response.read_sizes == [billing._BILLING_RESPONSE_BODY_MAX_BYTES + 1]
+    assert captured[0][0].full_url == "https://portal.example.test/api/billing/state"
+    assert captured[0][1] == 1
+
+
+def test_request_rejects_oversized_success_response(monkeypatch, _billing_token):
+    response = _FakeBillingResponse(
+        b"x" * (billing._BILLING_RESPONSE_BODY_MAX_BYTES + 1)
+    )
+    monkeypatch.setattr(
+        billing.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: response,
+    )
+
+    with pytest.raises(BillingError) as exc_info:
+        billing._request("GET", "/api/billing/state")
+
+    assert exc_info.value.error == "response_too_large"
+    assert response.read_sizes == [billing._BILLING_RESPONSE_BODY_MAX_BYTES + 1]
+
+
+def test_request_bounds_oversized_error_response(monkeypatch, _billing_token):
+    error = _FakeBillingHTTPError(
+        b"x" * (billing._BILLING_ERROR_BODY_MAX_BYTES + 1),
+        code=429,
+        headers={"Retry-After": "7"},
+    )
+    monkeypatch.setattr(
+        billing.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: (_ for _ in ()).throw(error),
+    )
+
+    with pytest.raises(BillingRateLimited) as exc_info:
+        billing._request("GET", "/api/billing/state")
+
+    assert exc_info.value.status == 429
+    assert exc_info.value.error == "response_too_large"
+    assert exc_info.value.retry_after == 7
+    assert error.read_sizes == [billing._BILLING_ERROR_BODY_MAX_BYTES + 1]


### PR DESCRIPTION
﻿## Summary

Fixes #54780.

Adds bounded billing response reads before JSON parsing:

- successful billing JSON bodies: 1 MiB
- HTTP error bodies: 64 KiB

Oversized success responses now raise a typed `BillingError`; oversized error responses are converted into the existing `_raise_for_error()` path with `response_too_large` so status-specific handling such as `BillingRateLimited` is preserved.

## Testing

- `uv run --extra dev python -m pytest tests\hermes_cli\test_billing_portal_url.py -q --basetemp .pytest-tmp-nous-billing`
- `git diff --check`

`autoreview` helper was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` returned no command).
