### PR TITLE
fix(anthropic): bound OAuth token responses

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -54,6 +54,7 @@ def _get_anthropic_sdk():
     return _anthropic_sdk
 
 logger = logging.getLogger(__name__)
+_OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
 
 THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
 # Hermes effort → Anthropic adaptive-thinking effort (output_config.effort).
@@ -1051,7 +1052,7 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
         )
         try:
             with urllib.request.urlopen(req, timeout=10) as resp:
-                result = json.loads(resp.read().decode())
+                result = _read_oauth_json_response(resp)
         except Exception as exc:
             last_error = exc
             logger.debug("Anthropic token refresh failed at %s: %s", endpoint, exc)
@@ -1071,6 +1072,19 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
     if last_error is not None:
         raise last_error
     raise ValueError("Anthropic token refresh failed")
+
+
+def _read_oauth_json_response(resp: Any) -> Dict[str, Any]:
+    body = resp.read(_OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(body) > _OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(
+            "Anthropic OAuth response exceeded "
+            f"{_OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    data = json.loads(body.decode())
+    if not isinstance(data, dict):
+        raise ValueError("Anthropic OAuth response was not a JSON object")
+    return data
 
 
 def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
@@ -1492,7 +1506,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             )
             try:
                 with urllib.request.urlopen(req, timeout=15) as resp:
-                    result = json.loads(resp.read().decode())
+                    result = _read_oauth_json_response(resp)
                 break
             except Exception as exc:
                 last_error = exc

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -73,6 +73,7 @@ def _get_anthropic_sdk():
     return _anthropic_sdk
 
 logger = logging.getLogger(__name__)
+_OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
 
 THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
 # Hermes effort → Anthropic adaptive-thinking effort (output_config.effort).
@@ -1147,7 +1148,7 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
         )
         try:
             with urllib.request.urlopen(req, timeout=10) as resp:
-                result = json.loads(resp.read().decode())
+                result = _read_oauth_json_response(resp)
         except Exception as exc:
             last_error = exc
             logger.debug("Anthropic token refresh failed at %s: %s", endpoint, exc)
@@ -1167,6 +1168,19 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
     if last_error is not None:
         raise last_error
     raise ValueError("Anthropic token refresh failed")
+
+
+def _read_oauth_json_response(resp: Any) -> Dict[str, Any]:
+    body = resp.read(_OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(body) > _OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(
+            "Anthropic OAuth response exceeded "
+            f"{_OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    data = json.loads(body.decode())
+    if not isinstance(data, dict):
+        raise ValueError("Anthropic OAuth response was not a JSON object")
+    return data
 
 
 def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
@@ -1610,7 +1624,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             )
             try:
                 with urllib.request.urlopen(req, timeout=15) as resp:
-                    result = json.loads(resp.read().decode())
+                    result = _read_oauth_json_response(resp)
                 break
             except Exception as exc:
                 last_error = exc

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10238,6 +10238,7 @@ try:
         _OAUTH_REDIRECT_URI as _ANTHROPIC_OAUTH_REDIRECT_URI,
         _OAUTH_SCOPES as _ANTHROPIC_OAUTH_SCOPES,
         _generate_pkce as _generate_pkce_pair,
+        _read_oauth_json_response as _read_anthropic_oauth_json_response,
     )
     _ANTHROPIC_OAUTH_AVAILABLE = True
 except ImportError:
@@ -10429,7 +10430,7 @@ def _submit_anthropic_pkce(
         )
         try:
             with urllib.request.urlopen(req, timeout=20) as resp:
-                result = json.loads(resp.read().decode())
+                result = _read_anthropic_oauth_json_response(resp)
             break
         except Exception as e:
             last_exc = e

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+import agent.anthropic_adapter as anthropic_adapter
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
     _is_azure_anthropic_endpoint,
@@ -27,6 +28,24 @@ from agent.anthropic_adapter import (
     run_oauth_setup_token,
 )
 from agent.transports import get_transport
+
+
+class _FakeOAuthResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> "_FakeOAuthResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
 
 
 # ---------------------------------------------------------------------------
