### PR TITLE
fix(gateway): keep streaming transport default on edit

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -562,14 +562,10 @@ class StreamingConfig:
     #   "edit"  — progressive editMessageText only (legacy behaviour).
     #   "off"   — disable streaming entirely.
     #
-    # Default is "auto": prefer native draft streaming on platforms that
-    # support it (Telegram DMs via sendMessageDraft, Bot API 9.5+) and fall
-    # back to edit-based streaming everywhere else.  This is safe as a global
-    # default because adapters without draft support (Discord, Slack, Matrix,
-    # …) report supports_draft_streaming() == False and transparently use the
-    # edit path — so "auto" never regresses non-Telegram platforms, it only
-    # upgrades the chats that can render the smoother native preview.
-    transport: str = "auto"
+    # Default is "edit": native draft streaming is still available by setting
+    # transport="auto" or "draft", but the global default must not silently
+    # change Telegram DM delivery semantics for existing users.
+    transport: str = "edit"
     edit_interval: float = DEFAULT_STREAMING_EDIT_INTERVAL
     buffer_threshold: int = DEFAULT_STREAMING_BUFFER_THRESHOLD
     cursor: str = DEFAULT_STREAMING_CURSOR
@@ -598,7 +594,7 @@ class StreamingConfig:
             return cls()
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
-            transport=data.get("transport", "auto"),
+            transport=data.get("transport", "edit"),
             edit_interval=_coerce_float(
                 data.get("edit_interval"), DEFAULT_STREAMING_EDIT_INTERVAL,
             ),

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -592,9 +592,19 @@ class StreamingConfig:
     def from_dict(cls, data: Dict[str, Any]) -> "StreamingConfig":
         if not isinstance(data, dict) or not data:
             return cls()
