### PR TITLE
fix(debug): bound paste upload responses

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -52,6 +52,7 @@ _DPASTE_COM_URL = "https://dpaste.com/api/"
 # Maximum bytes to read from a single log file for upload.
 # paste.rs caps at ~1 MB; we stay under that with headroom.
 _MAX_LOG_BYTES = 512_000
+_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES = 16 * 1024
 
 # Auto-delete pastes after this many seconds (6 hours).
 _AUTO_DELETE_SECONDS = 21600
@@ -272,10 +273,20 @@ def _upload_paste_rs(content: str) -> str:
         },
     )
     with urllib.request.urlopen(req, timeout=30) as resp:
-        url = resp.read().decode("utf-8").strip()
+        url = _read_paste_upload_url(resp, "paste.rs")
     if not url.startswith("http"):
         raise ValueError(f"Unexpected response from paste.rs: {url[:200]}")
     return url
+
+
+def _read_paste_upload_url(resp, service: str) -> str:
+    raw = resp.read(_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(
+            f"{service} response exceeded "
+            f"{_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    return raw.decode("utf-8").strip()
 
 
 def _upload_dpaste_com(content: str, expiry_days: int = 7) -> str:
@@ -308,7 +319,7 @@ def _upload_dpaste_com(content: str, expiry_days: int = 7) -> str:
         },
     )
     with urllib.request.urlopen(req, timeout=30) as resp:
-        url = resp.read().decode("utf-8").strip()
+        url = _read_paste_upload_url(resp, "dpaste.com")
     if not url.startswith("http"):
         raise ValueError(f"Unexpected response from dpaste.com: {url[:200]}")
     return url

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -60,6 +60,7 @@ _DPASTE_COM_URL = "https://dpaste.com/api/"
 # Maximum bytes to read from a single log file for upload.
 # paste.rs caps at ~1 MB; we stay under that with headroom.
 _MAX_LOG_BYTES = 512_000
+_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES = 16 * 1024
 
 # Auto-delete pastes after this many seconds (6 hours).
 _AUTO_DELETE_SECONDS = 21600
@@ -284,10 +285,20 @@ def _upload_paste_rs(content: str) -> str:
         },
     )
     with urllib.request.urlopen(req, timeout=30) as resp:
-        url = resp.read().decode("utf-8").strip()
+        url = _read_paste_upload_url(resp, "paste.rs")
     if not url.startswith("http"):
         raise ValueError(f"Unexpected response from paste.rs: {url[:200]}")
     return url
+
+
+def _read_paste_upload_url(resp, service: str) -> str:
+    raw = resp.read(_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(
+            f"{service} response exceeded "
+            f"{_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES} bytes"
+        )
+    return raw.decode("utf-8").strip()
 
 
 def _upload_dpaste_com(content: str, expiry_days: int = 7) -> str:
@@ -320,7 +331,7 @@ def _upload_dpaste_com(content: str, expiry_days: int = 7) -> str:
         },
     )
     with urllib.request.urlopen(req, timeout=30) as resp:
-        url = resp.read().decode("utf-8").strip()
+        url = _read_paste_upload_url(resp, "dpaste.com")
     if not url.startswith("http"):
         raise ValueError(f"Unexpected response from dpaste.com: {url[:200]}")
     return url

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -49,7 +49,10 @@ class TestUploadPasteRs:
     """Test paste.rs upload path."""
 
     def test_upload_paste_rs_success(self):
-        from hermes_cli.debug import _upload_paste_rs
+        from hermes_cli.debug import (
+            _PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES,
+            _upload_paste_rs,
+        )
 
         mock_resp = MagicMock()
         mock_resp.read.return_value = b"https://paste.rs/abc123\n"
@@ -60,6 +63,22 @@ class TestUploadPasteRs:
             url = _upload_paste_rs("hello world")
 
         assert url == "https://paste.rs/abc123"
