### PR TITLE
fix(bedrock): report 1M context for Opus 4.6+/Sonnet 4.6

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1296,9 +1296,23 @@ def classify_bedrock_error(error_message: str) -> str:
 # detection is unavailable.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
-    # Anthropic Claude models on Bedrock
-    "anthropic.claude-opus-4-6":     200_000,
-    "anthropic.claude-sonnet-4-6":   200_000,
+    # Anthropic Claude models on Bedrock.
+    # NOTE: Opus 4.6+ and Sonnet 4.6 support a 1M context window on Bedrock,
+    # gated behind the ``context-1m-2025-08-07`` beta header which
+    # build_anthropic_bedrock_client() (agent/anthropic_adapter.py) attaches
+    # unconditionally to the AnthropicBedrock client used for the provider
+    # (wired at agent/agent_init.py). These entries must therefore report 1M,
+    # not 200K, or context-usage accounting under-reports the real window (the
+    # client requests 1M on the wire while the meter caps at 200K). Older
+    # 3.x / Sonnet-4 / Haiku models have no 1M support and stay at 200K.
+    # Ordering matters: get_bedrock_context_length() picks the LONGEST matching
+    # substring, so more specific keys (e.g. "claude-opus-4-8") must precede the
+    # bare "claude-opus-4" / "claude-sonnet-4" fallbacks to win for an id like
+    # "us.anthropic.claude-opus-4-8".
+    "anthropic.claude-opus-4-8":     1_000_000,
+    "anthropic.claude-opus-4-7":     1_000_000,
+    "anthropic.claude-opus-4-6":     1_000_000,
+    "anthropic.claude-sonnet-4-6":   1_000_000,
     "anthropic.claude-sonnet-4-5":   200_000,
     "anthropic.claude-haiku-4-5":    200_000,
     "anthropic.claude-opus-4":       200_000,

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1305,10 +1305,12 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # not 200K, or context-usage accounting under-reports the real window (the
     # client requests 1M on the wire while the meter caps at 200K). Older
     # 3.x / Sonnet-4 / Haiku models have no 1M support and stay at 200K.
-    # Ordering matters: get_bedrock_context_length() picks the LONGEST matching
-    # substring, so more specific keys (e.g. "claude-opus-4-8") must precede the
-    # bare "claude-opus-4" / "claude-sonnet-4" fallbacks to win for an id like
-    # "us.anthropic.claude-opus-4-8".
+    # Note: get_bedrock_context_length() resolves an id by the LONGEST matching
+    # key (by string length), independent of insertion order — so e.g.
+    # "claude-opus-4-8" wins over the bare "claude-opus-4" for an id like
+    # "us.anthropic.claude-opus-4-8" regardless of where each key sits here.
+    # (Insertion order would only matter for same-length key ties, which we
+    # don't have.) Keys are grouped specific-first purely for readability.
     "anthropic.claude-opus-4-8":     1_000_000,
     "anthropic.claude-opus-4-7":     1_000_000,
     "anthropic.claude-opus-4-6":     1_000_000,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1167,11 +1167,23 @@ class TestBedrockContextLength:
 
     def test_claude_opus_4_6(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 200_000
+        # Opus 4.6+ serves a 1M window on Bedrock (context-1m beta attached
+        # unconditionally by build_anthropic_bedrock_client).
+        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 1_000_000
+
+    def test_claude_opus_versioned_newer(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("us.anthropic.claude-opus-4-8") == 1_000_000
 
     def test_claude_sonnet_versioned(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 200_000
+        # Sonnet 4.6 also serves 1M on Bedrock.
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 1_000_000
+
+    def test_claude_sonnet_4_5_stays_200k(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Sonnet 4.5 has no 1M support — must remain 200K.
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-5-20250101-v1:0") == 200_000
 
     def test_nova_pro(self):
         from agent.bedrock_adapter import get_bedrock_context_length
@@ -1188,7 +1200,7 @@ class TestBedrockContextLength:
     def test_inference_profile_resolves(self):
         from agent.bedrock_adapter import get_bedrock_context_length
         # Cross-region inference profiles contain the base model ID
-        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 200_000
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 1_000_000
 
     def test_longest_prefix_wins(self):
         from agent.bedrock_adapter import get_bedrock_context_length


### PR DESCRIPTION
## Problem

`BEDROCK_CONTEXT_LENGTHS` reported 200K for Opus 4.6 / Sonnet 4.6, but `build_anthropic_bedrock_client()` attaches the `context-1m-2025-08-07` beta header unconditionally to the `AnthropicBedrock` client used by the Bedrock provider (wired at `agent/agent_init.py:653`). These models actually serve a **1M** window on Bedrock, so context-usage accounting under-reported the real window (the client requests 1M on the wire while the meter capped at 200K).

## Fix

Bump Opus 4.6/4.7/4.8 and Sonnet 4.6 to `1_000_000`. Older 3.x / Sonnet-4 / Haiku models have no 1M support and stay at 200K.

Added an ordering note: `get_bedrock_context_length()` picks the **longest** matching substring, so specific keys (e.g. `claude-opus-4-8`) must precede the bare `claude-opus-4` fallback for ids like `us.anthropic.claude-opus-4-8`.

## Verification

- Traced `build_anthropic_bedrock_client` (anthropic_adapter.py:867) -> sends the 1M beta unconditionally; confirmed it is the client wired for the provider at agent_init.py:653.
- Verified live: status bar reports `/1M` for `us.anthropic.claude-opus-4-8` after the fix.