@@ -510,6 +529,54 @@ class TestRefreshOauthToken:
     def test_returns_none_without_refresh_token(self):
         creds = {"accessToken": "expired", "refreshToken": "", "expiresAt": 0}
         assert _refresh_oauth_token(creds) is None
+
+    def test_pure_refresh_bounds_response_read(self, monkeypatch):
+        response = _FakeOAuthResponse(
+            json.dumps(
+                {
+                    "access_token": "new-token-abc",
+                    "refresh_token": "new-refresh-456",
+                    "expires_in": 7200,
+                }
+            ).encode()
+        )
+        captured = []
+
+        def _urlopen(req, timeout):
+            captured.append((req, timeout))
+            return response
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+        result = anthropic_adapter.refresh_anthropic_oauth_pure(
+            "refresh-123",
+            use_json=True,
+        )
+
+        assert result["access_token"] == "new-token-abc"
+        assert result["refresh_token"] == "new-refresh-456"
+        assert response.read_sizes == [
+            anthropic_adapter._OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1
+        ]
+        assert captured[0][0].full_url == "https://platform.claude.com/v1/oauth/token"
+        assert captured[0][1] == 10
+
+    def test_pure_refresh_rejects_oversized_response(self, monkeypatch):
+        response = _FakeOAuthResponse(
+            b"x" * (anthropic_adapter._OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1)
+        )
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda *args, **kwargs: response,
+        )
+
+        with pytest.raises(ValueError, match="Anthropic OAuth response exceeded"):
+            anthropic_adapter.refresh_anthropic_oauth_pure("refresh-123")
+
+        assert response.read_sizes == [
+            anthropic_adapter._OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1,
+            anthropic_adapter._OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1,
+        ]
 
     def test_successful_refresh(self, tmp_path, monkeypatch):
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+import agent.anthropic_adapter as anthropic_adapter
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
     _is_azure_anthropic_endpoint,
@@ -27,6 +28,24 @@ from agent.anthropic_adapter import (
     run_oauth_setup_token,
 )
 from agent.transports import get_transport
+
+
+class _FakeOAuthResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> "_FakeOAuthResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size is None or size < 0:
+            return self.body
+        return self.body[:size]
 
 
 # ---------------------------------------------------------------------------
@@ -385,6 +404,54 @@ class TestRefreshOauthToken:
         )
         creds = {"accessToken": "expired", "refreshToken": "", "expiresAt": 0}
         assert _refresh_oauth_token(creds) is None
