### PR TITLE
docs(readme): clarify bundled Git Bash fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run this in PowerShell:
 iex (irm https://hermes-agent.nousresearch.com/install.ps1)
 ```
 
-The installer handles everything: uv, Python 3.11, Node.js, ripgrep, ffmpeg, **and a portable Git Bash** (MinGit, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install). Hermes uses this bundled Git Bash to run shell commands.
+The installer handles everything: uv, Python 3.11, Node.js, ripgrep, ffmpeg, **and a portable Git Bash** (MinGit, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install). When no system Git is found, Hermes uses this bundled Git Bash to run shell commands.
 
 If you already have Git installed, the installer detects it and uses that instead. Otherwise a ~45MB MinGit download is all you need — it won't touch or interfere with any system Git.
 


### PR DESCRIPTION
## Summary
- Clarifies that the CLI can fall back to the bundled Git Bash on Windows when `bash` is not already on `PATH`.

## Test plan
- `git diff --check HEAD^ HEAD`

## Scope / safety
- Documentation-only README change.
- No deploy, merge, release, or runtime changes.
