### PR TITLE
fix(security): block Docker cold-start sandbox escape via config race

### DIFF
--- a/tests/tools/test_docker_cold_start_guard.py
+++ b/tests/tools/test_docker_cold_start_guard.py
@@ -178,3 +178,36 @@ class TestResolveBackendType:
         # Must not raise — local → local is a safe fallback.
         config = _tt_mod._get_env_config()
         assert config["env_type"] == "local"
+
+    def test_config_bridge_failure_preserves_explicit_termin_env(self, monkeypatch):
+        """When bridge fails but TERMINAL_ENV=docker was explicitly set, keep it."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "my-image")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            lambda env=None: (_ for _ in ()).throw(RuntimeError("Bridge error")),
+        )
+        cfg = {"terminal": {"backend": "docker", "docker_image": "cfg-image"}}
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+
+        # TERMINAL_ENV=docker is preserved; TERMINAL_DOCKER_IMAGE is wiped.
+        # config.yaml says docker → RuntimeError.
+        with pytest.raises(RuntimeError, match="Refusing to downgrade"):
+            _tt_mod._get_env_config()
+
+    def test_config_bridge_and_config_read_both_fail(self, monkeypatch):
+        """When both bridge and fallback config read fail, refuse to run."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            lambda env=None: (_ for _ in ()).throw(RuntimeError("Bridge error")),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: (_ for _ in ()).throw(OSError("Config unreadable")),
+        )
+
+        with pytest.raises(RuntimeError, match="config.yaml is unreadable"):
+            _tt_mod._get_env_config()

--- a/tests/tools/test_docker_cold_start_guard.py
+++ b/tests/tools/test_docker_cold_start_guard.py
@@ -1,0 +1,113 @@
+"""Regression tests for Docker cold-start sandbox escape (#54354).
+
+When ``TERMINAL_ENV`` is not set but ``terminal.backend`` is configured
+in config.yaml, ``_resolve_backend_type()`` must read the backend type
+directly from the config file instead of falling back to ``"local"``.
+"""
+
+import os
+import sys
+from pathlib import Path
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+try:
+    import tools.terminal_tool  # noqa: F401
+    _tt_mod = sys.modules["tools.terminal_tool"]
+except ImportError:
+    pytest.skip("hermes-agent tools not importable (missing deps)", allow_module_level=True)
+
+
+class TestResolveBackendType:
+    """_resolve_backend_type() must not silently downgrade Docker to local."""
+
+    def test_env_var_takes_priority(self, monkeypatch):
+        """When TERMINAL_ENV is explicitly set, it must win."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        assert _tt_mod._resolve_backend_type() == "docker"
+
+        monkeypatch.setenv("TERMINAL_ENV", "modal")
+        assert _tt_mod._resolve_backend_type() == "modal"
+
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        assert _tt_mod._resolve_backend_type() == "local"
+
+    def test_env_var_set_to_ssh(self, monkeypatch):
+        """Explicit TERMINAL_ENV=ssh must be honoured."""
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        assert _tt_mod._resolve_backend_type() == "ssh"
+
+    def test_falls_back_to_config_when_env_not_set(self, monkeypatch):
+        """When TERMINAL_ENV is not set, read terminal.backend from config.yaml."""
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+        def _fake_cfg():
+            return {"terminal": {"backend": "docker"}}
+
+        monkeypatch.setattr(
+            _tt_mod, "_resolve_backend_type",
+            lambda: "docker" if _fake_cfg()["terminal"]["backend"] == "docker" else "local",
+        )
+        # Directly test the config fallback path
+        from hermes_cli.config import load_config_readonly
+
+        original_load = load_config_readonly
+
+        def _mock_load_config():
+            return {"terminal": {"backend": "docker"}}
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
+        )
+        # Clear any cached import — _resolve_backend_type does a fresh import
+        # inside the function, so the monkeypatch on the module is picked up.
+        assert _tt_mod._resolve_backend_type() == "docker"
+
+    def test_falls_back_to_local_when_config_has_no_terminal_section(self, monkeypatch):
+        """When config.yaml has no terminal section, default to local."""
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+        def _mock_load_config():
+            return {}
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
+        )
+        assert _tt_mod._resolve_backend_type() == "local"
+
+    def test_falls_back_to_local_when_config_terminal_has_no_backend(self, monkeypatch):
+        """When terminal.backend is absent from config, default to local."""
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+        def _mock_load_config():
+            return {"terminal": {"cwd": "/home/user"}}
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
+        )
+        assert _tt_mod._resolve_backend_type() == "local"
+
+    def test_falls_back_to_local_when_config_load_fails(self, monkeypatch):
+        """When config.yaml is unreadable, default to local (no crash)."""
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+        def _mock_load_config():
+            raise OSError("Permission denied")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
+        )
+        # Must not raise — falls back to local
+        assert _tt_mod._resolve_backend_type() == "local"
+
+    def test_docker_backend_flows_through_get_env_config(self, monkeypatch):
+        """End-to-end: _get_env_config() returns docker config when backend is docker."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        config = _tt_mod._get_env_config()
+        assert config["env_type"] == "docker"
+        assert config["docker_image"].startswith("nikolaik/python-nodejs")
+        assert config["cwd"] == "/root"

