### PR TITLE
fix(bedrock): alias long MCP tool names

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -27,6 +27,7 @@ the same Converse API integration in TypeScript via ``@aws-sdk/client-bedrock``.
 Requires: ``boto3`` (optional dependency — only needed when using the Bedrock provider).
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -59,6 +60,34 @@ _bedrock_control_client_cache: Dict[str, Any] = {}
 
 
 _MIN_BOTO3_VERSION = (1, 34, 59)
+_BEDROCK_TOOL_NAME_MAX_LENGTH = 64
+_BEDROCK_TOOL_NAME_HASH_LENGTH = 10
+_BEDROCK_TOOL_NAME_ALIASES: Dict[str, str] = {}
+_BEDROCK_TOOL_NAME_REVERSE_ALIASES: Dict[str, str] = {}
+
+
+def _bedrock_wire_tool_name(name: str) -> str:
+    """Return a Bedrock-safe tool name and remember how to restore it."""
+    if not name or len(name) <= _BEDROCK_TOOL_NAME_MAX_LENGTH:
+        return name
+
+    cached = _BEDROCK_TOOL_NAME_ALIASES.get(name)
+    if cached:
+        return cached
+
+    digest = hashlib.sha1(name.encode("utf-8")).hexdigest()[:_BEDROCK_TOOL_NAME_HASH_LENGTH]
+    stem_length = _BEDROCK_TOOL_NAME_MAX_LENGTH - len(digest) - 1
+    stem = re.sub(r"[^A-Za-z0-9_]", "_", name[:stem_length]).rstrip("_") or "tool"
+    alias = f"{stem}_{digest}"
+
+    _BEDROCK_TOOL_NAME_ALIASES[name] = alias
+    _BEDROCK_TOOL_NAME_REVERSE_ALIASES[alias] = name
+    return alias
+
+
+def _restore_bedrock_tool_name(name: str) -> str:
+    """Restore a provider-local Bedrock tool alias to the Hermes tool name."""
+    return _BEDROCK_TOOL_NAME_REVERSE_ALIASES.get(name, name)
 
 
 def _require_boto3():
