### PR TITLE
fix(dashboard-auth): skip auto-SSO redirect for password-only providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -182,9 +182,16 @@ def _auto_sso_response(request: Request) -> Response | None:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None
 
+    provider = providers[0]
+
+    # Password-only providers (e.g. BasicAuthProvider) don't support the
+    # OAuth redirect dance that /auth/login initiates.  Fall through to
+    # the normal /login interstitial which renders a password form.
+    if getattr(provider, "supports_password", False):
+        return None
+
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
-    provider = providers[0]
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
## Summary

Fix a `NotImplementedError` crash when the dashboard is bound to a
non-loopback host with a password-only auth provider (e.g.
`BasicAuthProvider`).

## Background

PR #54846 introduced `_auto_sso_response()` to silently bounce
unauthenticated users through the portal OAuth flow when exactly one
interactive provider is registered. The assumption was that a single
provider would always be an OAuth provider — but `BasicAuthProvider`
sets `supports_password = True` and has no OAuth redirect flow. Its
`start_login()` raises `NotImplementedError`:

```
File "hermes_cli/dashboard_auth/routes.py", line 197, in auth_login
    ls = p.start_login(redirect_uri=_redirect_uri(request))
File "plugins/dashboard_auth/basic/__init__.py", line 230, in start_login
    raise NotImplementedError(
NotImplementedError: BasicAuthProvider is password-only; there is no
OAuth redirect flow. The login page POSTs to /auth/password-login instead.
```

This only triggers when **all** of the following hold:

1. Dashboard binds to a non-loopback address (`--host 0.0.0.0`)
2. Auth gate is active (`auth_required = True`)
3. Only `BasicAuthProvider` is registered (no OAuth provider)
4. User has no existing session cookie

## Fix

In `_auto_sso_response()`, check `supports_password` before attempting
the OAuth redirect. When the sole provider is password-only, return
`None` so the caller falls through to the normal `/login` interstitial
which renders the username/password form.

## Testing

Verified locally:

- `--host 0.0.0.0` with `BasicAuthProvider` only → login page renders
  correctly (was: 500 `NotImplementedError`)
- `--host 127.0.0.1` → auth gate inactive, unaffected
- Multiple providers → already returns `None` at the `len != 1` check,
  unaffected