### PR TITLE
fix(models): bound remote catalog manifest reads

### DIFF
--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -76,6 +76,7 @@ DEFAULT_CATALOG_FALLBACK_URLS: tuple[str, ...] = (
 DEFAULT_TTL_HOURS = 1
 DEFAULT_FETCH_TIMEOUT = 8.0
 SUPPORTED_SCHEMA_VERSION = 1
+_MAX_CATALOG_RESPONSE_BYTES = 16 * 1024 * 1024
 
 _HERMES_USER_AGENT = f"hermes-cli/{_HERMES_VERSION}"
 
@@ -133,8 +134,14 @@ def _fetch_manifest(url: str, timeout: float) -> dict[str, Any] | None:
             },
         )
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            data = json.loads(resp.read().decode())
-    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+            data = json.loads(_read_manifest_payload(resp))
+    except (
+        urllib.error.URLError,
+        TimeoutError,
+        json.JSONDecodeError,
+        OSError,
+        ValueError,
+    ) as exc:
         logger.info("model catalog fetch failed (%s): %s", url, exc)
         return None
     except Exception as exc:  # pragma: no cover — defensive
@@ -146,6 +153,15 @@ def _fetch_manifest(url: str, timeout: float) -> dict[str, Any] | None:
         return None
 
     return data
+
+
+def _read_manifest_payload(resp: Any) -> str:
+    raw = resp.read(_MAX_CATALOG_RESPONSE_BYTES + 1)
+    if len(raw) > _MAX_CATALOG_RESPONSE_BYTES:
+        raise ValueError(
+            f"model catalog response exceeded {_MAX_CATALOG_RESPONSE_BYTES} bytes"
+        )
+    return raw.decode()
 
 
 def _fetch_manifest_with_fallback(

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -52,6 +52,24 @@ def _valid_manifest() -> dict:
     }
 
 
+class _FakeCatalogResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> "_FakeCatalogResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+
 class TestValidation:
     def test_accepts_well_formed_manifest(self, isolated_home):
         from hermes_cli.model_catalog import _validate_manifest
@@ -95,6 +113,50 @@ class TestValidation:
 
 
 class TestFetchSuccess:
+    def test_fetch_manifest_bounds_response_read(self, isolated_home, monkeypatch):
+        from hermes_cli import model_catalog
+
+        response = _FakeCatalogResponse(json.dumps(_valid_manifest()).encode())
+        captured = []
+
+        def _urlopen(req, timeout):
+            captured.append((req, timeout))
+            return response
+
+        monkeypatch.setattr(model_catalog.urllib.request, "urlopen", _urlopen)
+
+        assert model_catalog._fetch_manifest(
+            "https://catalog.example.test/model-catalog.json",
+            timeout=2.0,
+        ) == _valid_manifest()
+        assert response.read_sizes == [
+            model_catalog._MAX_CATALOG_RESPONSE_BYTES + 1
+        ]
+        assert captured[0][0].full_url == (
+            "https://catalog.example.test/model-catalog.json"
+        )
+        assert captured[0][1] == 2.0
+
+    def test_fetch_manifest_rejects_oversized_response(self, isolated_home, monkeypatch):
+        from hermes_cli import model_catalog
+
+        response = _FakeCatalogResponse(
+            b"x" * (model_catalog._MAX_CATALOG_RESPONSE_BYTES + 1)
+        )
+        monkeypatch.setattr(
+            model_catalog.urllib.request,
+            "urlopen",
+            lambda *args, **kwargs: response,
+        )
+
+        assert model_catalog._fetch_manifest(
+            "https://catalog.example.test/model-catalog.json",
+            timeout=2.0,
+        ) is None
+        assert response.read_sizes == [
+            model_catalog._MAX_CATALOG_RESPONSE_BYTES + 1
+        ]
+
     def test_fetch_and_cache_writes_disk(self, isolated_home):
         from hermes_cli import model_catalog
         manifest = _valid_manifest()


### PR DESCRIPTION
﻿## Summary

Fixes #54792.

Bounds remote model catalog manifest reads to 16 MiB before JSON parsing. Oversized responses now raise through the existing `_fetch_manifest()` failure path, so callers keep using stale disk cache, an empty catalog, or hardcoded model lists as they already do for network/JSON/schema failures.

The cap matches the model catalog body-size guard used by the generic provider `/models` work, but this PR is scoped to `hermes_cli/model_catalog.py` remote manifest fetching and provider override URLs.

## Testing

- `uv run --extra dev python -m pytest tests\hermes_cli\test_model_catalog.py -q --basetemp .pytest-tmp-model-catalog`
- `git diff --check`

`autoreview` helper was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` returned no command).
