### PR TITLE
feat(cron): add cron.drift_guard_enabled config gate for the #44585 spend guard

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2399,6 +2399,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Back-compat: an axis with no snapshot (pre-existing jobs, no_agent, or
         # any axis whose creation-time resolution failed) behaves exactly as
         # before — the guard never engages for it. Pinned axes are unaffected.
+        # Config gate: cron.drift_guard_enabled (default True). Set to false to
+        # let unpinned jobs always run on the current global default without
+        # skipping on drift. The user explicitly opted out of the spend guard.
+        _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg.get("cron", {}), dict) else {}
+        _drift_guard_enabled = _cron_cfg.get("drift_guard_enabled", True)
         _drift: list[str] = []
         _provider_snapshot = (job.get("provider_snapshot") or "").strip().lower()
         if _provider_snapshot and not (job.get("provider") or "").strip():
@@ -2414,7 +2419,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _drift.append(
                     f"model '{_model_snapshot}' -> '{_current_model}'"
                 )
-        if _drift:
+        if _drift and _drift_guard_enabled:
             _changes = "; ".join(_drift)
             logger.warning(
                 "Job '%s': SKIPPED — global inference config drifted since "

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2499,6 +2499,12 @@ DEFAULT_CONFIG = {
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.
         "output_retention": 50,
+        # Fail-closed spend guard (#44585): when an UNPINNED job's global
+        # inference config has drifted from the snapshot taken at job creation
+        # (provider and/or model changed), skip the run and make NO paid call.
+        # Default True (safe). Set false to let unpinned jobs always run on the
+        # CURRENT global default, re-snapshotting each run — no drift skips.
+        "drift_guard_enabled": True,
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -152,6 +152,31 @@ class TestProviderDriftGuard:
         assert error is None
         assert agent_constructed is True
 
+    def test_e_guard_disabled_via_config_runs_despite_drift(self, tmp_path):
+        """(e) cron.drift_guard_enabled=false → unpinned drift runs, no skip.
+
+        The guard is opt-out: when an operator sets cron.drift_guard_enabled
+        to false in config.yaml, an unpinned job whose snapshot != current
+        provider must STILL run on the current default (the paid call IS made),
+        re-snapshotting each run, instead of failing closed. Default behavior
+        (guard on) is covered by test_b above.
+        """
+        import yaml
+
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"cron": {"drift_guard_enabled": False}}),
+            encoding="utf-8",
+        )
+        job = _base_job(provider_snapshot="openrouter")
+        success, output, final_response, error, agent_constructed = \
+            _run_with_current_provider(job, "nous", tmp_path)
+
+        # Guard disabled → job runs on the current provider, paid call made.
+        assert agent_constructed is True
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+
 
 class TestCreateJobSnapshot:
     """create_job captures provider_snapshot for unpinned agent jobs only."""


### PR DESCRIPTION
## Summary

The provider/model-drift fail-closed guard (#44585) skips any **unpinned** cron job whose global inference config has drifted from the snapshot taken at job creation. That is the right *default*, but today it is **unconditional** — an operator who deliberately switches their global default model (e.g. provider experiments, swapping the daily-driver model) has no way to let unpinned jobs follow the current default short of pinning every job individually.

This adds an opt-out config gate, **`cron.drift_guard_enabled`** (default `True`, preserving the existing safe behavior). When set to `false`, the fail-closed branch is skipped and unpinned jobs run on the current global default, re-snapshotting each run.

## Changes

- **`cron/scheduler.py`** — read `cron.drift_guard_enabled` from the already-loaded `_cfg` (no extra I/O); gate the existing fail-closed branch (`if _drift and _drift_guard_enabled:`). Default `True`, so absent config = unchanged behavior.
- **`hermes_cli/config.py`** — document the flag in `DEFAULT_CONFIG['cron']`.
- **`tests/cron/test_cron_provider_pin.py`** — add `test_e_guard_disabled_via_config_runs_despite_drift`: an unpinned, drifted job **runs** (paid call made, no skip) when the flag is `false`. The 14 existing guard tests are unchanged and still pass (guard on by default).

## Behavior matrix

| Job state | Drift | `drift_guard_enabled` | Result |
|---|---|---|---|
| unpinned | none | true (default) | runs |
| unpinned | yes | true (default) | **skips** (fail closed, no spend) |
| unpinned | yes | false | runs on current default |
| pinned | any | any | runs (unaffected) |

## Test Plan

- [x] `pytest tests/cron/test_cron_provider_pin.py` — 15 passed (14 existing + 1 new)
- [x] Default behavior (flag absent / true) unchanged: `test_b` / model-drift tests still fail closed
- [x] Flag `false` lets unpinned drift run: `test_e`

Backwards compatible and cache-safe — no new env var (config-only), no change to the default fail-closed posture.