### PR TITLE
feat: allow Discord free-response threads

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2249,6 +2249,7 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
+        "free_response_threads": False,  # If True, all Discord threads can start without @mention
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4377,6 +4377,21 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_THREAD_REQUIRE_MENTION", "false").lower() in {"true", "1", "yes", "on"}
 
+    def _discord_free_response_threads(self) -> bool:
+        """Return whether all Discord threads can start without @mention.
+
+        ``thread_require_mention`` controls follow-ups in threads where the bot
+        has already participated. This setting is broader: when enabled, any
+        Discord thread is treated as free-response for the first message too,
+        while ordinary server channels can still keep ``require_mention``.
+        """
+        configured = self.config.extra.get("free_response_threads")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("DISCORD_FREE_RESPONSE_THREADS", "false").lower() in {"true", "1", "yes", "on"}
+
     def _discord_history_backfill(self) -> bool:
         """Return whether history backfill is enabled for shared sessions."""
         configured = self.config.extra.get("history_backfill")
@@ -5379,6 +5394,7 @@ class DiscordAdapter(BasePlatformAdapter):
             is_free_channel = (
                 "*" in free_channels
                 or bool(channel_ids & free_channels)
+                or (is_thread and self._discord_free_response_threads())
                 or is_voice_linked_channel
             )
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -108,6 +108,7 @@ def adapter(monkeypatch):
     for _var in (
         "DISCORD_REQUIRE_MENTION",
         "DISCORD_THREAD_REQUIRE_MENTION",
+        "DISCORD_FREE_RESPONSE_THREADS",
         "DISCORD_FREE_RESPONSE_CHANNELS",
         "DISCORD_AUTO_THREAD",
         "DISCORD_NO_THREAD_CHANNELS",
@@ -463,6 +464,48 @@ async def test_discord_unknown_thread_still_requires_mention(adapter, monkeypatc
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_free_response_threads_allows_unknown_thread_start(adapter, monkeypatch):
+    """Configured free-response threads allow starting in any thread without @mention."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_THREADS", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    thread = FakeThread(channel_id=789, name="some thread")
+    message = make_message(channel=thread, content="hello from unknown thread")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "hello from unknown thread"
+    assert event.source.chat_id == "789"
+    assert event.source.thread_id == "789"
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_discord_free_response_threads_config_extra(adapter, monkeypatch):
+    """discord.free_response_threads works from config.yaml without opening parent channels."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_THREADS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["free_response_threads"] = True
+
+    channel_message = make_message(channel=FakeTextChannel(channel_id=111), content="plain channel")
+    await adapter._handle_message(channel_message)
+    adapter.handle_message.assert_not_awaited()
+
+    thread = FakeThread(channel_id=789, name="some thread")
+    thread_message = make_message(channel=thread, content="plain thread")
+    await adapter._handle_message(thread_message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "plain thread"
+    assert event.source.chat_type == "thread"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `discord.free_response_threads` config default.
- Allow configured Discord threads to bypass mention/DM reply gating.
- Add regression coverage for configured free-response threads while preserving default ignore behavior.

## Test Plan
- [x] `git diff --check origin/main...HEAD`
- [x] `python -m pytest tests/gateway/test_discord_free_response.py -q -o 'addopts='`