--- a/tests/tools/test_docker_cold_start_guard.py
+++ b/tests/tools/test_docker_cold_start_guard.py
@@ -5,7 +5,6 @@ in config.yaml, ``_resolve_backend_type()`` must read the backend type
 directly from the config file instead of falling back to ``"local"``.
 """
 
-import os
 import sys
 from pathlib import Path
 import pytest
@@ -24,8 +23,11 @@ except ImportError:
 class TestResolveBackendType:
     """_resolve_backend_type() must not silently downgrade Docker to local."""
 
-    def test_env_var_takes_priority(self, monkeypatch):
-        """When TERMINAL_ENV is explicitly set, it must win."""
+    def test_env_var_used_when_no_terminal_config_exists(self, monkeypatch):
+        """When config has no terminal section, TERMINAL_ENV remains usable."""
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
+
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         assert _tt_mod._resolve_backend_type() == "docker"
 
@@ -35,8 +37,10 @@ class TestResolveBackendType:
         monkeypatch.setenv("TERMINAL_ENV", "local")
         assert _tt_mod._resolve_backend_type() == "local"
 
-    def test_env_var_set_to_ssh(self, monkeypatch):
-        """Explicit TERMINAL_ENV=ssh must be honoured."""
+    def test_env_var_set_to_ssh_without_terminal_config(self, monkeypatch):
+        """Explicit TERMINAL_ENV=ssh must be honoured without terminal config."""
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
         monkeypatch.setenv("TERMINAL_ENV", "ssh")
         assert _tt_mod._resolve_backend_type() == "ssh"
 
@@ -44,26 +48,26 @@ class TestResolveBackendType:
         """When TERMINAL_ENV is not set, read terminal.backend from config.yaml."""
         monkeypatch.delenv("TERMINAL_ENV", raising=False)
 
-        def _fake_cfg():
+        def _mock_load_config():
             return {"terminal": {"backend": "docker"}}
 
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
         monkeypatch.setattr(
-            _tt_mod, "_resolve_backend_type",
-            lambda: "docker" if _fake_cfg()["terminal"]["backend"] == "docker" else "local",
+            "hermes_cli.config.load_config_readonly", _mock_load_config,
         )
-        # Directly test the config fallback path
-        from hermes_cli.config import load_config_readonly
+        assert _tt_mod._resolve_backend_type() == "docker"
 
-        original_load = load_config_readonly
+    def test_config_backend_overrides_stale_env_var(self, monkeypatch):
+        """When config has terminal.backend, config.yaml is authoritative."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
 
         def _mock_load_config():
             return {"terminal": {"backend": "docker"}}
 
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
         monkeypatch.setattr(
             "hermes_cli.config.load_config_readonly", _mock_load_config,
         )
-        # Clear any cached import — _resolve_backend_type does a fresh import
-        # inside the function, so the monkeypatch on the module is picked up.
         assert _tt_mod._resolve_backend_type() == "docker"
 
     def test_falls_back_to_local_when_config_has_no_terminal_section(self, monkeypatch):
