### PR TITLE
fix(agent): collapse degenerate token-repetition spam before persist

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -33,6 +33,7 @@ from agent.model_metadata import is_local_endpoint
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
+    collapse_degenerate_repetition,
 )
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
@@ -906,6 +907,27 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # compression, title generation.
     if isinstance(_san_content, str) and _san_content:
         _san_content = agent._strip_think_blocks(_san_content).strip()
+
+    # Collapse degenerate token-repetition spam ("call call call …") before the
+    # content is persisted. Some models (Claude Opus 4.x especially) pad the
+    # assistant content with one short word repeated dozens of times when they
+    # intend to issue a tool call but the structured call doesn't materialize.
+    # Left in place, the run enters durable history and becomes a bad few-shot
+    # that makes later turns imitate the degeneration (same failure mode as the
+    # leaked-tool-call loop, #50279). The collapse is conservative — only a long
+    # run of the SAME short token separated by whitespace is touched — so real
+    # prose is never altered (no-op fast path when clean).
+    if isinstance(_san_content, str) and _san_content:
+        _san_content, _degen_runs = collapse_degenerate_repetition(_san_content)
+        if _degen_runs:
+            logger.warning(
+                "Collapsed %d degenerate token-repetition run(s) from assistant "
+                "content before persist (model=%s provider=%s finish_reason=%s)",
+                _degen_runs,
+                getattr(agent, "model", "unknown"),
+                getattr(agent, "provider", "unknown"),
+                finish_reason,
+            )
 
     # Defence-in-depth: redact credentials (PATs, API keys, Bearer tokens)
     # from assistant content BEFORE the message enters conversation history.

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -461,6 +461,96 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
     return found
 
 
