### PR TITLE
fix(bedrock): plumb discovery.provider_filter into model discovery

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -384,19 +384,46 @@ def resolve_bedrock_region(env: Optional[Dict[str, str]] = None) -> str:
     return "us-east-1"
 
 
-def bedrock_model_ids_or_none() -> Optional[List[str]]:
+def configured_bedrock_provider_filter() -> Optional[List[str]]:
+    """Read ``bedrock.discovery.provider_filter`` from the user's config.
+
+    Returns the configured list of provider names (e.g. ``["anthropic"]``)
+    to restrict model discovery to, or ``None`` when unset/empty so callers
+    pass through to unfiltered discovery. Lazily imports the config loader to
+    avoid a circular import (``hermes_cli.config`` pulls in agent modules).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+        discovery = (cfg.get("bedrock") or {}).get("discovery") or {}
+        raw = discovery.get("provider_filter") or []
+        filt = [str(p).strip() for p in raw if str(p).strip()]
+        return filt or None
+    except Exception:
+        return None
+
+
+def bedrock_model_ids_or_none(no_cache: bool = False) -> Optional[List[str]]:
     """Live-discover Bedrock model IDs for the active region.
 
     Returns a list of model ID strings if discovery succeeds and yields
     at least one model, or ``None`` on failure / empty result.  Callers
     should fall back to the static curated list when ``None`` is returned.
 
+    Pass ``no_cache=True`` to bypass the in-memory discovery cache so the
+    result reflects a live API call with the current ``provider_filter``.
+
     This helper consolidates the discover → extract-ids → fallback
     pattern that was previously duplicated across ``provider_model_ids``,
     ``list_authenticated_providers`` section 2, and section 3.
     """
     try:
-        discovered = discover_bedrock_models(resolve_bedrock_region())
+        discovered = discover_bedrock_models(
+            resolve_bedrock_region(),
+            provider_filter=configured_bedrock_provider_filter(),
+            no_cache=no_cache,
+        )
         if discovered:
             return [m["id"] for m in discovered]
     except Exception:
@@ -1095,6 +1122,7 @@ def reset_discovery_cache():
 def discover_bedrock_models(
     region: str,
     provider_filter: Optional[List[str]] = None,
+    no_cache: bool = False,
 ) -> List[Dict[str, Any]]:
     """Discover available Bedrock foundation models and inference profiles.
 
@@ -1107,6 +1135,10 @@ def discover_bedrock_models(
       - ``streaming``: Whether streaming is supported
 
     Caches results for 1 hour per region to avoid repeated API calls.
+    Pass ``no_cache=True`` to bypass the in-memory cache entirely (skip both
+    the read and the write) — useful for diagnostics where you need to prove
+    a result comes from a live API call with the current ``provider_filter``
+    rather than a stale cached entry.
 
     Mirrors OpenClaw's ``discoverBedrockModels()`` in
     ``extensions/amazon-bedrock/discovery.ts``.
@@ -1114,9 +1146,10 @@ def discover_bedrock_models(
     import time
 
     cache_key = f"{region}:{','.join(sorted(provider_filter or []))}"
-    cached = _discovery_cache.get(cache_key)
-    if cached and (time.time() - cached["timestamp"]) < _DISCOVERY_CACHE_TTL_SECONDS:
-        return cached["models"]
+    if not no_cache:
+        cached = _discovery_cache.get(cache_key)
+        if cached and (time.time() - cached["timestamp"]) < _DISCOVERY_CACHE_TTL_SECONDS:
+            return cached["models"]
 
     try:
         client = _get_bedrock_control_client(region)
@@ -1217,10 +1250,11 @@ def discover_bedrock_models(
         m["name"].lower(),
     ))
 
-    _discovery_cache[cache_key] = {
-        "timestamp": time.time(),
-        "models": models,
-    }
+    if not no_cache:
+        _discovery_cache[cache_key] = {
+            "timestamp": time.time(),
+            "models": models,
+        }
     return models
 
 

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -398,6 +398,10 @@ def configured_bedrock_provider_filter() -> Optional[List[str]]:
         cfg = load_config_readonly()
         discovery = (cfg.get("bedrock") or {}).get("discovery") or {}
         raw = discovery.get("provider_filter") or []
+        # Tolerate a bare string (e.g. ``provider_filter: anthropic``) — wrap
+        # it in a list so we don't iterate its characters into a broken filter.
+        if isinstance(raw, str):
+            raw = [raw]
         filt = [str(p).strip() for p in raw if str(p).strip()]
         return filt or None
     except Exception:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2150,6 +2150,7 @@ def _model_flow_bedrock(config, current_model=""):
             resolve_aws_auth_env_var,
             resolve_bedrock_region,
             discover_bedrock_models,
+            configured_bedrock_provider_filter,
         )
     except ImportError:
         print("  ✗ boto3 is not installed. Install it with:")
