### PR TITLE
fix(steer): only inject /steer into a running turn; confirm busy-input steers

### DIFF
--- a/tests/tui_gateway/test_steer_command.py
+++ b/tests/tui_gateway/test_steer_command.py
@@ -1,0 +1,219 @@
+"""Tests for /steer handling in tui_gateway's ``command.dispatch``.
+
+This is the server-side dispatch path for ``/steer``. The Ink TUI handles
+``/steer`` client-side (ui-tui/src/app/slash/commands/core.ts), so in practice
+this branch is reached by clients that dispatch slash commands server-side —
+notably the Electron desktop app, where ``/steer`` is an ``exec`` command.
+
+The contract under test:
+
+* A steer is injected into the live turn ONLY when the session is actually
+  running. The handler returns an ``exec`` confirmation in that case.
+* If the turn is running but its deferred agent build has not finished (or the
+  agent rejects the steer), the text is queued server-side for the next turn
+  and an ``exec`` acknowledgement prevents busy clients from dropping it.
+* When the session is idle (no running turn) the text is returned as a plain
+  next-turn ``send`` — even if the session still holds an agent object. This
+  matches the handler's "no active run, treat as next-turn message" intent and
+  avoids claiming a mid-turn injection that cannot happen.
+* Empty / whitespace-only args are a usage error.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+def _make_session(server, agent=None, running=True):
+    sid = "sid-test"
+    s = {
+        "session_key": "tui-steer-session-1",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": running,
+        "attached_images": [],
+        "cols": 120,
+        "transport": object(),
+    }
+    if agent is not None:
+        s["agent"] = agent
+    server._sessions[sid] = s
+    return sid
+
+
+def _call(server, method, **params):
+    handler = server._methods[method]
+    return handler(1, params)
+
+
+class _AcceptingAgent:
+    def __init__(self):
+        self.seen = []
+
+    def steer(self, text):
+        self.seen.append(text)
+        return True
+
+
+class _RaisingAgent:
+    def __init__(self):
+        self.seen = []
+
+    def steer(self, text):
+        self.seen.append(text)
+        raise RuntimeError("boom")
+
+
+class _RejectingAgent:
+    def __init__(self):
+        self.seen = []
+
+    def steer(self, text):
+        self.seen.append(text)
+        return False
+
+
+# ── usage / validation ────────────────────────────────────────────────
+
+
+def test_steer_empty_arg_is_usage_error(server):
+    sid = _make_session(server, agent=_AcceptingAgent())
+    r = _call(server, "command.dispatch", name="steer", arg="", session_id=sid)
+    assert "error" in r
+    assert r["error"]["code"] == 4004
+
+
+def test_steer_whitespace_only_is_usage_error(server):
+    sid = _make_session(server, agent=_AcceptingAgent())
+    r = _call(server, "command.dispatch", name="steer", arg="   ", session_id=sid)
+    assert "error" in r
+    assert r["error"]["code"] == 4004
+
+
+# ── running turn: inject + confirm ────────────────────────────────────
+
+
+def test_steer_running_agent_returns_exec_confirmation(server):
+    agent = _AcceptingAgent()
+    sid = _make_session(server, agent=agent, running=True)
+    r = _call(
+        server, "command.dispatch", name="steer", arg="check the logs", session_id=sid
+    )
+    result = r["result"]
+    assert result["type"] == "exec"
+    assert "queued" in result["output"].lower()
+    assert agent.seen == ["check the logs"]
+
+
+def test_steer_strips_surrounding_whitespace_before_injecting(server):
+    """The injected text (and the echo) is trimmed, matching the session.steer RPC."""
+    agent = _AcceptingAgent()
+    sid = _make_session(server, agent=agent, running=True)
+    r = _call(
+        server,
+        "command.dispatch",
+        name="steer",
+        arg="  check the logs  ",
+        session_id=sid,
+    )
+    assert agent.seen == ["check the logs"]
+    assert "  check" not in r["result"]["output"]
+
+
+def test_steer_running_agent_exception_queues_server_side(server):
+    """A failed live injection must remain on the server, not be dropped."""
+    sid = _make_session(server, agent=_RaisingAgent(), running=True)
+    r = _call(
+        server, "command.dispatch", name="steer", arg="please stop", session_id=sid
+    )
+    result = r["result"]
+    assert result["type"] == "exec"
+    assert "fail" in result["output"].lower()
+    assert "queued for next turn" in result["output"].lower()
+    assert server._sessions[sid]["queued_prompt"]["text"] == "please stop"
+
+
+def test_steer_running_agent_rejection_queues_server_side(server):
+    agent = _RejectingAgent()
+    sid = _make_session(server, agent=agent, running=True)
+    r = _call(
+        server, "command.dispatch", name="steer", arg="please stop", session_id=sid
+    )
+    result = r["result"]
+    assert result["type"] == "exec"
+    assert "rejected" in result["output"].lower()
+    assert server._sessions[sid]["queued_prompt"]["text"] == "please stop"
+    assert agent.seen == ["please stop"]
+
+
+def test_steer_running_before_agent_ready_queues_server_side(server):
+    """prompt.submit marks a turn running before the deferred agent is ready.
+
+    Returning ``send`` here loses the text because Desktop rejects send
+    directives while busy. Keep it on the gateway's existing next-turn queue.
+    """
+    sid = _make_session(server, agent=None, running=True)
+    session = server._sessions[sid]
+    r = _call(server, "command.dispatch", name="steer", arg="hello", session_id=sid)
+    result = r["result"]
+    assert result["type"] == "exec"
+    assert "still starting" in result["output"].lower()
+    assert "queued for next turn" in result["output"].lower()
+    assert session["queued_prompt"] == {
+        "text": "hello",
+        "transport": session["transport"],
+    }
+
+
+# ── idle session: genuine next-turn message, NOT a mid-turn injection ──
+
+
+def test_steer_idle_agent_falls_back_to_send_without_injecting(server):
+    """A session that still holds an agent but is NOT running must not inject —
+    it returns a plain next-turn send and never calls steer()."""
+    agent = _AcceptingAgent()
+    sid = _make_session(server, agent=agent, running=False)
+    r = _call(server, "command.dispatch", name="steer", arg="hello", session_id=sid)
+    result = r["result"]
+    assert result["type"] == "send"
+    assert result["message"] == "hello"
+    assert agent.seen == []  # steer() never called when idle
+
+
+def test_steer_idle_without_agent_falls_back_to_plain_send(server):
+    sid = _make_session(server, agent=None, running=False)
+    r = _call(server, "command.dispatch", name="steer", arg="hello", session_id=sid)
+    result = r["result"]
+    assert result["type"] == "send"
+    assert result["message"] == "hello"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12162,24 +12162,60 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"type": "send", "message": content})
 
     if name == "steer":
-        if not arg:
+        text = (arg or "").strip()
+        if not text:
             return _err(rid, 4004, "usage: /steer <prompt>")
-        agent = session.get("agent") if session else None
-        if agent and hasattr(agent, "steer"):
-            try:
-                accepted = agent.steer(arg)
-                if accepted:
+        preview = text if len(text) <= 80 else text[:80] + "..."
+        if session:
+            # Keep the running check and fallback enqueue atomic with turn
+            # teardown. Otherwise the turn could finish and drain its queue
+            # between those operations, stranding this message until some
+            # later turn happens to complete.
+            with session["history_lock"]:
+                if session.get("running"):
+                    agent = session.get("agent")
+                    fallback = "agent is still starting"
+                    if agent and hasattr(agent, "steer"):
+                        try:
+                            accepted = agent.steer(text)
+                        except Exception as exc:
+                            accepted = False
+                            fallback = f"steer failed ({exc})"
+                        else:
+                            fallback = "steer rejected"
+                        if accepted:
+                            return _ok(
+                                rid,
+                                {
+                                    "type": "exec",
+                                    "output": f"⏩ Steer queued — arrives after the next tool call: {preview}",
+                                },
+                            )
+                    elif agent is not None:
+                        fallback = "agent does not support steer"
+
+                    # A running session can briefly have no agent while the
+                    # deferred build is in flight. Desktop refuses `send`
+                    # directives while busy, so keep the text on the server's
+                    # normal next-turn queue instead of handing it back to a
+                    # client that must drop it.
+                    _enqueue_prompt(
+                        session,
+                        text,
+                        current_transport() or session.get("transport"),
+                    )
+                    session["last_active"] = time.time()
                     return _ok(
                         rid,
                         {
                             "type": "exec",
-                            "output": f"⏩ Steer queued — arrives after the next tool call: {arg[:80]}{'...' if len(arg) > 80 else ''}",
+                            "output": f"{fallback} — message queued for next turn: {preview}",
                         },
                     )
-            except Exception:
-                pass
-        # Fallback: no active run, treat as next-turn message
-        return _ok(rid, {"type": "send", "message": arg})
+
+        # With no running turn this is a genuine next-turn message. Returning
+        # `send` is safe because the client is idle and can submit it normally.
+        return _ok(rid, {"type": "send", "message": text})
 
     if name == "goal":
         if not session:

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -201,7 +201,9 @@ export function useSubmission(opts: UseSubmissionOptions) {
           .then(raw => {
             const r = asRpcResult<SessionSteerResponse>(raw)
 
-            if (r?.status !== 'queued') {
+            if (r?.status === 'queued') {
+              sys(`steer queued — arrives after next tool call: "${full.slice(0, 50)}${full.length > 50 ? '…' : ''}"`)
+            } else {
               fallback('steer rejected — message queued for next turn')
             }
           })


### PR DESCRIPTION
## TL;DR

Makes TUI/Desktop steering truthful and lossless across all session states:

1. An idle session can retain its agent object. `/steer` previously treated that stale agent as a live turn, queued text for an unrelated future turn, and claimed it would arrive after the next tool call. Live injection now requires `session["running"]`.
2. A newly submitted turn has the inverse startup window: `running` is already true while deferred agent construction is still in flight. Desktop rejects `send` directives while busy, so returning one there drops the text. On current `main`, this PR now uses the gateway's existing `queued_prompt` path for any running turn that cannot accept the steer, and returns an `exec` acknowledgement.
3. Ink busy-input steering now prints a success acknowledgement instead of making an accepted steer look like swallowed input.

## Behavior

- **Running + steer accepted:** inject after the next tool call and return an `exec` confirmation.
- **Running + agent still starting / steer rejected / steer failed:** retain the text server-side as the next turn and return an `exec` explanation. The queue operation is atomic with turn teardown, so the message cannot miss the drain edge.
- **Idle:** return `send` so the client submits it as a normal next turn. A retained idle agent is never steered.
- **Blank input:** return the `/steer <prompt>` usage error.

The server-side `command.dispatch` path is used by clients such as Electron Desktop. Ink's slash command is client-side, while busy-input steer uses `session.steer` directly.

## Why use `queued_prompt`

Recent `main` added a server-owned next-turn queue for mid-turn submissions, including client-transport pinning and post-turn draining. Reusing it avoids a second pending-message mechanism and fixes the startup race without relying on a busy client to resubmit.

## Tests

`tests/tui_gateway/test_steer_command.py` covers:

- accepted live steer and confirmation;
- trimming;
- idle retained-agent fallback without calling `steer()`;
- deferred-build startup race (running with no agent);
- rejected and raised steers queued server-side;
- idle no-agent fallback;
- empty and whitespace-only usage errors.

Validation:

```
python -m pytest tests/tui_gateway/test_steer_command.py -q
# 9 passed

python -m pytest \
  tests/test_tui_gateway_server.py::test_session_steer_calls_agent_steer_when_agent_supports_it \
  tests/test_tui_gateway_server.py::test_interrupt_drops_queued_prompt_for_session -q
# 2 passed

cd ui-tui && npm run typecheck
```

## Scope / safety

- One server handler, one Ink acknowledgement line, and focused regression tests.
- No system-prompt, toolset, or message-history mutation changes; prompt caching and role alternation are unaffected.
