### PR TITLE
feat: filter personal skills in CLI

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -905,14 +905,38 @@ def inspect_skill(identifier: str) -> Optional[dict]:
     return out
 
 
+def _truthy_frontmatter_value(value: object) -> bool:
+    """Return True for common YAML truthy spellings used by skill metadata."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def _is_user_specific_skill(skill: dict, source_type: str) -> bool:
+    """Return True for local skills explicitly tagged as user-specific."""
+    if source_type != "local":
+        return False
+
+    raw_metadata = skill.get("metadata")
+    metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+    raw_hermes_meta = metadata.get("hermes")
+    hermes_meta = raw_hermes_meta if isinstance(raw_hermes_meta, dict) else {}
+    return _truthy_frontmatter_value(hermes_meta.get("user_specific"))
+
+
 def do_list(source_filter: str = "all",
             enabled_only: bool = False,
+            personal_only: bool = False,
             console: Optional[Console] = None) -> None:
     """List installed skills, distinguishing hub, builtin, and local skills.
 
     Args:
         source_filter: ``all`` | ``hub`` | ``builtin`` | ``local``.
         enabled_only: If True, hide disabled skills from the output.
+        personal_only: If True, show local user-specific / agent-created skills
+            rather than every locally installed skill.
 
     Enabled/disabled state is resolved against the currently active profile's
     config — ``hermes -p <profile> skills list`` reads that profile's
