### PR TITLE
fix(relay): bound provision responses

### DIFF
--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import os
 from typing import Optional
 
+_PROVISION_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+
 
 def relay_url() -> Optional[str]:
     """The connector relay endpoint URL, or None when relay is not configured.
@@ -418,11 +420,11 @@ def _post_provision(
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
+            payload = _read_provision_json_response(resp)
     except urllib.error.HTTPError as exc:
         detail = ""
         try:
-            detail = (json.loads(exc.read().decode()) or {}).get("error", "")
+            detail = (_read_provision_json_response(exc) or {}).get("error", "")
         except Exception:
             pass
         raise RuntimeError(
@@ -433,6 +435,21 @@ def _post_provision(
 
     if not isinstance(payload, dict) or not payload.get("secret"):
         raise RuntimeError("connector returned an unexpected response (no secret)")
+    return payload
+
+
+def _read_provision_json_response(resp) -> dict:
+    import json
+
+    raw = resp.read(_PROVISION_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _PROVISION_RESPONSE_BODY_MAX_BYTES:
+        raise RuntimeError(
+            "connector response exceeded "
+            f"{_PROVISION_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    payload = json.loads(raw.decode())
+    if not isinstance(payload, dict):
+        raise RuntimeError("connector returned an unexpected response")
     return payload
 
 

--- a/tests/gateway/relay/test_self_provision.py
+++ b/tests/gateway/relay/test_self_provision.py
@@ -221,8 +221,9 @@ def test_post_provision_body_includes_instanceId_only_when_set(monkeypatch):
         def __exit__(self, *a):
             return False
 
-        def read(self):
-            return json.dumps({"secret": "a" * 64, "deliveryKey": "b" * 64, "tenant": "t", "gatewayId": "gw-1"}).encode()
+        def read(self, size=-1):
+            data = json.dumps({"secret": "a" * 64, "deliveryKey": "b" * 64, "tenant": "t", "gatewayId": "gw-1"}).encode()
+            return data if size < 0 else data[:size]
 
     def _fake_urlopen(req, timeout=None):  # noqa: ANN001
         sent["body"] = json.loads(req.data.decode())
@@ -254,6 +255,66 @@ def test_post_provision_body_includes_instanceId_only_when_set(monkeypatch):
         route_keys=[],
     )
     assert "instanceId" not in sent["body"]
+
+
+def test_post_provision_bounds_success_response(monkeypatch):
+    import json
+
+    captured = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, size=-1):
+            captured["read_size"] = size
+            return json.dumps({"secret": "a" * 64, "deliveryKey": "b" * 64, "tenant": "t", "gatewayId": "gw-1"}).encode()
+
+    def _fake_urlopen(req, timeout=None):  # noqa: ANN001
+        return _Resp()
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    payload = relay._post_provision(
+        provision_url="https://c.example/relay/provision",
+        access_token="tok",
+        gateway_id="gw-1",
+        platform="discord",
+        bot_id="app",
+        gateway_endpoint=None,
+        route_keys=[],
+    )
+    assert payload["secret"] == "a" * 64
+    assert captured["read_size"] == relay._PROVISION_RESPONSE_BODY_MAX_BYTES + 1
+
+
+def test_post_provision_rejects_oversized_response(monkeypatch):
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, size=-1):
+            return b"x" * size
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda req, timeout=None: _Resp())
+    monkeypatch.setattr(relay, "_PROVISION_RESPONSE_BODY_MAX_BYTES", 8)
+
+    with pytest.raises(RuntimeError, match="connector response exceeded"):
+        relay._post_provision(
+            provision_url="https://c.example/relay/provision",
+            access_token="tok",
+            gateway_id="gw-1",
+            platform="discord",
+            bot_id="app",
+            gateway_endpoint=None,
+            route_keys=[],
+        )
 
 
 # ─────────────────── wake-url forwarding (Phase 5 Unit C) ───────────────────
@@ -314,8 +375,9 @@ def test_post_provision_body_includes_wakeUrl_only_when_set(monkeypatch):
         def __exit__(self, *a):
             return False
 
-        def read(self):
-            return json.dumps({"secret": "a" * 64, "deliveryKey": "b" * 64, "tenant": "t", "gatewayId": "gw-1"}).encode()
+        def read(self, size=-1):
+            data = json.dumps({"secret": "a" * 64, "deliveryKey": "b" * 64, "tenant": "t", "gatewayId": "gw-1"}).encode()
+            return data if size < 0 else data[:size]
 
     def _fake_urlopen(req, timeout=None):  # noqa: ANN001
         sent["body"] = json.loads(req.data.decode())


### PR DESCRIPTION
Fixes #54800

## Summary

- Add a bounded JSON response reader for relay provision responses.
- Apply the same cap to HTTP error response details.
- Keep existing fail-soft behavior: oversized provision responses surface as provision failures, and boot can continue without relay credentials.

## Tests

- `uv run --extra dev python -m pytest tests\gateway\relay\test_self_provision.py -q --basetemp .pytest-tmp-relay-provision`
- `uv run --extra dev python -m pytest tests\gateway\relay\test_relay_multiplatform.py -q --basetemp .pytest-tmp-relay-multiplatform`
- `git diff --check`

`autoreview` was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` found no command).