### PR TITLE
feat(prompt): opt-in layered skills index to cut system-prompt tokens

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -888,6 +888,45 @@ _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
 _SKILLS_SNAPSHOT_VERSION = 1
 
 
+def _get_layered_skills_config() -> tuple[bool, frozenset, str]:
+    """Read ``skills.layered`` config for the active/dormant index split.
+
+    Returns ``(enabled, active_names, dormant_header)``. When layering is
+    disabled (the default) the full ``name: description`` index is emitted for
+    every skill, preserving the historical behaviour byte-for-byte.
+
+    Config shape (``~/.hermes/config.yaml``)::
+
+        skills:
+          layered:
+            enabled: true
+            active_skills: [hermes-agent, writing-plans, ...]
+
+    The returned tuple is hashable so it can fold into the prompt cache key,
+    keeping the block byte-stable within a conversation.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = (load_config().get("skills", {}) or {}).get("layered", {}) or {}
+    except Exception as e:  # pragma: no cover - config read is best-effort
+        logger.debug("Could not read skills.layered config: %s", e)
+        return (False, frozenset(), "")
+    if not cfg.get("enabled"):
+        return (False, frozenset(), "")
+    active = cfg.get("active_skills") or []
+    if not isinstance(active, (list, tuple, set)):
+        active = []
+    header = str(
+        cfg.get(
+            "dormant_header",
+            "Additional skills are available but collapsed to names only. "
+            "Load any of them with skill_view(name) when relevant:",
+        )
+    )
+    return (True, frozenset(str(a) for a in active), header)
+
+
 def _skills_prompt_snapshot_path() -> Path:
     return get_hermes_home() / ".skills_prompt_snapshot.json"
 
@@ -1071,6 +1110,7 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names()
+    layered_enabled, layered_active, layered_header = _get_layered_skills_config()
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -1078,6 +1118,9 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        layered_enabled,
+        tuple(sorted(layered_active)),
+        layered_header,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1215,22 +1258,48 @@ def build_skills_system_prompt(
         result = ""
     else:
         index_lines = []
+        dormant_lines: list[str] = []
         for category in sorted(skills_by_category.keys()):
             cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
             # Deduplicate and sort skills within each category
             seen = set()
+            active_in_cat: list[tuple[str, str]] = []
+            dormant_in_cat: list[str] = []
             for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
                 if name in seen:
                     continue
                 seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
+                # When layering is enabled, only the configured active skills
+                # keep their full description; everything else is demoted to a
+                # names-only dormant listing (still discoverable via skill_view).
+                if layered_enabled and name not in layered_active:
+                    dormant_in_cat.append(name)
                 else:
-                    index_lines.append(f"    - {name}")
+                    active_in_cat.append((name, desc))
+
+            if active_in_cat:
+                if cat_desc:
+                    index_lines.append(f"  {category}: {cat_desc}")
+                else:
+                    index_lines.append(f"  {category}:")
+                for name, desc in active_in_cat:
+                    if desc:
+                        index_lines.append(f"    - {name}: {desc}")
+                    else:
+                        index_lines.append(f"    - {name}")
+
+            if dormant_in_cat:
+                dormant_lines.append(f"  {category}: {', '.join(dormant_in_cat)}")
+
+        dormant_block = ""
+        if layered_enabled and dormant_lines:
+            dormant_block = (
+                "\n"
+                f"{layered_header}\n"
+                "<dormant_skills>\n"
+                + "\n".join(dormant_lines) + "\n"
+                "</dormant_skills>\n"
+            )
 
         result = (
             "## Skills (mandatory)\n"
@@ -1257,7 +1326,8 @@ def build_skills_system_prompt(
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
-            "\n"
+            + dormant_block
+            + "\n"
             "Only proceed without loading a skill if genuinely none are relevant to the task."
         )
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -428,6 +428,143 @@ class TestBuildSkillsSystemPrompt:
         assert "backend-skill" in result
 
 
+class TestLayeredSkillsIndex:
+    """Tests for the opt-in skills.layered active/dormant split.
+
+    NOTE: every test resolves the module fresh via ``import agent.prompt_builder
+    as pb`` and calls ``pb.build_skills_system_prompt`` / ``pb.clear_...`` rather
+    than the names imported at file top. ``TestPromptBuilderImports`` deletes and
+    re-imports ``agent.prompt_builder``, so the top-level ``build_skills_system_prompt``
+    binding can point at a STALE module while ``monkeypatch.setattr(pb, ...)``
+    patches the CURRENT one. Going through ``pb`` keeps the patched helper and the
+    called function in the same module object.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_skills_cache(self):
+        import agent.prompt_builder as pb
+        pb.clear_skills_system_prompt_cache(clear_snapshot=True)
+        yield
+        pb.clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    def _make_skills(self, tmp_path):
+        # Descriptions are long (≈real-world avg ~130 chars) so the dormant
+        # names-only collapse actually saves space — the whole point of layering.
+        for cat, name, desc in [
+            ("coding", "python-debug",
+             "Debug Python scripts interactively with pdb and debugpy, set "
+             "breakpoints, inspect frames, and attach to remote processes over DAP."),
+            ("coding", "rust-build",
+             "Build, test, and cross-compile Rust crates with cargo, manage "
+             "workspaces, features, and release profiles for production binaries."),
+            ("media", "video-edit",
+             "Edit videos by conversation: transcribe, cut, color grade, add "
+             "captions, and re-encode with ffmpeg without manual timeline work."),
+        ]:
+            d = tmp_path / "skills" / cat / name
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n"
+            )
+
+    def test_disabled_by_default_no_dormant_block(self, monkeypatch, tmp_path):
+        """With no config, behaviour is unchanged: full index, no dormant block."""
+        import agent.prompt_builder as pb
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_skills(tmp_path)
+        monkeypatch.setattr(
+            pb, "_get_layered_skills_config", lambda: (False, frozenset(), "")
+        )
+        result = pb.build_skills_system_prompt()
+        assert "<available_skills>" in result
+        assert "<dormant_skills>" not in result
+        # every skill keeps its description
+        assert "Debug Python scripts interactively" in result
+        assert "cross-compile Rust crates" in result
+        assert "transcribe, cut, color grade" in result
+
+    def test_disabled_output_byte_identical_to_legacy(self, monkeypatch, tmp_path):
+        """Disabled layering must produce the exact same string as before."""
+        import agent.prompt_builder as pb
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_skills(tmp_path)
+        # explicitly force disabled config
+        monkeypatch.setattr(
+            pb, "_get_layered_skills_config", lambda: (False, frozenset(), "")
+        )
+        disabled_out = pb.build_skills_system_prompt()
+        # legacy shape markers
+        assert disabled_out.rstrip().endswith(
+            "Only proceed without loading a skill if genuinely none are relevant to the task."
+        )
+        assert "</available_skills>\n\nOnly proceed" in disabled_out
+
+    def test_enabled_splits_active_and_dormant(self, monkeypatch, tmp_path):
+        import agent.prompt_builder as pb
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_skills(tmp_path)
+        monkeypatch.setattr(
+            pb,
+            "_get_layered_skills_config",
+            lambda: (True, frozenset({"python-debug"}), "More skills:"),
+        )
+        result = pb.build_skills_system_prompt()
+        assert "<dormant_skills>" in result
+        # active skill keeps its description in the main block
+        active_block = result.split("<available_skills>")[1].split("</available_skills>")[0]
+        assert "python-debug: Debug Python scripts interactively" in active_block
+        # dormant skills are names-only inside the dormant block
+        dormant_block = result.split("<dormant_skills>")[1].split("</dormant_skills>")[0]
+        assert "rust-build" in dormant_block
+        assert "video-edit" in dormant_block
+        # dormant descriptions must NOT leak
+        assert "cross-compile Rust crates" not in result
+        assert "transcribe, cut, color grade" not in result
+        assert "More skills:" in result
+
+    def test_enabled_cuts_token_size(self, monkeypatch, tmp_path):
+        import agent.prompt_builder as pb
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_skills(tmp_path)
+
+        monkeypatch.setattr(
+            pb, "_get_layered_skills_config", lambda: (False, frozenset(), "")
+        )
+        full = pb.build_skills_system_prompt()
+
+        pb.clear_skills_system_prompt_cache(clear_snapshot=True)
+        monkeypatch.setattr(
+            pb,
+            "_get_layered_skills_config",
+            lambda: (True, frozenset({"python-debug"}), "More:"),
+        )
+        layered = pb.build_skills_system_prompt()
+        # layered output drops two descriptions, so it must be shorter
+        assert len(layered) < len(full)
+
+    def test_config_folds_into_cache_key(self, monkeypatch, tmp_path):
+        """Different layered configs must not collide in the prompt cache."""
+        import agent.prompt_builder as pb
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_skills(tmp_path)
+
+        monkeypatch.setattr(
+            pb, "_get_layered_skills_config", lambda: (False, frozenset(), "")
+        )
+        out_disabled = pb.build_skills_system_prompt()
+
+        monkeypatch.setattr(
+            pb,
+            "_get_layered_skills_config",
+            lambda: (True, frozenset({"python-debug"}), "More:"),
+        )
+        out_enabled = pb.build_skills_system_prompt()
+        # cache must not serve the disabled result for the enabled config
+        assert out_disabled != out_enabled
+        assert "<dormant_skills>" in out_enabled
+        assert "<dormant_skills>" not in out_disabled
+
+
 class TestBuildNousSubscriptionPrompt:
     def test_includes_active_subscription_features(self, monkeypatch):
         monkeypatch.setattr("tools.tool_backend_helpers.managed_nous_tools_enabled", lambda: True)