@@ -937,6 +961,8 @@ def do_list(source_filter: str = "all",
     title = "Installed Skills"
     if enabled_only:
         title += " (enabled only)"
+    if personal_only:
+        title += " (personal only)"
 
     table = Table(title=title)
     table.add_column("Name", style="bold cyan")
@@ -972,6 +998,9 @@ def do_list(source_filter: str = "all",
         if source_filter != "all" and source_filter != source_type:
             continue
 
+        if personal_only and not _is_user_specific_skill(skill, source_type):
+            continue
+
         is_enabled = name not in disabled_names
         if enabled_only and not is_enabled:
             continue
@@ -996,6 +1025,8 @@ def do_list(source_filter: str = "all",
 
     c.print(table)
     summary = f"[dim]{hub_count} hub-installed, {builtin_count} builtin, {local_count} local"
+    if personal_only:
+        summary += " (personal filter applied)"
     if enabled_only:
         summary += f" — {enabled_count} enabled shown"
     else:
@@ -1702,6 +1733,7 @@ def skills_command(args) -> None:
         do_list(
             source_filter=args.source,
             enabled_only=getattr(args, "enabled_only", False),
+            personal_only=getattr(args, "personal", False),
         )
     elif action == "check":
         do_check(name=getattr(args, "name", None))
@@ -1879,11 +1911,17 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
     elif action == "list":
         source_filter = "all"
         enabled_only = "--enabled-only" in args or "--enabled" in args
+        personal_only = "--personal" in args or "--user" in args
         if "--source" in args:
             idx = args.index("--source")
             if idx + 1 < len(args):
                 source_filter = args[idx + 1]
-        do_list(source_filter=source_filter, enabled_only=enabled_only, console=c)
+        do_list(
+            source_filter=source_filter,
+            enabled_only=enabled_only,
+            personal_only=personal_only,
+            console=c,
+        )
 
     elif action == "check":
         name = args[0] if args else None
@@ -1981,8 +2019,8 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]search[/] <query>              Search registries for skills\n"
         "  [cyan]install[/] <identifier>        Install a skill (with security scan)\n"
         "  [cyan]inspect[/] <identifier>        Preview a skill without installing\n"
-        "  [cyan]list[/] [--source hub|builtin|local] [--enabled-only]\n"
-        "       List installed skills; --enabled-only filters to the active profile's live set\n"
+        "  [cyan]list[/] [--source hub|builtin|local] [--enabled-only] [--personal]\n"
+        "       List installed skills; --personal filters to local user-specific/agent-created skills\n"
         "  [cyan]check[/] [name]                Check hub skills for upstream updates\n"
         "  [cyan]update[/] [name]               Update hub skills with upstream changes\n"
         "  [cyan]audit[/] [name]                Re-scan hub skills for security\n"

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -914,16 +914,34 @@ def _truthy_frontmatter_value(value: object) -> bool:
     return bool(value)
 
 
-def _is_user_specific_skill(skill: dict, source_type: str) -> bool:
-    """Return True for local skills explicitly tagged as user-specific."""
+def _is_user_specific_skill(skill: dict, source_type: str,
+                            usage_record: Optional[dict] = None) -> bool:
+    """Return True for local skills explicitly tagged as user-specific, or
+    recorded as agent-created in the ``.usage.json`` sidecar.
+
+    Legacy agent-created skills predate the frontmatter markers and are only
+    identifiable via their ``skill_manage(action="create")`` usage record.
+    """
     if source_type != "local":
         return False
+
+    if _truthy_frontmatter_value(skill.get("user_specific")):
+        return True
+    if _truthy_frontmatter_value(skill.get("owner_specific")):
+        return True
+    owner = skill.get("owner")
+    if isinstance(owner, str) and owner.strip():
+        return True
 
     raw_metadata = skill.get("metadata")
     metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
     raw_hermes_meta = metadata.get("hermes")
     hermes_meta = raw_hermes_meta if isinstance(raw_hermes_meta, dict) else {}
-    return _truthy_frontmatter_value(hermes_meta.get("user_specific"))
+    if _truthy_frontmatter_value(hermes_meta.get("user_specific")):
+        return True
+
+    from tools.skill_usage import _is_curator_managed_record
+    return _is_curator_managed_record(usage_record)
 
 
 def do_list(source_filter: str = "all",
@@ -957,6 +975,11 @@ def do_list(source_filter: str = "all",
     # Pull ALL skills (including disabled ones) so we can annotate status.
     all_skills = _find_all_skills(skip_disabled=True)
     disabled_names = get_disabled_skill_names()
+
+    usage_records = {}
+    if personal_only:
+        from tools.skill_usage import load_usage
+        usage_records = load_usage()
 
     title = "Installed Skills"
     if enabled_only:
@@ -998,7 +1021,9 @@ def do_list(source_filter: str = "all",
         if source_filter != "all" and source_filter != source_type:
             continue
 
-        if personal_only and not _is_user_specific_skill(skill, source_type):
+        if personal_only and not _is_user_specific_skill(
+            skill, source_type, usage_records.get(name)
+        ):
             continue
 
         is_enabled = name not in disabled_names

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -991,16 +991,34 @@ def _truthy_frontmatter_value(value: object) -> bool:
     return bool(value)
 
 
-def _is_user_specific_skill(skill: dict, source_type: str) -> bool:
-    """Return True for local skills explicitly tagged as user-specific."""
+def _is_user_specific_skill(skill: dict, source_type: str,
+                            usage_record: Optional[dict] = None) -> bool:
+    """Return True for local skills explicitly tagged as user-specific, or
+    recorded as agent-created in the ``.usage.json`` sidecar.
+
+    Legacy agent-created skills predate the frontmatter markers and are only
+    identifiable via their ``skill_manage(action="create")`` usage record.
+    """
     if source_type != "local":
         return False
+
+    if _truthy_frontmatter_value(skill.get("user_specific")):
+        return True
+    if _truthy_frontmatter_value(skill.get("owner_specific")):
+        return True
+    owner = skill.get("owner")
+    if isinstance(owner, str) and owner.strip():
+        return True
 
     raw_metadata = skill.get("metadata")
     metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
     raw_hermes_meta = metadata.get("hermes")
     hermes_meta = raw_hermes_meta if isinstance(raw_hermes_meta, dict) else {}
-    return _truthy_frontmatter_value(hermes_meta.get("user_specific"))
+    if _truthy_frontmatter_value(hermes_meta.get("user_specific")):
+        return True
+
+    from tools.skill_usage import _is_curator_managed_record
+    return _is_curator_managed_record(usage_record)
 
 
 def do_list(source_filter: str = "all",
@@ -1034,6 +1052,11 @@ def do_list(source_filter: str = "all",
     # Pull ALL skills (including disabled ones) so we can annotate status.
     all_skills = _find_all_skills(skip_disabled=True)
     disabled_names = get_disabled_skill_names()
+
+    usage_records = {}
+    if personal_only:
+        from tools.skill_usage import load_usage
+        usage_records = load_usage()
 
     title = "Installed Skills"
     if enabled_only:
@@ -1075,7 +1098,9 @@ def do_list(source_filter: str = "all",
         if source_filter != "all" and source_filter != source_type:
             continue
 
-        if personal_only and not _is_user_specific_skill(skill, source_type):
+        if personal_only and not _is_user_specific_skill(
+            skill, source_type, usage_records.get(name)
+        ):
             continue
 
         is_enabled = name not in disabled_names

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -982,14 +982,38 @@ def inspect_skill(identifier: str) -> Optional[dict]:
     return out
 
 
+def _truthy_frontmatter_value(value: object) -> bool:
+    """Return True for common YAML truthy spellings used by skill metadata."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def _is_user_specific_skill(skill: dict, source_type: str) -> bool:
+    """Return True for local skills explicitly tagged as user-specific."""
+    if source_type != "local":
+        return False
+
+    raw_metadata = skill.get("metadata")
+    metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+    raw_hermes_meta = metadata.get("hermes")
+    hermes_meta = raw_hermes_meta if isinstance(raw_hermes_meta, dict) else {}
+    return _truthy_frontmatter_value(hermes_meta.get("user_specific"))
+
+
 def do_list(source_filter: str = "all",
             enabled_only: bool = False,
+            personal_only: bool = False,
             console: Optional[Console] = None) -> None:
     """List installed skills, distinguishing hub, builtin, and local skills.
 
     Args:
         source_filter: ``all`` | ``hub`` | ``builtin`` | ``local``.
         enabled_only: If True, hide disabled skills from the output.
+        personal_only: If True, show local user-specific / agent-created skills
+            rather than every locally installed skill.
 
     Enabled/disabled state is resolved against the currently active profile's
     config — ``hermes -p <profile> skills list`` reads that profile's
@@ -1014,6 +1038,8 @@ def do_list(source_filter: str = "all",
     title = "Installed Skills"
     if enabled_only:
         title += " (enabled only)"
+    if personal_only:
+        title += " (personal only)"
 
     table = Table(title=title)
     table.add_column("Name", style="bold cyan")
@@ -1049,6 +1075,9 @@ def do_list(source_filter: str = "all",
         if source_filter != "all" and source_filter != source_type:
             continue
 
+        if personal_only and not _is_user_specific_skill(skill, source_type):
+            continue
+
         is_enabled = name not in disabled_names
         if enabled_only and not is_enabled:
             continue
@@ -1073,6 +1102,8 @@ def do_list(source_filter: str = "all",
 
     c.print(table)
     summary = f"[dim]{hub_count} hub-installed, {builtin_count} builtin, {local_count} local"
+    if personal_only:
+        summary += " (personal filter applied)"
     if enabled_only:
         summary += f" — {enabled_count} enabled shown"
     else:
@@ -1829,6 +1860,7 @@ def skills_command(args) -> None:
         do_list(
             source_filter=args.source,
             enabled_only=getattr(args, "enabled_only", False),
+            personal_only=getattr(args, "personal", False),
         )
     elif action == "check":
         do_check(name=getattr(args, "name", None))
@@ -2007,11 +2039,17 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
     elif action == "list":
         source_filter = "all"
         enabled_only = "--enabled-only" in args or "--enabled" in args
+        personal_only = "--personal" in args or "--user" in args
         if "--source" in args:
             idx = args.index("--source")
             if idx + 1 < len(args):
                 source_filter = args[idx + 1]
-        do_list(source_filter=source_filter, enabled_only=enabled_only, console=c)
+        do_list(
+            source_filter=source_filter,
+            enabled_only=enabled_only,
+            personal_only=personal_only,
+            console=c,
+        )
 
     elif action == "check":
         name = args[0] if args else None
@@ -2111,8 +2149,8 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]search[/] <query>              Search registries for skills\n"
         "  [cyan]install[/] <identifier>        Install a skill (with security scan)\n"
         "  [cyan]inspect[/] <identifier>        Preview a skill without installing\n"
-        "  [cyan]list[/] [--source hub|builtin|local] [--enabled-only]\n"
-        "       List installed skills; --enabled-only filters to the active profile's live set\n"
+        "  [cyan]list[/] [--source hub|builtin|local] [--enabled-only] [--personal]\n"
+        "       List installed skills; --personal filters to local user-specific/agent-created skills\n"
         "  [cyan]check[/] [name]                Check hub skills for upstream updates\n"
         "  [cyan]update[/] [name]               Update hub skills with upstream changes\n"
         "  [cyan]audit[/] [name]                Re-scan hub skills for security\n"

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -123,6 +123,14 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Hide disabled skills. Use with -p <profile> to see exactly "
         "which skills will load for that profile.",
     )
+    skills_list.add_argument(
+        "--personal",
+        "--user",
+        action="store_true",
+        dest="personal",
+        help="Show local skills marked as user-specific or created by the agent, "
+        "instead of every locally installed/inherited skill.",
+    )
 
     skills_check = skills_subparsers.add_parser(
         "check", help="Check installed hub skills for updates"

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -144,6 +144,14 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Hide disabled skills. Use with -p <profile> to see exactly "
         "which skills will load for that profile.",
     )
+    skills_list.add_argument(
+        "--personal",
+        "--user",
+        action="store_true",
+        dest="personal",
+        help="Show local skills marked as user-specific or created by the agent, "
+        "instead of every locally installed/inherited skill.",
+    )
 
     skills_check = skills_subparsers.add_parser(
         "check", help="Check installed hub skills for updates"

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -45,6 +45,21 @@ _ALL_THREE_SKILLS = [
     {"name": "local-skill", "category": "x", "description": "local"},
 ]
 
+_PERSONAL_SKILLS = _ALL_THREE_SKILLS + [
+    {
+        "name": "personal-meta-skill",
+        "category": "x",
+        "description": "user-specific",
+        "metadata": {"hermes": {"user_specific": True}},
+    },
+    {
+        "name": "legacy-agent-skill",
+        "category": "x",
+        "description": "agent-created legacy",
+        "author": "Hermes Agent",
+    },
+]
+
 _BUILTIN_MANIFEST = {"builtin-skill": "abc123"}
 
 
@@ -62,11 +77,11 @@ def three_source_env(monkeypatch, hub_env):
     return hub_env
 
 
-def _capture(source_filter: str = "all") -> str:
+def _capture(source_filter: str = "all", personal_only: bool = False) -> str:
     """Run do_list into a string buffer and return the output."""
     sink = StringIO()
     console = Console(file=sink, force_terminal=False, color_system=None)
-    do_list(source_filter=source_filter, console=console)
+    do_list(source_filter=source_filter, personal_only=personal_only, console=console)
     return sink.getvalue()
 
 
@@ -152,6 +167,44 @@ def test_do_list_filter_builtin(three_source_env):
     assert "builtin-skill" in output
     assert "hub-skill" not in output
     assert "local-skill" not in output
+
+
+def test_do_list_personal_filters_to_user_specific_local_skills(
+    monkeypatch, hub_env
+):
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+
+    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda **_kwargs: list(_PERSONAL_SKILLS))
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_BUILTIN_MANIFEST))
+
+    output = _capture(personal_only=True)
+
+    assert "personal-meta-skill" in output
+    assert "legacy-agent-skill" not in output
+    assert "local-skill" not in output
+    assert "builtin-skill" not in output
+    assert "hub-skill" not in output
+    assert "personal filter applied" in output
+
+
+def test_do_list_personal_does_not_include_author_without_metadata_marker(
+    monkeypatch, hub_env
+):
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+
+    skills = [
+        {"name": "builtin-skill", "category": "x", "description": "builtin", "author": "Hermes Agent"},
+        {"name": "local-skill", "category": "x", "description": "local", "author": "Hermes Agent"},
+    ]
+    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda **_kwargs: skills)
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_BUILTIN_MANIFEST))
+
+    output = _capture(personal_only=True)
+
+    assert "local-skill" not in output
+    assert "builtin-skill" not in output
 
 
 def test_do_list_renders_status_column(three_source_env, monkeypatch):

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -169,16 +169,26 @@ def test_do_list_filter_builtin(three_source_env):
     assert "local-skill" not in output
 
 
-def test_do_list_personal_filters_to_user_specific_local_skills(
-    monkeypatch, hub_env
-):
+def _personal_capture(monkeypatch, skills, usage=None, hub_entries=None) -> str:
+    """Run do_list(personal_only=True) against stubbed skills + usage records."""
+    import tools.skill_usage as skill_usage
+    import tools.skills_hub as hub
     import tools.skills_sync as skills_sync
     import tools.skills_tool as skills_tool
 
-    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda **_kwargs: list(_PERSONAL_SKILLS))
+    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda **_kwargs: list(skills))
     monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_BUILTIN_MANIFEST))
