### PR TITLE
fix(windows): bound managed Node heal downloads

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -288,6 +288,8 @@ def _candidate_node_command_names(command: str) -> list[str]:
 
 
 _HERMES_NODE_TARGET_MAJOR = int(os.environ.get("HERMES_NODE_TARGET_MAJOR", "22"))
+_NODE_INDEX_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+_NODE_ZIP_RESPONSE_BODY_MAX_BYTES = 256 * 1024 * 1024
 _managed_node_heal_attempted = False
 _NODE_BOOTSTRAP_SCRIPT = Path(__file__).resolve().parent / "scripts" / "lib" / "node-bootstrap.sh"
 
@@ -367,8 +369,12 @@ def _heal_managed_node_windows() -> bool:
     index_url = f"https://nodejs.org/dist/latest-v{_HERMES_NODE_TARGET_MAJOR}.x/"
     try:
         with urllib.request.urlopen(index_url, timeout=60) as response:
-            index_html = response.read().decode("utf-8", errors="replace")
-    except OSError:
+            index_html = _read_response_with_limit(
+                response,
+                _NODE_INDEX_RESPONSE_BODY_MAX_BYTES,
+                "Node release index",
+            ).decode("utf-8", errors="replace")
+    except (OSError, ValueError):
         return False
 
     match = re.search(
@@ -382,8 +388,12 @@ def _heal_managed_node_windows() -> bool:
     download_url = f"{index_url}{zip_name}"
     try:
         with urllib.request.urlopen(download_url, timeout=300) as response:
-            zip_bytes = response.read()
-    except OSError:
+            zip_bytes = _read_response_with_limit(
+                response,
+                _NODE_ZIP_RESPONSE_BODY_MAX_BYTES,
+                "Node Windows zip",
+            )
+    except (OSError, ValueError):
         return False
 
     try:
@@ -406,6 +416,13 @@ def _heal_managed_node_windows() -> bool:
         return False
 
     return node_tool_runnable(str(target / "node.exe"))
+
+
+def _read_response_with_limit(response, max_bytes: int, label: str) -> bytes:
+    data = response.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        raise ValueError(f"{label} response exceeded {max_bytes} bytes")
+    return data
 
 
 def heal_hermes_managed_node() -> bool:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -208,6 +208,117 @@ class TestHermesManagedNode:
         assert parts[:2] == [str(node_dir), str(bin_dir)]
         assert parts[-1] == "system-node"
 
+    def test_windows_managed_node_heal_bounds_download_reads(self, tmp_path, monkeypatch):
+        import io
+        import urllib.request
+        import zipfile
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        zip_name = "node-v22.1.0-win-x64.zip"
+        zip_root = zip_name.removesuffix(".zip")
+        archive_bytes = io.BytesIO()
+        with zipfile.ZipFile(archive_bytes, "w") as archive:
+            archive.writestr(f"{zip_root}/node.exe", b"node")
+
+        captured = {}
+
+        class _Resp:
+            def __init__(self, label, payload):
+                self.label = label
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, size=-1):
+                captured[self.label] = size
+                return self.payload if size < 0 else self.payload[:size]
+
+        def fake_urlopen(url, timeout=None):
+            if str(url).endswith("/latest-v22.x/"):
+                return _Resp("index", f'<a href="{zip_name}">{zip_name}</a>'.encode())
+            return _Resp("zip", archive_bytes.getvalue())
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "AMD64")
+        monkeypatch.delenv("PROCESSOR_ARCHITEW6432", raising=False)
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(hermes_constants, "node_tool_runnable", lambda path: True)
+
+        assert hermes_constants._heal_managed_node_windows() is True
+        assert captured["index"] == hermes_constants._NODE_INDEX_RESPONSE_BODY_MAX_BYTES + 1
+        assert captured["zip"] == hermes_constants._NODE_ZIP_RESPONSE_BODY_MAX_BYTES + 1
+        assert (home / "node" / "node.exe").is_file()
+
+    def test_windows_managed_node_heal_rejects_oversized_index(self, tmp_path, monkeypatch):
+        import urllib.request
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        calls = []
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, size=-1):
+                return b"x" * size
+
+        def fake_urlopen(url, timeout=None):
+            calls.append(str(url))
+            return _Resp()
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "AMD64")
+        monkeypatch.delenv("PROCESSOR_ARCHITEW6432", raising=False)
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(hermes_constants, "_NODE_INDEX_RESPONSE_BODY_MAX_BYTES", 8)
+
+        assert hermes_constants._heal_managed_node_windows() is False
+        assert calls == ["https://nodejs.org/dist/latest-v22.x/"]
+        assert not (home / "node").exists()
+
+    def test_windows_managed_node_heal_rejects_oversized_zip(self, tmp_path, monkeypatch):
+        import urllib.request
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        zip_name = "node-v22.1.0-win-x64.zip"
+
+        class _Resp:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, size=-1):
+                return self.payload if size < 0 else self.payload[:size]
+
+        def fake_urlopen(url, timeout=None):
+            if str(url).endswith("/latest-v22.x/"):
+                return _Resp(f'<a href="{zip_name}">{zip_name}</a>'.encode())
+            return _Resp(b"x" * 9)
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "AMD64")
+        monkeypatch.delenv("PROCESSOR_ARCHITEW6432", raising=False)
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(hermes_constants, "_NODE_ZIP_RESPONSE_BODY_MAX_BYTES", 8)
+
+        assert hermes_constants._heal_managed_node_windows() is False
+        assert not (home / "node").exists()
+
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX shell stubs; Windows uses .cmd shims")
 class TestNodeToolRunnable:


### PR DESCRIPTION
﻿Fixes #54815

## Summary

- Add explicit response-size caps for the Windows managed Node repair release index and Node zip downloads.
- Keep the existing fail-soft behavior: oversized downloads make the repair attempt return `False`.
- Cover success, oversized index, and oversized zip cases with unit tests.

## Tests

- `uv run --extra dev python -m pytest tests\test_hermes_constants.py -q -k "HermesManagedNode" --basetemp .pytest-tmp-node-heal`
- `git diff --check`

Additional check attempted:

- `uv run --extra dev python -m pytest tests\test_hermes_constants.py -q --basetemp .pytest-tmp-hermes-constants-full` reached `61 passed, 15 skipped` but failed 5 existing Windows-environment tests: one native default path expectation and four symlink tests requiring privileges (`WinError 1314`). Those failures are outside the touched managed Node repair path.

`autoreview` was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` found no command).
