### PR TITLE
fix(webhook): validate Notion HMAC signatures (X-Notion-Signature)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -770,6 +770,14 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return hmac.compare_digest(gl_token, secret)
 
+        # Notion: X-Notion-Signature = sha256=<hex HMAC-SHA256(secret, raw_body)>
+        notion_sig = _header("X-Notion-Signature")
+        if notion_sig:
+            expected = "sha256=" + hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(notion_sig, expected)
+
         # Generic: X-Webhook-Signature = <hex HMAC-SHA256>
         generic_sig = request.headers.get("X-Webhook-Signature", "")
         if generic_sig:

--- a/tests/gateway/test_webhook_notion_signature.py
+++ b/tests/gateway/test_webhook_notion_signature.py
@@ -1,0 +1,58 @@
+import hashlib
+import hmac
+
+from multidict import CIMultiDict
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+
+
+class DummyRequest:
+    def __init__(self, headers):
+        self.headers = CIMultiDict(headers)
+
+
+def _adapter():
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "secret": "global-secret",
+                "routes": {},
+            },
+        )
+    )
+
+
+def _notion_signature(secret: str, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def test_validate_notion_signature_header_accepts_valid_signature():
+    adapter = _adapter()
+    secret = "notion-verification-token"
+    body = b'{"type":"comment.created","entity":{"id":"page-id"}}'
+    request = DummyRequest({"X-Notion-Signature": _notion_signature(secret, body)})
+
+    assert adapter._validate_signature(request, body, secret) is True
+
+
+def test_validate_notion_signature_header_rejects_tampered_body():
+    adapter = _adapter()
+    secret = "notion-verification-token"
+    original_body = b'{"type":"comment.created","entity":{"id":"page-id"}}'
+    tampered_body = b'{"type":"comment.updated","entity":{"id":"page-id"}}'
+    request = DummyRequest({"X-Notion-Signature": _notion_signature(secret, original_body)})
+
+    assert adapter._validate_signature(request, tampered_body, secret) is False
+
+
+def test_validate_notion_signature_header_is_case_insensitive():
+    adapter = _adapter()
+    secret = "notion-verification-token"
+    body = b'{"type":"page.content_updated","entity":{"id":"page-id"}}'
+    request = DummyRequest({"x-notion-signature": _notion_signature(secret, body)})
+
+    assert adapter._validate_signature(request, body, secret) is True

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -387,6 +387,7 @@ The adapter validates incoming webhook signatures using the appropriate method f
 
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
+- **Notion**: `X-Notion-Signature` header — `sha256=` + HMAC-SHA256 hex digest of the raw body. Set the route `secret` to your Notion webhook subscription **verification token**.
 - **Generic**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest
 
 If a secret is configured but no recognized signature header is present, the request is rejected.
@@ -454,6 +455,7 @@ This is the same trust model that applies to everything the agent reads: web pag
 - Ensure the secret in your route config exactly matches the secret configured in the webhook source
 - For GitHub, the secret is HMAC-based — check `X-Hub-Signature-256`
 - For GitLab, the secret is a plain token match — check `X-Gitlab-Token`
+- For Notion, set the route secret to the subscription verification token and check `X-Notion-Signature` (`sha256=<HMAC-SHA256 of the raw body>`)
 - Check gateway logs for `Invalid signature` warnings
 
 ### Event being ignored


### PR DESCRIPTION
This replaces #32284 with a surgical version of the actual bugfix.

Notion comment webhooks arrive with `X-Notion-Signature: sha256=<hex>`, but `_validate_signature` only handled Svix, GitHub, GitLab, and the generic `X-Webhook-Signature` header. That meant valid Notion deliveries fell through to the unrecognized-header path and returned `401 Invalid signature`.

## What this PR does

- adds an explicit `X-Notion-Signature` verification branch in `gateway/platforms/webhook.py`
- computes `sha256=<hmac_sha256_hex(secret, raw_body)>`
- compares with `hmac.compare_digest`
- keeps header lookup case-insensitive via the existing `_header()` helper
- adds regression tests for:
  - valid signature accepted
  - tampered body rejected
  - lowercase `x-notion-signature` header accepted

## Why a replacement PR

#32284 drifted beyond the signature bug into broader webhook queue/routing changes and is now conflicted. This PR isolates the concrete Notion signature fix so it is easy to review and merge.

## Testing

```bash
pytest tests/gateway/test_webhook_notion_signature.py -q
pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py tests/gateway/test_webhook_dynamic_routes.py tests/gateway/test_webhook_integration.py tests/gateway/test_webhook_signature_rate_limit.py -q
```

Results from local run:
- `3 passed`
- `102 passed`
