### PR TITLE
fix(memory): bind mem_dir at MemoryStore init to prevent cross-profile path drift

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -126,6 +126,8 @@ class MemoryStore:
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        # Bind mem_dir at creation to prevent cross-profile path drift (issue #54937).
+        self._mem_dir = get_memory_dir()
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
 
@@ -242,9 +244,10 @@ class MemoryStore:
                     pass
             fd.close()
 
-    @staticmethod
-    def _path_for(target: str) -> Path:
-        mem_dir = get_memory_dir()
+    def _path_for(self, target: str) -> Path:
+        # Use bound _mem_dir instead of re-resolving HERMES_HOME, which can
+        # change mid-process in single-process multi-profile WebUI (issue #54937).
+        mem_dir = self._mem_dir
         if target == "user":
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"


### PR DESCRIPTION
## Summary

`MemoryStore._path_for()` re-resolves `get_memory_dir()` (via `os.environ["HERMES_HOME"]`) on every write call. In single-process multi-profile WebUI deployments, `HERMES_HOME` changes when the active profile switches, causing `background_review` from profile A to write into profile B's `MEMORY.md`.

## Fix

Bind the memory directory once at `MemoryStore.__init__` time as `self._mem_dir`, and use it in `_path_for()` instead of re-reading the environment variable.

**Changes:**
- `tools/memory_tool.py`: Add `self._mem_dir = get_memory_dir()` in `__init__`
- `tools/memory_tool.py`: Change `_path_for` from `@staticmethod` to instance method using `self._mem_dir`

## Reproduction

1. Profile A and Profile B both have `memory_enabled: true`
2. Profile A's session triggers `background_review`
3. During review, `HERMES_HOME` points to Profile B (due to concurrent requests)
4. Review calls `memory(action=add)` → `_path_for()` reads current `HERMES_HOME` → writes to Profile B's `MEMORY.md`

## Related

- Issue: #54937