+    monkeypatch.setattr(skill_usage, "load_usage", lambda: dict(usage or {}))
+    if hub_entries is not None:
+        monkeypatch.setattr(hub, "HubLockFile", lambda: _DummyLockFile(list(hub_entries)))
 
-    output = _capture(personal_only=True)
+    return _capture(personal_only=True)
+
+
+def test_do_list_personal_filters_to_user_specific_local_skills(
+    monkeypatch, hub_env
+):
+    output = _personal_capture(monkeypatch, _PERSONAL_SKILLS)
 
     assert "personal-meta-skill" in output
     assert "legacy-agent-skill" not in output
@@ -191,20 +201,125 @@ def test_do_list_personal_filters_to_user_specific_local_skills(
 def test_do_list_personal_does_not_include_author_without_metadata_marker(
     monkeypatch, hub_env
 ):
-    import tools.skills_sync as skills_sync
-    import tools.skills_tool as skills_tool
-
     skills = [
         {"name": "builtin-skill", "category": "x", "description": "builtin", "author": "Hermes Agent"},
         {"name": "local-skill", "category": "x", "description": "local", "author": "Hermes Agent"},
     ]
-    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda **_kwargs: skills)
-    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_BUILTIN_MANIFEST))
 
-    output = _capture(personal_only=True)
+    output = _personal_capture(monkeypatch, skills)
 
     assert "local-skill" not in output
     assert "builtin-skill" not in output
