### PR TITLE
fix(tui_gateway): synthesize terminal completion notice for empty final_response (#54756)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12098,10 +12098,14 @@ def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
     assert "kimi-k2.6" in payload.get("text", "")
 
 
-def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
-    """An empty final_response with NO backend error must stay empty — do not
-    synthesize an error string. Preserves the existing None/empty-sentinel
-    semantics owned by downstream handlers."""
+def test_prompt_submit_synthesizes_graceful_fallback_for_empty_response(monkeypatch):
+    """An empty final_response with NO backend error gets a graceful
+    "The task completed." fallback so the TUI/desktop always receives a
+    terminal assistant bubble. We MUST NOT fabricate an "Error:" string
+    (handled by ``test_prompt_submit_surfaces_backend_error_as_visible_text``)
+    — the fallback is a neutral completion notice. Regression for #54756
+    where an empty successful turn left the client looking unfinished.
+    """
 
     class _Agent:
         def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
@@ -12138,7 +12142,110 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     payload = complete_events[-1][2]
     # Status stays "complete" because no error flag was set
     assert payload.get("status") == "complete"
-    # Text stays empty — we did NOT fabricate an "Error:" string
+    # Text is a graceful completion notice — NOT an "Error:" string
+    text = payload.get("text", "")
+    assert text, "expected graceful fallback text, got empty"
+    assert "Error:" not in text, f"must not fabricate Error: string, got {text!r}"
+
+
+def test_prompt_submit_falls_back_to_turn_completion_explanation(monkeypatch):
+    """When ``turn_exit_reason`` is set on an empty successful turn, prefer
+    the agent's turn-completion explainer (e.g. "No reply: …") over the
+    generic "The task completed." sentinel. Regression for #54756 — gives
+    users an actionable reason for the empty turn instead of a vague
+    completion notice.
+    """
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
+            return {
+                "final_response": "(empty)",
+                "messages": [],
+                "api_calls": 1,
+                "completed": True,
+                "turn_exit_reason": "empty_response_exhausted",
+            }
+
+        def _format_turn_completion_explanation(self, reason):
+            return f"No reply: {reason}"
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+
+    emitted: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload or {})),
+    )
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    server.handle_request(
+        {
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        }
+    )
+
+    complete_events = [e for e in emitted if e[0] == "message.complete"]
+    assert complete_events, "expected message.complete to be emitted"
+    payload = complete_events[-1][2]
+    text = payload.get("text", "")
+    assert text == "No reply: empty_response_exhausted", f"got {text!r}"
+
+
+def test_prompt_submit_does_not_synthesize_for_interrupted_turns(monkeypatch):
+    """The graceful fallback only fires for ``status == "complete"`` turns.
+    An interrupted turn with empty final_response must keep its existing
+    semantics — a fresh user prompt or a follow-up is the next move, and
+    a synthesised "The task completed." would lie about the outcome.
+    Regression guard for #54756 — the fallback is intentionally narrow.
+    """
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
+            return {
+                "final_response": None,
+                "messages": [],
+                "api_calls": 1,
+                "completed": False,
+                "interrupted": True,
+            }
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+
+    emitted: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload or {})),
+    )
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    server.handle_request(
+        {
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        }
+    )
+
+    complete_events = [e for e in emitted if e[0] == "message.complete"]
+    assert complete_events, "expected message.complete to be emitted"
+    payload = complete_events[-1][2]
+    assert payload.get("status") == "interrupted"
+    # Interrupted turns are not the failure mode — keep text empty so the
+    # client renders whatever partial state it already has.
     text = payload.get("text", "")
     assert text in {"", None}, f"expected empty text, got {text!r}"
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9813,6 +9813,42 @@ def _run_prompt_submit(
                     INTERRUPT_WAITING_FOR_MODEL_PREFIX
                 ):
                     raw = ""
