### PR TITLE
fix(web): promote token counts that round up to 1000K/1000M to the next unit

### DIFF
--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { formatTokenCount } from "./format";
+
+describe("formatTokenCount", () => {
+  it("promotes counts that round up to 1000K into the M unit", () => {
+    // [999.95K, 1M): rounding the mantissa to one decimal yields 1000.0, which
+    // must cross into the next unit rather than print "1000.0K".
+    expect(formatTokenCount(999_999)).toBe("1M");
+    expect(formatTokenCount(999_950)).toBe("1M");
+  });
+
+  it("does not emit a trailing .0 for whole M-band values", () => {
+    expect(formatTokenCount(999_999_999)).toBe("1000M");
+    expect(formatTokenCount(2_000_000)).toBe("2M");
+  });
+
+  it("keeps counts below the rounding band on their own unit", () => {
+    expect(formatTokenCount(999_500)).toBe("999.5K");
+    expect(formatTokenCount(999_949)).toBe("999.9K");
+  });
+
+  it("renders K-band values with one decimal of precision", () => {
+    expect(formatTokenCount(1_500)).toBe("1.5K");
+    expect(formatTokenCount(4_096)).toBe("4.1K");
+  });
+
+  it("strips trailing .0 for clean round numbers", () => {
+    expect(formatTokenCount(1_000)).toBe("1K");
+    expect(formatTokenCount(128_000)).toBe("128K");
+    expect(formatTokenCount(1_000_000)).toBe("1M");
+    expect(formatTokenCount(1_048_576)).toBe("1M");
+    expect(formatTokenCount(1_500_000)).toBe("1.5M");
+  });
+
+  it("returns sub-thousand counts verbatim", () => {
+    expect(formatTokenCount(0)).toBe("0");
+    expect(formatTokenCount(999)).toBe("999");
+  });
+});

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -3,7 +3,20 @@
  * Strips trailing ".0" for clean round numbers.
  */
 export function formatTokenCount(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(n % 1_000 === 0 ? 0 : 1)}K`;
+  // Round the mantissa to one decimal *before* settling on a unit, then strip a
+  // trailing ".0" for whole numbers. Rounding after the unit is chosen lets a
+  // value in the [999.95, 1000) band (e.g. 999_999) print as "1000.0K" instead
+  // of crossing into the next unit, so promote when the rounded mantissa hits
+  // 1000.
+  const fmt = (value: number, unit: string): string =>
+    `${value.toFixed(Number.isInteger(value) ? 0 : 1)}${unit}`;
+  if (n >= 1_000_000) {
+    return fmt(Math.round((n / 1_000_000) * 10) / 10, "M");
+  }
+  if (n >= 1_000) {
+    const k = Math.round((n / 1_000) * 10) / 10;
+    if (k >= 1000) return fmt(Math.round((n / 1_000_000) * 10) / 10, "M");
+    return fmt(k, "K");
+  }
   return String(n);
 }


### PR DESCRIPTION
## What does this PR do?

`formatTokenCount` (`web/src/lib/format.ts`) chose the K/M unit from the **raw magnitude** but rounded the mantissa **after** the unit was locked in. `.toFixed(1)` rounds any value in the `[999.95K, 1M)` band up to the literal string `"1000.0K"`, so a 999,999-token context window rendered as **`1000.0K`** instead of crossing into the next unit (`1M`). The M band had the analogous flaw (`999_999_999` → `1000.0M`).

A second, related defect: the old whole-number guard `n % 1_000_000 === 0` only stripped the trailing `.0` when `n` was an *exact* multiple of the unit, so values that merely round to a whole mantissa printed a stray decimal (e.g. `1_048_576` → `1.0M`).

The fix rounds the mantissa **first**, promotes to the next unit when the rounded K-band value reaches `1000`, and strips a trailing `.0` based on the rounded value.

This surfaces in the dashboard **Models UI** — `ModelInfoCard.tsx` (effective/auto context length, max_output_tokens) and `ModelsPage.tsx` (context_window, max_output_tokens) both render through this helper, so a model advertising e.g. a 999,999-token window showed the wrong label.

### Before / After

| Input | Before | After |
| --- | --- | --- |
| `999_999` | `1000.0K` | `1M` |
| `999_950` | `1000.0K` | `1M` |
| `999_999_999` | `1000.0M` | `1000M` |
| `1_048_576` | `1.0M` | `1M` |
| `999_500` | `999.5K` | `999.5K` (unchanged) |
| `1_000_000` | `1M` | `1M` (unchanged) |
| `1_500` | `1.5K` | `1.5K` (unchanged) |

## Related Issue

Code-originated (no filed issue).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/lib/format.ts` — round the mantissa before selecting the unit; promote a K-band value that rounds to `≥ 1000` into the M unit; strip the trailing `.0` based on the rounded value.
- `web/src/lib/format.test.ts` — new vitest suite covering the `[999.95K, 1M)` promotion band, M-band whole-number stripping, and the unaffected anchors.

## How to Test

1. `cd web && npm test` (`vitest run`) — the new `format.test.ts` suite passes; the whole `web/src/lib` suite is green (37 tests).
2. Regression direction proven: with the production hunk reverted, `format.test.ts` goes red on `999_999 → "1M"`, `999_999_999 → "1000M"`, and `1_048_576 → "1M"`; restoring the fix turns it green.
3. `npm run typecheck` and `npm run lint` both pass on the touched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all pass (web: `vitest run` — this is a TypeScript change; `pytest` is N/A)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure numeric formatting, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A