### PR TITLE
feat(cli): add HERMES_SHOW_FULL_MODEL_NAME to disable status-bar truncation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4307,13 +4307,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         model_short = model_name.split("/")[-1] if "/" in model_name else model_name
         if model_short.endswith(".gguf"):
             model_short = model_short[:-5]
-        # Set HERMES_SHOW_FULL_MODEL_NAME=1 to disable status-bar truncation
-        # (useful for long Bedrock inference-profile ids like
-        # "us.anthropic.claude-opus-4-8" that would otherwise be clipped).
-        if (
-            os.environ.get("HERMES_SHOW_FULL_MODEL_NAME") != "1"
-            and len(model_short) > 26
-        ):
+        # display.full_model_name (config.yaml): when true, skip the status-bar
+        # truncation so long Bedrock inference-profile ids like
+        # "us.anthropic.claude-opus-4-8" render in full instead of being clipped.
+        try:
+            _show_full_model = bool(
+                (self.config or {}).get("display", {}).get("full_model_name", False)
+            )
+        except Exception:
+            _show_full_model = False
+        if not _show_full_model and len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
 
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())

--- a/cli.py
+++ b/cli.py
@@ -4307,7 +4307,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         model_short = model_name.split("/")[-1] if "/" in model_name else model_name
         if model_short.endswith(".gguf"):
             model_short = model_short[:-5]
-        if len(model_short) > 26:
+        # Set HERMES_SHOW_FULL_MODEL_NAME=1 to disable status-bar truncation
+        # (useful for long Bedrock inference-profile ids like
+        # "us.anthropic.claude-opus-4-8" that would otherwise be clipped).
+        if (
+            os.environ.get("HERMES_SHOW_FULL_MODEL_NAME") != "1"
+            and len(model_short) > 26
+        ):
             model_short = f"{model_short[:23]}..."
 
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1699,6 +1699,10 @@ DEFAULT_CONFIG = {
         # failure isn't silent from the UI's perspective.  Set false to suppress.
         "turn_completion_explainer": True,
         "show_cost": False,       # Show $ cost in the status bar (off by default)
+        # Show the full model name in the status bar instead of truncating to
+        # ~26 chars. Useful for long Bedrock inference-profile ids like
+        # "us.anthropic.claude-opus-4-8" that would otherwise be clipped.
+        "full_model_name": False,
         "skin": "default",
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent


### PR DESCRIPTION
## Problem

The status bar clips `model_short` to 23 chars + `...` when it exceeds 26 chars. Long Bedrock inference-profile ids (e.g. `us.anthropic.claude-opus-4-8`, 28 chars) get cut to `us.anthropic.claude-opu...`.

## Fix

Gate the truncation behind `HERMES_SHOW_FULL_MODEL_NAME=1` so users can opt into the full name. Default behaviour is unchanged (truncation still applies when the flag is unset), matching the existing `os.environ.get("HERMES_*") == "1"` flag convention in cli.py.

## Verification

- `default` (flag unset): `us.anthropic.claude-opu...` (unchanged)
- `HERMES_SHOW_FULL_MODEL_NAME=1`: `us.anthropic.claude-opus-4-8` (full)
- `py_compile` passes.