### PR TITLE
fix(session-db): enrich NULL session metadata via upsert

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1486,14 +1486,35 @@ class SessionDB:
         parent_session_id: str = None,
         cwd: str = None,
     ) -> None:
-        """Shared INSERT OR IGNORE for session rows."""
+        """Insert a session row, enriching NULL metadata on conflict.
+
+        The gateway's ``get_or_create_session`` creates a bare row (source +
+        user_id) *before* the agent exists; the agent's later
+        ``create_session`` then carries the real ``model`` / ``model_config`` /
+        ``system_prompt``. A plain ``INSERT OR IGNORE`` silently dropped that
+        enrichment, leaving gateway sessions with NULL model/billing metadata.
+        The ``ON CONFLICT`` upsert backfills those fields via ``COALESCE`` —
+        only filling columns that are still NULL, never overwriting values an
+        earlier writer already set (so a later bare call with source="unknown"
+        can't clobber a real source/model).
+        """
         def _do(conn):
             conn.execute(
-                """INSERT OR IGNORE INTO sessions (
+                """INSERT INTO sessions (
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
                    model, model_config, system_prompt, parent_session_id, cwd, started_at
                 )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(id) DO UPDATE SET
+                       model = COALESCE(sessions.model, excluded.model),
+                       model_config = COALESCE(sessions.model_config, excluded.model_config),
+                       system_prompt = COALESCE(sessions.system_prompt, excluded.system_prompt),
+                       session_key = COALESCE(sessions.session_key, excluded.session_key),
+                       chat_id = COALESCE(sessions.chat_id, excluded.chat_id),
+                       chat_type = COALESCE(sessions.chat_type, excluded.chat_type),
+                       thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
+                       parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
+                       cwd = COALESCE(sessions.cwd, excluded.cwd)""",
                 (
                     session_id,
                     source,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -96,6 +96,37 @@ class TestSessionLifecycle:
     def test_get_nonexistent_session(self, db):
         assert db.get_session("nonexistent") is None
 
+    def test_create_session_enriches_null_metadata_on_conflict(self, db):
+        """Gateway creates a bare row first; the agent's later create_session
+        must backfill model/model_config/system_prompt without clobbering the
+        gateway's source/user_id/chat_id. Regression for NULL gateway metadata
+        (sessions with NULL billing_provider/model)."""
+        # Gateway bare row (source + user_id only), before the agent exists.
+        db.create_session("s1", source="telegram", user_id="u1", chat_id="c1")
+        bare = db.get_session("s1")
+        assert bare["model"] is None
+        # Agent enriches — passes source="cli" but real metadata.
+        db.create_session(
+            "s1", source="cli", model="claude-opus-4-6",
+            model_config={"max_iterations": 90}, system_prompt="SYS",
+        )
+        enriched = db.get_session("s1")
+        assert enriched["model"] == "claude-opus-4-6"
+        assert enriched["system_prompt"] == "SYS"
+        # Gateway-owned fields preserved (NOT clobbered by source="cli").
+        assert enriched["source"] == "telegram"
+        assert enriched["user_id"] == "u1"
+        assert enriched["chat_id"] == "c1"
+
+    def test_create_session_does_not_overwrite_existing_metadata(self, db):
+        """A later bare write (source='unknown', model=...) must not overwrite
+        a model/source an earlier writer already set."""
+        db.create_session("s1", source="cli", model="real-model")
+        db.create_session("s1", source="unknown", model="should-not-win")
+        session = db.get_session("s1")
+        assert session["model"] == "real-model"
+        assert session["source"] == "cli"
+
     def test_update_session_cwd_persists_git_branch(self, db):
         db.create_session(session_id="s1", source="cli")
         db.update_session_cwd("s1", "/work/repo", git_branch="pets-feature")


### PR DESCRIPTION
## Summary

Gateway sessions now persist their model and billing metadata instead of leaving it NULL.

**Root cause:** the gateway's `get_or_create_session()` writes a bare session row (source + user_id) *before* the agent exists. The agent's later `create_session()` carries the real `model` / `model_config` / `system_prompt`, but `_insert_session_row` used `INSERT OR IGNORE`, which silently dropped that enrichment because the row already existed. Gateway sessions were left with NULL model and NULL billing metadata.

## Changes

- `hermes_state.py`: `_insert_session_row` switches from `INSERT OR IGNORE` to `INSERT ... ON CONFLICT(id) DO UPDATE` with `COALESCE`. NULL columns (`model`, `model_config`, `system_prompt`, `session_key`, `chat_id`, `chat_type`, `thread_id`, `parent_session_id`, `cwd`) get backfilled by a later writer; values an earlier writer already set are never overwritten (a later bare write with `source='unknown'` cannot clobber a real source/model).
- `tests/test_hermes_state.py`: two regression tests — enrichment-on-conflict and no-overwrite-of-existing.

## Validation

| | Before | After |
|---|---|---|
| Gateway session model field | NULL (enrichment dropped) | backfilled from agent's create_session |
| Existing model overwritten by bare write | n/a | no (COALESCE keeps earlier value) |
| state-DB tests | — | 295/295 pass |
| E2E scenarios (bare→enrich, no-overwrite, fresh create, token-write path) | — | 4/4 pass |

## Credit

Original report and fix direction by @LucidPaths in #5048. That PR's other three claims (alias pricing, cached-agent stale session_id, silent token errors) are already addressed on current `main` — alias pricing is handled by canonical alias pricing keys + `_normalize_anthropic_model_name`, the session_id sync is now agent-driven via `agent_result["session_id"]`, and token-write paths already use `logger.debug`/`logger.warning`. This PR salvages the one remaining live gap.

## Infographic

![Session metadata upsert fix](https://v3b.fal.media/files/b/0aa03b5f/0rmKbzRxca4mPGYUipg7Q_cmCkRwFY.png)
