### PR TITLE
Fix MarkupError crash when a single-query prompt contains Rich markup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15667,7 +15667,7 @@ def main(
                 # invocations are fast.
                 _query_label = query or ("[image attached]" if single_query_images else "")
                 if _query_label:
-                    cli.console.print(f"[bold blue]Query:[/] {_query_label}")
+                    cli.console.print(f"[bold blue]Query:[/] {_escape(_query_label)}")
                 # Surface security advisories before the agent runs — short
                 # banner, doesn't depend on the welcome banner being shown.
                 cli._show_security_advisories()


### PR DESCRIPTION
## Problem

`hermes chat -q "<prompt>"` echoes the query via:

```python
cli.console.print(f"[bold blue]Query:[/] {_query_label}")
```

`_query_label` is the full query, interpolated into a **Rich markup** string. Any prompt containing a Rich-significant token — most commonly a *closing* tag such as `[/foo]` — raises `rich.errors.MarkupError` and **aborts the agent at startup, before any model call**.

### Reproduction (pre-fix)
```
$ hermes chat -q 'see [/foo] done'
...
rich.errors.MarkupError: closing tag '[/foo]' at position N doesn't match any open tag
```
This bites any automated/headless caller whose prompt (or injected context) can contain `[/...]` — e.g. a prompt that quotes CLI usage like `--body[/--ref]`.

## Fix

Escape the label with the already-imported `_escape` (`rich.markup.escape`, imported at the top of `cli.py`):

```python
cli.console.print(f"[bold blue]Query:[/] {_escape(_query_label)}")
```

This is **display-only** — the agent still receives the raw query via `cli.chat(query, ...)`. The echoed `Query:` line now renders the token literally instead of crashing. Open tags like `[--ref x]` were already tolerated; only mismatched/closing tags triggered the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)