### PR TITLE
feat(telegram): add rich all markdown option

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -375,6 +375,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # as plain text, which is worse than degraded table/task-list rendering
         # for command snippets and mobile handoffs.
         self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
+        # Operator preference: when rich_messages is enabled, route ordinary
+        # markdown (headings, bold/italic, simple lists) through Bot API 10.1
+        # rich messages too.  This keeps the default copy-friendly MarkdownV2
+        # behavior while allowing users to prefer Telegram's richer native view.
+        self._rich_all_markdown_enabled: bool = self._coerce_bool_extra("rich_all_markdown", False)
         # Rich draft previews use a separate opt-in. Telegram macOS / Desktop
         # can leave Bot API 10.1 rich draft frames visually overlaid until the
         # chat is redrawn, while final rich messages remain useful.
@@ -1172,6 +1177,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not content:
             return False
+        if getattr(self, "_rich_all_markdown_enabled", False):
+            return bool(content.strip())
         if any(_TABLE_SEPARATOR_RE.match(line) for line in content.splitlines()):
             return True
         if re.search(r"(?m)^\s*[-*]\s+\[[ xX]\]\s+", content):

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -297,6 +297,21 @@ async def test_plain_markdown_stays_on_legacy_path():
 
 
 @pytest.mark.asyncio
+async def test_rich_all_markdown_routes_plain_markdown_to_rich():
+    """Local/operator opt-in: render ordinary markdown through Bot API rich too."""
+    adapter = _make_adapter(extra={"rich_all_markdown": True})
+
+    result = await adapter.send("12345", "## Heading\n\nHello **there**")
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_awaited_once()
+    bot.send_message.assert_not_called()
+    assert _rich_api_kwargs(adapter)["rich_message"]["markdown"] == "## Heading\n\nHello **there**"
+
+
+@pytest.mark.asyncio
 async def test_expect_edits_metadata_keeps_preview_on_legacy_path():
     adapter = _make_adapter()
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -973,10 +973,11 @@ gateway:
     telegram:
       extra:
         rich_messages: true
+        rich_all_markdown: false
         rich_drafts: false
 ```
 
-This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. `rich_drafts` controls the experimental rich draft preview path during Telegram DM streaming and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
+This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. Set `rich_all_markdown: true` if you also want ordinary markdown (headings, bold/italic, simple lists) to use Telegram's rich-message renderer instead of the MarkdownV2 path. `rich_drafts` controls the experimental rich draft preview path during Telegram DM streaming and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
 
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
@@ -894,9 +894,10 @@ gateway:
     telegram:
       extra:
         rich_messages: true
+        rich_all_markdown: false
 ```
 
-这个设置用于客户端渲染/复制兼容性；当 Telegram 拒绝富消息 API 调用时，Hermes 已经会自动回退。如果你只是想在保持富消息启用的同时恢复旧版「始终使用代码块」表格行为，可在 `config.yaml` 中设置 `telegram.pretty_tables: false` 禁用表格规范化（默认：`true`）。
+这个设置用于客户端渲染/复制兼容性；当 Telegram 拒绝富消息 API 调用时，Hermes 已经会自动回退。如果你还想让普通 markdown（标题、粗体/斜体、简单列表）也使用 Telegram 富消息渲染器而不是 MarkdownV2 路径，请设置 `rich_all_markdown: true`。如果你只是想在保持富消息启用的同时恢复旧版「始终使用代码块」表格行为，可在 `config.yaml` 中设置 `telegram.pretty_tables: false` 禁用表格规范化（默认：`true`）。
 
 **链接预览。** Telegram 会为机器人消息中的 URL 自动生成链接预览。如果你希望抑制这些预览（长 `/tools` 输出、提及十个链接的 Agent 回复等）：
 


### PR DESCRIPTION
## Summary
- add `telegram.extra.rich_all_markdown` as an opt-in modifier for Bot API 10.1 rich messages
- keep the default copy-friendly MarkdownV2 path unchanged for ordinary markdown
- document the setting in Telegram messaging docs, including zh-Hans translation

## Behavior
When `rich_messages: true`, Hermes already routes tables/task lists/details/math through `sendRichMessage` because the legacy MarkdownV2 path degrades those constructs. This PR adds `rich_all_markdown: true` for operators who also prefer ordinary markdown (headings, bold/italic, simple lists) to use Telegram's rich-message renderer.

## Tests
- `python -m pytest tests/gateway/test_telegram_rich_messages.py -q`
