### PR TITLE
fix(camofox): clear stale tab_id on 404 so the next navigate can recover

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import requests
 
 from tools.browser_camofox import (
     camofox_back,
@@ -430,6 +431,171 @@ class TestCamofoxVisionConfig:
         assert result["analysis"] == "Default camofox screenshot analysis"
         assert mock_llm.call_args.kwargs["temperature"] == 0.1
         assert mock_llm.call_args.kwargs["timeout"] == 120.0
+
+
+# ---------------------------------------------------------------------------
+# Routing integration — verify browser_tool routes to camofox
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Stale tab 404 cleanup — sibling operations must clear tab_id on 404
+# so the next navigate can create a fresh tab (#54729 follow-up).
+# ---------------------------------------------------------------------------
+
+
+def _mock_404_response():
+    """Build a requests.Response that looks like a Camofox 404."""
+    resp = MagicMock()
+    resp.status_code = 404
+    resp.json.return_value = {}
+    resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+    return resp
+
+
+def _mock_500_response():
+    """Build a requests.Response that looks like a Camofox 500."""
+    resp = MagicMock()
+    resp.status_code = 500
+    resp.json.return_value = {}
+    resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+    return resp
+
+
+class TestStaleTabCleanup:
+    """When Camofox garbage-collects a tab, operations must clear the stale
+    tab_id and return an actionable error instead of leaving the session in a
+    permanently broken state where every subsequent call also 404s."""
+
+    def _setup_session(self, mock_post, monkeypatch, task_id):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(json_data={"tabId": "stale-tab", "url": "https://x.com"})
+        camofox_navigate("https://x.com", task_id=task_id)
+
+    @patch("tools.browser_camofox.requests.get")
+    @patch("tools.browser_camofox.requests.post")
+    def test_snapshot_clears_tab_on_404(self, mock_post, mock_get, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_snap")
+        mock_get.return_value = _mock_404_response()
+        result = json.loads(camofox_snapshot(task_id="stale_snap"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+        from tools.browser_camofox import _get_session
+        session = _get_session("stale_snap")
+        assert session["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_click_clears_tab_on_404(self, mock_post, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_click")
+        mock_post.return_value = _mock_404_response()
+        result = json.loads(camofox_click("e1", task_id="stale_click"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_click")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_type_clears_tab_on_404(self, mock_post, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_type")
+        mock_post.return_value = _mock_404_response()
+        result = json.loads(camofox_type("e1", "hello", task_id="stale_type"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_type")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_scroll_clears_tab_on_404(self, mock_post, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_scroll")
+        mock_post.return_value = _mock_404_response()
+        result = json.loads(camofox_scroll("down", task_id="stale_scroll"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_scroll")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_back_clears_tab_on_404(self, mock_post, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_back")
+        mock_post.return_value = _mock_404_response()
+        result = json.loads(camofox_back(task_id="stale_back"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_back")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_press_clears_tab_on_404(self, mock_post, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_press")
+        mock_post.return_value = _mock_404_response()
+        result = json.loads(camofox_press("Enter", task_id="stale_press"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_press")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.get")
+    @patch("tools.browser_camofox.requests.post")
+    def test_get_images_clears_tab_on_404(self, mock_post, mock_get, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_img")
+        mock_get.return_value = _mock_404_response()
+        result = json.loads(camofox_get_images(task_id="stale_img"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_img")["tab_id"] is None
+
+    @patch("tools.browser_camofox._get_raw")
+    @patch("tools.browser_camofox.requests.post")
+    def test_vision_clears_tab_on_404(self, mock_post, mock_get_raw, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_vis")
+        mock_get_raw.side_effect = requests.HTTPError(
+            response=MagicMock(status_code=404),
+        )
+        result = json.loads(camofox_vision("what?", task_id="stale_vis"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_vis")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_non_404_error_still_propagates(self, mock_post, monkeypatch):
+        """A 500 must NOT clear tab_id — only 404 (stale tab) triggers cleanup."""
+        self._setup_session(mock_post, monkeypatch, "stale_500")
+        mock_post.return_value = _mock_500_response()
+        result = json.loads(camofox_click("e1", task_id="stale_500"))
+        assert result["success"] is False
+
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_500")["tab_id"] == "stale-tab"
+
+    @patch("tools.browser_camofox.requests.get")
+    @patch("tools.browser_camofox.requests.post")
+    def test_navigate_recovers_after_stale_tab_cleared_by_click(self, mock_post, mock_get, monkeypatch):
+        """After click clears a stale tab, navigate should create a fresh one."""
+        self._setup_session(mock_post, monkeypatch, "stale_recover")
+
+        # click hits 404 → clears tab_id
+        mock_post.return_value = _mock_404_response()
+        camofox_click("e1", task_id="stale_recover")
+
+        # navigate now sees tab_id=None and creates a new tab
+        mock_post.return_value = _mock_response(json_data={"tabId": "fresh-tab", "url": "https://y.com"})
+        mock_get.return_value = _mock_response(json_data={"snapshot": "", "refsCount": 0})
+        result = json.loads(camofox_navigate("https://y.com", task_id="stale_recover"))
+        assert result["success"] is True
+        assert result["url"] == "https://y.com"
+
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_recover")["tab_id"] == "fresh-tab"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -461,6 +461,24 @@ def _delete(path: str, body: dict = None, timeout: Optional[int] = None) -> dict
     return resp.json()
 
 
+_STALE_TAB_ERROR = (
+    "Browser tab was garbage-collected by the Camofox server. "
+    "Call browser_navigate to open a new tab."
+)
+
+
+def _clear_stale_tab(session: Dict[str, Any], exc: requests.HTTPError) -> bool:
+    """If *exc* is a 404, clear the stale tab_id so the next navigate recovers."""
+    if exc.response is not None and exc.response.status_code == 404:
+        logger.warning(
+            "Camofox tab %s returned 404 — tab was garbage collected.",
+            session.get("tab_id"),
+        )
+        session["tab_id"] = None
+        return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Tool implementations
 # ---------------------------------------------------------------------------
@@ -554,10 +572,15 @@ def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
-        data = _get(
-            f"/tabs/{session['tab_id']}/snapshot",
-            params={"userId": session["user_id"]},
-        )
+        try:
+            data = _get(
+                f"/tabs/{session['tab_id']}/snapshot",
+                params={"userId": session["user_id"]},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
 
         snapshot = data.get("snapshot", "")
         refs_count = data.get("refsCount", 0)
@@ -594,10 +617,15 @@ def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
         # Strip @ prefix if present (our tool convention)
         clean_ref = ref.lstrip("@")
 
-        data = _post(
-            f"/tabs/{session['tab_id']}/click",
-            {"userId": session["user_id"], "ref": clean_ref},
-        )
+        try:
+            data = _post(
+                f"/tabs/{session['tab_id']}/click",
+                {"userId": session["user_id"], "ref": clean_ref},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         return json.dumps({
             "success": True,
             "clicked": clean_ref,
@@ -616,10 +644,15 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
 
         clean_ref = ref.lstrip("@")
 
-        _post(
-            f"/tabs/{session['tab_id']}/type",
-            {"userId": session["user_id"], "ref": clean_ref, "text": text},
-        )
+        try:
+            _post(
+                f"/tabs/{session['tab_id']}/type",
+                {"userId": session["user_id"], "ref": clean_ref, "text": text},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         from agent.display import (
             redact_browser_typed_text_for_display,
             redact_tool_args_for_display,
@@ -651,10 +684,15 @@ def camofox_scroll(direction: str, task_id: Optional[str] = None) -> str:
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
-        _post(
-            f"/tabs/{session['tab_id']}/scroll",
-            {"userId": session["user_id"], "direction": direction},
-        )
+        try:
+            _post(
+                f"/tabs/{session['tab_id']}/scroll",
+                {"userId": session["user_id"], "direction": direction},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         return json.dumps({"success": True, "scrolled": direction})
     except Exception as e:
         return tool_error(str(e), success=False)
@@ -667,10 +705,15 @@ def camofox_back(task_id: Optional[str] = None) -> str:
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
-        data = _post(
-            f"/tabs/{session['tab_id']}/back",
-            {"userId": session["user_id"]},
-        )
+        try:
+            data = _post(
+                f"/tabs/{session['tab_id']}/back",
+                {"userId": session["user_id"]},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         return json.dumps({"success": True, "url": data.get("url", "")})
     except Exception as e:
         return tool_error(str(e), success=False)
@@ -683,10 +726,15 @@ def camofox_press(key: str, task_id: Optional[str] = None) -> str:
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
-        _post(
-            f"/tabs/{session['tab_id']}/press",
-            {"userId": session["user_id"], "key": key},
-        )
+        try:
+            _post(
+                f"/tabs/{session['tab_id']}/press",
+                {"userId": session["user_id"], "key": key},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         return json.dumps({"success": True, "pressed": key})
     except Exception as e:
         return tool_error(str(e), success=False)
@@ -720,10 +768,15 @@ def camofox_get_images(task_id: Optional[str] = None) -> str:
 
         import re
 
-        data = _get(
-            f"/tabs/{session['tab_id']}/snapshot",
-            params={"userId": session["user_id"]},
-        )
+        try:
+            data = _get(
+                f"/tabs/{session['tab_id']}/snapshot",
+                params={"userId": session["user_id"]},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         snapshot = data.get("snapshot", "")
 
         # Parse img elements from the accessibility tree.
@@ -763,10 +816,15 @@ def camofox_vision(question: str, annotate: bool = False,
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
         # Get screenshot as binary PNG
-        resp = _get_raw(
-            f"/tabs/{session['tab_id']}/screenshot",
-            params={"userId": session["user_id"]},
-        )
+        try:
+            resp = _get_raw(
+                f"/tabs/{session['tab_id']}/screenshot",
+                params={"userId": session["user_id"]},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
 
         # Save screenshot to cache
         from hermes_constants import get_hermes_home


### PR DESCRIPTION
## Summary

- When the Camofox server garbage-collects an idle tab, every operation except `navigate` returns a raw HTTP 404 **and leaves the stale `tab_id` in the session dict**. This traps the session in an unrecoverable 404 loop — click, type, scroll, snapshot all keep failing until the user manually closes and re-navigates.
- `navigate` already handles this (#54729): it catches the 404, clears `tab_id`, and creates a fresh tab. The sibling operations (`snapshot`, `click`, `type`, `scroll`, `back`, `press`, `get_images`, `vision`) were missed.
- Unlike `navigate`, these operations cannot auto-recover (they have no target URL), so the fix clears the stale `tab_id` and returns an actionable error: *"Call browser_navigate to open a new tab."* This unblocks the session: the next `navigate` sees `tab_id=None` and creates a fresh tab normally.

## Changes

- **`_clear_stale_tab()`** helper — catches 404, clears `session["tab_id"]`, logs a warning. Reused by all eight affected functions.
- **`_STALE_TAB_ERROR`** — shared actionable error message.
- **8 tool functions** wrapped with the 404 guard: `camofox_snapshot`, `camofox_click`, `camofox_type`, `camofox_scroll`, `camofox_back`, `camofox_press`, `camofox_get_images`, `camofox_vision`.
- Non-404 errors (e.g. 500) re-raise and do **not** clear `tab_id`.

## Test plan

- [x] 8 tests: each affected operation returns actionable error + clears `tab_id` on 404
- [x] 1 test: 500 error does NOT clear `tab_id` (only 404 triggers cleanup)
- [x] 1 test: full recovery flow — click 404 clears state → navigate creates fresh tab
- [x] All 88 existing Camofox tests pass (0 regressions)