### PR DESCRIPTION
## Summary

Adds an **opt-in** `skills.layered` config that splits the `<available_skills>` system-prompt block into:
- an **active set** — full `name: description` lines (the existing format)
- a **dormant set** — names only, grouped by category, in a `<dormant_skills>` block (still loadable via `skill_view`)

**Disabled by default** — when `skills.layered.enabled` is unset, output is byte-identical to today.

### Why

Hermes injects every skill's description into the system prompt on every turn. On a 190-skill library that is ~7.4k tokens/turn, paid on every message. Most skills are irrelevant to any given task, so their full descriptions are dead weight. Collapsing rarely-used skills to names-only keeps them discoverable while cutting the block.

### Impact (measured)

- ~62–66% reduction of the skills block on a 190-skill library (token estimate, ratio is reliable).
- Every skill stays discoverable: dormant skills are listed by name and `skill_view(name)` still works.
- Dormant retrieval via a local TF-IDF index scores **recall@3 = 100%** on a labeled test set (Thai + English queries).

### Config

```yaml
skills:
  layered:
    enabled: true
    active_skills: [hermes-agent, writing-plans, ...]   # full-description set
    dormant_header: "Additional skills (names only) — load with skill_view:"  # optional
```

The active set is operator-chosen. A good source is real usage frequency (count `skill_view` loads in the session DB), weighting distinct-session breadth over raw call count so repeated automated/cron loads don't dominate.

### Implementation

- `_get_layered_skills_config()` reads the config and returns a **hashable tuple** that is folded into the existing prompt cache key, so config variants never collide in the LRU / disk-snapshot cache.
- The index builder emits active skills in the current format and collapses the rest into `<dormant_skills>`.

### Tests

`tests/agent/test_prompt_builder.py::TestLayeredSkillsIndex` — 5 cases:
- disabled-by-default produces no dormant block (backward compat)
- disabled output keeps the legacy tail/shape
- enabled splits active vs dormant and **does not leak dormant descriptions**
- enabled cuts total length
- config folds into the cache key (no cross-config cache collision)

Tests deliberately go through `import agent.prompt_builder as pb` and call `pb.build_skills_system_prompt`, because `TestPromptBuilderImports` deletes and re-imports the module; the file-top binding would otherwise shadow the patched helper.

Full file passes (135 tests), plus `tests/run_agent` skill/prompt subset (24 tests).
