### PR TITLE
fix(hermes): move own-message reply context into Photon adapter

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1454,7 +1454,6 @@ class MessageEvent:
     # Reply context
     reply_to_message_id: Optional[str] = None
     reply_to_text: Optional[str] = None  # Text of the replied-to message (for context injection)
-    reply_to_is_own_message: bool = False  # True when the user replied to this bot/assistant's message
     
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1454,6 +1454,7 @@ class MessageEvent:
     # Reply context
     reply_to_message_id: Optional[str] = None
     reply_to_text: Optional[str] = None  # Text of the replied-to message (for context injection)
+    reply_to_is_own_message: bool = False  # True when the user replied to this bot/assistant's message
     
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8609,13 +8609,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
             reply_snippet = event.reply_to_text[:500]
-            if getattr(event, "reply_to_is_own_message", False):
-                message_text = (
-                    f'[Replying to your previous message: "{reply_snippet}"]\n\n'
-                    f"{message_text}"
-                )
-            else:
-                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+            message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         if "@" in message_text:
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3377,7 +3377,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._failed_platforms[adapter.platform] = {
                     "config": platform_config,
                     "attempts": 0,
-                    "next_retry": time.monotonic() + 30,
+                    "next_retry": time.monotonic(),
                 }
                 logger.info(
                     "%s queued for background reconnection",
@@ -6146,6 +6146,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 for _ in range(30):
                     if not self._running:
                         return
+                    if self._failed_platforms:
+                        break
                     await asyncio.sleep(1)
                 continue
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8609,7 +8609,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
             reply_snippet = event.reply_to_text[:500]
-            message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+            if getattr(event, "reply_to_is_own_message", False):
+                message_text = (
+                    f'[Replying to your previous message: "{reply_snippet}"]\n\n'
+                    f"{message_text}"
+                )
+            else:
+                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         if "@" in message_text:
             try:

--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -162,7 +162,8 @@ All env vars are documented in `plugin.yaml`. The most important:
 (no `^` range) and installed with `npm ci`, because the SDK ships breaking
 majors (v2 removed `defineFusorPlatform`; v3 reworked space construction; v5
 split it into `@spectrum-ts/*` packages, with `spectrum-ts` as the umbrella
-that re-exports them). A floating range or `npm install spectrum-ts@latest`
+that re-exports them; v8 made `richlink` outbound-only, so inbound rich links
+now arrive as plain `text`). A floating range or `npm install spectrum-ts@latest`
 would let a breaking release take down fresh setups silently. Upgrades are
 deliberate:
 

--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -152,7 +152,7 @@ All env vars are documented in `plugin.yaml`. The most important:
   as a synthetic `reaction:added:<emoji>` event. Removal after a sidecar
   restart is best-effort — the live reaction handle is lost, so a stale
   tapback heals when the next reaction replaces it. Group spaces stay
-  reachable across restarts via spectrum-ts v3's `space.get(id)`.
+  reachable across restarts via spectrum-ts' `space.get(id)`.
 - **Message effects, polls** — supported by `spectrum-ts` but not yet
   exposed; the sidecar is the natural place to add them.
 
@@ -160,19 +160,29 @@ All env vars are documented in `plugin.yaml`. The most important:
 
 `spectrum-ts` is pinned to an **exact version** in `sidecar/package.json`
 (no `^` range) and installed with `npm ci`, because the SDK ships breaking
-majors (v2 removed `defineFusorPlatform`; v3 reworked space construction).
-A floating range or `npm install spectrum-ts@latest` would let a breaking
-release take down fresh setups silently. Upgrades are deliberate:
+majors (v2 removed `defineFusorPlatform`; v3 reworked space construction; v5
+split it into `@spectrum-ts/*` packages, with `spectrum-ts` as the umbrella
+that re-exports them). A floating range or `npm install spectrum-ts@latest`
+would let a breaking release take down fresh setups silently. Upgrades are
+deliberate:
 
 1. Read the [SDK release notes](https://github.com/photon-hq/spectrum-ts/releases)
    for every version between the current pin and the target.
 2. Bump the exact pin in `sidecar/package.json`, then run `npm install`
    inside `sidecar/` to regenerate `package-lock.json`. Commit both.
-3. Migrate `sidecar/index.mjs` against the new typings
-   (`sidecar/node_modules/spectrum-ts/dist/*.d.ts` is the source of truth —
-   the hosted docs can lag).
-4. Run `pytest tests/plugins/platforms/photon/`.
-5. Verify end-to-end: `hermes photon status`, a DM and a group roundtrip,
+3. Migrate `sidecar/index.mjs` against the new typings. `spectrum-ts` re-exports
+   `@spectrum-ts/core` (the framework: `Spectrum`, content builders,
+   `Space`/`Message`) and `@spectrum-ts/imessage` (the provider), so the source
+   of truth is `sidecar/node_modules/@spectrum-ts/{core,imessage}/dist/*.d.ts`
+   (the hosted docs can lag).
+4. Re-validate `sidecar/patch-spectrum-mixed-attachments.mjs`. It rewrites the
+   compiled iMessage inbound mappers in `@spectrum-ts/imessage/dist/index.js`
+   so a bubble with both text and attachments keeps its typed text; the anchors
+   are tied to that build's output. `npm install` runs it via `postinstall` and
+   fails loudly if the anchors no longer match — update them to the new output
+   (`test_spectrum_patch.py` covers the patch).
+5. Run `pytest tests/plugins/platforms/photon/`.
+6. Verify end-to-end: `hermes photon status`, a DM and a group roundtrip,
    and an agent reply into a group right after a gateway restart (exercises
    `space.get` rehydration).
 

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -91,7 +91,11 @@ _SIDECAR_DIR = Path(__file__).parent / "sidecar"
 _PHOTON_RETRYABLE_PATTERNS = (
     "internal sidecar error",
     "upstream connect error",
+    "upstream unavailable",
+    "connection dropped",
     "reset reason: overflow",
+    "upstream_overflow",
+    "upstream_unavailable",
 )
 
 # Minimum seconds between typing-indicator calls for the same chat.
@@ -235,8 +239,10 @@ class PhotonAdapter(BasePlatformAdapter):
         self._sidecar_proc: Optional[subprocess.Popen] = None
         self._sidecar_supervisor_task: Optional[asyncio.Task] = None
         self._inbound_task: Optional[asyncio.Task] = None
+        self._sidecar_health_task: Optional[asyncio.Task] = None
         self._inbound_running = False
         self._http_client: Optional["httpx.AsyncClient"] = None
+        self._sidecar_health_interval = 15.0
         # Lightweight in-memory dedup. The gRPC stream is at-least-once, so we
         # may see the same messageId more than once (e.g. after a reconnect).
         self._seen_messages: Dict[str, float] = {}
@@ -370,6 +376,9 @@ class PhotonAdapter(BasePlatformAdapter):
         self._inbound_task = asyncio.get_event_loop().create_task(
             self._inbound_loop()
         )
+        self._sidecar_health_task = asyncio.get_event_loop().create_task(
+            self._monitor_sidecar_health()
+        )
 
         self._mark_connected()
         logger.info(
@@ -380,6 +389,17 @@ class PhotonAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         self._inbound_running = False
+        if self._sidecar_health_task is not None:
+            task = self._sidecar_health_task
+            self._sidecar_health_task = None
+            task.cancel()
+            if task is not asyncio.current_task():
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    pass
         if self._inbound_task is not None:
             self._inbound_task.cancel()
             try:
@@ -439,6 +459,49 @@ class PhotonAdapter(BasePlatformAdapter):
                 )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
+
+    async def _monitor_sidecar_health(self) -> None:
+        """Promote degraded upstream Photon stream health into reconnect.
+
+        The sidecar HTTP process can stay alive while spectrum-ts repeatedly
+        fails to maintain the upstream inbound gRPC stream. Polling `/healthz`
+        keeps that from becoming a silent inbound outage.
+        """
+        while self._inbound_running:
+            await asyncio.sleep(self._sidecar_health_interval)
+            if not self._inbound_running:
+                break
+            try:
+                data = await self._sidecar_call("/healthz", {})
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("[photon] sidecar health check failed: %s", exc)
+                continue
+
+            stream = data.get("stream") if isinstance(data, dict) else None
+            if not isinstance(stream, dict) or stream.get("ok") is not False:
+                continue
+
+            state = str(stream.get("state") or "unknown")
+            degraded_for_ms = stream.get("degradedForMs")
+            last_issue = str(stream.get("lastIssue") or "unknown stream issue")
+            message = (
+                "Photon upstream stream degraded"
+                f" (state={state}, degradedForMs={degraded_for_ms}): "
+                f"{last_issue}"
+            )
+            logger.error("[photon] %s", message)
+            self._set_fatal_error(
+                "UPSTREAM_STREAM_DEGRADED",
+                message,
+                retryable=True,
+            )
+            try:
+                await self._notify_fatal_error()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("[photon] fatal-error notification failed: %s", exc)
+            break
 
     async def _on_inbound_line(self, line: str) -> None:
         try:

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -85,6 +85,20 @@ _DEDUP_WINDOW_SECONDS = 48 * 3600
 
 _SIDECAR_DIR = Path(__file__).parent / "sidecar"
 
+# Photon / Envoy / spectrum-ts error substrings that indicate a transient
+# upstream overload rather than a permanent failure.  These are not in the
+# core _RETRYABLE_ERROR_PATTERNS because they are specific to this adapter.
+_PHOTON_RETRYABLE_PATTERNS = (
+    "internal sidecar error",
+    "upstream connect error",
+    "reset reason: overflow",
+)
+
+# Minimum seconds between typing-indicator calls for the same chat.
+# iMessage is a personal channel — suppressing rapid repeats reduces
+# upstream gRPC pressure during Photon overflow events.
+_TYPING_COOLDOWN_SECONDS = 5.0
+
 # Group-chat mention wake words. When ``require_mention`` is enabled, group
 # messages are ignored unless they match one of these patterns — same
 # behavior and defaults as the BlueBubbles iMessage channel so the two
@@ -234,6 +248,8 @@ class PhotonAdapter(BasePlatformAdapter):
         # react action default to "the message that triggered me" without
         # requiring the model to thread message ids through tool calls.
         self._last_inbound_by_chat: Dict[str, str] = {}
+        # Last time we sent a typing indicator per chat, for cooldown gating.
+        self._typing_last_sent: Dict[str, float] = {}
 
         # Group-chat mention gating (parity with BlueBubbles). When enabled,
         # group messages are ignored unless they match a wake word; DMs are
@@ -988,6 +1004,10 @@ class PhotonAdapter(BasePlatformAdapter):
         )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
