### PR TITLE
fix(gateway): silence runtime notices for public chat agents

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -47,6 +47,10 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "interim_assistant_messages": True,
     "long_running_notifications": True,
     "busy_ack_detail": True,
+    # Runtime/lifecycle notices (compression, retry/backoff, fallback, provider
+    # status). Public-facing operational agents should opt this off per profile
+    # and only deliver final business-safe assistant answers.
+    "runtime_notices": True,
     # When true, delete tool-progress / "⏳ Working — N min" / status bubbles
     # after the final response lands on platforms that support message
     # deletion (e.g. Telegram). Off by default — progress is still shown
@@ -71,6 +75,7 @@ _TIER_HIGH = {
     "interim_assistant_messages": True,
     "long_running_notifications": True,
     "busy_ack_detail": True,
+    "runtime_notices": True,
 }
 
 _TIER_MEDIUM = {
@@ -81,6 +86,7 @@ _TIER_MEDIUM = {
     "interim_assistant_messages": True,
     "long_running_notifications": True,
     "busy_ack_detail": True,
+    "runtime_notices": True,
 }
 
 _TIER_LOW = {
@@ -91,6 +97,7 @@ _TIER_LOW = {
     "interim_assistant_messages": False,
     "long_running_notifications": False,
     "busy_ack_detail": False,
+    "runtime_notices": False,
 }
 
 _TIER_MINIMAL = {
@@ -101,6 +108,7 @@ _TIER_MINIMAL = {
     "interim_assistant_messages": False,
     "long_running_notifications": False,
     "busy_ack_detail": False,
+    "runtime_notices": False,
 }
 
 _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
@@ -240,6 +248,7 @@ def _normalise(setting: str, value: Any) -> Any:
         "interim_assistant_messages",
         "long_running_notifications",
         "busy_ack_detail",
+        "runtime_notices",
     }:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -97,7 +97,9 @@ _TIER_LOW = {
     "interim_assistant_messages": False,
     "long_running_notifications": False,
     "busy_ack_detail": False,
-    "runtime_notices": False,
+    # Keep lifecycle notices default-enabled for back-compat even on quiet
+    # platforms; public/customer-facing agents opt out explicitly per profile.
+    "runtime_notices": True,
 }
 
 _TIER_MINIMAL = {
@@ -108,7 +110,9 @@ _TIER_MINIMAL = {
     "interim_assistant_messages": False,
     "long_running_notifications": False,
     "busy_ack_detail": False,
-    "runtime_notices": False,
+    # Programmatic/raw surfaces such as webhooks must keep diagnostics unless
+    # a profile explicitly disables runtime_notices.
+    "runtime_notices": True,
 }
 
 _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -77,6 +77,8 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|configured\s+compression\s+model\s+.+\s+failed"
     r"|no\s+auxiliary\s+llm\s+provider\s+configured"
     r"|auto-lowered\s+compression\s+threshold"
+    r"|codex\s+gpt[-\s]?5\.5\s+caps\s+context"
+    r"|auto[-\s]?compaction\s+was\s+raised"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
     r"|session\s+compressed\s+\d+\s+times"
@@ -15400,6 +15402,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             platform=source.platform,
             require_platform_override_for={Platform.MATTERMOST},
         )
+        _runtime_status_notices_enabled = _resolve_gateway_display_bool(
+            user_config,
+            platform_key,
+            "runtime_notices",
+            default=True,
+            platform=source.platform,
+        )
         needs_progress_queue = tool_progress_enabled or _thinking_enabled
 
 
@@ -16084,6 +16093,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
                 return
+            if not _runtime_status_notices_enabled:
+                logger.debug(
+                    "status_callback suppressed by runtime_notices=false for %s/%s: %s",
+                    source.platform.value if source.platform else "unknown",
+                    event_type,
+                    _redact_gateway_user_facing_secrets(str(message or ""))[:160],
+                )
+                return
             prepared_message = _prepare_gateway_status_message(
                 source.platform,
                 event_type,
@@ -16475,6 +16492,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             def _notice_callback_sync(notice) -> None:
                 if not _status_adapter or not _run_still_current():
                     return
+                if not _runtime_status_notices_enabled:
+                    logger.debug(
+                        "notice_callback suppressed by runtime_notices=false for %s",
+                        source.platform.value if source.platform else "unknown",
+                    )
+                    return
                 try:
                     line = render_notice_line(notice)
                 except Exception:
@@ -16502,6 +16525,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             def _deliver_bg_review_message(message: str) -> None:
                 if not _status_adapter or not _run_still_current():
+                    return
+                if not _runtime_status_notices_enabled:
+                    logger.debug(
+                        "background_review_callback suppressed by runtime_notices=false for %s",
+                        source.platform.value if source.platform else "unknown",
+                    )
                     return
                 safe_schedule_threadsafe(
                     _status_adapter.send(

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -3,8 +3,10 @@
 import pytest
 
 from gateway.config import Platform
+from gateway.display_config import OVERRIDEABLE_KEYS, resolve_display_setting
 from gateway.run import (
     _prepare_gateway_status_message,
+    _resolve_gateway_display_bool,
     _sanitize_gateway_final_response,
 )
 
@@ -33,6 +35,7 @@ NOISY_STATUS_MESSAGES = [
     "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
     "⚠️  Session compressed 12 times — accuracy may degrade. Consider /new to start fresh.",
     "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
+    "Codex gpt-5.5 caps context at ~512k tokens; auto-compaction was raised to prevent truncation.",
     "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
     "⏳ Retrying in 4.2s (attempt 1/3)...",
 ]
@@ -134,6 +137,34 @@ def test_plugin_platform_string_suppresses_noise():
     message = "⏳ Retrying in 4.2s (attempt 1/3)..."
 
     assert _prepare_gateway_status_message("irc", "warn", message) is None
+
+
+def test_runtime_notices_can_be_disabled_per_whatsapp_profile():
+    """Public WhatsApp agents can suppress Hermes lifecycle/runtime notices."""
+    cfg = {
+        "display": {
+            "runtime_notices": True,
+            "platforms": {"whatsapp": {"runtime_notices": False}},
+        }
+    }
+
+    assert "runtime_notices" in OVERRIDEABLE_KEYS
+    assert resolve_display_setting(cfg, "whatsapp", "runtime_notices") is False
+    assert (
+        _resolve_gateway_display_bool(
+            cfg,
+            "whatsapp",
+            "runtime_notices",
+            default=True,
+            platform=Platform.WHATSAPP,
+        )
+        is False
+    )
+
+
+def test_runtime_notices_default_remains_enabled_for_whatsapp_backcompat():
+    """Existing WhatsApp profiles keep lifecycle notices unless they opt out."""
+    assert resolve_display_setting({}, "whatsapp", "runtime_notices") is True
 
 
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -167,6 +167,18 @@ def test_runtime_notices_default_remains_enabled_for_whatsapp_backcompat():
     assert resolve_display_setting({}, "whatsapp", "runtime_notices") is True
 
 
+@pytest.mark.parametrize("platform", ["local", "api_server", "webhook", "msgraph_webhook"])
+def test_runtime_notices_default_remains_enabled_for_raw_surfaces(platform):
+    """Raw/programmatic surfaces keep diagnostics unless explicitly opted out."""
+    assert resolve_display_setting({}, platform, "runtime_notices") is True
+
+
+@pytest.mark.parametrize("platform", ["signal", "sms", "email", "homeassistant"])
+def test_quiet_tiers_keep_runtime_notices_enabled_for_backcompat(platform):
+    """Quiet display tiers still preserve runtime notices by default."""
+    assert resolve_display_setting({}, platform, "runtime_notices") is True
+
+
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)
 def test_chat_gateways_keep_normal_answers(platform):
     """Normal assistant content must pass through unchanged on chat surfaces."""

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1418,6 +1418,7 @@ display:
   platforms: {}           # Per-platform display overrides (see below)
   tool_progress_overrides: {}  # DEPRECATED — use display.platforms instead
   interim_assistant_messages: true  # Gateway: send natural mid-turn assistant updates as separate messages
+  runtime_notices: true     # Gateway: send lifecycle/runtime notices (set false for public-facing agents)
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
   personality: "kawaii"  # Legacy cosmetic field still surfaced in some summaries
   compact: false          # Compact output mode (less whitespace)
@@ -1510,6 +1511,13 @@ display:
       tool_progress: verbose  # detailed progress on Telegram
     slack:
       tool_progress: 'off'    # quiet in shared Slack workspace
+    whatsapp:
+      tool_progress: 'off'
+      streaming: false
+      interim_assistant_messages: false
+      long_running_notifications: false
+      busy_ack_detail: false
+      runtime_notices: false  # final-answer-only for public/customer channels
 ```
 
 Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`. The legacy `display.tool_progress_overrides` key still loads for backward compatibility but is deprecated and migrated into `display.platforms` on first load.
@@ -1517,6 +1525,8 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+
+`runtime_notices` is gateway-only. When enabled, Hermes may send lifecycle/runtime notices such as context compression, retry/backoff, usage-band, or background-review summaries. Set it to `false` for public-facing agents such as receptionists or customer support bots so the contact receives only the final assistant answer.
 
 ## Privacy
 


### PR DESCRIPTION
## Summary
- Add `display.runtime_notices` as a gateway display setting with per-platform overrides.
- Suppress gateway lifecycle/status notices, credit/out-of-band notices, and background-review notices when `runtime_notices=false`.
- Treat Codex context-cap / auto-compaction notices as chat-surface operational noise.
- Preserve backward compatibility by keeping runtime notices enabled by default on existing platforms, including quiet/raw surfaces; public agents opt out explicitly.
- Document the final-answer-only WhatsApp/public-agent configuration pattern.

## Why
Public/customer-facing agents (for example WhatsApp receptionists) should not leak internal model/runtime notices like context compaction, retry, or provider lifecycle messages to contacts. They should deliver only the final business-safe assistant response when configured that way.

## Test plan
- `git diff --check`
- `python -m py_compile gateway/display_config.py gateway/run.py tests/gateway/test_telegram_noise_filter.py`
- `python -m pytest tests/gateway/test_telegram_noise_filter.py -q` → `220 passed`
- Direct Python smoke: `runtime_notices` resolves to `False` for `display.platforms.whatsapp.runtime_notices=false`; default WhatsApp/raw/quiet-tier surfaces remain `True`; webhook raw retry status is preserved; WhatsApp noisy retry status is suppressed.
- Added-line secret scan for common token/key patterns: no findings.
- Independent reviewer subagent reviewed the original PR scope; follow-up backcompat fix addresses the blocker it identified around `webhook`/quiet-tier defaults.

## Notes
- Behavioral settings are exposed through `config.yaml`, not new environment variables.
- Existing profiles keep runtime notices unless they explicitly set `display.runtime_notices=false` or `display.platforms.<platform>.runtime_notices=false`.