### PR TITLE
fix(tui): resolve workspace deps in install check

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1391,6 +1391,92 @@ to avoid false-positive reinstalls on every launch.
 """
 
 
+def _tui_relevant_lock_entries(
+    packages: dict, *, root: Path, ws_root: Path
+) -> set[str]:
+    """Return root-lock entries that can affect the TUI launch install.
+
+    Workspace checkouts use one root ``package-lock.json`` for every frontend
+    workspace (``web``, ``apps/*``, ``ui-tui``).  ``npm install --workspace
+    ui-tui`` legitimately actualizes only the selected workspace, its child
+    workspaces, and their dependency graph into npm's hidden lockfile. Entries
+    for unrelated workspaces such as ``apps/bootstrap-installer`` must not force
+    a TUI reinstall on every dashboard launch.
+
+    Follow lockfile package *paths*, not just dependency names. npm can satisfy a
+    dependency with a nested entry (for example
+    ``node_modules/strip-ansi/node_modules/ansi-regex``) even when another
+    version of the same package also exists at ``node_modules/ansi-regex`` for a
+    different workspace. A name-only ``node_modules/<dep>`` lookup would compare
+    the wrong package and reintroduce the false-positive install loop.
+    """
+    if ws_root == root:
+        return set(packages)
+    try:
+        workspace = root.relative_to(ws_root).as_posix()
+    except ValueError:
+        return set(packages)
+
+    relevant: set[str] = {""}
+    queue: list[str] = []
+
+    def add(name: str | None) -> None:
+        if name and name in packages and name not in relevant:
+            relevant.add(name)
+            queue.append(name)
+
+    for name in packages:
+        if name == workspace or name.startswith(f"{workspace}/packages/"):
+            add(name)
+
+    def dependency_names(pkg: dict, *, include_dev: bool) -> set[str]:
+        deps: set[str] = set()
+        keys = ["dependencies", "optionalDependencies", "peerDependencies"]
+        if include_dev:
+            keys.append("devDependencies")
+        for key in keys:
+            raw = pkg.get(key)
+            if isinstance(raw, dict):
+                deps.update(str(dep) for dep in raw)
+        return deps
+
+    def package_parent_dirs(name: str) -> list[str]:
+        parts = name.split("/") if name else []
+        parents: list[str] = []
+        seen: set[str] = set()
+        for idx in range(len(parts), -1, -1):
+            parent = "/".join(parts[:idx])
+            if parent not in seen:
+                seen.add(parent)
+                parents.append(parent)
+        return parents
+
+    def resolve_dependency(dep: str, *, from_entry: str) -> str | None:
+        for parent in package_parent_dirs(from_entry):
+            candidate = (
+                f"{parent}/node_modules/{dep}" if parent else f"node_modules/{dep}"
+            )
+            if candidate in packages:
+                return candidate
+        return None
+
+    while queue:
+        name = queue.pop()
+        pkg = packages.get(name)
+        if not isinstance(pkg, dict):
+            continue
+
+        resolved = pkg.get("resolved")
+        if pkg.get("link") and isinstance(resolved, str):
+            add(resolved)
+
+        include_dev = name == workspace or name.startswith(f"{workspace}/packages/")
+        for dep in dependency_names(pkg, include_dev=include_dev):
+            add(resolve_dependency(dep, from_entry=name))
+
+    return relevant
+
+
 def _workspace_root(dir: Path) -> Path:
     """Return the npm workspace root for *dir*.
 
@@ -1464,15 +1550,17 @@ def _tui_need_npm_install(root: Path) -> bool:
     already match, which used to trigger a spurious "Installing TUI
     dependencies" on every launch.
 
-    For each entry in the root lock's ``packages`` map:
+    For each TUI-relevant entry in the root lock's ``packages`` map:
       - missing from hidden lock → reinstall (unless the entry is marked
         ``optional`` or ``peer``, which npm may intentionally skip per platform)
       - present but with differing fields (excluding npm-written runtime
         annotations like ``ideallyInert``) → reinstall
 
-    Extra entries that exist only in the hidden lock are ignored — stale
-    transitives left over from a removed dependency don't break runtime and
-    we'd rather not force a reinstall for them. Falls back to mtime
+    Non-TUI workspace package entries (``web``, ``apps/*``) are ignored because
+    a scoped ``npm install --workspace ui-tui`` legitimately leaves them out of
+    the hidden lockfile. Extra entries that exist only in the hidden lock are
+    ignored — stale transitives left over from a removed dependency don't break
+    runtime, and we'd rather not force a reinstall for them. Falls back to mtime
     comparison if either lockfile is unparseable.
     """
     # Prebuilt self-contained bundle (nix / packaged release): no lockfile
@@ -1502,10 +1590,24 @@ def _tui_need_npm_install(root: Path) -> bool:
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return lock.stat().st_mtime > marker.stat().st_mtime
 
-    def comparable(pkg: dict) -> dict:
-        return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
+    def comparable(name: str, pkg: dict) -> dict:
+        ignored = set(_NPM_LOCK_RUNTIME_KEYS)
+        if ws_root != root and not name.startswith("node_modules/"):
+            ignored.update(
+                {
+                    "dependencies",
+                    "devDependencies",
+                    "optionalDependencies",
+                    "peerDependencies",
+                }
+            )
+        return {k: v for k, v in pkg.items() if k not in ignored}
+
+    relevant_entries = _tui_relevant_lock_entries(wanted, root=root, ws_root=ws_root)
 
     for name, pkg in wanted.items():
+        if name not in relevant_entries:
+            continue
         if not name:
             continue
 
@@ -1517,8 +1619,8 @@ def _tui_need_npm_install(root: Path) -> bool:
                 continue
             return True
 
-        if isinstance(installed[name], dict) and comparable(pkg) != comparable(
-            installed[name]
+        if isinstance(installed[name], dict) and comparable(name, pkg) != comparable(
+            name, installed[name]
         ):
             return True
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -70,6 +70,109 @@ def test_no_install_when_only_optional_peer_package_missing_from_hidden_lock(tmp
     assert main_mod._tui_need_npm_install(tmp_path) is False
 
 
+def test_no_install_when_unrelated_workspace_missing_from_hidden_lock(tmp_path: Path, main_mod) -> None:
+    """Scoped TUI installs do not actualize every root workspace package."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"version":"0.0.0","dependencies":{"foo":"1.0.0"}},'
+        '"ui-tui/packages/hermes-ink":{"version":"0.0.0"},'
+        '"apps/bootstrap-installer":{"version":"0.0.1","dependencies":{"bar":"1.0.0"}},'
+        '"web":{"version":"0.0.0"},'
+        '"node_modules/foo":{"version":"1.0.0"},'
+        '"node_modules/bar":{"version":"1.0.0"}'
+        '}}'
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"version":"0.0.0"},'
+        '"ui-tui/packages/hermes-ink":{"version":"0.0.0"},'
+        '"node_modules/foo":{"version":"1.0.0"}'
+        '}}'
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_no_install_when_workspace_dependency_resolves_to_nested_lock_entry(
+    tmp_path: Path, main_mod
+) -> None:
+    """npm may install a dependency under its parent instead of the root.
+
+    The freshness check must follow package-lock paths the same way Node/npm
+    resolution does; otherwise a root entry for an unrelated version of the
+    same package name can force a reinstall even though the workspace's actual
+    nested dependency is installed.
+    """
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"version":"0.0.0","dependencies":{"strip-ansi":"^7.0.0"}},'
+        '"node_modules/strip-ansi":{"version":"7.1.2","dependencies":{"ansi-regex":"^6.0.1"}},'
+        '"node_modules/strip-ansi/node_modules/ansi-regex":{"version":"6.2.2"},'
+        '"node_modules/ansi-regex":{"version":"5.0.1"}'
+        '}}'
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"version":"0.0.0"},'
+        '"node_modules/strip-ansi":{"version":"7.1.2","dependencies":{"ansi-regex":"^6.0.1"}},'
+        '"node_modules/strip-ansi/node_modules/ansi-regex":{"version":"6.2.2"}'
+        '}}'
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_install_when_nested_workspace_dependency_missing_from_hidden_lock(
+    tmp_path: Path, main_mod
+) -> None:
+    """A root package with the same name does not satisfy a nested dependency."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"version":"0.0.0","dependencies":{"strip-ansi":"^7.0.0"}},'
+        '"node_modules/strip-ansi":{"version":"7.1.2","dependencies":{"ansi-regex":"^6.0.1"}},'
+        '"node_modules/strip-ansi/node_modules/ansi-regex":{"version":"6.2.2"},'
+        '"node_modules/ansi-regex":{"version":"5.0.1"}'
+        '}}'
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"version":"0.0.0"},'
+        '"node_modules/strip-ansi":{"version":"7.1.2","dependencies":{"ansi-regex":"^6.0.1"}},'
+        '"node_modules/ansi-regex":{"version":"5.0.1"}'
+        '}}'
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_install_when_tui_workspace_dependency_missing_from_hidden_lock(
+    tmp_path: Path, main_mod
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"version":"0.0.0","dependencies":{"foo":"1.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"}'
+        '}}'
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{"ui-tui":{"version":"0.0.0"}}}'
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
 def test_no_install_when_only_peer_annotation_differs(tmp_path: Path, main_mod) -> None:
     """npm 9 drops the ``peer`` flag from the hidden lock on dev-deps that are
     *also* declared as peers.  That's a cosmetic difference — the package is


### PR DESCRIPTION
## Summary

This fixes a false-positive TUI dependency freshness check in workspace checkouts.

Hermes source checkouts use one root `package-lock.json`, but TUI launch installs are intentionally scoped to `npm install --workspace ui-tui` so dashboard/TUI startup does not resolve unrelated `web` or `apps/*` dependencies. After that scoped install, npm's hidden lockfile contains the selected TUI workspace graph, not the whole monorepo graph. `_tui_need_npm_install()` was still comparing the root lockfile as if the entire workspace had been actualized, so it could return `True` immediately after a successful TUI install and trigger `Installing TUI dependencies…` again on later launches.

This PR narrows the comparison to lockfile entries that can affect the TUI launch/install path and resolves dependencies by lockfile package path so nested dependencies are handled correctly.

## Reproduction

On a clean upstream checkout, run the same scoped install that the dashboard/TUI startup path uses:

```bash
npm install --workspace ui-tui --silent --no-fund --no-audit --progress=false

PYTHONPATH=$PWD python - <<'PY'
from pathlib import Path
from hermes_cli.main import _tui_need_npm_install
print(_tui_need_npm_install(Path("ui-tui")))
PY
```

Observed before this patch:

```text
True
```

That means the next dashboard/TUI launch can decide that npm install is still required even though the scoped install already completed.

In the same environment I also observed npm 11 rewriting root `package-lock.json` metadata for platform-optional esbuild packages, e.g. removing `"peer": true` entries. That lockfile metadata churn is a related symptom amplifier because the false-positive path repeatedly invokes `npm install`, but the npm metadata rewrite itself is treated as a non-goal for this PR.

## Root cause

The existing freshness check compared every entry in the root `package-lock.json` against `node_modules/.package-lock.json`.

That assumption no longer matches the install strategy:

- root `package-lock.json` describes all frontend workspaces (`ui-tui`, `web`, `apps/*`, etc.)
- TUI startup runs a scoped install for `ui-tui`
- npm's hidden lockfile records the packages actually installed for that scoped workspace graph
- unrelated workspace entries such as `apps/bootstrap-installer`, `web`, desktop/electron deps, and their links may legitimately be absent

A name-only dependency closure is also insufficient. For example, a dependency can resolve to a nested lockfile package path:

```text
ui-tui/packages/hermes-ink -> strip-ansi -> ansi-regex
actual installed package: node_modules/strip-ansi/node_modules/ansi-regex
wrong name-only lookup:  node_modules/ansi-regex
```

Comparing the wrong package path reintroduces the same false-positive reinstall loop.

## Fix

The patch adds `_tui_relevant_lock_entries()` and uses it inside `_tui_need_npm_install()`.

For workspace checkouts, the relevant set is built by:

- seeding the TUI workspace (`ui-tui`) and child TUI workspaces (`ui-tui/packages/*`)
- following npm lockfile `link` entries through their `resolved` targets
- following `dependencies`, `optionalDependencies`, and `peerDependencies`
- including `devDependencies` only for the actual TUI workspace/package entries, so TUI build tools remain checked without pulling unrelated workspace dev deps into the comparison
- resolving dependency names through lockfile package paths from the dependent package upward, so nested packages are selected before unrelated root-level packages with the same name

The existing safeguards are preserved:

- standalone/subpackage lockfile layouts still compare the full local lockfile
- prebuilt bundle layouts without a lockfile still skip npm install
- optional/peer packages that npm may intentionally skip do not force reinstall
- npm-written runtime metadata such as `peer` / `ideallyInert` remains ignored for comparison
- extra hidden-lock entries are still ignored
- parse failures still fall back to mtime comparison

## Validation

Local validation:

```text
scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py
=> 33 tests passed
```

Related regression suite:

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_tui_npm_install.py \
  tests/hermes_cli/test_web_ui_build.py \
  tests/hermes_cli/test_cmd_update.py
=> 81 tests passed
```

Tight reproduction loop after the patch, using a checkout where `npm install --workspace ui-tui` had already completed:

```text
_tui_need_npm_install(Path("/tmp/hermes-upstream-repro/ui-tui")) -> False
```

Runtime smoke on macOS source checkout:

```text
_tui_need_npm_install(Path("ui-tui")) -> False
Dashboard served on 127.0.0.1:9119
Dashboard Chat page loaded
Browser console JS errors: 0
No npm install process observed during the smoke check
```

The new/updated tests cover both sides of the behavior:

- unrelated workspace entries missing from the hidden lockfile do not force reinstall
- a TUI workspace dependency resolved to a nested lockfile path does not force reinstall just because a root package of the same name is absent
- a missing nested TUI dependency still forces reinstall
- a missing direct TUI workspace dependency still forces reinstall
- version/integrity mismatches still force reinstall
- npm runtime metadata differences remain ignored

## Risks / limitations

- This does not change the npm install command, install strategy, or build strategy.
- This does not claim to fix npm 11's `package-lock.json` metadata rewrite by itself. If npm install runs for a legitimate missing/stale dependency, npm may still rewrite lockfile metadata. This PR removes the false-positive path that repeatedly triggers that install.
- I validated the live runtime path on macOS. Docker, Nix/prebuilt, Termux, and Windows were not exercised as live environments, but the existing code paths for those layouts are preserved and covered by the targeted unit tests where applicable.
- GitHub Actions for this fork PR may require maintainer approval before official upstream checks run.

## Alternatives considered

- Disabling `_tui_need_npm_install()` would hide the symptom but remove the intended self-heal behavior for stale/missing TUI dependencies.
- Returning to an unscoped npm install would risk resolving unrelated workspaces such as desktop/electron dependencies during TUI startup.
- Switching the startup install from `npm install` to `npm ci` might address some lockfile churn, but that is a broader install-strategy change and is intentionally left out of this focused fix.
