### PR TITLE
fix(gateway): strip internal tool-trace banners from chat output

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2250,6 +2250,24 @@ def _strip_media_directives(text: str) -> str:
     return _strip_media_tag_directives(text)
 
 
+_INTERNAL_TOOL_TRACE_LINE_RE = re.compile(
+    r"(?im)^[ \t]*(?:\u26a0\ufe0f?\s*)?\U0001f6e0\ufe0f?\s*"
+    r"`[^`\r\n]*(?:\(|\b)agent(?:\)|\b)[^`\r\n]*`\s+"
+    r"(?:failed|errored|timed\s+out|cancelled|canceled|blocked)\b[^\r\n]*(?:\r?\n|$)"
+)
+
+
+def strip_internal_tool_trace_lines(text: str) -> str:
+    """Strip internal assistant tool-trace lines from user-visible chat text."""
+    if not text:
+        return text
+    if "\U0001f6e0" not in text and "agent" not in str(text).lower():
+        return text
+    cleaned = _INTERNAL_TOOL_TRACE_LINE_RE.sub("", str(text))
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.rstrip()
+
+
 class BasePlatformAdapter(ABC):
     """
     Base class for platform adapters.
@@ -3677,20 +3695,24 @@ class BasePlatformAdapter(ABC):
 
     @staticmethod
     def strip_media_directives_for_display(text: str) -> str:
-        """Strip MEDIA: directives from streamed/display text.
+        """Strip internal directives from streamed/display text.
 
         Known-extension tags are removed unconditionally (same as
         ``MEDIA_TAG_CLEANUP_RE``). Extension-less tags are removed only when
         ``validate_media_delivery_path`` accepts the path so undeliverable
-        paths stay visible for debugging.
+        paths stay visible for debugging. Internal assistant tool-trace lines
+        are also removed before content is shown to users.
         """
-        if (
-            "MEDIA:" not in text
-            and "[[audio_as_voice]]" not in text
-            and "[[as_document]]" not in text
-        ):
+        has_media_directive = (
+            "MEDIA:" in text
+            or "[[audio_as_voice]]" in text
+            or "[[as_document]]" in text
+        )
+        has_tool_trace = "\U0001f6e0" in text and "agent" in str(text).lower()
+        if not has_media_directive and not has_tool_trace:
             return text
-        cleaned = _strip_media_tag_directives(text)
+        cleaned = _strip_media_tag_directives(text) if has_media_directive else str(text)
+        cleaned = strip_internal_tool_trace_lines(cleaned)
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
         return cleaned.rstrip()
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2881,6 +2881,28 @@ def _strip_media_directives(text: str) -> str:
     return _strip_media_tag_directives(text)
 
 
+_INTERNAL_TOOL_TRACE_LINE_RE = re.compile(
+    r"(?im)^[ \t]*(?:\u26a0\ufe0f?\s*)?\U0001f6e0\ufe0f?\s*"
+    r"`[^`\r\n]*(?:\(|\b)agent(?:\)|\b)[^`\r\n]*`\s+"
+    r"(?:failed|errored|timed\s+out|cancelled|canceled|blocked)\b[^\r\n]*(?:\r?\n|$)"
+)
+_INTERNAL_TOOL_TRACE_STREAM_PREFIX_RE = re.compile(
+    r"(?i)^[ \t]*(?:\u26a0\ufe0f?\s*)?\U0001f6e0\ufe0f?\s*"
+    r"`[^`\r\n]*(?:\(|\b)agent(?:\)|\b)[^`\r\n]*`\s*"
+)
+
+
+def strip_internal_tool_trace_lines(text: str) -> str:
+    """Strip internal assistant tool-trace lines from user-visible chat text."""
+    if not text:
+        return text
+    if "\U0001f6e0" not in text and "agent" not in str(text).lower():
+        return text
+    cleaned = _INTERNAL_TOOL_TRACE_LINE_RE.sub("", str(text))
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.rstrip()
+
+
 class BasePlatformAdapter(ABC):
     """
     Base class for platform adapters.
@@ -4974,20 +4996,27 @@ class BasePlatformAdapter(ABC):
 
     @staticmethod
     def strip_media_directives_for_display(text: str) -> str:
-        """Strip MEDIA: directives from streamed/display text.
+        """Strip internal directives from streamed/display text.
 
         Known-extension tags are removed unconditionally (same as
         ``MEDIA_TAG_CLEANUP_RE``). Extension-less tags are removed only when
         ``validate_media_delivery_path`` accepts the path so undeliverable
-        paths stay visible for debugging.
+        paths stay visible for debugging. Internal assistant tool-trace lines
+        are also removed before content is shown to users.
         """
