### PR TITLE
chore(honcho): upgrade honcho-ai SDK 2.0.1 -> 2.1.2

### DIFF
--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -510,15 +510,15 @@ def _ensure_sdk_installed() -> bool:
         pass
 
     print("  honcho-ai is not installed.")
-    answer = _prompt("Install it now? (honcho-ai>=2.0.1)", default="y")
+    answer = _prompt("Install it now? (honcho-ai>=2.1.2)", default="y")
     if answer.lower() not in {"y", "yes"}:
-        print("  Skipping install. Run: pip install 'honcho-ai>=2.0.1'\n")
+        print("  Skipping install. Run: pip install 'honcho-ai>=2.1.2'\n")
         return False
 
     import subprocess
     print("  Installing honcho-ai...", flush=True)
     result = subprocess.run(
-        [sys.executable, "-m", "pip", "install", "honcho-ai>=2.0.1"],
+        [sys.executable, "-m", "pip", "install", "honcho-ai>=2.1.2"],
         capture_output=True,
         text=True,
         stdin=subprocess.DEVNULL,
@@ -528,7 +528,7 @@ def _ensure_sdk_installed() -> bool:
         return True
     else:
         print(f"  Install failed:\n{result.stderr.strip()}")
-        print("  Run manually: pip install 'honcho-ai>=2.0.1'\n")
+        print("  Run manually: pip install 'honcho-ai>=2.1.2'\n")
         return False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ pty = [
   # any existing `pip install hermes-agent[pty]` invocations resolve cleanly
   # without pulling in extra packages.
 ]
-honcho = ["honcho-ai==2.0.1"]
+honcho = ["honcho-ai==2.1.2"]
 # Cloud memory providers — opt-in, lazy-installed via tools/lazy_deps.py
 # (memory.supermemory / memory.mem0) at first use. Exact pins MUST match the
 # LAZY_DEPS pins (enforced by tests/test_project_metadata.py). Deliberately

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -135,7 +135,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "image.fal": ("fal-client==0.13.1",),
 
     # ─── Memory providers ──────────────────────────────────────────────────
-    "memory.honcho": ("honcho-ai==2.0.1",),
+    "memory.honcho": ("honcho-ai==2.1.2",),
     "memory.hindsight": ("hindsight-client==0.6.1",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed

--- a/uv.lock
+++ b/uv.lock
@@ -1774,7 +1774,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
     { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
-    { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.0.1" },
+    { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.1.2" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.5.3" },
@@ -1881,16 +1881,16 @@ wheels = [
 
 [[package]]
 name = "honcho-ai"
-version = "2.0.1"
+version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/30/d30ba159404050d53b4b1b1c4477f9591f43af18758be1fb7dab6afbfe7d/honcho_ai-2.0.1.tar.gz", hash = "sha256:6fdeebf9454e62bc523d57888e50359e67baafdb21f68621f9c14e08dc00623a", size = 46732, upload-time = "2026-02-09T21:03:26.99Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/15/31d391c007047cd40cd05943312d807b16f7b977c168fce1f3efdc8dff27/honcho_ai-2.1.2.tar.gz", hash = "sha256:f2c01463931e1a16cc4396790e1b0387d596fb5eb8d6dc830d6ab742f8701224", size = 48699, upload-time = "2026-05-23T21:55:29.205Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/de/83fda0c057cfa11d6b5ed532623184591aa7dcff4a067934ba6811026229/honcho_ai-2.0.1-py3-none-any.whl", hash = "sha256:94887e61d59f353e1e1e20b395858040780f5d67ca1e9d450538646544e4e42f", size = 56780, upload-time = "2026-02-09T21:03:25.992Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c3/e8aa785fd37092e856be70dbe53b4f289ba6500392cdc727ebb6f1cdbea4/honcho_ai-2.1.2-py3-none-any.whl", hash = "sha256:a22220f01a63f6a3c1d4625aaef0a142577b83981c42dcb61177631863fbaa4f", size = 58910, upload-time = "2026-05-23T21:55:30.3Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Upgrades the `honcho-ai` SDK from `2.0.1` to `2.1.2` (latest 2.x).

Bumped in all four places the version is referenced:
- `pyproject.toml` — `honcho` extra
- `tools/lazy_deps.py` — runtime lazy-install pin
- `plugins/memory/honcho/cli.py` — setup install hints (`>=2.1.2`)
- `uv.lock` — locked version + hashes (honcho-ai only; no other packages touched)

## Why

Keep the memory plugin on the current Honcho SDK.

## Compatibility

`2.1.2` is an additive minor release. Diffing the SDK source against `2.0.1`, every symbol the plugin uses is preserved:

- `Honcho`, `SessionPeerConfig`
- `.peer` / `.session` / `.chat` / `.context` / `.search` / `.representation` / `.add_messages` / `.add_peers` / `.upload_file` / `.workspaces`

No public methods were removed or had signatures changed (the only `client.py`/`session.py` deltas are new methods plus an internal closure-param rename). No new required transitive deps — still `httpx`, `pydantic`, `typing-extensions`.

## Testing

- `tests/honcho_plugin/` + `test_honcho_session_context` + client config/concurrency + startup-fail-open + `test_memory_provider_init` → **398 passed**
- `tests/tools/test_lazy_deps.py` → **61 passed**