+# ---------------------------------------------------------------------------
+# Degenerate token-repetition collapse
+# ---------------------------------------------------------------------------
+#
+# Some models — Claude Opus 4.x most notably — fall into a *neural text
+# degeneration* loop when they want to issue a tool call but the structured
+# tool-call tokens don't materialize: instead of emitting the call, the model
+# pads the assistant CONTENT with the same short word over and over
+# ("call call call …", "court court …", "la la la …") until it hits the token
+# cap or spontaneously recovers. The same turn often still carries a real
+# tool call alongside the spam, so the garbage gets persisted into history —
+# where, per the leaked-tool-call lesson (#50279), it becomes a bad few-shot
+# that makes *later* turns imitate the very same degeneration.
+#
+# This collapses such a run at the storage boundary (build_assistant_message),
+# mirroring the surrogate / think-strip / secret-redact sanitizers that already
+# run there. It is deliberately conservative: it only fires on a long run of
+# the SAME short alphanumeric token separated solely by whitespace, so ordinary
+# prose, repeated list bullets, code, or legitimately repeated short phrases are
+# never touched. Detection (``text_has_degenerate_repetition``) is exposed
+# separately so the conversation loop can also *count* occurrences and re-prompt
+# for a real tool call rather than silently swallowing the turn.
+
+# A "token" here is a short run of word characters (letters/digits/_), the shape
+# that degeneration produces. We cap length so this never matches a repeated
+# real sentence — genuine loops are single short words.
+_DEGENERATE_TOKEN = r"[A-Za-z0-9_]{1,20}"
+
+# Run of the same token repeated, separated only by whitespace. The backref
+# \1 forces every repeat to be IDENTICAL to the first. Default threshold of 8
+# total occurrences (the first token + 7 backref repeats) is well clear of any
+# natural writing while catching the 50-100x runs degeneration produces.
+_DEGENERATE_RUN_MIN = 8
+
+
+def _degenerate_run_regex(min_repeats: int) -> "re.Pattern[str]":
+    # (token)( ws (same token) ){min_repeats-1,}
+    backrefs = min_repeats - 1
+    pattern = (
+        r"\b(" + _DEGENERATE_TOKEN + r")"
+        r"(?:\s+\1\b){" + str(backrefs) + r",}"
+    )
+    return re.compile(pattern)
+
+
+def text_has_degenerate_repetition(text: str, min_repeats: int = _DEGENERATE_RUN_MIN) -> bool:
+    """Return True when ``text`` contains a degenerate same-token run.
+
+    Conservative detector: fires only on a run of one short alphanumeric token
+    repeated ``min_repeats`` or more times separated solely by whitespace
+    (e.g. ``"call call call …"``). Ordinary prose — even prose that repeats a
+    short word a handful of times — does not trip it. Used both to scrub the
+    run from persisted content and to let the loop re-prompt for the real
+    tool call the model was trying to make.
+    """
+    if not isinstance(text, str) or not text:
+        return False
+    return _degenerate_run_regex(max(2, min_repeats)).search(text) is not None
+
+
+def collapse_degenerate_repetition(
+    text: str, min_repeats: int = _DEGENERATE_RUN_MIN
+) -> tuple[str, int]:
+    """Collapse degenerate same-token runs to a single occurrence.
+
+    Returns ``(cleaned_text, runs_collapsed)``. Each qualifying run
+    (``"call call call …"``) is replaced by one instance of the token, so a
+    sentence that legitimately precedes or follows the spam is preserved while
+    the padding is removed. ``runs_collapsed`` is 0 (and the input returned
+    unchanged) when nothing degenerate is present — a fast common-case no-op.
+    """
+    if not isinstance(text, str) or not text:
+        return text, 0
+    regex = _degenerate_run_regex(max(2, min_repeats))
+    collapsed = 0
+
+    def _repl(match: "re.Match[str]") -> str:
+        nonlocal collapsed
+        collapsed += 1
+        return match.group(1)
+
+    cleaned = regex.sub(_repl, text)
+    if collapsed:
+        # A run that filled the whole turn can leave doubled blank lines or
+        # trailing whitespace behind; tidy without disturbing real prose.
+        cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+        cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+    return cleaned, collapsed
+
+
 __all__ = [
     "_SURROGATE_RE",
     "close_interrupted_tool_sequence",
@@ -474,4 +564,6 @@ __all__ = [
     "_sanitize_tools_non_ascii",
     "_strip_images_from_messages",
     "_sanitize_structure_non_ascii",
+    "text_has_degenerate_repetition",
+    "collapse_degenerate_repetition",
 ]

--- a/tests/agent/test_degenerate_repetition.py
+++ b/tests/agent/test_degenerate_repetition.py
@@ -1,0 +1,134 @@
+"""Tests for degenerate token-repetition detection + collapse.
+
+Covers ``agent.message_sanitization.text_has_degenerate_repetition`` and
+``collapse_degenerate_repetition`` — the storage-boundary scrubber that removes
+"call call call …" style neural-text-degeneration spam from assistant content
+before it is persisted (Claude Opus 4.x failure mode; see the leaked-tool-call
+lesson #50279 for why persisting the run is harmful — it becomes a bad few-shot
+that makes later turns imitate the degeneration).
+
+Design intent under test:
+- Conservative TRUE only on a long run of ONE short alphanumeric token
+  separated solely by whitespace.
+- Real prose, repeated list bullets, code, and short legitimate repeats below
+  the threshold must stay FALSE / unchanged.
+- Collapse preserves prose that precedes/follows the run and reduces the run to
+  a single occurrence of the token.
+"""
+
+import pytest
+
+from agent.message_sanitization import (
+    text_has_degenerate_repetition,
+    collapse_degenerate_repetition,
+)
+
+
+# --------------------------------------------------------------------------- #
+# True positives — degenerate runs that MUST be detected and collapsed
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "call " * 8,                              # exact default threshold
+        "call " * 100,                            # the real session magnitude
+        "ok " + "call " * 60,                     # short legit prefix + spam
+        "court " * 50,                            # observed 'court' variant
+        "la " * 80,                               # observed 'la' variant
+        "\n\n".join(["call"] * 40),               # newline-separated (real shape)
+        "word " * 8 + "and then a real sentence",  # spam then prose
+    ],
+)
+def test_detects_degenerate_runs(text):
+    assert text_has_degenerate_repetition(text) is True
+
+
+def test_real_session_shape_is_collapsed():
+    """Reconstruction of session 0bb74aa5f045 msg 68307: preamble + 100x 'call'
+    + a recovery sentence. After collapse the spam run is gone but both the
+    preamble and the trailing sentence survive."""
+    real = (
+        "完全可以——cron 唤醒和我刚才的重启唤醒是同一个机制。\n\n"
+        "courier 验证cron能不能稳定唤醒。\n\n"
+        "courier\n\n" + ("call\n\n" * 100)
+        + "I keep emitting empty filler. Let me make the actual tool call."
+    )
+    assert text_has_degenerate_repetition(real) is True
+    cleaned, runs = collapse_degenerate_repetition(real)
+    assert runs == 1
+    # The preamble and the recovery sentence are preserved verbatim.
+    assert "完全可以" in cleaned
+    assert "Let me make the actual tool call." in cleaned
+    # The 100x run is gone — only the single 'call' inside "tool call" plus the
+    # one collapsed token remain (i.e. far fewer than the original 100).
+    assert cleaned.count("call") <= 3
+    assert len(cleaned) < len(real) / 2
+
+
+def test_collapse_reduces_run_to_single_token():
+    cleaned, runs = collapse_degenerate_repetition("alpha " + "call " * 30)
+    assert runs == 1
+    assert cleaned == "alpha call"
+
+
+def test_multiple_distinct_runs_each_collapse():
+    text = "intro " + "call " * 12 + "middle prose here " + "court " * 12 + "end"
+    cleaned, runs = collapse_degenerate_repetition(text)
+    assert runs == 2
+    assert "intro" in cleaned and "middle prose here" in cleaned and "end" in cleaned
+    assert cleaned.count("call") == 1
+    assert cleaned.count("court") == 1
+
+
+# --------------------------------------------------------------------------- #
+# False positives — ordinary content that MUST stay untouched
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "I will call the function and then call it again to verify the result.",
+        "- item\n- item\n- item\n- item\n- item",          # repeated list bullets
+        "no no no no, that's wrong",                         # short legit repeat
+        "this is very very very very very very very good",   # 7 'very' < threshold
+        "call " * 7,                                          # one below threshold
+        "The word 'buffalo' repeated means buffalo buffalo buffalo here only thrice.",
+        "```\nx = 1\nx = 1\nx = 1\nx = 1\nx = 1\nx = 1\nx = 1\nx = 1\n```",
+        "",
+        "   ",
+    ],
+)
+def test_does_not_flag_ordinary_content(text):
+    assert text_has_degenerate_repetition(text) is False
+    cleaned, runs = collapse_degenerate_repetition(text)
+    assert runs == 0
+    assert cleaned == text  # exact no-op, content byte-for-byte preserved
+
+
+def test_non_string_inputs_are_safe():
+    assert text_has_degenerate_repetition(None) is False  # type: ignore[arg-type]
+    assert text_has_degenerate_repetition(123) is False   # type: ignore[arg-type]
+    cleaned, runs = collapse_degenerate_repetition(None)   # type: ignore[arg-type]
+    assert cleaned is None and runs == 0
+
+
+def test_threshold_boundary_is_exact():
+    """7 repeats stays clean, 8 (the default minimum) fires."""
+    assert text_has_degenerate_repetition("x " * 7) is False
+    assert text_has_degenerate_repetition("x " * 8) is True
+
+
+def test_custom_threshold_is_honored():
+    text = "call " * 5
+    assert text_has_degenerate_repetition(text, min_repeats=8) is False
+    assert text_has_degenerate_repetition(text, min_repeats=5) is True
+
+
+def test_different_tokens_interleaved_do_not_collapse():
+    """A B A B … is not a single-token run — the backref requires identity."""
+    text = "alpha beta " * 20
+    assert text_has_degenerate_repetition(text) is False
+    cleaned, runs = collapse_degenerate_repetition(text)
+    assert runs == 0
+    assert cleaned == text


