### PR TITLE
docs(google-gemini): explain google-gemini-cli removal and migration to gemini

### DIFF
--- a/website/docs/guides/google-gemini.md
+++ b/website/docs/guides/google-gemini.md
@@ -8,6 +8,10 @@ description: "Use Hermes Agent with Google Gemini — native AI Studio API, API-
 
 Hermes Agent supports Google Gemini as a native provider using the **Google AI Studio / Gemini API** — not the OpenAI-compatible endpoint. This lets Hermes translate its internal OpenAI-shaped message and tool loop into Gemini's native `generateContent` API while preserving tool calling, streaming, multimodal inputs, and Gemini-specific response metadata.
 
+:::info Looking for `google-gemini-cli` / Google OAuth?
+The older `google-gemini-cli` provider (which routed through the Google Code Assist / Gemini CLI backend at `cloudcode-pa.googleapis.com`) has been removed from `hermes model` and `hermes auth` because Google has stopped serving consumer Gemini CLI / Code Assist requests for free and AI Pro / Ultra accounts. If you need Gemini, use the `gemini` provider with a Google AI Studio API key as described in this guide. If you previously had `google-gemini-cli` configured, change `provider: google-gemini-cli` (or any `google-gemini-cli*` alias) to `provider: gemini` in `~/.hermes/config.yaml` and add `GOOGLE_API_KEY` to `~/.hermes/.env`. The 404 / 429 errors users saw from the old provider were a symptom of that backend being shut down, not a quota or model issue.
+:::
+
 ## Prerequisites
 
 - **Google AI Studio API key** — create one at [aistudio.google.com/apikey](https://aistudio.google.com/apikey)


### PR DESCRIPTION
Fixes #54891

## Description
The reporter was confused by the absence of `google-gemini-cli` from both `hermes model` and `hermes auth`, and asked for an explicit clarification of the current intended state. `google-gemini-cli` was removed in a prior release when Google stopped serving consumer Gemini CLI / Code Assist requests through `cloudcode-pa.googleapis.com`, but the migration path was not documented. This adds a top-of-page note in the Google Gemini guide explaining:

- That `google-gemini-cli` was removed because the underlying Code Assist / Gemini CLI consumer backend was shut down
- That users should use the `gemini` provider with a Google AI Studio API key
- How to migrate an existing `google-gemini-cli` `provider:` line in `config.yaml` to `gemini`
- That the 404 / 429 errors from `cloudcode-pa.googleapis.com` were a symptom of the backend shutdown, not a quota or model-selection issue

## Verification
- S1 (Secrets): no secrets introduced
- S2 (Personal refs): no personal refs introduced
- C1 (Conventional commits): commit message matches `fix(docs): ...`
- T1 (Tests): doc-only change in `website/docs/guides/google-gemini.md`; no test files needed
- F1 (Focused): 1 file changed, 4 insertions, all directly related to the migration note