### PR TITLE
fix: allow review tasks to complete

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3990,7 +3990,7 @@ def complete_task(
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``running|ready -> done`` and record ``result``.
+    """Transition ``running|ready|blocked|review -> done`` and record ``result``.
 
     Accepts a task that is merely ``ready`` too, so a manual CLI
     completion (``hermes kanban complete <id>``) works without requiring
@@ -4064,7 +4064,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked', 'review')
                 """,
                 (result, now, task_id),
             )
@@ -4081,7 +4081,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked', 'review')
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3895,6 +3895,52 @@ def test_claim_review_task_fails_when_already_claimed(kanban_home):
     assert second is None
 
 
+def test_complete_review_task_transitions_to_done(kanban_home):
+    """Review tasks should be completable after manual merge/reconciliation."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="merged PR handoff", assignee="alice")
+        _set_task_status(conn, t, "review")
+
+        assert kb.complete_task(conn, t, summary="merged and verified")
+
+        row = conn.execute(
+            "SELECT status, completed_at, result FROM tasks WHERE id = ?",
+            (t,),
+        ).fetchone()
+    assert row["status"] == "done"
+    assert row["completed_at"] is not None
+    assert row["result"] is None
+
+
+def test_complete_review_task_with_matching_expected_run_id_succeeds(kanban_home):
+    """A review task with its active run should complete by matching run id."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="merged PR handoff", assignee="alice")
+        claimed = kb.claim_task(conn, t)
+        assert claimed is not None
+        run_id = conn.execute(
+            "SELECT current_run_id FROM tasks WHERE id = ?",
+            (t,),
+        ).fetchone()["current_run_id"]
+        assert run_id is not None
+        _set_task_status(conn, t, "review")
+
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="merged and verified",
+            expected_run_id=run_id,
+        )
+
+        row = conn.execute(
+            "SELECT status, current_run_id, completed_at FROM tasks WHERE id = ?",
+            (t,),
+        ).fetchone()
+    assert row["status"] == "done"
+    assert row["current_run_id"] is None
+    assert row["completed_at"] is not None
+
+
 def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
     """dispatch_once dry-run sees review tasks and reports them as spawned."""
     with kb.connect() as conn:


### PR DESCRIPTION
## Summary
- allow Kanban `review` tasks to complete through the normal `complete_task()` path
- add regression coverage for both unclaimed and claimed review-task completion flows

 <img width="1672" height="941" alt="telegram-cloud-photo-size-5-6204238340098297560-w" src="https://github.com/user-attachments/assets/3698aa50-4bc7-4784-be91-83666e94774c" />

## Problem
Merged or manually reconciled review cards could get stranded in `review` because `complete_task()` rejected that status even though `review` is a live handoff lane in the Kanban workflow.

This is the bug reported in #54823.

## Root cause
`complete_task()` only allowed completion from `running`, `ready`, and `blocked`, but not from `review`.

## Fix
- update `complete_task()` to allow `review -> done`
- keep the existing run-closing behavior intact for the claimed-review case
- add focused tests covering:
  - completion of an unclaimed `review` task
  - completion of a claimed `review` task with `expected_run_id`

## Testing
- `python -m pytest tests/hermes_cli/test_kanban_db.py -q -k 'complete_review_task or claimed_review_task'`

Fixes #54823
