### PR TITLE
fix(line): enforce UTF-16 field budgets

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -92,7 +92,9 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    _prefix_within_utf16_limit,
     cache_image_from_bytes,
+    utf16_len,
 )
 from gateway.config import Platform
 
@@ -112,6 +114,7 @@ LINE_PER_BUBBLE_CHARS = 5000  # Hard limit per text message object
 LINE_SAFE_BUBBLE_CHARS = 4500  # Conservative limit for chunking
 LINE_MAX_MESSAGES_PER_CALL = 5  # API rejects >5 messages per Reply/Push
 LINE_REPLY_TOKEN_TTL_SECONDS = 50  # Conservative cap below LINE's ~60s
+LINE_ELLIPSIS = "…"
 
 # Webhook hardening
 WEBHOOK_BODY_MAX_BYTES = 1_048_576  # 1 MiB — webhooks are tiny JSON
@@ -147,6 +150,19 @@ _LINE_MESSAGE_TYPES = {
     "location": MessageType.LOCATION,
     "sticker": MessageType.STICKER,
 }
+
+
+def _line_truncate_utf16(text: str, limit: int, *, ellipsis: str = "") -> str:
+    """Trim LINE payload text to a UTF-16 budget without splitting emoji."""
+    if utf16_len(text) <= limit:
+        return text
+    suffix_budget = utf16_len(ellipsis)
+    if suffix_budget >= limit:
+        return _prefix_within_utf16_limit(ellipsis, limit)
+    prefix = _prefix_within_utf16_limit(text, limit - suffix_budget)
+    if ellipsis:
+        prefix = prefix.rstrip()
+    return prefix + ellipsis
 
 # A 1×1 transparent PNG used as fallback video preview thumbnail when no
 # explicit preview is supplied — LINE requires ``previewImageUrl`` for
