### PR TITLE
fix(gateway): allow /update from pip/pipx installs

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -34,7 +34,7 @@ from agent.i18n import t
 from gateway.config import HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.session import SessionSource, build_session_key
-from hermes_cli.config import cfg_get, clear_model_endpoint_credentials
+from hermes_cli.config import cfg_get, clear_model_endpoint_credentials, detect_install_method
 from utils import (
     atomic_json_write,
     atomic_yaml_write,
@@ -4011,7 +4011,12 @@ class GatewaySlashCommandsMixin:
         project_root = Path(__file__).parent.parent.resolve()
         git_dir = project_root / '.git'
 
-        if not git_dir.exists():
+        # pip/pipx installs don't have .git in the install tree but are
+        # fully updatable via ``pipx upgrade`` (which the spawned
+        # ``hermes update --gateway`` handles).  Only block when the
+        # install method is unknown *and* there's no .git directory.
+        install_method = detect_install_method(project_root)
+        if install_method != "pip" and not git_dir.exists():
             return t("gateway.update.not_git_repo")
 
         hermes_cmd = _resolve_hermes_bin()

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -63,47 +63,45 @@ class TestHandleUpdateCommand:
         mock_popen.assert_not_called()  # must return before reaching Popen
 
     @pytest.mark.asyncio
-    async def test_no_git_directory(self, tmp_path):
-        """Returns an error when .git does not exist."""
+    async def test_no_git_directory_unknown_method(self, tmp_path):
+        """Returns an error when .git is absent and install method is not pip."""
         runner = _make_runner()
         event = _make_event()
-        # Point _hermes_home to tmp_path and project_root to a dir without .git
         fake_root = tmp_path / "project"
         fake_root.mkdir()
+        (fake_root / "gateway").mkdir(parents=True)
+        (fake_root / "gateway" / "slash_commands.py").touch()
+        fake_file = str(fake_root / "gateway" / "slash_commands.py")
+
         with patch("gateway.run._hermes_home", tmp_path), \
-             patch("gateway.run.Path") as MockPath:
-            # Path(__file__).parent.parent.resolve() -> fake_root
-            MockPath.return_value = MagicMock()
-            MockPath.__truediv__ = Path.__truediv__
-            # Easier: just patch the __file__ resolution in the method
-            pass
-
-        # Simpler approach — mock at method level using a wrapper
-        runner = _make_runner()
-
-        with patch("gateway.run._hermes_home", tmp_path):
-            # The handler does Path(__file__).parent.parent.resolve()
-            # We need to make project_root / '.git' not exist.
-            # Since Path(__file__) resolves to the real gateway/run.py,
-            # project_root will be the real hermes-agent dir (which HAS .git).
-            # Patch Path to control this.
-            original_path = Path
-
-            class FakePath(type(Path())):
-                pass
-
-            # Actually, simplest: just patch the specific file attr.
-            # The _handle_update_command handler lives in gateway/slash_commands.py
-            # (extracted from run.py in the god-file decomposition); it resolves
-            # project_root via Path(__file__).parent.parent, so fake that file.
-            fake_file = str(fake_root / "gateway" / "slash_commands.py")
-            (fake_root / "gateway").mkdir(parents=True)
-            (fake_root / "gateway" / "slash_commands.py").touch()
-
-            with patch("gateway.slash_commands.__file__", fake_file):
-                result = await runner._handle_update_command(event)
+             patch("gateway.slash_commands.__file__", fake_file), \
+             patch("gateway.slash_commands.detect_install_method",
+                   return_value="git"):
+            result = await runner._handle_update_command(event)
 
         assert "Not a git repository" in result
+
+    @pytest.mark.asyncio
+    async def test_no_git_directory_pip_install_proceeds(self, tmp_path):
+        """pip/pipx installs without .git are allowed to proceed."""
+        runner = _make_runner()
+        event = _make_event()
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / "gateway").mkdir(parents=True)
+        (fake_root / "gateway" / "slash_commands.py").touch()
+        fake_file = str(fake_root / "gateway" / "slash_commands.py")
+
+        with patch("gateway.run._hermes_home", tmp_path), \
+             patch("gateway.slash_commands.__file__", fake_file), \
+             patch("gateway.slash_commands.detect_install_method",
+                   return_value="pip"), \
+             patch("shutil.which", return_value="/usr/bin/hermes"), \
+             patch("subprocess.Popen") as mock_popen:
+            result = await runner._handle_update_command(event)
+
+        # Should NOT return the "Not a git repository" error
+        assert "Not a git repository" not in result
 
     @pytest.mark.asyncio
     async def test_no_hermes_binary(self, tmp_path):


### PR DESCRIPTION
## Problem

`/update` from Telegram (and all other messaging platforms) returns "✗ Not a git repository — cannot update." on pip/pipx installs.

The handler hardcodes `Path(__file__).parent.parent.resolve() / '.git'` — for pipx installs this resolves into `site-packages/` where there's no `.git` directory, so the command bails immediately.

Meanwhile, CLI `hermes update` works fine because it uses `detect_install_method()` → sees the `pip` stamp → runs through the pipx wrapper.

## Fix

Use `detect_install_method(project_root)` before the `.git` gate. When the method is `pip`, skip the `.git` check — the spawned `hermes update --gateway` handles pipx installs correctly.

## Changes

- **`gateway/slash_commands.py`**: Import `detect_install_method` at module level; replace the unconditional `.git` check with `if install_method != "pip" and not git_dir.exists()`
- **`tests/gateway/test_update_command.py`**: Replace the single `test_no_git_directory` with two focused tests:
  - `test_no_git_directory_unknown_method` — still returns "Not a git repository" when method is not `pip`
  - `test_no_git_directory_pip_install_proceeds` — pip installs without `.git` proceed to spawn the update

All 36 tests pass.