### PR TITLE
fix(auxiliary): skip invalid api-key fallbacks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -186,6 +186,17 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
     return OpenAI(api_key=api_key, base_url=base_url, **kwargs)
 
 
+def _tag_auxiliary_client(client: Any, provider: str) -> Any:
+    """Attach the resolved provider identity when the client permits it."""
+    if client is None:
+        return None
+    try:
+        setattr(client, "_hermes_aux_provider_label", _normalize_chain_label(provider))
+    except Exception:
+        pass
+    return client
+
+
 # ── Interrupt protection for atomic auxiliary tasks ──────────────────────
 # Some auxiliary tasks must NOT be aborted mid-flight by a gateway interrupt
 # (e.g. an incoming user message while the agent is busy). Context
@@ -1913,7 +1924,10 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
                 if is_native_gemini_base_url(base_url):
-                    return GeminiNativeClient(api_key=api_key, base_url=base_url), model
+                    return _tag_auxiliary_client(
+                        GeminiNativeClient(api_key=api_key, base_url=base_url),
+                        provider_id,
+                    ), model
             extra = {}
             if base_url_host_matches(base_url, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
@@ -1936,7 +1950,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 extra["default_headers"] = _merged_aux
             _client = _create_openai_client(api_key=api_key, base_url=base_url, **extra)
             _client = _maybe_wrap_anthropic(_client, model, api_key, raw_base_url)
-            return _client, model
+            return _tag_auxiliary_client(_client, provider_id), model
 
         creds = resolve_api_key_provider_credentials(provider_id)
         api_key = str(creds.get("api_key", "")).strip()
@@ -1953,7 +1967,10 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
             if is_native_gemini_base_url(base_url):
-                return GeminiNativeClient(api_key=api_key, base_url=base_url), model
+                return _tag_auxiliary_client(
+                    GeminiNativeClient(api_key=api_key, base_url=base_url),
+                    provider_id,
+                ), model
         extra = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
             extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
@@ -1976,7 +1993,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             extra["default_headers"] = _merged_aux2
         _client = _create_openai_client(api_key=api_key, base_url=base_url, **extra)
         _client = _maybe_wrap_anthropic(_client, model, api_key, raw_base_url)
-        return _client, model
+        return _tag_auxiliary_client(_client, provider_id), model
 
     return None, None
 
@@ -3084,6 +3101,14 @@ def _is_auth_error(exc: Exception) -> bool:
     err_lower = str(exc).lower()
     if "error code: 401" in err_lower or "authenticationerror" in type(exc).__name__.lower():
         return True
+    if status == 400 and any(phrase in err_lower for phrase in (
+        "api key not valid",
+        "invalid api key",
+        "invalid_api_key",
+        "api key is invalid",
+        "provided api key is invalid",
+    )):
+        return True
     # xAI returns HTTP 403 with "unauthenticated:bad-credentials" when an OAuth2
     # access token has expired or is invalid — semantically a 401 auth failure,
     # even though the status code is 403 (PermissionDenied).
@@ -3341,8 +3366,11 @@ def _recoverable_pool_provider(
     main_runtime: Optional[Dict[str, Any]] = None,
 ) -> Optional[str]:
     """Infer which provider pool can recover the current auxiliary client."""
+    tagged = getattr(client, "_hermes_aux_provider_label", None)
+    if isinstance(tagged, str) and tagged.strip():
+        return tagged.strip()
     normalized = _normalize_aux_provider(resolved_provider)
-    if normalized not in {"", "auto", "custom"}:
+    if normalized not in {"", "auto", "custom", "api-key"}:
         return normalized
     base = str(getattr(client, "base_url", "") or "")
     if base_url_host_matches(base, "chatgpt.com"):
@@ -3357,6 +3385,8 @@ def _recoverable_pool_provider(
         return "copilot"
     if base_url_host_matches(base, "api.kimi.com"):
         return "kimi-coding"
+    if base_url_host_matches(base, "generativelanguage.googleapis.com"):
+        return "gemini"
     if base_url_host_matches(base, "api.x.ai"):
         return "xai-oauth"
     # For api_key providers not in the hardcoded list (e.g. opencode-go), match
@@ -3631,7 +3661,7 @@ def _auth_refresh_provider_for_route(
     Copilot/Codex/Anthropic/Nous routes too. (#20832)
     """
     normalized = _normalize_aux_provider(resolved_provider)
-    if normalized and normalized != "auto":
+    if normalized and normalized not in {"auto", "api-key"}:
         return normalized
     if base_url_host_matches(client_base_url, "api.githubcopilot.com"):
         return "copilot"
@@ -3641,6 +3671,8 @@ def _auth_refresh_provider_for_route(
         return "anthropic"
     if base_url_host_matches(client_base_url, "inference-api.nousresearch.com"):
         return "nous"
+    if base_url_host_matches(client_base_url, "generativelanguage.googleapis.com"):
+        return "gemini"
     return normalized
 
 
@@ -3686,7 +3718,10 @@ def _call_fallback_candidate_sync(
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
             raise
-        fb_provider = _auth_refresh_provider_for_route(fb_label, fb_base)
+        fb_provider = (
+            _recoverable_pool_provider(fb_label, fb_client)
+            or _auth_refresh_provider_for_route(fb_label, fb_base)
+        )
         if fb_provider not in {"auto", "", None} and _refresh_provider_credentials(fb_provider):
             retry_client, retry_model = _get_cached_client(fb_provider, fb_model)
             if retry_client is not None:
@@ -3744,7 +3779,10 @@ async def _call_fallback_candidate_async(
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
             raise
-        fb_provider = _auth_refresh_provider_for_route(fb_label, fb_base)
+        fb_provider = (
+            _recoverable_pool_provider(fb_label, fb_client)
+            or _auth_refresh_provider_for_route(fb_label, fb_base)
+        )
         if fb_provider not in {"auto", "", None} and _refresh_provider_credentials(fb_provider):
             retry_client, retry_model = _get_cached_client(
                 fb_provider, fb_model, async_mode=True)
@@ -4368,23 +4406,30 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     """
     from openai import AsyncOpenAI
 
+    provider_label = getattr(sync_client, "_hermes_aux_provider_label", None)
+
+    def _with_provider_label(client: Any) -> Tuple[Any, str]:
+        if isinstance(provider_label, str) and provider_label.strip():
+            _tag_auxiliary_client(client, provider_label)
+        return client, model
+
     if isinstance(sync_client, CodexAuxiliaryClient):
-        return AsyncCodexAuxiliaryClient(sync_client), model
+        return _with_provider_label(AsyncCodexAuxiliaryClient(sync_client))
     if isinstance(sync_client, AnthropicAuxiliaryClient):
-        return AsyncAnthropicAuxiliaryClient(sync_client), model
+        return _with_provider_label(AsyncAnthropicAuxiliaryClient(sync_client))
     if isinstance(sync_client, BedrockAuxiliaryClient):
-        return AsyncBedrockAuxiliaryClient(sync_client), model
+        return _with_provider_label(AsyncBedrockAuxiliaryClient(sync_client))
     try:
         from agent.gemini_native_adapter import GeminiNativeClient, AsyncGeminiNativeClient
 
         if isinstance(sync_client, GeminiNativeClient):
-            return AsyncGeminiNativeClient(sync_client), model
+            return _with_provider_label(AsyncGeminiNativeClient(sync_client))
     except ImportError:
         pass
     try:
         from agent.copilot_acp_client import CopilotACPClient
         if isinstance(sync_client, CopilotACPClient):
-            return sync_client, model
+            return _with_provider_label(sync_client)
     except ImportError:
         pass
 
@@ -4429,7 +4474,7 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     # See _create_openai_client: disable SDK-internal retries so Hermes owns
     # the auxiliary retry/timeout budget (issue #54465).
     async_kwargs.setdefault("max_retries", 0)
-    return AsyncOpenAI(**async_kwargs), model
+    return _with_provider_label(AsyncOpenAI(**async_kwargs))
 
 
 def _normalize_resolved_model(model_name: Optional[str], provider: str) -> Optional[str]:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2177,6 +2177,19 @@ class TestStaleFallbackCandidateSkip:
         return _AuxStreamTimeoutError(
             "Codex auxiliary Responses stream exceeded 120.0s total timeout")
 
+    def _gemini_invalid_key_err(self):
+        err = Exception(
+            "Gemini HTTP 400 (INVALID_ARGUMENT): API key not valid. "
+            "Please pass a valid API key."
+        )
+        err.status_code = 400
+        return err
+
+    def test_gemini_invalid_api_key_400_is_auth_error(self):
+        from agent.auxiliary_client import _is_auth_error
+
+        assert _is_auth_error(self._gemini_invalid_key_err()) is True
+
     def test_stale_anthropic_fallback_refreshes_and_retries(self, monkeypatch):
         """401 from the fallback candidate → refresh its creds → retry succeeds."""
         primary_client = MagicMock()
@@ -2261,6 +2274,112 @@ class TestStaleFallbackCandidateSkip:
         mock_mark.assert_called_once_with("anthropic")
         assert stale_fb.chat.completions.create.call_count == 1
         assert healthy_fb.chat.completions.create.call_count == 1
+
+    def test_invalid_gemini_api_key_candidate_is_skipped_sync(self, monkeypatch):
+        """Timeout -> invalid Gemini key -> next candidate succeeds."""
+        from agent.auxiliary_client import _is_provider_unhealthy
+
+        primary_client = MagicMock()
+        primary_client.base_url = "https://chatgpt.com/backend-api/codex"
+        primary_client.chat.completions.create.side_effect = self._timeout_err()
+
+        gemini_client = MagicMock()
+        gemini_client.base_url = "https://generativelanguage.googleapis.com/v1beta"
+        gemini_client._hermes_aux_provider_label = "gemini"
+        gemini_client.chat.completions.create.side_effect = self._gemini_invalid_key_err()
+
+        healthy_client = MagicMock()
+        healthy_client.base_url = "https://openrouter.ai/api/v1"
+        healthy_client.chat.completions.create.return_value = _DummyResponse("recovered")
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_main_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   side_effect=[
+                       (gemini_client, "gemini-2.5-flash", "api-key"),
+                       (healthy_client, "fallback-model", "openrouter"),
+                   ]) as mock_fallback, \
+             patch("agent.auxiliary_client._refresh_provider_credentials",
+                   return_value=False):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result.choices[0].message.content == "recovered"
+        assert mock_fallback.call_count == 2
+        assert gemini_client.chat.completions.create.call_count == 1
+        assert healthy_client.chat.completions.create.call_count == 1
+        assert _is_provider_unhealthy("gemini") is True
+        assert _is_provider_unhealthy("api-key") is False
+
+    @pytest.mark.asyncio
+    async def test_invalid_gemini_api_key_candidate_is_skipped_async(self, monkeypatch):
+        """Async fallback preserves Gemini identity and continues the chain."""
+        from agent.auxiliary_client import _is_provider_unhealthy
+
+        primary_async = MagicMock()
+        primary_async.base_url = "https://chatgpt.com/backend-api/codex"
+        primary_async.chat.completions.create = AsyncMock(side_effect=self._timeout_err())
+
+        gemini_sync = MagicMock()
+        gemini_sync.base_url = "https://generativelanguage.googleapis.com/v1beta"
+        gemini_sync._hermes_aux_provider_label = "gemini"
+        gemini_async = MagicMock()
+        gemini_async.base_url = gemini_sync.base_url
+        gemini_async._hermes_aux_provider_label = "gemini"
+        gemini_async.chat.completions.create = AsyncMock(
+            side_effect=self._gemini_invalid_key_err())
+
+        healthy_sync = MagicMock()
+        healthy_sync.base_url = "https://openrouter.ai/api/v1"
+        healthy_async = MagicMock()
+        healthy_async.base_url = healthy_sync.base_url
+        healthy_async.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("async-recovered"))
+
+        async_clients = {
+            id(gemini_sync): gemini_async,
+            id(healthy_sync): healthy_async,
+        }
+
+        def to_async(client, model, is_vision=False):
+            return async_clients[id(client)], model
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_async, "gpt-5.5")), \
+             patch("agent.auxiliary_client._to_async_client",
+                   side_effect=to_async), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_main_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   side_effect=[
+                       (gemini_sync, "gemini-2.5-flash", "api-key"),
+                       (healthy_sync, "fallback-model", "openrouter"),
+                   ]) as mock_fallback, \
+             patch("agent.auxiliary_client._refresh_provider_credentials",
+                   return_value=False):
+            result = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result.choices[0].message.content == "async-recovered"
+        assert mock_fallback.call_count == 2
+        assert gemini_async.chat.completions.create.await_count == 1
+        assert healthy_async.chat.completions.create.await_count == 1
+        assert _is_provider_unhealthy("gemini") is True
+        assert _is_provider_unhealthy("api-key") is False
 
     def test_non_auth_fallback_error_still_raises(self, monkeypatch):
         """A non-auth error from the fallback candidate propagates unchanged."""


### PR DESCRIPTION
## Summary

- Treat provider "invalid API key" responses as auxiliary auth failures, including Gemini's HTTP 400 `API key not valid` response.
- Tag API-key fallback clients with their resolved provider so a bad `api-key` fallback can mark the actual provider, such as `gemini`, unhealthy.
- Continue the built-in auto fallback chain when a fallback candidate fails due to invalid credentials.

## Root Cause

The auxiliary auto fallback path selected the coarse `api-key` fallback after a Codex timeout. If the selected direct provider was Gemini with an invalid key, the fallback request raised immediately and compression stopped instead of marking Gemini unusable and trying the next available fallback candidate.

## Tests

- `python -m pytest tests/agent/test_auxiliary_client.py -q`

Fixes #54684
