### PR TITLE
feat: add pre_tool_call mutate action support

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -393,7 +393,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             )
         else:
             try:
-                from hermes_cli.plugins import get_pre_tool_call_block_message
+                from hermes_cli.plugins import get_pre_tool_call_block_message, get_pre_tool_call_mutation
                 block_message = get_pre_tool_call_block_message(
                     function_name,
                     function_args,
@@ -404,6 +404,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                     middleware_trace=list(middleware_trace),
                 )
+                _mutation = get_pre_tool_call_mutation()
+                if _mutation and isinstance(function_args, dict):
+                    function_args.update(_mutation)
             except Exception:
                 block_message = None
 
@@ -926,7 +929,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             _block_error_type = "tool_scope_block"
         else:
             try:
-                from hermes_cli.plugins import get_pre_tool_call_block_message
+                from hermes_cli.plugins import get_pre_tool_call_block_message, get_pre_tool_call_mutation
                 _block_msg = get_pre_tool_call_block_message(
                     function_name,
                     function_args,
@@ -937,6 +940,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                     middleware_trace=list(middleware_trace),
                 )
+                _mutation = get_pre_tool_call_mutation()
+                if _mutation and isinstance(function_args, dict):
+                    function_args.update(_mutation)
             except Exception:
                 pass
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2020,13 +2020,55 @@ def get_pre_tool_call_block_message(
     for result in hook_results:
         if not isinstance(result, dict):
             continue
-        if result.get("action") != "block":
-            continue
-        message = result.get("message")
-        if isinstance(message, str) and message:
-            return message
+        action = result.get("action")
+        if action == "block":
+            message = result.get("message")
+            if isinstance(message, str) and message:
+                return message
+        elif action == "mutate":
+            args_update = result.get("args")
+            if isinstance(args_update, dict):
+                _store_pre_tool_call_mutation(args_update)
 
     return None
+
+
+# ---------------------------------------------------------------------------
+# pre_tool_call mutation support
+# ---------------------------------------------------------------------------
+
+import threading
+
+_pre_tool_call_mutation_storage = threading.local()
+
+
+def _store_pre_tool_call_mutation(args_update: Dict[str, Any]) -> None:
+    """Store a mutation request from a pre_tool_call hook."""
+    if not hasattr(_pre_tool_call_mutation_storage, "pending"):
+        _pre_tool_call_mutation_storage.pending = {}
+    _pre_tool_call_mutation_storage.pending.update(args_update)
+
+
+def get_pre_tool_call_mutation() -> Optional[Dict[str, Any]]:
+    """Retrieve any pending tool argument mutation from the current hook invocation.
+
+    Called by the tool executor after :func:`get_pre_tool_call_block_message`
+    to check if any plugin wants to modify the tool's arguments before
+    execution.  Mutations are single-use and cleared after retrieval.
+
+    Returns:
+        Dict of args to merge into the tool call, or None if no mutation.
+    """
+    return _consume_pre_tool_call_mutation()
+
+
+def _consume_pre_tool_call_mutation() -> Optional[Dict[str, Any]]:
+    """Consume and clear the pending mutation (single-use semantics)."""
+    if not hasattr(_pre_tool_call_mutation_storage, "pending"):
+        return None
+    pending = _pre_tool_call_mutation_storage.pending
+    _pre_tool_call_mutation_storage.pending = {}
+    return pending if pending else None
 
 
 def _ensure_plugins_discovered(force: bool = False) -> PluginManager:

--- a/model_tools.py
+++ b/model_tools.py
@@ -1055,7 +1055,7 @@ def handle_function_call(
         if not skip_pre_tool_call_hook:
             block_message: Optional[str] = None
             try:
-                from hermes_cli.plugins import get_pre_tool_call_block_message
+                from hermes_cli.plugins import get_pre_tool_call_block_message, get_pre_tool_call_mutation
                 block_message = get_pre_tool_call_block_message(
                     function_name,
                     function_args,
@@ -1066,6 +1066,9 @@ def handle_function_call(
                     api_request_id=api_request_id or "",
                     middleware_trace=list(_tool_middleware_trace),
                 )
+                _mutation = get_pre_tool_call_mutation()
+                if _mutation and isinstance(function_args, dict):
+                    function_args.update(_mutation)
             except Exception as _hook_err:
                 logger.debug("pre_tool_call hook error: %s", _hook_err)
 


### PR DESCRIPTION
## Summary

Extend the `pre_tool_call` hook to support `mutate` action, allowing plugins to modify tool arguments before execution. This enables RTK (Rust Token Killer) to transparently rewrite terminal commands (e.g., `git status` → `rtk git status`) before they execute, reducing token consumption by 60-90%.

## Changes

### 1. `hermes_cli/plugins.py`
- `get_pre_tool_call_block_message()`: Added detection for `mutate` action
- Added thread-local storage for mutation requests
- Added public API: `get_pre_tool_call_mutation()` and `_consume_pre_tool_call_mutation()`

### 2. `agent/tool_executor.py`
- Both `execute_tool_calls_concurrent()` and `execute_tool_calls_sequential()`: After block check, retrieve and apply any pending mutation

### 3. `model_tools.py`
- `handle_function_call()`: Same mutation retrieval and application

## Backward Compatibility

- Existing `block` action unchanged
- Observer-only hooks (return None) unaffected
- Only plugins returning `{"action": "mutate", "args": {...}}` trigger mutation

## Test Plan

- [ ] Existing block functionality still works
- [ ] RTK plugin can use mutate action to rewrite commands
- [ ] Observer-only hooks unaffected
- [ ] Thread-local storage doesn't leak between threads