### PR TITLE
fix(gateway): register BlueBubbles webhook on 127.0.0.1, not localhost (IPv6 ::1 ECONNREFUSED)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -304,8 +304,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def _webhook_url(self) -> str:
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
-        if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
-            host = "localhost"
+        # Wildcard bind addresses aren't routable as a destination, so map them
+        # to an explicit loopback. Use 127.0.0.1 (IPv4) rather than "localhost":
+        # on modern macOS "localhost" resolves to IPv6 ::1 first, but the
+        # webhook listener (web.TCPSite, see _start) binds the IPv4 loopback by
+        # default — so a "localhost" registration makes BlueBubbles POST to
+        # ::1 and get ECONNREFUSED. Registering the IPv4 literal keeps the
+        # destination in lockstep with the bind address.
+        if host in {"0.0.0.0", "::", "localhost"}:
+            host = "127.0.0.1"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -554,19 +554,28 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url property normalises local hosts to the IPv4 loopback.
+
+    Must register 127.0.0.1 rather than "localhost": the webhook listener
+    binds the IPv4 loopback (web.TCPSite default), but on modern macOS
+    "localhost" resolves to IPv6 ::1 first, so a "localhost" registration
+    makes BlueBubbles POST to ::1 and get ECONNREFUSED.
+    """
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 0.0.0.0 → normalized to 127.0.0.1 (IPv4)
+        assert "127.0.0.1" in adapter._webhook_url
+        assert "localhost" not in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
     @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
     def test_local_hosts_normalized(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
-        assert adapter._webhook_url.startswith("http://localhost:")
+        # All loopback/wildcard hosts must register as the IPv4 literal so the
+        # registered destination matches the IPv4 bind (no IPv6 ::1 mismatch).
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")


### PR DESCRIPTION
## Problem

On macOS, inbound iMessages reach the BlueBubbles server (stored, visible via `/api/v1/message/query`) but **never reach the Hermes gateway**. The BlueBubbles server log shows:

```
[WebhookService] Failed to dispatch "new-message" event to webhook: http://localhost:8645/bluebubbles-webhook
  -> Error: connect ECONNREFUSED ::1:8645
```

### Root cause

The webhook listener binds the **IPv4** loopback (`web.TCPSite` default in `_start`), but `_webhook_url` rewrote loopback/wildcard hosts to the string `"localhost"` for registration:

```python
if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
    host = "localhost"
```

On modern macOS, `localhost` resolves to IPv6 `::1` first. So BlueBubbles POSTs new-message events to `::1:<port>`, where nothing is listening → `ECONNREFUSED`. The same mismatch breaks **outbound** sends when `BLUEBUBBLES_SERVER_URL` uses `localhost`.

Because the rewrite always forces `localhost`, **no config value can work around it** — even setting `webhook_host: 127.0.0.1` gets rewritten back.

## Fix

Map loopback/wildcard hosts (`0.0.0.0`, `::`, `localhost`) to the IPv4 literal `127.0.0.1` so the registered destination matches the IPv4 bind:

```python
if host in {"0.0.0.0", "::", "localhost"}:
    host = "127.0.0.1"
```

Non-loopback custom hosts (e.g. a LAN IP like `192.168.1.50`) are still preserved untouched.

## Tests

Updated the two tests in `TestBlueBubblesWebhookUrl` that had frozen the old (buggy) `localhost` behavior — they now assert the IPv4 contract, with a docstring explaining why `localhost` must not be used. Added an explicit `"localhost" not in url` assertion to prevent regression.

```
pytest tests/gateway/test_bluebubbles.py
56 passed
```

Verified live: after the fix, a restarted gateway registers only `http://127.0.0.1:8645/...` (no duplicate `localhost` webhook), BlueBubbles dispatches with no `ECONNREFUSED`, and iMessage round-trips both directions.