### PR TITLE
fix: add .install_method to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ apps/desktop/demo/
 # PR body is the archive. See the hermes-agent-dev skill's
 # pr-infographic-workflow reference (storage rule + lapse #8 / #COMMIT-1).
 infographic/
+.install_method


### PR DESCRIPTION
## Problem

The `stamp_install_method()` function in `hermes_cli/config.py` writes `.install_method` to the project root to record the installation method. This file is intentionally created by the code but was **not** in `.gitignore`.

This causes `hermes update` to detect it as an untracked file on every run, stash it with `--include-untracked`, and prompt the user: *"Restore local changes now? [Y/n]"* — on **every single update**.

## Fix

Add `.install_method` to `.gitignore` so `git status --porcelain` no longer sees it as a local change.

## Verification

Before fix:
```
$ git status --porcelain
?? .install_method   # ← untracked, triggers stash every update
```

After fix:
```
$ git status --porcelain
# (clean — .install_method ignored)
```

This is a one-line fix with no behavior change — `.install_method` was always intended to be a local-only marker.