+
+
+def test_do_list_personal_accepts_top_level_user_specific_marker(
+    monkeypatch, hub_env
+):
+    skills = [
+        {"name": "flag-user-skill", "category": "x", "description": "d", "user_specific": True},
+    ]
+
+    output = _personal_capture(monkeypatch, skills)
+
+    assert "flag-user-skill" in output
+
+
+def test_do_list_personal_accepts_truthy_string_marker_spelling(
+    monkeypatch, hub_env
+):
+    skills = [
+        {"name": "flag-str-skill", "category": "x", "description": "d", "user_specific": "yes"},
+    ]
+
+    output = _personal_capture(monkeypatch, skills)
+
+    assert "flag-str-skill" in output
+
+
+def test_do_list_personal_accepts_owner_specific_marker(
+    monkeypatch, hub_env
+):
+    skills = [
+        {"name": "flag-owner-skill", "category": "x", "description": "d", "owner_specific": True},
+    ]
+
+    output = _personal_capture(monkeypatch, skills)
+
+    assert "flag-owner-skill" in output
+
+
+def test_do_list_personal_accepts_owner_field(
+    monkeypatch, hub_env
+):
+    skills = [
+        {"name": "owned-skill", "category": "x", "description": "d", "owner": "example-user"},
+    ]
+
+    output = _personal_capture(monkeypatch, skills)
+
+    assert "owned-skill" in output
+
+
+def test_do_list_personal_includes_agent_created_usage_record(
+    monkeypatch, hub_env
+):
+    """Legacy agent-created skills carry no frontmatter marker — only the
+    ``created_by: agent`` provenance record written by skill_manage(create)."""
+    skills = [
+        {"name": "old-agent-skill", "category": "x", "description": "d"},
+    ]
+    usage = {"old-agent-skill": {"created_by": "agent"}}
+
+    output = _personal_capture(monkeypatch, skills, usage=usage)
+
+    assert "old-agent-skill" in output
+
+
+def test_do_list_personal_includes_agent_created_flag_record(
+    monkeypatch, hub_env
+):
+    skills = [
+        {"name": "old-flag-skill", "category": "x", "description": "d"},
+    ]
+    usage = {"old-flag-skill": {"agent_created": True}}
+
+    output = _personal_capture(monkeypatch, skills, usage=usage)
+
+    assert "old-flag-skill" in output
+
+
+def test_do_list_personal_markers_do_not_leak_non_local_sources(
+    monkeypatch, hub_env
+):
+    """user_specific markers and agent-created records on hub/builtin skills
+    must not bypass the local-source guard."""
+    skills = [
+        {"name": "hub-skill", "category": "x", "description": "hub", "user_specific": True},
+        {"name": "builtin-skill", "category": "x", "description": "builtin", "user_specific": True},
+    ]
+    usage = {"builtin-skill": {"created_by": "agent"}}
+
+    output = _personal_capture(
+        monkeypatch, skills, usage=usage, hub_entries=[_HUB_ENTRY]
+    )
+
+    assert "hub-skill" not in output
+    assert "builtin-skill" not in output
+
+
+def test_handle_skills_slash_list_personal_and_user_aliases(monkeypatch):
+    calls = []
+
+    def fake_do_list(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr("hermes_cli.skills_hub.do_list", fake_do_list)
+
+    handle_skills_slash("/skills list --personal")
+    handle_skills_slash("/skills list --user")
+    handle_skills_slash("/skills list")
+
+    assert [c["personal_only"] for c in calls] == [True, True, False]
 
 
 def test_do_list_renders_status_column(three_source_env, monkeypatch):

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -118,16 +118,26 @@ def _capture_update(monkeypatch, results) -> tuple[str, list[tuple[str, str, boo
 # ---------------------------------------------------------------------------
 
 
-def test_do_list_personal_filters_to_user_specific_local_skills(
-    monkeypatch, hub_env
-):
+def _personal_capture(monkeypatch, skills, usage=None, hub_entries=None) -> str:
+    """Run do_list(personal_only=True) against stubbed skills + usage records."""
+    import tools.skill_usage as skill_usage
+    import tools.skills_hub as hub
     import tools.skills_sync as skills_sync
     import tools.skills_tool as skills_tool
 
-    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda **_kwargs: list(_PERSONAL_SKILLS))
+    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda **_kwargs: list(skills))
     monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_BUILTIN_MANIFEST))
