### PR TITLE
Bound Codex image generation error previews

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -94,6 +94,8 @@ _MAX_INPUT_IMAGE_BYTES = 25 * 1024 * 1024
 _ACCEPTED_INPUT_MIME = frozenset(
     {"image/png", "image/jpeg", "image/gif", "image/webp"}
 )
+_CODEX_ERROR_BODY_MAX_BYTES = 1024 * 1024
+_CODEX_ERROR_PREVIEW_CHARS = 500
 
 
 # ---------------------------------------------------------------------------
@@ -360,6 +362,37 @@ def _iter_sse_json(response: Any):
         yield payload
 
 
+def _codex_error_response_preview(response: Any) -> str:
+    """Read a bounded preview from a streamed Codex error response."""
+    chunks: List[bytes] = []
+    total = 0
+    limit = _CODEX_ERROR_BODY_MAX_BYTES
+
+    for chunk in response.iter_bytes():
+        if isinstance(chunk, str):
+            chunk = chunk.encode("utf-8", errors="replace")
+        if not isinstance(chunk, (bytes, bytearray)) or not chunk:
+            continue
+        remaining = limit + 1 - total
+        if remaining <= 0:
+            break
+        piece = bytes(chunk[:remaining])
+        chunks.append(piece)
+        total += len(piece)
+        if total > limit:
+            break
+
+    raw = b"".join(chunks)
+    truncated = len(raw) > limit
+    if truncated:
+        raw = raw[:limit]
+
+    preview = raw.decode("utf-8", errors="replace")[:_CODEX_ERROR_PREVIEW_CHARS]
+    if truncated:
+        preview += f" ... [truncated after {limit} bytes]"
+    return preview
+
+
 def _collect_image_b64(
     token: str,
     *,
@@ -392,8 +425,7 @@ def _collect_image_b64(
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as exc:
-                exc.response.read()
-                body = exc.response.text[:500]
+                body = _codex_error_response_preview(exc.response)
                 raise RuntimeError(
                     f"Codex Responses API returned HTTP {exc.response.status_code}: {body}"
                 ) from exc

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -414,6 +414,7 @@ def _collect_image_b64(
     """Stream a Codex Responses image_generation call and return the b64 image."""
     import httpx
     from agent.auxiliary_client import _codex_cloudflare_headers
+    from agent.bounded_response import read_streaming_error_body
 
     headers = _codex_cloudflare_headers(token)
     headers.update({
@@ -435,10 +436,10 @@ def _collect_image_b64(
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as exc:
-                exc.response.read()
+                body = read_streaming_error_body(exc.response)
                 raise RuntimeError(
                     f"Codex Responses API returned HTTP {exc.response.status_code}: "
-                    f"{_summarize_error_body(exc.response.text)}"
+                    f"{_summarize_error_body(body)}"
                 ) from exc
             for event in _iter_sse_json(response):
                 found = _extract_image_b64(event)

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -271,6 +271,17 @@ class TestGenerate:
             "item": {"type": "image_generation_call", "result": "abc"},
         }]
 
+    def test_error_response_preview_is_bounded(self, monkeypatch):
+        class _Response:
+            def iter_bytes(self):
+                yield b"a" * 8
+                yield b"b" * 8
+
+        monkeypatch.setattr(codex_plugin, "_CODEX_ERROR_BODY_MAX_BYTES", 10)
+        preview = codex_plugin._codex_error_response_preview(_Response())
+
+        assert preview == "a" * 8 + "b" * 2 + " ... [truncated after 10 bytes]"
+
     def test_final_response_sweep_recovers_image(self):
         """Completed response output is found by recursive payload scanning."""
         payload = {

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -300,8 +300,8 @@ class TestRequestShape:
         assert payload["tools"][0]["type"] == "image_generation"
         assert payload["instructions"]
 
-    def test_http_error_body_is_truncated_but_preserved(self, monkeypatch):
-        """A large error body is capped at 500 chars and still surfaced."""
+    def test_http_error_stream_is_bounded_and_preserved(self, monkeypatch):
+        """A streamed error is not fully drained and its message is surfaced."""
         import httpx
 
         body = json.dumps({
@@ -311,8 +311,22 @@ class TestRequestShape:
             },
         })
 
+        class _Body(httpx.SyncByteStream):
+            total_chunks = 128
+
+            def __init__(self):
+                self.yielded = 0
+
+            def __iter__(self):
+                yield body.encode()
+                for _ in range(self.total_chunks):
+                    self.yielded += 1
+                    yield b" " * 4096
+
+        stream = _Body()
+
         def _handler(request):
-            return httpx.Response(400, text=body, request=request)
+            return httpx.Response(400, stream=stream, request=request)
 
         real_client = httpx.Client
         monkeypatch.setattr(
@@ -337,6 +351,7 @@ class TestRequestShape:
         # Body is capped, but the actionable wire message still reaches the user.
         assert "tools' parameter" in message
         assert len(message) < len(body)
+        assert stream.yielded < stream.total_chunks
 
 
 # ── Plugin entry point ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a bounded preview reader for streamed Codex image-generation HTTP error responses
- avoid calling `response.read()` on non-2xx Codex Responses API errors before truncating the displayed message
- keep the existing 500-character diagnostic preview behavior, with an explicit truncation marker for oversized bodies

Fixes #54841

## Validation
- `uv run --extra dev python -m pytest tests\plugins\image_gen\test_openai_codex_provider.py -q --basetemp .pytest-tmp-codex-image-error-preview` (19 passed)
- `git diff --check`
- `autoreview` helper unavailable locally (`autoreview`, `agent-autoreview`, and `codex-autoreview` not found)