+
+    def test_pure_refresh_bounds_response_read(self, monkeypatch):
+        response = _FakeOAuthResponse(
+            json.dumps(
+                {
+                    "access_token": "new-token-abc",
+                    "refresh_token": "new-refresh-456",
+                    "expires_in": 7200,
+                }
+            ).encode()
+        )
+        captured = []
+
+        def _urlopen(req, timeout):
+            captured.append((req, timeout))
+            return response
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+        result = anthropic_adapter.refresh_anthropic_oauth_pure(
+            "refresh-123",
+            use_json=True,
+        )
+
+        assert result["access_token"] == "new-token-abc"
+        assert result["refresh_token"] == "new-refresh-456"
+        assert response.read_sizes == [
+            anthropic_adapter._OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1
+        ]
+        assert captured[0][0].full_url == "https://platform.claude.com/v1/oauth/token"
+        assert captured[0][1] == 10
+
+    def test_pure_refresh_rejects_oversized_response(self, monkeypatch):
+        response = _FakeOAuthResponse(
+            b"x" * (anthropic_adapter._OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1)
+        )
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda *args, **kwargs: response,
+        )
+
+        with pytest.raises(ValueError, match="Anthropic OAuth response exceeded"):
+            anthropic_adapter.refresh_anthropic_oauth_pure("refresh-123")
+
+        assert response.read_sizes == [
+            anthropic_adapter._OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1,
+            anthropic_adapter._OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1,
+        ]
 
     def test_successful_refresh(self, tmp_path, monkeypatch):
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -71,8 +71,10 @@ def _patch_oauth_flow(
         def __exit__(self, *_exc):
             return False
 
-        def read(self):
-            return self._body
+        def read(self, size: int = -1):
+            if size is None or size < 0:
+                return self._body
+            return self._body[:size]
 
     def fake_urlopen(req, *_a, **_kw):
         if capture_token_request is not None:
@@ -215,8 +217,10 @@ def test_login_token_exchange_falls_back_to_console_host(monkeypatch, tmp_path):
         def __exit__(self, *_exc):
             return False
 
-        def read(self):
-            return self._body
+        def read(self, size: int = -1):
+            if size is None or size < 0:
+                return self._body
+            return self._body[:size]
 
     def fake_urlopen(req, *_a, **_kw):
         attempts.append(req.full_url)

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -71,8 +71,12 @@ def _patch_oauth_flow(
         def __exit__(self, *_exc):
             return False
 
-        def read(self):
-            return self._body
+        def read(self, size: int = -1):
+            if capture_token_request is not None:
+                capture_token_request.setdefault("read_sizes", []).append(size)
+            if size is None or size < 0:
+                return self._body
+            return self._body[:size]
 
     def fake_urlopen(req, *_a, **_kw):
         if capture_token_request is not None:
@@ -176,7 +180,10 @@ def test_login_token_exchange_uses_platform_claude_host(monkeypatch, tmp_path):
 
     monkeypatch.setattr(builtins, "input", fake_input)
 
-    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+    from agent.anthropic_adapter import (
+        _OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES,
+        run_hermes_oauth_login_pure,
+    )
 
     result = run_hermes_oauth_login_pure()
 
@@ -185,8 +192,9 @@ def test_login_token_exchange_uses_platform_claude_host(monkeypatch, tmp_path):
         "login token exchange must target platform.claude.com first, not the "
         "dead console.anthropic.com host (regression of #45250 / #49821)"
     )
-
-
+    assert captured_token["read_sizes"] == [
+        _OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1
+    ]
 
 
 def test_callback_state_mismatch_aborts(monkeypatch, tmp_path, caplog):

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -695,5 +695,46 @@ def test_status_falls_through_to_generic_dispatcher_for_catalog_only_provider():
     assert out["has_refresh_token"] is True
 
 
+def test_anthropic_dashboard_token_exchange_bounds_response(monkeypatch):
+    from agent.anthropic_adapter import _OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES
+    from hermes_cli import web_server as ws
+
+    sid, sess = ws._new_oauth_session("anthropic", "pkce")
+    sess.update({"verifier": "verifier", "state": "state"})
+    read_sizes = []
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self, size=-1):
+            read_sizes.append(size)
+            return b"x" * size
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *_a, **_kw: _Response())
+    monkeypatch.setattr(
+        ws,
+        "_save_anthropic_oauth_creds",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            AssertionError("oversized response must not be persisted")
+        ),
+    )
+
+    try:
+        result = ws._submit_anthropic_pkce(sid, "code#state")
+    finally:
+        ws._oauth_sessions.pop(sid, None)
+
+    assert result["ok"] is False
+    assert read_sizes == [
+        _OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1,
+        _OAUTH_TOKEN_RESPONSE_BODY_MAX_BYTES + 1,
+    ]
+    assert "exceeded" in result["message"]
+
+
 
 


### PR DESCRIPTION
Fixes #54797

## Summary

- Add a shared bounded JSON reader for Anthropic OAuth token responses.
- Use it in both token refresh and PKCE login token exchange.
- Preserve existing failure/fallback behavior for oversized or invalid token responses.

## Tests

- `uv run --extra dev python -m pytest tests\agent\test_anthropic_adapter.py -q -k RefreshOauthToken --basetemp .pytest-tmp-anthropic-adapter-refresh`
- `uv run --extra dev python -m pytest tests\agent\test_anthropic_oauth_pkce.py -q --basetemp .pytest-tmp-anthropic-pkce`
- `uv run --extra dev python -m pytest tests\agent\test_anthropic_adapter.py -q --basetemp .pytest-tmp-anthropic-adapter-full`
- `git diff --check`

`autoreview` was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` found no command).