### PR TITLE
feat(mcp): add SAP ADT integration for ABAP source analysis

### DIFF
--- a/optional-mcps/sap-adt/README.md
+++ b/optional-mcps/sap-adt/README.md
@@ -1,0 +1,70 @@
+# SAP ADT MCP
+
+Hermes integration for reading ABAP source code, CDS views, and repository objects from SAP systems via the [ADT REST API](https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide/adt-rest-api).
+
+Backed by [adt-mcp](https://github.com/I076453/adt-mcp) — a TypeScript MCP server with 270+ unit tests, surgical `EditSource` diffing, and built-in safety controls.
+
+## What you can do
+
+| Tool | What it does |
+|---|---|
+| `GetObjectSource` | Read full source of a program, class, function group, etc. |
+| `ListPackageContents` | Browse all objects in an ABAP package |
+| `SearchObjects` | Find objects by name pattern across the system |
+| `GetObjectProperties` | Metadata: object type, package, last changed by, transport |
+| `GetIncludes` | List all includes of a program or function group |
+| `GetCDSSource` | Read CDS view / BDEF / DCLS source |
+| `GetContext` | Compressed public API of a dependency (~80 lines vs 1000+) |
+| `RunATC` | Run ABAP Test Cockpit static analysis on an object |
+| `RunUnitTests` | Execute ABAP Unit tests with coverage metrics |
+| `GetDataPreview` | Preview table or CDS view data (SELECT top N) |
+
+## Prerequisites
+
+- Node.js 18+
+- Network access to your SAP system on the ADT port (default 8080)
+- An ABAP user with `S_ADT_RES` authorization
+
+## Configuration
+
+`SAP_SYSTEMS` is a JSON array. Each entry describes one system:
+
+```json
+[
+  {
+    "name": "QJ6",
+    "baseUrl": "https://your-sap-host:8080",
+    "username": "YOUR_USER",
+    "password": "YOUR_PASSWORD"
+  }
+]
+```
+
+Store this in `~/.hermes/.env`:
+
+```
+SAP_SYSTEMS='[{"name":"QJ6","baseUrl":"https://your-host:8080","username":"user","password":"pass"}]'
+SAP_READ_ONLY=true
+```
+
+### Optional: restrict to specific packages
+
+```
+SAP_ALLOWED_PACKAGES=ZRF_*,/EPD/*
+```
+
+Wildcards are supported. Leave unset to allow access to all packages.
+
+## Safety
+
+`SAP_READ_ONLY=true` (the default) blocks all write operations at the server level — Hermes cannot create, modify, or delete any object on the SAP system. This is the recommended setting for analysis workflows such as ABAP report-to-RAP conversion.
+
+Only set `SAP_READ_ONLY=false` on a dedicated development system, never on production.
+
+## Usage example
+
+```
+You: Read the source of report rf_steuerinfo from QJ6 and list all its includes.
+
+Hermes: [calls GetObjectSource → GetIncludes → analyses structure]
+```

--- a/optional-mcps/sap-adt/manifest.yaml
+++ b/optional-mcps/sap-adt/manifest.yaml
@@ -1,0 +1,89 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: sap-adt
+description: Read ABAP source code, CDS views, and repository objects from SAP systems via ADT.
+source: https://github.com/I076453/adt-mcp
+
+# adt-mcp is a TypeScript/Node.js MCP server that communicates with SAP systems
+# over the ADT REST API (the same protocol used by ABAP Development Tools in
+# Eclipse and VS Code). It is installed locally via git clone + npm install and
+# launched as a stdio subprocess by Hermes.
+#
+# SAFETY: This entry enables SAP_READ_ONLY mode by default. Hermes can read and
+# analyse ABAP objects but cannot create, modify, or delete anything on the SAP
+# system. This is the recommended setting for analysis and migration workflows
+# (e.g. ABAP report-to-RAP conversion). Users who need write access must
+# explicitly opt in by editing SAP_READ_ONLY to "false" in ~/.hermes/.env.
+transport:
+  type: stdio
+  command: "node"
+  args:
+    - "${INSTALL_DIR}/dist/index.js"
+
+install:
+  type: git
+  url: https://github.com/I076453/adt-mcp.git
+  ref: main
+  bootstrap:
+    - "npm install"
+    - "npm run build"
+
+auth:
+  type: api_key
+  env:
+    - name: SAP_SYSTEMS
+      prompt: "SAP system config as JSON (see README for format)"
+      required: true
+      secret: false
+    - name: SAP_READ_ONLY
+      prompt: "Restrict to read-only operations? (true/false)"
+      default: "true"
+      required: false
+      secret: false
+    - name: SAP_ALLOWED_PACKAGES
+      prompt: "Comma-separated package allowlist, e.g. Z_MY_PKG,/MY/PKG (leave blank for no restriction)"
+      required: false
+      secret: false
+
+# Tool selection at install time:
+# Read tools are enabled by default. All write/mutating tools (CreateObject,
+# EditSource, etc.) are excluded from the default set — SAP_READ_ONLY enforces
+# this at the server level too, but explicit default_enabled gives a clear
+# read-only surface in the Hermes tool checklist.
+tools:
+  default_enabled:
+    - GetObjectSource
+    - ListPackageContents
+    - SearchObjects
+    - GetObjectProperties
+    - GetIncludes
+    - GetCDSSource
+    - GetContext
+    - RunATC
+    - RunUnitTests
+    - GetDataPreview
+
+post_install: |
+  adt-mcp connects to SAP systems over the ADT REST API (port 8080 by default).
+  You need network access to the target SAP system from this machine.
+
+  SAP_SYSTEMS must be a JSON array describing your system(s), for example:
+
+    [{"name":"QJ6","baseUrl":"https://your-host:8080","username":"your-user","password":"your-pass"}]
+
+  Store that value in ~/.hermes/.env as SAP_SYSTEMS='[...]'.
+
+  READ-ONLY MODE is ON by default (SAP_READ_ONLY=true). In this mode the server
+  will reject any tool calls that modify objects on the SAP system. To allow
+  writes, set SAP_READ_ONLY=false — only do this for a dedicated development
+  system, never for production.
+
+  If you only want Hermes to access specific packages, set SAP_ALLOWED_PACKAGES
+  to a comma-separated list (wildcards supported, e.g. "ZRF_*,/EPD/*").
+
+  Start a new Hermes session after installation to load the SAP ADT tools.
+
+  Re-run the tool checklist any time with:
+    hermes mcp configure sap-adt


### PR DESCRIPTION
## What does this PR do?

Adds a new optional MCP catalog entry for SAP ABAP Development Tools (ADT). This allows Hermes to connect to SAP systems and read ABAP source code, CDS views, package contents, and run static analysis — without modifying anything on the backend.

The primary use case is ABAP migration workflows (e.g. converting legacy ABAP reports to modern RAP/ABAP Cloud objects). The integration defaults to `SAP_READ_ONLY=true` so it is safe to point at a real system from day one.

Backed by https://github.com/I076453/adt-mcp — a TypeScript MCP server with 270+ unit tests, built-in package allowlisting, and surgical `EditSource` diffing for when write access is eventually needed.

## Related Issue

N/A — this is a new catalog entry with no existing issue.

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] ✨ New feature (non-breaking change that adds functionality)
* [ ] 🔒 Security fix
* [x] 📝 Documentation update
* [ ] ✅ Tests (adding or improving test coverage)
* [ ] ♻️ Refactor (no behavior change)
* [ ] 🎯 New skill (bundled or hub)

