### PR TITLE
fix(auxiliary): preserve max_tokens for NVIDIA NIM aux calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5489,10 +5489,24 @@ def _build_call_kwargs(
         # ``/anthropic`` endpoint reached through the OpenAI SDK wrapper), where
         # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
         # there.
+        #
+        # NVIDIA NIM (integrate.api.nvidia.com and local NIM endpoints) is a
+        # second exception: some models—notably minimaxai/minimax-m3—return HTTP
+        # 200 with an empty choices[] payload when max_tokens is omitted. The main
+        # NVIDIA chat path already sends an output cap via the provider profile;
+        # preserve it on the auxiliary path too.
         _effective_base = base_url or (
             _current_custom_base_url() if provider == "custom" else ""
         )
-        if _is_anthropic_compat_endpoint(provider, _effective_base):
+        _provider_norm = str(provider or "").strip().lower()
+        _is_nvidia_nim = (
+            _provider_norm in {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
+            or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
+        )
+        if (
+            _is_anthropic_compat_endpoint(provider, _effective_base)
+            or _is_nvidia_nim
+        ):
             kwargs["max_tokens"] = max_tokens
 
     if tools:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -163,6 +163,18 @@ class TestBuildCallKwargsMaxTokens:
         assert kwargs["max_tokens"] == 1234
         assert "max_completion_tokens" not in kwargs
 
+    def test_keeps_max_tokens_for_nvidia_nim(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="nvidia",
+            model="minimaxai/minimax-m3",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=4096,
+            base_url="https://integrate.api.nvidia.com/v1",
+        )
+        assert kwargs["max_tokens"] == 4096
+
 
 class TestNousTagsScoping:
     def test_tags_injected_when_provider_is_nous(self, monkeypatch):


### PR DESCRIPTION
## Summary
NVIDIA NIM auxiliary tasks (title generation, approval, MCP, compression, etc.) now keep the `max_tokens` output cap instead of dropping it, so models like `minimaxai/minimax-m3` on `integrate.api.nvidia.com` stop returning HTTP 200 with an empty `choices=[]` payload.

Root cause: `_build_call_kwargs()` deliberately omits `max_tokens` for most providers (to sidestep wire-format quirks), with the Anthropic Messages wire as the only exception. NVIDIA NIM is a second case where the cap is mandatory — the main chat path already sends it via the provider profile (`default_max_tokens=16384`), but the auxiliary path didn't.

## Changes
- `agent/auxiliary_client.py`: add NVIDIA NIM as a second `max_tokens` exception in `_build_call_kwargs()`, detected by provider name (`nvidia`/`nvidia-nim`/`nim`/`build-nvidia`/`nemotron`) **or** `base_url_host_matches(..., "integrate.api.nvidia.com")`.
- `tests/agent/test_auxiliary_client.py`: cover NVIDIA NIM `max_tokens` preservation.

## Validation
| Scenario | Before | After |
|---|---|---|
| NVIDIA aux (provider=nvidia) | drops max_tokens → empty `choices=[]` | preserves max_tokens |
| NVIDIA aux (host-match fallback) | drops max_tokens | preserves max_tokens |
| Non-NVIDIA OpenAI-compat (OpenRouter) | drops max_tokens | drops max_tokens (unchanged) |

- `pytest tests/agent/test_auxiliary_client.py` → 253 passed
- ruff clean; ty introduces no new diagnostics vs `main`
- E2E: confirmed behavior delta on both the provider-name path and the base_url host-match fallback

## Credit
Salvage of #54791 by @HexLab98 — original commits cherry-picked with authorship preserved. Discord report from Garry Mangat.

Closes #54791
