### PR TITLE
fix(security): fail-closed feishu webhook rate limiter + whatsapp bridge path guard

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3535,9 +3535,16 @@ class FeishuAdapter(BasePlatformAdapter):
             ]
             for k in stale_keys:
                 del self._webhook_rate_counts[k]
-            # If still at capacity after pruning, allow through without tracking.
+            # If still at capacity after pruning, deny untracked keys (fail closed).
+            # The table only fills with this many distinct (account, endpoint, IP)
+            # triples under abuse; allowing untracked requests through at capacity
+            # would let an attacker who flooded the table bypass the limiter entirely.
             if rate_key not in self._webhook_rate_counts and len(self._webhook_rate_counts) >= _FEISHU_WEBHOOK_RATE_MAX_KEYS:
-                return True
+                logger.warning(
+                    "[Feishu] Webhook rate-limit table at capacity (%d keys) — denying untracked key",
+                    _FEISHU_WEBHOOK_RATE_MAX_KEYS,
+                )
+                return False
         self._webhook_rate_counts[rate_key] = (1, now)
         return True
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -268,8 +268,37 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     cache_image_from_url,
     cache_audio_from_url,
+    IMAGE_CACHE_DIR,
+    AUDIO_CACHE_DIR,
+    VIDEO_CACHE_DIR,
+    DOCUMENT_CACHE_DIR,
 )
 from utils import env_int
+
+
+def _is_allowed_bridge_path(url: str) -> bool:
+    """Return True only when an absolute path from the bridge resolves inside a
+    known Hermes media cache directory.
+
+    The Baileys bridge is a local subprocess that downloads inbound media and
+    hands back absolute file paths. A compromised or buggy bridge could hand
+    back an arbitrary path (e.g. ``/etc/passwd``) which would otherwise be
+    attached verbatim and sent to the model. Resolve the path (following any
+    symlinks) and require it to live under one of the real cache roots — this
+    covers both the canonical ``cache/<kind>`` layout and the legacy
+    ``<kind>_cache`` layout that ``get_hermes_dir`` may return.
+    """
+    try:
+        resolved = Path(url).resolve()
+    except (OSError, ValueError):
+        return False
+    for root in (IMAGE_CACHE_DIR, AUDIO_CACHE_DIR, VIDEO_CACHE_DIR, DOCUMENT_CACHE_DIR):
+        try:
+            if resolved.is_relative_to(Path(root).resolve()):
+                return True
+        except (OSError, ValueError):
+            continue
+    return False
 
 
 def _file_content_hash(path: Path) -> str:
@@ -1193,9 +1222,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         media_types.append("image/jpeg")
                 elif msg_type == MessageType.PHOTO and os.path.isabs(url):
                     # Local file path — bridge already downloaded the image
-                    cached_urls.append(url)
-                    media_types.append("image/jpeg")
-                    print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
+                    if _is_allowed_bridge_path(url):
+                        cached_urls.append(url)
+                        media_types.append("image/jpeg")
+                        print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
+                    else:
+                        print(f"[{self.name}] Rejected bridge image path outside cache dir: {url}", flush=True)
                 elif msg_type == MessageType.VOICE and url.startswith(("http://", "https://")):
                     try:
                         cached_path = await cache_audio_from_url(url, ext=".ogg")
@@ -1208,20 +1240,29 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         media_types.append("audio/ogg")
                 elif msg_type == MessageType.VOICE and os.path.isabs(url):
                     # Local file path — bridge already downloaded the audio
-                    cached_urls.append(url)
-                    media_types.append("audio/ogg")
-                    print(f"[{self.name}] Using bridge-cached audio: {url}", flush=True)
+                    if _is_allowed_bridge_path(url):
+                        cached_urls.append(url)
+                        media_types.append("audio/ogg")
+                        print(f"[{self.name}] Using bridge-cached audio: {url}", flush=True)
+                    else:
+                        print(f"[{self.name}] Rejected bridge audio path outside cache dir: {url}", flush=True)
                 elif msg_type == MessageType.DOCUMENT and os.path.isabs(url):
                     # Local file path — bridge already downloaded the document
-                    cached_urls.append(url)
-                    ext = Path(url).suffix.lower()
-                    mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
-                    media_types.append(mime)
-                    print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
+                    if _is_allowed_bridge_path(url):
+                        cached_urls.append(url)
+                        ext = Path(url).suffix.lower()
+                        mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
+                        media_types.append(mime)
+                        print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
+                    else:
+                        print(f"[{self.name}] Rejected bridge document path outside cache dir: {url}", flush=True)
                 elif msg_type == MessageType.VIDEO and os.path.isabs(url):
-                    cached_urls.append(url)
-                    media_types.append("video/mp4")
-                    print(f"[{self.name}] Using bridge-cached video: {url}", flush=True)
+                    if _is_allowed_bridge_path(url):
+                        cached_urls.append(url)
+                        media_types.append("video/mp4")
+                        print(f"[{self.name}] Using bridge-cached video: {url}", flush=True)
+                    else:
+                        print(f"[{self.name}] Rejected bridge video path outside cache dir: {url}", flush=True)
                 else:
                     cached_urls.append(url)
                     media_types.append("unknown")


### PR DESCRIPTION
## Summary
Two adapters now fail **closed** instead of open. Salvages the two still-valid security items from #5381 onto the relocated plugin adapters.

#5381 had six claims; four are already on main or superseded (api_server `hmac.compare_digest` landed independently; the `shell=True` quick_commands "injection" is a wrong premise — those are user config, not agent-controlled; the discord/feishu adapters were extracted to `plugins/platforms/` and already enforce stronger auth). These two were real and unfixed.

## Changes
- `plugins/platforms/feishu/adapter.py`: webhook rate limiter denies **untracked** keys when the tracking table is at capacity after pruning stale entries (was: allow through untracked). All-fresh-at-capacity only happens under abuse, so the old behavior let an attacker who flooded the table bypass the limiter. Tracked keys and post-prune room are unaffected; a WARNING is logged on denial.
- `plugins/platforms/whatsapp/adapter.py`: absolute paths handed back by the Baileys bridge are validated to resolve inside a known media cache dir before being attached. A compromised/buggy bridge could otherwise return an arbitrary path (e.g. `/etc/passwd`) sent verbatim to the model. The guard `resolve()`s the path (following symlinks) and accepts both the canonical `cache/<kind>` and legacy `<kind>_cache` layouts.

## Validation
E2E with real imports against an isolated `HERMES_HOME` (not mocks):

| Check | Result |
|---|---|
| feishu: untracked key at capacity (all-fresh) | **denied** ✓ |
| feishu: already-tracked key at capacity | allowed ✓ |
| feishu: new key after stale-prune frees room | allowed ✓ |
| whatsapp: legit `cache/images/img.jpg` | accepted ✓ |
| whatsapp: `/etc/passwd` | rejected ✓ |
| whatsapp: traversal out of cache root | rejected ✓ |
| whatsapp: symlink in cache → `/etc/passwd` | rejected ✓ |

Original author @Mibayy credited via commit authorship. Closes the salvageable portion of #5381.

## Infographic
![Fail-Closed Security Hardening](https://v3b.fal.media/files/b/0aa03b6a/m0hSj_AUiulBsgNH82b3E_q7s30rmI.png)
