### PR TITLE
fix: preserve resumed compression hysteresis

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -961,15 +961,59 @@ class ContextCompressor(ContextEngine):
         self.last_rough_tokens_when_real_prompt_fit = max(baseline, rough_tokens)
         return True
 
-    def should_compress(self, prompt_tokens: int = None) -> bool:
+    def _messages_contain_context_summary(self, messages: Optional[List[Dict[str, Any]]]) -> bool:
+        """Return True when a loaded transcript already has a compaction handoff.
+
+        Gateway runs often construct a fresh ``ContextCompressor`` for each
+        inbound message, so ``compression_count`` may be zero even when the
+        persisted session has already been compacted. Detect the summary in
+        the messages themselves so anti-thrash decisions survive process/agent
+        boundaries.
+        """
+        if not messages:
+            return False
+        return any(self._is_context_summary_content(m.get("content")) for m in messages)
+
+    def _effective_trigger_tokens(self, messages: Optional[List[Dict[str, Any]]] = None) -> int:
+        """Return the trigger threshold for this turn.
+
+        First compression uses the configured threshold. Once a session has
+        already been compacted (either in this process or detected from a
+        persisted summary), use hysteresis: require meaningful growth beyond
+        the base threshold, but never wait past the near-limit safety trigger.
+        This prevents repeated compactions when fixed prompt/tool overhead
+        leaves a compressed session hovering just over the threshold.
+        """
+        base = self.threshold_tokens
+        already_compacted = self.compression_count > 0 or self._messages_contain_context_summary(messages)
+        if not already_compacted or self.context_length <= base:
+            return base
+
+        # Require ~15% growth beyond the configured threshold after a previous
+        # compaction, capped at 92% of the model context so we still compress
+        # before hitting provider limits. The hard lower bound keeps the
+        # effective trigger monotonic when users set thresholds above 92%.
+        growth_trigger = base + max(4096, int(base * 0.15))
+        near_limit_trigger = int(self.context_length * 0.92)
+        return max(base, min(growth_trigger, near_limit_trigger))
+
+    def should_compress(
+        self,
+        prompt_tokens: Optional[int] = None,
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> bool:
         """Check if context exceeds the compression threshold.
 
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
-        where each pass removes only 1-2 messages.
+        where each pass removes only 1-2 messages. After a session already
+        contains a compaction summary, a hysteresis threshold avoids repeatedly
+        re-compressing the same near-threshold transcript on every gateway
+        turn; near-limit contexts still compress.
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
-        if tokens < self.threshold_tokens:
+        trigger_tokens = self._effective_trigger_tokens(messages)
+        if tokens < trigger_tokens:
             return False
         # Anti-thrashing: back off if recent compressions were ineffective
         if self._ineffective_compression_count >= 2:

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -80,8 +80,16 @@ class ContextEngine(ABC):
         """
 
     @abstractmethod
-    def should_compress(self, prompt_tokens: int = None) -> bool:
-        """Return True if compaction should fire this turn."""
+    def should_compress(
+        self,
+        prompt_tokens: int | None = None,
+        messages: List[Dict[str, Any]] | None = None,
+    ) -> bool:
+        """Return True if compaction should fire this turn.
+
+        ``messages`` is optional for backward compatibility with older plugin
+        engines, but engines may use it to make resume-aware decisions.
+        """
 
     @abstractmethod
     def compress(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -73,6 +73,25 @@ logger = logging.getLogger(__name__)
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
 
+def _should_compress_with_messages(compressor: Any, prompt_tokens: int, messages: List[Dict[str, Any]]) -> bool:
+    """Call a context engine's compression predicate with transcript context when supported.
+
+    The built-in compressor uses ``messages`` to detect an already-compacted
+    resumed session and apply hysteresis. Third-party context engines may still
+    implement the older one-argument signature, so fall back without
+    ``messages`` for compatibility.
+    """
+    try:
+        return bool(compressor.should_compress(prompt_tokens, messages=messages))
+    except TypeError as exc:
+        # Only fall back for engines that do not accept the new keyword. Do not
+        # hide real TypeErrors raised inside an engine implementation.
+        message = str(exc)
+        if "messages" not in message or "unexpected keyword" not in message:
+            raise
+        return bool(compressor.should_compress(prompt_tokens))
+
+
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
     """Extract a provider-reported image dimension ceiling, if present."""
     parts = []
@@ -4409,7 +4428,7 @@ def run_conversation(
                         messages, tools=agent.tools or None
                     )
 
-                if agent.compression_enabled and _compressor.should_compress(_real_tokens):
+                if agent.compression_enabled and _should_compress_with_messages(_compressor, _real_tokens, messages):
                     agent._safe_print("  ⟳ compacting context…")
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -41,6 +41,42 @@ class TestShouldCompress:
         assert compressor.should_compress(prompt_tokens=90000) is True
         assert compressor.should_compress(prompt_tokens=50000) is False
 
+    def test_existing_compaction_summary_uses_hysteresis(self, compressor):
+        """A resumed compressed session should not compact again at the base threshold.
+
+        Gateway turns construct a fresh agent, so ``compression_count`` can be 0
+        even when the loaded transcript already contains a compaction handoff.
+        The compressor must detect the summary in messages and require a higher
+        post-compaction trigger before re-compressing, otherwise every new turn
+        near the threshold splits the session again.
+        """
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "assistant", "content": f"{SUMMARY_PREFIX}\nEarlier work."},
+            {"role": "user", "content": "current task"},
+        ]
+
+        compressor.compression_count = 0  # fresh gateway agent after resume
+        assert compressor.threshold_tokens == 85_000
+        assert compressor.should_compress(prompt_tokens=90_000, messages=messages) is False
+
+    def test_existing_compaction_summary_still_compresses_near_context_limit(self, compressor):
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "assistant", "content": f"{SUMMARY_PREFIX}\nEarlier work."},
+            {"role": "user", "content": "current task"},
+        ]
+
+        assert compressor.should_compress(prompt_tokens=93_000, messages=messages) is True
+
+    def test_uncompressed_session_still_uses_base_threshold(self, compressor):
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "current task"},
+        ]
+
+        assert compressor.should_compress(prompt_tokens=85_000, messages=messages) is True
+
 
 
 class TestUpdateFromResponse:

