### PR TITLE
docs(contributing): fix incorrect xdist reference in run_tests comment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1280,7 +1280,7 @@ def profile_env(tmp_path, monkeypatch):
 
 **ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces
 hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8,
-`-n auto` xdist workers, in-tree subprocess-isolation plugin). Direct `pytest`
+per-file subprocess isolation (one `python -m pytest <file>` per file, no xdist)). Direct `pytest`
 on a 16+ core developer machine with API keys set diverges from CI in ways
 that have caused multiple "works locally, fails in CI" incidents (and the reverse).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,7 @@ ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
 ### Run tests
 
 ```bash
-# Preferred — matches CI (hermetic env, 4 xdist workers); see AGENTS.md
+# Preferred — matches CI (hermetic env, per-file isolation); see AGENTS.md
 scripts/run_tests.sh
 
 # Alternative (activate the venv first). The wrapper is still recommended


### PR DESCRIPTION
## Summary

The comment above \scripts/run_tests.sh\ in CONTRIBUTING.md described the runner as using \4 xdist workers\:

\\\ash
# Preferred — matches CI (hermetic env, 4 xdist workers); see AGENTS.md
scripts/run_tests.sh
\\\

However, \scripts/run_tests.sh\ itself explicitly states:

> Per-file isolation via \scripts/run_tests_parallel.py\ — each test file runs in its own freshly-spawned \python -m pytest <file>\ subprocess. **No xdist, no shared workers**, no module-level leakage between files.

The runner uses a custom per-file subprocess parallel strategy, not pytest-xdist. Updated the comment to match the actual behavior.

## Validation

Docs-only change. Verified by reading \scripts/run_tests.sh\ header and comparing against the corrected comment. No runtime code modified.

Checked open PRs for overlap: [#44482](https://github.com/NousResearch/hermes-agent/pull/44482) addresses \website/docs/developer-guide/contributing.md\ (the published docs site); this PR corrects the root \CONTRIBUTING.md\ file.