### PR TITLE
Bound dashboard registration portal responses

### DIFF
--- a/hermes_cli/dashboard_register.py
+++ b/hermes_cli/dashboard_register.py
@@ -33,6 +33,9 @@ import urllib.request
 from typing import Optional
 
 
+_DASHBOARD_REGISTER_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
+
+
 # Docker-style name generator. Same vibe as Docker's adjective_surname, but
 # adjective_noun with a space-free underscore join so it drops cleanly into a
 # label field. There is NO uniqueness constraint on the portal side (the row
@@ -60,6 +63,23 @@ _NAME_NOUNS = (
 def _generate_dashboard_name() -> str:
     """Return a human-readable ``adjective_noun`` name (Docker-style)."""
     return f"{random.choice(_NAME_ADJECTIVES)}_{random.choice(_NAME_NOUNS)}"
+
+
+def _read_portal_json_response(resp) -> dict:
+    """Read a bounded JSON object response from the portal."""
+    raw = resp.read(_DASHBOARD_REGISTER_RESPONSE_BODY_MAX_BYTES + 1)
+    if len(raw) > _DASHBOARD_REGISTER_RESPONSE_BODY_MAX_BYTES:
+        raise RuntimeError(
+            "Portal response exceeded "
+            f"{_DASHBOARD_REGISTER_RESPONSE_BODY_MAX_BYTES} bytes."
+        )
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Portal returned an invalid JSON response.") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Portal returned an unexpected JSON response.")
+    return payload
 
 
 def _resolve_portal_base_url(override: Optional[str] = None) -> str:
@@ -139,12 +159,12 @@ def _register_self_hosted_client(
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
+            payload = _read_portal_json_response(resp)
     except urllib.error.HTTPError as exc:
         # The endpoint returns structured JSON errors ({error, error_description}).
         detail = ""
         try:
-            err_body = json.loads(exc.read().decode())
+            err_body = _read_portal_json_response(exc)
             detail = (
                 err_body.get("error_description")
                 or err_body.get("error")

--- a/tests/hermes_cli/test_dashboard_register.py
+++ b/tests/hermes_cli/test_dashboard_register.py
@@ -612,3 +612,62 @@ class TestPortalErrors:
         )
         assert code == 1
         assert "Not permitted here." in capsys.readouterr().out
+
+    def test_success_response_read_is_bounded(self):
+        reads: list[int] = []
+
+        class Body(BytesIO):
+            def read(self, size=-1):
+                reads.append(size)
+                return super().read(size)
+
+        body = Body(b'{"client_id":"agent:selfhost-1"}')
+        cm = MagicMock()
+        cm.__enter__.return_value = body
+
+        with patch.object(dr.urllib.request, "urlopen", return_value=cm):
+            payload = dr._register_self_hosted_client(
+                access_token="tok",
+                portal_base_url="https://portal.nousresearch.com",
+                name="dash",
+                custom_redirect_uri=None,
+            )
+
+        assert payload["client_id"] == "agent:selfhost-1"
+        assert reads == [dr._DASHBOARD_REGISTER_RESPONSE_BODY_MAX_BYTES + 1]
+
+    def test_oversized_success_response_is_rejected(self):
+        body = BytesIO(b"x" * (dr._DASHBOARD_REGISTER_RESPONSE_BODY_MAX_BYTES + 1))
+        cm = MagicMock()
+        cm.__enter__.return_value = body
+
+        with patch.object(dr.urllib.request, "urlopen", return_value=cm):
+            with pytest.raises(RuntimeError, match="exceeded"):
+                dr._register_self_hosted_client(
+                    access_token="tok",
+                    portal_base_url="https://portal.nousresearch.com",
+                    name="dash",
+                    custom_redirect_uri=None,
+                )
+
+    def test_oversized_error_response_falls_back_to_http_status(self):
+        err = urllib.error.HTTPError(
+            url="https://portal.nousresearch.com/api/oauth/self-hosted-client",
+            code=500,
+            msg="err",
+            hdrs=None,
+            fp=BytesIO(
+                b"x" * (dr._DASHBOARD_REGISTER_RESPONSE_BODY_MAX_BYTES + 1)
+            ),
+        )
+
+        with patch.object(dr.urllib.request, "urlopen", side_effect=err):
+            with pytest.raises(RuntimeError, match="Portal returned HTTP 500") as exc:
+                dr._register_self_hosted_client(
+                    access_token="tok",
+                    portal_base_url="https://portal.nousresearch.com",
+                    name="dash",
+                    custom_redirect_uri=None,
+                )
+
+        assert "xxx" not in str(exc.value)


### PR DESCRIPTION
## Summary
- add a 1 MiB cap for `hermes dashboard register` portal JSON responses
- reuse the bounded reader for both success and structured HTTP error bodies
- keep oversized HTTP error responses on the existing generic `Portal returned HTTP <code>` path instead of buffering the body

Fixes #54832

## Validation
- `uv run --extra dev python -m pytest tests\hermes_cli\test_dashboard_register.py -q --basetemp .pytest-tmp-dashboard-register` (40 passed)
- `git diff --check`
- `autoreview` helper unavailable locally (`autoreview`, `agent-autoreview`, and `codex-autoreview` not found)