### PR TITLE
fix(msgraph): bound token response reads

### DIFF
--- a/tests/tools/test_microsoft_graph_auth.py
+++ b/tests/tools/test_microsoft_graph_auth.py
@@ -7,6 +7,7 @@ import asyncio
 import httpx
 import pytest
 
+import tools.microsoft_graph_auth as graph_auth
 from tools.microsoft_graph_auth import (
     CachedAccessToken,
     DEFAULT_GRAPH_SCOPE,
@@ -15,6 +16,17 @@ from tools.microsoft_graph_auth import (
     MicrosoftGraphTokenError,
     MicrosoftGraphTokenProvider,
 )
+
+
+class _ChunkStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+        self.yielded_chunks = 0
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            self.yielded_chunks += 1
+            yield chunk
 
 
 class TestGraphCredentials:
@@ -177,3 +189,21 @@ class TestMicrosoftGraphTokenProvider:
         with pytest.raises(MicrosoftGraphTokenError) as exc:
             await provider.get_access_token()
         assert "bad secret" in str(exc.value)
+
+    async def test_token_response_body_is_bounded_while_reading(self, monkeypatch):
+        monkeypatch.setattr(graph_auth, "GRAPH_TOKEN_RESPONSE_MAX_BYTES", 10)
+        stream = _ChunkStream([b"12345", b"67890", b"X", b"unread"])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, stream=stream)
+
+        provider = MicrosoftGraphTokenProvider(
+            GraphCredentials("tenant", "client", "secret"),
+            transport=httpx.MockTransport(handler),
+        )
+
+        with pytest.raises(MicrosoftGraphTokenError) as exc:
+            await provider.get_access_token()
+
+        assert "exceeded 10 bytes" in str(exc.value)
+        assert stream.yielded_chunks == 3

--- a/tools/microsoft_graph_auth.py
+++ b/tools/microsoft_graph_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import time
 from dataclasses import dataclass
@@ -14,6 +15,7 @@ import httpx
 DEFAULT_GRAPH_SCOPE = "https://graph.microsoft.com/.default"
 DEFAULT_GRAPH_AUTHORITY_URL = "https://login.microsoftonline.com"
 DEFAULT_TOKEN_SKEW_SECONDS = 120
+GRAPH_TOKEN_RESPONSE_MAX_BYTES = 16 * 1024 * 1024
 
 
 class MicrosoftGraphAuthError(RuntimeError):
@@ -177,21 +179,24 @@ class MicrosoftGraphTokenProvider:
             timeout=httpx.Timeout(self.timeout),
             transport=self._transport,
         ) as client:
-            response = await client.post(
+            async with client.stream(
+                "POST",
                 self.credentials.token_url,
                 data=data,
                 headers=headers,
-            )
+            ) as response:
+                status_code = response.status_code
+                body = await _read_token_response_body(response)
 
-        if response.status_code >= 400:
-            detail = _extract_error_detail(response)
+        if status_code >= 400:
+            detail = _extract_error_detail(body)
             raise MicrosoftGraphTokenError(
                 "Microsoft Graph token request failed with HTTP "
-                f"{response.status_code}: {detail}"
+                f"{status_code}: {detail}"
             )
 
         try:
-            payload = response.json()
+            payload = _parse_json_body(body)
         except ValueError as exc:
             raise MicrosoftGraphTokenError(
                 "Microsoft Graph token response was not valid JSON."
@@ -220,11 +225,33 @@ class MicrosoftGraphTokenProvider:
         )
 
 
-def _extract_error_detail(response: httpx.Response) -> str:
+async def _read_token_response_body(response: httpx.Response) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in response.aiter_bytes():
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > GRAPH_TOKEN_RESPONSE_MAX_BYTES:
+            raise MicrosoftGraphTokenError(
+                "Microsoft Graph token response exceeded "
+                f"{GRAPH_TOKEN_RESPONSE_MAX_BYTES} bytes (got {total})."
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _parse_json_body(body: bytes) -> Any:
+    if not body:
+        raise ValueError("empty response")
+    return json.loads(body.decode("utf-8"))
+
+
+def _extract_error_detail(body: bytes) -> str:
     try:
-        payload = response.json()
+        payload = _parse_json_body(body)
     except ValueError:
-        text = response.text.strip()
+        text = body.decode("utf-8", errors="replace").strip()
         return text or "unknown error"
 
     if isinstance(payload, dict):


### PR DESCRIPTION
## Summary

- stream Microsoft Graph token responses with a 16 MiB cap before JSON/error parsing
- preserve existing token parsing and HTTP error detail behavior from bounded bytes
- add regression coverage proving an oversized body stops after the first over-cap chunk

## Context

This follows the OAuth response-body cap pattern from OpenClaw:

- openclaw/openclaw#97628

Closes #54974.

## Duplicate Audit

Live search found related response-cap PRs for other OAuth/onboarding paths (#54750 Copilot, #54762 Feishu, #54932 WeCom), but not for `tools/microsoft_graph_auth.py`. This PR is limited to the Microsoft Graph app-only token helper used by Graph/Teams integrations.

## Tests

- `uv run --extra dev python -m pytest tests\tools\test_microsoft_graph_auth.py -q --basetemp .pytest-tmp-msgraph-token-response-cap`
- `uv run --extra dev python -m ruff check tools\microsoft_graph_auth.py tests\tools\test_microsoft_graph_auth.py`
- `git diff --check`