@@ -2199,7 +2200,9 @@ def _model_flow_bedrock(config, current_model=""):
 
     # 3. Model discovery — try live API first, fall back to static list
     print(f"  Discovering models in {region}...")
-    live_models = discover_bedrock_models(region)
+    live_models = discover_bedrock_models(
+        region, provider_filter=configured_bedrock_provider_filter()
+    )
 
     if live_models:
         _EXCLUDE_PREFIXES = (

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2415,7 +2415,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     if normalized == "bedrock":
         try:
             from agent.bedrock_adapter import bedrock_model_ids_or_none
-            ids = bedrock_model_ids_or_none()
+            ids = bedrock_model_ids_or_none(no_cache=force_refresh)
             if ids is not None:
                 return ids
         except Exception:
@@ -4110,9 +4110,15 @@ def validate_requested_model(
     # AWS SDK control plane (ListFoundationModels + ListInferenceProfiles).
     if normalized == "bedrock":
         try:
-            from agent.bedrock_adapter import discover_bedrock_models, resolve_bedrock_region
+            from agent.bedrock_adapter import (
+                discover_bedrock_models,
+                resolve_bedrock_region,
+                configured_bedrock_provider_filter,
+            )
             region = resolve_bedrock_region()
-            discovered = discover_bedrock_models(region)
+            discovered = discover_bedrock_models(
+                region, provider_filter=configured_bedrock_provider_filter()
+            )
             discovered_ids = {m["id"] for m in discovered}
             if requested in discovered_ids:
                 return {

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1712,3 +1712,163 @@ class TestRequireBoto3VersionCheck:
         with patch.dict("sys.modules", {"boto3": fake_boto3}):
             result = _require_boto3()
             assert result is fake_boto3
+
+
+# ---------------------------------------------------------------------------
+# provider_filter config plumbing + discovery cache bypass
+# ---------------------------------------------------------------------------
+
+class TestConfiguredBedrockProviderFilter:
+    """``bedrock.discovery.provider_filter`` is read and normalized correctly."""
+
+    def _patch_config(self, value):
+        """Patch hermes_cli.config.load_config_readonly to return a config
+        whose bedrock.discovery.provider_filter is ``value``."""
+        import hermes_cli.config as cfg_mod
+        return patch.object(
+            cfg_mod,
+            "load_config_readonly",
+            return_value={"bedrock": {"discovery": {"provider_filter": value}}},
+        )
+
+    def test_returns_list_when_configured(self):
+        from agent.bedrock_adapter import configured_bedrock_provider_filter
+        with self._patch_config(["anthropic", "meta"]):
+            assert configured_bedrock_provider_filter() == ["anthropic", "meta"]
+
+    def test_coerces_bare_string_to_single_element_list(self):
+        """A scalar ``provider_filter: anthropic`` must not be iterated into
+        characters (['a','n','t',...]) — it should become ['anthropic']."""
+        from agent.bedrock_adapter import configured_bedrock_provider_filter
+        with self._patch_config("anthropic"):
+            assert configured_bedrock_provider_filter() == ["anthropic"]
+
+    def test_strips_whitespace_and_drops_empties(self):
+        from agent.bedrock_adapter import configured_bedrock_provider_filter
+        with self._patch_config(["  anthropic  ", "", "   "]):
+            assert configured_bedrock_provider_filter() == ["anthropic"]
+
+    def test_returns_none_when_unset(self):
+        from agent.bedrock_adapter import configured_bedrock_provider_filter
+        with self._patch_config([]):
+            assert configured_bedrock_provider_filter() is None
+
+    def test_returns_none_on_config_error(self):
+        from agent.bedrock_adapter import configured_bedrock_provider_filter
+        import hermes_cli.config as cfg_mod
+        with patch.object(cfg_mod, "load_config_readonly", side_effect=Exception("boom")):
+            assert configured_bedrock_provider_filter() is None
+
+
+class TestDiscoverBedrockModelsFilterPlumbing:
+    """The configured filter must actually reach the foundation-model loop."""
+
+    def _fake_control_client(self):
+        client = MagicMock()
+        client.list_foundation_models.return_value = {
+            "modelSummaries": [
+                {
+                    "modelId": "anthropic.claude-opus-4",
+                    "modelName": "Claude Opus 4",
+                    "providerName": "Anthropic",
+                    "modelLifecycle": {"status": "ACTIVE"},
+                    "responseStreamingSupported": True,
+                    "outputModalities": ["TEXT"],
+                    "inputModalities": ["TEXT"],
+                },
+                {
+                    "modelId": "meta.llama4",
+                    "modelName": "Llama 4",
+                    "providerName": "Meta",
+                    "modelLifecycle": {"status": "ACTIVE"},
+                    "responseStreamingSupported": True,
+                    "outputModalities": ["TEXT"],
+                    "inputModalities": ["TEXT"],
+                },
+            ]
+        }
+        client.list_inference_profiles.return_value = {"inferenceProfileSummaries": []}
+        return client
+
+    def test_filter_excludes_non_matching_providers(self):
+        import agent.bedrock_adapter as ba
+        ba._discovery_cache.clear()
+        with patch.object(ba, "_get_bedrock_control_client", return_value=self._fake_control_client()):
+            models = ba.discover_bedrock_models(
+                "us-east-1", provider_filter=["anthropic"], no_cache=True
+            )
+        ids = {m["id"] for m in models}
+        assert "anthropic.claude-opus-4" in ids
+        assert "meta.llama4" not in ids
+
+    def test_no_filter_returns_all_providers(self):
+        import agent.bedrock_adapter as ba
+        ba._discovery_cache.clear()
+        with patch.object(ba, "_get_bedrock_control_client", return_value=self._fake_control_client()):
+            models = ba.discover_bedrock_models("us-east-1", provider_filter=None, no_cache=True)
+        ids = {m["id"] for m in models}
+        assert {"anthropic.claude-opus-4", "meta.llama4"} <= ids
+
+
+class TestDiscoverBedrockModelsNoCache:
+    """``no_cache=True`` bypasses both the cache read and the cache write."""
+
+    def _fake_control_client(self, model_id="anthropic.claude-opus-4"):
+        client = MagicMock()
+        client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": model_id,
+                "modelName": model_id,
+                "providerName": "Anthropic",
+                "modelLifecycle": {"status": "ACTIVE"},
+                "responseStreamingSupported": True,
+                "outputModalities": ["TEXT"],
+                "inputModalities": ["TEXT"],
+            }]
+        }
+        client.list_inference_profiles.return_value = {"inferenceProfileSummaries": []}
+        return client
+
+    def test_no_cache_ignores_a_primed_cache_entry(self):
+        """A stale cache entry must NOT be returned when no_cache=True."""
+        import agent.bedrock_adapter as ba
+        import time
+        ba._discovery_cache.clear()
+        # Prime the cache for the unfiltered key with a bogus stale value.
+        ba._discovery_cache["us-east-1:"] = {
+            "timestamp": time.time(),
+            "models": [{"id": "STALE.cached-model"}],
+        }
+        with patch.object(ba, "_get_bedrock_control_client",
+                          return_value=self._fake_control_client()):
+            models = ba.discover_bedrock_models("us-east-1", provider_filter=None, no_cache=True)
+        ids = {m["id"] for m in models}
+        assert "STALE.cached-model" not in ids
+        assert "anthropic.claude-opus-4" in ids
+
+    def test_no_cache_does_not_write_to_cache(self):
+        """no_cache=True must not populate _discovery_cache."""
+        import agent.bedrock_adapter as ba
+        ba._discovery_cache.clear()
+        with patch.object(ba, "_get_bedrock_control_client",
+                          return_value=self._fake_control_client()):
+            ba.discover_bedrock_models("us-east-1", provider_filter=None, no_cache=True)
+        assert ba._discovery_cache == {}, (
+            "no_cache=True must not write a cache entry"
+        )
+
+    def test_default_path_reads_and_writes_cache(self):
+        """Sanity: without no_cache, the cache is used (write then read)."""
+        import agent.bedrock_adapter as ba
+        ba._discovery_cache.clear()
+        fake = self._fake_control_client()
+        with patch.object(ba, "_get_bedrock_control_client", return_value=fake):
+            first = ba.discover_bedrock_models("us-east-1", provider_filter=None)
+            # Cache key for an empty/None filter is "<region>:".
+            assert "us-east-1:" in ba._discovery_cache
+            # Second call should hit the cache and not re-list models.
+            second = ba.discover_bedrock_models("us-east-1", provider_filter=None)
+        assert first == second
+        assert fake.list_foundation_models.call_count == 1, (
+            "cached call must not re-invoke the AWS API"
+        )

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1872,3 +1872,32 @@ class TestDiscoverBedrockModelsNoCache:
         assert fake.list_foundation_models.call_count == 1, (
             "cached call must not re-invoke the AWS API"
         )
