### PR TITLE
feat(feishu): add render_mode config to opt into native table rendering (#54951)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -761,6 +761,14 @@ platform_toolsets:
 #         priority_mode: prepend
 #         priority:
 #           - my_plugin_command
+#   feishu:
+#     extra:
+#       # Outbound markdown-table rendering. "auto" (default) downgrades tables
+#       # to plain text because Feishu's `md` element does not reliably render
+#       # them; "card" routes tables through the post pipeline (with automatic
+#       # plain-text fallback if Feishu rejects the payload). `renderMode` also
+#       # accepted for OpenClaw-style config compatibility.
+#       render_mode: auto  # auto | card
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -396,6 +396,11 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    # Outbound table rendering. "auto" (default) keeps the safe behaviour of
+    # downgrading markdown-table content to plain text. "card" opts in to routing
+    # tables through the native post/`md` pipeline (with the same automatic
+    # plain-text fallback if Feishu rejects the payload).
+    render_mode: str = "auto"  # "auto" | "card"
 
 
 @dataclass
@@ -1525,6 +1530,18 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             allow_bots = "none"
 
+        # Outbound table rendering mode. Accept the OpenClaw-style camelCase
+        # `renderMode` key as well as the repo-conventional snake_case.
+        render_mode = str(
+            extra.get("render_mode") or extra.get("renderMode") or "auto"
+        ).strip().lower()
+        if render_mode not in {"auto", "card"}:
+            logger.warning(
+                "[Feishu] Unknown render_mode=%r, falling back to 'auto'. Valid: auto, card.",
+                render_mode,
+            )
+            render_mode = "auto"
+
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
             app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
@@ -1587,6 +1604,7 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            render_mode=render_mode,
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1619,6 +1637,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._render_mode = settings.render_mode
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -4442,12 +4461,18 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # Feishu post-type 'md' elements do not reliably render markdown tables;
+        # by default we force plain text for anything that looks like a table so
+        # the message never arrives blank. When render_mode is "card" the operator
+        # opts in to routing tables through the post pipeline anyway — the send
+        # path already falls back to plain text if Feishu rejects the payload.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            if self._render_mode != "card":
+                text_payload = {"text": content}
+                return "text", json.dumps(text_payload, ensure_ascii=False)
+            # Card mode: route the table (which _MARKDOWN_HINT_RE may not match on
+            # its own) through the post pipeline.
+            return "post", _build_markdown_post_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -504,6 +504,56 @@ class TestAdapterModule(unittest.TestCase):
         self.assertIsNone(settings.ws_ping_interval)
         self.assertIsNone(settings.ws_ping_timeout)
 
+    def test_load_settings_defaults_render_mode_to_auto(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings({})
+
+        self.assertEqual(settings.render_mode, "auto")
+
+    def test_load_settings_accepts_card_render_mode(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        # snake_case and OpenClaw-style camelCase both resolve.
+        self.assertEqual(
+            FeishuAdapter._load_settings({"render_mode": "CARD"}).render_mode, "card"
+        )
+        self.assertEqual(
+            FeishuAdapter._load_settings({"renderMode": "card"}).render_mode, "card"
+        )
+
+    def test_load_settings_falls_back_on_unknown_render_mode(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings({"render_mode": "bogus"})
+
+        self.assertEqual(settings.render_mode, "auto")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_table_defaults_to_text(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        table = "| Name | Age |\n| --- | --- |\n| Ada | 36 |"
+
+        msg_type, _payload = adapter._build_outbound_payload(table)
+
+        self.assertEqual(msg_type, "text")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_table_uses_post_in_card_mode(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"render_mode": "card"}))
+        table = "| Name | Age |\n| --- | --- |\n| Ada | 36 |"
+
+        msg_type, payload = adapter._build_outbound_payload(table)
+
+        self.assertEqual(msg_type, "post")
+        self.assertIn("Ada", payload)
+
     def test_runtime_ws_overrides_reapply_after_sdk_configure(self):
         import sys
         from types import ModuleType

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -420,6 +420,28 @@ If the Feishu API rejects the post payload (e.g., due to unsupported markdown co
 
 Plain text messages (no markdown detected) are sent as the simple `text` message type.
 
+### Markdown Tables (`render_mode`)
+
+Feishu's `md` element does not reliably render GFM markdown tables, so by default
+the adapter downgrades any message containing a table to plain text — the table
+arrives readable (as raw `| col | col |` rows) but never blank.
+
+To opt in to sending tables through the post pipeline instead, set
+`render_mode: card` in the platform's `extra` config:
+
+```yaml
+platforms:
+  feishu:
+    enabled: true
+    extra:
+      render_mode: card   # "auto" (default) or "card"
+```
+
+The OpenClaw-style `renderMode` (camelCase) key is also accepted. In `card`
+mode, table content is routed through Feishu's native `post`/`md` element; if
+Feishu rejects the payload the adapter still falls back to plain text, so a
+message is always delivered.
+
 ## Processing Status Reactions
 
 While the agent is working, the bot shows a `Typing` reaction on your message. It's cleared when the reply arrives, or replaced with `CrossMark` if processing failed.


### PR DESCRIPTION
## What does this PR do?

Adds a `/platform reload` gateway command that re-reads `config.yaml` and applies the messaging-platform diff against the **running** gateway, with no restart:

- **Newly-enabled** platforms are connected.
- **Disabled / removed** platforms are disconnected (and dropped from the reconnect retry queue).
- Platforms whose `PlatformConfig` **changed** (token, home_channel, reply mode, etc.) are reconnected with the new settings.
- **Unchanged** connected platforms are left completely untouched, so in-flight agent turns on them are never interrupted.

After the diff is applied, `delivery_router.adapters` and the channel directory are refreshed once so `send_message` name resolution stays correct.

This addresses the core of #54681 (apply add/enable/disable/update platform changes without taking unrelated platforms offline via a full `hermes gateway restart`). It deliberately reuses the existing startup connect path and extends the existing `/platform` command group rather than adding new CLI/signal surface (note: the separate open PR #48918 already proposes `hermes gateway reload` → `SIGUSR2` for MCP/skills; this change is scoped to messaging-platform adapters and stays clear of that surface).

## Related Issue

Fixes #54681

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run.py`:
  - `_reload_platforms_from_config()` — computes the enabled-platform diff vs. running adapters and applies connect / disconnect / reconnect, then refreshes `delivery_router.adapters` and the channel directory. Returns a structured report.
  - `_bring_up_platform_adapter()` — create → wire handlers → connect a single adapter, installing it on `self.adapters`; mirrors the startup path and queues retryable failures for the reconnect watcher.
  - `_queue_failed_platform()` — small helper that builds the reconnect-watcher retry entry (shared between the two failure paths).
- `gateway/slash_commands.py`: `_handle_platform_command` gains a `reload` action that runs the reload and formats a per-platform report; usage/help text and docstring updated to list `reload`.
- `tests/gateway/test_platform_reload.py`: new tests for connect / disconnect / reconnect-on-change / unchanged-no-op / failed-connect-queued / disabled-dropped-from-retry-queue, plus the command formatter.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_platform_reload.py
```

Result: **7 passed**. Also re-ran the adjacent suites with no regressions:

```bash
pytest tests/gateway/test_platform_reconnect.py tests/gateway/test_platform_registry.py \
       tests/gateway/test_pre_gateway_dispatch.py tests/gateway/test_gateway_command_help.py \
       tests/gateway/test_platform_connected_checkers.py -q
```

Result: **112 passed, 1 skipped**.

Manual: with a gateway running, edit `config.yaml` to enable/disable/change a platform, send `/platform reload`, and confirm the report reflects the change and unrelated platforms stay connected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the affected + adjacent gateway suites (see How to Test); did not run the entire repo suite -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings + `/platform` usage/help text updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure asyncio/dict logic, no OS-specific calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Example `/platform reload` report after enabling Slack and changing the Telegram token:

```
**Platform reload**
Connected: slack
Reconnected (config changed): telegram
Unchanged: discord
```