--- a/tests/agent/test_conversation_loop_compression.py
+++ b/tests/agent/test_conversation_loop_compression.py
@@ -1,0 +1,45 @@
+"""Tests for compression decisions in the conversation loop."""
+
+import pytest
+
+from agent.conversation_loop import _should_compress_with_messages
+
+
+def test_should_compress_with_messages_passes_transcript_context():
+    class Recorder:
+        def __init__(self):
+            self.calls = []
+
+        def should_compress(self, prompt_tokens=None, messages=None):
+            self.calls.append((prompt_tokens, messages))
+            return True
+
+    compressor = Recorder()
+    messages = [{"role": "assistant", "content": "summary"}]
+
+    assert _should_compress_with_messages(compressor, 90_000, messages) is True
+    assert compressor.calls == [(90_000, messages)]
+
+
+def test_should_compress_with_messages_falls_back_for_legacy_engines():
+    class Legacy:
+        def __init__(self):
+            self.calls = []
+
+        def should_compress(self, prompt_tokens=None):
+            self.calls.append(prompt_tokens)
+            return False
+
+    compressor = Legacy()
+
+    assert _should_compress_with_messages(compressor, 90_000, []) is False
+    assert compressor.calls == [90_000]
+
+
+def test_should_compress_with_messages_does_not_hide_internal_type_errors():
+    class Broken:
+        def should_compress(self, prompt_tokens=None, messages=None):
+            raise TypeError("internal bug unrelated to keyword handling")
+
+    with pytest.raises(TypeError, match="internal bug"):
+        _should_compress_with_messages(Broken(), 90_000, [])


### PR DESCRIPTION
## Summary
- Detect persisted compaction summaries in the loaded transcript when deciding whether to compress again.
- Apply a post-compaction hysteresis threshold so resumed gateway sessions do not immediately re-compact the same near-threshold context.
- Pass transcript messages into the compression predicate, with a compatibility fallback for third-party/legacy context engines.

## Why
Gateway platform turns can construct a fresh `ContextCompressor`, so in-process counters such as `compression_count` may be zero even when the session transcript already contains a compaction handoff. If fixed prompt/tool/schema overhead keeps the compressed request near the configured threshold, the previous logic can compact again on subsequent turns.

This keeps the first compression behavior unchanged, but after a prior compaction requires meaningful growth beyond the base threshold while still forcing compression near the model context limit.

## Test Plan
- [x] `venv/bin/python -m pytest tests/agent/test_context_compressor.py tests/agent/test_conversation_loop_compression.py -q -o 'addopts='`
- [x] `git diff --check origin/main...HEAD`
