### PR TITLE
fix(tests): test_user_config_skipped_when_flag_set is affected by real project_root/cli-config.yaml

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -51,6 +51,7 @@ os.environ["HERMES_QUIET"] = "1"  # Our own modules
 
 import yaml
 
+from hermes_cli.config import get_project_root
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
@@ -372,7 +373,7 @@ def load_cli_config() -> Dict[str, Any]:
     """
     # Check user config first ({HERMES_HOME}/config.yaml)
     user_config_path = _hermes_home / 'config.yaml'
-    project_config_path = Path(__file__).parent / 'cli-config.yaml'
+    project_config_path = get_project_root() / 'cli-config.yaml'
 
     # --ignore-user-config: force-skip the user config.yaml (still honor project
     # config as a fallback so defaults stay sensible).

--- a/tests/hermes_cli/test_ignore_user_config_flags.py
+++ b/tests/hermes_cli/test_ignore_user_config_flags.py
@@ -59,10 +59,23 @@ class TestIgnoreUserConfigEnvGate:
         ).lstrip()
         (tmp_path / "config.yaml").write_text(config_yaml)
 
-    def _reload_cli(self, monkeypatch, tmp_path):
+    def _write_project_config(self, project_path, model_default):
+        config_yaml = textwrap.dedent(
+            f"""
+            model:
+              default: {model_default}
+              provider: openrouter
+              base_url: "https://api.model.com"
+            """
+        ).lstrip()
+        (project_path / "cli-config.yaml").write_text(config_yaml)
+
+    def _reload_cli(self, monkeypatch, tmp_path, project_root=None):
         """Point cli._hermes_home at tmp_path and return a fresh load_cli_config."""
         import cli
         monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+        if project_root:
+            monkeypatch.setattr(cli, "get_project_root", lambda: project_root)
         return cli.load_cli_config
 
     def test_user_config_loaded_when_flag_unset(self, tmp_path, monkeypatch):
@@ -75,16 +88,30 @@ class TestIgnoreUserConfigEnvGate:
         assert cfg["model"]["default"] == "anthropic/claude-sonnet-4.6"
         assert cfg["agent"]["system_prompt"] == "from user config"
 
-    def test_user_config_skipped_when_flag_set(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize(
+        "create_project_config,expected_model_default",
+        [
+            pytest.param(True, "project/model-default", id="project-config-exists"),
+            pytest.param(False, "", id="project-config-does-not-exist"),
+        ],
+    )
+    def test_user_config_skipped_when_flag_set(self, create_project_config, expected_model_default, tmp_path, monkeypatch):
         """With HERMES_IGNORE_USER_CONFIG=1, user config.yaml is ignored.
 
         The built-in default ``model.default`` is empty string (no user override),
         and the user's ``agent.system_prompt`` is not seen.
         """
-        self._write_user_config(tmp_path, "anthropic/claude-sonnet-4.6")
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        self._write_user_config(hermes_home, "anthropic/claude-sonnet-4.6")
         monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "1")
 
-        load_cli_config = self._reload_cli(monkeypatch, tmp_path)
+        project_root = tmp_path / "project_root"
+        project_root.mkdir()
+        if create_project_config:
+            self._write_project_config(project_root, "project/model-default")
+
+        load_cli_config = self._reload_cli(monkeypatch, hermes_home, project_root)
         cfg = load_cli_config()
 
         # User-set "system_prompt: from user config" MUST NOT leak through
@@ -93,7 +120,7 @@ class TestIgnoreUserConfigEnvGate:
         # User-set model.default MUST NOT leak through — either the built-in
         # default ("" or unset) or a project-level fallback, but never the
         # user's value
-        assert cfg["model"].get("default", "") != "anthropic/claude-sonnet-4.6"
+        assert cfg["model"].get("default") == expected_model_default
 
     def test_flag_ignored_when_set_to_other_value(self, tmp_path, monkeypatch):
         """Only the literal value "1" activates the bypass, matching the yolo pattern."""


### PR DESCRIPTION

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

This fix runs the test with a fake project root directory where project config file cli-config.yaml is created.

This fix covers both cases of existing and non-existing project config.



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Fixed test `TestIgnoreUserConfigEnvGate.test_user_config_skipped_when_flag_set`

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Just run the test.
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

