### PR TITLE
fix(dashboard-auth): skip auto-SSO redirect for password-only providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -182,9 +182,14 @@ def _auto_sso_response(request: Request) -> Response | None:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None
 
-    from hermes_cli.dashboard_auth.prefix import prefix_from_request
-
     provider = providers[0]
+    # Password-only providers (e.g. BasicAuthProvider) have no OAuth redirect
+    # flow — start_login() raises NotImplementedError.  They need the
+    # interstitial /login form, so skip auto-SSO for them.
+    if getattr(provider, "supports_password", False):
+        return None
+
+    from hermes_cli.dashboard_auth.prefix import prefix_from_request
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
## Summary

`_auto_sso_response()` in `hermes_cli/dashboard_auth/middleware.py` auto-redirects unauthenticated HTML navigations to `/auth/login?provider=<name>` when exactly one interactive provider is registered. This is an optimization for the OAuth (Nous Portal) case — it skips the `/login` interstitial click.

**Bug:** When the sole registered provider is password-only (e.g. `BasicAuthProvider` with `supports_password = True`), the redirect hits `/auth/login` → `p.start_login()` → `NotImplementedError`:

```
NotImplementedError: BasicAuthProvider is password-only; there is no OAuth redirect flow.
The login page POSTs to /auth/password-login instead.
```

This produces an **Internal Server Error** on every unauthenticated dashboard load when basic auth is the only provider — the user never sees the login form.

## Fix

Skip the auto-SSO redirect when the single provider has `supports_password = True`. Falls through to `_unauth_response()` → the `/login` interstitial, which renders the credential form and POSTs to `/auth/password-login` as designed.

## Reproduction

1. Configure `dashboard.basic_auth` (username + password_hash) in config.yaml with no OAuth provider
2. Start dashboard on a non-loopback host: `hermes dashboard --host 0.0.0.0 --port 9119`
3. Visit the dashboard URL → 500 Internal Server Error

## Test plan

- [ ] Dashboard with only BasicAuthProvider configured loads the `/login` interstitial form
- [ ] Dashboard with only OAuth provider still auto-redirects to OAuth (no regression)
- [ ] Dashboard with 2+ providers still shows `/login` chooser (no regression)