### PR TITLE
fix(sanitization): repair concatenated/duplicated tool_call arguments

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -220,6 +220,31 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 
+    # Repair pass 0.5: some local models (e.g. Qwen 4B) emit their tool-call
+    # arguments twice, concatenated — '{...}{...' — which json.loads rejects
+    # as "Extra data". Decode just the first complete JSON value (the model's
+    # intended args) and drop the duplicated/truncated tail. If that first
+    # value is an empty object but more data follows, prefer the next value.
+    try:
+        decoder = json.JSONDecoder()
+        obj, end = decoder.raw_decode(raw_stripped)
+        if isinstance(obj, dict) and not obj and end < len(raw_stripped):
+            try:
+                obj2, _ = decoder.raw_decode(raw_stripped[end:].lstrip())
+                if isinstance(obj2, dict) and obj2:
+                    obj = obj2
+            except (json.JSONDecodeError, ValueError):
+                pass
+        if end < len(raw_stripped):
+            logger.warning(
+                "Repaired concatenated/duplicated tool_call arguments for %s "
+                "(kept first complete object)",
+                tool_name,
+            )
+        return json.dumps(obj, separators=(",", ":"))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+
     # Attempt common JSON repairs
     fixed = raw_stripped
     # 1. Strip trailing commas before } or ]

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -140,3 +140,26 @@ class TestRepairToolCallArguments:
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
 
+    # -- Stage 0.5: concatenated / duplicated argument objects --
+
+    def test_concatenated_duplicate_objects_keeps_first(self):
+        """Some local models emit their args twice: '{...}{...'. json.loads
+        rejects this as 'Extra data'; we keep the first complete object."""
+        raw = '{"attachment_id": "fil_x", "message_id": "msg_y"}{"attachment_id":'
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == {"attachment_id": "fil_x", "message_id": "msg_y"}
+
+    def test_exact_duplicate_objects(self):
+        result = _repair_tool_call_arguments('{"a": 1}{"a": 1}', "t")
+        assert json.loads(result) == {"a": 1}
+
+    def test_empty_first_object_prefers_next(self):
+        """A leading '{}' followed by the real args -> take the real args."""
+        result = _repair_tool_call_arguments('{}{"a": 1}', "t")
+        assert json.loads(result) == {"a": 1}
+
+    def test_clean_single_object_untouched(self):
+        """A well-formed single object must pass through unchanged."""
+        result = _repair_tool_call_arguments('{"attachment_id": "fil_x"}', "t")
+        assert json.loads(result) == {"attachment_id": "fil_x"}
+


### PR DESCRIPTION
## Problem

Some local models (observed with Qwen 4B) emit their tool-call arguments **twice, concatenated** into a single `arguments` string:

```
{"attachment_id": "fil_x", "message_id": "msg_y"}{"attachment_id":
```

`json.loads` rejects this with `Extra data`. The existing repair passes in `_repair_tool_call_arguments` (trailing-comma strip, brace balancing, control-char escaping) can't recover a complete-object-plus-tail, so it falls through to the last-resort `"{}"`. The tool is then invoked with **no arguments** and fails — e.g. an MCP tool that requires `message_id`/`attachment_id` errors out, and the surrounding agent turn produces:

```
WARNING agent.message_sanitization: Unrepairable tool_call arguments for <tool> — replaced with empty object (was: {"...":"..."}{"...
```

## Fix

Add a repair pass (between the `strict=False` reserialise pass and the brace-balancing heuristics) that uses `json.JSONDecoder().raw_decode()` to parse just the **first complete JSON value** — the model's intended arguments — and drop the duplicated/truncated tail. If that first value is an empty object but more data follows, it prefers the next value (handles a leading `{}` artifact).

Well-formed single objects are unaffected: they're already returned by the earlier `strict=False` pass and never reach this code.

## Tests

Added cases to `tests/run_agent/test_repair_tool_call_arguments.py`:
- concatenated duplicate where the tail is truncated → keeps first object
- exact duplicate `{...}{...}` → first object
- leading `{}` then real args → prefers real args
- clean single object → unchanged