### PR TITLE
fix(memory): allow setup provider-specific args

### DIFF
--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -6,6 +6,7 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
 
 
@@ -31,6 +32,13 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         nargs="?",
         default=None,
         help="Provider to configure directly (e.g. honcho), skipping the picker",
+    )
+    _setup_parser.add_argument(
+        "provider_args",
+        nargs=argparse.REMAINDER,
+        default=[],
+        metavar="PROVIDER_ARG",
+        help="Provider-specific setup arguments passed through to the selected provider",
     )
     memory_sub.add_parser("status", help="Show current memory provider config")
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")

--- a/tests/hermes_cli/test_memory_setup_provider_arg.py
+++ b/tests/hermes_cli/test_memory_setup_provider_arg.py
@@ -7,13 +7,35 @@ because the per-provider ``hermes <provider>`` subcommand is only registered
 once that provider is active.
 """
 
+import argparse
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from hermes_cli import memory_setup
+from hermes_cli.subcommands.memory import build_memory_parser
+
+
+def _memory_parser():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_memory_parser(subparsers, cmd_memory=lambda args: None)
+    return parser
 
 
 class TestMemorySetupProviderRouting:
+    def test_setup_accepts_provider_specific_args(self):
+        args = _memory_parser().parse_args([
+            "memory",
+            "setup",
+            "mem0",
+            "--mode",
+            "oss",
+            "--dry-run",
+        ])
+
+        assert args.provider == "mem0"
+        assert args.provider_args == ["--mode", "oss", "--dry-run"]
+
     def test_setup_with_provider_arg_skips_picker(self):
         """`memory setup honcho` routes straight to cmd_setup_provider."""
         args = SimpleNamespace(memory_command="setup", provider="honcho")


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes memory setup mem0 --mode oss ... --dry-run` being rejected by the top-level parser before provider setup runs. The provider already parses its own setup flags; this keeps the core parser generic by accepting the remaining provider-specific arguments with `argparse.REMAINDER`.

Fixes #54945.

## Changes

- Add the generic `provider_args` remainder to `memory setup <provider>`.
- Add focused parser regression coverage for provider-specific flags.

This branch was rebuilt on current `main` after review. The superseded self-hosted backend, setup, and scope commits are no longer included.

## Verification

- RED on current `main`: the focused test failed with `SystemExit: 2` and `unrecognized arguments: --mode oss --dry-run`.
- GREEN: `scripts/run_tests.sh tests/hermes_cli/test_memory_setup_provider_arg.py -q` — 8 passed.
- `ruff check hermes_cli/subcommands/memory.py tests/hermes_cli/test_memory_setup_provider_arg.py` — passed.
- `git diff --check` — passed.

## Checklist

- [x] Bug fix is limited to the reported parser boundary.
- [x] Behavioral regression test added.
- [x] Branch refreshed from current `main`.
- [x] No dependency, config, runtime, or documentation changes.