+        mock_resp.read.assert_called_once_with(_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES + 1)
+
+    def test_upload_paste_rs_rejects_oversized_response(self):
+        from hermes_cli.debug import (
+            _PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES,
+            _upload_paste_rs,
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"x" * (_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES + 1)
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("hermes_cli.debug.urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(ValueError, match="paste\\.rs response exceeded"):
+                _upload_paste_rs("hello world")
 
     def test_upload_paste_rs_bad_response(self):
         from hermes_cli.debug import _upload_paste_rs
@@ -88,7 +107,10 @@ class TestUploadDpasteCom:
     """Test dpaste.com fallback upload path."""
 
     def test_upload_dpaste_com_success(self):
-        from hermes_cli.debug import _upload_dpaste_com
+        from hermes_cli.debug import (
+            _PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES,
+            _upload_dpaste_com,
+        )
 
         mock_resp = MagicMock()
         mock_resp.read.return_value = b"https://dpaste.com/ABCDEFG\n"
@@ -99,6 +121,22 @@ class TestUploadDpasteCom:
             url = _upload_dpaste_com("hello world", expiry_days=7)
 
         assert url == "https://dpaste.com/ABCDEFG"
+        mock_resp.read.assert_called_once_with(_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES + 1)
+
+    def test_upload_dpaste_com_rejects_oversized_response(self):
+        from hermes_cli.debug import (
+            _PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES,
+            _upload_dpaste_com,
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"x" * (_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES + 1)
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("hermes_cli.debug.urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(ValueError, match="dpaste\\.com response exceeded"):
+                _upload_dpaste_com("hello world", expiry_days=7)
 
 
 class TestUploadToPastebin:

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -49,7 +49,10 @@ class TestUploadPasteRs:
     """Test paste.rs upload path."""
 
     def test_upload_paste_rs_success(self):
-        from hermes_cli.debug import _upload_paste_rs
+        from hermes_cli.debug import (
+            _PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES,
+            _upload_paste_rs,
+        )
 
         mock_resp = MagicMock()
         mock_resp.read.return_value = b"https://paste.rs/abc123\n"
@@ -60,6 +63,22 @@ class TestUploadPasteRs:
             url = _upload_paste_rs("hello world")
 
         assert url == "https://paste.rs/abc123"
+        mock_resp.read.assert_called_once_with(_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES + 1)
+
+    def test_upload_paste_rs_rejects_oversized_response(self):
+        from hermes_cli.debug import (
+            _PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES,
+            _upload_paste_rs,
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"x" * (_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES + 1)
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("hermes_cli.debug.urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(ValueError, match="paste\\.rs response exceeded"):
+                _upload_paste_rs("hello world")
 
 
     def test_upload_paste_rs_network_error(self):
@@ -73,6 +92,23 @@ class TestUploadPasteRs:
                 _upload_paste_rs("test")
 
 
+class TestUploadDpasteCom:
+    """Test dpaste.com fallback upload path."""
+
+    def test_upload_dpaste_com_rejects_oversized_response(self):
+        from hermes_cli.debug import (
+            _PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES,
+            _upload_dpaste_com,
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"x" * (_PASTE_UPLOAD_RESPONSE_BODY_MAX_BYTES + 1)
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("hermes_cli.debug.urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(ValueError, match="dpaste\\.com response exceeded"):
+                _upload_dpaste_com("hello world", expiry_days=7)
 
 
 class TestUploadToPastebin:


### PR DESCRIPTION
﻿Fixes #54819

## Summary

- Add a small response-size cap for paste upload URL responses.
- Share the bounded reader across paste.rs and dpaste.com upload helpers.
- Preserve existing fallback/error behavior for invalid paste responses.

## Tests

- `uv run --extra dev python -m pytest tests\hermes_cli\test_debug.py -q -k "UploadPasteRs or UploadDpasteCom or UploadToPastebin" --basetemp .pytest-tmp-debug-paste-focused`
- `git diff --check`

Additional check attempted:

- `uv run --extra dev python -m pytest tests\hermes_cli\test_debug.py -q --basetemp .pytest-tmp-debug-paste` reached `76 passed` but failed one existing Windows log truncation boundary test (`TestCaptureLogSnapshot.test_keeps_first_line_when_truncation_on_boundary`, expected 10 kept lines but got 9). That failure is outside the touched paste upload response path.

`autoreview` was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` found no command).
