### PR TITLE
fix(security): bound OSV response reads

### DIFF
--- a/hermes_cli/security_audit.py
+++ b/hermes_cli/security_audit.py
@@ -37,6 +37,7 @@ OSV_VULN_URL = "https://api.osv.dev/v1/vulns/{vid}"
 OSV_BATCH_MAX = 1000  # OSV documented hard cap per request
 HTTP_TIMEOUT = 20
 DETAIL_PARALLELISM = 8
+_HTTP_JSON_RESPONSE_BODY_MAX_BYTES = 16 * 1024 * 1024
 
 # Severity ordering for --fail-on gating. UNKNOWN sits below LOW so it
 # never blocks unless --fail-on is passed something even lower (we don't
@@ -288,13 +289,22 @@ def _http_post_json(url: str, payload: dict) -> dict:
         url, data=data, headers={"Content-Type": "application/json"}, method="POST"
     )
     with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        return json.loads(_read_http_json_response(resp))
 
 
 def _http_get_json(url: str) -> dict:
     req = urllib.request.Request(url, method="GET")
     with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        return json.loads(_read_http_json_response(resp))
+
+
+def _read_http_json_response(resp) -> str:
+    body = resp.read(_HTTP_JSON_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(body) > _HTTP_JSON_RESPONSE_BODY_MAX_BYTES:
+        raise urllib.error.URLError(
+            f"response body exceeded {_HTTP_JSON_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    return body.decode("utf-8")
 
 
 def _osv_query_batch(components: list[Component]) -> dict[Component, list[str]]:

--- a/tests/hermes_cli/test_security_audit.py
+++ b/tests/hermes_cli/test_security_audit.py
@@ -14,6 +14,24 @@ from unittest.mock import patch
 from hermes_cli import security_audit as sa
 
 
+class _FakeHTTPResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> "_FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
+
+
 # ─── Parsers ──────────────────────────────────────────────────────────────────
 
 
@@ -156,6 +174,52 @@ class TestSeverityExtraction:
 
 
 # ─── End-to-end orchestration with mocked OSV ─────────────────────────────────
+
+
+class TestHTTPJson:
+    def test_http_get_json_bounds_response_read(self, monkeypatch):
+        response = _FakeHTTPResponse(b'{"ok": true}')
+        captured = []
+
+        def _urlopen(req, timeout):
+            captured.append((req, timeout))
+            return response
+
+        monkeypatch.setattr(sa.urllib.request, "urlopen", _urlopen)
+
+        assert sa._http_get_json("https://api.osv.dev/v1/vulns/X") == {"ok": True}
+        assert response.read_sizes == [
+            sa._HTTP_JSON_RESPONSE_BODY_MAX_BYTES + 1
+        ]
+        assert captured[0][0].full_url == "https://api.osv.dev/v1/vulns/X"
+        assert captured[0][1] == sa.HTTP_TIMEOUT
+
+    def test_osv_batch_wraps_oversized_response_as_runtime_error(self, monkeypatch):
+        response = _FakeHTTPResponse(
+            b"x" * (sa._HTTP_JSON_RESPONSE_BODY_MAX_BYTES + 1)
+        )
+        monkeypatch.setattr(
+            sa.urllib.request,
+            "urlopen",
+            lambda *args, **kwargs: response,
+        )
+        component = sa.Component(
+            name="pkg",
+            version="1.0",
+            ecosystem="PyPI",
+            source="venv",
+        )
+
+        try:
+            sa._osv_query_batch([component])
+        except RuntimeError as exc:
+            assert "OSV batch query failed" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+
+        assert response.read_sizes == [
+            sa._HTTP_JSON_RESPONSE_BODY_MAX_BYTES + 1
+        ]
 
 
 class TestRunAudit:


### PR DESCRIPTION
﻿## Summary

Fixes #54794.

Bounds OSV JSON response reads in `hermes_cli.security_audit` to 16 MiB before JSON parsing. Oversized bodies are converted into `urllib.error.URLError`, which keeps the existing failure behavior:

- batch queries are wrapped as `RuntimeError` and reported by `cmd_security_audit()`
- detail fetches degrade to an unknown-severity vulnerability record

## Testing

- `uv run --extra dev python -m pytest tests\hermes_cli\test_security_audit.py -q --basetemp .pytest-tmp-security-audit`
- `git diff --check`

`autoreview` helper was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` returned no command).
