### PR TITLE
fix(update): treat downstream shallow commits as current

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -237,7 +237,27 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         )
         if not head_rev or not target_rev:
             return None
-        return 0 if head_rev == target_rev else UPDATE_AVAILABLE_NO_COUNT
+        if head_rev == target_rev:
+            return 0
+
+        # A shallow installer checkout may legitimately carry downstream or
+        # packaging commits on top of the fetched upstream tip. Exact SHA
+        # comparison would report a phantom update forever in that state even
+        # though origin/main is already contained in HEAD. When the fetched
+        # target is an ancestor of HEAD, treat the checkout as up-to-date.
+        try:
+            ancestor = subprocess.run(
+                ["git", "merge-base", "--is-ancestor", target_rev, head_rev],
+                capture_output=True,
+                timeout=5,
+                cwd=str(repo_dir),
+            )
+            if ancestor.returncode == 0:
+                return 0
+        except Exception:
+            pass
+
+        return UPDATE_AVAILABLE_NO_COUNT
 
     try:
         result = subprocess.run(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8490,7 +8490,8 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
 
     if is_shallow:
         # No history to count across the shallow boundary. Compare tip SHAs and
-        # report presence-only (mirrors the banner's _check_via_local_git).
+        # then allow downstream/local carried commits whose HEAD already
+        # contains the fetched compare tip (mirrors banner._check_via_local_git).
         head_sha = subprocess.run(
             git_cmd + ["rev-parse", "HEAD"],
             cwd=PROJECT_ROOT, capture_output=True, text=True,
@@ -8499,7 +8500,16 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
             git_cmd + ["rev-parse", compare_branch],
             cwd=PROJECT_ROOT, capture_output=True, text=True,
         ).stdout.strip()
-        if head_sha and target_sha and head_sha == target_sha:
+        up_to_date = bool(head_sha and target_sha and head_sha == target_sha)
+        if not up_to_date and head_sha and target_sha:
+            ancestor = subprocess.run(
+                git_cmd + ["merge-base", "--is-ancestor", target_sha, head_sha],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            up_to_date = ancestor.returncode == 0
+        if up_to_date:
             print("✓ Already up to date.")
         else:
             print(f"⚕ Update available (behind {compare_branch}).")

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -704,6 +704,42 @@ def test_cmd_update_fetch_is_scoped_to_target_branch(monkeypatch, tmp_path):
     assert ["git", "fetch", "origin"] not in recorded
 
 
+def test_cmd_update_check_shallow_with_downstream_commit_reports_current(monkeypatch, tmp_path, capsys):
+    """`hermes update --check` should not report a phantom update when
+    a shallow checkout carries downstream commits on top of the fetched tip.
+    """
+    _setup_update_mocks(monkeypatch, tmp_path)
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return SimpleNamespace(stdout="true\n", stderr="", returncode=0)
+        if cmd == ["git", "fetch", "--depth", "1", "upstream", "main"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd == ["git", "rev-parse", "--verify", "--quiet", "upstream/main"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return SimpleNamespace(stdout="downstream-sha\n", stderr="", returncode=0)
+        if cmd == ["git", "rev-parse", "upstream/main"]:
+            return SimpleNamespace(stdout="upstream-sha\n", stderr="", returncode=0)
+        if cmd == ["git", "merge-base", "--is-ancestor", "upstream-sha", "downstream-sha"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd[:2] == ["git", "rev-list"]:
+            raise AssertionError("shallow check path must not count commits")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main._cmd_update_check()
+
+    out = capsys.readouterr().out
+    assert "Already up to date" in out
+    assert "Update available" not in out
+    assert ["git", "merge-base", "--is-ancestor", "upstream-sha", "downstream-sha"] in calls
+
+
 # ---------------------------------------------------------------------------
 # Fetch failure — friendly error messages
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -170,6 +170,46 @@ def test_check_via_local_git_shallow_clone_behind_reports_no_count(tmp_path):
     assert ["git", "fetch", "origin", "--depth", "1", "--quiet"] in calls
 
 
+def test_check_via_local_git_shallow_clone_with_downstream_commit_is_current(tmp_path):
+    """Shallow clones may carry downstream commits on top of upstream.
+
+    If the fetched upstream tip is already an ancestor of HEAD, the checkout is
+    current even though the two tip SHAs differ. The banner should not report a
+    phantom update in that state.
+    """
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="true\n")
+        if cmd[:2] == ["git", "fetch"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="downstream-sha\n")
+        if cmd == ["git", "rev-parse", "FETCH_HEAD"]:
+            return MagicMock(returncode=0, stdout="upstream-sha\n")
+        if cmd == ["git", "merge-base", "--is-ancestor", "upstream-sha", "downstream-sha"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            raise AssertionError("shallow path must not count across the boundary")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == 0
+    assert ["git", "merge-base", "--is-ancestor", "upstream-sha", "downstream-sha"] in calls
+
+
 def test_check_via_local_git_shallow_clone_up_to_date(tmp_path):
     """Shallow clone whose tip matches upstream reports up-to-date (0)."""
     import hermes_cli.banner as banner


### PR DESCRIPTION
## Summary
- Treat shallow checkouts with downstream commits on top of the fetched upstream tip as up to date.
- Covers both the passive banner update check and `hermes update --check`.
- Adds regression tests for the ancestor case so shallow checkouts do not report phantom updates.

## Problem
Installer checkouts can be shallow. In that mode, the update checker avoids counting commits across the shallow boundary and compares tip SHAs instead.

That works for a plain shallow checkout, but it reports an update forever when the checkout carries downstream or packaging commits on top of the fetched upstream tip: `HEAD` and the fetched tip differ, even though the fetched tip is already contained in `HEAD`.

## Root cause
The shallow update paths only treated exact SHA equality as current. They did not check whether the fetched compare ref was an ancestor of `HEAD` before reporting an update.

## Fix
When the shallow-path tip SHAs differ, run:

```bash
git merge-base --is-ancestor <fetched-tip> HEAD
```

If that succeeds, the checkout already contains the fetched upstream tip and should be reported as up to date. If it fails, the existing presence-only update reporting remains unchanged.

## Tests
- [x] `scripts/run_tests.sh tests/hermes_cli/test_update_check.py tests/hermes_cli/test_update_autostash.py -q`
