### PR TITLE
fix(desktop): show tooltip on Gateway statusbar button

### DIFF
--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -101,59 +101,59 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
   if (item.variant === 'menu' && (item.menuContent || (item.menuItems && item.menuItems.length > 0))) {
     return (
-      <Tip label={item.title}>
-        <DropdownMenu onOpenChange={setMenuOpen} open={menuOpen}>
-          <DropdownMenuTrigger asChild>
+      <DropdownMenu onOpenChange={setMenuOpen} open={menuOpen}>
+        <DropdownMenuTrigger asChild>
+          <Tip label={item.title}>
             <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
               {content}
             </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align={item.menuAlign ?? 'start'}
-            className={cn('w-56', item.menuContent && 'p-0', item.menuClassName)}
-            side="top"
-            sideOffset={8}
-          >
-            {item.menuContent
-              ? typeof item.menuContent === 'function'
-                ? item.menuContent(() => setMenuOpen(false))
-                : item.menuContent
-              : (item.menuItems ?? [])
-                  .filter(menuItem => !menuItem.hidden)
-                  .map(menuItem => (
-                    <DropdownMenuItem
-                      className={cn('gap-2 text-foreground focus:bg-accent [&_svg]:size-4', menuItem.className)}
-                      disabled={menuItem.disabled}
-                      key={menuItem.id}
-                      onSelect={() => {
-                        if (menuItem.to) {
-                          navigate(menuItem.to)
-                        }
+          </Tip>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align={item.menuAlign ?? 'start'}
+          className={cn('w-56', item.menuContent && 'p-0', item.menuClassName)}
+          side="top"
+          sideOffset={8}
+        >
+          {item.menuContent
+            ? typeof item.menuContent === 'function'
+              ? item.menuContent(() => setMenuOpen(false))
+              : item.menuContent
+            : (item.menuItems ?? [])
+                .filter(menuItem => !menuItem.hidden)
+                .map(menuItem => (
+                  <DropdownMenuItem
+                    className={cn('gap-2 text-foreground focus:bg-accent [&_svg]:size-4', menuItem.className)}
+                    disabled={menuItem.disabled}
+                    key={menuItem.id}
+                    onSelect={() => {
+                      if (menuItem.to) {
+                        navigate(menuItem.to)
+                      }
 
-                        menuItem.onSelect?.()
-                      }}
-                    >
-                      {menuItem.href ? (
-                        <a
-                          className="inline-flex w-full items-center gap-2"
-                          href={menuItem.href}
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          {menuItem.icon}
-                          <span className="truncate">{menuItem.label}</span>
-                        </a>
-                      ) : (
-                        <>
-                          {menuItem.icon}
-                          <span className="truncate">{menuItem.label}</span>
-                        </>
-                      )}
-                    </DropdownMenuItem>
-                  ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </Tip>
+                      menuItem.onSelect?.()
+                    }}
+                  >
+                    {menuItem.href ? (
+                      <a
+                        className="inline-flex w-full items-center gap-2"
+                        href={menuItem.href}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        {menuItem.icon}
+                        <span className="truncate">{menuItem.label}</span>
+                      </a>
+                    ) : (
+                      <>
+                        {menuItem.icon}
+                        <span className="truncate">{menuItem.label}</span>
+                      </>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
     )
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Gateway statusbar tooltip not appearing on hover.

All other statusbar items (Terminal, YOLO, Agents, Cron, version, timers) render as plain DOM elements (`<button>`, `<div>`, `<a>`), so wrapping them in `<Tip>` works correctly — Radix can attach hover listeners directly to the DOM node. Gateway is the only item with `variant === 'menu'`. The previous code wrapped `<DropdownMenu>` in `<Tip>`, but `<DropdownMenu>` is a React context provider, not a DOM element — so Radix could not attach hover listeners and the tooltip silently failed. Fixed by moving `<Tip>` inside `<DropdownMenuTrigger asChild>`, directly wrapping the `<button>`.

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `apps/desktop/src/app/shell/statusbar-controls.tsx` — moved `<Tip label={item.title}>` inside `<DropdownMenuTrigger asChild>` for the `variant === 'menu'` branch so the tooltip trigger is a real DOM node

## How to Test
1. Launch the desktop app
2. Hover over the Gateway statusbar button (e.g. "Gateway ready")
3. Verify a styled dark tooltip appears

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills
N/A

## Screenshots / Logs

<img width="246" height="132" alt="Gateway" src="https://github.com/user-attachments/assets/7d5d2203-ec8c-4ee8-8fce-fcbfdb3ff08b" />
