### PR TITLE
docs: create dev venv outside the source tree (root-cause fix for #7779)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,13 +149,20 @@ this way, make sure you run the `hermes` entrypoint from this venv; running the
 system `python3 -m hermes_cli.main` can pick up unrelated system Python
 packages.
 
+Create the venv **outside** the cloned source tree. A venv that lives inside
+the directory the agent operates from can be wiped by a relative-path command
+the agent runs against its own checkout (`rm -rf venv`, `uv venv venv`, etc.),
+which silently destroys the running runtime mid-session. Keeping it outside the
+tree means no relative path from the workspace resolves to it.
+
 ```bash
 git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
 
-# Create venv with Python 3.11
-uv venv venv --python 3.11
-export VIRTUAL_ENV="$(pwd)/venv"
+# Create venv with Python 3.11, OUTSIDE the source tree
+uv venv ~/.hermes/venvs/hermes-dev --python 3.11
+export VIRTUAL_ENV="$HOME/.hermes/venvs/hermes-dev"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install with all extras (messaging, cron, CLI menus, dev tools)
 uv pip install -e ".[all,dev]"

--- a/README.md
+++ b/README.md
@@ -232,10 +232,14 @@ scripts/run_tests.sh
 Manual clone fallback (for throwaway clones/CI where you intentionally do not
 want the managed install layout):
 
+Create the venv outside the cloned source tree — a venv inside the directory
+the agent operates from can be wiped by a relative-path command the agent runs
+against its own checkout, destroying the running runtime mid-session.
+
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
-uv venv .venv --python 3.11
-source .venv/bin/activate
+uv venv ~/.hermes/venvs/hermes-dev --python 3.11
+source ~/.hermes/venvs/hermes-dev/bin/activate
 uv pip install -e ".[all,dev]"
 scripts/run_tests.sh
 ```

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -74,13 +74,20 @@ this way, make sure you run the `hermes` entrypoint from this venv; running the
 system `python3 -m hermes_cli.main` can pick up unrelated system Python
 packages.
 
+Create the venv **outside** the cloned source tree. A venv that lives inside
+the directory the agent operates from can be wiped by a relative-path command
+the agent runs against its own checkout (`rm -rf venv`, `uv venv venv`, etc.),
+which silently destroys the running runtime mid-session. Keeping it outside the
+tree means no relative path from the workspace resolves to it.
+
 ```bash
 git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
 
-# Create venv with Python 3.11
-uv venv venv --python 3.11
-export VIRTUAL_ENV="$(pwd)/venv"
+# Create venv with Python 3.11, OUTSIDE the source tree
+uv venv ~/.hermes/venvs/hermes-dev --python 3.11
+export VIRTUAL_ENV="$HOME/.hermes/venvs/hermes-dev"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install with all extras (messaging, cron, CLI menus, dev tools)
 uv pip install -e ".[all,dev]"

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -171,7 +171,9 @@ If you installed manually (not via the quick installer):
 
 ```bash
 cd /path/to/hermes-agent
-export VIRTUAL_ENV="$(pwd)/venv"
+# Activate the venv you created during install (outside the source tree)
+export VIRTUAL_ENV="$HOME/.hermes/venvs/hermes-dev"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Pull latest code
 git pull origin main


### PR DESCRIPTION
## Summary

A manually-installed dev venv that lives *inside* the cloned repo can be destroyed by the agent running a relative-path command against its own checkout — `rm -rf venv`, `uv venv venv`, etc. — which silently wipes the running runtime mid-session (next API call dies on a missing `certifi/cacert.pem`). This moves the canonical manual-install venv **outside** the source tree so the bug class is physically impossible: no relative path from the agent's workspace resolves to its own runtime.

Root cause of #7779. Closes the bug at the install layout rather than chasing commands.

## Why not a command blocklist

PR #7780 proposed enumerating destructive commands (`uv venv`, `rm`, `mv`, `uv pip uninstall`, …) and hard-blocking them. That's the wrong shape: the action space is unbounded — `cp -r`, `rsync --delete`, `find -delete`, `truncate`, `ln -sf /dev/null`, `tar -C`, a `>` redirect, or any `python -c "shutil.rmtree(sys.prefix)"` all destroy the venv identically and none are caught. Even within its own list, `bash -c 'rm -rf venv'`, shell globs (`./ven*`), and `$VAR` indirection defeat the `shlex` parse. It also hard-blocked the entire source dir and routine `uv pip uninstall` non-bypassably, regressing in-tree edits. Closed in favor of this.

## Changes

- `CONTRIBUTING.md`: manual-clone fallback creates the venv at `~/.hermes/venvs/hermes-dev` instead of in-tree `venv/`, with a note on why.
- `README.md`: same for the manual-clone fallback block.
- `website/docs/developer-guide/contributing.md`: canonical docs mirror of CONTRIBUTING — kept in sync.
- `website/docs/getting-started/updating.md`: manual-update block activates the outside-tree venv.

The managed `install.sh` layout (which already puts the venv under `~/.hermes/hermes-agent/`) is unchanged.

## Validation

Docs-only. Markdown code fences verified balanced across all four files; edits touch only fenced code blocks and added prose (no MDX/JSX). No `run_tests.sh` needed.

## Follow-up

A separate defense-in-depth PR will add a post-exec runtime-integrity probe that fails closed on the next turn if a command broke `sys.prefix`, bounding the blast radius for the open-ended action space a blocklist can't enumerate.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa03bfc/FXG5xqomRtb4vmCJm33rl_TPHUhYEZ.png)
