### PR TITLE
fix(security): bound MCP OSV response reads

### DIFF
--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -171,6 +171,50 @@ class TestCheckPackageForMalware:
             assert call_data["package"]["ecosystem"] == "PyPI"
             assert call_data["package"]["name"] == "mcp-server-fetch"
 
+    def test_query_osv_bounds_response_read(self):
+        """OSV JSON should be read with a defensive size cap."""
+        import tools.osv_check as osv_check
+
+        captured = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, size=-1):
+                captured["size"] = size
+                data = json.dumps({"vulns": [{"id": "MAL-1"}]}).encode()
+                return data if size < 0 else data[:size]
+
+        with patch("tools.osv_check.urllib.request.urlopen", return_value=_Resp()):
+            result = _query_osv("evil-pkg", "npm")
+
+        assert result == [{"id": "MAL-1"}]
+        assert captured["size"] == osv_check._OSV_RESPONSE_BODY_MAX_BYTES + 1
+
+    def test_oversized_osv_response_fails_open(self, monkeypatch):
+        """Oversized OSV responses should use the existing fail-open behavior."""
+        import tools.osv_check as osv_check
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, size=-1):
+                return b"x" * size
+
+        monkeypatch.setattr(osv_check, "_OSV_RESPONSE_BODY_MAX_BYTES", 8)
+        with patch("tools.osv_check.urllib.request.urlopen", return_value=_Resp()):
+            result = check_package_for_malware("npx", ["evil-pkg"])
+
+        assert result is None
+
 
 class TestLiveOsvQuery:
     """Live integration test against the real OSV API. Skipped if offline."""

--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -189,6 +189,55 @@ class TestCheckPackageForMalware:
             check_package_for_malware("uvx", ["mcp-server-fetch"])
         assert mock_url.call_count == 2
 
+    def test_query_osv_bounds_response_read(self):
+        """OSV JSON should be read with a defensive size cap."""
+        import tools.osv_check as osv_check
+
+        captured = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, size=-1):
+                captured["size"] = size
+                data = json.dumps({"vulns": [{"id": "MAL-1"}]}).encode()
+                return data if size < 0 else data[:size]
+
+        with patch("tools.osv_check.urllib.request.urlopen", return_value=_Resp()):
+            result = _query_osv("evil-pkg", "npm")
+
+        assert result == [{"id": "MAL-1"}]
+        assert captured["size"] == osv_check._OSV_RESPONSE_BODY_MAX_BYTES + 1
+
+    def test_oversized_osv_response_fails_open(self, monkeypatch):
+        """Oversized OSV responses should use the existing fail-open behavior."""
+        import tools.osv_check as osv_check
+
+        captured = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, size=-1):
+                captured["size"] = size
+                assert size >= 0, "OSV response reads must always be bounded"
+                return b"x" * size
+
+        monkeypatch.setattr(osv_check, "_OSV_RESPONSE_BODY_MAX_BYTES", 8)
+        with patch("tools.osv_check.urllib.request.urlopen", return_value=_Resp()):
+            result = check_package_for_malware("npx", ["evil-pkg"])
+
+        assert result is None
+        assert captured["size"] == osv_check._OSV_RESPONSE_BODY_MAX_BYTES + 1
+
 
 class TestLiveOsvQuery:
     """Live integration test against the real OSV API. Skipped if offline."""

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 _OSV_ENDPOINT = os.getenv("OSV_ENDPOINT", "https://api.osv.dev/v1/query")
 _TIMEOUT = 10  # seconds
+_OSV_RESPONSE_BODY_MAX_BYTES = 16 * 1024 * 1024
 
 
 def check_package_for_malware(
@@ -162,8 +163,18 @@ def _query_osv(
     )
 
     with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
-        result = json.loads(resp.read())
+        result = _read_osv_json_response(resp)
 
     vulns = result.get("vulns", [])
     # Only malware advisories — ignore regular CVEs
     return [v for v in vulns if v.get("id", "").startswith("MAL-")]
+
+
+def _read_osv_json_response(resp) -> dict:
+    raw = resp.read(_OSV_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _OSV_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(f"OSV response exceeded {_OSV_RESPONSE_BODY_MAX_BYTES} bytes")
+    result = json.loads(raw)
+    if not isinstance(result, dict):
+        raise ValueError("OSV response was not a JSON object")
+    return result

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 _OSV_ENDPOINT = os.getenv("OSV_ENDPOINT", "https://api.osv.dev/v1/query")
 _TIMEOUT = 10  # seconds
+_OSV_RESPONSE_BODY_MAX_BYTES = 16 * 1024 * 1024
 
 # Result cache: (ecosystem, package, version) -> (expiry_monotonic, result).
 # MCP reconnect ladders, stdio recycles, and parked-server self-probes re-run
@@ -211,8 +212,18 @@ def _query_osv(
     )
 
     with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
-        result = json.loads(resp.read())
+        result = _read_osv_json_response(resp)
 
     vulns = result.get("vulns", [])
     # Only malware advisories — ignore regular CVEs
     return [v for v in vulns if v.get("id", "").startswith("MAL-")]
+
+
+def _read_osv_json_response(resp) -> dict:
+    raw = resp.read(_OSV_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _OSV_RESPONSE_BODY_MAX_BYTES:
+        raise ValueError(f"OSV response exceeded {_OSV_RESPONSE_BODY_MAX_BYTES} bytes")
+    result = json.loads(raw)
+    if not isinstance(result, dict):
+        raise ValueError("OSV response was not a JSON object")
+    return result


### PR DESCRIPTION
﻿Fixes #54828

## Summary

- Add a bounded JSON reader for the MCP malware preflight OSV response.
- Keep existing fail-open behavior when the response is oversized or invalid.
- Cover bounded success reads and oversized-response fail-open behavior.

## Tests

- `uv run --extra dev python -m pytest tests\tools\test_osv_check.py -q -k "not LiveOsvQuery" --basetemp .pytest-tmp-osv-tool`
- `git diff --check`

`autoreview` was not available on this Windows environment (`Get-Command autoreview,agent-autoreview,codex-autoreview` found no command).
