### PR TITLE
fix(bedrock): set Claude 4-7/4-8 Bedrock context to 1M to match native table

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1296,7 +1296,18 @@ def classify_bedrock_error(error_message: str) -> str:
 # detection is unavailable.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
-    # Anthropic Claude models on Bedrock
+    # Anthropic Claude 4-7 / 4-8 generation — 1M context, matching the
+    # native Anthropic table in agent/model_metadata.py (claude-opus-4-8 etc.).
+    # Without explicit keys here these newer slugs collide on the shorter
+    # "anthropic.claude-opus-4" substring below and silently under-report at
+    # 200K. Longest-key-first matching in get_bedrock_context_length() ensures
+    # these win over the generic claude-4 entries.
+    "anthropic.claude-opus-4-8":     1_000_000,
+    "anthropic.claude-opus-4-7":     1_000_000,
+    "anthropic.claude-sonnet-4-8":   1_000_000,
+    "anthropic.claude-sonnet-4-7":   1_000_000,
+    "anthropic.claude-haiku-4-7":    1_000_000,
+    # Anthropic Claude 4-6 and earlier on Bedrock (200K window)
     "anthropic.claude-opus-4-6":     200_000,
     "anthropic.claude-sonnet-4-6":   200_000,
     "anthropic.claude-sonnet-4-5":   200_000,


### PR DESCRIPTION
## Summary

Claude 4-7 / 4-8 models on **Bedrock** silently resolve to a **200K** context window instead of **1M**, contradicting the native Anthropic table in the same codebase.

## Root cause

`BEDROCK_CONTEXT_LENGTHS` in `agent/bedrock_adapter.py` only had keys through the **claude-4-6** generation. `get_bedrock_context_length()` uses longest-substring matching, so newer slugs like `anthropic.claude-opus-4-8` / `-sonnet-4-8` / `-opus-4-7` fell through to the generic `"anthropic.claude-opus-4": 200_000` entry (a substring of the newer IDs).

Meanwhile `DEFAULT_CONTEXT_LENGTHS` in `agent/model_metadata.py` already lists the native path at 1M:

```python
"claude-opus-4-8": 1000000,
"claude-opus-4-7": 1000000,
"claude-sonnet-4-6": 1000000,
```

So the **same model** resolved to **1M on the native Anthropic path** and **200K on the Bedrock path** — an internal contradiction. Bedrock users had to manually set `model.context_length` in config to work around it.

## Fix

Add explicit 4-7 / 4-8 keys (opus / sonnet / haiku) at `1_000_000` to the Bedrock table so it matches the native table. Longest-key-first matching ensures these win over the generic `claude-4` entries while **claude-4-6 and earlier stay at 200K**.

## Verification

```
OK   global.anthropic.claude-opus-4-8              got=  1000000 exp=1000000
OK   anthropic.claude-opus-4-8-20260601-v1:0       got=  1000000 exp=1000000
OK   anthropic.claude-sonnet-4-8                   got=  1000000 exp=1000000
OK   anthropic.claude-opus-4-7                     got=  1000000 exp=1000000
OK   anthropic.claude-opus-4-6                     got=   200000 exp=200000   (unchanged)
OK   anthropic.claude-sonnet-4-5                   got=   200000 exp=200000   (unchanged)
OK   anthropic.claude-opus-4                       got=   200000 exp=200000   (unchanged)
OK   anthropic.claude-3-opus                       got=   200000 exp=200000   (unchanged)
OK   amazon.nova-pro                               got=   300000 exp=300000   (unchanged)
OK   meta.llama4-scout                             got=   128000 exp=128000   (unchanged)
ALL PASS
```

## Note for maintainers

This aligns the Bedrock table with the native table's 1M assumption for the 4-7/4-8 generation. If AWS Bedrock enforces a lower usable cap for these models, or requires a `context-1m` beta opt-in (the adapter currently sends no such header), the values here should track whatever the native table commits to — the two tables should not disagree for the same model. Flagging in case the native 1M entries themselves need revisiting.