+        now = time.time()
+        if now - self._typing_last_sent.get(chat_id, 0.0) < _TYPING_COOLDOWN_SECONDS:
+            return
+        self._typing_last_sent[chat_id] = now
         try:
             await self._sidecar_call(
                 "/typing", {"spaceId": chat_id, "state": "start"}
@@ -996,6 +1016,7 @@ class PhotonAdapter(BasePlatformAdapter):
             logger.debug("[photon] send_typing failed: %s", e)
 
     async def stop_typing(self, chat_id: str) -> None:
+        self._typing_last_sent.pop(chat_id, None)
         try:
             await self._sidecar_call(
                 "/typing", {"spaceId": chat_id, "state": "stop"}
@@ -1189,13 +1210,22 @@ class PhotonAdapter(BasePlatformAdapter):
             return content
         return strip_markdown(content)
 
+    @staticmethod
+    def _is_retryable_error(error: Optional[str]) -> bool:
+        if BasePlatformAdapter._is_retryable_error(error):
+            return True
+        if not error:
+            return False
+        lowered = error.lower()
+        return any(pat in lowered for pat in _PHOTON_RETRYABLE_PATTERNS)
+
     async def _send_with_retry(
         self,
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
         metadata: Any = None,
-        max_retries: int = 2,
+        max_retries: int = 1,
         base_delay: float = 2.0,
     ) -> SendResult:
         """Retry sends without the generic Markdown banner.

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -855,6 +855,21 @@ class PhotonAdapter(BasePlatformAdapter):
                 logger.info("[photon-sidecar] %s", line.decode("utf-8", "replace").rstrip())
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("[photon-sidecar] supervisor exited: %s", e)
+        if self._inbound_running:
+            exit_code = proc.poll()
+            logger.error(
+                "[photon] sidecar exited unexpectedly (code %s) — triggering reconnect",
+                exit_code,
+            )
+            self._set_fatal_error(
+                "SIDECAR_CRASHED",
+                f"Photon sidecar exited unexpectedly (code {exit_code})",
+                retryable=True,
+            )
+            try:
+                await self._notify_fatal_error()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("[photon] fatal-error notification failed: %s", exc)
 
     async def _stop_sidecar(self) -> None:
         proc = self._sidecar_proc

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -645,11 +645,16 @@ class PhotonAdapter(BasePlatformAdapter):
             )
             # Correlate the tapback to the message it reacted to, so the agent
             # sees WHAT was reacted to. `is_ours` above guarantees the target is
-            # one of the bot's own messages, so reply_to_is_own_message holds and
-            # the gateway injects `[Replying to your previous message: "..."]`.
+            # one of the bot's own messages. Prefix reply_to_text with
+            # "your previous message: " so the generic gateway handler emits
+            # `[Replying to: "your previous message: ..."]`.
             # reply_to_text comes from the sidecar (hydrated reaction target);
             # it's None for attachment/voice-only targets, and the gateway only
             # injects the pointer when both id and text are present.
+            target_text = content.get("targetText") or None
+            reply_to_text = (
+                f"your previous message: {target_text}" if target_text else None
+            )
             await self.handle_message(
                 MessageEvent(
                     text=f"reaction:added:{emoji}",
@@ -657,8 +662,7 @@ class PhotonAdapter(BasePlatformAdapter):
                     source=source,
                     message_id=event.get("messageId"),
                     reply_to_message_id=target_id,
-                    reply_to_text=content.get("targetText") or None,
-                    reply_to_is_own_message=True,
+                    reply_to_text=reply_to_text,
                     raw_message=event,
                     timestamp=timestamp,
                 )

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -550,7 +550,8 @@ class PhotonAdapter(BasePlatformAdapter):
                           "encoding"?}
                        | {"type": "reaction", "emoji": "❤️",
                           "targetMessageId": "..." | null,
-                          "targetDirection": "inbound"|"outbound" | null},
+                          "targetDirection": "inbound"|"outbound" | null,
+                          "targetText": "..." | null},
               "timestamp": "2026-05-14T19:06:32.000Z"
 
         Attachment and voice content carry the bytes inline as base64 ``data``
@@ -642,12 +643,22 @@ class PhotonAdapter(BasePlatformAdapter):
                 user_id=sender_id,
                 user_name=sender_id or None,
             )
+            # Correlate the tapback to the message it reacted to, so the agent
+            # sees WHAT was reacted to. `is_ours` above guarantees the target is
+            # one of the bot's own messages, so reply_to_is_own_message holds and
+            # the gateway injects `[Replying to your previous message: "..."]`.
+            # reply_to_text comes from the sidecar (hydrated reaction target);
+            # it's None for attachment/voice-only targets, and the gateway only
+            # injects the pointer when both id and text are present.
             await self.handle_message(
                 MessageEvent(
                     text=f"reaction:added:{emoji}",
                     message_type=MessageType.TEXT,
                     source=source,
                     message_id=event.get("messageId"),
+                    reply_to_message_id=target_id,
+                    reply_to_text=content.get("targetText") or None,
+                    reply_to_is_own_message=True,
                     raw_message=event,
                     timestamp=timestamp,
                 )

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1274,7 +1274,12 @@ class PhotonAdapter(BasePlatformAdapter):
         try:
             data = await self._sidecar_call("/send", body)
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            # Preserve the exception TYPE when str(e) is empty -- httpx timeout
+            # exceptions (ReadTimeout/WriteTimeout) often stringify to "" -- so
+            # _is_timeout_error() can detect a read/write timeout and SUPPRESS the
+            # plain-text fallback. A slow-but-delivered /send must not be re-sent,
+            # or the user gets a duplicate iMessage.
+            return SendResult(success=False, error=str(e) or type(e).__name__)
         self._record_sent_message(data.get("messageId"))
         return SendResult(success=True, message_id=data.get("messageId"))
 
@@ -1336,9 +1341,12 @@ class PhotonAdapter(BasePlatformAdapter):
         # persistent _http_client was created on (e.g. via _run_async in
         # send_message_tool).  The inbound streaming loop continues to use
         # _http_client directly — it always runs on the gateway's loop.
+        # Photon's free-tier ack latency is variable (observed 8s to >30s); use an
+        # env-configurable timeout (default 90s) so a slow-but-delivered send is
+        # not false-failed into a duplicate fallback.
         url = f"http://{self._sidecar_bind}:{self._sidecar_port}{path}"
         headers = {"X-Hermes-Sidecar-Token": self._sidecar_token}
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=float(os.getenv("PHOTON_SIDECAR_TIMEOUT") or 90.0)) as client:
             resp = await client.post(url, json=body, headers=headers)
         if resp.status_code != 200:
             raise RuntimeError(

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -376,11 +376,12 @@ def _install_sidecar() -> int:
         return 1
     # spectrum-ts is pinned exactly in package.json/package-lock.json because
     # the SDK ships breaking majors (v2 removed defineFusorPlatform; v3
-    # reworked space construction). Upgrades are deliberate: bump the pin,
-    # migrate sidecar/index.mjs, re-run the photon tests — never `@latest`
-    # (see README "Upgrading spectrum-ts"). `npm ci` installs the committed
-    # lockfile verbatim; fall back to `npm install` when the lockfile is
-    # missing or drifted (e.g. a dev checkout mid-upgrade).
+    # reworked space construction; v5 split it into @spectrum-ts/* packages).
+    # Upgrades are deliberate: bump the pin, migrate sidecar/index.mjs, re-run
+    # the photon tests — never `@latest` (see README "Upgrading spectrum-ts").
+    # `npm ci` installs the committed lockfile verbatim; fall back to
+    # `npm install` when the lockfile is missing or drifted (e.g. a dev
+    # checkout mid-upgrade).
     print(f"  $ cd {_SIDECAR_DIR} && {npm} ci")
     proc = subprocess.run(  # noqa: S603
         [npm, "ci"],

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -38,7 +38,7 @@
 // On SIGINT/SIGTERM the sidecar calls `app.stop()` (3s graceful) before
 // exiting. Logs go to stderr; Python supervises restart.
 //
-// Requires spectrum-ts 3.x — pinned exactly in package.json because the SDK
+// Requires spectrum-ts 7.x — pinned exactly in package.json because the SDK
 // ships breaking majors; see README "Upgrading spectrum-ts".
 //
 // Env vars (required):

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -495,6 +495,31 @@ async function normalizeEvent(space, message) {
   }
 }
 
+function inboundStreamErrorMessage(e) {
+  const msg = e && e.message ? e.message : String(e);
+  let out = "photon-sidecar: inbound stream errored — restarting: " + msg;
+
+  // The Spectrum SDK surfaces Photon cloud CatchUpEvents failures as an
+  // iMessage internal error. Local Hermes allowlists cannot cause or fix this:
+  // inbound messages stop before they reach the gateway. Add an explicit hint
+  // so operators know to retry/restart or escalate to Photon support instead
+  // of chasing PHOTON_ALLOWED_USERS / pairing configuration.
+  const details = String(e?.cause?.details || e?.details || "");
+  const path = String(e?.cause?.path || e?.path || "");
+  const code = String(e?.code || "");
+  if (
+    path.includes("EventService/CatchUpEvents") ||
+    details.includes("Unknown server error occurred") ||
+    (code === "internalError" && msg.includes("Unknown server error"))
+  ) {
+    out +=
+      " | Photon Spectrum CatchUpEvents returned an internal server error; " +
+      "this is upstream of Hermes, so inbound iMessages may not be delivered " +
+      "until Photon recovers or the stream is re-established.";
+  }
+  return out;
+}
+
 // spectrum-ts handles in-session gRPC reconnects internally, but if the async
 // iterator itself throws or ends, this consumer would stop forever. Wrap it in
 // a re-subscribe loop with capped exponential backoff + jitter so inbound
@@ -526,12 +551,7 @@ async function normalizeEvent(space, message) {
     } catch (e) {
       consecutiveFailures += 1;
       const reason = e && e.message ? e.message : String(e);
-      console.error(
-        "photon-sidecar: inbound stream errored — restarting (" +
-          consecutiveFailures +
-          "): " +
-          reason
-      );
+      console.error(inboundStreamErrorMessage(e));
       markStreamRecovering(reason);
     }
     // If the stream keeps ending/erroring back-to-back, spectrum-ts's internal

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -169,20 +169,39 @@ function markStreamRecovering(reason) {
   }
 }
 
+function classifyStreamLog(text) {
+  if (!text.includes("[spectrum.stream]")) return;
+  const reason = text.split("\n", 1)[0];
+  if (text.includes("persistently failing")) {
+    markStreamDegraded(reason);
+  } else if (text.includes("stream interrupted")) {
+    markStreamRecovering(reason);
+  }
+}
+
+// spectrum-ts routes its stream telemetry through @photon-ai/otel's
+// createLogger, which sends severity >= ERROR to console.error and
+// everything else (WARN/INFO) to console.log. The two lines we key off
+// land on *different* channels: `log.error("stream persistently failing")`
+// -> console.error, but `log.warn("stream interrupted; reconnecting")`
+// -> console.log. Patch both so the recovering/degraded counters see the
+// interrupt bursts, not just the terminal "persistently failing" line.
 const originalConsoleError = console.error.bind(console);
 console.error = (...args) => {
   const text = args
     .map((arg) => (arg && arg.stack ? arg.stack : String(arg)))
     .join(" ");
-  if (text.includes("[spectrum.stream]")) {
-    const reason = text.split("\n", 1)[0];
-    if (text.includes("persistently failing")) {
-      markStreamDegraded(reason);
-    } else if (text.includes("stream interrupted")) {
-      markStreamRecovering(reason);
-    }
-  }
+  classifyStreamLog(text);
   originalConsoleError(...args);
+};
+
+const originalConsoleLog = console.log.bind(console);
+console.log = (...args) => {
+  const text = args
+    .map((arg) => (arg && arg.stack ? arg.stack : String(arg)))
+    .join(" ");
+  classifyStreamLog(text);
+  originalConsoleLog(...args);
 };
 
 if (!projectId || !projectSecret || !sharedToken) {

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -81,6 +81,109 @@ const E164_RE = /^\+\d{6,}$/;
 const MAX_KNOWN_SPACES = 2048;
 const MAX_KNOWN_MESSAGES = 1024;
 const MAX_REACTION_HANDLES = 512;
+const STREAM_DEGRADED_RESTART_MS =
+  Number(process.env.PHOTON_STREAM_DEGRADED_RESTART_MS) || 90 * 1000;
+const STREAM_INTERRUPTED_DEGRADE_COUNT =
+  Number(process.env.PHOTON_STREAM_INTERRUPTED_DEGRADE_COUNT) || 3;
+
+const streamHealth = {
+  state: "starting",
+  degradedSince: null,
+  lastHealthyAt: null,
+  lastIssueAt: null,
+  lastIssue: null,
+  issueCount: 0,
+};
+let streamRestartTimer = null;
+
+function streamHealthSnapshot() {
+  const now = Date.now();
+  const degradedForMs =
+    streamHealth.degradedSince === null ? 0 : now - streamHealth.degradedSince;
+  return {
+    ok: streamHealth.state !== "degraded",
+    state: streamHealth.state,
+    degradedForMs,
+    restartAfterMs: STREAM_DEGRADED_RESTART_MS,
+    lastHealthyAt: streamHealth.lastHealthyAt,
+    lastIssueAt: streamHealth.lastIssueAt,
+    lastIssue: streamHealth.lastIssue,
+    issueCount: streamHealth.issueCount,
+  };
+}
+
+function markStreamHealthy() {
+  streamHealth.state = "healthy";
+  streamHealth.degradedSince = null;
+  streamHealth.lastHealthyAt = new Date().toISOString();
+  streamHealth.issueCount = 0;
+  if (streamRestartTimer) {
+    clearTimeout(streamRestartTimer);
+    streamRestartTimer = null;
+  }
+}
+
+function scheduleStreamRestart() {
+  if (STREAM_DEGRADED_RESTART_MS <= 0 || streamRestartTimer) return;
+  streamRestartTimer = setTimeout(() => {
+    streamRestartTimer = null;
+    if (streamHealth.state !== "degraded" || streamHealth.degradedSince === null) {
+      return;
+    }
+    const degradedForMs = Date.now() - streamHealth.degradedSince;
+    if (degradedForMs < STREAM_DEGRADED_RESTART_MS) {
+      scheduleStreamRestart();
+      return;
+    }
+    console.error(
+      `photon-sidecar: upstream stream degraded for ${degradedForMs}ms; ` +
+        "exiting so Hermes can restart the Photon adapter"
+    );
+    process.exit(75);
+  }, STREAM_DEGRADED_RESTART_MS + 1000);
+  streamRestartTimer.unref();
+}
+
+function markStreamDegraded(reason) {
+  const now = Date.now();
+  if (streamHealth.state !== "degraded") {
+    streamHealth.degradedSince = now;
+  }
+  streamHealth.state = "degraded";
+  streamHealth.lastIssueAt = new Date(now).toISOString();
+  streamHealth.lastIssue = reason;
+  streamHealth.issueCount += 1;
+  scheduleStreamRestart();
+}
+
+function markStreamRecovering(reason) {
+  if (streamHealth.state !== "recovering") {
+    streamHealth.issueCount = 0;
+  }
+  streamHealth.state = "recovering";
+  streamHealth.lastIssueAt = new Date().toISOString();
+  streamHealth.lastIssue = reason;
+  streamHealth.issueCount += 1;
+  if (streamHealth.issueCount >= STREAM_INTERRUPTED_DEGRADE_COUNT) {
+    markStreamDegraded(reason);
+  }
+}
+
+const originalConsoleError = console.error.bind(console);
+console.error = (...args) => {
+  const text = args
+    .map((arg) => (arg && arg.stack ? arg.stack : String(arg)))
+    .join(" ");
+  if (text.includes("[spectrum.stream]")) {
+    const reason = text.split("\n", 1)[0];
+    if (text.includes("persistently failing")) {
+      markStreamDegraded(reason);
+    } else if (text.includes("stream interrupted")) {
+      markStreamRecovering(reason);
+    }
+  }
+  originalConsoleError(...args);
+};
 
 if (!projectId || !projectSecret || !sharedToken) {
   console.error(
@@ -405,6 +508,7 @@ async function normalizeEvent(space, message) {
       for await (const [space, message] of app.messages) {
         backoff = 1000; // healthy traffic — reset
         consecutiveFailures = 0;
+        markStreamHealthy();
         stampInboundHeartbeat(); // real upstream message => upstream is alive
         // Only forward inbound messages (ignore our own outbound echoes).
         if (message && message.direction && message.direction !== "inbound") {
@@ -418,14 +522,17 @@ async function normalizeEvent(space, message) {
       }
       console.error("photon-sidecar: inbound stream ended — re-subscribing");
       consecutiveFailures += 1;
+      markStreamRecovering("inbound stream ended");
     } catch (e) {
       consecutiveFailures += 1;
+      const reason = e && e.message ? e.message : String(e);
       console.error(
         "photon-sidecar: inbound stream errored — restarting (" +
           consecutiveFailures +
           "): " +
-          (e && e.message ? e.message : String(e))
+          reason
       );
+      markStreamRecovering(reason);
     }
     // If the stream keeps ending/erroring back-to-back, spectrum-ts's internal
     // reconnect is not recovering -> exit for a fresh-channel restart.
@@ -595,7 +702,7 @@ const server = http.createServer(async (req, res) => {
   }
   try {
     if (req.url === "/healthz") {
-      return ok(res, {});
+      return ok(res, { stream: streamHealthSnapshot() });
     }
     if (req.url === "/shutdown") {
       ok(res, {});

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -38,7 +38,7 @@
 // On SIGINT/SIGTERM the sidecar calls `app.stop()` (3s graceful) before
 // exiting. Logs go to stderr; Python supervises restart.
 //
-// Requires spectrum-ts 7.x — pinned exactly in package.json because the SDK
+// Requires spectrum-ts 8.x — pinned exactly in package.json because the SDK
 // ships breaking majors; see README "Upgrading spectrum-ts".
 //
 // Env vars (required):

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -454,6 +454,35 @@ async function normalizeBinaryContent(content) {
   return meta;
 }
 
+// Best-effort text preview of a reaction's resolved target Message, so the
+// Python adapter can populate the gateway's `reply_to_text` (context: WHAT was
+// tapped back). The SDK only emits a reaction once it has resolved the full
+// target Message (toReactionMessages bails otherwise), so `target.content` is
+// hydrated here — no extra round trip. Handles plain text and our patched mixed
+// text+attachment groups (first text child); null for attachment/voice-only
+// targets. Capped so one long bubble can't balloon the NDJSON line.
+const REACTION_TARGET_TEXT_CAP = 2000;
+function reactionTargetText(target) {
+  const c = target && typeof target === "object" ? target.content : null;
+  if (!c || typeof c !== "object") return null;
+  let text = null;
+  if (c.type === "text") {
+    text = c.text;
+  } else if (c.type === "group") {
+    for (const item of Array.isArray(c.items) ? c.items : []) {
+      const ic = item && typeof item === "object" ? item.content : null;
+      if (ic && ic.type === "text" && ic.text) {
+        text = ic.text;
+        break;
+      }
+    }
+  }
+  if (typeof text !== "string" || !text) return null;
+  return text.length > REACTION_TARGET_TEXT_CAP
+    ? text.slice(0, REACTION_TARGET_TEXT_CAP)
+    : text;
+}
+
 async function normalizeContent(content) {
   if (!content || typeof content !== "object") {
     return { type: "unknown" };
@@ -475,14 +504,18 @@ async function normalizeContent(content) {
     return { type: "group", items };
   }
   if (content.type === "reaction") {
+    const target = content.target;
     return {
       type: "reaction",
       emoji: content.emoji || "",
-      targetMessageId: content.target?.id ?? null,
+      targetMessageId: target?.id ?? null,
       // Lets Python gate "is this a reaction to one of MY messages" without
       // tracking every outbound id. May be null if the provider doesn't
       // hydrate the target — Python falls back to its own sent-id cache.
-      targetDirection: content.target?.direction ?? null,
+      targetDirection: target?.direction ?? null,
+      // Text of the reacted-to message, so Python can correlate the tapback to
+      // the gateway's reply_to_text. Null for attachment/voice-only targets.
+      targetText: reactionTargetText(target),
     };
   }
   return { type: content.type || "unknown" };

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -58,6 +58,7 @@ import http from "node:http";
 import crypto from "node:crypto";
 import { once } from "node:events";
 import { patchSpectrumTs } from "./patch-spectrum-mixed-attachments.mjs";
+import fs from "node:fs";
 
 const projectId = process.env.PHOTON_PROJECT_ID;
 const projectSecret = process.env.PHOTON_PROJECT_SECRET;
@@ -214,6 +215,54 @@ function clearConsumer(res) {
   if (consumerRes === res) consumerRes = null;
 }
 
+// Operational heartbeat: stamp a file whenever the inbound consumer pipe is
+// actively serviced (on connect + every keepalive tick). A watchdog treats a
+// stale file as a dead inbound pipe and restarts the bridge -- this is the one
+// failure mode launchd KeepAlive + the process-liveness reaper miss (the bridge
+// process stays up while the /inbound pipe silently dies). Opt-in: only writes
+// when PHOTON_SIDECAR_HEARTBEAT_PATH is set, so upstream behavior is unchanged.
+const HEARTBEAT_PATH = process.env.PHOTON_SIDECAR_HEARTBEAT_PATH || "";
+function stampInboundHeartbeat() {
+  if (!HEARTBEAT_PATH) return;
+  try {
+    fs.writeFileSync(HEARTBEAT_PATH, String(Date.now()));
+  } catch {
+    /* heartbeat is best-effort; never let it break inbound */
+  }
+}
+
+// The spectrum-ts upstream gRPC channel to Photon can drop ("[upstream]
+// Connection dropped") and NOT self-recover: inbound + outbound both silently
+// stop. spectrum-ts's in-session reconnect is unreliable here, so a clean
+// process restart (fresh channel) is the recovery. We detect the dead-upstream
+// error and exit non-zero; the supervisor (start_photon_keez.sh) and the
+// launchd reaper relaunch the sidecar with a new connection.
+function isUpstreamDown(e) {
+  // High-confidence dead-channel signals only. A false positive here costs a
+  // ~90s bridge restart (sidecar exits -> heartbeat stale -> reaper), so we do
+  // NOT treat transient/ambiguous errors (timeouts, "unavailable") as fatal.
+  const msg = (e && (e.message || String(e))) || "";
+  const name = (e && e.name) || "";
+  return (
+    name === "ConnectionError" ||
+    /connection dropped/i.test(msg) ||
+    /\[upstream\]\s*connection/i.test(msg)
+  );
+}
+
+let _exitingForUpstream = false;
+function exitForUpstream(reason) {
+  if (_exitingForUpstream) return;
+  _exitingForUpstream = true;
+  console.error(
+    "photon-sidecar: upstream connection dead (" +
+      reason +
+      ") -> exiting for a clean restart"
+  );
+  // Brief delay so any in-flight HTTP response flushes, then exit non-zero.
+  setTimeout(() => process.exit(75), 250);
+}
+
 // Write one NDJSON line to the active consumer. Blocks until a consumer is
 // connected; if the write fails (consumer vanished mid-flight) we wait for a
 // new consumer and retry, so a message is never silently dropped here.
@@ -349,10 +398,14 @@ async function normalizeEvent(space, message) {
 // always recovers (the adapter dedupes any catch-up replay).
 (async () => {
   let backoff = 1000;
+  let consecutiveFailures = 0;
+  const MAX_CONSECUTIVE_FAILURES = 5; // ~ backoff maxed out => upstream is dead
   for (;;) {
     try {
       for await (const [space, message] of app.messages) {
         backoff = 1000; // healthy traffic — reset
+        consecutiveFailures = 0;
+        stampInboundHeartbeat(); // real upstream message => upstream is alive
         // Only forward inbound messages (ignore our own outbound echoes).
         if (message && message.direction && message.direction !== "inbound") {
           continue;
@@ -364,11 +417,21 @@ async function normalizeEvent(space, message) {
         await deliver(JSON.stringify(event));
       }
       console.error("photon-sidecar: inbound stream ended — re-subscribing");
+      consecutiveFailures += 1;
     } catch (e) {
+      consecutiveFailures += 1;
       console.error(
-        "photon-sidecar: inbound stream errored — restarting: " +
+        "photon-sidecar: inbound stream errored — restarting (" +
+          consecutiveFailures +
+          "): " +
           (e && e.message ? e.message : String(e))
       );
+    }
+    // If the stream keeps ending/erroring back-to-back, spectrum-ts's internal
+    // reconnect is not recovering -> exit for a fresh-channel restart.
+    if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      exitForUpstream("inbound stream stuck x" + consecutiveFailures);
+      return;
     }
     await new Promise((r) =>
       setTimeout(r, backoff + Math.random() * backoff * 0.2)
@@ -446,11 +509,13 @@ function handleInbound(req, res) {
     }
   }
   setConsumer(res);
+  stampInboundHeartbeat();
   // Heartbeat keeps the socket warm through idle periods and lets the Python
   // side detect a dead pipe promptly.
   const heartbeat = setInterval(() => {
     try {
       res.write("\n");
+      stampInboundHeartbeat();
     } catch {
       /* ignore */
     }
@@ -667,7 +732,12 @@ const server = http.createServer(async (req, res) => {
     );
     // serverError() intentionally returns a generic message — see its
     // body for the rationale.
-    return serverError(res);
+    serverError(res);
+    // A dead upstream surfaces here first (send/typing throw it). Exit so the
+    // supervisor restarts the sidecar with a fresh Photon channel rather than
+    // limping on with inbound + outbound both broken.
+    if (isUpstreamDown(e)) exitForUpstream("handler error");
+    return;
   }
 });
 

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "@hermes-agent/photon-sidecar",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-agent/photon-sidecar",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
-        "spectrum-ts": "3.1.0"
+        "spectrum-ts": "7.0.0"
       },
       "engines": {
         "node": ">=18.17"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@grpc/grpc-js": {
@@ -62,15 +62,6 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
-    "node_modules/@msgpack/msgpack": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
-      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -81,9 +72,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.216.0.tgz",
-      "integrity": "sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -93,9 +84,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
-      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -123,6 +114,7 @@
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
       "integrity": "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/core": "2.7.1",
@@ -137,38 +129,11 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
-      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
       "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/otlp-exporter-base": "0.218.0",
@@ -183,69 +148,7 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
-      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-transformer": "0.218.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
-      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-logs": "0.218.0",
-        "@opentelemetry/sdk-metrics": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
-      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
@@ -261,40 +164,7 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.216.0.tgz",
-      "integrity": "sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.216.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
-      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
@@ -309,6 +179,204 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -339,9 +407,9 @@
       }
     },
     "node_modules/@photon-ai/advanced-imessage": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@photon-ai/advanced-imessage/-/advanced-imessage-0.11.2.tgz",
-      "integrity": "sha512-3mjzy1IIBtsCQK6kAB8dbFCK0np7hS256wwW+nqNL8vKz0W5nRhu1iKAwyZxP8Z470dtNX5RjNgcl9I4wZeuTA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/advanced-imessage/-/advanced-imessage-0.12.0.tgz",
+      "integrity": "sha512-cqSq/ew48P3S+4xXpQmS/mDgpa+ijlKYKkQ4MExsQEjHfrJ0DpPJGuY5VHgzfTqV9wYVGyA3TNkDfse/ZRDxoA==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
@@ -369,18 +437,18 @@
       }
     },
     "node_modules/@photon-ai/otel": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-0.1.1.tgz",
-      "integrity": "sha512-t/NVepO5+fHOLWDI+Eht+RC8PTik0wi7HQsKhU4yPqBjY5JncXmoBZLnWFvG+/qJ/pn6w+tveabKG9pykfkqKg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-1.0.0.tgz",
+      "integrity": "sha512-5fACVHN7BtGS+phglVAxun5QLckNUSS4p750oCxR//m9JNVzFQMoLFWfC6DnWBP/W0/+B2yP75+3NMVLodEJEg==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/api-logs": "^0.216.0",
+        "@opentelemetry/api-logs": "^0.218.0",
         "@opentelemetry/context-async-hooks": "^2.7.1",
-        "@opentelemetry/exporter-logs-otlp-http": "^0.216.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/resources": "^2.7.1",
-        "@opentelemetry/sdk-logs": "^0.216.0",
+        "@opentelemetry/sdk-logs": "^0.218.0",
         "@opentelemetry/sdk-trace-base": "^2.7.1"
       },
       "engines": {
@@ -442,10 +510,110 @@
       }
     },
     "node_modules/@repeaterjs/repeater": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
-      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.1.0.tgz",
+      "integrity": "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==",
       "license": "MIT"
+    },
+    "node_modules/@spectrum-ts/core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-zZmXHeVmoM8RBgGSlVW46njM/vNM2M35NQOTHu8vzufWp25eOT3ERIry1AX2vbri7X34Le3V9W1lwuQYZ+hufw==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/otel": "^1.0.0",
+        "@photon-ai/proto": "^0.2.4",
+        "@repeaterjs/repeater": "^3.0.6",
+        "marked": "^18.0.5",
+        "mime-types": "^3.0.1",
+        "open-graph-scraper": "^6.11.0",
+        "vcf": "^2.1.2",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "ffmpeg-static": "^5",
+        "typescript": "^5 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ffmpeg-static": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@spectrum-ts/imessage": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-7.0.0.tgz",
+      "integrity": "sha512-j3btkqaxvq21QZRQUCHcamM/8md4bTxa1TWuACToxju3VUl0dafyLDLk6g1Y27DFn3ivo+8ZyLRNi4MiI7HwiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/advanced-imessage": "^0.12.0",
+        "@photon-ai/imessage-kit": "^3.0.0",
+        "@photon-ai/otel": "^1.0.0",
+        "lru-cache": "^11.0.0",
+        "marked": "^18.0.5",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^7.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/slack": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-7.0.0.tgz",
+      "integrity": "sha512-sDNBUE6oObEuu9qgUVyX47sJ4uB6EbNYlMH09KBjBCYOrnYvuNox2n1I7xnKu3c2zKV3hSQluP7b9+1o3jubTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/slack": "^0.2.0",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^7.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/telegram": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-7.0.0.tgz",
+      "integrity": "sha512-W+OGwH4S7aOMZ7/KHwsVZsGbs+9MqEUK83g10kJmOpVQxVR7Bp9jkQTBvNJlP++ilJhb5ETow+67ky+fMA1yfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/telegram-ts": "10.0.0",
+        "marked": "^18.0.5",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^7.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/terminal": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-7.0.0.tgz",
+      "integrity": "sha512-2fSqdcRogOdk+B+pDVnMj7cdRTlvcFjS6haK/77yjRXhkwx+99hLrTe3skmU/jIVUXTC3Ujy67x0A4R2D3X4Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^7.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/whatsapp-business": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-7.0.0.tgz",
+      "integrity": "sha512-3EPP7bUn9RgURus3J1RCOAyfXSDJ5KehD5mMPfTQysZRyRBM5ePDU6w11p4/DiosLk+5X0hXaA9G9uz1gmNZxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/whatsapp-business": "^0.1.1",
+        "mime-types": "^3.0.1",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^7.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
     },
     "node_modules/abort-controller-x": {
       "version": "0.5.0",
@@ -477,15 +645,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/async-mutex": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -507,29 +666,10 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/better-grpc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/better-grpc/-/better-grpc-0.3.2.tgz",
-      "integrity": "sha512-e+u6C4zHwjE5g7vOvDpFeMe7Nas7FU+xa6FktiheRTcOpEdD5nag+uoIw7L5bPXdxxg995feBAXLwIay/npEqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@msgpack/msgpack": "^3.1.2",
-        "async-mutex": "^0.5.0",
-        "it-pushable": "^3.2.3",
-        "nice-grpc": "^2.1.13",
-        "zod": "^4.1.12"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      }
-    },
     "node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -604,9 +744,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "license": "MIT"
     },
     "node_modules/cheerio": {
@@ -1008,15 +1148,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/it-pushable": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.4.tgz",
-      "integrity": "sha512-WSD7Ss4oCRfDZJT4ldLWr0Bom/muY90xxoJ5PQnU3uSKf0kxCOeehqZtiJX1ARqn+ymXGh1bxpDW9bDNHp2ivQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "p-defer": "^4.0.0"
-      }
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -1182,18 +1313,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/p-defer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
-      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -1275,6 +1394,7 @@
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
       "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
       },
@@ -1361,9 +1481,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -1421,38 +1541,17 @@
       }
     },
     "node_modules/spectrum-ts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-3.1.0.tgz",
-      "integrity": "sha512-Dv5rsXATxGUXFnKf3VPK0VpkMPyVkf4HHUYkti0V2AKhz2m+ut3I1UPNMsvZOsiqmF+5hW8Xvrw+u/I82+XcDA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-7.0.0.tgz",
+      "integrity": "sha512-YdfU5CEZKQL7feyyQylwbzwG+f7Kk4h7OZxztok5iNdYGY1dTpUvJrTpkkLCwXOewsJR9M2n4os5hmJvUWeO6g==",
       "license": "MIT",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.11.0",
-        "@photon-ai/imessage-kit": "^3.0.0",
-        "@photon-ai/otel": "^0.1.1",
-        "@photon-ai/proto": "^0.2.4",
-        "@photon-ai/slack": "^0.2.0",
-        "@photon-ai/telegram-ts": "10.0.0",
-        "@photon-ai/whatsapp-business": "^0.1.1",
-        "@repeaterjs/repeater": "^3.0.6",
-        "better-grpc": "^0.3.2",
-        "lru-cache": "^11.0.0",
-        "marked": "^18.0.5",
-        "mime-types": "^3.0.1",
-        "nice-grpc": "^2.1.16",
-        "nice-grpc-common": "^2.0.2",
-        "open-graph-scraper": "^6.11.0",
-        "type-fest": "^5.4.1",
-        "vcf": "^2.1.2",
-        "zod": "^4.2.1"
-      },
-      "peerDependencies": {
-        "ffmpeg-static": "^5",
-        "typescript": "^5 || ^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ffmpeg-static": {
-          "optional": true
-        }
+        "@spectrum-ts/core": "7.0.0",
+        "@spectrum-ts/imessage": "7.0.0",
+        "@spectrum-ts/slack": "7.0.0",
+        "@spectrum-ts/telegram": "7.0.0",
+        "@spectrum-ts/terminal": "7.0.0",
+        "@spectrum-ts/whatsapp-business": "7.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -1501,18 +1600,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -1549,12 +1636,6 @@
       "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
       "license": "MIT"
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1568,25 +1649,10 @@
         "node": "*"
       }
     },
-    "node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -1598,9 +1664,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -1691,9 +1757,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
-        "spectrum-ts": "7.0.0"
+        "spectrum-ts": "8.0.0"
       },
       "engines": {
         "node": ">=18.17"
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -129,6 +129,21 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
@@ -146,6 +161,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
@@ -197,6 +227,21 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-transformer": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
@@ -215,6 +260,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
@@ -266,21 +326,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-logs": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
@@ -297,6 +342,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
@@ -331,6 +391,21 @@
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
@@ -362,21 +437,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -437,19 +497,21 @@
       }
     },
     "node_modules/@photon-ai/otel": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-1.0.0.tgz",
-      "integrity": "sha512-5fACVHN7BtGS+phglVAxun5QLckNUSS4p750oCxR//m9JNVzFQMoLFWfC6DnWBP/W0/+B2yP75+3NMVLodEJEg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-1.1.0.tgz",
+      "integrity": "sha512-v6Ai5Anws+gkjzZQirXpuF6VtS4DmSnpx9o208R2mhwqONNp2iqwQx4400C6r8oyqv7mz65tkkTd083kG5/kng==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.218.0",
         "@opentelemetry/context-async-hooks": "^2.7.1",
+        "@opentelemetry/core": "^2.7.1",
         "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/resources": "^2.7.1",
         "@opentelemetry/sdk-logs": "^0.218.0",
-        "@opentelemetry/sdk-trace-base": "^2.7.1"
+        "@opentelemetry/sdk-trace-base": "^2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.41.1"
       },
       "engines": {
         "node": ">=20"
@@ -516,9 +578,9 @@
       "license": "MIT"
     },
     "node_modules/@spectrum-ts/core": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-7.0.0.tgz",
-      "integrity": "sha512-zZmXHeVmoM8RBgGSlVW46njM/vNM2M35NQOTHu8vzufWp25eOT3ERIry1AX2vbri7X34Le3V9W1lwuQYZ+hufw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-8.0.0.tgz",
+      "integrity": "sha512-qcMcx1Vf/hVKzyGkbNfrVf6q7t4Zsnr65Riq843W1ButJQnUf8MhCPwnSOavWYkd8IVXL4XSndqMMdOP9xPJeg==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/otel": "^1.0.0",
@@ -541,9 +603,9 @@
       }
     },
     "node_modules/@spectrum-ts/imessage": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-7.0.0.tgz",
-      "integrity": "sha512-j3btkqaxvq21QZRQUCHcamM/8md4bTxa1TWuACToxju3VUl0dafyLDLk6g1Y27DFn3ivo+8ZyLRNi4MiI7HwiA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-8.0.0.tgz",
+      "integrity": "sha512-HjWoAZqXxuRsiY33aiJs4g6u/R8HE4V0/rtDd0wE2b+Hq/U0owDuc6T0+cLjrM/rC03jvVkTCnKSMeJWF+mYUA==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.12.0",
@@ -554,28 +616,28 @@
         "zod": "^4.2.1"
       },
       "peerDependencies": {
-        "@spectrum-ts/core": "^7.0.0",
+        "@spectrum-ts/core": "^8.0.0",
         "typescript": "^5 || ^6.0.0"
       }
     },
     "node_modules/@spectrum-ts/slack": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-7.0.0.tgz",
-      "integrity": "sha512-sDNBUE6oObEuu9qgUVyX47sJ4uB6EbNYlMH09KBjBCYOrnYvuNox2n1I7xnKu3c2zKV3hSQluP7b9+1o3jubTA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-8.0.0.tgz",
+      "integrity": "sha512-UHLL0xxThDUBPYGbT2ms9Xq5B8dSQy3SoRZX88a04i649UebnjKg9cPU2amxA8gzRcARkQrfLFtq0CFz1jXcfw==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/slack": "^0.2.0",
         "zod": "^4.2.1"
       },
       "peerDependencies": {
-        "@spectrum-ts/core": "^7.0.0",
+        "@spectrum-ts/core": "^8.0.0",
         "typescript": "^5 || ^6.0.0"
       }
     },
     "node_modules/@spectrum-ts/telegram": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-7.0.0.tgz",
-      "integrity": "sha512-W+OGwH4S7aOMZ7/KHwsVZsGbs+9MqEUK83g10kJmOpVQxVR7Bp9jkQTBvNJlP++ilJhb5ETow+67ky+fMA1yfA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-8.0.0.tgz",
+      "integrity": "sha512-pvF9LrXdcewDthh89viu2lQxcxmmeXfu8MZpymIJSpP66SjCbTwhIbWkVFQbrJbBjLcB3UdyXdQv3dNoquEcRQ==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/telegram-ts": "10.0.0",
@@ -583,27 +645,27 @@
         "zod": "^4.2.1"
       },
       "peerDependencies": {
-        "@spectrum-ts/core": "^7.0.0",
+        "@spectrum-ts/core": "^8.0.0",
         "typescript": "^5 || ^6.0.0"
       }
     },
     "node_modules/@spectrum-ts/terminal": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-7.0.0.tgz",
-      "integrity": "sha512-2fSqdcRogOdk+B+pDVnMj7cdRTlvcFjS6haK/77yjRXhkwx+99hLrTe3skmU/jIVUXTC3Ujy67x0A4R2D3X4Vw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-8.0.0.tgz",
+      "integrity": "sha512-VOyirdioTMAuR7+QNsWt708hG2ZVwt4qhyn/6CXbhnqM/V2FbEu5vNkbOlrxNj4o3y4Lr1mWMih2Fb3udJd+Nw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.2.1"
       },
       "peerDependencies": {
-        "@spectrum-ts/core": "^7.0.0",
+        "@spectrum-ts/core": "^8.0.0",
         "typescript": "^5 || ^6.0.0"
       }
     },
     "node_modules/@spectrum-ts/whatsapp-business": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-7.0.0.tgz",
-      "integrity": "sha512-3EPP7bUn9RgURus3J1RCOAyfXSDJ5KehD5mMPfTQysZRyRBM5ePDU6w11p4/DiosLk+5X0hXaA9G9uz1gmNZxQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-8.0.0.tgz",
+      "integrity": "sha512-O4mlJi/YtFpnNsiqMo5aReC/nKg66voPp0botJW+MUWZpMlon4/tJ8uVXTUwzQFwOmNRjifVTSD+R/Tll3Kvaw==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/whatsapp-business": "^0.1.1",
@@ -611,7 +673,7 @@
         "zod": "^4.2.1"
       },
       "peerDependencies": {
-        "@spectrum-ts/core": "^7.0.0",
+        "@spectrum-ts/core": "^8.0.0",
         "typescript": "^5 || ^6.0.0"
       }
     },
@@ -1299,15 +1361,15 @@
       }
     },
     "node_modules/open-graph-scraper": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/open-graph-scraper/-/open-graph-scraper-6.11.0.tgz",
-      "integrity": "sha512-KkO3qMMzJj9KYGtCl19dRtncb+RuBiG/P9BgukcAG4p2w9wSAWTE90vL6/xqth1K9ThkYF/+xfTGrVvU79TJtQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/open-graph-scraper/-/open-graph-scraper-6.12.0.tgz",
+      "integrity": "sha512-x0fS3eHxdCox+rFBhQSVe+qBznSPn1pspp8A4BoaVEkiECZEwagEb8z06swLfaFFE2gefj1BvEBeJmdeGTDnYw==",
       "license": "MIT",
       "dependencies": {
-        "chardet": "^2.1.1",
-        "cheerio": "^1.1.2",
-        "iconv-lite": "^0.7.0",
-        "undici": "^7.16.0"
+        "chardet": "^2.2.0",
+        "cheerio": "^1.2.0",
+        "iconv-lite": "^0.7.2",
+        "undici": "^7.28.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1541,17 +1603,17 @@
       }
     },
     "node_modules/spectrum-ts": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-7.0.0.tgz",
-      "integrity": "sha512-YdfU5CEZKQL7feyyQylwbzwG+f7Kk4h7OZxztok5iNdYGY1dTpUvJrTpkkLCwXOewsJR9M2n4os5hmJvUWeO6g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-8.0.0.tgz",
+      "integrity": "sha512-MY/GeqWZ+aptIpG6q0385eSizxiqNo0bAEvEfSqI1ObifhsLTbxnak1ibOpfKIJF38+gR6x9hf50WXetPE36Xw==",
       "license": "MIT",
       "dependencies": {
-        "@spectrum-ts/core": "7.0.0",
-        "@spectrum-ts/imessage": "7.0.0",
-        "@spectrum-ts/slack": "7.0.0",
-        "@spectrum-ts/telegram": "7.0.0",
-        "@spectrum-ts/terminal": "7.0.0",
-        "@spectrum-ts/whatsapp-business": "7.0.0"
+        "@spectrum-ts/core": "8.0.0",
+        "@spectrum-ts/imessage": "8.0.0",
+        "@spectrum-ts/slack": "8.0.0",
+        "@spectrum-ts/telegram": "8.0.0",
+        "@spectrum-ts/terminal": "8.0.0",
+        "@spectrum-ts/whatsapp-business": "8.0.0"
       }
     },
     "node_modules/string_decoder": {

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -13,7 +13,7 @@
     "node": ">=18.17"
   },
   "dependencies": {
-    "spectrum-ts": "7.0.0"
+    "spectrum-ts": "8.0.0"
   },
   "overrides": {
     "protobufjs": "8.6.1",

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hermes-agent/photon-sidecar",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Spectrum-ts bridge for the Hermes Agent Photon platform plugin.",
   "type": "module",
   "main": "index.mjs",
@@ -13,7 +13,7 @@
     "node": ">=18.17"
   },
   "dependencies": {
-    "spectrum-ts": "3.1.0"
+    "spectrum-ts": "7.0.0"
   },
   "overrides": {
     "protobufjs": "8.6.1",

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
 // Patch spectrum-ts' iMessage inbound mapper until upstream preserves mixed
-// text + attachment Apple events. The current spectrum-ts mapper returns only
+// text + attachment Apple events. The mapper returns only
 // buildAttachmentMessage(...) whenever attachments are present, which drops
-// event.message.content.text before Hermes can see it.
+// `message.content.text` before Hermes can see it. We rewrite the two inbound
+// mappers — `rebuildFromAppleMessage` (used by `space.getMessage`) and
+// `toInboundMessages` (used by the live stream) — so a bubble carrying both
+// text and attachment(s) surfaces as a group whose first child is the typed
+// text. Paths with no text are rewritten to byte-identical behavior, so only
+// mixed text+attachment messages change shape.
+//
+// Since spectrum-ts 5.x split the SDK into scoped packages, the iMessage mapper
+// lives in `@spectrum-ts/imessage/dist/index.js` (it used to be a chunk under
+// `spectrum-ts/dist`). The published output is tab-indented and uses
+// `const ... = async` declarations; the anchors below match that exactly and
+// fail loudly if a future spectrum-ts reshapes the mapper.
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -21,47 +32,51 @@ function replaceOnce(source, from, to, label) {
   return source.replace(from, to);
 }
 
-function replaceFirst(source, from, to, label) {
-  if (!source.includes(from)) {
-    throw new Error(`expected at least one ${label} match, found 0`);
+function replaceExactly(source, from, to, expected, label) {
+  const count = source.split(from).length - 1;
+  if (count !== expected) {
+    throw new Error(
+      `expected exactly ${expected} ${label} matches, found ${count}`
+    );
   }
-  return source.replace(from, to);
+  return source.split(from).join(to);
 }
 
-function addTextChildSnippet(messageExpr) {
-  return `if (text2) {\n      items.unshift({\n        ...base,\n        id: formatChildId(0, messageGuidStr),\n        content: asText(text2),\n        partIndex: 0,\n        parentId: messageGuidStr\n      });\n    }`;
+// The text-first child of a mixed text+attachment group, indented `tabs` deep
+// (the object's closing brace sits at `tabs`; its properties one level in).
+function textChild(tabs) {
+  const t = "\t".repeat(tabs);
+  return (
+    `{\n${t}\t...base,\n${t}\tid: formatChildId(0, messageGuidStr),` +
+    `\n${t}\tcontent: asText(text2),\n${t}\tpartIndex: 0,` +
+    `\n${t}\tparentId: messageGuidStr\n${t}}`
+  );
 }
 
 function patchRebuild(source) {
+  // Capture the bubble text before the attachment branches consume it. The
+  // existing no-attachment branch keeps its own `const text` declaration, so a
+  // distinct name avoids a redeclaration.
   source = replaceOnce(
     source,
-    `  const attachments = messageAttachments(message);\n  if (attachments.length === 1) {`,
-    `  const attachments = messageAttachments(message);\n  const text2 = message.content.text;\n  if (attachments.length === 1) {`,
+    `\tconst attachments = messageAttachments(message);\n\tif (attachments.length === 1) {`,
+    `\tconst attachments = messageAttachments(message);\n\tconst text2 = message.content.text;\n\tif (attachments.length === 1) {`,
     "rebuild text capture"
   );
+  // Single attachment: when text is present, push it to slot 0 and the
+  // attachment to slot 1, then wrap both in a group.
   source = replaceOnce(
     source,
-    `    return buildAttachmentMessage(client, base, info, messageGuidStr, 0);`,
-    `    const msg2 = await buildAttachmentMessage(\n      client,\n      base,\n      info,\n      text2 ? formatChildId(1, messageGuidStr) : messageGuidStr,\n      text2 ? 1 : 0,\n      text2 ? messageGuidStr : void 0\n    );\n    if (text2) {\n      const textMsg = {\n        ...base,\n        id: formatChildId(0, messageGuidStr),\n        content: asText(text2),\n        partIndex: 0,\n        parentId: messageGuidStr\n      };\n      return {\n        ...base,\n        id: messageGuidStr,\n        content: asProviderGroup([textMsg, msg2])\n      };\n    }\n    return msg2;`,
+    `\t\treturn buildAttachmentMessage(client, base, info, messageGuidStr, 0);`,
+    `\t\tconst msg2 = await buildAttachmentMessage(client, base, info, text2 ? formatChildId(1, messageGuidStr) : messageGuidStr, text2 ? 1 : 0, text2 ? messageGuidStr : void 0);\n\t\tif (text2) {\n\t\t\tconst textMsg = ${textChild(3)};\n\t\t\treturn {\n\t\t\t\t...base,\n\t\t\t\tid: messageGuidStr,\n\t\t\t\tcontent: asProviderGroup([textMsg, msg2])\n\t\t\t};\n\t\t}\n\t\treturn msg2;`,
     "rebuild single attachment"
   );
-  source = replaceFirst(
+  // Multi attachment: prepend the text child to the group's items.
+  source = replaceOnce(
     source,
-    `          formatChildId(i, messageGuidStr),\n          i,\n          messageGuidStr`,
-    `          formatChildId(text2 ? i + 1 : i, messageGuidStr),\n          text2 ? i + 1 : i,\n          messageGuidStr`,
-    "rebuild multi attachment child index"
-  );
-  source = replaceFirst(
-    source,
-    `    return {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };\n  }\n  if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {`,
-    `    ${addTextChildSnippet("message")}\n    return {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };\n  }\n  if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {`,
+    `\t\treturn {\n\t\t\t...base,\n\t\t\tid: messageGuidStr,\n\t\t\tcontent: asProviderGroup(items)\n\t\t};`,
+    `\t\tif (text2) {\n\t\t\titems.unshift(${textChild(3)});\n\t\t}\n\t\treturn {\n\t\t\t...base,\n\t\t\tid: messageGuidStr,\n\t\t\tcontent: asProviderGroup(items)\n\t\t};`,
     "rebuild multi attachment text child"
-  );
-  source = replaceFirst(
-    source,
-    `  const text2 = message.content.text;\n  return {\n    ...base,`,
-    `  return {\n    ...base,`,
-    "rebuild duplicate text declaration"
   );
   return source;
 }
@@ -69,41 +84,47 @@ function patchRebuild(source) {
 function patchInbound(source) {
   source = replaceOnce(
     source,
-    `  const attachments = messageAttachments(event.message);\n  if (attachments.length === 1) {`,
-    `  const attachments = messageAttachments(event.message);\n  const text2 = event.message.content.text;\n  if (attachments.length === 1) {`,
+    `\tconst attachments = messageAttachments(event.message);\n\tif (attachments.length === 1) {`,
+    `\tconst attachments = messageAttachments(event.message);\n\tconst text2 = event.message.content.text;\n\tif (attachments.length === 1) {`,
     "inbound text capture"
   );
   source = replaceOnce(
     source,
-    `      messageGuidStr,\n      0\n    );\n    cacheMessage(cache, msg2);\n    return [msg2];`,
-    `      text2 ? formatChildId(1, messageGuidStr) : messageGuidStr,\n      text2 ? 1 : 0,\n      text2 ? messageGuidStr : void 0\n    );\n    if (text2) {\n      const textMsg = {\n        ...base,\n        id: formatChildId(0, messageGuidStr),\n        content: asText(text2),\n        partIndex: 0,\n        parentId: messageGuidStr\n      };\n      const parent = {\n        ...base,\n        id: messageGuidStr,\n        content: asProviderGroup([textMsg, msg2])\n      };\n      cacheMessage(cache, parent);\n      return [parent];\n    }\n    cacheMessage(cache, msg2);\n    return [msg2];`,
+    `\t\tconst msg = await buildAttachmentMessage(client, base, info, messageGuidStr, 0);\n\t\tcacheMessage(cache, msg);\n\t\treturn [msg];`,
+    `\t\tconst msg = await buildAttachmentMessage(client, base, info, text2 ? formatChildId(1, messageGuidStr) : messageGuidStr, text2 ? 1 : 0, text2 ? messageGuidStr : void 0);\n\t\tif (text2) {\n\t\t\tconst textMsg = ${textChild(3)};\n\t\t\tconst parent = {\n\t\t\t\t...base,\n\t\t\t\tid: messageGuidStr,\n\t\t\t\tcontent: asProviderGroup([textMsg, msg])\n\t\t\t};\n\t\t\tcacheMessage(cache, parent);\n\t\t\treturn [parent];\n\t\t}\n\t\tcacheMessage(cache, msg);\n\t\treturn [msg];`,
     "inbound single attachment"
   );
   source = replaceOnce(
     source,
-    `          formatChildId(i, messageGuidStr),\n          i,\n          messageGuidStr`,
-    `          formatChildId(text2 ? i + 1 : i, messageGuidStr),\n          text2 ? i + 1 : i,\n          messageGuidStr`,
-    "inbound multi attachment child index"
-  );
-  source = replaceOnce(
-    source,
-    `    const parent = {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };`,
-    `    ${addTextChildSnippet("event.message")}\n    const parent = {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };`,
+    `\t\tconst parent = {\n\t\t\t...base,\n\t\t\tid: messageGuidStr,\n\t\t\tcontent: asProviderGroup(items)\n\t\t};`,
+    `\t\tif (text2) {\n\t\t\titems.unshift(${textChild(3)});\n\t\t}\n\t\tconst parent = {\n\t\t\t...base,\n\t\t\tid: messageGuidStr,\n\t\t\tcontent: asProviderGroup(items)\n\t\t};`,
     "inbound multi attachment text child"
-  );
-  source = replaceOnce(
-    source,
-    `  const text2 = event.message.content.text;\n  const msg = {`,
-    `  const msg = {`,
-    "inbound duplicate text declaration"
   );
   return source;
 }
 
+// Shift attachment part indices by one when a text child occupies slot 0. The
+// push line is byte-identical in both mappers, so patch both occurrences.
+function patchChildIndices(source) {
+  return replaceExactly(
+    source,
+    `items.push(await buildAttachmentMessage(client, base, info, formatChildId(i, messageGuidStr), i, messageGuidStr));`,
+    `items.push(await buildAttachmentMessage(client, base, info, formatChildId(text2 ? i + 1 : i, messageGuidStr), text2 ? i + 1 : i, messageGuidStr));`,
+    2,
+    "multi attachment child index"
+  );
+}
+
 export function patchSpectrumTs(root = scriptDir()) {
-  const dist = path.join(root, "node_modules", "spectrum-ts", "dist");
+  const dist = path.join(
+    root,
+    "node_modules",
+    "@spectrum-ts",
+    "imessage",
+    "dist"
+  );
   if (!fs.existsSync(dist)) {
-    throw new Error(`spectrum-ts dist not found: ${dist}`);
+    throw new Error(`@spectrum-ts/imessage dist not found: ${dist}`);
   }
   const files = fs.readdirSync(dist)
     .filter((name) => name.endsWith(".js"))
@@ -117,18 +138,20 @@ export function patchSpectrumTs(root = scriptDir()) {
     // Normalize to LF for matching so the patch works regardless of the
     // checkout's line-ending style (Windows git autocrlf produces CRLF,
     // which would otherwise defeat the \n-based search strings). The
-    // original EOL style is restored on write.
+    // original EOL style is restored on write. Indentation in the published
+    // tarball is tabs; the anchors match that directly.
     const CR = String.fromCharCode(13);
     const CRLF = CR + "\n";
     const usedCRLF = raw.includes(CRLF);
     const original = usedCRLF ? raw.split(CRLF).join("\n") : raw;
-    if (!original.includes("var toInboundMessages = async") ||
-        !original.includes("var rebuildFromAppleMessage = async")) {
+    if (!original.includes("const toInboundMessages = async") ||
+        !original.includes("const rebuildFromAppleMessage = async")) {
       continue;
     }
     let patched = original;
     patched = patchRebuild(patched);
     patched = patchInbound(patched);
+    patched = patchChildIndices(patched);
     patched = `// ${MARKER}\n${patched}`;
     if (usedCRLF) {
       patched = patched.split("\n").join(CRLF);
@@ -136,7 +159,7 @@ export function patchSpectrumTs(root = scriptDir()) {
     fs.writeFileSync(file, patched, "utf8");
     return { patched: true, file };
   }
-  throw new Error("could not find spectrum-ts iMessage inbound chunk to patch");
+  throw new Error("could not find @spectrum-ts/imessage iMessage inbound chunk to patch");
 }
 
 const _invokedDirectly =

--- a/plugins/ragnos-governance/__init__.py
+++ b/plugins/ragnos-governance/__init__.py
@@ -1,0 +1,45 @@
+"""ragnos-governance plugin: universal pre-tool-call gate + governance telemetry.
+
+OBSERVE by default (records every tool call to the governance ledger). Set
+``RAGNOS_GOVERNANCE_ENFORCE=1`` plus ``RAGNOS_GOVERNANCE_FORBIDDEN_TOOLS`` to
+BLOCK gated tools so they route through the Hermes Hub (preview + approval).
+
+This is the Sprint 2 governance overlay from the Hermes realignment spec. It is
+additive and lives entirely in the RAGnos-owned ``plugins/ragnos-governance/``
+surface; it never edits upstream core, so the upstream conformance gate stays
+green.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from . import governance
+
+
+def _on_pre_tool_call(*, tool_name: str = "", args: Optional[dict] = None, **_kwargs: Any) -> Optional[dict]:
+    enforce = governance.is_enforcing()
+    verdict = governance.evaluate_tool(
+        tool_name,
+        args,
+        enforce=enforce,
+        forbidden=governance.forbidden_tools(),
+    )
+    governance.record_event(
+        "pre_tool_call",
+        {"tool": tool_name, "enforce": enforce, "blocked": verdict is not None},
+    )
+    return verdict
+
+
+def _on_post_tool_call(*, tool_name: str = "", **_kwargs: Any) -> None:
+    governance.record_event("post_tool_call", {"tool": tool_name})
+
+
+def _on_session_end(**_kwargs: Any) -> None:
+    governance.record_event("session_end", {})
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_tool_call", _on_pre_tool_call)
+    ctx.register_hook("post_tool_call", _on_post_tool_call)
+    ctx.register_hook("on_session_end", _on_session_end)

--- a/plugins/ragnos-governance/governance.py
+++ b/plugins/ragnos-governance/governance.py
@@ -1,0 +1,82 @@
+"""RAGnos governance policy: a deterministic pre-tool-call gate + telemetry.
+
+Pure, dependency-free policy so it is hermetically testable. The plugin
+(``__init__.py``) wires these functions into the gateway's ``pre_tool_call`` /
+``post_tool_call`` / ``on_session_end`` hooks.
+
+OBSERVE by default: every tool call is recorded to a JSONL governance ledger.
+Set ``RAGNOS_GOVERNANCE_ENFORCE=1`` (plus ``RAGNOS_GOVERNANCE_FORBIDDEN_TOOLS``)
+to BLOCK gated tools so they must route through the Hermes Hub (preview +
+approval). This file edits no upstream code; it lives only under
+``plugins/ragnos-governance/`` (a RAGnos-owned surface).
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+ENFORCE_ENV = "RAGNOS_GOVERNANCE_ENFORCE"
+FORBIDDEN_ENV = "RAGNOS_GOVERNANCE_FORBIDDEN_TOOLS"
+LEDGER_ENV = "RAGNOS_GOVERNANCE_LEDGER"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def is_enforcing(env: Optional[Mapping[str, str]] = None) -> bool:
+    env = os.environ if env is None else env
+    return str(env.get(ENFORCE_ENV, "")).strip().lower() in _TRUTHY
+
+
+def forbidden_tools(env: Optional[Mapping[str, str]] = None) -> frozenset[str]:
+    env = os.environ if env is None else env
+    raw = str(env.get(FORBIDDEN_ENV, "")).strip()
+    if not raw:
+        return frozenset()
+    return frozenset(part.strip() for part in raw.replace("\n", ",").split(",") if part.strip())
+
+
+def evaluate_tool(
+    tool_name: str,
+    args: Optional[Mapping[str, Any]] = None,
+    *,
+    enforce: bool = False,
+    forbidden: frozenset[str] = frozenset(),
+) -> Optional[dict[str, str]]:
+    """Return a block directive when a gated tool runs under enforcement, else None.
+
+    The return shape matches the gateway's ``get_pre_tool_call_block_message``
+    contract: ``{"action": "block", "message": "..."}``.
+    """
+    if enforce and tool_name in forbidden:
+        return {
+            "action": "block",
+            "message": (
+                f"RAGnos governance: tool '{tool_name}' is gated. Route it through "
+                "the Hermes Hub (preview + approval) instead of calling it directly."
+            ),
+        }
+    return None
+
+
+def record_event(event_type: str, payload: Mapping[str, Any], *, env: Optional[Mapping[str, str]] = None) -> None:
+    """Append a governance telemetry event to the JSONL ledger (best effort)."""
+    env = os.environ if env is None else env
+    path = ledger_path(env)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        row = {"event_type": event_type, **dict(payload)}
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row, default=str) + "\n")
+    except Exception:  # noqa: BLE001 - telemetry must never break a tool call.
+        pass
+
+
+def ledger_path(env: Optional[Mapping[str, str]] = None) -> Path:
+    env = os.environ if env is None else env
+    raw = env.get(LEDGER_ENV)
+    if raw:
+        return Path(str(raw)).expanduser()
+    home = env.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    return Path(home).expanduser() / "ragnos-governance" / "governance-ledger.jsonl"

--- a/plugins/ragnos-governance/plugin.yaml
+++ b/plugins/ragnos-governance/plugin.yaml
@@ -1,0 +1,8 @@
+name: ragnos-governance
+version: 0.1.0
+description: "RAGnos governance overlay: observes every tool call to a ledger and (when RAGNOS_GOVERNANCE_ENFORCE=1) blocks gated mutating tools so they route through the Hermes Hub. Observe-only by default."
+author: "RAGnos"
+hooks:
+  - pre_tool_call
+  - post_tool_call
+  - on_session_end

--- a/plugins/ragnos-governance/test_governance.py
+++ b/plugins/ragnos-governance/test_governance.py
@@ -1,0 +1,60 @@
+"""Hermetic tests for the RAGnos governance policy (Sprint 2).
+
+Imports governance.py by path so the hyphenated plugin dir name does not block
+a normal ``import``.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "ragnos_governance_governance", Path(__file__).parent / "governance.py"
+)
+governance = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(governance)
+
+
+def test_observe_mode_never_blocks() -> None:
+    # Default (no enforcement): no tool is ever blocked.
+    assert governance.evaluate_tool("delete_everything", {}, enforce=False, forbidden=frozenset({"delete_everything"})) is None
+
+
+def test_enforced_forbidden_tool_is_blocked() -> None:
+    verdict = governance.evaluate_tool(
+        "send_money", {}, enforce=True, forbidden=frozenset({"send_money"})
+    )
+    assert verdict is not None
+    assert verdict["action"] == "block"
+    assert "send_money" in verdict["message"]
+    assert "Hermes Hub" in verdict["message"]
+
+
+def test_enforced_but_unlisted_tool_is_allowed() -> None:
+    assert governance.evaluate_tool("read_file", {}, enforce=True, forbidden=frozenset({"send_money"})) is None
+
+
+def test_is_enforcing_reads_env() -> None:
+    assert governance.is_enforcing({"RAGNOS_GOVERNANCE_ENFORCE": "1"}) is True
+    assert governance.is_enforcing({"RAGNOS_GOVERNANCE_ENFORCE": "true"}) is True
+    assert governance.is_enforcing({}) is False
+    assert governance.is_enforcing({"RAGNOS_GOVERNANCE_ENFORCE": "0"}) is False
+
+
+def test_forbidden_tools_parses_env_list() -> None:
+    got = governance.forbidden_tools({"RAGNOS_GOVERNANCE_FORBIDDEN_TOOLS": "a, b ,c"})
+    assert got == frozenset({"a", "b", "c"})
+    assert governance.forbidden_tools({}) == frozenset()
+
+
+def test_record_event_appends_jsonl(tmp_path: Path) -> None:
+    ledger = tmp_path / "ledger.jsonl"
+    env = {"RAGNOS_GOVERNANCE_LEDGER": str(ledger)}
+    governance.record_event("pre_tool_call", {"tool": "x", "blocked": False}, env=env)
+    governance.record_event("post_tool_call", {"tool": "x"}, env=env)
+    rows = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 2
+    assert rows[0]["event_type"] == "pre_tool_call"
+    assert rows[0]["tool"] == "x"
+    assert rows[1]["event_type"] == "post_tool_call"

--- a/ragnos/README.md
+++ b/ragnos/README.md
@@ -1,0 +1,55 @@
+RAGnos additions to the hermes-agent fork
+=========================================
+
+This directory holds the ONLY RAGnos-authored files in the
+`ragnos-labs/hermes-agent` fork of `NousResearch/hermes-agent`. Everything else
+is upstream, used UNMODIFIED, so we can pull updates cleanly.
+
+Why a fork
+----------
+The official Photon (iMessage) plugin (`plugins/platforms/photon/`) is a finished,
+maintained drop-in: a Python adapter + a Node `spectrum-ts` sidecar + tests. Our
+custom Hermes Hub treats hermes-agent OSS as its baseline. Rather than rebuild the
+iMessage transport, we fork, use the official adapter as-is, and bridge it to Keez.
+
+Topology
+--------
+Sibling service (this checkout) runs the official Photon adapter with ONLY the
+Photon platform active. It bridges to the RAGnos Hub at two seams that live in the
+Hub package (`tools/home-agent/src/home_agent/`), NOT here:
+
+* Inbound  (SEAM 1): `home_agent.photon_inbound.build_keez_handler` -> Keez daemon.
+* Outbound (SEAM 2): `home_agent.photon_delivery` -> sidecar `/send` (Morning Brief,
+  Hermes Hub alerts pushed to the phone).
+
+`ragnos/run_photon_keez.py` is the entrypoint: it imports the unmodified official
+adapter and injects the Keez handler via the adapter's public
+`set_message_handler` seam. No upstream file is edited.
+
+Pulling upstream updates
+------------------------
+    git fetch upstream
+    git merge upstream/main        # or rebase ragnos/main onto upstream/main
+    cd plugins/platforms/photon/sidecar && npm install   # if sidecar deps changed
+
+Our changes are confined to `ragnos/`, so merges should not conflict with upstream.
+
+Running it (live activation, human-gated)
+-----------------------------------------
+1. `hermes photon setup --phone +1XXXXXXXXXX`  (device-code login at
+   app.photon.codes; creates a Spectrum project, links the number, installs the
+   sidecar). This is the one step a human must do; it needs a Photon account + a
+   phone.
+2. Put `PHOTON_PROJECT_ID` / `PHOTON_PROJECT_SECRET` / `PHOTON_SIDECAR_TOKEN` in
+   Infisical and render them into this service's env (do NOT use `~/.hermes/.env`
+   in production).
+3. Set `PHOTON_ALLOWED_USERS=+1XXXXXXXXXX` and
+   `HOME_AGENT_SRC=/Users/huntercanning/dev/ragnos/workspace/tools/home-agent/src`.
+4. `python ragnos/run_photon_keez.py`  (a launchd unit stages this; see the RAGnos
+   repo `scripts/launchd/`).
+
+Verification without live Photon
+--------------------------------
+The RAGnos repo ships a battle-test that runs THIS adapter against a fake sidecar
+(no Photon account needed):
+`tools/home-agent/scripts/photon_battle_test.py` (11 scenarios, fault + concurrency).

