### PR TITLE
fix(trajectory): flatten multimodal list content to string in ShareGPT records

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -71,6 +71,29 @@ def agent_runtime_owns_post_tool_hook(agent: Any, function_name: str) -> bool:
     return bool(memory_manager and memory_manager.has_tool(function_name))
 
 
+def _trajectory_content_to_str(content: Any) -> str:
+    """Flatten possibly-multimodal message content to a plain string.
+
+    ``_trajectory_normalize_msg`` preserves list-shaped multimodal content
+    (image parts already replaced by ``[screenshot]`` text parts), but the
+    text-only ShareGPT trajectory format expects ``content`` to be a string.
+    Joining the text parts here keeps multimodal user/assistant turns from
+    crashing (``.strip()``/concatenation on a list) or silently writing a
+    Python list as a record ``value``. Identity for plain strings.
+    """
+    if isinstance(content, list):
+        parts = []
+        for p in content:
+            if isinstance(p, dict):
+                parts.append(str(p.get("text", "")))
+            else:
+                parts.append(str(p))
+        return "".join(parts)
+    if content is None:
+        return ""
+    return content if isinstance(content, str) else str(content)
+
+
 def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
     """
     Convert internal message format to trajectory format for saving.
@@ -134,10 +157,11 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
                 if msg.get("reasoning") and msg["reasoning"].strip():
                     content = f"<think>\n{msg['reasoning']}\n</think>\n"
                 
-                if msg.get("content") and msg["content"].strip():
+                msg_content = _trajectory_content_to_str(msg.get("content"))
+                if msg_content and msg_content.strip():
                     # Convert any <REASONING_SCRATCHPAD> tags to <think> tags
                     # (used when native thinking is disabled and model reasons via XML)
-                    content += convert_scratchpad_to_think(msg["content"]) + "\n"
+                    content += convert_scratchpad_to_think(msg_content) + "\n"
                 
                 # Add tool calls wrapped in XML tags
                 for tool_call in msg["tool_calls"]:
@@ -218,7 +242,7 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
                 
                 # Convert any <REASONING_SCRATCHPAD> tags to <think> tags
                 # (used when native thinking is disabled and model reasons via XML)
-                raw_content = msg["content"] or ""
+                raw_content = _trajectory_content_to_str(msg.get("content"))
                 content += convert_scratchpad_to_think(raw_content)
                 
                 # Ensure every gpt turn has a <think> block (empty if no reasoning)
@@ -233,7 +257,7 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
         elif msg["role"] == "user":
             trajectory.append({
                 "from": "human",
-                "value": msg["content"]
+                "value": _trajectory_content_to_str(msg.get("content"))
             })
         
         i += 1

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -79,7 +79,9 @@ def _trajectory_content_to_str(content: Any) -> str:
     text-only ShareGPT trajectory format expects ``content`` to be a string.
     Joining the text parts here keeps multimodal user/assistant turns from
     crashing (``.strip()``/concatenation on a list) or silently writing a
-    Python list as a record ``value``. Identity for plain strings.
+    Python list as a record ``value``. Identity for plain strings. Parts are
+    joined with newlines to match ``_multimodal_text_summary`` and avoid
+    merging adjacent text segments into one run-on token.
     """
     if isinstance(content, list):
         parts = []
@@ -88,7 +90,7 @@ def _trajectory_content_to_str(content: Any) -> str:
                 parts.append(str(p.get("text", "")))
             else:
                 parts.append(str(p))
-        return "".join(parts)
+        return "\n".join(parts)
     if content is None:
         return ""
     return content if isinstance(content, str) else str(content)

