### PR TITLE
feat(image-gen): add per-call size override

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -45,6 +45,7 @@ import abc
 import base64
 import datetime
 import logging
+import struct
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -259,6 +260,63 @@ def save_b64_image(
     path = _images_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
     path.write_bytes(raw)
     return path
+
+
+def image_dimensions(path: str | Path) -> Optional[Tuple[int, int]]:
+    """Return image dimensions for common generated-image formats, if readable."""
+    try:
+        data = Path(path).read_bytes()
+    except Exception:
+        return None
+
+    if data.startswith(b"\x89PNG\r\n\x1a\n") and len(data) >= 24:
+        return struct.unpack(">II", data[16:24])
+    if data[:6] in (b"GIF87a", b"GIF89a") and len(data) >= 10:
+        return struct.unpack("<HH", data[6:10])
+    if data.startswith(b"RIFF") and data[8:12] == b"WEBP" and len(data) >= 30:
+        if data[12:16] == b"VP8X":
+            return (int.from_bytes(data[24:27], "little") + 1, int.from_bytes(data[27:30], "little") + 1)
+        if data[12:16] == b"VP8 ":
+            start = data.find(b"\x9d\x01\x2a")
+            if start >= 0 and len(data) >= start + 7:
+                width, height = struct.unpack("<HH", data[start + 3:start + 7])
+                return (width & 0x3FFF, height & 0x3FFF)
+        if data[12:16] == b"VP8L" and len(data) >= 25:
+            bits = int.from_bytes(data[21:25], "little")
+            return ((bits & 0x3FFF) + 1, ((bits >> 14) & 0x3FFF) + 1)
+    if data.startswith(b"\xff\xd8"):
+        i = 2
+        while i + 9 < len(data):
+            if data[i] != 0xFF:
+                i += 1
+                continue
+            marker = data[i + 1]
+            i += 2
+            if marker in (0xD8, 0xD9) or 0xD0 <= marker <= 0xD7:
+                continue
+            if i + 2 > len(data):
+                break
+            length = int.from_bytes(data[i:i + 2], "big")
+            if length < 2 or i + length > len(data):
+                break
+            if marker in {0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF}:
+                height = int.from_bytes(data[i + 3:i + 5], "big")
+                width = int.from_bytes(data[i + 5:i + 7], "big")
+                return (width, height)
+            i += length
+    return None
+
+
+def size_metadata(path: str | Path, requested_size: str) -> Dict[str, Any]:
+    """Return requested/actual size metadata for a saved generated image."""
+    extra: Dict[str, Any] = {"requested_size": requested_size}
+    dims = image_dimensions(path)
+    if dims:
+        actual_size = f"{dims[0]}x{dims[1]}"
+        extra.update({"actual_size": actual_size, "actual_width": dims[0], "actual_height": dims[1]})
+        if requested_size != "auto" and actual_size != requested_size:
+            extra["warning"] = f"Requested image size {requested_size}, but saved image is {actual_size}."
+    return extra
 
 
 # Extension inference for save_url_image — keep small and explicit.  We don't

--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -148,6 +148,9 @@ class ImageGenProvider(abc.ABC):
             {
                 "modalities": ["text", "image"],   # which inputs the backend accepts
                 "max_reference_images": 9,          # cap for reference_image_urls
+                "supports_size": False,             # explicit per-call size for text-to-image
+                "supports_image_to_image_size": False,  # explicit per-call size for edits
+                "size_description": "...",          # human-readable accepted values
             }
 
         ``modalities`` declares whether the active backend/model supports
@@ -160,6 +163,8 @@ class ImageGenProvider(abc.ABC):
         return {
             "modalities": ["text"],
             "max_reference_images": 0,
+            "supports_size": False,
+            "supports_image_to_image_size": False,
         }
 
     @abc.abstractmethod

--- a/plugins/image_gen/fal/__init__.py
+++ b/plugins/image_gen/fal/__init__.py
@@ -109,11 +109,21 @@ class FalImageGenProvider(ImageGenProvider):
         except Exception:  # noqa: BLE001
             return {"modalities": ["text"], "max_reference_images": 0}
         if meta.get("edit_endpoint"):
+            edit_supports = meta.get("edit_supports") or set()
             return {
                 "modalities": ["text", "image"],
                 "max_reference_images": int(meta.get("max_reference_images") or 1),
+                "supports_size": any(k in meta.get("supports", set()) for k in ("image_size", "resolution", "aspect_ratio")),
+                "supports_image_to_image_size": any(k in edit_supports for k in ("image_size", "resolution", "aspect_ratio")),
+                "size_description": "Native FAL size key only when the active model supports image_size, resolution, or aspect_ratio.",
             }
-        return {"modalities": ["text"], "max_reference_images": 0}
+        return {
+            "modalities": ["text"],
+            "max_reference_images": 0,
+            "supports_size": any(k in meta.get("supports", set()) for k in ("image_size", "resolution", "aspect_ratio")),
+            "supports_image_to_image_size": False,
+            "size_description": "Native FAL size key only when the active model supports image_size, resolution, or aspect_ratio.",
+        }
 
     def generate(
         self,
@@ -143,6 +153,7 @@ class FalImageGenProvider(ImageGenProvider):
                 "num_images",
                 "output_format",
                 "seed",
+                "size",
             )
             if key in kwargs and kwargs[key] is not None
         }

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -29,6 +29,7 @@ from agent.image_gen_provider import (
     error_response,
     resolve_aspect_ratio,
     save_b64_image,
+    size_metadata,
     success_response,
 )
 
