### PR TITLE
Enforce Raft bridge body limit while reading

### DIFF
--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -97,6 +97,17 @@ _RAFT_TURN_IDS: set[str] = set()
 _RAFT_PROMPT_TURN_IDS: set[str] = set()
 
 
+async def _read_limited_request_body(request: "web.Request", max_bytes: int) -> bytes:
+    """Read at most ``max_bytes`` from a request body, detecting overflow."""
+    try:
+        body = await request.content.readexactly(max_bytes + 1)
+    except asyncio.IncompleteReadError as exc:
+        body = exc.partial
+    if len(body) > max_bytes:
+        raise ValueError("payload_too_large")
+    return body
+
+
 def check_raft_requirements() -> bool:
     """Check if Raft channel dependencies are available.
 
@@ -599,7 +610,9 @@ class RaftAdapter(BasePlatformAdapter):
             return web.json_response({"ok": False, "error": "payload_too_large"}, status=413)
 
         try:
-            raw_body = await request.read()
+            raw_body = await _read_limited_request_body(request, self._max_body_bytes)
+        except ValueError:
+            return web.json_response({"ok": False, "error": "payload_too_large"}, status=413)
         except Exception:
             return web.json_response({"ok": False, "error": "bad_request"}, status=400)
 
@@ -646,8 +659,11 @@ class RaftAdapter(BasePlatformAdapter):
             return web.json_response({"ok": False, "error": "payload_too_large"}, status=413)
 
         try:
-            payload = json.loads(await request.text())
+            raw_body = await _read_limited_request_body(request, self._max_body_bytes)
+            payload = json.loads(raw_body)
             self._activity_queue.push(payload)
+        except ValueError:
+            return web.json_response({"ok": False, "error": "payload_too_large"}, status=413)
         except json.JSONDecodeError:
             return web.json_response({"ok": False, "error": "invalid_json"}, status=400)
         except Exception as exc:

--- a/tests/plugins/test_raft_body_limit.py
+++ b/tests/plugins/test_raft_body_limit.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from plugins.platforms.raft.adapter import _read_limited_request_body
+
+
+class _Content:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_size = None
+
+    async def readexactly(self, size: int) -> bytes:
+        self.read_size = size
+        if len(self.body) < size:
+            raise asyncio.IncompleteReadError(self.body, size)
+        return self.body[:size]
+
+
+class _Request:
+    def __init__(self, body: bytes):
+        self.content = _Content(body)
+
+
+def test_read_limited_request_body_returns_short_body():
+    request = _Request(b'{"ok":true}')
+
+    body = asyncio.run(_read_limited_request_body(request, 16))
+
+    assert body == b'{"ok":true}'
+    assert request.content.read_size == 17
+
+
+def test_read_limited_request_body_rejects_oversized_body():
+    request = _Request(b"x" * 17)
+
+    with pytest.raises(ValueError, match="payload_too_large"):
+        asyncio.run(_read_limited_request_body(request, 16))
+
+    assert request.content.read_size == 17


### PR DESCRIPTION
## Summary
- add a bounded request-body reader for the Raft bridge adapter
- enforce `max_body_bytes` while reading `/wake` and `/activity`, not only from `Content-Length`
- preserve the existing `payload_too_large` 413 response for oversized bridge bodies

Fixes #54844

## Validation
- `uv run --extra dev python -m pytest tests\plugins\test_raft_body_limit.py tests\plugins\test_raft_check_fn_silent.py -q --basetemp .pytest-tmp-raft-body-limit` (7 passed)
- `git diff --check`
- `autoreview` helper unavailable locally (`autoreview`, `agent-autoreview`, and `codex-autoreview` not found)