@@ -73,6 +77,7 @@ class TestResolveBackendType:
         def _mock_load_config():
             return {}
 
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
         monkeypatch.setattr(
             "hermes_cli.config.load_config_readonly", _mock_load_config,
         )
@@ -85,6 +90,7 @@ class TestResolveBackendType:
         def _mock_load_config():
             return {"terminal": {"cwd": "/home/user"}}
 
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
         monkeypatch.setattr(
             "hermes_cli.config.load_config_readonly", _mock_load_config,
         )
@@ -97,17 +103,45 @@ class TestResolveBackendType:
         def _mock_load_config():
             raise OSError("Permission denied")
 
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", _mock_load_config)
         monkeypatch.setattr(
             "hermes_cli.config.load_config_readonly", _mock_load_config,
         )
         # Must not raise — falls back to local
         assert _tt_mod._resolve_backend_type() == "local"
 
-    def test_docker_backend_flows_through_get_env_config(self, monkeypatch):
-        """End-to-end: _get_env_config() returns docker config when backend is docker."""
-        monkeypatch.setenv("TERMINAL_ENV", "docker")
-        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    def test_docker_backend_flows_through_get_env_config_from_config(self, monkeypatch):
+        """End-to-end: _get_env_config() uses config.yaml during cold start."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "stale-image")
+
+        cfg = {
+            "terminal": {
+                "backend": "docker",
+                "docker_image": "python:3.12-slim",
+                "docker_forward_env": ["OPENAI_API_KEY"],
+                "docker_volumes": ["/tmp:/host-tmp:ro"],
+                "docker_env": {"HERMES_TEST": "1"},
+                "docker_extra_args": ["--network=none"],
+                "timeout": 42,
+                "container_cpu": 2.5,
+                "container_memory": 1024,
+                "container_disk": 2048,
+            }
+        }
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: cfg)
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
         config = _tt_mod._get_env_config()
+
         assert config["env_type"] == "docker"
-        assert config["docker_image"].startswith("nikolaik/python-nodejs")
+        assert config["docker_image"] == "python:3.12-slim"
+        assert config["docker_forward_env"] == ["OPENAI_API_KEY"]
+        assert config["docker_volumes"] == ["/tmp:/host-tmp:ro"]
+        assert config["docker_env"] == {"HERMES_TEST": "1"}
+        assert config["docker_extra_args"] == ["--network=none"]
+        assert config["timeout"] == 42
+        assert config["container_cpu"] == 2.5
+        assert config["container_memory"] == 1024
+        assert config["container_disk"] == 2048
         assert config["cwd"] == "/root"

--- a/tests/tools/test_docker_cold_start_guard.py
+++ b/tests/tools/test_docker_cold_start_guard.py
@@ -145,3 +145,36 @@ class TestResolveBackendType:
         assert config["container_memory"] == 1024
         assert config["container_disk"] == 2048
         assert config["cwd"] == "/root"
+
+    def test_config_bridge_failure_raises_when_backend_is_docker(self, monkeypatch):
+        """When config bridge fails and config intends Docker, fail closed."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "stale-image")
+
+        # Simulate a config bridge failure.
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            lambda env=None: (_ for _ in ()).throw(RuntimeError("Bridge error")),
+        )
+        # load_config_readonly still returns the intended Docker config
+        # for the fallback check in _get_env_config.
+        cfg = {"terminal": {"backend": "docker"}}
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+
+        with pytest.raises(RuntimeError, match="Refusing to downgrade"):
+            _tt_mod._get_env_config()
+
+    def test_config_bridge_failure_allows_local_when_backend_is_local(self, monkeypatch):
+        """When config bridge fails but config intends local, it is safe to proceed."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            lambda env=None: (_ for _ in ()).throw(RuntimeError("Bridge error")),
+        )
+        cfg = {"terminal": {"backend": "local"}}
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+
+        # Must not raise — local → local is a safe fallback.
+        config = _tt_mod._get_env_config()
+        assert config["env_type"] == "local"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1237,11 +1237,40 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
+def _resolve_backend_type() -> str:
+    """Return the terminal backend type, bypassing env var propagation race.
+
+    ``TERMINAL_ENV`` is bridged from ``terminal.backend`` via
+    ``apply_terminal_config_to_env()``, but that bridging may not have
+    completed by the time the first tool call arrives — especially in
+    gateway/launchd-managed processes where env propagation is asynchronous.
+
+    When ``TERMINAL_ENV`` is explicitly set it is still authoritative
+    (child processes, operator overrides).  When it is missing, fall back
+    to reading ``terminal.backend`` directly from config.yaml so we never
+    silently downgrade to local on the first cold-start tool call (#54354).
+    """
+    env_val = os.getenv("TERMINAL_ENV")
+    if env_val:
+        return env_val
+
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly()
+        backend = cfg.get("terminal", {}).get("backend")
+        if isinstance(backend, str) and backend:
+            return backend
+    except Exception:
+        pass
+
+    return "local"
+
+
 def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    env_type = _resolve_backend_type()
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona"}

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1251,6 +1251,11 @@ def _terminal_env_snapshot() -> Dict[str, str]:
     terminal tools run. A cold-start tool call can arrive before that bridge has
     completed, so build a local snapshot here as the final guard. This preserves
     the existing config bridge semantics without mutating process-global env.
+
+    When the config bridge fails, stale TERMINAL_* values are stripped from the
+    snapshot so callers cannot silently downgrade an isolated backend (Docker,
+    Modal, etc.) to host-local execution. The caller must check for the
+    ``_config_bridge_failed`` sentinel and refuse to run.
     """
     env = dict(os.environ)
 
@@ -1259,6 +1264,12 @@ def _terminal_env_snapshot() -> Dict[str, str]:
         apply_terminal_config_to_env(env=env)
     except Exception:
         logger.debug("Could not bridge terminal config into env snapshot", exc_info=True)
+        # Fail closed: wipe stale terminal env vars so a configured isolated
+        # backend cannot be silently downgraded to host-local execution.
+        for key in list(env.keys()):
+            if key.startswith("TERMINAL_"):
+                env.pop(key, None)
+        env["_config_bridge_failed"] = "1"
 
     return env
 
@@ -1279,6 +1290,23 @@ def _get_env_config() -> Dict[str, Any]:
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     terminal_env = _terminal_env_snapshot()
     env_type = _resolve_backend_type(terminal_env)
+
+    if terminal_env.get("_config_bridge_failed"):
+        # The config bridge failed and stripped stale TERMINAL_* values.
+        # Check whether config.yaml intends an isolated backend; if so, fail
+        # closed instead of silently downgrading to host-local execution.
+        try:
+            from hermes_cli.config import load_config_readonly
+            cfg = load_config_readonly()
+            intended = cfg.get("terminal", {}).get("backend", "local")
+        except Exception:
+            intended = "local"
+        if intended != "local":
+            raise RuntimeError(
+                f"Terminal config bridge failed. Refusing to downgrade "
+                f"terminal.backend={intended} to local execution. "
+                f"Check hermes CLI config connectivity."
+            )
     
     mount_docker_cwd = terminal_env.get("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona"}

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1266,8 +1266,11 @@ def _terminal_env_snapshot() -> Dict[str, str]:
         logger.debug("Could not bridge terminal config into env snapshot", exc_info=True)
         # Fail closed: wipe stale terminal env vars so a configured isolated
         # backend cannot be silently downgraded to host-local execution.
+        # Preserve TERMINAL_ENV — the user's explicit backend choice set in
+        # the process environment must survive so env-only configuration
+        # (no config.yaml) is not regressed.
         for key in list(env.keys()):
-            if key.startswith("TERMINAL_"):
+            if key.startswith("TERMINAL_") and key != "TERMINAL_ENV":
                 env.pop(key, None)
         env["_config_bridge_failed"] = "1"
 
@@ -1295,12 +1298,22 @@ def _get_env_config() -> Dict[str, Any]:
         # The config bridge failed and stripped stale TERMINAL_* values.
         # Check whether config.yaml intends an isolated backend; if so, fail
         # closed instead of silently downgrading to host-local execution.
+        config_readable = True
         try:
             from hermes_cli.config import load_config_readonly
             cfg = load_config_readonly()
             intended = cfg.get("terminal", {}).get("backend", "local")
         except Exception:
+            config_readable = False
             intended = "local"
+        if not config_readable:
+            # Cannot verify the intended backend — refuse to run rather
+            # than silently execute on the host.
+            raise RuntimeError(
+                "Terminal config bridge failed and config.yaml is unreadable. "
+                "Refusing to run terminal without confirmed backend. "
+                "Check hermes CLI config connectivity."
+            )
         if intended != "local":
             raise RuntimeError(
                 f"Terminal config bridge failed. Refusing to downgrade "

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1177,13 +1177,20 @@ def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
 
 # Configuration from environment variables
 
-def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer"):
+def _parse_env_var(
+    name: str,
+    default: str,
+    converter: Any = int,
+    type_label: str = "integer",
+    env: Optional[Dict[str, str]] = None,
+):
     """Parse an environment variable with *converter*, raising a clear error on bad values.
 
     Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
     causes an unhandled ValueError that kills every terminal command.
     """
-    raw = os.getenv(name, default)
+    source = os.environ if env is None else env
+    raw = source.get(name, default)
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
@@ -1237,31 +1244,31 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
-def _resolve_backend_type() -> str:
-    """Return the terminal backend type, bypassing env var propagation race.
+def _terminal_env_snapshot() -> Dict[str, str]:
+    """Return terminal env values with config.yaml bridged in.
 
-    ``TERMINAL_ENV`` is bridged from ``terminal.backend`` via
-    ``apply_terminal_config_to_env()``, but that bridging may not have
-    completed by the time the first tool call arrives — especially in
-    gateway/launchd-managed processes where env propagation is asynchronous.
-
-    When ``TERMINAL_ENV`` is explicitly set it is still authoritative
-    (child processes, operator overrides).  When it is missing, fall back
-    to reading ``terminal.backend`` directly from config.yaml so we never
-    silently downgrade to local on the first cold-start tool call (#54354).
+    ``apply_terminal_config_to_env()`` is normally called by launch paths before
+    terminal tools run. A cold-start tool call can arrive before that bridge has
+    completed, so build a local snapshot here as the final guard. This preserves
+    the existing config bridge semantics without mutating process-global env.
     """
-    env_val = os.getenv("TERMINAL_ENV")
-    if env_val:
-        return env_val
+    env = dict(os.environ)
 
     try:
-        from hermes_cli.config import load_config_readonly
-        cfg = load_config_readonly()
-        backend = cfg.get("terminal", {}).get("backend")
-        if isinstance(backend, str) and backend:
-            return backend
+        from hermes_cli.config import apply_terminal_config_to_env
+        apply_terminal_config_to_env(env=env)
     except Exception:
-        pass
+        logger.debug("Could not bridge terminal config into env snapshot", exc_info=True)
+
+    return env
+
+
+def _resolve_backend_type(env: Optional[Dict[str, str]] = None) -> str:
+    """Return the terminal backend type after applying config.yaml bridge."""
+    source = _terminal_env_snapshot() if env is None else env
+    env_val = source.get("TERMINAL_ENV")
+    if env_val:
+        return env_val
 
     return "local"
 
@@ -1270,9 +1277,10 @@ def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    env_type = _resolve_backend_type()
+    terminal_env = _terminal_env_snapshot()
+    env_type = _resolve_backend_type(terminal_env)
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = terminal_env.get("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona"}
     docker_backend = env_type == "docker"
 
@@ -1281,19 +1289,19 @@ def _get_env_config() -> Dict[str, Any]:
     # until a backend that can consume them is selected; a stale or invalid
     # Docker value should not make local terminal/execute_code unusable.
     if container_backend:
-        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number")
-        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120")
-        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200")
+        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number", terminal_env)
+        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120", env=terminal_env)
+        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200", env=terminal_env)
     else:
         container_cpu = 1.0
         container_memory = 5120
         container_disk = 51200
 
     if docker_backend:
-        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
-        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
-        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
-        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
+        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON", terminal_env)
+        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON", terminal_env)
+        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON", terminal_env)
+        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON", terminal_env)
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1314,12 +1322,12 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = terminal_env.get("TERMINAL_CWD", default_cwd)
     if cwd:
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = terminal_env.get("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1337,39 +1345,39 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(terminal_env.get("TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": terminal_env.get("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
+        "singularity_image": terminal_env.get("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
+        "modal_image": terminal_env.get("TERMINAL_MODAL_IMAGE", default_image),
+        "daytona_image": terminal_env.get("TERMINAL_DAYTONA_IMAGE", default_image),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180", env=terminal_env),
+        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300", env=terminal_env),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
-        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_host": terminal_env.get("TERMINAL_SSH_HOST", ""),
+        "ssh_user": terminal_env.get("TERMINAL_SSH_USER", ""),
+        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22", env=terminal_env),
+        "ssh_key": terminal_env.get("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
+        "ssh_persistent": terminal_env.get(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            terminal_env.get("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": terminal_env.get("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": terminal_env.get("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": terminal_env.get("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         # Cross-process container reuse (issue #20561).  The docs claim
         # "ONE long-lived container shared across sessions" — this toggle
@@ -1377,14 +1385,14 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
+        "docker_persist_across_processes": terminal_env.get(
             "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
         ).lower() in {"true", "1", "yes"},
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
+        "docker_orphan_reaper": terminal_env.get(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a Docker sandbox escape where the first tool call after a cold start can execute on the **host** instead of the configured Docker backend.

The root cause is a terminal config propagation race: terminal tools normally read `TERMINAL_*` env vars, while `config.yaml` is bridged into those env vars by launch paths. On a cold-start tool call, that bridge may not have completed yet, or the process may still have stale terminal env values.

This PR makes `_get_env_config()` build a local terminal env snapshot by applying the existing `apply_terminal_config_to_env()` bridge before resolving the backend. That keeps the existing config semantics intact: when `config.yaml` contains a `terminal` section, it is authoritative over stale env values, but the function does not mutate process-global `os.environ`.

## Related Issue

Fixes #54354

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- Add a local terminal env snapshot path in `tools/terminal_tool.py` that applies `terminal.*` config before reading `TERMINAL_*` values.
- Resolve `TERMINAL_ENV` from that snapshot, so `terminal.backend: docker` wins over missing or stale env during cold start.
- Read the rest of Docker/container terminal settings from the same snapshot as well: image, cwd, volumes, docker env, extra args, timeout, and resource limits.
- Keep fallback behavior for installs with no `terminal` config section: existing env vars still work and default to `local` when absent.
- Strengthen regression coverage so tests exercise the real implementation instead of monkeypatching the function under test.

## How to test

```bash
scripts/run_tests.sh tests/tools/test_docker_cold_start_guard.py -q
scripts/run_tests.sh tests/gateway/test_config_cwd_bridge.py tests/tools/test_docker_cold_start_guard.py -q
scripts/run_tests.sh tests/tools/test_terminal_config_env_sync.py tests/tools/test_parse_env_var.py tests/tools/test_terminal_tool.py tests/tools/test_modal_sandbox_fixes.py tests/tools/test_ssh_environment.py tests/tools/test_gateway_cwd_contract.py tests/tools/test_container_cwd_sanitize.py -q
venv/bin/ruff check tests/tools/test_docker_cold_start_guard.py tools/terminal_tool.py
git diff --check
```

Manual Docker smoke test performed with a temporary `HERMES_HOME/config.yaml`:

```yaml
terminal:
  backend: docker
  docker_image: python:3.10-slim
```

With `TERMINAL_ENV` and `TERMINAL_DOCKER_IMAGE` unset, `_get_env_config()` resolved `env_type=docker` and `docker_image=python:3.10-slim`; `terminal_tool()` executed inside Docker and printed `SMOKE_DOCKER True`.

## Platforms tested

- Linux (Python 3.12)
- Docker Engine 29.1.3