--- a/ragnos/photon_register.py
+++ b/ragnos/photon_register.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Register your iMessage number on an EXISTING Photon project (keys in hand).
+
+Use this when you ALREADY have PHOTON_PROJECT_ID (the spectrumProjectId) and
+PHOTON_PROJECT_SECRET and do NOT want the device-login flow in photon_setup.py
+(which rotates your project secret and would invalidate keys you already hold).
+
+It registers your number as a Spectrum user (Basic auth with your project creds,
+no dashboard login) and prints the agent's iMessage number to text. Idempotent.
+
+    PHOTON_PROJECT_ID=... PHOTON_PROJECT_SECRET=... PYTHONPATH=$(pwd) \
+        python ragnos/photon_register.py --phone +1XXXXXXXXXX
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+_FORK_ROOT = Path(__file__).resolve().parent.parent
+if str(_FORK_ROOT) not in sys.path:
+    sys.path.insert(0, str(_FORK_ROOT))
+
+from plugins.platforms.photon import auth as photon_auth  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Register a number on an existing Photon project.")
+    ap.add_argument("--phone", required=True, help="Your iMessage number, E.164 (e.g. +15551234567)")
+    args = ap.parse_args()
+
+    project_id = os.environ.get("PHOTON_PROJECT_ID", "").strip()
+    project_secret = os.environ.get("PHOTON_PROJECT_SECRET", "").strip()
+    if not project_id or not project_secret:
+        print(
+            "Set PHOTON_PROJECT_ID (spectrumProjectId) and PHOTON_PROJECT_SECRET in the "
+            "environment first (e.g. `source ~/.hermes/ragnos-photon.env`).",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        user, created = photon_auth.register_user_if_absent(
+            project_id, project_secret, phone_number=args.phone
+        )
+    except Exception as e:  # noqa: BLE001
+        print(f"registration failed: {e}", file=sys.stderr)
+        return 1
+
+    print("registered your number" if created else "your number is already registered")
+    agent_number = photon_auth.user_assigned_line(user)
+    print()
+    if agent_number:
+        print("=" * 60)
+        print(f"  Agent iMessage number: {agent_number}")
+        print("  Text THIS number from your phone to reach Keez.")
+        print("=" * 60)
+    else:
+        print("  No iMessage line assigned yet; the free shared tier usually assigns")
+        print("  one within a moment. Re-run, or check the Photon dashboard.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ragnos/photon_setup.py
+++ b/ragnos/photon_setup.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Standalone Photon provisioning for the RAGnos Hermes Hub iMessage surface.
+
+Does exactly what `hermes photon setup --phone ...` does, WITHOUT installing the
+full hermes CLI. It drives the fork's self-contained
+`plugins/platforms/photon/auth.py` (httpx only): device-code login, find/create
+the "Hermes Agent" project, enable Spectrum, rotate the project secret, register
+your number, and surface the agent's iMessage line.
+
+Credentials persist to ~/.hermes/auth.json (the official adapter reads them from
+there). Your number is also written into ~/.hermes/ragnos-photon.env as
+PHOTON_ALLOWED_USERS so the runner authorizes your own inbound messages.
+
+Prereq: a Photon account (sign up at https://app.photon.codes/ ; the free tier is
+enough for personal use). Then:
+
+    PYTHONPATH=$(pwd) python ragnos/photon_setup.py --phone +1XXXXXXXXXX
+
+Approve the device login in your browser, then text the printed agent number.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+_FORK_ROOT = Path(__file__).resolve().parent.parent
+if str(_FORK_ROOT) not in sys.path:
+    sys.path.insert(0, str(_FORK_ROOT))
+
+from plugins.platforms.photon import auth as photon_auth  # noqa: E402
+
+
+def _print_code(code) -> None:
+    target = code.verification_uri_complete or code.verification_uri
+    print()
+    print("  Open this URL:  " + str(target))
+    print("  Enter the code: " + str(code.user_code))
+    print("  (waiting for browser approval; Ctrl-C to cancel)")
+    print()
+
+
+def _write_allowlist(phone: str) -> None:
+    """Fill PHOTON_ALLOWED_USERS in ~/.hermes/ragnos-photon.env (default-deny
+    means the runner must allowlist your own number to accept your texts)."""
+    envf = Path(os.path.expanduser("~/.hermes/ragnos-photon.env"))
+    if not envf.exists():
+        return
+    out = []
+    found = False
+    for ln in envf.read_text().splitlines():
+        if ln.startswith("export PHOTON_ALLOWED_USERS="):
+            out.append(f"export PHOTON_ALLOWED_USERS={phone}")
+            found = True
+        else:
+            out.append(ln)
+    if not found:
+        out.append(f"export PHOTON_ALLOWED_USERS={phone}")
+    envf.write_text("\n".join(out) + "\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Provision Photon iMessage for the Hermes Hub.")
+    ap.add_argument("--phone", required=True, help="Your iMessage number, E.164 (e.g. +15551234567)")
+    ap.add_argument("--project-name", default=None, help="Project name (default: 'Hermes Agent')")
+    ap.add_argument("--no-browser", action="store_true", help="Print the login URL instead of opening a browser")
+    args = ap.parse_args()
+
+    # 1. Device-code login (interactive: approve in the browser).
+    token = photon_auth.load_photon_token()
+    if not token:
+        print("[1/4] Photon device login...")
+        token = photon_auth.login_device_flow(open_browser=not args.no_browser, on_user_code=_print_code)
+        print("  logged in (token saved to %s)" % photon_auth._auth_json_path())
+    else:
+        print("[1/4] Reusing existing Photon token")
+
+    # 2. Find or create the project.
+    name = args.project_name or photon_auth.DEFAULT_PROJECT_NAME
+    dashboard_id = photon_auth.load_dashboard_project_id()
+    if dashboard_id:
+        print("[2/4] Reusing configured project")
+    else:
+        existing = photon_auth.find_project_by_name(token, name)
+        if existing and existing.get("id"):
+            dashboard_id = existing["id"]
+            print(f"[2/4] Found project '{name}'")
+        else:
+            print(f"[2/4] Creating project '{name}'...")
+            dashboard_id = photon_auth.create_project(token, name=name).get("id")
+    if not dashboard_id:
+        print("could not resolve a Photon project id", file=sys.stderr)
+        return 1
+
+    # 3. Enable Spectrum, rotate the secret, persist creds.
+    print("[3/4] Enabling Spectrum and provisioning credentials...")
+    proj = photon_auth.ensure_spectrum_enabled(token, dashboard_id)
+    spectrum_id = str(proj.get("spectrumProjectId") or "")
+    if not spectrum_id:
+        print("spectrum provisioning failed: no spectrum project id", file=sys.stderr)
+        return 1
+    secret = photon_auth.regenerate_project_secret(token, dashboard_id)
+    photon_auth.store_project_credentials(
+        spectrum_project_id=spectrum_id, project_secret=secret,
+        dashboard_project_id=dashboard_id, name=name,
+    )
+    print(f"  Spectrum enabled (project {spectrum_id}); secret saved to auth.json")
+
+    # 4. Register your number + surface the agent's iMessage line.
+    print("[4/4] Registering your number...")
+    user, created = photon_auth.register_user_if_absent(spectrum_id, secret, phone_number=args.phone)
+    print("  phone registered" if created else "  phone already registered")
+    _write_allowlist(args.phone)
+    agent_number = photon_auth.user_assigned_line(user)
+    if not agent_number:
+        try:
+            line = photon_auth.get_imessage_line(token, dashboard_id)
+            agent_number = line.get("phoneNumber") if line else None
+        except Exception as e:  # noqa: BLE001
+            print(f"  (could not fetch the assigned line: {e})", file=sys.stderr)
+    photon_auth.store_user_numbers(
+        phone_number=args.phone, assigned_phone_number=agent_number,
+        user_id=str(user.get("id")) if user.get("id") else None,
+        dashboard_project_id=dashboard_id,
+    )
+    print()
+    if agent_number:
+        print("=" * 64)
+        print(f"  Your agent's iMessage number: {agent_number}")
+        print("  Text THIS number from your phone to reach Keez.")
+        print("=" * 64)
+    else:
+        print("  No iMessage line assigned yet; check the Photon dashboard.")
+    print("\nDone. Tell me it is provisioned and I will start the runner.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ragnos/run_photon_audition_reply.py
+++ b/ragnos/run_photon_audition_reply.py
@@ -74,7 +74,9 @@ async def _run() -> int:
     if not await adapter.connect():
         log.error("adapter.connect() failed (missing creds or sidecar). See logs above.")
         return 1
-    log.info("connected; audition-reply inbound active (allowlist=%d). Ctrl-C to stop.", len(allow))
+    cos_enabled = os.environ.get("KEEZ_TEXT_COS_ENABLED", "").strip().lower()
+    mode = "full CoS" if cos_enabled in {"1", "true", "yes", "on"} else "audition-reply"
+    log.info("connected; %s inbound active (allowlist=%d). Ctrl-C to stop.", mode, len(allow))
     try:
         while True:
             await asyncio.sleep(3600)

--- a/ragnos/run_photon_audition_reply.py
+++ b/ragnos/run_photon_audition_reply.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""RAGnos sibling-service entrypoint: Photon inbound adapter -> Keez CoS over text.
+
+The inbound runner. It installs the UNIFIED conversational-CoS handler from
+``home_agent.cos_text_handler.build_live_cos_handler``, gated by
+``KEEZ_TEXT_COS_ENABLED``:
+  off (default) -> delegates verbatim to the audition-reply handler (today's
+                   behavior: reply to the most-recent audition alert, confirm,
+                   send via gws). Nothing else is answered.
+  on            -> full conversational CoS: text Keez anything; it answers drawing
+                   from the entire system (brain + Librarian + live sources) and
+                   takes actions (auto low-risk / confirm high-risk). Audition
+                   reply is absorbed as the email-reply path.
+
+Sidecar policy (CRITICAL): this runner does NOT spawn a sidecar. It sets
+``PHOTON_SIDECAR_AUTOSTART=false`` so it connects to the EXISTING durable
+``io.ragnos.photon-sidecar`` (127.0.0.1:8789) and consumes its ``/inbound``
+stream. Two sidecars would fight over the port; there must be exactly one
+(the launchd-managed photon-sidecar). See scripts/launchd/photon-sidecar.sh.
+
+Inbound:  iMessage -> Photon -> (existing) sidecar -> this adapter -> audition
+          reply handler -> gws gmail reply. The adapter auto-sends the handler's
+          returned confirm/sent/cancel string back to the operator's chat.
+
+Env (rendered from Infisical in production):
+  PHOTON_PROJECT_ID, PHOTON_PROJECT_SECRET   from ``hermes photon setup``
+  PHOTON_SIDECAR_TOKEN                        shared secret (sidecar control)
+  PHOTON_ALLOWED_USERS                        E.164 allowlist (operator number)
+  HOME_AGENT_SRC                              path to RAGnos tools/home-agent/src
+  RAGNOS_WORKSPACE                            repo root (gws.js + threads file)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+
+def _allowlist() -> list[str]:
+    raw = os.environ.get("PHOTON_ALLOWED_USERS", "")
+    return [p.strip() for p in raw.replace("\n", ",").split(",") if p.strip()]
+
+
+async def _run() -> int:
+    logging.basicConfig(
+        level=os.environ.get("PHOTON_KEEZ_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    log = logging.getLogger("photon-audition-reply")
+
+    # Never spawn a competing sidecar: consume the durable photon-sidecar's stream.
+    os.environ.setdefault("PHOTON_SIDECAR_AUTOSTART", "false")
+
+    home_src = os.environ.get("HOME_AGENT_SRC")
+    if home_src and home_src not in sys.path:
+        sys.path.insert(0, home_src)
+
+    from gateway.config import PlatformConfig
+    from plugins.platforms.photon.adapter import PhotonAdapter
+    from home_agent.cos_text_handler import build_live_cos_handler
+
+    allow = _allowlist()
+    if not allow:
+        log.error("PHOTON_ALLOWED_USERS empty -- refusing to start (would block all). Set it in Infisical.")
+        return 78  # EX_CONFIG: do not crash-loop fast on a config gap
+
+    # Unified conversational-CoS handler. Gated by KEEZ_TEXT_COS_ENABLED:
+    #   off (default) -> delegates verbatim to the audition-reply handler (today's behavior).
+    #   on            -> full CoS (brain + live sources + audition absorbed).
+    adapter = PhotonAdapter(PlatformConfig(extra={}))
+    adapter.set_message_handler(build_live_cos_handler(os.environ))
+
+    if not await adapter.connect():
+        log.error("adapter.connect() failed (missing creds or sidecar). See logs above.")
+        return 1
+    log.info("connected; audition-reply inbound active (allowlist=%d). Ctrl-C to stop.", len(allow))
+    try:
+        while True:
+            await asyncio.sleep(3600)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        log.info("shutting down")
+    finally:
+        await adapter.disconnect()
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ragnos/run_photon_keez.py
+++ b/ragnos/run_photon_keez.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""RAGnos sibling-service entrypoint: official Photon adapter -> Keez daemon.
+
+This is the ONLY RAGnos-authored runtime file in the fork. It imports the
+UNMODIFIED upstream Photon adapter and injects our Keez bridge handler (from the
+RAGnos Hermes Hub package ``home_agent.photon_inbound``) via the adapter's public
+``set_message_handler`` seam. Keeping our additions in ``ragnos/`` (never editing
+upstream files) keeps ``git fetch upstream && merge`` clean.
+
+Inbound:  iMessage -> Photon -> sidecar -> official adapter -> this handler -> Keez.
+Outbound replies are auto-sent by the adapter. Outbound *push* (Morning Brief /
+Hermes Hub alerts) is handled separately by the Hub via
+``home_agent.photon_delivery`` against the same sidecar.
+
+Env (rendered from Infisical in production; see ragnos/README.md):
+  PHOTON_PROJECT_ID, PHOTON_PROJECT_SECRET   from ``hermes photon setup``
+  PHOTON_SIDECAR_TOKEN                        shared secret (outbound uses it too)
+  PHOTON_ALLOWED_USERS                        E.164 allowlist (comma/newline list)
+  HOME_AGENT_SRC                              path to RAGnos tools/home-agent/src
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+
+def _allowlist() -> list[str]:
+    raw = os.environ.get("PHOTON_ALLOWED_USERS", "")
+    return [p.strip() for p in raw.replace("\n", ",").split(",") if p.strip()]
+
+
+async def _run() -> int:
+    logging.basicConfig(
+        level=os.environ.get("PHOTON_KEEZ_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    log = logging.getLogger("photon-keez")
+
+    # The Hub package (home_agent) lives in the RAGnos monorepo, not this fork.
+    home_src = os.environ.get("HOME_AGENT_SRC")
+    if home_src and home_src not in sys.path:
+        sys.path.insert(0, home_src)
+
+    from gateway.config import PlatformConfig
+    from plugins.platforms.photon.adapter import PhotonAdapter
+    from home_agent.photon_inbound import build_keez_handler
+
+    adapter = PhotonAdapter(PlatformConfig(extra={}))
+    adapter.set_message_handler(build_keez_handler(allowlist=_allowlist()))
+
+    if not await adapter.connect():
+        log.error("adapter.connect() failed (missing creds or sidecar). See logs above.")
+        return 1
+    log.info("connected; routing iMessage <-> Keez (allowlist=%d). Ctrl-C to stop.", len(_allowlist()))
+    try:
+        while True:
+            await asyncio.sleep(3600)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        log.info("shutting down")
+    finally:
+        await adapter.disconnect()
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ragnos/start_photon_keez.sh
+++ b/ragnos/start_photon_keez.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Start the Photon -> Keez runner with creds pulled live from Infisical.
+#
+# No plaintext env file: the 4 PHOTON_* secrets live in Infisical (workspace
+# 3820769e-...). This reads them with the read-only daemon token at launch,
+# exports them into the runner's process env, and execs run_photon_keez.py.
+# Set PHOTON_KEEZ_PYTHON to a python that has httpx + the home_agent package.
+set -euo pipefail
+
+FORK="$(cd "$(dirname "$0")/.." && pwd)"
+PROJECT=3820769e-6d2a-4c15-ac4a-212382efa34e
+READ_TOKEN="$(cat "$HOME/.infisical/agent-token.json")"
+
+fetch() {
+  curl -s "https://app.infisical.com/api/v3/secrets/raw/$1?workspaceId=$PROJECT&environment=prod&secretPath=/&type=shared" \
+    -H "Authorization: Bearer $READ_TOKEN" \
+    | python3 -c "import json,sys; print(json.load(sys.stdin).get('secret',{}).get('secretValue',''))"
+}
+
+export PHOTON_PROJECT_ID="$(fetch PHOTON_PROJECT_ID)"
+export PHOTON_PROJECT_SECRET="$(fetch PHOTON_PROJECT_SECRET)"
+export PHOTON_SIDECAR_TOKEN="$(fetch PHOTON_SIDECAR_TOKEN)"
+export PHOTON_ALLOWED_USERS="$(fetch PHOTON_ALLOWED_USERS)"
+export PYTHONPATH="$FORK"
+
+if [ -z "$PHOTON_PROJECT_ID" ] || [ -z "$PHOTON_PROJECT_SECRET" ]; then
+  echo "[start] missing PHOTON creds from Infisical (read token stale?)" >&2
+  exit 1
+fi
+
+# Defensive port reclaim before launch. A hard-crashed (kill -9 / OOM) runner
+# skips its finally-block cleanup, orphaning its child spectrum-ts sidecar, which
+# keeps LISTENing on 127.0.0.1:8789. The fresh sidecar then cannot bind and the
+# runner crash-loops under launchd KeepAlive. Kill any stale sidecar and wait for
+# the port to clear. Idempotent: a no-op on the normal-exit path (finally already
+# cleans up) and when nothing is stale.
+pkill -f "plugins/platforms/photon/sidecar/index.mjs" 2>/dev/null || true
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  lsof -ti tcp:8789 >/dev/null 2>&1 || break
+  sleep 1
+done
+
+PY_BIN="${PHOTON_KEEZ_PYTHON:-python3}"
+echo "[start] launching Photon->Keez runner (allowlist set, creds from Infisical)"
+
+# Supervise the runner as a CHILD (do not exec). When it dies -- even via a hard
+# kill -9 / OOM that skips the runner's own finally-block cleanup -- this wrapper
+# regains control and reaps the orphaned spectrum-ts sidecar. That matters for
+# two reasons: the orphaned sidecar keeps LISTENing on 8789 (blocking the next
+# bind) AND, being a surviving child of this launchd job, it keeps the job
+# "alive" so KeepAlive never fires. Reaping it lets this wrapper exit cleanly so
+# launchd respawns a fresh instance. The TERM/INT trap forwards launchd's stop
+# signal to the runner so a graceful stop still runs the runner's own cleanup.
+_reap_sidecar() { pkill -f "plugins/platforms/photon/sidecar/index.mjs" 2>/dev/null || true; }
+"$PY_BIN" "$FORK/ragnos/run_photon_keez.py" &
+RUNNER_PID=$!
+trap 'kill -TERM "$RUNNER_PID" 2>/dev/null || true' TERM INT
+wait "$RUNNER_PID"
+STATUS=$?
+_reap_sidecar
+exit "$STATUS"

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -545,6 +545,24 @@ class TestRuntimeDisconnectQueuing:
         assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 0
 
     @pytest.mark.asyncio
+    async def test_retryable_runtime_error_reconnects_immediately(self):
+        """Runtime failures should not wait for the startup retry delay."""
+        runner = _make_runner()
+        runner.stop = AsyncMock()
+
+        adapter = StubAdapter(succeed=True)
+        adapter._set_fatal_error("sidecar_crashed", "bridge exited", retryable=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        before = time.monotonic()
+        await runner._handle_adapter_fatal_error(adapter)
+        after = time.monotonic()
+
+        info = runner._failed_platforms[Platform.TELEGRAM]
+        assert info["attempts"] == 0
+        assert before <= info["next_retry"] <= after
+
+    @pytest.mark.asyncio
     async def test_nonretryable_runtime_error_not_queued(self):
         """Non-retryable runtime errors should not be queued for reconnection."""
         runner = _make_runner()
@@ -765,4 +783,3 @@ class TestPlatformSlashCommand:
         runner = _make_runner()
         out = await runner._handle_platform_command(self._make_event("/platform"))
         assert "Gateway platforms" in out
-

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -101,14 +101,15 @@ async def test_reply_prefix_still_injected_when_text_in_history():
 
 @pytest.mark.asyncio
 async def test_own_message_reply_prefix_marks_assistant_message():
+    """Own-message reply context is encoded in reply_to_text by the adapter
+    so the generic gateway handler emits the right framing without a core edit."""
     runner = _make_runner()
     source = _source()
     event = MessageEvent(
         text="this one",
         source=source,
         reply_to_message_id="42",
-        reply_to_text="Use the direct train.",
-        reply_to_is_own_message=True,
+        reply_to_text="your previous message: Use the direct train.",
     )
 
     result = await runner._prepare_inbound_message_text(
@@ -119,7 +120,7 @@ async def test_own_message_reply_prefix_marks_assistant_message():
 
     assert result is not None
     assert result.startswith(
-        '[Replying to your previous message: "Use the direct train."]'
+        '[Replying to: "your previous message: Use the direct train."]'
     )
     assert result.endswith("this one")
 

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -100,6 +100,31 @@ async def test_reply_prefix_still_injected_when_text_in_history():
 
 
 @pytest.mark.asyncio
+async def test_own_message_reply_prefix_marks_assistant_message():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="this one",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="Use the direct train.",
+        reply_to_is_own_message=True,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith(
+        '[Replying to your previous message: "Use the direct train."]'
+    )
+    assert result.endswith("this one")
+
+
+@pytest.mark.asyncio
 async def test_no_prefix_without_reply_context():
     runner = _make_runner()
     source = _source()

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -12,6 +12,8 @@ dying (issue #50185):
      ``retryable=True`` fatal so the gateway reconnect watcher revives the
      platform — instead of returning silently and leaving ``_inbound_loop``
      spinning against a dead port.
+  4. ``_monitor_sidecar_health`` promotes degraded upstream stream health
+     reported by ``/healthz`` into the same retryable reconnect path.
 
 No Node sidecar is spawned and no ports are bound.
 """
@@ -195,3 +197,40 @@ async def test_clean_shutdown_does_not_raise_fatal(
 
     assert adapter.has_fatal_error is False
     assert notified == []
+
+
+@pytest.mark.asyncio
+async def test_degraded_stream_health_raises_retryable_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._inbound_running = True
+    adapter._sidecar_health_interval = 0.0
+
+    async def _fake_call(path: str, payload: Dict[str, Any]) -> Any:
+        assert path == "/healthz"
+        return {
+            "ok": True,
+            "stream": {
+                "ok": False,
+                "state": "degraded",
+                "degradedForMs": 120000,
+                "lastIssue": "[spectrum.stream] stream interrupted; reconnecting",
+            },
+        }
+
+    notified: list[bool] = []
+
+    async def _fake_notify() -> None:
+        notified.append(True)
+        adapter._inbound_running = False
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_call)
+    monkeypatch.setattr(adapter, "_notify_fatal_error", _fake_notify)
+
+    await adapter._monitor_sidecar_health()
+
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_code == "UPSTREAM_STREAM_DEGRADED"
+    assert adapter.fatal_error_retryable is True
+    assert notified == [True]

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -1,0 +1,197 @@
+"""Photon adapter resilience to transient Spectrum/Envoy upstream overflow.
+
+Covers the three behaviors that let the adapter ride through a Photon
+"reset reason: overflow" event instead of degrading delivery and silently
+dying (issue #50185):
+
+  1. ``_is_retryable_error`` classifies the Envoy/sidecar overflow strings as
+     retryable so ``_send_with_retry`` actually engages its backoff loop.
+  2. ``send_typing`` is rate-gated per chat, and ``stop_typing`` resets the
+     gate so the next turn's typing indicator fires immediately.
+  3. ``_supervise_sidecar`` detects an unexpected sidecar exit and raises a
+     ``retryable=True`` fatal so the gateway reconnect watcher revives the
+     platform — instead of returning silently and leaving ``_inbound_loop``
+     spinning against a dead port.
+
+No Node sidecar is spawned and no ports are bound.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    cfg = PlatformConfig(enabled=True, token="", extra={})
+    return PhotonAdapter(cfg)
+
+
+# -- Gap 1: retryable classification of overflow errors ---------------------
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        "UNAVAILABLE: internal sidecar error",
+        "upstream connect error or disconnect/reset before headers",
+        "reset reason: overflow",
+        # Case-insensitive: real strings arrive with mixed case.
+        "Internal Sidecar Error",
+    ],
+)
+def test_overflow_strings_classified_retryable(error: str) -> None:
+    assert PhotonAdapter._is_retryable_error(error) is True
+
+
+def test_unrelated_error_not_retryable() -> None:
+    # A genuine permanent failure must NOT be retried.
+    assert PhotonAdapter._is_retryable_error("400 bad request: invalid spaceId") is False
+    assert PhotonAdapter._is_retryable_error(None) is False
+
+
+def test_base_network_patterns_still_match() -> None:
+    # The override delegates to the base classifier first, so generic
+    # network strings keep working.
+    assert PhotonAdapter._is_retryable_error("ConnectError: connection refused") is True
+
+
+# -- Gap 2: typing-indicator cooldown ---------------------------------------
+
+@pytest.mark.asyncio
+async def test_typing_cooldown_suppresses_rapid_repeats(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls: list[Dict[str, Any]] = []
+
+    async def _fake_call(path: str, payload: Dict[str, Any]) -> Any:
+        calls.append(payload)
+        return {"ok": True}
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_call)
+
+    # First call fires; immediate repeats are suppressed by the cooldown.
+    await adapter.send_typing("chat-1")
+    await adapter.send_typing("chat-1")
+    await adapter.send_typing("chat-1")
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_typing_cooldown_is_per_chat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls: list[str] = []
+
+    async def _fake_call(path: str, payload: Dict[str, Any]) -> Any:
+        calls.append(payload["spaceId"])
+        return {"ok": True}
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_call)
+
+    # Different chats have independent cooldowns.
+    await adapter.send_typing("chat-1")
+    await adapter.send_typing("chat-2")
+
+    assert calls == ["chat-1", "chat-2"]
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_resets_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    starts = 0
+
+    async def _fake_call(path: str, payload: Dict[str, Any]) -> Any:
+        nonlocal starts
+        if payload.get("state") == "start":
+            starts += 1
+        return {"ok": True}
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_call)
+
+    # A start, then a stop (end of turn), then a start for the next turn must
+    # fire immediately — the cooldown only suppresses rapid consecutive starts
+    # without an intervening stop.
+    await adapter.send_typing("chat-1")
+    await adapter.stop_typing("chat-1")
+    await adapter.send_typing("chat-1")
+
+    assert starts == 2
+
+
+# -- Gap 3: sidecar crash detection -----------------------------------------
+
+class _EofStdout:
+    """A proc.stdout whose readline() reports immediate EOF (dead sidecar)."""
+
+    def readline(self) -> bytes:
+        return b""
+
+
+class _DeadProc:
+    """Minimal subprocess.Popen stand-in for a sidecar that has exited."""
+
+    def __init__(self, exit_code: int = 1) -> None:
+        self.stdout = _EofStdout()
+        self.stdin = None
+        self._exit_code = exit_code
+
+    def poll(self) -> int:
+        return self._exit_code
+
+
+@pytest.mark.asyncio
+async def test_unexpected_sidecar_exit_raises_retryable_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    # Simulate a live session whose sidecar then dies underneath it.
+    adapter._inbound_running = True
+
+    notified: list[bool] = []
+
+    async def _fake_notify() -> None:
+        notified.append(True)
+
+    monkeypatch.setattr(adapter, "_notify_fatal_error", _fake_notify)
+
+    await adapter._supervise_sidecar(_DeadProc(exit_code=137))  # type: ignore[arg-type]
+
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_code == "SIDECAR_CRASHED"
+    # retryable=True routes the platform into the reconnect watcher rather
+    # than crashing the whole gateway.
+    assert adapter.fatal_error_retryable is True
+    assert adapter._running is False
+    assert notified == [True]
+
+
+@pytest.mark.asyncio
+async def test_clean_shutdown_does_not_raise_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    # disconnect() sets _inbound_running = False before stopping the sidecar,
+    # so the detection block must NOT fire on a clean shutdown.
+    adapter._inbound_running = False
+
+    notified: list[bool] = []
+
+    async def _fake_notify() -> None:
+        notified.append(True)
+
+    monkeypatch.setattr(adapter, "_notify_fatal_error", _fake_notify)
+
+    await adapter._supervise_sidecar(_DeadProc(exit_code=0))  # type: ignore[arg-type]
+
+    assert adapter.has_fatal_error is False
+    assert notified == []

--- a/tests/plugins/platforms/photon/test_reactions.py
+++ b/tests/plugins/platforms/photon/test_reactions.py
@@ -233,11 +233,11 @@ async def test_inbound_reaction_on_bot_message_routed(
     assert event.text == "reaction:added:❤️"
     assert event.message_type == MessageType.TEXT
     assert event.source.chat_id == "+15551234567"
-    # The tapback correlates to the bot message it reacted to, so the gateway
-    # can inject `[Replying to your previous message: "..."]` for context.
+    # The tapback correlates to the bot message it reacted to. The adapter
+    # prefixes reply_to_text with "your previous message: " so the generic
+    # gateway handler emits `[Replying to: "your previous message: ..."]`.
     assert event.reply_to_message_id == "bot-msg-1"
-    assert event.reply_to_text == "the bot's earlier reply"
-    assert event.reply_to_is_own_message is True
+    assert event.reply_to_text == "your previous message: the bot's earlier reply"
 
 
 @pytest.mark.asyncio
@@ -256,7 +256,6 @@ async def test_inbound_reaction_without_target_text_correlates_id_only(
     event = captured[0]
     assert event.reply_to_message_id == "bot-msg-1"
     assert event.reply_to_text is None
-    assert event.reply_to_is_own_message is True
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/photon/test_reactions.py
+++ b/tests/plugins/platforms/photon/test_reactions.py
@@ -72,6 +72,7 @@ def _reaction_event(
     target_id: str = "bot-msg-1",
     target_direction: Any = "outbound",
     space_type: str = "dm",
+    target_text: Any = "the bot's earlier reply",
 ) -> Dict[str, Any]:
     return {
         "messageId": "reaction-evt-1",
@@ -83,6 +84,9 @@ def _reaction_event(
             "emoji": emoji,
             "targetMessageId": target_id,
             "targetDirection": target_direction,
+            # The sidecar always emits this key (hydrated reaction target);
+            # null when the reacted-to message carried no text.
+            "targetText": target_text,
         },
         "timestamp": "2026-06-11T10:00:00.000Z",
     }
@@ -229,6 +233,30 @@ async def test_inbound_reaction_on_bot_message_routed(
     assert event.text == "reaction:added:❤️"
     assert event.message_type == MessageType.TEXT
     assert event.source.chat_id == "+15551234567"
+    # The tapback correlates to the bot message it reacted to, so the gateway
+    # can inject `[Replying to your previous message: "..."]` for context.
+    assert event.reply_to_message_id == "bot-msg-1"
+    assert event.reply_to_text == "the bot's earlier reply"
+    assert event.reply_to_is_own_message is True
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_without_target_text_correlates_id_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tapback on an attachment-only bot message (no text) still correlates the
+    id, but leaves reply_to_text unset — the gateway then skips the reply pointer
+    (it injects only when both id and text are present)."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture_handled(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_reaction_event(target_text=None))
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.reply_to_message_id == "bot-msg-1"
+    assert event.reply_to_text is None
+    assert event.reply_to_is_own_message is True
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -26,6 +26,23 @@ def test_sidecar_healthz_reports_stream_health() -> None:
     assert "process.exit(75);" in index
 
 
+def test_sidecar_intercepts_both_console_channels() -> None:
+    """spectrum-ts routes its stream telemetry through @photon-ai/otel, which
+    sends severity >= ERROR to console.error and WARN/INFO to console.log.
+    The two lines the health monitor keys off land on *different* channels:
+    `log.error("stream persistently failing")` -> console.error, but
+    `log.warn("stream interrupted; reconnecting")` -> console.log. Patching
+    only console.error would miss every interrupt burst (the primary silent-
+    inbound symptom), so both channels must be intercepted.
+    """
+    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
+    assert "function classifyStreamLog(" in index
+    assert "console.error = (...args) =>" in index
+    assert "console.log = (...args) =>" in index
+    # Both wrappers must feed the shared classifier.
+    assert index.count("classifyStreamLog(text)") >= 2
+
+
 def test_sidecar_labels_catchup_internal_errors_as_upstream_photon() -> None:
     """Photon cloud stream failures should not look like local auth problems."""
     index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -26,6 +26,15 @@ def test_sidecar_healthz_reports_stream_health() -> None:
     assert "process.exit(75);" in index
 
 
+def test_sidecar_labels_catchup_internal_errors_as_upstream_photon() -> None:
+    """Photon cloud stream failures should not look like local auth problems."""
+    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
+    assert "function inboundStreamErrorMessage" in index
+    assert "EventService/CatchUpEvents" in index
+    assert "this is upstream of Hermes" in index
+    assert "PHOTON_ALLOWED_USERS" in index
+
+
 def test_spectrum_patch_preserves_text_when_single_attachment(tmp_path: Path) -> None:
     """The sidecar dependency patch must turn text+one attachment into group content."""
     dist = tmp_path / "node_modules" / "spectrum-ts" / "dist"

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -52,128 +52,127 @@ def test_sidecar_labels_catchup_internal_errors_as_upstream_photon() -> None:
     assert "PHOTON_ALLOWED_USERS" in index
 
 
-def test_spectrum_patch_preserves_text_when_single_attachment(tmp_path: Path) -> None:
-    """The sidecar dependency patch must turn text+one attachment into group content."""
-    dist = tmp_path / "node_modules" / "spectrum-ts" / "dist"
+def _tabify(src: str) -> str:
+    """Convert the fixture's two-space indentation to the tab indentation that
+    spectrum-ts ships in `@spectrum-ts/imessage/dist`, so the patch anchors
+    (which match tabs) apply exactly as they do against a real install."""
+    out = []
+    for line in src.split("\n"):
+        stripped = line.lstrip(" ")
+        indent = len(line) - len(stripped)
+        out.append("\t" * (indent // 2) + " " * (indent % 2) + stripped)
+    return "\n".join(out)
+
+
+# A faithful, *executable* slice of spectrum-ts 7.x's iMessage inbound mapper:
+# the two functions the patch rewrites (`rebuildFromAppleMessage` for
+# `space.getMessage`, `toInboundMessages` for the live stream), plus stubs of
+# the helpers they close over. Mirrors the published shape — tab-indented (via
+# `_tabify`), `const ... = async` declarations, single-line builder calls — so
+# the anchors exercise the real code path, and exporting the two functions lets
+# the test assert runtime behavior rather than only string shape.
+_SPECTRUM_IMESSAGE_FIXTURE = """
+const formatChildId = (partIndex, parentGuid) => `p:${partIndex}/${parentGuid}`;
+const asText = (text) => ({ type: "text", text });
+const asCustom = (message) => ({ type: "custom" });
+const asProviderGroup = (items) => ({ type: "group", items });
+const messageAttachments = (message) => message.content.attachments ?? [];
+const getBalloonBundleId = () => "";
+const URL_BALLOON_BUNDLE_ID = "url-balloon";
+const toRichlinkMessage = (message, base, id) => ({ ...base, id, content: { type: "richlink" } });
+const buildMessageBase = (message, chatGuidHint, timestamp, phone) => ({ direction: "inbound", sender: { id: "s" }, space: { id: "sp", type: "dm", phone }, timestamp });
+const buildAttachmentMessage = async (client, base, info, id, partIndex, parentId) => {
+  const msg = { ...base, id, content: { type: "attachment", id: info.guid }, partIndex };
+  if (parentId !== void 0) msg.parentId = parentId;
+  return msg;
+};
+const cacheMessage = (cache, message) => { cache.set(message.id, message); };
+const rebuildFromAppleMessage = async (client, message, phone, chatGuidHint) => {
+  const messageGuidStr = message.guid;
+  const base = buildMessageBase(message, chatGuidHint, message.dateCreated ?? /* @__PURE__ */ new Date(), phone);
+  const attachments = messageAttachments(message);
+  if (attachments.length === 1) {
+    const info = attachments[0];
+    if (!info) throw new Error("Unreachable: attachments.length === 1 but no element");
+    return buildAttachmentMessage(client, base, info, messageGuidStr, 0);
+  }
+  if (attachments.length > 1) {
+    const items = [];
+    for (let i = 0; i < attachments.length; i++) {
+      const info = attachments[i];
+      if (!info) continue;
+      items.push(await buildAttachmentMessage(client, base, info, formatChildId(i, messageGuidStr), i, messageGuidStr));
+    }
+    return {
+      ...base,
+      id: messageGuidStr,
+      content: asProviderGroup(items)
+    };
+  }
+  if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) return toRichlinkMessage(message, base, messageGuidStr);
+  const text = message.content.text;
+  return {
+    ...base,
+    id: messageGuidStr,
+    content: text ? asText(text) : asCustom(message)
+  };
+};
+const toInboundMessages = async (client, cache, event, phone) => {
+  const base = buildMessageBase(event.message, event.chatGuid, event.occurredAt, phone);
+  const messageGuidStr = event.message.guid;
+  if (getBalloonBundleId(event.message) === URL_BALLOON_BUNDLE_ID) {
+    const msg = toRichlinkMessage(event.message, base, messageGuidStr);
+    cacheMessage(cache, msg);
+    return [msg];
+  }
+  const attachments = messageAttachments(event.message);
+  if (attachments.length === 1) {
+    const info = attachments[0];
+    if (!info) throw new Error("Unreachable: attachments.length === 1 but no element");
+    const msg = await buildAttachmentMessage(client, base, info, messageGuidStr, 0);
+    cacheMessage(cache, msg);
+    return [msg];
+  }
+  if (attachments.length > 1) {
+    const items = [];
+    for (let i = 0; i < attachments.length; i++) {
+      const info = attachments[i];
+      if (!info) continue;
+      items.push(await buildAttachmentMessage(client, base, info, formatChildId(i, messageGuidStr), i, messageGuidStr));
+    }
+    const parent = {
+      ...base,
+      id: messageGuidStr,
+      content: asProviderGroup(items)
+    };
+    cacheMessage(cache, parent);
+    return [parent];
+  }
+  const text = event.message.content.text;
+  const msg = {
+    ...base,
+    id: messageGuidStr,
+    content: text ? asText(text) : asCustom(event.message)
+  };
+  cacheMessage(cache, msg);
+  return [msg];
+};
+export { rebuildFromAppleMessage, toInboundMessages };
+"""
+
+
+def _write_fixture(tmp_path: Path) -> Path:
+    dist = tmp_path / "node_modules" / "@spectrum-ts" / "imessage" / "dist"
     dist.mkdir(parents=True)
-    chunk = dist / "chunk-test.js"
-    chunk.write_text(
-        textwrap.dedent(
-            """
-            var rebuildFromAppleMessage = async (client, message, phone, chatGuidHint) => {
-              const messageGuidStr = message.guid;
-              const timestamp = message.dateCreated ?? /* @__PURE__ */ new Date();
-              const base = buildMessageBase(message, chatGuidHint, timestamp, phone);
-              const attachments = messageAttachments(message);
-              if (attachments.length === 1) {
-                const info = attachments[0];
-                if (!info) {
-                  throw new Error("Unreachable: attachments.length === 1 but no element");
-                }
-                return buildAttachmentMessage(client, base, info, messageGuidStr, 0);
-              }
-              if (attachments.length > 1) {
-                const items = [];
-                for (let i = 0; i < attachments.length; i++) {
-                  const info = attachments[i];
-                  if (!info) {
-                    continue;
-                  }
-                  items.push(
-                    await buildAttachmentMessage(
-                      client,
-                      base,
-                      info,
-                      formatChildId(i, messageGuidStr),
-                      i,
-                      messageGuidStr
-                    )
-                  );
-                }
-                return {
-                  ...base,
-                  id: messageGuidStr,
-                  content: asProviderGroup(items)
-                };
-              }
-              if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {
-                return toRichlinkMessage(message, base, messageGuidStr);
-              }
-              const text2 = message.content.text;
-              return {
-                ...base,
-                id: messageGuidStr,
-                content: text2 ? asText(text2) : asCustom(message)
-              };
-            };
-            var toInboundMessages = async (client, cache, event, phone) => {
-              const base = buildMessageBase(
-                event.message,
-                event.chatGuid,
-                event.occurredAt,
-                phone
-              );
-              const messageGuidStr = event.message.guid;
-              if (getBalloonBundleId(event.message) === URL_BALLOON_BUNDLE_ID) {
-                const msg2 = toRichlinkMessage(event.message, base, messageGuidStr);
-                cacheMessage(cache, msg2);
-                return [msg2];
-              }
-              const attachments = messageAttachments(event.message);
-              if (attachments.length === 1) {
-                const info = attachments[0];
-                if (!info) {
-                  throw new Error("Unreachable: attachments.length === 1 but no element");
-                }
-                const msg2 = await buildAttachmentMessage(
-                  client,
-                  base,
-                  info,
-                  messageGuidStr,
-                  0
-                );
-                cacheMessage(cache, msg2);
-                return [msg2];
-              }
-              if (attachments.length > 1) {
-                const items = [];
-                for (let i = 0; i < attachments.length; i++) {
-                  const info = attachments[i];
-                  if (!info) {
-                    continue;
-                  }
-                  items.push(
-                    await buildAttachmentMessage(
-                      client,
-                      base,
-                      info,
-                      formatChildId(i, messageGuidStr),
-                      i,
-                      messageGuidStr
-                    )
-                  );
-                }
-                const parent = {
-                  ...base,
-                  id: messageGuidStr,
-                  content: asProviderGroup(items)
-                };
-                cacheMessage(cache, parent);
-                return [parent];
-              }
-              const text2 = event.message.content.text;
-              const msg = {
-                ...base,
-                id: messageGuidStr,
-                content: text2 ? asText(text2) : asCustom(event.message)
-              };
-              cacheMessage(cache, msg);
-              return [msg];
-            };
-            """
-        ),
-        encoding="utf-8",
-    )
+    chunk = dist / "index.js"
+    chunk.write_text(_tabify(_SPECTRUM_IMESSAGE_FIXTURE), encoding="utf-8")
+    return chunk
+
+
+def test_spectrum_patch_rewrites_the_imessage_mapper(tmp_path: Path) -> None:
+    """The dependency patch must apply to the 7.x `@spectrum-ts/imessage` chunk
+    and rewrite both inbound mappers to thread text through attachment bubbles."""
+    chunk = _write_fixture(tmp_path)
 
     result = subprocess.run(
         ["node", str(_PATCHER), str(tmp_path)],
@@ -182,10 +181,84 @@ def test_spectrum_patch_preserves_text_when_single_attachment(tmp_path: Path) ->
         capture_output=True,
         check=False,
     )
-
     assert result.returncode == 0, result.stderr
+
     patched = chunk.read_text(encoding="utf-8")
     assert "Preserve mixed text + attachment iMessage payloads" in patched
-    assert "content: asProviderGroup([textMsg, msg2])" in patched
+    # Single-attachment bubbles wrap the text + attachment in a group...
+    assert "content: asProviderGroup([textMsg, msg2])" in patched  # rebuild
+    assert "content: asProviderGroup([textMsg, msg])" in patched  # inbound
+    # ...multi-attachment bubbles keep the group and shift attachment indices.
     assert "content: asProviderGroup(items)" in patched
     assert "formatChildId(text2 ? i + 1 : i, messageGuidStr)" in patched
+    # The text is captured in both mappers before the attachment branches run.
+    assert "const text2 = message.content.text;" in patched
+    assert "const text2 = event.message.content.text;" in patched
+
+    # Re-running is a no-op (idempotent self-heal on every sidecar start).
+    again = subprocess.run(
+        ["node", str(_PATCHER), str(tmp_path)],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert again.returncode == 0, again.stderr
+    assert chunk.read_text(encoding="utf-8") == patched
+
+
+def test_spectrum_patch_preserves_text_at_runtime(tmp_path: Path) -> None:
+    """Execute the patched mappers and assert mixed bubbles become groups whose
+    first child is the typed text, while text-free bubbles keep their exact
+    original shape (id/partIndex/parentId) so message identity is unchanged."""
+    chunk = _write_fixture(tmp_path)
+    patch = subprocess.run(
+        ["node", str(_PATCHER), str(tmp_path)],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert patch.returncode == 0, patch.stderr
+
+    harness = textwrap.dedent(
+        f"""
+        import {{ rebuildFromAppleMessage, toInboundMessages }} from {str(chunk)!r};
+        const assert = (c, m) => {{ if (!c) {{ console.error("FAIL: " + m); process.exit(1); }} }};
+
+        // Mixed text + single attachment -> group [text@0, attachment@1].
+        let r = await rebuildFromAppleMessage(null, {{ guid: "G", content: {{ text: "hello", attachments: [{{ guid: "A0" }}] }} }}, "+1");
+        assert(r.content.type === "group" && r.id === "G", "single+text -> group parent id=guid");
+        assert(r.content.items.length === 2, "two items");
+        assert(r.content.items[0].content.type === "text" && r.content.items[0].content.text === "hello" && r.content.items[0].partIndex === 0 && r.content.items[0].id === "p:0/G", "text child @0");
+        assert(r.content.items[1].content.type === "attachment" && r.content.items[1].partIndex === 1 && r.content.items[1].id === "p:1/G" && r.content.items[1].parentId === "G", "attachment child @1");
+
+        // Single attachment, no text -> unchanged bare attachment.
+        r = await rebuildFromAppleMessage(null, {{ guid: "G", content: {{ text: "", attachments: [{{ guid: "A0" }}] }} }}, "+1");
+        assert(r.content.type === "attachment" && r.id === "G" && r.partIndex === 0 && r.parentId === undefined, "no-text single attachment unchanged");
+
+        // Multi attachment + text via the live stream -> group [text@0, att@1, att@2].
+        let arr = await toInboundMessages(null, new Map(), {{ message: {{ guid: "G2", content: {{ text: "cap", attachments: [{{ guid: "A0" }}, {{ guid: "A1" }}] }} }} }}, "+1");
+        assert(arr.length === 1 && arr[0].content.type === "group", "multi+text -> single group");
+        let items = arr[0].content.items;
+        assert(items.length === 3 && items[0].content.type === "text" && items[0].partIndex === 0, "text first @0");
+        assert(items[1].partIndex === 1 && items[1].id === "p:1/G2" && items[2].partIndex === 2 && items[2].id === "p:2/G2", "attachments shifted to @1,@2");
+
+        // Multi attachment, no text -> unchanged (attachments at @0,@1).
+        arr = await toInboundMessages(null, new Map(), {{ message: {{ guid: "G3", content: {{ attachments: [{{ guid: "A0" }}, {{ guid: "A1" }}] }} }} }}, "+1");
+        items = arr[0].content.items;
+        assert(items.length === 2 && items[0].partIndex === 0 && items[0].id === "p:0/G3" && items[1].partIndex === 1, "no-text multi unchanged");
+
+        // Text only, no attachments -> plain text (unchanged).
+        r = await rebuildFromAppleMessage(null, {{ guid: "G4", content: {{ text: "just text", attachments: [] }} }}, "+1");
+        assert(r.content.type === "text" && r.content.text === "just text" && r.id === "G4", "text-only unchanged");
+        """
+    )
+    run = subprocess.run(
+        ["node", "--input-type=module", "-e", harness],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stderr

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -64,7 +64,7 @@ def _tabify(src: str) -> str:
     return "\n".join(out)
 
 
-# A faithful, *executable* slice of spectrum-ts 7.x's iMessage inbound mapper:
+# A faithful, *executable* slice of spectrum-ts 8.x's iMessage inbound mapper:
 # the two functions the patch rewrites (`rebuildFromAppleMessage` for
 # `space.getMessage`, `toInboundMessages` for the live stream), plus stubs of
 # the helpers they close over. Mirrors the published shape — tab-indented (via
@@ -77,9 +77,6 @@ const asText = (text) => ({ type: "text", text });
 const asCustom = (message) => ({ type: "custom" });
 const asProviderGroup = (items) => ({ type: "group", items });
 const messageAttachments = (message) => message.content.attachments ?? [];
-const getBalloonBundleId = () => "";
-const URL_BALLOON_BUNDLE_ID = "url-balloon";
-const toRichlinkMessage = (message, base, id) => ({ ...base, id, content: { type: "richlink" } });
 const buildMessageBase = (message, chatGuidHint, timestamp, phone) => ({ direction: "inbound", sender: { id: "s" }, space: { id: "sp", type: "dm", phone }, timestamp });
 const buildAttachmentMessage = async (client, base, info, id, partIndex, parentId) => {
   const msg = { ...base, id, content: { type: "attachment", id: info.guid }, partIndex };
@@ -109,7 +106,6 @@ const rebuildFromAppleMessage = async (client, message, phone, chatGuidHint) => 
       content: asProviderGroup(items)
     };
   }
-  if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) return toRichlinkMessage(message, base, messageGuidStr);
   const text = message.content.text;
   return {
     ...base,
@@ -120,11 +116,6 @@ const rebuildFromAppleMessage = async (client, message, phone, chatGuidHint) => 
 const toInboundMessages = async (client, cache, event, phone) => {
   const base = buildMessageBase(event.message, event.chatGuid, event.occurredAt, phone);
   const messageGuidStr = event.message.guid;
-  if (getBalloonBundleId(event.message) === URL_BALLOON_BUNDLE_ID) {
-    const msg = toRichlinkMessage(event.message, base, messageGuidStr);
-    cacheMessage(cache, msg);
-    return [msg];
-  }
   const attachments = messageAttachments(event.message);
   if (attachments.length === 1) {
     const info = attachments[0];
@@ -170,7 +161,7 @@ def _write_fixture(tmp_path: Path) -> Path:
 
 
 def test_spectrum_patch_rewrites_the_imessage_mapper(tmp_path: Path) -> None:
-    """The dependency patch must apply to the 7.x `@spectrum-ts/imessage` chunk
+    """The dependency patch must apply to the 8.x `@spectrum-ts/imessage` chunk
     and rewrite both inbound mappers to thread text through attachment bubbles."""
     chunk = _write_fixture(tmp_path)
 

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -17,6 +17,15 @@ def test_sidecar_applies_spectrum_patch_before_importing_sdk() -> None:
     assert index.index("patchSpectrumTs();") < index.index('await import("spectrum-ts")')
 
 
+def test_sidecar_healthz_reports_stream_health() -> None:
+    """Local process health must include upstream stream health."""
+    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
+    assert "function streamHealthSnapshot()" in index
+    assert 'return ok(res, { stream: streamHealthSnapshot() });' in index
+    assert "STREAM_INTERRUPTED_DEGRADE_COUNT" in index
+    assert "process.exit(75);" in index
+
+
 def test_spectrum_patch_preserves_text_when_single_attachment(tmp_path: Path) -> None:
     """The sidecar dependency patch must turn text+one attachment into group content."""
     dist = tmp_path / "node_modules" / "spectrum-ts" / "dist"


### PR DESCRIPTION
## Summary

- Restores `gateway/platforms/base.py` and `gateway/run.py` to upstream state, clearing the `hermes-upstream-conformance` preflight failure.
- Removes `reply_to_is_own_message: bool = False` from `MessageEvent` (core edit).
- Removes the `if getattr(event, "reply_to_is_own_message", False)` branch from `gateway/run.py` (core edit).
- The Photon adapter now prefixes `reply_to_text` with `"your previous message: "` for tapback events on bot messages, so the generic gateway handler emits `[Replying to: "your previous message: ..."]` — same agent-visible signal, no core changes needed.

## Verification

- `pytest tests/gateway/test_reply_to_injection.py tests/plugins/platforms/photon/test_reactions.py`: 19 passed
- `git diff upstream/main -- gateway/platforms/base.py gateway/run.py`: empty (files restored to upstream)

## Backlog Items
- Clears the Hermes upstream conformance preflight block