+    monkeypatch.setattr(skill_usage, "load_usage", lambda: dict(usage or {}))
+    if hub_entries is not None:
+        monkeypatch.setattr(hub, "HubLockFile", lambda: _DummyLockFile(list(hub_entries)))
 
-    output = _capture(personal_only=True)
+    return _capture(personal_only=True)
+
+
+def test_do_list_personal_filters_to_user_specific_local_skills(
+    monkeypatch, hub_env
+):
+    output = _personal_capture(monkeypatch, _PERSONAL_SKILLS)
 
     assert "personal-meta-skill" in output
     assert "legacy-agent-skill" not in output
@@ -140,21 +150,110 @@ def test_do_list_personal_filters_to_user_specific_local_skills(
 def test_do_list_personal_does_not_include_author_without_metadata_marker(
     monkeypatch, hub_env
 ):
-    import tools.skills_sync as skills_sync
-    import tools.skills_tool as skills_tool
-
     skills = [
         {"name": "builtin-skill", "category": "x", "description": "builtin", "author": "Hermes Agent"},
         {"name": "local-skill", "category": "x", "description": "local", "author": "Hermes Agent"},
     ]
-    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda **_kwargs: skills)
-    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_BUILTIN_MANIFEST))
 
-    output = _capture(personal_only=True)
+    output = _personal_capture(monkeypatch, skills)
 
     assert "local-skill" not in output
     assert "builtin-skill" not in output
 
+
+def test_do_list_personal_accepts_top_level_user_specific_marker(
+    monkeypatch, hub_env
+):
+    skills = [
+        {"name": "flag-user-skill", "category": "x", "description": "d", "user_specific": True},
+    ]
+
+    output = _personal_capture(monkeypatch, skills)
+
+    assert "flag-user-skill" in output
+
+
+def test_do_list_personal_accepts_truthy_string_marker_spelling(
+    monkeypatch, hub_env
+):
+    skills = [
+        {"name": "flag-str-skill", "category": "x", "description": "d", "user_specific": "yes"},
+    ]
+
+    output = _personal_capture(monkeypatch, skills)
+
+    assert "flag-str-skill" in output
+
+
+def test_do_list_personal_accepts_owner_specific_marker(
+    monkeypatch, hub_env
+):
+    skills = [
+        {"name": "flag-owner-skill", "category": "x", "description": "d", "owner_specific": True},
+    ]
+
+    output = _personal_capture(monkeypatch, skills)
+
+    assert "flag-owner-skill" in output
+
+
+def test_do_list_personal_accepts_owner_field(
+    monkeypatch, hub_env
+):
+    skills = [
+        {"name": "owned-skill", "category": "x", "description": "d", "owner": "example-user"},
+    ]
+
+    output = _personal_capture(monkeypatch, skills)
+
+    assert "owned-skill" in output
+
+
+def test_do_list_personal_includes_agent_created_usage_record(
+    monkeypatch, hub_env
+):
+    """Legacy agent-created skills carry no frontmatter marker — only the
+    ``created_by: agent`` provenance record written by skill_manage(create)."""
+    skills = [
+        {"name": "old-agent-skill", "category": "x", "description": "d"},
+    ]
+    usage = {"old-agent-skill": {"created_by": "agent"}}
+
+    output = _personal_capture(monkeypatch, skills, usage=usage)
+
+    assert "old-agent-skill" in output
+
+
+def test_do_list_personal_includes_agent_created_flag_record(
+    monkeypatch, hub_env
+):
+    skills = [
+        {"name": "old-flag-skill", "category": "x", "description": "d"},
+    ]
+    usage = {"old-flag-skill": {"agent_created": True}}
+
+    output = _personal_capture(monkeypatch, skills, usage=usage)
+
+    assert "old-flag-skill" in output
+
+
+def test_do_list_personal_markers_do_not_leak_non_local_sources(
+    monkeypatch, hub_env
+):
+    """user_specific markers and agent-created records on hub/builtin skills
+    must not bypass the local-source guard."""
+    skills = [
+        {"name": "hub-skill", "category": "x", "description": "hub", "user_specific": True},
+        {"name": "builtin-skill", "category": "x", "description": "builtin", "user_specific": True},
+    ]
+    usage = {"builtin-skill": {"created_by": "agent"}}
+
+    output = _personal_capture(
+        monkeypatch, skills, usage=usage, hub_entries=[_HUB_ENTRY]
+    )
+
+    assert "hub-skill" not in output
+    assert "builtin-skill" not in output
 
 
 def test_do_list_platform_env_is_ignored(three_source_env, monkeypatch):

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -45,6 +45,21 @@ _ALL_THREE_SKILLS = [
     {"name": "local-skill", "category": "x", "description": "local"},
 ]
 
