### PR TITLE
Fix Windows compatibility: /dev/tty fallback and process tree termination

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1141,7 +1141,9 @@ def _reset_terminal_input_modes_on_exit() -> None:
     except Exception:
         pass
     try:
-        with open("/dev/tty", "w", encoding="ascii") as tty:
+        # Windows doesn't have /dev/tty — use CON instead
+        tty_path = "CON" if sys.platform == "win32" else "/dev/tty"
+        with open(tty_path, "w", encoding="ascii") as tty:
             tty.write(_TERMINAL_INPUT_MODE_RESET_SEQ)
             tty.flush()
     except Exception:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -658,7 +658,27 @@ class LocalEnvironment(BaseEnvironment):
 
         try:
             if _IS_WINDOWS:
-                proc.terminate()
+                # Windows: use taskkill /T to kill the entire process tree.
+                # proc.terminate() only kills the parent process, leaving
+                # orphaned child processes behind.
+                try:
+                    subprocess.run(
+                        ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        timeout=5,
+                    )
+                except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+                    # Fallback to terminate() if taskkill fails
+                    try:
+                        proc.terminate()
+                    except Exception:
+                        pass
+                # Wait for process to exit
+                try:
+                    proc.wait(timeout=2.0)
+                except subprocess.TimeoutExpired:
+                    pass
             else:
                 try:
                     pgid = os.getpgid(proc.pid)


### PR DESCRIPTION

What does this PR do?
Fix two Windows-specific compatibility issues that affect Hermes stability and resource management on Windows platforms.

Related Issue
No existing issue found. This PR addresses real-world Windows compatibility problems discovered during local development and testing.

Type of Change
[x] 🐛 Bug fix (non-breaking change that fixes an issue)
Changes Made
cli.py (line ~1144): Added platform check in _reset_terminal_input_modes() to use CON device on Windows instead of /dev/tty
tools/environments/local.py (line ~660): Changed Windows branch in _kill_process() to use taskkill /T /F /PID for terminating the entire process tree, with fallback to proc.terminate()
How to Test
Test 1 (cli.py): Redirect stdout and verify no FileNotFoundError on Windows when exiting TUI
Test 2 (local.py): Create a process with child processes, call _kill_process(), verify all child processes are terminated (no orphan processes remain)
Test 3: Run existing test suite on Windows to ensure no regressions
Checklist
Code
[x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
[x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
[x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
[x] My PR contains only changes related to this fix/feature (no unrelated commits)
[ ] I've run pytest tests/ -q and all tests pass (Note: Full test suite not run due to environment limitations)
[ ] I've added tests for my changes (Note: Manual testing performed, automated tests not added)
[x] I've tested on my platform: Windows 11
Documentation & Housekeeping
[x] I've updated relevant documentation — or N/A
[x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
[x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
[x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
[x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
---

**Note**: Some code was AI-assisted, reviewed and tested by human.