### PR TITLE
fix(gateway): use last_prompt_tokens for session-reset activity check

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1217,8 +1217,11 @@ class SessionStore:
                     # Session is being auto-reset.
                     was_auto_reset = True
                     auto_reset_reason = reset_reason
-                    # Track whether the expired session had any real conversation
-                    reset_had_activity = entry.total_tokens > 0
+                    # Track whether the expired session had any real conversation.
+                    # total_tokens is never written (token counts migrated to
+                    # agent-direct persistence) so it is always 0 — use
+                    # last_prompt_tokens, which is updated on every turn.
+                    reset_had_activity = entry.last_prompt_tokens > 0
                     db_end_session_id = entry.session_id
             else:
                 was_auto_reset = False

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -153,8 +153,9 @@ class TestSessionEntryReason:
         source = _make_source()
 
         entry1 = store.get_or_create_session(source)
-        # Simulate some conversation happened
-        entry1.total_tokens = 5000
+        # Simulate some conversation happened (last_prompt_tokens is the field
+        # written on every turn; total_tokens is never persisted).
+        entry1.last_prompt_tokens = 5000
         entry1.updated_at = datetime.now() - timedelta(minutes=5)
         store._save()
 
@@ -245,7 +246,7 @@ class TestSessionEntryAutoResetRoundtrip:
         source = _make_source()
 
         entry = store.get_or_create_session(source)
-        entry.total_tokens = 1000
+        entry.last_prompt_tokens = 1000
         entry.updated_at = datetime.now() - timedelta(minutes=5)
         store._save()
 


### PR DESCRIPTION
## Summary
Session-reset notifications now fire for sessions that actually had activity. The activity check read `entry.total_tokens`, which is never written anymore (token counts migrated to agent-direct persistence), so `reset_had_activity` was always `False` and the user was never told their active session had been auto-reset.

Root cause: `reset_had_activity = entry.total_tokens > 0` in `get_or_create_session`. `total_tokens` is only a field default + serialized value — nothing assigns it. `last_prompt_tokens` is the field updated on every turn (run.py).

## Changes
- `gateway/session.py`: activity check reads `last_prompt_tokens` instead of the dead `total_tokens` field.
- `tests/gateway/test_session_reset_notify.py`: fixtures now set `last_prompt_tokens` (the field production records) instead of `total_tokens`.

## Validation
| | Before | After |
|---|---|---|
| Active session auto-reset | `reset_had_activity=False` → no notify | `True` → notifies |
| Idle/no-activity session | `False` → no notify | `False` → no notify |
| `tests/gateway/test_session.py` | — | 92 passed |
| `tests/gateway/test_session_reset_notify.py` | — | passed |
| E2E (real SessionStore) | — | active→notify, idle→silent |

## Attribution
Salvaged from #5383 by @Mibayy. That PR's title/body described an unrelated session-ID-header fix, but the branch's actual commit was this session-reset fix (the contributor force-pushed a different change without updating the description). The stream_consumer half of the original commit is already addressed on current `main`, so only the session.py fix was lifted, with @Mibayy's authorship preserved. Closes #5383.

## Infographic
![Session-reset notification fix](https://v3b.fal.media/files/b/0aa03b68/YV34jwnQ_o1tTkwtnahUW_adKeb9vw.png)