-        if (
-            "MEDIA:" not in text
-            and "[[audio_as_voice]]" not in text
-            and "[[as_document]]" not in text
-        ):
+        has_media_directive = (
+            "MEDIA:" in text
+            or "[[audio_as_voice]]" in text
+            or "[[as_document]]" in text
+        )
+        has_tool_trace = "\U0001f6e0" in text and "agent" in str(text).lower()
+        if not has_media_directive and not has_tool_trace:
             return text
-        cleaned = _strip_media_tag_directives(text)
+        cleaned = _strip_media_tag_directives(text) if has_media_directive else str(text)
+        cleaned = strip_internal_tool_trace_lines(cleaned)
+        tail = cleaned.rsplit("\n", 1)[-1]
+        if _INTERNAL_TOOL_TRACE_STREAM_PREFIX_RE.match(tail):
+            cleaned = cleaned[:-len(tail)]
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
         return cleaned.rstrip()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -425,7 +425,9 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     if _gateway_surface_passes_raw_text(platform):
         return text
 
-    redacted = _redact_gateway_user_facing_secrets(str(text))
+    redacted = strip_internal_tool_trace_lines(
+        _redact_gateway_user_facing_secrets(str(text))
+    )
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted
@@ -443,7 +445,7 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     if _gateway_surface_passes_raw_text(platform):
         return text
 
-    text = _redact_gateway_user_facing_secrets(text)
+    text = strip_internal_tool_trace_lines(_redact_gateway_user_facing_secrets(text))
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
         return None
     if _looks_like_gateway_provider_error(text):
@@ -1723,6 +1725,7 @@ from gateway.platforms.base import (
     MessageType,
     _reply_anchor_for_event,
     merge_pending_message_event,
+    strip_internal_tool_trace_lines,
 )
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -749,7 +749,9 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     if str(text).strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX):
         return ""
 
-    redacted = _redact_gateway_user_facing_secrets(str(text))
+    redacted = strip_internal_tool_trace_lines(
+        _redact_gateway_user_facing_secrets(str(text))
+    )
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted
@@ -767,7 +769,9 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     if _gateway_surface_passes_raw_text(platform):
         return text
 
-    text = _redact_gateway_user_facing_secrets(text)
+    text = strip_internal_tool_trace_lines(_redact_gateway_user_facing_secrets(text))
+    if not text:
+        return None
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
         # Opt-in #52995: `compression.progress_notices: true` lets ROUTINE
         # compression progress statuses through to chat platforms. The
