### PR TITLE
fix(qqbot): add is_reconnect parameter to QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Summary

All other platform adapters (Signal, WhatsApp, Webhook, API Server, BlueBubbles, WeChat, Yuanbao) already accept the `is_reconnect` keyword argument in their `connect()` methods. `QQAdapter.connect()` was the only one missing it, causing a `TypeError` when the gateway runner attempts to reconnect after a network interruption.

## Change

```diff
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
```

## Impact

Fixes QQ Bot gateway crashing with: `QQAdapter.connect() got an unexpected keyword argument is_reconnect`

## Related

- `gateway/run.py:_connect_adapter_with_timeout()` calls `adapter.connect(is_reconnect=...)` for all platforms
- All other platform adapters already have this parameter