+
+
+class TestBedrockModelIdsOrNonePlumbsFilter:
+    """Regression guard: the call site must pass the *configured* filter into
+    discovery, so bedrock.discovery.provider_filter cannot silently go dead."""
+
+    def test_configured_filter_reaches_discover_call(self):
+        import agent.bedrock_adapter as ba
+        sentinel = ["anthropic"]
+        with patch.object(ba, "configured_bedrock_provider_filter",
+                          return_value=sentinel) as cfg, \
+             patch.object(ba, "discover_bedrock_models",
+                          return_value=[{"id": "anthropic.claude-opus-4"}]) as disc, \
+             patch.object(ba, "resolve_bedrock_region", return_value="us-east-1"):
+            ids = ba.bedrock_model_ids_or_none()
+        assert ids == ["anthropic.claude-opus-4"]
+        cfg.assert_called_once()
+        # The configured filter sentinel must be forwarded verbatim.
+        _, kwargs = disc.call_args
+        assert kwargs.get("provider_filter") == sentinel
+
+    def test_no_cache_flag_is_forwarded(self):
+        import agent.bedrock_adapter as ba
+        with patch.object(ba, "configured_bedrock_provider_filter", return_value=None), \
+             patch.object(ba, "discover_bedrock_models", return_value=[]) as disc, \
+             patch.object(ba, "resolve_bedrock_region", return_value="us-east-1"):
+            ba.bedrock_model_ids_or_none(no_cache=True)
+        _, kwargs = disc.call_args
+        assert kwargs.get("no_cache") is True