@@ -2477,6 +2481,7 @@ from gateway.platforms.base import (
     _reply_anchor_for_event,
     build_auto_tts_output_path,
     merge_pending_message_event,
+    strip_internal_tool_trace_lines,
     utf16_len,
 )
 from gateway.shutdown_watchdog import (

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -84,6 +84,21 @@ class TestCleanForDisplay:
         # But "media:" is lowercase so won't match either
         assert result == text
 
+    def test_internal_tool_trace_line_stripped(self):
+        """Internal tool-trace banners are removed from streamed display text."""
+        text = (
+            "Done.\n"
+            "\u26a0\ufe0f \U0001f6e0\ufe0f `search repos (agent)` failed"
+        )
+
+        assert GatewayStreamConsumer._clean_for_display(text) == "Done."
+
+    def test_ordinary_tool_failure_prose_preserved(self):
+        """Normal explanations about failed tools are not trace banners."""
+        text = "The `pytest` command failed; rerun it after installing pytest."
+
+        assert GatewayStreamConsumer._clean_for_display(text) == text
+
 
 # ── Integration: _send_or_edit strips MEDIA: ─────────────────────────────
 

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -72,6 +72,21 @@ class TestCleanForDisplay:
         assert "[[audio_as_voice]]" not in result
         assert "MEDIA:" not in result
 
+    def test_internal_tool_trace_line_stripped(self):
+        """Internal tool-trace banners are removed from streamed display text."""
+        text = (
+            "Done.\n"
+            "\u26a0\ufe0f \U0001f6e0\ufe0f `search repos (agent)` failed"
+        )
+
+        assert GatewayStreamConsumer._clean_for_display(text) == "Done."
+        assert GatewayStreamConsumer._clean_for_display(text.removesuffix("led")) == "Done."
+
+    def test_ordinary_tool_failure_prose_preserved(self):
+        """Normal explanations about failed tools are not trace banners."""
+        text = "The `pytest` command failed; rerun it after installing pytest."
+
+        assert GatewayStreamConsumer._clean_for_display(text) == text
 
 # ── Integration: _send_or_edit strips MEDIA: ─────────────────────────────
 

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -144,6 +144,36 @@ def test_chat_gateways_keep_normal_answers(platform):
     assert _sanitize_gateway_final_response(platform, answer) == answer
 
 
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_strip_internal_tool_trace_lines(platform):
+    """Internal tool trace banners must not be delivered as chat content."""
+    raw = (
+        "Done.\n"
+        "\u26a0\ufe0f \U0001f6e0\ufe0f `search repos (agent)` failed"
+    )
+
+    assert _sanitize_gateway_final_response(platform, raw) == "Done."
+
+
+def test_programmatic_surfaces_keep_internal_tool_trace_lines():
+    """Local/API/webhook diagnostics keep raw tool trace text."""
+    raw = (
+        "Done.\n"
+        "\u26a0\ufe0f \U0001f6e0\ufe0f `search repos (agent)` failed"
+    )
+
+    for platform in ("local", "api_server", "webhook", "msgraph_webhook"):
+        assert _sanitize_gateway_final_response(platform, raw) == raw
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_preserve_ordinary_tool_failure_prose(platform):
+    """Only internal trace banners are stripped; normal explanation stays."""
+    answer = "The `pytest` command failed; rerun it after installing pytest."
+
+    assert _sanitize_gateway_final_response(platform, answer) == answer
+
+
 def test_telegram_status_sanitizes_raw_provider_security_errors():
     """Provider policy/security bodies should be replaced before chat delivery."""
     raw = (

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -255,6 +255,45 @@ def test_chat_gateways_drop_interrupt_sentinel(platform):
     assert _sanitize_gateway_final_response("local", sentinel) == sentinel
 
 
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_strip_internal_tool_trace_lines(platform):
+    """Internal tool trace banners must not be delivered as chat content."""
+    raw = (
+        "Done.\n"
+        "\u26a0\ufe0f \U0001f6e0\ufe0f `search repos (agent)` failed"
+    )
+
+    assert _sanitize_gateway_final_response(platform, raw) == "Done."
+
+
+def test_programmatic_surfaces_keep_internal_tool_trace_lines():
+    """Local/API/webhook diagnostics keep raw tool trace text."""
+    raw = (
+        "Done.\n"
+        "\u26a0\ufe0f \U0001f6e0\ufe0f `search repos (agent)` failed"
+    )
+
+    for platform in ("local", "api_server", "webhook", "msgraph_webhook"):
+        assert _sanitize_gateway_final_response(platform, raw) == raw
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_preserve_ordinary_tool_failure_prose(platform):
+    """Only internal trace banners are stripped; normal explanation stays."""
+    answer = "The `pytest` command failed; rerun it after installing pytest."
+
+    assert _sanitize_gateway_final_response(platform, answer) == answer
+
+
+def test_status_tool_trace_banner_stripped_only_for_chat():
+    """Status delivery shares the chat/raw sanitizer boundary."""
+    raw = "Done.\n⚠️ 🛠️ `search repos (agent)` failed"
+
+    assert _prepare_gateway_status_message("telegram", "warn", raw) == "Done."
+    assert _prepare_gateway_status_message("telegram", "warn", raw[5:]) is None
+    assert _prepare_gateway_status_message("local", "warn", raw) == raw
+
+
 def test_telegram_status_sanitizes_raw_provider_security_errors():
     """Provider policy/security bodies should be replaced before chat delivery."""
     raw = (


### PR DESCRIPTION
﻿## Summary

- add a shared user-visible text sanitizer for internal tool-trace banner lines, for example:

```text
\u26a0\ufe0f \U0001f6e0\ufe0f `search repos (agent)` failed
```

- apply it to chat final-response/status sanitization while preserving raw programmatic surfaces
- apply the same cleanup to `GatewayStreamConsumer._clean_for_display()` so streamed chat text gets the same backstop

## Context

This ports the same outbound boundary covered by OpenClaw's recent Slack/Matrix fixes:

- openclaw/openclaw#97367
- openclaw/openclaw#97372

Fixes #54957.

## Duplicate Audit

Related but not a duplicate of #38732: that PR blocks stale commentary after final delivery and fixes a Telegram duplicate-send path. This PR is a narrower outbound sanitizer for already-assembled chat text that contains internal tool-trace banner lines, and it applies to final responses, status messages, and streaming display cleanup across chat surfaces while preserving raw local/API/webhook diagnostics.

Also adjacent to #30574, #53334, and #54865, but those cover compression/status/error/runtime notices. This PR only strips the internal tool-trace banner shape shown above.

## Tests

- `TMP=.tmp-pytest TEMP=.tmp-pytest TMPDIR=.tmp-pytest .\.venv\Scripts\python.exe -m pytest tests/gateway/test_telegram_noise_filter.py tests/gateway/test_stream_consumer.py -q` (325 passed)
- `TMP=.tmp-pytest TEMP=.tmp-pytest TMPDIR=.tmp-pytest .\.venv\Scripts\python.exe -m ruff check gateway/platforms/base.py gateway/run.py gateway/stream_consumer.py tests/gateway/test_telegram_noise_filter.py tests/gateway/test_stream_consumer.py`
- `git diff --check`
