### PR TITLE
fix(session_search): detect FTS capability on read-only connections

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -841,6 +841,22 @@ class SessionDB:
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                # Read-only-safe FTS capability detection (no DDL): the virtual
+                # tables already exist if the owning profile initialised them.
+                # Probe, don't build — a SELECT against the FTS virtual table
+                # is safe on a mode=ro connection and fails cleanly to False
+                # on an older runtime that lacks the FTS5 module / trigram
+                # tokenizer.
+                try:
+                    self._conn.execute("SELECT 1 FROM messages_fts LIMIT 1").fetchone()
+                    self._fts_enabled = True
+                    try:
+                        self._conn.execute("SELECT 1 FROM messages_fts_trigram LIMIT 1").fetchone()
+                        self._trigram_available = True
+                    except sqlite3.OperationalError:
+                        self._trigram_available = False
+                except sqlite3.OperationalError:
+                    self._fts_enabled = False
                 return
 
             self.db_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Problem

Fixes #54861

`SessionDB(read_only=True)` previously returned early from `__init__` without probing FTS5 availability, leaving `_fts_enabled` permanently `False`. This caused `search_messages()` to return empty results for all cross-profile discovery queries, even when the target profile's FTS index was fully populated and healthy.

## Root Cause

The `read_only` branch (L827-844) opens a `mode=ro` connection and returns early to avoid DDL. However, the only place `_fts_enabled` is set to `True` is inside `_init_schema()`, which is skipped for read-only connections. The early return that correctly avoids DDL also incorrectly skips FTS capability detection.

## Fix

Add a read-only-safe capability probe before the early return:

1. `SELECT 1 FROM messages_fts LIMIT 1` — detects FTS5 availability
2. `SELECT 1 FROM messages_fts_trigram LIMIT 1` — detects trigram tokenizer
3. Sets `_fts_enabled` and `_trigram_available` accordingly

This probe is safe on a `mode=ro` connection (it's a read-only SELECT against an existing virtual table) and fails cleanly to `False` on older runtimes that lack FTS5.

## Testing

- Verified that a read-only connection can probe FTS5 on an existing database
- The probe fails gracefully when the virtual table doesn't exist
- No DDL is executed (preserving the no-write-lock invariant)

## Impact

- Cross-profile `session_search` discovery queries now return results
- Single-profile users are unaffected (they use read-write connections)
- No behavioral change for providers that don't use cross-profile search