### PR DESCRIPTION
## Summary

`bedrock.discovery.provider_filter` was a **dead config key**. It is defined and
documented in `hermes_cli/config.py` ("Only show models from these providers"),
and `discover_bedrock_models()` already supported a `provider_filter` argument —
but **no call site ever read the config value and passed it through**. As a
result the filter silently did nothing: every Bedrock user saw all ~120-130
models across every provider regardless of the setting.

This PR plumbs the configured filter into all three discovery call sites and
adds a `no_cache` diagnostic option so the filter's effect can be verified
independently of the discovery cache.

## Changes

- **`agent/bedrock_adapter.py`**
  - New `configured_bedrock_provider_filter()` helper reads
    `bedrock.discovery.provider_filter` from config (lazy import of
    `load_config_readonly` to avoid a circular import; fails safe to `None`;
    normalizes/strips entries; empty → `None` = unfiltered).
  - `bedrock_model_ids_or_none()` now forwards the configured filter and gains
    a `no_cache` parameter.
  - `discover_bedrock_models()` gains `no_cache: bool = False` which bypasses
    the in-memory discovery cache on **both** read and write — for diagnostics
    that must prove a result came from a live API call with the current filter
    rather than a stale cached entry.
- **`hermes_cli/models.py`**
  - `provider_model_ids()` bedrock branch forwards `no_cache=force_refresh`, so
    `--refresh` busts the in-memory cache too (previously it only cleared the
    on-disk picker cache, leaving a long-running process serving stale in-memory
    results for up to the 1h TTL).
  - `validate_requested_model()` bedrock branch passes the configured filter.
- **`hermes_cli/model_setup_flows.py`**
  - Interactive `hermes model` / `hermes setup` Bedrock picker passes the
    configured filter.

## Why two cache layers matter (root cause notes)

There are two independent caches between config and the picker:
1. In-memory `_discovery_cache` in `bedrock_adapter.py` (1h TTL, dies on restart).
2. On-disk picker cache `_provider_models_cache` in `models.py` (persisted to
   `$HERMES_HOME`, keyed by credential fingerprint).

The on-disk layer is why a plain restart did not surface the fix — only
`hermes model --refresh` (which calls `clear_provider_models_cache()`) busted
it. The new `no_cache` path additionally guarantees the in-memory layer can be
bypassed for conclusive cause attribution.

## Test plan

Verified live against a real AWS account (profile with Bedrock access,
us-east-1):

- Unfiltered discovery: **130** models across 18 providers.
- `provider_filter=["anthropic"]`: **30** models, providers = {Anthropic,
  inference-profile}, **zero** non-Anthropic leakage.
- `no_cache=True` filtered call returns 30 live (cache keys unchanged — proves
  no read/write of cache); repeated `no_cache=True` calls re-hit the network
  each time; a normal cached call returns instantly and adds the
  `region:anthropic` key. Confirms the filter — not a cache artifact — produces
  the narrowed list.
- `py_compile` passes on all three files.
- Existing `tests/agent/test_bedrock_adapter.py::test_provider_filter` already
  covers the filter logic itself; this PR only changes whether the configured
  value reaches it.

## Notes

- The cache key already includes the filter string
  (`f"{region}:{','.join(sorted(provider_filter or []))}"`), so filtered and
  unfiltered results can never collide in cache — the bug was purely missing
  plumbing, not a cache-key collision.
