### PR TITLE
Add Codex upstream to local proxy broker

### DIFF
--- a/hermes_cli/proxy/adapters/__init__.py
+++ b/hermes_cli/proxy/adapters/__init__.py
@@ -8,6 +8,7 @@ token. See :class:`UpstreamAdapter` for the contract.
 from typing import Dict, Type
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter
+from hermes_cli.proxy.adapters.codex import OpenAICodexAdapter
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
@@ -15,6 +16,7 @@ from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 # the ``hermes proxy start --provider <name>`` CLI flag.
 ADAPTERS: Dict[str, Type[UpstreamAdapter]] = {
     "nous": NousPortalAdapter,
+    "openai-codex": OpenAICodexAdapter,
     "xai": XAIGrokAdapter,
 }
 

--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import FrozenSet, Optional
+from typing import Dict, FrozenSet, Optional
 
 
 @dataclass(frozen=True)
@@ -33,6 +33,9 @@ class UpstreamCredential:
 
     expires_at: Optional[str] = None
     """ISO-8601 expiry timestamp for the bearer, when known. Informational."""
+
+    extra_headers: Optional[Dict[str, str]] = None
+    """Provider-required request headers to attach after client headers are filtered."""
 
 
 class UpstreamAdapter(ABC):

--- a/hermes_cli/proxy/adapters/codex.py
+++ b/hermes_cli/proxy/adapters/codex.py
@@ -1,0 +1,135 @@
+"""OpenAI Codex (ChatGPT OAuth) upstream adapter.
+
+This adapter lets ``hermes proxy`` act as the single local owner of the
+ChatGPT/Codex OAuth token chain. Downstream Hermes/OpenClaw clients can point at
+``http://127.0.0.1:8645/v1`` with a dummy bearer; the proxy resolves the current
+Codex token from the shared Hermes credential pool, attaches the Cloudflare-safe
+Codex headers, and refreshes through the existing pool machinery on a 401.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import FrozenSet, Optional
+
+from agent.credential_pool import CredentialPool, PooledCredential, load_pool
+from agent.auxiliary_client import _codex_cloudflare_headers
+from hermes_cli.auth import DEFAULT_CODEX_BASE_URL
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+
+logger = logging.getLogger(__name__)
+
+_POOL_PROVIDER = "openai-codex"
+
+_ALLOWED_PATHS: FrozenSet[str] = frozenset(
+    {
+        "/responses",
+        "/chat/completions",
+        "/completions",
+        "/embeddings",
+        "/models",
+    }
+)
+
+
+class OpenAICodexAdapter(UpstreamAdapter):
+    """Proxy upstream for ChatGPT-account Codex OAuth credentials."""
+
+    auth_hint = "hermes auth add openai-codex"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pool: Optional[CredentialPool] = None
+
+    @property
+    def name(self) -> str:
+        return "openai-codex"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenAI Codex"
+
+    @property
+    def allowed_paths(self) -> FrozenSet[str]:
+        return _ALLOWED_PATHS
+
+    def is_authenticated(self) -> bool:
+        pool = self._load_pool()
+        return bool(pool and pool.has_available())
+
+    def get_credential(self) -> UpstreamCredential:
+        with self._lock:
+            pool = self._load_pool()
+            if pool is None or not pool.has_credentials():
+                raise RuntimeError(
+                    "No OpenAI Codex OAuth credentials found. Run "
+                    "`hermes auth add openai-codex` first."
+                )
+
+            entry = pool.select()
+            if entry is None:
+                raise RuntimeError(
+                    "No available OpenAI Codex OAuth credentials found. Run "
+                    "`hermes auth reset openai-codex` or re-authenticate with "
+                    "`hermes auth add openai-codex`."
+                )
+            self._pool = pool
+            return self._credential_from_entry(entry)
+
+    def get_retry_credential(
+        self,
+        *,
+        failed_credential: UpstreamCredential,
+        status_code: int,
+    ) -> Optional[UpstreamCredential]:
+        if status_code != 401:
+            return None
+
+        with self._lock:
+            pool = self._pool or self._load_pool()
+            if pool is None:
+                return None
+            refreshed = pool.try_refresh_current()
+            if refreshed is None:
+                return None
+            retry_cred = self._credential_from_entry(refreshed)
+            if retry_cred.bearer == failed_credential.bearer:
+                return None
+            logger.info("proxy: Codex upstream returned 401; retrying with refreshed token")
+            return retry_cred
+
+    def _load_pool(self) -> Optional[CredentialPool]:
+        try:
+            return load_pool(_POOL_PROVIDER)
+        except Exception as exc:
+            logger.warning("proxy: failed to load OpenAI Codex credential pool: %s", exc)
+            return None
+
+    def _credential_from_entry(self, entry: PooledCredential) -> UpstreamCredential:
+        bearer = (
+            getattr(entry, "runtime_api_key", None)
+            or getattr(entry, "access_token", "")
+            or ""
+        )
+        bearer = str(bearer).strip()
+        if not bearer:
+            raise RuntimeError(
+                "OpenAI Codex credential pool entry did not contain an access token. "
+                "Re-authenticate with `hermes auth add openai-codex`."
+            )
+
+        # Always route Codex through the ChatGPT Codex backend. Pool entries may
+        # contain historical or user-overridden base URLs; the broker's contract
+        # is to be the stable local façade in front of this upstream.
+        base_url = str(DEFAULT_CODEX_BASE_URL).strip().rstrip("/")
+
+        return UpstreamCredential(
+            bearer=bearer,
+            base_url=base_url,
+            expires_at=getattr(entry, "expires_at", None),
+            extra_headers=_codex_cloudflare_headers(bearer),
+        )
+
+
+__all__ = ["OpenAICodexAdapter"]

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -12,8 +12,10 @@ or rewrite request/response bodies. It's a credential-attaching forwarder.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import signal
+import time
 from typing import Optional
 
 try:
@@ -81,6 +83,101 @@ def _filter_response_headers(headers) -> dict:
     return out
 
 
+def _codex_chat_completions_to_responses(body: bytes) -> tuple[bytes, str]:
+    """Translate OpenAI chat.completions JSON into Codex Responses JSON.
+
+    The ChatGPT Codex backend only accepts ``/responses`` with ``stream=true``.
+    ``hermes proxy`` still exposes ``/v1/chat/completions`` so OpenAI-compatible
+    clients can borrow the broker without learning Codex's private wire shape.
+    """
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    payload = json.loads(body.decode("utf-8") if body else "{}")
+    messages = payload.get("messages") or []
+    model = str(payload.get("model") or "gpt-5.5")
+    instructions = None
+    replay_messages = []
+    if isinstance(messages, list):
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") == "system" and instructions is None:
+                content = msg.get("content") or ""
+                instructions = content if isinstance(content, str) else str(content)
+            else:
+                replay_messages.append(msg)
+
+    responses_payload = {
+        "model": model,
+        "input": _chat_messages_to_responses_input(replay_messages) or [
+            {"role": "user", "content": ""}
+        ],
+        "store": False,
+        "stream": True,
+    }
+    if instructions:
+        responses_payload["instructions"] = instructions
+    extra_body = payload.get("extra_body")
+    if isinstance(extra_body, dict):
+        reasoning = extra_body.get("reasoning")
+        if isinstance(reasoning, dict) and reasoning.get("enabled") is not False:
+            effort = reasoning.get("effort") or "medium"
+            if effort == "minimal":
+                effort = "low"
+            responses_payload["reasoning"] = {"effort": effort, "summary": "auto"}
+            responses_payload["include"] = ["reasoning.encrypted_content"]
+
+    return json.dumps(responses_payload).encode("utf-8"), model
+
+
+async def _codex_responses_sse_to_chat_json(upstream_resp, *, model: str) -> "web.Response":
+    """Collect a Codex Responses SSE stream and return chat.completions JSON."""
+    raw = await upstream_resp.text(errors="replace")
+    text_parts = []
+    response_id = None
+    usage = None
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        data_s = line[len("data:"):].strip()
+        if not data_s or data_s == "[DONE]":
+            continue
+        try:
+            event = json.loads(data_s)
+        except Exception:
+            continue
+        event_type = event.get("type")
+        if event_type == "response.created":
+            response = event.get("response") or {}
+            response_id = response.get("id") or response_id
+        elif event_type == "response.output_text.delta":
+            delta = event.get("delta")
+            if isinstance(delta, str):
+                text_parts.append(delta)
+        elif event_type == "response.completed":
+            response = event.get("response") or {}
+            response_id = response.get("id") or response_id
+            usage = response.get("usage") or usage
+
+    body = {
+        "id": response_id or f"chatcmpl-codex-proxy-{int(time.time())}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "".join(text_parts)},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    if usage is not None:
+        body["usage"] = usage
+    return web.json_response(body)
+
+
 def create_app(adapter: UpstreamAdapter) -> "web.Application":
     """Build the aiohttp application bound to a specific upstream adapter."""
     if not AIOHTTP_AVAILABLE:
@@ -129,21 +226,32 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
         # need to forward large multipart uploads we'll switch to streaming
         # the request body too.
         body = await request.read()
+        codex_chat_compat = adapter.name == "openai-codex" and rel_path == "/chat/completions"
+        codex_chat_model = ""
+        upstream_rel_path = rel_path
+        if codex_chat_compat:
+            try:
+                body, codex_chat_model = _codex_chat_completions_to_responses(body)
+                upstream_rel_path = "/responses"
+            except Exception as exc:
+                return _json_error(400, f"invalid chat.completions request: {exc}", code="bad_request")
 
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=15, sock_read=300)
 
         async def _send_upstream(active_cred: UpstreamCredential):
-            upstream_url = f"{active_cred.base_url.rstrip('/')}{rel_path}"
+            upstream_url = f"{active_cred.base_url.rstrip('/')}{upstream_rel_path}"
             # Preserve query string verbatim.
             if request.query_string:
                 upstream_url = f"{upstream_url}?{request.query_string}"
 
             fwd_headers = _filter_request_headers(request.headers)
             fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
+            if active_cred.extra_headers:
+                fwd_headers.update(active_cred.extra_headers)
 
             logger.debug(
                 "proxy: forwarding %s %s -> %s (body=%d bytes)",
-                request.method, rel_path, upstream_url, len(body),
+                request.method, upstream_rel_path, upstream_url, len(body),
             )
 
             try:
@@ -211,6 +319,16 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                 if upstream_resp is None:
                     return session_or_response
                 session = session_or_response
+
+        if codex_chat_compat:
+            try:
+                return await _codex_responses_sse_to_chat_json(
+                    upstream_resp,
+                    model=codex_chat_model or "gpt-5.5",
+                )
+            finally:
+                upstream_resp.release()
+                await session.close()
 
         # Stream response back. Headers first, then chunked body.
         resp = web.StreamResponse(

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -321,7 +321,7 @@ def build_gateway_parser(
     proxy_start.add_argument(
         "--provider",
         default="nous",
-        help="Upstream provider: nous or xai (default: nous). See `hermes proxy providers`.",
+        help="Upstream provider: nous, openai-codex, or xai (default: nous). See `hermes proxy providers`.",
     )
     proxy_start.add_argument(
         "--host",

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -13,6 +13,7 @@ import pytest
 
 from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
 from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+from hermes_cli.proxy.adapters.codex import OpenAICodexAdapter
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
@@ -30,6 +31,10 @@ def test_registry_lists_xai():
     assert "xai" in ADAPTERS
 
 
+def test_registry_lists_openai_codex():
+    assert "openai-codex" in ADAPTERS
+
+
 def test_get_adapter_returns_instance():
     adapter = get_adapter("nous")
     assert isinstance(adapter, NousPortalAdapter)
@@ -42,10 +47,17 @@ def test_get_adapter_returns_xai_instance():
     assert isinstance(adapter, UpstreamAdapter)
 
 
+def test_get_adapter_returns_codex_instance():
+    adapter = get_adapter("openai-codex")
+    assert isinstance(adapter, OpenAICodexAdapter)
+    assert isinstance(adapter, UpstreamAdapter)
+
+
 def test_get_adapter_case_insensitive():
     assert isinstance(get_adapter("NOUS"), NousPortalAdapter)
     assert isinstance(get_adapter("  Nous  "), NousPortalAdapter)
     assert isinstance(get_adapter("XAI"), XAIGrokAdapter)
+    assert isinstance(get_adapter("OPENAI-CODEX"), OpenAICodexAdapter)
 
 
 def test_get_adapter_unknown_provider_raises():
@@ -565,6 +577,187 @@ def test_xai_adapter_retry_returns_none_for_unrelated_status(tmp_path, monkeypat
 
 
 # ---------------------------------------------------------------------------
+# OpenAICodexAdapter
+# ---------------------------------------------------------------------------
+
+
+def _write_codex_pool_entry(
+    hermes_home: Path,
+    *,
+    access_token: str = "codex-access-token",
+    refresh_token: str = "codex-refresh-token",
+    base_url: str = "https://chatgpt.com/backend-api/codex",
+    source: str = "device_code",
+) -> Path:
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                },
+                "last_refresh": "2026-06-29T00:00:00Z",
+            }
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "codex123",
+                    "label": "codex-test",
+                    "provider": "openai-codex",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": source,
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "base_url": base_url,
+                }
+            ]
+        },
+    }))
+    return auth_path
+
+
+def test_codex_adapter_metadata():
+    adapter = OpenAICodexAdapter()
+    assert adapter.name == "openai-codex"
+    assert adapter.display_name == "OpenAI Codex"
+    assert "/responses" in adapter.allowed_paths
+    assert "/chat/completions" in adapter.allowed_paths
+    assert "/models" in adapter.allowed_paths
+
+
+def test_codex_adapter_not_authenticated_when_no_pool_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {},
+    }))
+    assert not OpenAICodexAdapter().is_authenticated()
+
+
+def test_codex_adapter_get_credential_uses_shared_pool_and_cloudflare_headers(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_codex_pool_entry(tmp_path, access_token="pool-access-token")
+
+    with patch(
+        "hermes_cli.proxy.adapters.codex._codex_cloudflare_headers",
+        return_value={"originator": "codex_cli_rs", "ChatGPT-Account-ID": "acct-test"},
+    ) as mock_headers:
+        cred = OpenAICodexAdapter().get_credential()
+
+    mock_headers.assert_called_once_with("pool-access-token")
+    assert cred.bearer == "pool-access-token"
+    assert cred.base_url == "https://chatgpt.com/backend-api/codex"
+    assert cred.extra_headers == {
+        "originator": "codex_cli_rs",
+        "ChatGPT-Account-ID": "acct-test",
+    }
+
+
+def test_codex_adapter_retry_refreshes_current_pool_entry_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_codex_pool_entry(tmp_path, access_token="old-access-token")
+
+    refresh_calls = []
+
+    def fake_refresh(access_token, refresh_token, **kwargs):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "last_refresh": "2026-06-29T01:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", fake_refresh)
+    monkeypatch.setattr(
+        "hermes_cli.proxy.adapters.codex._codex_cloudflare_headers",
+        lambda token: {"originator": "codex_cli_rs", "token-seen": token},
+    )
+
+    adapter = OpenAICodexAdapter()
+    failed = adapter.get_credential()
+    retry = adapter.get_retry_credential(
+        failed_credential=failed,
+        status_code=401,
+    )
+
+    assert retry is not None
+    assert retry.bearer == "new-access-token"
+    assert retry.extra_headers["token-seen"] == "new-access-token"
+    assert refresh_calls == [("old-access-token", "codex-refresh-token")]
+
+
+def test_codex_adapter_retry_skips_non_401(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_codex_pool_entry(tmp_path)
+
+    def _refresh_must_not_run(*args, **kwargs):
+        raise AssertionError("refresh_codex_oauth_pure must not run on non-401")
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", _refresh_must_not_run)
+
+    adapter = OpenAICodexAdapter()
+    failed = adapter.get_credential()
+    for status in (200, 400, 403, 429, 500):
+        assert adapter.get_retry_credential(
+            failed_credential=failed,
+            status_code=status,
+        ) is None
+
+
+def test_codex_adapter_concurrent_refresh_serialized(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_codex_pool_entry(tmp_path, access_token="old-access-token")
+
+    in_flight = threading.Event()
+    overlap_detected = threading.Event()
+    refresh_calls = []
+
+    def serial_refresh(access_token, refresh_token, **kwargs):
+        if in_flight.is_set():
+            overlap_detected.set()
+        in_flight.set()
+        try:
+            import time
+            time.sleep(0.05)
+            refresh_calls.append((access_token, refresh_token))
+            return {
+                "access_token": f"new-access-{len(refresh_calls)}",
+                "refresh_token": f"new-refresh-{len(refresh_calls)}",
+                "last_refresh": "2026-06-29T01:00:00Z",
+            }
+        finally:
+            in_flight.clear()
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", serial_refresh)
+
+    adapter = OpenAICodexAdapter()
+    failed = adapter.get_credential()
+    errors = []
+
+    def worker():
+        try:
+            adapter.get_retry_credential(failed_credential=failed, status_code=401)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert not overlap_detected.is_set(), "Codex refresh calls overlapped — lock is broken"
+    assert len(refresh_calls) == 3
+
+
+# ---------------------------------------------------------------------------
 # Server: path filtering + forwarding
 #
 # We run the proxy AND a fake upstream as real aiohttp servers on ephemeral
@@ -582,12 +775,14 @@ class FakeAdapter(UpstreamAdapter):
 
     def __init__(self, base_url: str, bearer: str = "test-bearer",
                  allowed=None, raise_on_credential=False,
-                 retry_bearer: str | None = None):
+                 retry_bearer: str | None = None,
+                 extra_headers: dict | None = None):
         self._base_url = base_url
         self._bearer = bearer
         self._allowed = frozenset(allowed or ["/chat/completions"])
         self._raise = raise_on_credential
         self._retry_bearer = retry_bearer
+        self._extra_headers = extra_headers or {}
         self.calls = 0
         self.retry_calls = 0
 
@@ -609,6 +804,7 @@ class FakeAdapter(UpstreamAdapter):
         return UpstreamCredential(
             bearer=self._bearer, base_url=self._base_url,
             expires_at="2099-01-01T00:00:00Z",
+            extra_headers=dict(self._extra_headers),
         )
 
     def get_retry_credential(self, *, failed_credential, status_code):
@@ -641,6 +837,8 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
             "method": request.method,
             "path": request.path,
             "auth": request.headers.get("Authorization"),
+            "originator": request.headers.get("originator"),
+            "account_id": request.headers.get("ChatGPT-Account-ID"),
             "body": body.decode("utf-8") if body else "",
         })
         return web.json_response({"echoed": True, "path": request.path})
@@ -658,7 +856,36 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
     app = web.Application()
     app.router.add_route("*", "/v1/chat/completions", echo)
     app.router.add_route("*", "/v1/embeddings", echo)
+    app.router.add_route("*", "/v1/responses", echo)
     app.router.add_route("*", "/v1/sse", sse)
+    return app
+
+
+def _build_codex_responses_upstream(captured: Dict[str, Any]) -> "web.Application":
+    async def responses(request):
+        body = await request.read()
+        captured["requests"].append({
+            "method": request.method,
+            "path": request.path,
+            "auth": request.headers.get("Authorization"),
+            "originator": request.headers.get("originator"),
+            "account_id": request.headers.get("ChatGPT-Account-ID"),
+            "body": body.decode("utf-8") if body else "",
+        })
+        resp = web.StreamResponse(status=200, headers={"Content-Type": "text/event-stream"})
+        await resp.prepare(request)
+        for payload in [
+            {"type": "response.created", "response": {"id": "resp-test"}},
+            {"type": "response.output_text.delta", "delta": "BROKER_"},
+            {"type": "response.output_text.delta", "delta": "OK"},
+            {"type": "response.completed", "response": {"id": "resp-test", "usage": {}}},
+        ]:
+            await resp.write(f"data: {json.dumps(payload)}\n\n".encode())
+        await resp.write_eof()
+        return resp
+
+    app = web.Application()
+    app.router.add_route("*", "/v1/responses", responses)
     return app
 
 
@@ -704,6 +931,91 @@ def test_server_forwards_chat_completions():
             req = captured["requests"][0]
             assert req["auth"] == "Bearer real-portal-key"
             assert "Hermes-4-70B" in req["body"]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_forwards_adapter_extra_headers():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            bearer="codex-access-token",
+            extra_headers={
+                "originator": "codex_cli_rs",
+                "ChatGPT-Account-ID": "acct-proxy-test",
+            },
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"model": "gpt-5.5"},
+                    headers={
+                        "Authorization": "Bearer dummy",
+                        "originator": "client-should-not-win",
+                    },
+                ) as resp:
+                    assert resp.status == 200
+
+            req = captured["requests"][0]
+            assert req["auth"] == "Bearer codex-access-token"
+            assert req["originator"] == "codex_cli_rs"
+            assert req["account_id"] == "acct-proxy-test"
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_codex_chat_completions_maps_to_responses_and_returns_chat_json():
+    class CodexFakeAdapter(FakeAdapter):
+        @property
+        def name(self):
+            return "openai-codex"
+
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_codex_responses_upstream(captured))
+        adapter = CodexFakeAdapter(
+            f"{upstream_base}/v1",
+            bearer="codex-access-token",
+            allowed=["/chat/completions", "/responses"],
+            extra_headers={"originator": "codex_cli_rs"},
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={
+                        "model": "gpt-5.5",
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                    headers={"Authorization": "Bearer dummy"},
+                ) as resp:
+                    assert resp.status == 200
+                    data = await resp.json()
+
+            assert data["choices"][0]["message"]["content"] == "BROKER_OK"
+            req = captured["requests"][0]
+            assert req["path"] == "/v1/responses"
+            assert req["auth"] == "Bearer codex-access-token"
+            assert req["originator"] == "codex_cli_rs"
+            forwarded = json.loads(req["body"])
+            assert forwarded["model"] == "gpt-5.5"
+            assert forwarded["stream"] is True
+            assert forwarded["store"] is False
+            assert "messages" not in forwarded
+            assert "input" in forwarded
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()


### PR DESCRIPTION
## Summary
- add `openai-codex` as a `hermes proxy` upstream backed by the shared Hermes Codex credential pool
- forward Codex-required Cloudflare headers via proxy credentials and refresh once on upstream 401 through existing pool refresh logic
- expose OpenAI-compatible `/v1/chat/completions` by translating to Codex `/responses` streaming and returning chat-completion JSON
- register the provider in `hermes proxy providers` and update CLI help

## Verify-first notes
- Reviewed `hermes_cli/proxy/adapters/base.py`, `nous_portal.py`, `xai.py`, and `server.py` contract.
- Reused existing `agent.credential_pool.load_pool("openai-codex")`, `pool.select()`, and `pool.try_refresh_current()`; no new OAuth implementation.
- Reused `agent.auxiliary_client._codex_cloudflare_headers` for `originator`, `User-Agent`, and `ChatGPT-Account-ID`.
- Inspected Hermes profile config base_url locations and OpenClaw `openclaw.json` Codex model references without modifying live config.
- Live rollout was limited to a temporary foreground proxy smoke; no launchd service or profile/OpenClaw config was changed in this PR.

## Tests / proof
- `python -m pytest tests/hermes_cli/test_proxy.py tests/agent/test_codex_cloudflare_headers.py -q` → 62 passed
- `python -m py_compile hermes_cli/proxy/adapters/codex.py hermes_cli/proxy/adapters/base.py hermes_cli/proxy/server.py hermes_cli/proxy/adapters/__init__.py hermes_cli/subcommands/gateway.py tests/hermes_cli/test_proxy.py`
- `git diff --check`
- Temporary live proxy smoke on `127.0.0.1:8645`:
  - `/health` → `{"status":"ok","upstream":"OpenAI Codex","authenticated":true}`
  - `/v1/chat/completions` with dummy bearer/model `gpt-5.5` → HTTP 200, content `BROKER_OK`

## Rollout safety
No live config was changed. Next staged rollout step is to install/run the proxy service persistently, then repoint one low-traffic Hermes profile to `http://127.0.0.1:8645/v1`, verify, then continue profile-by-profile before OpenClaw.