--- a/tests/agent/test_trajectory_format.py
+++ b/tests/agent/test_trajectory_format.py
@@ -1,0 +1,93 @@
+"""Regression tests for ``convert_to_trajectory_format`` multimodal handling.
+
+``_trajectory_normalize_msg`` keeps multimodal message content as a *list* of
+parts (image parts replaced by ``[screenshot]`` text parts), but the text-only
+ShareGPT trajectory format expects ``content`` to be a string. Before the fix,
+any conversation containing an image (vision / computer-use / screenshot tools)
+either crashed during trajectory saving or silently wrote a Python list as a
+record ``value``. These tests exercise all three str-assuming sites.
+"""
+
+from agent.agent_runtime_helpers import convert_to_trajectory_format
+
+
+class _FakeAgent:
+    """Minimal stand-in exposing only what the converter touches."""
+
+    def _format_tools_for_system_message(self) -> str:
+        return ""
+
+
+def _multimodal_user_content():
+    return [
+        {"type": "text", "text": "what is in this screenshot?"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]
+
+
+def test_multimodal_user_turn_value_is_str():
+    """A multimodal user turn must serialize to a string ShareGPT value."""
+    messages = [
+        {"role": "user", "content": "first prompt"},
+        {"role": "user", "content": _multimodal_user_content()},
+    ]
+    trajectory = convert_to_trajectory_format(
+        _FakeAgent(), messages, user_query="first prompt", completed=True
+    )
+    human_turns = [t for t in trajectory if t["from"] == "human"]
+    # The second human turn corresponds to the multimodal user message.
+    multimodal_turn = human_turns[-1]
+    assert isinstance(multimodal_turn["value"], str)
+    assert "what is in this screenshot?" in multimodal_turn["value"]
+    # The image part was normalized to a [screenshot] placeholder upstream and
+    # must survive flattening rather than being dropped or crashing.
+    assert "[screenshot]" in multimodal_turn["value"]
+
+
+def test_multimodal_assistant_turn_no_crash():
+    """A regular assistant turn with list content must not raise (TypeError)."""
+    messages = [
+        {"role": "user", "content": "look at this"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "I see a cat"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,BBBB"}},
+            ],
+        },
+    ]
+    trajectory = convert_to_trajectory_format(
+        _FakeAgent(), messages, user_query="look at this", completed=True
+    )
+    gpt_turns = [t for t in trajectory if t["from"] == "gpt"]
+    assert gpt_turns, "expected an assistant (gpt) turn"
+    assert isinstance(gpt_turns[-1]["value"], str)
+    assert "I see a cat" in gpt_turns[-1]["value"]
+
+
+def test_assistant_tool_calls_list_content_no_crash():
+    """Assistant turn with tool_calls AND list content must not raise (AttributeError)."""
+    messages = [
+        {"role": "user", "content": "click the button"},
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "clicking now"}],
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "click", "arguments": '{"x": 1, "y": 2}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "{\"ok\": true}"},
+    ]
+    trajectory = convert_to_trajectory_format(
+        _FakeAgent(), messages, user_query="click the button", completed=True
+    )
+    gpt_turns = [t for t in trajectory if t["from"] == "gpt"]
+    assert gpt_turns, "expected an assistant (gpt) turn"
+    value = gpt_turns[-1]["value"]
+    assert isinstance(value, str)
+    assert "clicking now" in value
+    assert "<tool_call>" in value


### PR DESCRIPTION
## What does this PR do?

Fixes trajectory saving (`save_trajectories` / datagen) corrupting or crashing on any conversation that contains an image (vision / computer-use / screenshot tools).

`convert_to_trajectory_format` runs `_trajectory_normalize_msg` over every message, which **preserves multimodal content as a list** of parts — image parts are replaced by `{"type":"text","text":"[screenshot]"}` placeholders, but the list shape is kept. Three downstream sites in the converter assume `content` is a `str`, so a multimodal turn either raises or silently writes a malformed record.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py`: add a small `_trajectory_content_to_str` helper that flattens list content (already image-stripped to `[screenshot]` text parts) to a plain string, and apply it at the three str-assuming sites:
  - assistant-with-tool_calls turn — `msg["content"].strip()` → `AttributeError: 'list' object has no attribute 'strip'`
  - regular assistant turn — `convert_scratchpad_to_think(msg["content"])` → `TypeError: can only concatenate str (not "list") to str`
  - user turn — `"value": msg["content"]` → silently wrote a Python **list** as the ShareGPT `value`, corrupting the SFT record
- `tests/agent/test_trajectory_format.py` (new): regression coverage for all three paths.

The helper is the identity for plain strings, so non-multimodal trajectories are unchanged. The tool-result branch is untouched (tool messages already normalize to a string via `_multimodal_text_summary`).

## How to Test

1. Run the new regression test: `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_trajectory_format.py -v` — 3 passed.
2. Fail-before / pass-after (verified): reverting the three site edits makes the tests fail with exactly the predicted errors — `AssertionError` (user `value` is a list), `TypeError` (assistant concat), `AttributeError` (assistant+tool_calls `.strip()`). Restoring the fix turns all three green.
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/run_agent/test_run_agent.py -q` — 405 passed (no regression in the main agent loop).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the touched-area tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — added a docstring on the new helper; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure string handling)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A