### PR TITLE
fix(anthropic): bound model list response reads

### DIFF
--- a/plugins/model-providers/anthropic/__init__.py
+++ b/plugins/model-providers/anthropic/__init__.py
@@ -8,6 +8,17 @@ from providers import register_provider
 from providers.base import ProviderProfile
 
 logger = logging.getLogger(__name__)
+_ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+
+
+def _read_anthropic_models_payload(resp) -> str:
+    raw = resp.read(_ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(
+            "Anthropic models response exceeded "
+            f"{_ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    return raw.decode()
 
 
 class AnthropicProfile(ProviderProfile):
@@ -29,7 +40,7 @@ class AnthropicProfile(ProviderProfile):
             req.add_header("anthropic-version", "2023-06-01")
             req.add_header("Accept", "application/json")
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                data = json.loads(resp.read().decode())
+                data = json.loads(_read_anthropic_models_payload(resp))
             return [
                 m["id"]
                 for m in data.get("data", [])

--- a/plugins/model-providers/anthropic/__init__.py
+++ b/plugins/model-providers/anthropic/__init__.py
@@ -9,6 +9,17 @@ from providers import register_provider
 from providers.base import ProviderProfile
 
 logger = logging.getLogger(__name__)
+_ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+
+
+def _read_anthropic_models_payload(resp) -> str:
+    raw = resp.read(_ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(
+            "Anthropic models response exceeded "
+            f"{_ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    return raw.decode()
 
 
 class AnthropicProfile(ProviderProfile):
@@ -30,7 +41,7 @@ class AnthropicProfile(ProviderProfile):
             req.add_header("anthropic-version", "2023-06-01")
             req.add_header("Accept", "application/json")
             with open_credentialed_url(req, timeout=timeout) as resp:
-                data = json.loads(resp.read().decode())
+                data = json.loads(_read_anthropic_models_payload(resp))
             return [
                 m["id"]
                 for m in data.get("data", [])

--- a/tests/plugins/model_providers/test_anthropic_profile.py
+++ b/tests/plugins/model_providers/test_anthropic_profile.py
@@ -1,0 +1,87 @@
+"""Tests for the native Anthropic provider profile."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+class _FakeAnthropicModelsResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> "_FakeAnthropicModelsResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+
+@pytest.fixture
+def anthropic_profile():
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("anthropic")
+    assert profile is not None, "anthropic provider profile must be registered"
+    return profile
+
+
+@pytest.fixture
+def anthropic_module(anthropic_profile):
+    import model_tools  # noqa: F401
+
+    return sys.modules[anthropic_profile.__class__.__module__]
+
+
+def test_fetch_models_bounds_response_read(
+    monkeypatch,
+    anthropic_module,
+    anthropic_profile,
+):
+    response = _FakeAnthropicModelsResponse(
+        b'{"data": [{"id": "claude-test"}]}'
+    )
+    captured = []
+
+    def _urlopen(req, timeout):
+        captured.append((req, timeout))
+        return response
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    assert anthropic_profile.fetch_models(api_key="sk-test", timeout=2.0) == [
+        "claude-test"
+    ]
+    assert response.read_sizes == [
+        anthropic_module._ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES + 1
+    ]
+    assert captured[0][0].full_url == "https://api.anthropic.com/v1/models"
+    assert captured[0][1] == 2.0
+
+
+def test_fetch_models_rejects_oversized_response(
+    monkeypatch,
+    anthropic_module,
+    anthropic_profile,
+):
+    response = _FakeAnthropicModelsResponse(
+        b"x" * (anthropic_module._ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES + 1)
+    )
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: response,
+    )
+
+    assert anthropic_profile.fetch_models(api_key="sk-test") is None
+    assert response.read_sizes == [
+        anthropic_module._ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES + 1
+    ]

--- a/tests/plugins/model_providers/test_anthropic_profile.py
+++ b/tests/plugins/model_providers/test_anthropic_profile.py
@@ -1,0 +1,92 @@
+"""Tests for the native Anthropic provider profile."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+class _FakeAnthropicModelsResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> "_FakeAnthropicModelsResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+
+@pytest.fixture
+def anthropic_profile():
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("anthropic")
+    assert profile is not None, "anthropic provider profile must be registered"
+    return profile
+
+
+@pytest.fixture
+def anthropic_module(anthropic_profile):
+    import model_tools  # noqa: F401
+
+    return sys.modules[anthropic_profile.__class__.__module__]
+
+
+def test_fetch_models_bounds_response_read(
+    monkeypatch,
+    anthropic_module,
+    anthropic_profile,
+):
+    response = _FakeAnthropicModelsResponse(
+        b'{"data": [{"id": "claude-test"}]}'
+    )
+    captured = []
+
+    def _open_credentialed_url(req, timeout):
+        captured.append((req, timeout))
+        return response
+
+    monkeypatch.setattr(
+        anthropic_module,
+        "open_credentialed_url",
+        _open_credentialed_url,
+    )
+
+    assert anthropic_profile.fetch_models(api_key="sk-test", timeout=2.0) == [
+        "claude-test"
+    ]
+    assert response.read_sizes == [
+        anthropic_module._ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES + 1
+    ]
+    assert captured[0][0].full_url == "https://api.anthropic.com/v1/models"
+    assert captured[0][1] == 2.0
+
+
+def test_fetch_models_rejects_oversized_response(
+    monkeypatch,
+    anthropic_module,
+    anthropic_profile,
+):
+    response = _FakeAnthropicModelsResponse(
+        b"x" * (anthropic_module._ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES + 1)
+    )
+    monkeypatch.setattr(
+        anthropic_module,
+        "open_credentialed_url",
+        lambda *args, **kwargs: response,
+    )
+
+    assert anthropic_profile.fetch_models(api_key="sk-test") is None
+    assert response.read_sizes == [
+        anthropic_module._ANTHROPIC_MODELS_RESPONSE_BODY_MAX_BYTES + 1
+    ]


### PR DESCRIPTION
﻿## Summary

Fixes #54786.

Bounds the native Anthropic profile's `/v1/models` response read before JSON parsing. Oversized bodies now raise inside the existing `except Exception` block and return `None`, preserving the current non-fatal fallback behavior for model list fetch failures.

This is a provider-specific follow-up to the generic catalog-read work in #42930/#54735; Anthropic overrides `fetch_models()` and does not inherit the generic `ProviderProfile.fetch_models()` implementation.

## Testing

- `uv run --extra dev python -m pytest tests\plugins\model_providers\test_anthropic_profile.py -q --basetemp .pytest-tmp-anthropic-profile`
- `uv run --extra dev python -m pytest tests\providers\test_plugin_discovery.py -q --basetemp .pytest-tmp-provider-discovery`
- `git diff --check`

`autoreview` helper was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` returned no command).