## Changes Made

* `optional-mcps/sap-adt/manifest.yaml` — MCP catalog entry: stdio transport via `adt-mcp`, read-only default, `api_key` auth with `SAP_SYSTEMS` / `SAP_READ_ONLY` / `SAP_ALLOWED_PACKAGES` env vars, curated `default_enabled` tool list
* `optional-mcps/sap-adt/README.md` — setup instructions, configuration examples, safety notes, usage example

## How to Test

1. Run `hermes mcp install optional/sap-adt` (once catalog pickup is in place)
2. Set `SAP_SYSTEMS` in `~/.hermes/.env` pointing at a real or mock ADT endpoint
3. Start a Hermes session and verify the read tools appear: `GetObjectSource`, `ListPackageContents`, etc.
4. Confirm that write tools (e.g. `EditSource`) are blocked when `SAP_READ_ONLY=true`

## Checklist

### Code

* [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
* [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.) (`feat(mcp): add SAP ADT integration for ABAP source analysis`)
* [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
* [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
* [ ] I've run `pytest tests/ -q` and all tests pass (N/A — manifest-only, no Python code added)
* [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) (N/A — no executable code; the manifest is declarative config)
* [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

* [x] I've updated relevant documentation (README, `docs/`, docstrings) — README.md added
* [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
* [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
* [ ] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (manifest is platform-agnostic; `adt-mcp` is Node.js and runs cross-platform)
* [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A (tools are defined by the upstream `adt-mcp` server)

## For New Skills

N/A — this is an optional MCP entry, not a skill.

## Screenshots / Logs

N/A — declarative manifest, no runtime output to capture at PR time.