@@ -192,7 +193,6 @@ def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[st
             "quality": quality,
             "output_format": "png",
             "background": "opaque",
-            "partial_images": 1,
         }],
         "tool_choice": {
             "type": "allowed_tools",
@@ -204,16 +204,13 @@ def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[st
 
 
 def _extract_image_b64(value: Any) -> Optional[str]:
-    """Return the newest image b64 embedded in a Responses event payload."""
+    """Return the newest final image b64 embedded in a Responses event payload."""
     found: Optional[str] = None
     if isinstance(value, dict):
         if value.get("type") == "image_generation_call":
             result = value.get("result")
             if isinstance(result, str) and result:
                 found = result
-        partial = value.get("partial_image_b64")
-        if isinstance(partial, str) and partial:
-            found = partial
         for child in value.values():
             nested = _extract_image_b64(child)
             if nested:
@@ -496,13 +493,15 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
+        extra: Dict[str, Any] = {"size": size, "quality": meta["quality"]}
+        extra.update(size_metadata(saved_path, size))
         return success_response(
             image=str(saved_path),
             model=tier_id,
             prompt=prompt,
             aspect_ratio=aspect,
             provider="openai-codex",
-            extra={"size": size, "quality": meta["quality"]},
+            extra=extra,
         )
 
 

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -70,6 +70,37 @@ _SIZES = {
     "portrait": "1024x1536",
 }
 
+
+def _resolve_size(aspect: str, requested: Any = None) -> Tuple[Optional[str], Optional[str]]:
+    """Return (size, error) for gpt-image-2 per-call sizes."""
+    if requested is None or (isinstance(requested, str) and not requested.strip()):
+        return _SIZES.get(aspect, _SIZES["square"]), None
+    if not isinstance(requested, str):
+        return None, "size must be a string like '1024x1024' or 'auto'"
+
+    value = requested.strip().lower()
+    if value == "auto":
+        return "auto", None
+    if "x" not in value:
+        return None, "size must be 'auto' or '<width>x<height>'"
+    left, right = value.split("x", 1)
+    if not (left.isdigit() and right.isdigit()):
+        return None, "size width and height must be positive integers"
+    width = int(left)
+    height = int(right)
+    if width <= 0 or height <= 0:
+        return None, "size width and height must be positive"
+    if width % 16 != 0 or height % 16 != 0:
+        return None, "size width and height must be multiples of 16"
+    if max(width, height) >= 3840:
+        return None, "size max edge must be less than 3840"
+    if max(width, height) / min(width, height) > 3:
+        return None, "size aspect ratio must be <= 3:1"
+    pixels = width * height
+    if pixels < 655_360 or pixels > 8_294_400:
+        return None, "size total pixels must be between 655360 and 8294400"
+    return f"{width}x{height}", None
+
 # Codex Responses surface used for the request. The chat model itself is only
 # the host that calls the ``image_generation`` tool; the actual image work is
 # done by ``API_MODEL``.
@@ -333,7 +364,14 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         # users who need editing should use the `openai` (API key), `fal`, or
         # `xai` backends. Declaring text-only keeps the dynamic tool schema
         # honest so the model doesn't attempt an unsupported edit.
-        return {"modalities": ["text"], "max_reference_images": 0}
+        return {
+            "modalities": ["text"],
+            "max_reference_images": 0,
+            "supports_size": True,
+            "supports_image_to_image_size": False,
+            "supported_sizes": list(_SIZES.values()) + ["auto", "<width>x<height>"],
+            "size_description": "'auto' or '<width>x<height>'; dimensions must be positive multiples of 16, max edge <3840, aspect ratio <=3:1, pixels 655360–8294400.",
+        }
 
     def generate(
         self,
@@ -392,7 +430,17 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             )
 
         tier_id, meta = _resolve_model()
-        size = _SIZES.get(aspect, _SIZES["square"])
+        size, size_error = _resolve_size(aspect, kwargs.get("size"))
+        if size_error:
+            return error_response(
+                error=size_error,
+                error_type="invalid_argument",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        assert size is not None
 
         token = _read_codex_access_token()
         if not token:

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -81,6 +81,42 @@ _SIZES = {
 }
 
 
+def _resolve_size(aspect: str, requested: Any = None) -> Tuple[Optional[str], Optional[str]]:
+    """Return (size, error) for gpt-image-2 per-call sizes.
+
+    OpenAI accepts ``auto`` or literal ``<width>x<height>`` strings for
+    gpt-image-2. Keep validation client-side so invalid explicit sizes do not
+    make an API call.
+    """
+    if requested is None or (isinstance(requested, str) and not requested.strip()):
+        return _SIZES.get(aspect, _SIZES["square"]), None
+    if not isinstance(requested, str):
+        return None, "size must be a string like '1024x1024' or 'auto'"
+
+    value = requested.strip().lower()
+    if value == "auto":
+        return "auto", None
+    if "x" not in value:
+        return None, "size must be 'auto' or '<width>x<height>'"
+    left, right = value.split("x", 1)
+    if not (left.isdigit() and right.isdigit()):
+        return None, "size width and height must be positive integers"
+    width = int(left)
+    height = int(right)
+    if width <= 0 or height <= 0:
+        return None, "size width and height must be positive"
+    if width % 16 != 0 or height % 16 != 0:
+        return None, "size width and height must be multiples of 16"
+    if max(width, height) >= 3840:
+        return None, "size max edge must be less than 3840"
+    if max(width, height) / min(width, height) > 3:
+        return None, "size aspect ratio must be <= 3:1"
+    pixels = width * height
+    if pixels < 655_360 or pixels > 8_294_400:
+        return None, "size total pixels must be between 655360 and 8294400"
+    return f"{width}x{height}", None
+
+
 def _load_openai_config() -> Dict[str, Any]:
     """Read ``image_gen`` from config.yaml (returns {} on any failure)."""
     try:
@@ -210,7 +246,14 @@ class OpenAIImageGenProvider(ImageGenProvider):
     def capabilities(self) -> Dict[str, Any]:
         # gpt-image-2 supports editing via images.edit() with up to 16 source
         # images.
-        return {"modalities": ["text", "image"], "max_reference_images": 16}
+        return {
+            "modalities": ["text", "image"],
+            "max_reference_images": 16,
+            "supports_size": True,
+            "supports_image_to_image_size": True,
+            "supported_sizes": list(_SIZES.values()) + ["auto", "<width>x<height>"],
+            "size_description": "'auto' or '<width>x<height>'; dimensions must be positive multiples of 16, max edge <3840, aspect ratio <=3:1, pixels 655360–8294400.",
+        }
 
     def generate(
         self,
@@ -255,7 +298,17 @@ class OpenAIImageGenProvider(ImageGenProvider):
             )
 
         tier_id, meta = _resolve_model()
-        size = _SIZES.get(aspect, _SIZES["square"])
+        size, size_error = _resolve_size(aspect, kwargs.get("size"))
+        if size_error:
+            return error_response(
+                error=size_error,
+                error_type="invalid_argument",
+                provider="openai",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        assert size is not None
 
         # Collect source images (primary + references) for image-to-image.
         sources: List[str] = []

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -35,6 +35,7 @@ from agent.image_gen_provider import (
     resolve_aspect_ratio,
     save_b64_image,
     save_url_image,
+    size_metadata,
     success_response,
 )
 
@@ -403,6 +404,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         url = getattr(first, "url", None)
         revised_prompt = getattr(first, "revised_prompt", None)
 
+        saved_path = None
         if b64:
             try:
                 saved_path = save_b64_image(b64, prefix=f"openai_{tier_id}")
@@ -443,6 +445,8 @@ class OpenAIImageGenProvider(ImageGenProvider):
             )
 
         extra: Dict[str, Any] = {"size": size, "quality": meta["quality"]}
+        if saved_path is not None and image_ref == str(saved_path):
+            extra.update(size_metadata(saved_path, size))
         if revised_prompt:
             extra["revised_prompt"] = revised_prompt
 

--- a/tests/plugins/image_gen/test_fal_provider.py
+++ b/tests/plugins/image_gen/test_fal_provider.py
@@ -179,6 +179,28 @@ class TestFalImageGenProviderGenerate:
         assert "guidance_scale" not in seen
         assert seen.get("num_images") == 2
 
+    def test_generate_passthrough_includes_explicit_size(self, monkeypatch):
+        import tools.image_generation_tool as image_tool
+        from plugins.image_gen.fal import FalImageGenProvider
+
+        seen = {}
+
+        def fake(prompt, aspect_ratio, **kwargs):
+            seen.update(kwargs)
+            return json.dumps({"success": True, "image": "x"})
+
+        monkeypatch.setattr(image_tool, "image_generate_tool", fake)
+        monkeypatch.setattr(image_tool, "_resolve_fal_model",
+                            lambda: ("fal-ai/flux-2/klein/9b", {}))
+
+        FalImageGenProvider().generate(
+            "p",
+            aspect_ratio="landscape",
+            size="landscape_16_9",
+        )
+
+        assert seen["size"] == "landscape_16_9"
+
     def test_generate_catches_exception_from_legacy(self, monkeypatch):
         import tools.image_generation_tool as image_tool
         from plugins.image_gen.fal import FalImageGenProvider

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -160,6 +160,37 @@ class TestGenerate:
         assert tool["background"] == "opaque"
         assert tool["partial_images"] == 1
 
+    def test_generate_passes_requested_size(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality):
+            captured["size"] = size
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("a cat", size="1152x2496")
+        assert result["success"] is True
+        assert captured["size"] == "1152x2496"
+        assert result["size"] == "1152x2496"
+
+    def test_invalid_size_fails_before_stream(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        called = False
+
+        def _collect(*args, **kwargs):
+            nonlocal called
+            called = True
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("a cat", size="123x456")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert called is False
+
     def test_partial_image_event_used_when_done_missing(self):
         """If output_item.done is missing, partial_image_b64 is accepted."""
         payload = {

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -32,6 +32,16 @@ def _b64_png() -> str:
     return base64.b64encode(bytes.fromhex(_PNG_HEX)).decode()
 
 
+def _b64_png_size(width: int, height: int) -> str:
+    import base64
+    return base64.b64encode(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+        + width.to_bytes(4, "big")
+        + height.to_bytes(4, "big")
+        + b"\x08\x06\x00\x00\x00\x00\x00\x00\x00"
+    ).decode()
+
+
 @pytest.fixture(autouse=True)
 def _tmp_hermes_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -158,7 +168,7 @@ class TestGenerate:
         assert tool["size"] == "1024x1536"
         assert tool["output_format"] == "png"
         assert tool["background"] == "opaque"
-        assert tool["partial_images"] == 1
+        assert "partial_images" not in tool
 
     def test_generate_passes_requested_size(self, provider, monkeypatch):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
@@ -174,6 +184,19 @@ class TestGenerate:
         assert result["success"] is True
         assert captured["size"] == "1152x2496"
         assert result["size"] == "1152x2496"
+
+    def test_generate_size_metadata_reports_actual_saved_dimensions(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", lambda *a, **kw: _b64_png_size(1086, 1448))
+
+        result = provider.generate("a cat", size="1152x1536")
+        assert result["success"] is True
+        assert result["size"] == "1152x1536"
+        assert result["requested_size"] == "1152x1536"
+        assert result["actual_size"] == "1086x1448"
+        assert result["actual_width"] == 1086
+        assert result["actual_height"] == 1448
+        assert "Requested image size 1152x1536" in result["warning"]
 
     def test_invalid_size_fails_before_stream(self, provider, monkeypatch):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
@@ -191,13 +214,12 @@ class TestGenerate:
         assert result["error_type"] == "invalid_argument"
         assert called is False
 
-    def test_partial_image_event_used_when_done_missing(self):
-        """If output_item.done is missing, partial_image_b64 is accepted."""
+    def test_partial_image_event_is_not_final_success(self):
         payload = {
             "type": "response.image_generation_call.partial_image",
             "partial_image_b64": _b64_png(),
         }
-        assert codex_plugin._extract_image_b64(payload) == _b64_png()
+        assert codex_plugin._extract_image_b64(payload) is None
 
     def test_sse_parser_handles_event_and_data_lines(self):
         class _Response:

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -24,6 +24,16 @@ def _b64_png() -> str:
     return base64.b64encode(bytes.fromhex(_PNG_HEX)).decode()
 
 
+def _b64_png_size(width: int, height: int) -> str:
+    import base64
+    return base64.b64encode(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+        + width.to_bytes(4, "big")
+        + height.to_bytes(4, "big")
+        + b"\x08\x06\x00\x00\x00\x00\x00\x00\x00"
+    ).decode()
+
+
 def _fake_response(*, b64=None, url=None, revised_prompt=None):
     item = SimpleNamespace(b64_json=b64, url=url, revised_prompt=revised_prompt)
     return SimpleNamespace(data=[item])
@@ -207,6 +217,22 @@ class TestGenerate:
         assert result["size"] == "1280x1024"
         assert fake_client.images.generate.call_args.kwargs["size"] == "1280x1024"
 
+    def test_custom_size_metadata_reports_actual_saved_dimensions(self, provider):
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png_size(1086, 1448))
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", aspect_ratio="square", size="1152x1536")
+
+        assert result["success"] is True
+        assert result["size"] == "1152x1536"
+        assert result["requested_size"] == "1152x1536"
+        assert result["actual_size"] == "1086x1448"
+        assert result["actual_width"] == 1086
+        assert result["actual_height"] == 1448
+        assert "Requested image size 1152x1536" in result["warning"]
+        assert fake_client.images.generate.call_args.kwargs["size"] == "1152x1536"
+
     def test_invalid_custom_size_rejected_before_api_call(self, provider):
         fake_client = MagicMock()
 
@@ -229,6 +255,9 @@ class TestGenerate:
         assert result["success"] is True
         assert result["modality"] == "image"
         assert result["size"] == "1280x1024"
+        assert result["requested_size"] == "1280x1024"
+        assert result["actual_size"] == "1x1"
+        assert "Requested image size 1280x1024" in result["warning"]
         assert fake_client.images.edit.call_args.kwargs["size"] == "1280x1024"
         fake_client.images.generate.assert_not_called()
 

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -196,6 +196,42 @@ class TestGenerate:
 
         assert fake_client.images.generate.call_args.kwargs["size"] == expected_size
 
+    def test_custom_size_passed_to_text_generation(self, provider):
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", aspect_ratio="square", size="1280x1024")
+
+        assert result["success"] is True
+        assert result["size"] == "1280x1024"
+        assert fake_client.images.generate.call_args.kwargs["size"] == "1280x1024"
+
+    def test_invalid_custom_size_rejected_before_api_call(self, provider):
+        fake_client = MagicMock()
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", size="1000x1000")
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        fake_client.images.generate.assert_not_called()
+        fake_client.images.edit.assert_not_called()
+
+    def test_custom_size_passed_to_edit(self, provider):
+        fake_client = MagicMock()
+        fake_client.images.edit.return_value = _fake_response(b64=_b64_png())
+        data_url = f"data:image/png;base64,{_b64_png()}"
+
+        with _patched_openai(fake_client):
+            result = provider.generate("make it cinematic", image_url=data_url, size="1280x1024")
+
+        assert result["success"] is True
+        assert result["modality"] == "image"
+        assert result["size"] == "1280x1024"
+        assert fake_client.images.edit.call_args.kwargs["size"] == "1280x1024"
+        fake_client.images.generate.assert_not_called()
+
     def test_revised_prompt_passed_through(self, provider):
         fake_client = MagicMock()
         fake_client.images.generate.return_value = _fake_response(

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -102,6 +102,24 @@ class TestImageSizePresetFamily:
         p = image_tool._build_fal_payload("fal-ai/flux-2/klein/9b", "hello", "portrait")
         assert p["image_size"] == "portrait_16_9"
 
+    def test_klein_explicit_size_must_be_declared_preset(self, image_tool):
+        p = image_tool._build_fal_payload(
+            "fal-ai/flux-2/klein/9b",
+            "hello",
+            "square",
+            size="landscape_16_9",
+        )
+        assert p["image_size"] == "landscape_16_9"
+
+    def test_klein_rejects_unknown_explicit_size_preset(self, image_tool):
+        with pytest.raises(ValueError, match="Invalid size"):
+            image_tool._build_fal_payload(
+                "fal-ai/flux-2/klein/9b",
+                "hello",
+                "square",
+                size="not-a-real-preset",
+            )
+
 
 class TestAspectRatioFamily:
     """Nano-banana uses aspect_ratio enum, NOT image_size."""
@@ -119,6 +137,34 @@ class TestAspectRatioFamily:
         p = image_tool._build_fal_payload("fal-ai/nano-banana-pro", "hello", "portrait")
         assert p["aspect_ratio"] == "9:16"
 
+    def test_nano_banana_explicit_resolution_preserves_aspect_ratio(self, image_tool):
+        p = image_tool._build_fal_payload(
+            "fal-ai/nano-banana-pro",
+            "hello",
+            "portrait",
+            size="2K",
+        )
+        assert p["resolution"] == "2K"
+        assert p["aspect_ratio"] == "9:16"
+
+    def test_nano_banana_accepts_declared_native_ratio_size(self, image_tool):
+        p = image_tool._build_fal_payload(
+            "fal-ai/nano-banana-pro",
+            "hello",
+            "landscape",
+            size="1:1",
+        )
+        assert p["aspect_ratio"] == "1:1"
+
+    def test_nano_banana_rejects_unknown_resolution_token(self, image_tool):
+        with pytest.raises(ValueError, match="Invalid size"):
+            image_tool._build_fal_payload(
+                "fal-ai/nano-banana-pro",
+                "hello",
+                "landscape",
+                size="8K",
+            )
+
 
 class TestGptLiteralFamily:
     """GPT-Image 1.5 uses literal size strings."""
@@ -134,6 +180,24 @@ class TestGptLiteralFamily:
     def test_gpt_portrait_is_literal(self, image_tool):
         p = image_tool._build_fal_payload("fal-ai/gpt-image-1.5", "hello", "portrait")
         assert p["image_size"] == "1024x1536"
+
+    def test_gpt_literal_accepts_valid_explicit_literal_size(self, image_tool):
+        p = image_tool._build_fal_payload(
+            "fal-ai/gpt-image-1.5",
+            "hello",
+            "square",
+            size="1536x1024",
+        )
+        assert p["image_size"] == "1536x1024"
+
+    def test_gpt_literal_rejects_invalid_explicit_literal_size(self, image_tool):
+        with pytest.raises(ValueError, match="Invalid size"):
+            image_tool._build_fal_payload(
+                "fal-ai/gpt-image-1.5",
+                "hello",
+                "square",
+                size="123x456",
+            )
 
 
 class TestGptImage2Presets:
@@ -177,6 +241,33 @@ class TestGptImage2Presets:
         # seed isn't in the GPT Image 2 API surface either.
         p = image_tool._build_fal_payload("fal-ai/gpt-image-2", "hi", "square", seed=42)
         assert "seed" not in p
+
+    def test_gpt2_explicit_size_must_be_declared_preset(self, image_tool):
+        p = image_tool._build_fal_payload("fal-ai/gpt-image-2", "hi", "square", size="landscape_4_3")
+        assert p["image_size"] == "landscape_4_3"
+
+    def test_gpt2_rejects_literal_size_for_preset_model(self, image_tool):
+        with pytest.raises(ValueError, match="Invalid size"):
+            image_tool._build_fal_payload("fal-ai/gpt-image-2", "hi", "square", size="123x456")
+
+    def test_edit_endpoint_rejects_size_when_native_key_unsupported(self, image_tool):
+        with pytest.raises(ValueError, match="size is not supported"):
+            image_tool._build_fal_edit_payload(
+                "fal-ai/gpt-image-2",
+                "edit it",
+                ["https://example.com/base.png"],
+                size="1536x1024",
+            )
+
+    def test_edit_endpoint_accepts_resolution_when_supported(self, image_tool):
+        p = image_tool._build_fal_edit_payload(
+            "fal-ai/nano-banana-pro",
+            "edit it",
+            ["https://example.com/base.png"],
+            size="2K",
+        )
+        assert p["resolution"] == "2K"
+        assert p["aspect_ratio"] == "16:9"
 
 
 # ---------------------------------------------------------------------------
@@ -370,13 +461,62 @@ class TestRegistryIntegration:
         config choice, never an agent-level arg."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
         assert set(props.keys()) == {
-            "prompt", "aspect_ratio", "image_url", "reference_image_urls",
+            "prompt", "aspect_ratio", "image_url", "reference_image_urls", "size",
         }
         assert image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["required"] == ["prompt"]
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]
         assert set(enum) == {"landscape", "square", "portrait"}
+
+    def test_plugin_dispatch_forwards_size_when_supported(self, image_tool, monkeypatch):
+        captured = {}
+
+        class Provider:
+            name = "mock"
+            display_name = "Mock"
+
+            def default_model(self):
+                return "mock-model"
+
+            def capabilities(self):
+                return {"modalities": ["text", "image"], "supports_size": True, "supports_image_to_image_size": True}
+
+            def generate(self, **kwargs):
+                captured.update(kwargs)
+                return {"success": True, "image": "https://example.com/out.png"}
+
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "mock")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: None)
+        monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **kw: None)
+        monkeypatch.setattr("agent.image_gen_registry.get_provider", lambda name: Provider())
+
+        raw = image_tool._dispatch_to_plugin_provider("hi", "square", size="1024x1024")
+        assert raw is not None
+        assert captured["size"] == "1024x1024"
+
+    def test_plugin_dispatch_rejects_size_when_unsupported(self, image_tool, monkeypatch):
+        class Provider:
+            name = "mock"
+            display_name = "Mock"
+
+            def default_model(self):
+                return "mock-model"
+
+            def capabilities(self):
+                return {"modalities": ["text"], "supports_size": False}
+
+            def generate(self, **kwargs):  # pragma: no cover - should not be called
+                raise AssertionError("provider should not be called")
+
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "mock")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: None)
+        monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **kw: None)
+        monkeypatch.setattr("agent.image_gen_registry.get_provider", lambda name: Provider())
+
+        raw = image_tool._dispatch_to_plugin_provider("hi", "square", size="1024x1024")
+        assert raw is not None
+        assert "size_unsupported" in raw
 
 
 # ---------------------------------------------------------------------------

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -562,12 +562,67 @@ def _resolve_fal_model() -> tuple:
     return model_id, FAL_MODELS[model_id]
 
 
