### PR TITLE
fix(google_chat): restore protected regions in reverse order in format_message

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2091,9 +2091,16 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # Collapse double spaces left over from stripped chars.
         text = re.sub(r"  +", " ", text)
 
-        # Restore protected regions.
-        for key, value in placeholders.items():
-            text = text.replace(key, value)
+        # Restore protected regions in reverse (outer-first) insertion order.
+        # Placeholders are created inner-first (e.g. inline code before the
+        # header that wraps it), so an outer placeholder's stored value can
+        # contain an earlier (inner) placeholder key. Restoring forward would
+        # re-inject that inner sentinel only after its key had already been
+        # passed, leaving a raw \x00GC{n}\x00 control sequence in the output.
+        # Reverse order injects the outer value first so the inner key still
+        # has a later pass to resolve. Mirrors the Slack adapter's restore loop.
+        for key in reversed(placeholders):
+            text = text.replace(key, placeholders[key])
 
         return text
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2501,6 +2501,24 @@ class TestFormatMessage:
         out = GoogleChatAdapter.format_message("rate is ** TBD")
         assert "**" in out  # not converted
 
+    def test_inline_code_inside_header_is_restored(self):
+        """Inline code nested inside a header must not leak NUL sentinels.
+
+        The header placeholder is created AFTER the inline-code placeholder,
+        so its stored value contains the inner code key. Restoring in forward
+        (insertion) order re-injected that inner sentinel after its key had
+        already been passed, shipping a raw \\x00GC0\\x00 control sequence.
+        """
+        out = GoogleChatAdapter.format_message("## Run `npm test` now")
+        assert out == "*Run `npm test` now*"
+        assert "\x00" not in out
+
+    def test_inline_code_inside_bold_is_restored(self):
+        """Inline code nested inside a bold span must round-trip cleanly."""
+        out = GoogleChatAdapter.format_message("**use `git` here**")
+        assert "\x00" not in out
+        assert "`git`" in out
+
 
 class TestADCFallback:
     """When no SA JSON is configured, fall back to Application Default Credentials.


### PR DESCRIPTION
## What does this PR do?

Fixes outbound Google Chat messages emitting literal `\x00GC{n}\x00` control sentinels (rendered as tofu/garbage) whenever inline code or a link is nested inside a header or bold span.

`format_message` protects regions (fenced/inline code, headers, bold, links) by substituting `\x00GC{n}\x00` sentinels and stashing the originals in an insertion-ordered `placeholders` dict, then restores them at the end. Placeholders are created **inner-first** (e.g. inline code before the header that wraps it), so an outer placeholder's stored value can contain an earlier inner placeholder key. Restoring in forward (insertion) order re-injects the inner sentinel only after its key was already passed — so the raw control sequence is never resolved and ships to Chat.

Restoring in **reverse** (outer-first) order injects the outer value first, leaving the re-injected inner key a later pass to resolve. This mirrors the Slack adapter's restore loop (`plugins/platforms/slack/adapter.py`: `for key in reversed(placeholders): ...`), which already does this correctly; the Google Chat adapter diverged.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/google_chat/adapter.py` (`format_message`): restore protected regions in reverse insertion order (`for key in reversed(placeholders)`) instead of forward, mirroring the Slack sibling.
- `tests/gateway/test_google_chat.py` (`TestFormatMessage`): add `test_inline_code_inside_header_is_restored` and `test_inline_code_inside_bold_is_restored`.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_google_chat.py::TestFormatMessage -v` — 14 passed.
2. Fail-before / pass-after (verified): with forward-order restore, `format_message("**use \`git\` here**")` returns `*use \x00GC0\x00 here*` (raw sentinel leaks) and `format_message("## Run \`npm test\` now")` likewise leaks `\x00GC0\x00`; both new tests fail. Reverse order yields `*use \`git\` here*` and `*Run \`npm test\` now*` with no `\x00`, both pass.
3. Full adapter suite: `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_google_chat.py -q` — 162 passed.

## Scope / Positioning

Distinct from open #35644 (lambertian, "8 ... correctness bugs"): that PR fixes other functions in this file (`_run_supervisor`, `_chunk_text`, `send`, `_build_message_event`, `_download_attachment`, `send_image_file`, `_send_file`, `_on_pubsub_message`, `connect`) and does **not** touch `format_message` or the placeholder-restore loop. This change is scoped solely to the `format_message` restore order; no function-level overlap.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the touched-area tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — added an explanatory comment on the restore loop; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure string handling)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A