### PR TITLE
fix(moa): route bedrock MoA slots through signed bedrock branch

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -99,7 +99,16 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
         # provider-backed targets whose provider branch adds auth refresh,
         # request metadata, or request-shape adapters. Keep those providers
         # identified by name.
-        if resolved_provider in {"nous", "openai-codex", "xai-oauth"}:
+        # ``bedrock`` belongs here too: its provider branch builds an
+        # AWS-SigV4-signed client (or IAM-role-signed) against the
+        # bedrock-runtime endpoint. resolve_runtime_provider returns that
+        # endpoint's base_url plus a PLACEHOLDER api_key ("aws-sdk") — there is
+        # no real bearer token. Forwarding base_url+api_key makes call_llm treat
+        # it as a plain OpenAI-compatible endpoint and POST with an unsigned
+        # fake bearer, which Bedrock answers with an empty/malformed
+        # ChatCompletion (choices=None). Keeping it identified by name routes it
+        # through the real signed bedrock branch.
+        if resolved_provider in {"nous", "openai-codex", "xai-oauth", "bedrock"}:
             return out
         # Pass the resolved endpoint through so call_llm builds the request for
         # the provider's actual API surface instead of auto-detecting. base_url


### PR DESCRIPTION
## Summary

MoA presets that use a **Bedrock** model as the aggregator (or as a reference) fail: the aggregator turn returns an empty/malformed `ChatCompletion` (`choices=None`), which trips the auxiliary response validator and aborts the turn.

## Root cause

`_slot_runtime()` in `agent/moa_loop.py` resolves each MoA slot to its real runtime and, for most providers, forwards the resolved `base_url` + `api_key` to `call_llm`. A small name-preserve set (`nous`, `openai-codex`, `xai-oauth`) is exempted because their auth isn't a forwardable bearer token.

**Bedrock was missing from that set.** `resolve_runtime_provider` returns:

- `api_mode = anthropic_messages`
- `base_url = https://bedrock-runtime.<region>.amazonaws.com`
- `api_key  = "aws-sdk"`  ← a **placeholder**, not a real token (auth is AWS SigV4 / IAM-role signing)

So `_slot_runtime` forwarded the bedrock-runtime URL plus the fake `"aws-sdk"` key. `call_llm` then treated it as a plain OpenAI-compatible endpoint and issued an **unsigned bearer POST** to the Bedrock runtime. Bedrock answered with an empty/malformed `ChatCompletion`, failing `.choices[0].message` validation.

References using real bearer tokens (e.g. `openai-codex`, custom xAI) survived because their auth works through the forwarded path; only Bedrock's SigV4 path broke.

## Fix

Add `bedrock` to the name-preserve set so bedrock slots are passed by **provider name only**, routing through `call_llm`'s dedicated SigV4-signed bedrock branch (the same branch the main agent already uses successfully).

```python
if resolved_provider in {"nous", "openai-codex", "xai-oauth", "bedrock"}:
    return out
```

## Verification

- `_slot_runtime({provider:"bedrock", ...})` now returns only `['provider','model']` — no leaked `base_url` / placeholder key.
- Direct `call_llm(provider="bedrock", ...)` aggregator call returns a valid completion.
- Full `aggregate_moa_context()` end-to-end with a bedrock aggregator now produces a complete synthesis instead of an empty `ChatCompletion`.

## Impact

Affects any MoA preset with a bedrock aggregator or bedrock reference. No effect on non-bedrock providers.