+_PERSONAL_SKILLS = _ALL_THREE_SKILLS + [
+    {
+        "name": "personal-meta-skill",
+        "category": "x",
+        "description": "user-specific",
+        "metadata": {"hermes": {"user_specific": True}},
+    },
+    {
+        "name": "legacy-agent-skill",
+        "category": "x",
+        "description": "agent-created legacy",
+        "author": "Hermes Agent",
+    },
+]
+
 _BUILTIN_MANIFEST = {"builtin-skill": "abc123"}
 
 
@@ -62,11 +77,11 @@ def three_source_env(monkeypatch, hub_env):
     return hub_env
 
 
-def _capture(source_filter: str = "all") -> str:
+def _capture(source_filter: str = "all", personal_only: bool = False) -> str:
     """Run do_list into a string buffer and return the output."""
     sink = StringIO()
     console = Console(file=sink, force_terminal=False, color_system=None)
-    do_list(source_filter=source_filter, console=console)
+    do_list(source_filter=source_filter, personal_only=personal_only, console=console)
     return sink.getvalue()
 
 
@@ -102,6 +117,43 @@ def _capture_update(monkeypatch, results) -> tuple[str, list[tuple[str, str, boo
 # Tests
 # ---------------------------------------------------------------------------
 
+
+def test_do_list_personal_filters_to_user_specific_local_skills(
+    monkeypatch, hub_env
+):
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+
+    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda **_kwargs: list(_PERSONAL_SKILLS))
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_BUILTIN_MANIFEST))
+
+    output = _capture(personal_only=True)
+
+    assert "personal-meta-skill" in output
+    assert "legacy-agent-skill" not in output
+    assert "local-skill" not in output
+    assert "builtin-skill" not in output
+    assert "hub-skill" not in output
+    assert "personal filter applied" in output
+
+
+def test_do_list_personal_does_not_include_author_without_metadata_marker(
+    monkeypatch, hub_env
+):
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+
+    skills = [
+        {"name": "builtin-skill", "category": "x", "description": "builtin", "author": "Hermes Agent"},
+        {"name": "local-skill", "category": "x", "description": "local", "author": "Hermes Agent"},
+    ]
+    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda **_kwargs: skills)
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_BUILTIN_MANIFEST))
+
+    output = _capture(personal_only=True)
+
+    assert "local-skill" not in output
+    assert "builtin-skill" not in output
 
 
 

--- a/tests/hermes_cli/test_skills_list_personal_flag.py
+++ b/tests/hermes_cli/test_skills_list_personal_flag.py
@@ -1,0 +1,43 @@
+"""
+Tests for --personal / --user flag on `hermes skills list`.
+
+--personal / --user → args.personal → do_list(personal_only=True): show local
+skills explicitly marked user-specific or recorded as agent-created, instead
+of every locally installed skill.
+"""
+
+import sys
+
+
+def _run_skills_list(monkeypatch, argv):
+    from hermes_cli.main import main
+
+    captured = {}
+
+    def fake_skills_command(args):
+        captured["personal"] = getattr(args, "personal", None)
+
+    monkeypatch.setattr("hermes_cli.skills_hub.skills_command", fake_skills_command)
+    monkeypatch.setattr(sys, "argv", argv)
+
+    main()
+    return captured
+
+
+def test_cli_skills_list_personal_flag(monkeypatch):
+    captured = _run_skills_list(monkeypatch, ["hermes", "skills", "list", "--personal"])
+
+    assert captured["personal"] is True
+
+
+def test_cli_skills_list_user_alias(monkeypatch):
+    """--user must behave identically to --personal."""
+    captured = _run_skills_list(monkeypatch, ["hermes", "skills", "list", "--user"])
+
+    assert captured["personal"] is True
+
+
+def test_cli_skills_list_personal_defaults_false(monkeypatch):
+    captured = _run_skills_list(monkeypatch, ["hermes", "skills", "list"])
+
+    assert captured["personal"] is False

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -210,6 +210,40 @@ class TestCreateSkill:
         assert result["success"] is True
         assert (tmp_path / "my-skill" / "SKILL.md").exists()
 
