### PR TITLE
fix(ci): gate arm64 docker build-cache write to push/release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -159,8 +159,10 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Log in to ghcr.io so the registry-backed build cache below can be
-      # read (cache-from) on every event and written (cache-to) on
-      # push/release.  Uses the workflow's GITHUB_TOKEN, which is valid for
+      # read (cache-from) on every event.  The cache is only WRITTEN
+      # (cache-to) on push-to-main / release — PR runs (and forks) lack
+      # ghcr.io org-package write, so the write is gated on the build step
+      # below.  Uses the workflow's GITHUB_TOKEN, which is valid for
       # the whole job — unlike the gha cache backend's short-lived Azure SAS
       # token, which expired mid-build on slow cold-cache arm64 runs and
       # crashed the build before the tests ran (the reason the gha cache
@@ -191,7 +193,12 @@ jobs:
           build-args: |
             HERMES_GIT_SHA=${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64
-          cache-to: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64,mode=max
+          # Only WRITE the registry cache on push-to-main / release.  PR runs
+          # (especially fork PRs) get a GITHUB_TOKEN capped at packages:read,
+          # so a cache-to export 403s with "installation not allowed to Write
+          # organization package" and fails the whole build.  An empty cache-to
+          # makes buildkit skip the export; PRs still build warm via cache-from.
+          cache-to: ${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release') && 'type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64,mode=max' || '' }}
 
       - name: Install uv for docker tests
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0


### PR DESCRIPTION
## Summary
Fork/PR runs no longer fail on `build-arm64` — the arm64 docker build step now only **writes** its registry build cache on push-to-main / release, not on PRs.

Root cause: the build step exported its build cache unconditionally (`cache-to: type=registry` → `ghcr.io/nousresearch/hermes-agent:buildcache-arm64`). On `pull_request` events the `GITHUB_TOKEN` is capped at `packages: read` (forks especially), so the export 403s with `error writing layer blob: denied: installation not allowed to Write organization package` and fails the whole job.

## Why it's recent (regression archaeology)
The org-package write has existed since #37129 (Jun 2) but was **masked** while Docker didn't run on PRs. The Jun 26 refactor `docker-publish.yml -> docker.yml` rewired the workflow into the `ci.yml` orchestrator (which runs on `pull_request`) via `workflow_call`, **unmasking** it. Every fork PR's `build-arm64` has gone red since.

| Date | Commit | Effect |
|---|---|---|
| Jun 2 | #37129 | arm64 `cache-to: type=registry` introduced (latent — forks can't write) |
| Jun 23 | "build Docker on main + release only, never on PRs" | defect masked |
| Jun 26 | `docker-publish.yml -> docker.yml` | rewired into ci.yml (runs on PRs) → unmasked |

## Changes
- `.github/workflows/docker.yml`: gate the `build-arm64` build step's `cache-to` to push-to-main / release only (matching the already-gated *Push arm64 by digest* step). Empty `cache-to` makes buildkit skip the export; PRs still build warm via `cache-from`.
- Fix the misleading comment that claimed the write was already gated.

amd64 is unaffected — it uses `type=gha` (per-repo Actions cache, fork-writable).

## Validation
| Event | cache-to | Org-package write? |
|---|---|---|
| pull_request (fork) | `''` (skip export) | no — fixed |
| push → main | registry, mode=max | yes (warms cache) |
| push → non-main branch | `''` | no |
| release | registry, mode=max | yes |

- YAML parses cleanly; arm64 build step keeps `cache-from` on all events.
- GHA expression precedence simulated across all four event/ref combinations (above).
