### PR TITLE
fix(desktop): strip pipe tails from single-command shell summaries

### DIFF
--- a/apps/desktop/src/lib/summarize-command.test.ts
+++ b/apps/desktop/src/lib/summarize-command.test.ts
@@ -57,6 +57,10 @@ describe('summarizeShellCommand', () => {
     expect(summarizeShellCommand('cd /x && tsc --noEmit 2>&1 | tail -20')).toBe('tsc --noEmit')
   })
 
+  it('strips a pipe tail from a single bare command (no leading cd)', () => {
+    expect(summarizeShellCommand('tsc --noEmit 2>&1 | tail -20')).toBe('tsc --noEmit')
+  })
+
   it('drops a leading echo banner around a single command', () => {
     expect(
       summarizeShellCommand(

--- a/apps/desktop/src/lib/summarize-command.ts
+++ b/apps/desktop/src/lib/summarize-command.ts
@@ -195,7 +195,7 @@ export function summarizeShellCommand(raw: string): string {
   const segments = splitCompoundCommand(original)
 
   if (segments.length <= 1) {
-    return cleanSegment(original) || original
+    return (segments.length === 1 ? cleanSegment(segments[0]!) : '') || original
   }
 
   const core = segments.map(cleanSegment).filter(segment => {


### PR DESCRIPTION
## What does this PR do?

Fixes a display bug in the desktop shell-command summarizer (`apps/desktop/src/lib/summarize-command.ts`). The single-segment fast path re-cleaned the **raw** `original` input through `cleanSegment`, which only strips redirects (`2>&1`, `>`, `<`) and env prefixes — it **never** strips pipe tails. So a single bare command ending in a recognized pipe tail (`| tail`, `| head`, `| wc`, `| sort`, `| uniq`) leaked that tail into the row label, even though `splitCompoundCommand` had already pipe-stripped its segments.

This created a cross-path inconsistency for the *same logical command*:

- `tsc --noEmit 2>&1 | tail -20` rendered as `tsc --noEmit | tail -20` (wrong — single-segment path).
- The same command with an incidental `cd /x &&` prefix took the multi-segment path and correctly rendered `tsc --noEmit` (this is the existing test at `summarize-command.test.ts:56-57`).

The fix cleans the already-pipe-stripped `segments[0]` instead of the raw `original` in the single-segment branch. The length guard keeps `segments[0]` access safe; the zero-segment degenerate case (everything filtered to empty, e.g. raw `| tail`) still falls back to `original`, preserving current behavior.

## Related Issue

No filed issue — author-found regression in a hot fresh module (the file was added whole by #52321 on Jun 25, which did not address the single-segment path). Display-only; the full command remains available via Copy / detail.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/summarize-command.ts`: in the `segments.length <= 1` branch, clean the already-pipe-stripped `segments[0]` rather than re-cleaning the raw `original`.
- `apps/desktop/src/lib/summarize-command.test.ts`: add a regression case for a single bare command (no leading `cd`) ending in a pipe tail.

## How to Test

1. `cd apps/desktop`
2. Run the suite for this module (vitest). Before the fix, the new case fails:
   `expected 'tsc --noEmit | tail -20' to be 'tsc --noEmit'`. After the fix all 19 cases pass.
3. Regression guard verified both directions: the new test is RED on clean `main` (returns `tsc --noEmit | tail -20`) and GREEN after the one-line fix. The 18 pre-existing assertions — including the all-plumbing `cd /x && export FOO=1` → returns original, the in-quotes operator cases, the env-assignment case, and the `2>&1`-on-pipeline case — all still pass.
4. `npm run --prefix apps/desktop typecheck` and `eslint` on both touched files are clean (no new errors introduced).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- N/A — TypeScript-only change; ran the desktop vitest suite instead (19/19 pass) -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure string logic, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A