### PR TITLE
fix(banner): bound PyPI update response

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -263,6 +263,22 @@ def _version_tuple(v: str) -> tuple[int, ...]:
     return tuple(parts)
 
 
+_PYPI_JSON_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+
+
+def _read_pypi_json_response(resp) -> dict:
+    raw = resp.read(_PYPI_JSON_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _PYPI_JSON_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(
+            "PyPI response exceeded "
+            f"{_PYPI_JSON_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    data = json.loads(raw.decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("PyPI response was not a JSON object")
+    return data
+
+
 def _fetch_pypi_latest(package: str = "hermes-agent") -> Optional[str]:
     """Fetch the latest version of a package from PyPI. Returns None on failure."""
     try:
@@ -270,7 +286,7 @@ def _fetch_pypi_latest(package: str = "hermes-agent") -> Optional[str]:
         url = f"https://pypi.org/pypi/{package}/json"
         req = urllib.request.Request(url, headers={"Accept": "application/json"})
         with urllib.request.urlopen(req, timeout=5) as resp:
-            data = json.loads(resp.read())
+            data = _read_pypi_json_response(resp)
             return data.get("info", {}).get("version")
     except Exception:
         return None

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -313,6 +313,54 @@ def test_check_for_updates_non_docker_still_checks(tmp_path, monkeypatch):
     mock_run.assert_not_called()
 
 
+def test_fetch_pypi_latest_bounds_response_read(monkeypatch):
+    """PyPI update JSON should be read with a defensive size cap."""
+    import urllib.request
+
+    import hermes_cli.banner as banner
+
+    captured = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, size=-1):
+            captured["size"] = size
+            data = json.dumps({"info": {"version": "9.9.9"}}).encode()
+            return data if size < 0 else data[:size]
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: _Resp())
+
+    assert banner._fetch_pypi_latest("hermes-agent") == "9.9.9"
+    assert captured["size"] == banner._PYPI_JSON_RESPONSE_BODY_MAX_BYTES + 1
+
+
+def test_fetch_pypi_latest_rejects_oversized_response(monkeypatch):
+    """Oversized PyPI JSON should be treated like an update-check miss."""
+    import urllib.request
+
+    import hermes_cli.banner as banner
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, size=-1):
+            return b"x" * size
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: _Resp())
+    monkeypatch.setattr(banner, "_PYPI_JSON_RESPONSE_BODY_MAX_BYTES", 8)
+
+    assert banner._fetch_pypi_latest("hermes-agent") is None
+
+
 def test_prefetch_non_blocking():
     """prefetch_update_check() should return immediately without blocking."""
     import hermes_cli.banner as banner


### PR DESCRIPTION
﻿Fixes #54811

## Summary

- Add a bounded reader for PyPI update-check JSON.
- Treat oversized/non-object PyPI responses like existing fetch failures (`None`).
- Preserve existing version comparison and cache behavior.

## Tests

- `uv run --extra dev python -m pytest tests\hermes_cli\test_update_check.py -q --basetemp .pytest-tmp-pypi-update`
- `git diff --check`

`autoreview` was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` found no command).
