### PR TITLE
fix(mem0): bound Ollama tags response

### DIFF
--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -23,6 +23,8 @@ from ._oss_providers import (
     validate_oss_config,
 )
 
+_OLLAMA_TAGS_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+
 
 def _curses_select(title: str, items: list[tuple[str, str]], default: int = 0) -> int:
     """Interactive single-select with arrow keys."""
@@ -535,13 +537,23 @@ def _ollama_has_model(url: str, model: str) -> bool:
     """Check if Ollama already has a model pulled."""
     try:
         req = urllib.request.Request(f"{url}/api/tags", method="GET")
-        resp = urllib.request.urlopen(req, timeout=5)
-        data = json.loads(resp.read())
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = _read_json_response(resp, _OLLAMA_TAGS_RESPONSE_BODY_MAX_BYTES)
         names = [m.get("name", "") for m in data.get("models", [])]
         base_model = model.split(":")[0]
         return any(model in n or base_model in n for n in names)
     except Exception:
         return False
+
+
+def _read_json_response(resp, max_bytes: int) -> dict:
+    raw = resp.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise ValueError(f"response exceeded {max_bytes} bytes")
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("response was not a JSON object")
+    return data
 
 
 def _ensure_pgvector_extension(pg_config: dict) -> None:

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -23,6 +23,8 @@ from ._oss_providers import (
     validate_oss_config,
 )
 
+_OLLAMA_TAGS_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+
 
 def _curses_select(title: str, items: list[tuple[str, str]], default: int = 0) -> int:
     """Interactive single-select with arrow keys."""
@@ -665,13 +667,23 @@ def _ollama_has_model(url: str, model: str) -> bool:
     """Check if Ollama already has a model pulled."""
     try:
         req = urllib.request.Request(f"{url}/api/tags", method="GET")
-        resp = urllib.request.urlopen(req, timeout=5)
-        data = json.loads(resp.read())
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = _read_json_response(resp, _OLLAMA_TAGS_RESPONSE_BODY_MAX_BYTES)
         names = [m.get("name", "") for m in data.get("models", [])]
         base_model = model.split(":")[0]
         return any(model in n or base_model in n for n in names)
     except Exception:
         return False
+
+
+def _read_json_response(resp, max_bytes: int) -> dict:
+    raw = resp.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise ValueError(f"response exceeded {max_bytes} bytes")
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("response was not a JSON object")
+    return data
 
 
 def _ensure_pgvector_extension(pg_config: dict) -> None:

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -12,6 +12,7 @@ from plugins.memory.mem0._setup import (
     build_oss_config,
     _write_env,
     post_setup,
+    _ollama_has_model,
     _check_qdrant_path,
     _check_ollama,
     _check_pgvector,
@@ -245,6 +246,56 @@ class TestConnectivityChecks:
     def test_ollama_unreachable(self):
         ok, msg = _check_ollama("http://localhost:1")
         assert ok is False
+
+    def test_ollama_has_model_bounds_tags_response_read(self, monkeypatch):
+        import plugins.memory.mem0._setup as setup_mod
+
+        captured = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, size=-1):
+                captured["size"] = size
+                data = json.dumps({
+                    "models": [{"name": "llama3:latest"}],
+                }).encode()
+                return data if size < 0 else data[:size]
+
+        monkeypatch.setattr(
+            setup_mod.urllib.request,
+            "urlopen",
+            lambda req, timeout=None: _Resp(),
+        )
+
+        assert _ollama_has_model("http://localhost:11434", "llama3:latest") is True
+        assert captured["size"] == setup_mod._OLLAMA_TAGS_RESPONSE_BODY_MAX_BYTES + 1
+
+    def test_ollama_has_model_rejects_oversized_tags_response(self, monkeypatch):
+        import plugins.memory.mem0._setup as setup_mod
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, size=-1):
+                return b"x" * size
+
+        monkeypatch.setattr(setup_mod, "_OLLAMA_TAGS_RESPONSE_BODY_MAX_BYTES", 8)
+        monkeypatch.setattr(
+            setup_mod.urllib.request,
+            "urlopen",
+            lambda req, timeout=None: _Resp(),
+        )
+
+        assert _ollama_has_model("http://localhost:11434", "llama3:latest") is False
 
     def test_pgvector_unreachable(self):
         ok, msg = _check_pgvector("localhost", 1)

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -13,6 +13,7 @@ from plugins.memory.mem0._setup import (
     _write_env,
     _prompt_api_key,
     post_setup,
+    _ollama_has_model,
     _check_qdrant_path,
     _check_ollama,
     _check_pgvector,
@@ -230,4 +231,58 @@ class TestConnectivityChecks:
         ok, msg = _check_qdrant_path(str(tmp_path / "qdrant"))
         assert ok is True
 
+
+    def test_ollama_has_model_bounds_tags_response_read(self, monkeypatch):
+        import plugins.memory.mem0._setup as setup_mod
+
+        captured = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                captured["closed"] = True
+                return False
+
+            def read(self, size=-1):
+                captured["size"] = size
+                data = captured.get("body") or json.dumps(
+                    {"models": [{"name": "llama3:latest"}]}
+                ).encode()
+                return data if size < 0 else data[:size]
+
+        monkeypatch.setattr(
+            setup_mod.urllib.request,
+            "urlopen",
+            lambda req, timeout=None: _Resp(),
+        )
+
+        assert _ollama_has_model("http://localhost:11434", "llama3:latest") is True
+        assert captured["size"] == setup_mod._OLLAMA_TAGS_RESPONSE_BODY_MAX_BYTES + 1
+        captured.update(body=b"[]", closed=False)
+        assert _ollama_has_model("http://localhost:11434", "llama3:latest") is False
+        assert captured["closed"] is True
+
+    def test_ollama_has_model_rejects_oversized_tags_response(self, monkeypatch):
+        import plugins.memory.mem0._setup as setup_mod
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, size=-1):
+                return b"x" * size
+
+        monkeypatch.setattr(setup_mod, "_OLLAMA_TAGS_RESPONSE_BODY_MAX_BYTES", 8)
+        monkeypatch.setattr(
+            setup_mod.urllib.request,
+            "urlopen",
+            lambda req, timeout=None: _Resp(),
+        )
+
+        assert _ollama_has_model("http://localhost:11434", "llama3:latest") is False
 


### PR DESCRIPTION
﻿Fixes #54826

## Summary

- Add a bounded JSON response reader for Mem0 setup's Ollama `/api/tags` model-presence check.
- Treat oversized/non-object responses like existing failed checks (`False`).
- Ensure the HTTP response is closed via the context manager.

## Tests

- `uv run --extra dev python -m pytest tests\plugins\memory\test_mem0_setup.py -q --basetemp .pytest-tmp-mem0-setup`
- `git diff --check`

`autoreview` was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` found no command).