+    def test_create_skill_tags_user_specific_metadata(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT)
+
+        assert result["success"] is True
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text(encoding="utf-8")
+        assert "metadata:" in content
+        assert "hermes:" in content
+        assert "user_specific: true" in content
+
+    def test_create_skill_preserves_existing_hermes_metadata(self, tmp_path):
+        content = """\
+---
+name: test-skill
+description: A test skill for unit testing.
+metadata:
+  hermes:
+    tags:
+    - testing
+---
+
+# Test Skill
+
+Step 1: Do the thing.
+"""
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", content)
+
+        assert result["success"] is True
+        written = (tmp_path / "my-skill" / "SKILL.md").read_text(encoding="utf-8")
+        assert "tags:" in written
+        assert "- testing" in written
+        assert "user_specific: true" in written
+
     def test_create_with_category(self, tmp_path):
         with _skill_dir(tmp_path):
             result = _create_skill("my-skill", VALID_SKILL_CONTENT, category="devops")

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -156,6 +156,40 @@ class TestCreateSkill:
         assert result["success"] is True
         assert (tmp_path / "my-skill" / "SKILL.md").exists()
 
+    def test_create_skill_tags_user_specific_metadata(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT)
+
+        assert result["success"] is True
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text(encoding="utf-8")
+        assert "metadata:" in content
+        assert "hermes:" in content
+        assert "user_specific: true" in content
+
+    def test_create_skill_preserves_existing_hermes_metadata(self, tmp_path):
+        content = """\
+---
+name: test-skill
+description: A test skill for unit testing.
+metadata:
+  hermes:
+    tags:
+    - testing
+---
+
+# Test Skill
+
+Step 1: Do the thing.
+"""
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", content)
+
+        assert result["success"] is True
+        written = (tmp_path / "my-skill" / "SKILL.md").read_text(encoding="utf-8")
+        assert "tags:" in written
+        assert "- testing" in written
+        assert "user_specific: true" in written
+
     def test_create_duplicate_blocked(self, tmp_path):
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -471,6 +471,37 @@ def _validate_frontmatter(content: str) -> Optional[str]:
     return None
 
 
+def _mark_session_created_skill_user_specific(content: str) -> str:
+    """Tag skills created by Hermes in-session as user/profile-specific."""
+    end_match = re.search(r'\n---\s*\n', content[3:])
+    if not end_match:
+        return content
+
+    yaml_content = content[3:end_match.start() + 3]
+    body = content[end_match.end() + 3:]
+    parsed = yaml.safe_load(yaml_content) or {}
+    if not isinstance(parsed, dict):
+        return content
+
+    metadata = parsed.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    hermes_metadata = metadata.get("hermes")
+    if not isinstance(hermes_metadata, dict):
+        hermes_metadata = {}
+    hermes_metadata["user_specific"] = True
+    metadata["hermes"] = hermes_metadata
+    parsed["metadata"] = metadata
+
+    new_frontmatter = yaml.safe_dump(
+        parsed,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    ).strip()
+    return f"---\n{new_frontmatter}\n---\n{body}"
+
+
 def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[str]:
     """Check that content doesn't exceed the character limit for agent writes.
 
@@ -715,6 +746,10 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     err = _validate_frontmatter(content)
     if err:
         return {"success": False, "error": err}
+
+    # Skills created by Hermes in a session are local user/profile skills.
+    # Mark them explicitly instead of making `--personal` guess later.
+    content = _mark_session_created_skill_user_specific(content)
 
     err = _validate_content_size(content)
     if err:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -747,13 +747,15 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     if err:
         return {"success": False, "error": err}
 
-    # Skills created by Hermes in a session are local user/profile skills.
-    # Mark them explicitly instead of making `--personal` guess later.
-    content = _mark_session_created_skill_user_specific(content)
-
     err = _validate_content_size(content)
     if err:
         return {"success": False, "error": err}
+
+    # Skills created by Hermes in a session are local user/profile skills.
+    # Mark them explicitly instead of making `--personal` guess later. Runs
+    # after size validation: the injected marker is system bookkeeping and
+    # must not consume the agent's content budget.
+    content = _mark_session_created_skill_user_specific(content)
 
     # Check for name collisions across all directories
     existing = _find_skill(name)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -620,6 +620,37 @@ def _validate_frontmatter(content: str, *, new_skill: bool = False) -> Optional[
     return None
 
 
+def _mark_session_created_skill_user_specific(content: str) -> str:
+    """Tag skills created by Hermes in-session as user/profile-specific."""
+    end_match = re.search(r'\n---\s*\n', content[3:])
+    if not end_match:
+        return content
+
+    yaml_content = content[3:end_match.start() + 3]
+    body = content[end_match.end() + 3:]
+    parsed = yaml.safe_load(yaml_content) or {}
+    if not isinstance(parsed, dict):
+        return content
+
+    metadata = parsed.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    hermes_metadata = metadata.get("hermes")
+    if not isinstance(hermes_metadata, dict):
+        hermes_metadata = {}
+    hermes_metadata["user_specific"] = True
+    metadata["hermes"] = hermes_metadata
+    parsed["metadata"] = metadata
+
+    new_frontmatter = yaml.safe_dump(
+        parsed,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    ).strip()
+    return f"---\n{new_frontmatter}\n---\n{body}"
+
+
 def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[str]:
     """Check that content doesn't exceed the character limit for agent writes.
 
