### PR TITLE
fix(openviking): default viking_search to user namespace when no scope given

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -399,7 +399,10 @@ SEARCH_SCHEMA = {
         "Semantic search over the OpenViking knowledge base. "
         "Returns ranked results with viking:// URIs for deeper reading. "
         "Use mode='deep' for complex queries that need reasoning across "
-        "multiple sources, 'fast' for simple lookups."
+        "multiple sources, 'fast' for simple lookups. "
+        "By default, search is scoped to the current user's namespace "
+        "(viking://user/{user}/peers/{agent}/). Pass an explicit 'scope' "
+        "(e.g. 'viking://resources/') to search elsewhere."
     ),
     "parameters": {
         "type": "object",
@@ -3379,6 +3382,36 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 return False
         return None
 
+    def _compute_default_search_target_uri(self) -> Optional[str]:
+        """Return the default ``target_uri`` for an un-scoped search.
+
+        OpenViking's dev-mode retrieval hardcodes the ``default`` tenant
+        in the request context, so un-scoped searches never visit the
+        actual user's URI and return zero results. We default to the
+        user's own namespace so un-scoped calls work in the common case.
+
+        Resolution order:
+          1. ``OPENVIKING_SEARCH_DEFAULT_TARGET_URI`` env var (full override)
+          2. ``viking://user/{user}/peers/{agent}/`` derived from the
+             configured account/user/agent (the path where ``viking_remember``
+             actually stores content for the local user)
+          3. ``None`` — fall through to OpenViking's built-in default
+        """
+        env_override = os.environ.get("OPENVIKING_SEARCH_DEFAULT_TARGET_URI", "").strip()
+        if env_override:
+            return env_override
+        if not self._client:
+            return None
+        user = (self._client._user or "").strip()
+        agent = (self._client._agent or "").strip()
+        # Skip the synthetic "default" tenant — that would just put us
+        # back into the hardcoded namespace we're trying to escape.
+        if not user or user == "default":
+            return None
+        if not agent or agent == "default":
+            return f"viking://user/{user}/"
+        return f"viking://user/{user}/peers/{agent}/"
+
     def _tool_search(self, args: dict) -> str:
         query = args.get("query", "")
         if not query:
@@ -3388,6 +3421,16 @@ class OpenVikingMemoryProvider(MemoryProvider):
         mode = args.get("mode", "auto")
         if args.get("scope"):
             payload["target_uri"] = args["scope"]
+        else:
+            # When no explicit scope is provided, default to the user's own
+            # namespace. OpenViking's dev-mode retrieval otherwise hardcodes
+            # the "default" tenant and never visits the actual user's URI,
+            # which makes un-scoped searches return zero results for any
+            # real user. The default can be overridden via the
+            # OPENVIKING_SEARCH_DEFAULT_TARGET_URI env var.
+            default_target = self._compute_default_search_target_uri()
+            if default_target:
+                payload["target_uri"] = default_target
         if args.get("limit"):
             payload["limit"] = args["limit"]
 


### PR DESCRIPTION
## Problem

`viking_search` (the OpenViking memory provider exposed by hermes-agent) returns zero results for un-scoped queries, even when the same user just stored content via `viking_remember` in the same session.

## Root cause

OpenViking's HTTP server (v0.4.5) hardcodes the tenant to `default` in dev-mode auth when no `X-OpenViking-User` header is present (see `openviking/server/auth/__init__.py: get_request_context`, lines 130-138):

```python
ctx = RequestContext(
    user=UserIdentifier(
        identity.account_id or "default",
        identity.user_id or "default",
    ),
    ...
)
```

The retriever uses that context to compute its default `target_uri` and never visits the actual user's namespace (`viking://user/{user}/peers/{agent}/`, where `viking_remember` actually writes content). The server's vector index is global, so the data is there — the retrieval just never looks at the right URI.

End result: agents call `viking_search('my note about X')` and get back `{memories: [], total: 0}`, then conclude nothing was saved. The user is left wondering why their memory is empty.

## Fix

When `viking_search` is called without an explicit `scope`, derive a default `target_uri` from the configured account/user/agent identity that the client already has. Default scope is `viking://user/{user}/peers/{agent}/` — the URI where `viking_remember` actually writes.

Resolution order (in `_compute_default_search_target_uri`):
1. `OPENVIKING_SEARCH_DEFAULT_TARGET_URI` env var (full override)
2. `viking://user/{user}/peers/{agent}/` from the client config
3. `None` — fall through to OpenViking's built-in default (preserves existing behavior for users with `OPENVIKING_USER=default`)

The synthetic `default` tenant is intentionally skipped — that's the namespace we're trying to escape from.

## Test plan

- [x] Manual reproduction (before fix): `viking_search('surf')` → `total: 0` despite notes existing at `viking://user/carlo/peers/hermes/memories/preferences/`
- [x] Manual reproduction (after fix): `viking_search('surf')` → `total: 2` with scores 0.56 and 0.22
- [x] Explicit `scope` parameter still wins (no regression)
- [x] Empty/missing user config falls through gracefully

## Out of scope

This only addresses the *client-side* default. The underlying server bug (dev-mode auth hardcoding `default`) lives in the OpenViking repo and should be reported there separately. This fix makes the hermes-agent plugin work correctly regardless of when that upstream bug gets fixed.

## Files changed

- `plugins/memory/openviking/__init__.py` (+44 / -1):
  - New helper: `_compute_default_search_target_uri()`
  - `_tool_search` uses it when no `scope` arg is passed
  - Schema description updated to document the default behavior