@@ -218,24 +234,25 @@ def split_for_line(text: str, max_chars: int = LINE_SAFE_BUBBLE_CHARS) -> List[s
     """
     if not text:
         return []
-    if len(text) <= max_chars:
+    if utf16_len(text) <= max_chars:
         return [text]
 
     chunks: List[str] = []
     remaining = text
     while remaining and len(chunks) < LINE_MAX_MESSAGES_PER_CALL:
-        if len(remaining) <= max_chars:
+        if utf16_len(remaining) <= max_chars:
             chunks.append(remaining)
             remaining = ""
             break
+        max_cp = len(_prefix_within_utf16_limit(remaining, max_chars))
         # Try to break on the latest paragraph or newline within budget.
-        cut = remaining.rfind("\n\n", 0, max_chars)
+        cut = remaining.rfind("\n\n", 0, max_cp + 1)
         if cut < int(max_chars * 0.5):
-            cut = remaining.rfind("\n", 0, max_chars)
+            cut = remaining.rfind("\n", 0, max_cp + 1)
         if cut < int(max_chars * 0.5):
-            cut = remaining.rfind(" ", 0, max_chars)
+            cut = remaining.rfind(" ", 0, max_cp + 1)
         if cut <= 0:
-            cut = max_chars
+            cut = max_cp
         chunks.append(remaining[:cut].rstrip())
         remaining = remaining[cut:].lstrip()
 
@@ -243,11 +260,19 @@ def split_for_line(text: str, max_chars: int = LINE_SAFE_BUBBLE_CHARS) -> List[s
         # Truncate gracefully — caller already burned its 5-bubble budget.
         if chunks:
             tail = chunks[-1]
-            if len(tail) > max_chars - 1:
-                tail = tail[: max_chars - 1]
-            chunks[-1] = tail.rstrip() + "…"
+            chunks[-1] = _line_truncate_utf16(
+                tail,
+                max_chars,
+                ellipsis=LINE_ELLIPSIS,
+            )
         else:
-            chunks.append(remaining[: max_chars - 1] + "…")
+            chunks.append(
+                _line_truncate_utf16(
+                    remaining,
+                    max_chars,
+                    ellipsis=LINE_ELLIPSIS,
+                )
+            )
     return chunks
 
 
@@ -534,8 +559,11 @@ class _LineClient:
 
 def _text_message(text: str) -> Dict[str, Any]:
     """Build a LINE text message object, capped to per-bubble max."""
-    if len(text) > LINE_PER_BUBBLE_CHARS:
-        text = text[: LINE_PER_BUBBLE_CHARS - 1] + "…"
+    text = _line_truncate_utf16(
+        text,
+        LINE_PER_BUBBLE_CHARS,
+        ellipsis=LINE_ELLIPSIS,
+    )
     return {"type": "text", "text": text}
 
 
@@ -574,8 +602,10 @@ def build_postback_button_message(
 
     LINE limits: ``text`` ≤ 160 chars, ``altText`` ≤ 400 chars.
     """
-    truncated = text if len(text) <= 160 else text[:157] + "..."
-    alt = text if len(text) <= 400 else text[:397] + "..."
+    truncated = _line_truncate_utf16(text, 160, ellipsis="...")
+    alt = _line_truncate_utf16(text, 400, ellipsis="...")
+    label = _line_truncate_utf16(button_label, 20) or "Get answer"
+    display_text = _line_truncate_utf16(button_label, 300) or "Get answer"
     return {
         "type": "template",
         "altText": alt,
@@ -585,11 +615,11 @@ def build_postback_button_message(
             "actions": [
                 {
                     "type": "postback",
-                    "label": button_label[:20] or "Get answer",
+                    "label": label,
                     "data": json.dumps(
                         {"action": "show_response", "request_id": request_id}
                     ),
-                    "displayText": button_label[:300] or "Get answer",
+                    "displayText": display_text,
                 }
             ],
         },

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -312,7 +312,7 @@ def split_for_line(text: str, max_chars: int = LINE_SAFE_BUBBLE_CHARS) -> List[s
         if chunks:
             tail = chunks[-1]
             chunks[-1] = _line_truncate_utf16(
-                tail,
+                tail + LINE_ELLIPSIS,
                 max_chars,
                 ellipsis=LINE_ELLIPSIS,
             )

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -117,10 +117,12 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    _prefix_within_utf16_limit,
     cache_audio_from_bytes,
     cache_document_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
+    utf16_len,
 )
 from gateway.config import Platform
 
@@ -140,6 +142,7 @@ LINE_PER_BUBBLE_CHARS = 5000  # Hard limit per text message object
 LINE_SAFE_BUBBLE_CHARS = 4500  # Conservative limit for chunking
 LINE_MAX_MESSAGES_PER_CALL = 5  # API rejects >5 messages per Reply/Push
 LINE_REPLY_TOKEN_TTL_SECONDS = 50  # Conservative cap below LINE's ~60s
+LINE_ELLIPSIS = "…"
 
 # Webhook hardening
 WEBHOOK_BODY_MAX_BYTES = 1_048_576  # 1 MiB — webhooks are tiny JSON
@@ -198,6 +201,19 @@ _LINE_MESSAGE_TYPES = {
     "location": MessageType.LOCATION,
     "sticker": MessageType.STICKER,
 }
+
+
+def _line_truncate_utf16(text: str, limit: int, *, ellipsis: str = "") -> str:
+    """Trim LINE payload text to a UTF-16 budget without splitting emoji."""
+    if utf16_len(text) <= limit:
+        return text
+    suffix_budget = utf16_len(ellipsis)
+    if suffix_budget >= limit:
+        return _prefix_within_utf16_limit(ellipsis, limit)
+    prefix = _prefix_within_utf16_limit(text, limit - suffix_budget)
+    if ellipsis:
+        prefix = prefix.rstrip()
+    return prefix + ellipsis
 
 # A 1×1 transparent PNG used as fallback video preview thumbnail when no
 # explicit preview is supplied — LINE requires ``previewImageUrl`` for
@@ -269,24 +285,25 @@ def split_for_line(text: str, max_chars: int = LINE_SAFE_BUBBLE_CHARS) -> List[s
     """
     if not text:
         return []
-    if len(text) <= max_chars:
+    if utf16_len(text) <= max_chars:
         return [text]
 
     chunks: List[str] = []
     remaining = text
     while remaining and len(chunks) < LINE_MAX_MESSAGES_PER_CALL:
-        if len(remaining) <= max_chars:
+        if utf16_len(remaining) <= max_chars:
             chunks.append(remaining)
             remaining = ""
             break
+        max_cp = len(_prefix_within_utf16_limit(remaining, max_chars))
         # Try to break on the latest paragraph or newline within budget.
-        cut = remaining.rfind("\n\n", 0, max_chars)
+        cut = remaining.rfind("\n\n", 0, max_cp + 1)
         if cut < int(max_chars * 0.5):
-            cut = remaining.rfind("\n", 0, max_chars)
+            cut = remaining.rfind("\n", 0, max_cp + 1)
         if cut < int(max_chars * 0.5):
-            cut = remaining.rfind(" ", 0, max_chars)
+            cut = remaining.rfind(" ", 0, max_cp + 1)
         if cut <= 0:
-            cut = max_chars
+            cut = max_cp
         chunks.append(remaining[:cut].rstrip())
         remaining = remaining[cut:].lstrip()
 
@@ -294,11 +311,19 @@ def split_for_line(text: str, max_chars: int = LINE_SAFE_BUBBLE_CHARS) -> List[s
         # Truncate gracefully — caller already burned its 5-bubble budget.
         if chunks:
             tail = chunks[-1]
-            if len(tail) > max_chars - 1:
-                tail = tail[: max_chars - 1]
-            chunks[-1] = tail.rstrip() + "…"
+            chunks[-1] = _line_truncate_utf16(
+                tail,
+                max_chars,
+                ellipsis=LINE_ELLIPSIS,
+            )
         else:
-            chunks.append(remaining[: max_chars - 1] + "…")
+            chunks.append(
+                _line_truncate_utf16(
+                    remaining,
+                    max_chars,
+                    ellipsis=LINE_ELLIPSIS,
+                )
+            )
     return chunks
 
 
@@ -587,8 +612,11 @@ class _LineClient:
 
 def _text_message(text: str) -> Dict[str, Any]:
     """Build a LINE text message object, capped to per-bubble max."""
-    if len(text) > LINE_PER_BUBBLE_CHARS:
-        text = text[: LINE_PER_BUBBLE_CHARS - 1] + "…"
+    text = _line_truncate_utf16(
+        text,
+        LINE_PER_BUBBLE_CHARS,
+        ellipsis=LINE_ELLIPSIS,
+    )
     return {"type": "text", "text": text}
 
 
@@ -627,8 +655,10 @@ def build_postback_button_message(
 
     LINE limits: ``text`` ≤ 160 chars, ``altText`` ≤ 400 chars.
     """
-    truncated = text if len(text) <= 160 else text[:157] + "..."
-    alt = text if len(text) <= 400 else text[:397] + "..."
+    truncated = _line_truncate_utf16(text, 160, ellipsis="...")
+    alt = _line_truncate_utf16(text, 400, ellipsis="...")
+    label = _line_truncate_utf16(button_label, 20) or "Get answer"
+    display_text = _line_truncate_utf16(button_label, 300) or "Get answer"
     return {
         "type": "template",
         "altText": alt,
@@ -638,11 +668,11 @@ def build_postback_button_message(
             "actions": [
                 {
                     "type": "postback",
-                    "label": button_label[:20] or "Get answer",
+                    "label": label,
                     "data": json.dumps(
                         {"action": "show_response", "request_id": request_id}
                     ),
-                    "displayText": button_label[:300] or "Get answer",
+                    "displayText": display_text,
                 }
             ],
         },

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -33,6 +33,9 @@ verify_line_signature = _line.verify_line_signature
 strip_markdown_preserving_urls = _line.strip_markdown_preserving_urls
 split_for_line = _line.split_for_line
 build_postback_button_message = _line.build_postback_button_message
+_line_truncate_utf16 = _line._line_truncate_utf16
+_text_message = _line._text_message
+utf16_len = _line.utf16_len
 _resolve_chat = _line._resolve_chat
 _allowed_for_source = _line._allowed_for_source
 _is_system_bypass = _line._is_system_bypass
@@ -295,6 +298,18 @@ class TestMarkdownAndChunking:
         chunks = split_for_line(text)
         assert len(chunks) <= 5
 
+    def test_line_truncate_respects_utf16_budget(self):
+        text = ("a" * 19) + "😀" + "tail"
+        out = _line_truncate_utf16(text, 20)
+        assert utf16_len(out) <= 20
+        assert out == "a" * 19
+
+    def test_split_final_chunk_respects_utf16_budget_with_emoji(self):
+        text = "\n".join(("x" * 9) + "😀" for _ in range(20))
+        chunks = split_for_line(text, max_chars=10)
+        assert len(chunks) <= 5
+        assert all(utf16_len(chunk) <= 10 for chunk in chunks)
+
 
 # ---------------------------------------------------------------------------
 # 7. Send routing (reply -> push fallback, batching, system-bypass)
@@ -555,6 +570,21 @@ class TestPostbackButtonShape:
         long = "x" * 500
         msg = build_postback_button_message(long, "Tap", "rid")
         assert len(msg["altText"]) <= 400
+
+    def test_template_fields_respect_utf16_limits(self):
+        text = ("a" * 158) + "😀" + "x"
+        button_label = ("b" * 19) + "😀" + "x"
+        msg = build_postback_button_message(text, button_label, "rid")
+        action = msg["template"]["actions"][0]
+
+        assert utf16_len(msg["template"]["text"]) <= 160
+        assert utf16_len(msg["altText"]) <= 400
+        assert utf16_len(action["label"]) <= 20
+        assert utf16_len(action["displayText"]) <= 300
+
+    def test_text_message_respects_utf16_limit(self):
+        msg = _text_message(("x" * 4999) + "😀")
+        assert utf16_len(msg["text"]) <= 5000
 
 
 class TestCheckRequirements:

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -34,6 +34,9 @@ verify_line_signature = _line.verify_line_signature
 strip_markdown_preserving_urls = _line.strip_markdown_preserving_urls
 split_for_line = _line.split_for_line
 build_postback_button_message = _line.build_postback_button_message
+_line_truncate_utf16 = _line._line_truncate_utf16
+_text_message = _line._text_message
+utf16_len = _line.utf16_len
 _resolve_chat = _line._resolve_chat
 _allowed_for_source = _line._allowed_for_source
 _is_system_bypass = _line._is_system_bypass
@@ -166,6 +169,18 @@ class TestMarkdownAndChunking:
         text = "\n\n".join(["x" * 100 for _ in range(1000)])
         chunks = split_for_line(text)
         assert len(chunks) <= 5
+
+    def test_line_truncate_respects_utf16_budget(self):
+        text = ("a" * 19) + "😀" + "tail"
+        out = _line_truncate_utf16(text, 20)
+        assert utf16_len(out) <= 20
+        assert out == "a" * 19
+
+    def test_split_final_chunk_respects_utf16_budget_with_emoji(self):
+        text = "\n".join(("x" * 9) + "😀" for _ in range(20))
+        chunks = split_for_line(text, max_chars=10)
+        assert len(chunks) <= 5
+        assert all(utf16_len(chunk) <= 10 for chunk in chunks)
 
 
 # ---------------------------------------------------------------------------
@@ -336,6 +351,21 @@ class TestPostbackButtonShape:
         assert actions[0]["type"] == "postback"
         data = json.loads(actions[0]["data"])
         assert data == {"action": "show_response", "request_id": "rid-1"}
+
+    def test_template_fields_respect_utf16_limits(self):
+        text = ("a" * 158) + "😀" + "x"
+        button_label = ("b" * 19) + "😀" + "x"
+        msg = build_postback_button_message(text, button_label, "rid")
+        action = msg["template"]["actions"][0]
+
+        assert utf16_len(msg["template"]["text"]) <= 160
+        assert utf16_len(msg["altText"]) <= 400
+        assert utf16_len(action["label"]) <= 20
+        assert utf16_len(action["displayText"]) <= 300
+
+    def test_text_message_respects_utf16_limit(self):
+        msg = _text_message(("x" * 4999) + "😀")
+        assert utf16_len(msg["text"]) <= 5000
 
 
 class TestCheckRequirements:

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -181,6 +181,7 @@ class TestMarkdownAndChunking:
         chunks = split_for_line(text, max_chars=10)
         assert len(chunks) <= 5
         assert all(utf16_len(chunk) <= 10 for chunk in chunks)
+        assert chunks[-1].endswith("…")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add a small LINE-specific UTF-16 truncation helper using the existing gateway UTF-16 utilities
- enforce UTF-16 budgets for LINE split chunks, text bubbles, template text/altText, and postback label/displayText
- add emoji-heavy regression tests for the affected LINE payload fields

## Context

This follows the same LINE boundary covered by OpenClaw's recent fixes:

- openclaw/openclaw#97470
- openclaw/openclaw#97428

Closes #54993.

## Duplicate Audit

Live GitHub search found no open Hermes PR or issue for LINE UTF-16 truncation, LINE action-label UTF-16 limits, or LINE template field UTF-16 budgets. Adjacent LINE PRs add approval buttons or broader LINE features, but they do not enforce the existing adapter's platform string budgets.

## Tests

- `uv run --extra dev python -m pytest tests\gateway\test_line_plugin.py -q --basetemp .pytest-tmp-line-utf16-truncation`
- `uv run --extra dev python -m ruff check plugins\platforms\line\adapter.py tests\gateway\test_line_plugin.py`
- `git diff --check`

Autoreview was not available in this worktree (`.agents/skills/autoreview/scripts/autoreview` not present).