### PR DESCRIPTION
## Problem

Some models — Claude Opus 4.x most notably — fall into a *neural-text degeneration* loop when they intend to issue a tool call but the structured tool-call tokens don't materialize. Instead of emitting the call, the model pads the assistant **content** with one short word repeated dozens of times until it hits the token cap or spontaneously recovers:

```
courier 验证cron能不能稳定唤醒。

courier

call

call

call
… (×100) …

I keep emitting empty filler. Let me make the actual tool call.
```

(Real transcript shape — preamble, then ~100× `call`, then a recovery sentence. Observed variants include `court court …` and `la la la …`.)

The same turn frequently still carries a **real** tool call alongside the spam, so the run gets persisted into history — where, exactly like the leaked-tool-call case (#50279), it becomes a bad few-shot that makes *later* turns imitate the degeneration. Related reports: #52968 (catastrophic feedback loop / "digital stutter"), #13208.

## Why a content sanitizer (and not just a loop guard)

This is deliberately scoped to **not** duplicate existing machinery:

- The `tool_guardrails` controller (#34778) detects repeated **structured** tool calls — it never inspects assistant *content*.
- The leaked-tool-call guard (#50279) catches a tool call emitted as an `<invoke>` block — but plain-word spam isn't an invoke block.

Neither sees plain-token content spam, which is what this degeneration actually produces. Cleaning it at the persistence boundary breaks the self-reinforcing few-shot loop for every downstream consumer (state.db, session JSON, gateway delivery, compression, title generation).

## Change

- **`agent/message_sanitization.py`** — `text_has_degenerate_repetition()` and `collapse_degenerate_repetition()`. A run is only matched when ONE short alphanumeric token (≤20 chars) repeats ≥8 times separated solely by whitespace (backref-enforced identity). Each run collapses to a single occurrence so prose before/after the spam is preserved; clean content is an exact byte-for-byte no-op (fast common-case path).
- **`agent/chat_completion_helpers.py`** — invoke the collapse in `build_assistant_message` right after the existing think-strip and before secret-redact, logging a warning with model/provider/finish_reason when a run is collapsed. This is the single storage boundary every persisted assistant message flows through, so it covers the case where spam rides alongside a real tool call.

## Conservative by construction

The detector fires only on a genuine single-token run. Verified non-firing on: ordinary prose that repeats a short word a few times, repeated list bullets, short legit repeats below threshold, interleaved `A B A B …`, and code blocks. The default threshold (8) sits well clear of natural writing while catching the 50–100× runs degeneration produces.

## Tests

`tests/agent/test_degenerate_repetition.py` — 23 cases covering the real 100× `call` session shape, `court`/`la` variants, multi-run collapse, the exact 8-vs-7 threshold boundary, custom thresholds, interleaved tokens (must not collapse), and false-positive guards (prose, bullets, short repeats, code, non-string inputs).

```
23 passed   (new file)
78 passed   (new + tests/cli/test_reasoning_command.py build_assistant_message regressions, on clean origin/main)
```

cc @nesquina — suggested labels `type/feature` / `comp/agent` (I can't set them as an external contributor). This complements the #34778 guardrail and the #50279 leak guard rather than overlapping them; happy to adjust the threshold default or make it config-driven under `tool_loop_guardrails` if you'd prefer.