+def _validate_fal_explicit_size(
+    model_id: str,
+    meta: Dict[str, Any],
+    supports: set,
+    size: str,
+) -> tuple[str, str]:
+    """Validate an explicit FAL ``size`` and return the native payload key/value."""
+    size_style = meta["size_style"]
+    declared_values = {str(value) for value in meta.get("sizes", {}).values()}
+    explicit = size.strip()
+    resolution = explicit.upper()
+
+    if size_style == "image_size_preset":
+        if "image_size" not in supports:
+            raise ValueError(f"size is not supported by FAL model '{model_id}'")
+        if explicit not in declared_values:
+            allowed = ", ".join(sorted(declared_values))
+            raise ValueError(
+                f"Invalid size for FAL model '{model_id}': {explicit!r}. "
+                f"Allowed values: {allowed}"
+            )
+        return "image_size", explicit
+
+    if size_style == "gpt_literal":
+        if "image_size" not in supports:
+            raise ValueError(f"size is not supported by FAL model '{model_id}'")
+        from plugins.image_gen.openai import _resolve_size as _resolve_openai_size
+
+        resolved, error = _resolve_openai_size("square", explicit)
+        if error or resolved is None:
+            raise ValueError(
+                f"Invalid size for FAL model '{model_id}': {explicit!r}. {error}"
+            )
+        return "image_size", resolved
+
+    if size_style == "aspect_ratio":
+        if resolution in {"1K", "2K", "4K"} and "resolution" in supports:
+            return "resolution", resolution
+        if explicit in declared_values and "aspect_ratio" in supports:
+            return "aspect_ratio", explicit
+        allowed = set()
+        if "resolution" in supports:
+            allowed.update({"1K", "2K", "4K"})
+        if "aspect_ratio" in supports:
+            allowed.update(declared_values)
+        allowed_text = ", ".join(sorted(allowed)) or "none"
+        raise ValueError(
+            f"Invalid size for FAL model '{model_id}': {explicit!r}. "
+            f"Allowed values: {allowed_text}"
+        )
+
+    raise ValueError(f"Unknown size_style: {size_style!r}")
+
+
 def _build_fal_payload(
     model_id: str,
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
     seed: Optional[int] = None,
     overrides: Optional[Dict[str, Any]] = None,
+    size: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build a FAL request payload for `model_id` from unified inputs.
 
@@ -586,7 +641,19 @@ def _build_fal_payload(
     payload: Dict[str, Any] = dict(meta.get("defaults", {}))
     payload["prompt"] = (prompt or "").strip()
 
-    if size_style in {"image_size_preset", "gpt_literal"}:
+    explicit_size = size.strip() if isinstance(size, str) and size.strip() else None
+    if explicit_size:
+        native_key, native_value = _validate_fal_explicit_size(
+            model_id,
+            meta,
+            meta["supports"],
+            explicit_size,
+        )
+        payload[native_key] = native_value
+        if native_key == "resolution":
+            if "aspect_ratio" in meta["supports"] and size_style == "aspect_ratio":
+                payload["aspect_ratio"] = sizes[aspect]
+    elif size_style in {"image_size_preset", "gpt_literal"}:
         payload["image_size"] = sizes[aspect]
     elif size_style == "aspect_ratio":
         payload["aspect_ratio"] = sizes[aspect]
@@ -618,6 +685,7 @@ def _build_fal_edit_payload(
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
     seed: Optional[int] = None,
     overrides: Optional[Dict[str, Any]] = None,
+    size: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build a FAL *edit* request payload (image-to-image) from unified inputs.
 
@@ -641,10 +709,25 @@ def _build_fal_edit_payload(
     payload["prompt"] = (prompt or "").strip()
     payload["image_urls"] = list(image_urls)
 
+    explicit_size = size.strip() if isinstance(size, str) and size.strip() else None
+    if explicit_size:
+        native_key, native_value = _validate_fal_explicit_size(
+            model_id,
+            meta,
+            edit_supports,
+            explicit_size,
+        )
+        payload[native_key] = native_value
+        if native_key == "resolution":
+            if "aspect_ratio" in edit_supports and size_style == "aspect_ratio":
+                payload["aspect_ratio"] = sizes[aspect]
+
     # Only express output size when the edit endpoint advertises the key.
     # gpt-image-2 edit auto-infers size from the input, so `image_size` is
     # intentionally absent from its edit_supports whitelist.
-    if size_style in {"image_size_preset", "gpt_literal"} and "image_size" in edit_supports:
+    if explicit_size:
+        pass
+    elif size_style in {"image_size_preset", "gpt_literal"} and "image_size" in edit_supports:
         payload["image_size"] = sizes[aspect]
     elif size_style == "aspect_ratio" and "aspect_ratio" in edit_supports:
         payload["aspect_ratio"] = sizes[aspect]
@@ -845,6 +928,7 @@ def image_generate_tool(
     seed: Optional[int] = None,
     image_url: Optional[str] = None,
     reference_image_urls: Optional[list] = None,
+    size: Optional[str] = None,
 ) -> str:
     """Generate an image from a text prompt, or edit a source image, via FAL.
 
@@ -886,6 +970,7 @@ def image_generate_tool(
             "num_images": num_images,
             "output_format": output_format,
             "seed": seed,
+            "size": size,
             "modality": modality,
             "source_images": len(source_images),
         },
@@ -939,7 +1024,7 @@ def image_generate_tool(
             clamped_sources = source_images[:max_refs] if max_refs > 0 else source_images
             arguments = _build_fal_edit_payload(
                 model_id, prompt, clamped_sources, aspect_lc,
-                seed=seed, overrides=overrides,
+                seed=seed, overrides=overrides, size=size,
             )
             endpoint = edit_endpoint
             logger.info(
@@ -949,7 +1034,7 @@ def image_generate_tool(
             )
         else:
             arguments = _build_fal_payload(
-                model_id, prompt, aspect_lc, seed=seed, overrides=overrides,
+                model_id, prompt, aspect_lc, seed=seed, overrides=overrides, size=size,
             )
             endpoint = model_id
             logger.info(
@@ -1226,6 +1311,15 @@ IMAGE_GENERATE_SCHEMA = {
                     "capped per-model; the description above indicates the max."
                 ),
             },
+            "size": {
+                "type": "string",
+                "description": (
+                    "Optional explicit output size override for providers that "
+                    "support it. For OpenAI/OpenAI-Codex gpt-image-2 use "
+                    "'auto' or '<width>x<height>' (for example '1024x1024'); "
+                    "when omitted, aspect_ratio selects the existing default."
+                ),
+            },
         },
         "required": ["prompt"],
     },
@@ -1276,6 +1370,7 @@ def _dispatch_to_plugin_provider(
     aspect_ratio: str,
     image_url: Optional[str] = None,
     reference_image_urls: Optional[list] = None,
+    size: Optional[str] = None,
 ):
     """Route the call to a plugin-registered provider when one is selected.
 
@@ -1333,6 +1428,7 @@ def _dispatch_to_plugin_provider(
             "error_type": "provider_not_registered",
         })
 
+    explicit_size = size.strip() if isinstance(size, str) and size.strip() else None
     kwargs: Dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
     try:
         if configured_model:
@@ -1346,6 +1442,21 @@ def _dispatch_to_plugin_provider(
             norm_refs = normalize_reference_images(reference_image_urls)
         if norm_refs:
             kwargs["reference_image_urls"] = norm_refs
+        if explicit_size:
+            caps = provider.capabilities() or {}
+            is_edit = "image_url" in kwargs or "reference_image_urls" in kwargs
+            key = "supports_image_to_image_size" if is_edit else "supports_size"
+            if not caps.get(key):
+                return json.dumps({
+                    "success": False,
+                    "image": None,
+                    "error": (
+                        f"Provider '{getattr(provider, 'name', '?')}' does not "
+                        f"support explicit size for {'image-to-image / editing' if is_edit else 'text-to-image'}."
+                    ),
+                    "error_type": "size_unsupported",
+                })
+            kwargs["size"] = explicit_size
         result = provider.generate(**kwargs)
     except TypeError as exc:
         # A provider whose generate() signature predates image_url support
@@ -1517,6 +1628,7 @@ def _handle_image_generate(args, **kw):
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
     image_url = args.get("image_url")
     reference_image_urls = args.get("reference_image_urls")
+    size = args.get("size")
     task_id = kw.get("task_id")
 
     # Route to a plugin-registered provider if one is active (and it's
@@ -1526,6 +1638,7 @@ def _handle_image_generate(args, **kw):
         prompt, aspect_ratio,
         image_url=image_url,
         reference_image_urls=reference_image_urls,
+        size=size,
     )
     if dispatched is not None:
         return _postprocess_image_generate_result(dispatched, task_id=task_id)
@@ -1548,6 +1661,7 @@ def _handle_image_generate(args, **kw):
         aspect_ratio=aspect_ratio,
         image_url=image_url,
         reference_image_urls=reference_image_urls,
+        size=size,
     )
     return _postprocess_image_generate_result(raw, task_id=task_id)
 


### PR DESCRIPTION
## Summary
- Add optional `size` to `image_generate` and forward it through plugin dispatch / FAL fallback.
- Let OpenAI and OpenAI-Codex gpt-image-2 accept `auto` or validated custom `<width>x<height>` sizes while preserving the existing `aspect_ratio` defaults when omitted.
- Validate unsupported/invalid explicit sizes before provider/API calls, including FAL text/edit capability checks.

## Test Plan
- `python3.12 -m pytest tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py tests/plugins/image_gen/test_openai_provider.py tests/plugins/image_gen/test_openai_codex_provider.py tests/plugins/image_gen/test_fal_provider.py -q -o addopts=`
- Static diff scan for common secret/shell/eval/pickle patterns: `static_scan_findings=0`

## Related
- Addresses the `size` portion of #21662.
- Prior closed/unmerged attempt: #14819.
- Nearby open PRs seen during duplicate check: #30730, #18827, #41159, #49597.