@@ -482,7 +511,7 @@ def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
         parameters = fn.get("parameters", {"type": "object", "properties": {}})
         result.append({
             "toolSpec": {
-                "name": name,
+                "name": _bedrock_wire_tool_name(name),
                 "description": description,
                 "inputSchema": {"json": parameters},
             }
@@ -620,7 +649,7 @@ def convert_messages_to_converse(
                 content_blocks.append({
                     "toolUse": {
                         "toolUseId": tc.get("id", ""),
-                        "name": fn.get("name", ""),
+                        "name": _bedrock_wire_tool_name(fn.get("name", "")),
                         "input": args_dict,
                     }
                 })
@@ -714,7 +743,7 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
                 id=tu.get("toolUseId", ""),
                 type="function",
                 function=SimpleNamespace(
-                    name=tu.get("name", ""),
+                    name=_restore_bedrock_tool_name(tu.get("name", "")),
                     arguments=json.dumps(tu.get("input", {})),
                 ),
             ))
@@ -828,7 +857,7 @@ def stream_converse_with_callbacks(
                     current_text_buffer = []
                 current_tool = {
                     "toolUseId": start["toolUse"].get("toolUseId", ""),
-                    "name": start["toolUse"].get("name", ""),
+                    "name": _restore_bedrock_tool_name(start["toolUse"].get("name", "")),
                     "input_json": "",
                 }
                 if on_tool_start:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -154,6 +154,24 @@ class TestResolveBedrocRegion:
 class TestConvertToolsToConverse:
     """Test OpenAI → Bedrock Converse tool definition conversion."""
 
+    def test_aliases_long_tool_names_for_bedrock_limit(self):
+        from agent.bedrock_adapter import convert_tools_to_converse
+        long_name = "mcp_extremely_long_server_name_with_many_segments_search_repositories"
+        assert len(long_name) > 64
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": long_name,
+                "description": "Search repositories",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }]
+        result = convert_tools_to_converse(tools)
+        spec = result[0]["toolSpec"]
+        assert spec["name"] != long_name
+        assert len(spec["name"]) <= 64
+        assert spec["description"] == "Search repositories"
+
     def test_converts_single_tool(self):
         from agent.bedrock_adapter import convert_tools_to_converse
         tools = [{
@@ -258,6 +276,30 @@ class TestConvertMessagesToConverse:
         assert tool_use_blocks[0]["toolUse"]["name"] == "read_file"
         assert tool_use_blocks[0]["toolUse"]["toolUseId"] == "call_123"
         assert tool_use_blocks[0]["toolUse"]["input"] == {"path": "/tmp/test.txt"}
+
+    def test_assistant_tool_calls_use_bedrock_aliases_for_long_names(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        long_name = "mcp_extremely_long_server_name_with_many_segments_search_repositories"
+        assert len(long_name) > 64
+        messages = [
+            {"role": "user", "content": "Search"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_long",
+                    "type": "function",
+                    "function": {"name": long_name, "arguments": "{}"},
+                }],
+            },
+        ]
+        _, msgs = convert_messages_to_converse(messages)
+        assistant_content = msgs[1]["content"]
+        tool_use_blocks = [b for b in assistant_content if "toolUse" in b]
+        assert len(tool_use_blocks) == 1
+        wire_name = tool_use_blocks[0]["toolUse"]["name"]
+        assert wire_name != long_name
+        assert len(wire_name) <= 64
 
     def test_tool_result_becomes_user_message(self):
         from agent.bedrock_adapter import convert_messages_to_converse
@@ -418,6 +460,32 @@ class TestNormalizeConverseResponse:
         assert tool_calls[0].function.name == "read_file"
         assert json.loads(tool_calls[0].function.arguments) == {"path": "/tmp/test.txt"}
 
+    def test_tool_use_response_restores_long_bedrock_aliases(self):
+        from agent.bedrock_adapter import convert_tools_to_converse, normalize_converse_response
+        long_name = "mcp_extremely_long_server_name_with_many_segments_search_repositories"
+        tools = [{"type": "function", "function": {
+            "name": long_name,
+            "description": "Search repositories",
+            "parameters": {},
+        }}]
+        wire_name = convert_tools_to_converse(tools)[0]["toolSpec"]["name"]
+        assert wire_name != long_name
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"toolUse": {"toolUseId": "call_long", "name": wire_name, "input": {}}},
+                    ],
+                },
+            },
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 0, "outputTokens": 0},
+        }
+        result = normalize_converse_response(response)
+        tool_calls = result.choices[0].message.tool_calls
+        assert tool_calls[0].function.name == long_name
+
     def test_multiple_tool_calls(self):
         from agent.bedrock_adapter import normalize_converse_response
         response = {
@@ -525,6 +593,32 @@ class TestNormalizeConverseStreamEvents:
         assert tc[0].id == "call_1"
         assert tc[0].function.name == "read_file"
         assert json.loads(tc[0].function.arguments) == {"path": "/tmp/f"}
+
+    def test_tool_use_stream_restores_long_bedrock_aliases(self):
+        from agent.bedrock_adapter import convert_tools_to_converse, normalize_converse_stream_events
+        long_name = "mcp_extremely_long_server_name_with_many_segments_search_repositories"
+        tools = [{"type": "function", "function": {
+            "name": long_name,
+            "description": "Search repositories",
+            "parameters": {},
+        }}]
+        wire_name = convert_tools_to_converse(tools)[0]["toolSpec"]["name"]
+        assert wire_name != long_name
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {
+                "toolUse": {"toolUseId": "call_long", "name": wire_name},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {
+                "toolUse": {"input": "{}"},
+            }}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0}}},
+        ]}
+        result = normalize_converse_stream_events(events)
+        tool_calls = result.choices[0].message.tool_calls
+        assert tool_calls[0].function.name == long_name
 
     def test_mixed_text_and_tool_stream(self):
         from agent.bedrock_adapter import normalize_converse_stream_events


### PR DESCRIPTION
## Summary

- Alias Bedrock Converse tool names that exceed AWS's 64-character limit.
- Keep the aliasing provider-local to Bedrock so Hermes/MCP tool names remain unchanged elsewhere.
- Restore Bedrock tool-use aliases back to the original Hermes tool names for non-streaming and streaming responses.

## Root Cause

MCP tool names are generated from the server and tool names, so long MCP server names can produce valid Hermes tool names that exceed Bedrock Converse's `toolSpec.name` limit. The Bedrock adapter passed those names through unchanged.

## Tests

- `python -m pytest tests/agent/test_bedrock_adapter.py -q`

Fixes #54863