+
+                # When final_response is still missing, empty, or the bare
+                # "(empty)" sentinel after the turn finalizer ran — the
+                # explainer may have been disabled, thrown, or skipped for
+                # interrupted turns — provide a fallback so the client never
+                # receives an empty message.complete text for a
+                # non-interrupted, non-error turn. The TUI/desktop clear busy
+                # on `message.complete` regardless, but an empty bubble makes
+                # the turn look unfinished (#54756). Matches the sentinel the
+                # conversation loop sets when retries are exhausted
+                # (agent/conversation_loop.py line ~4668). ``raw`` can be None
+                # when the run never produced a final_response, so normalize
+                # to a string before the strip check. ``_response_synthesized``
+                # marks the fallback path so downstream stages (auto-title,
+                # voice TTS) can tell a genuine model reply apart from a
+                # placeholder completion notice and skip derived side-effects.
+                _response_synthesized = False
+                if status == "complete":
+                    if not isinstance(raw, str):
+                        raw = "" if raw is None else str(raw)
+                    _stripped = raw.strip()
+                    if not _stripped or _stripped == "(empty)":
+                        turn_exit = result.get("turn_exit_reason", "")
+                        _explanation = ""
+                        if turn_exit:
+                            try:
+                                _explanation = (
+                                    agent._format_turn_completion_explanation(
+                                        turn_exit
+                                    )
+                                    or ""
+                                )
+                            except Exception:
+                                _explanation = ""
+                        raw = _explanation or "The task completed."
+                        _response_synthesized = True
                 lr = result.get("last_reasoning")
                 if isinstance(lr, str) and lr.strip():
                     last_reasoning = lr.strip()
@@ -9935,6 +9971,7 @@ def _run_prompt_submit(
                 status == "complete"
                 and isinstance(raw, str)
                 and raw.strip()
+                and not _response_synthesized
                 and isinstance(text, str)
                 and text.strip()
             ):
@@ -9978,15 +10015,18 @@ def _run_prompt_submit(
                 except Exception:
                     pass
 
-            # Voice TTS fallback: when the streaming pipeline couldn't start
-            # (no provider / missing deps probed at turn start), speak the
-            # final text whole (cli.py:_voice_speak_response parity). The
-            # streaming path already spoke everything via tts_queue.
+            # CLI parity: when voice-mode TTS is on, speak the agent reply
+            # (cli.py:_voice_speak_response).  Only the final text — tool
+            # calls / reasoning already stream separately and would be
+            # noisy to read aloud. Synthesised completion notices are
+            # skipped — the assistant never spoke them, TTS should not
+            # pretend it did.
             if (
                 status == "complete"
                 and tts_queue is None
                 and isinstance(raw, str)
                 and raw.strip()
+                and not _response_synthesized
                 and _voice_tts_enabled()
             ):
                 try:


### PR DESCRIPTION
Fixes #54756

## Description

When the backend finishes a turn with no visible final reply (model returned empty content after retries, or never produced a final_response at all), the TUI/desktop was receiving a message.complete event with empty text. The client clears its busy state on message.complete regardless, so the turn doesn't hang — but an empty bubble makes the chat history look unfinished and leaves the user wondering whether the model is still working.

The fix replaces the empty/whitespace/'(empty)'-sentinel raw text with a graceful fallback in the _run_prompt_submit handler:

- If turn_exit_reason is set, surface the agent's existing turn-completion explainer (e.g. 'No reply: ...') for an actionable reason.
- Otherwise fall back to a neutral 'The task completed.' notice.

Scope is narrow: the fallback only fires for status == 'complete' (non-interrupted, non-error turns). Interrupted turns keep their existing empty-text semantics — a fresh user prompt or follow-up is the next move, and a synthesised completion notice would lie about the outcome. Real backend errors are unaffected: the earlier 'Error: <detail>' branch still wins.

A new _response_synthesized flag tracks the fallback path so downstream stages (auto-title, voice-mode TTS) can tell a genuine model reply apart from a placeholder completion notice and skip derived side-effects — synthesised text must not seed a session title or be spoken aloud by TTS.

## Verification

- 301 tests in tests/test_tui_gateway_server.py pass.
- Three new regression tests added for #54756.
- python -c 'import tui_gateway.server' compiles clean.

## Quality gates

- S1 (secrets): clean
- S2 (personal refs): clean
- C1 (conventional commits): fix(...): header
- T1 (tests): 301/301 pass in tests/test_tui_gateway_server.py
- F1 (focused): +153/-6 across 2 files, no unrelated changes