### PR TITLE
Bound webhook test response output

### DIFF
--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -26,6 +26,7 @@ from hermes_cli.config import cfg_get
 
 _SUBSCRIPTIONS_FILENAME = "webhook_subscriptions.json"
 _SUBSCRIPTIONS_FILE_MODE = 0o600
+_WEBHOOK_TEST_RESPONSE_BODY_MAX_BYTES = 1024 * 1024
 
 
 def _hermes_home() -> Path:
@@ -134,6 +135,15 @@ def _require_webhook_enabled() -> bool:
         return True
     print(_setup_hint())
     return False
+
+
+def _read_webhook_test_response(resp) -> tuple[str, bool]:
+    """Return a bounded response preview and whether it was truncated."""
+    raw = resp.read(_WEBHOOK_TEST_RESPONSE_BODY_MAX_BYTES + 1)
+    truncated = len(raw) > _WEBHOOK_TEST_RESPONSE_BODY_MAX_BYTES
+    if truncated:
+        raw = raw[:_WEBHOOK_TEST_RESPONSE_BODY_MAX_BYTES]
+    return raw.decode("utf-8", errors="replace"), truncated
 
 
 def webhook_command(args):
@@ -291,8 +301,13 @@ def _cmd_test(args):
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=10) as resp:
-            body = resp.read().decode()
-            print(f"  Response ({resp.status}): {body}")
+            body, truncated = _read_webhook_test_response(resp)
+            suffix = (
+                f" (truncated after {_WEBHOOK_TEST_RESPONSE_BODY_MAX_BYTES} bytes)"
+                if truncated
+                else ""
+            )
+            print(f"  Response ({resp.status}){suffix}: {body}")
     except Exception as e:
         print(f"  Error: {e}")
         print("  Is the gateway running? (hermes gateway run)")

--- a/tests/hermes_cli/test_webhook.py
+++ b/tests/hermes_cli/test_webhook.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import hermes_cli.webhook as webhook
+
+
+class _Response:
+    status = 202
+
+    def __init__(self, body: bytes, reads: list[int]):
+        self._body = body
+        self._reads = reads
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, size=-1):
+        self._reads.append(size)
+        return self._body[:size] if size >= 0 else self._body
+
+
+def _args(**overrides):
+    values = {"name": "build", "payload": '{"ok":true}'}
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_webhook_test_reads_bounded_response(monkeypatch, capsys):
+    monkeypatch.setattr(webhook, "_WEBHOOK_TEST_RESPONSE_BODY_MAX_BYTES", 8)
+    monkeypatch.setattr(
+        webhook,
+        "_load_subscriptions",
+        lambda: {"build": {"secret": "secret"}},
+    )
+    monkeypatch.setattr(webhook, "_get_webhook_base_url", lambda: "http://127.0.0.1:8644")
+    reads: list[int] = []
+
+    def fake_urlopen(req, timeout=0):
+        assert req.full_url == "http://127.0.0.1:8644/webhooks/build"
+        assert timeout == 10
+        return _Response(b"accepted", reads)
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        webhook._cmd_test(_args())
+
+    assert reads == [9]
+    out = capsys.readouterr().out
+    assert "Response (202): accepted" in out
+    assert "truncated" not in out
+
+
+def test_webhook_test_truncates_oversized_response(monkeypatch, capsys):
+    monkeypatch.setattr(webhook, "_WEBHOOK_TEST_RESPONSE_BODY_MAX_BYTES", 8)
+    monkeypatch.setattr(
+        webhook,
+        "_load_subscriptions",
+        lambda: {"build": {"secret": "secret"}},
+    )
+    monkeypatch.setattr(webhook, "_get_webhook_base_url", lambda: "http://127.0.0.1:8644")
+    reads: list[int] = []
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_Response(b"accepted-extra", reads),
+    ):
+        webhook._cmd_test(_args())
+
+    assert reads == [9]
+    out = capsys.readouterr().out
+    assert "Response (202) (truncated after 8 bytes): accepted" in out
+    assert "extra" not in out


### PR DESCRIPTION
## Summary
- add a bounded response preview for `hermes webhook test`
- read only `limit + 1` bytes so oversized diagnostic responses are detected without buffering the whole body
- print an explicit truncation marker while preserving normal short-response output

Fixes #54836

## Validation
- `uv run --extra dev python -m pytest tests\hermes_cli\test_webhook.py -q --basetemp .pytest-tmp-webhook-test` (2 passed)
- `git diff --check`
- `autoreview` helper unavailable locally (`autoreview`, `agent-autoreview`, and `codex-autoreview` not found)