### PR TITLE
fix(hindsight): bound version probe response reads

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -62,6 +62,7 @@ _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # overwrites prior turns server-side, so we keep the per-process
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
+_HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES = 64 * 1024
 _VALID_BUDGETS = {"low", "mid", "high"}
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
@@ -191,7 +192,7 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
         req.add_header("Authorization", f"Bearer {api_key}")
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
-            payload = resp.read().decode("utf-8", errors="replace")
+            payload = _read_hindsight_version_payload(resp)
         data = json.loads(payload)
     except Exception as exc:
         logger.debug("Hindsight /version probe failed for %s: %s", url, exc)
@@ -200,6 +201,16 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
         return None
     version = data.get("version") or data.get("api_version")
     return str(version) if version else None
+
+
+def _read_hindsight_version_payload(resp: Any) -> str:
+    raw = resp.read(_HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(
+            "Hindsight /version response exceeded "
+            f"{_HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    return raw.decode("utf-8", errors="replace")
 
 
 def _check_api_supports_update_mode_append(api_url: str,

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -65,6 +65,7 @@ _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # overwrites prior turns server-side, so we keep the per-process
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
+_HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES = 64 * 1024
 _VALID_BUDGETS = {"low", "mid", "high"}
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
@@ -203,7 +204,7 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
         req.add_header("Authorization", f"Bearer {api_key}")
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
-            payload = resp.read().decode("utf-8", errors="replace")
+            payload = _read_hindsight_version_payload(resp)
         data = json.loads(payload)
     except Exception as exc:
         logger.debug("Hindsight /version probe failed for %s: %s", url, exc)
@@ -212,6 +213,16 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
         return None
     version = data.get("version") or data.get("api_version")
     return str(version) if version else None
+
+
+def _read_hindsight_version_payload(resp: Any) -> str:
+    raw = resp.read(_HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(
+            "Hindsight /version response exceeded "
+            f"{_HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    return raw.decode("utf-8", errors="replace")
 
 
 def _check_api_supports_update_mode_append(api_url: str,

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import plugins.memory.hindsight as hindsight
 from hermes_cli.memory_setup import _CANCELLED
 from plugins.memory.hindsight import (
     HindsightMemoryProvider,
@@ -27,6 +28,7 @@ from plugins.memory.hindsight import (
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _fetch_hindsight_api_version,
 )
 
 
@@ -141,6 +143,61 @@ def _assert_cloud_client_lazy_installed_before_import(tmp_path, monkeypatch, mod
         "timeout": 120.0,
         "api_key": "test-key",
     }
+
+
+class _FakeVersionResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> "_FakeVersionResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+
+def test_fetch_hindsight_api_version_bounds_response_read(monkeypatch):
+    response = _FakeVersionResponse(b'{"version": "0.5.6"}')
+    captured = []
+
+    def _urlopen(req, timeout):
+        captured.append((req, timeout))
+        return response
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    assert _fetch_hindsight_api_version(
+        "https://api.example.test",
+        "hindsight-key",
+        timeout=3.0,
+    ) == "0.5.6"
+    assert response.read_sizes == [
+        hindsight._HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES + 1
+    ]
+    assert captured[0][0].full_url == "https://api.example.test/version"
+    assert captured[0][1] == 3.0
+
+
+def test_fetch_hindsight_api_version_rejects_oversized_response(monkeypatch):
+    response = _FakeVersionResponse(
+        b"x" * (hindsight._HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES + 1)
+    )
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: response,
+    )
+
+    assert _fetch_hindsight_api_version("https://api.example.test") is None
+    assert response.read_sizes == [
+        hindsight._HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES + 1
+    ]
 
 
 class _FakeSessionDB:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import plugins.memory.hindsight as hindsight
 from hermes_cli.memory_setup import _CANCELLED
 from plugins.memory.hindsight import (
     HindsightMemoryProvider,
@@ -30,6 +31,7 @@ from plugins.memory.hindsight import (
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _fetch_hindsight_api_version,
 )
 
 
@@ -150,6 +152,61 @@ def _assert_cloud_client_lazy_installed_before_import(tmp_path, monkeypatch, mod
         "timeout": 120.0,
         "api_key": "test-key",
     }
+
+
+class _FakeVersionResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> "_FakeVersionResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+
+def test_fetch_hindsight_api_version_bounds_response_read(monkeypatch):
+    response = _FakeVersionResponse(b'{"version": "0.5.6"}')
+    captured = []
+
+    def _urlopen(req, timeout):
+        captured.append((req, timeout))
+        return response
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    assert _fetch_hindsight_api_version(
+        "https://api.example.test",
+        "hindsight-key",
+        timeout=3.0,
+    ) == "0.5.6"
+    assert response.read_sizes == [
+        hindsight._HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES + 1
+    ]
+    assert captured[0][0].full_url == "https://api.example.test/version"
+    assert captured[0][1] == 3.0
+
+
+def test_fetch_hindsight_api_version_rejects_oversized_response(monkeypatch):
+    response = _FakeVersionResponse(
+        b"x" * (hindsight._HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES + 1)
+    )
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: response,
+    )
+
+    assert _fetch_hindsight_api_version("https://api.example.test") is None
+    assert response.read_sizes == [
+        hindsight._HINDSIGHT_VERSION_RESPONSE_BODY_MAX_BYTES + 1
+    ]
 
 
 class _FakeSessionDB:


### PR DESCRIPTION
﻿## Summary

Fixes #54783.

Bounds the Hindsight `/version` capability probe to 64 KiB before JSON parsing. Oversized responses now raise inside the existing probe try/except and are treated like any other probe failure (`None`), preserving the legacy/no-append fallback behavior.

## Testing

- `uv run --extra dev python -m pytest tests\plugins\memory\test_hindsight_provider.py -q -k "fetch_hindsight_api_version" --basetemp .pytest-tmp-hindsight-version`
- `git diff --check`

Additional note: full `tests\plugins\memory\test_hindsight_provider.py` on this Windows environment reports 3 unrelated `TestPostSetup.test_local_embedded_setup_*` failures around profile env materialization. I confirmed the representative failure `test_local_embedded_setup_materializes_profile_env` also fails on `origin/main` in the clean scan worktree.

`autoreview` helper was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` returned no command).