+        transport = data.get("transport", "edit")
+        if not isinstance(transport, str) or transport.strip().lower() not in {
+            "auto",
+            "draft",
+            "edit",
+            "off",
+        }:
+            transport = "edit"
+        else:
+            transport = transport.strip().lower()
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
-            transport=data.get("transport", "edit"),
+            transport=transport,
             edit_interval=_coerce_float(
                 data.get("edit_interval"), DEFAULT_STREAMING_EDIT_INTERVAL,
             ),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3020,15 +3020,11 @@ DEFAULT_CONFIG = {
         #   "auto"  — prefer native draft streaming where the platform
         #             supports it (Telegram DMs via sendMessageDraft,
         #             Bot API 9.5+) and fall back to edit-based elsewhere.
-        #             Safe global default: platforms without draft support
-        #             (Discord, Slack, Matrix, Telegram groups) transparently
-        #             use the edit path, so "auto" only upgrades chats that
-        #             can render the smoother native preview.
         #   "draft" — explicitly request native drafts; falls back to edit
         #             when the platform/chat doesn't support them.
-        #   "edit"  — progressive editMessageText only (legacy behavior).
+        #   "edit"  — progressive editMessageText only (legacy/default behavior).
         #   "off"   — disable streaming entirely (same as enabled: false).
-        "transport": "auto",
+        "transport": "edit",
         # Minimum seconds between progressive edits — tuned for Telegram's
         # ~1 edit/s flood envelope.
         "edit_interval": 0.8,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -271,6 +271,11 @@ class TestStreamingConfig:
         restored = StreamingConfig.from_dict({"enabled": "true", "transport": "auto"})
         assert restored.transport == "auto"
 
+    def test_malformed_transport_falls_back_to_edit(self):
+        for transport in (None, 42, [], "invalid"):
+            restored = StreamingConfig.from_dict({"transport": transport})
+            assert restored.transport == "edit"
+
     def test_from_dict_coerces_quoted_false_enabled(self):
         restored = StreamingConfig.from_dict({"enabled": "false"})
         assert restored.enabled is False
@@ -290,7 +295,7 @@ class TestStreamingConfig:
     def test_from_dict_malformed_section_falls_back_to_defaults(self):
         restored = StreamingConfig.from_dict("enabled")
         assert restored.enabled is False
-        assert restored.transport == "auto"
+        assert restored.transport == "edit"
 
 
 class TestGatewayConfigRoundtrip:
@@ -413,7 +418,7 @@ class TestGatewayConfigRoundtrip:
         assert restored.default_reset_policy.mode == SessionResetPolicy().mode
         assert restored.reset_by_type == {}
         assert restored.reset_by_platform == {}
-        assert restored.streaming.transport == "auto"
+        assert restored.streaming.transport == "edit"
 
     def test_get_notice_delivery_defaults_to_public(self):
         config = GatewayConfig(
@@ -621,7 +626,7 @@ class TestLoadGatewayConfig:
 
         config = load_gateway_config()
 
-        assert config.streaming.transport == "auto"
+        assert config.streaming.transport == "edit"
 
     def test_bridges_discord_thread_require_mention_from_config_yaml(self, tmp_path, monkeypatch):
         """discord.thread_require_mention in config.yaml should reach the runtime env var."""

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -261,11 +261,14 @@ class TestSessionResetPolicy:
 
 
 class TestStreamingConfig:
-    def test_defaults_to_auto_transport(self):
-        # "auto" prefers native draft streaming where the platform supports
-        # it (Telegram DMs) and falls back to edit-based everywhere else, so
-        # it is safe as the global out-of-the-box default.
+    def test_defaults_to_edit_transport(self):
+        # Draft streaming remains opt-in via transport="auto" or "draft";
+        # the global default must preserve the edit-based delivery path.
         restored = StreamingConfig.from_dict({"enabled": "true"})
+        assert restored.transport == "edit"
+
+    def test_preserves_explicit_auto_transport(self):
+        restored = StreamingConfig.from_dict({"enabled": "true", "transport": "auto"})
         assert restored.transport == "auto"
 
     def test_from_dict_coerces_quoted_false_enabled(self):

--- a/tests/gateway/test_per_platform_streaming_defaults.py
+++ b/tests/gateway/test_per_platform_streaming_defaults.py
@@ -16,6 +16,7 @@ def test_default_per_platform_streaming_flags():
     plats = DEFAULT_CONFIG["display"]["platforms"]
     assert plats["telegram"]["streaming"] is True
     assert plats["discord"]["streaming"] is False
+    assert DEFAULT_CONFIG["streaming"]["transport"] == "edit"
 
 
 def test_resolver_telegram_on_discord_off_when_global_enabled():

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -932,9 +932,9 @@ When streaming is enabled (`gateway.streaming.enabled: true`), Hermes picks one 
 
 | Value | Behaviour |
 |---|---|
-| `auto` (default) | Native draft streaming on supported chats (currently Telegram DMs); legacy edit-based path otherwise. Falls back gracefully if a draft frame fails. |
+| `auto` | Opt in to native draft streaming on supported chats (currently Telegram DMs); use the legacy edit-based path otherwise. Falls back gracefully if a draft frame fails. |
 | `draft` | Force native drafts. Logs a downgrade and falls back to edit if the chat doesn't support drafts (e.g. groups/topics). |
-| `edit` | Legacy progressive `editMessageText` polling for every chat type. |
+| `edit` (default) | Legacy progressive `editMessageText` polling for every chat type. |
 | `off` | Disable streaming entirely (final reply only, no progressive updates). |
 
 In `~/.hermes/config.yaml`:
@@ -943,12 +943,12 @@ In `~/.hermes/config.yaml`:
 gateway:
   streaming:
     enabled: true
-    transport: auto    # auto | draft | edit | off
+    transport: edit    # default; use auto or draft to opt in to drafts
 ```
 
 **What you'll see in DMs with `edit` (default)** — the gateway sends a normal preview message and progressively updates it via `editMessageText`, avoiding Telegram's draft-preview collapse/rollback effect.
 
-**What you'll see in DMs with `auto` or `draft`** — Telegram shows an animated draft preview that updates token-by-token. When the reply finishes, it's delivered as a regular message and the draft preview clears naturally on the client. Drafts have no message id, so the final answer is what stays in your chat history.
+**What you'll see in DMs with `auto` or `draft` (opt-in)** — Telegram shows an animated draft preview that updates token-by-token. When the reply finishes, it's delivered as a regular message and the draft preview clears naturally on the client. Drafts have no message id, so the final answer is what stays in your chat history.
 
 **What about groups, supergroups, forum topics?** Telegram restricts `sendMessageDraft` to private chats (DMs). The gateway transparently falls back to the edit-based path for everything else — same UX as before.
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
@@ -853,9 +853,9 @@ platforms:
 
 | 值 | 行为 |
 |---|---|
-| `auto`（默认） | 在支持的聊天（目前为 Telegram 私聊）上使用原生草稿流式传输；否则使用旧版基于编辑的路径。如果草稿帧失败，会优雅回退。 |
+| `auto` | 选择启用原生草稿流式传输：在支持的聊天（目前为 Telegram 私聊）中使用草稿，否则使用旧版基于编辑的路径。如果草稿帧失败，会优雅回退。 |
 | `draft` | 强制使用原生草稿。如果聊天不支持草稿（例如群组/话题），记录降级日志并回退到编辑方式。 |
-| `edit` | 对所有聊天类型使用旧版渐进式 `editMessageText` 轮询。 |
+| `edit`（默认） | 对所有聊天类型使用旧版渐进式 `editMessageText` 轮询。 |
 | `off` | 完全禁用流式传输（仅最终回复，无渐进更新）。 |
 
 在 `~/.hermes/config.yaml` 中：
@@ -864,12 +864,12 @@ platforms:
 gateway:
   streaming:
     enabled: true
-    transport: auto    # auto | draft | edit | off
+    transport: edit    # 默认值；使用 auto 或 draft 选择启用草稿
 ```
 
 **使用 `edit` 传输时私聊中的效果** — gateway 发送一条普通预览消息，并通过 `editMessageText` 渐进更新，避免 Telegram 草稿预览折叠/回滚效果。
 
-**使用 `auto` 或 `draft` 时私聊中的效果** — Telegram 显示逐 token 更新的动画草稿预览。回复完成后，它作为普通消息投递，草稿预览在客户端自然清除。草稿没有消息 ID，因此最终答案才是保留在聊天历史中的内容。
+**选择使用 `auto` 或 `draft` 时私聊中的效果** — Telegram 显示逐 token 更新的动画草稿预览。回复完成后，它作为普通消息投递，草稿预览在客户端自然清除。草稿没有消息 ID，因此最终答案才是保留在聊天历史中的内容。
 
 **群组、超级群组、论坛话题怎么办？** Telegram 将 `sendMessageDraft` 限制为私聊（私信）。gateway 对其他所有内容透明地回退到基于编辑的路径——与之前的用户体验相同。
 


### PR DESCRIPTION
## Summary

- Restore the gateway streaming transport default to `edit`.
- Keep native draft streaming available when users explicitly set `transport: auto` or `transport: draft`.
- Add regression coverage for both `StreamingConfig` and `DEFAULT_CONFIG`.

## Root Cause

`StreamingConfig` and the default config both used `transport: auto`, which made Telegram DMs auto-select native draft streaming when global streaming was enabled. The runtime consumer's own default remained `edit`, so the gateway-level default unintentionally changed delivery behavior before users explicitly opted in.

## Tests

- `python -m pytest tests/gateway/test_config.py tests/gateway/test_stream_consumer_draft.py tests/gateway/test_per_platform_streaming_defaults.py tests/test_gateway_streaming_nested_config.py -q`

Fixes #54817