@@ -920,6 +951,10 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     err = _validate_frontmatter(content, new_skill=True)
     if err:
         return {"success": False, "error": err}
+
+    # Skills created by Hermes in a session are local user/profile skills.
+    # Mark them explicitly instead of making `--personal` guess later.
+    content = _mark_session_created_skill_user_specific(content)
 
     err = _validate_content_size(content)
     if err:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -952,13 +952,15 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     if err:
         return {"success": False, "error": err}
 
-    # Skills created by Hermes in a session are local user/profile skills.
-    # Mark them explicitly instead of making `--personal` guess later.
-    content = _mark_session_created_skill_user_specific(content)
-
     err = _validate_content_size(content)
     if err:
         return {"success": False, "error": err}
+
+    # Skills created by Hermes in a session are local user/profile skills.
+    # Mark them explicitly instead of making `--personal` guess later. Runs
+    # after size validation: the injected marker is system bookkeeping and
+    # must not consume the agent's content budget.
+    content = _mark_session_created_skill_user_specific(content)
 
     # Check for name collisions across all directories
     existing = _find_skill(name)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -667,6 +667,17 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     "name": name,
                     "description": description,
                     "category": category,
+                    # Keep provenance-adjacent frontmatter available to CLI
+                    # listing commands without requiring a second filesystem
+                    # scan.  The public ``skills_list`` tool still projects
+                    # this down to name/description, so the model-facing tool
+                    # stays compact.
+                    "path": str(skill_md),
+                    "author": frontmatter.get("author", ""),
+                    "metadata": frontmatter.get("metadata", {}) or {},
+                    "owner": frontmatter.get("owner", ""),
+                    "user_specific": frontmatter.get("user_specific", False),
+                    "owner_specific": frontmatter.get("owner_specific", False),
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
@@ -739,12 +750,21 @@ def skills_list(category: str = None, task_id: str = None) -> str:
             {s.get("category") for s in all_skills if s.get("category")}
         )
 
+        public_skills = [
+            {
+                "name": skill.get("name", ""),
+                "description": skill.get("description", ""),
+                "category": skill.get("category", ""),
+            }
+            for skill in all_skills
+        ]
+
         return json.dumps(
             {
                 "success": True,
-                "skills": all_skills,
+                "skills": public_skills,
                 "categories": categories,
-                "count": len(all_skills),
+                "count": len(public_skills),
                 "hint": "Use skill_view(name) to see full content, tags, and linked files",
             },
             ensure_ascii=False,

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -777,6 +777,17 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     "name": name,
                     "description": description,
                     "category": category,
+                    # Keep provenance-adjacent frontmatter available to CLI
+                    # listing commands without requiring a second filesystem
+                    # scan.  The public ``skills_list`` tool still projects
+                    # this down to name/description, so the model-facing tool
+                    # stays compact.
+                    "path": str(skill_md),
+                    "author": frontmatter.get("author", ""),
+                    "metadata": frontmatter.get("metadata", {}) or {},
+                    "owner": frontmatter.get("owner", ""),
+                    "user_specific": frontmatter.get("user_specific", False),
+                    "owner_specific": frontmatter.get("owner_specific", False),
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
@@ -859,12 +870,21 @@ def skills_list(category: str = None, task_id: str = None) -> str:
             {s.get("category") for s in all_skills if s.get("category")}
         )
 
+        public_skills = [
+            {
+                "name": skill.get("name", ""),
+                "description": skill.get("description", ""),
+                "category": skill.get("category", ""),
+            }
+            for skill in all_skills
+        ]
+
         return json.dumps(
             {
                 "success": True,
-                "skills": all_skills,
+                "skills": public_skills,
                 "categories": categories,
-                "count": len(all_skills),
+                "count": len(public_skills),
                 "hint": "Use skill_view(name) to see full content, tags, and linked files",
             },
             ensure_ascii=False,


### PR DESCRIPTION
## Summary
- add `hermes skills list --personal` / `--user` to show local user-specific or agent-created skills separately from inherited/installed skills
- classify personal skills from the explicit frontmatter markers (`user_specific`, `owner_specific`, `owner`, `metadata.hermes.user_specific`) plus the established agent-created provenance record (`created_by == "agent"` / `agent_created is True` in `.usage.json`), so legacy agent-created skills that predate the markers are included; the `author:` string alone is never trusted
- keep model-facing `skills_list` output compact by projecting internal provenance metadata back down to name/description/category

## Why
`hermes skills list --source local` answers where a skill is stored, but not whether it was made for the user. Local skill libraries often contain a mixture of user-created procedural memory, installed hub/official skills, and inherited/bundled content. This gives users a direct way to inspect their own skills.

## Verification
- `python -m pytest tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_skills_list_personal_flag.py tests/hermes_cli/test_skills_subparser.py tests/tools/test_skill_manager_tool.py -q` → 149 passed
- `python -m pytest tests/tools -k skill -q` → 690 passed (includes `test_skill_size_limits.py`, green again after the ordering fix)
- `python -m hermes_cli.main skills list --help` shows `--personal, --user`
- `python -m hermes_cli.main skills list --personal` renders an `Installed Skills (personal only)` table
