### PR TITLE
fix(auth): reject command-shaped API key values

### DIFF
--- a/agent/credential_persistence.py
+++ b/agent/credential_persistence.py
@@ -92,6 +92,15 @@ _SECRET_VALUE_SUFFIXES = (
 )
 
 _CAMEL_CASE_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_COMMAND_API_KEY_HEAD_RE = re.compile(
+    r"^\s*(?:[$>]\s*)?(?:hermes|openclaw)\b",
+    re.IGNORECASE,
+)
+_COMMAND_API_KEY_AUTH_MARKER_RE = re.compile(
+    r"(?:^|\s)(?:auth|setup|model|portal|onboard)\b"
+    r"|(?:^|\s)--(?:api-key|auth-choice|auth-type|type|provider|model|label|non-interactive)\b",
+    re.IGNORECASE,
+)
 
 
 def _normalize_key(key: Any) -> str:
@@ -109,6 +118,22 @@ def is_borrowed_credential_source(source: Any, provider_id: Any = None) -> bool:
         return False
     normalized_provider = str(provider_id or "").strip().lower()
     return (normalized_provider, normalized_source) not in _PERSISTABLE_PROVIDER_SOURCES
+
+
+def is_command_shaped_api_key(value: Any) -> bool:
+    """Return True when an API-key input is clearly a copied CLI command.
+
+    This deliberately stays narrow: it only rejects Hermes/OpenClaw command
+    lines that also contain auth/setup/model/onboard markers or auth flags.
+    Normal secrets that merely contain words like "hermes" remain accepted.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return False
+    return bool(
+        _COMMAND_API_KEY_HEAD_RE.search(text)
+        and _COMMAND_API_KEY_AUTH_MARKER_RE.search(text)
+    )
 
 
 def _is_secret_payload_key(key: Any) -> bool:

--- a/agent/credential_persistence.py
+++ b/agent/credential_persistence.py
@@ -92,6 +92,18 @@ _SECRET_VALUE_SUFFIXES = (
 )
 
 _CAMEL_CASE_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_COMMAND_API_KEY_HEAD_RE = re.compile(
+    r"^\s*(?:[$>]\s*)?(?:hermes|openclaw)\b",
+    re.IGNORECASE,
+)
+_COMMAND_API_KEY_AUTH_MARKER_RE = re.compile(
+    r"(?:^|\s)(?:auth|setup|model|portal|onboard)\b"
+    r"|(?:^|\s)--(?:api-key|auth-choice|auth-type|type|provider|model|label|non-interactive)\b",
+    re.IGNORECASE,
+)
+_COMMAND_API_KEY_CONFIG_SET_RE = re.compile(
+    r"(?:^|\s)config\s+set\s+\S*(?:api[-_]?key)\b", re.IGNORECASE
+)
 
 
 def _normalize_key(key: Any) -> str:
@@ -109,6 +121,25 @@ def is_borrowed_credential_source(source: Any, provider_id: Any = None) -> bool:
         return False
     normalized_provider = str(provider_id or "").strip().lower()
     return (normalized_provider, normalized_source) not in _PERSISTABLE_PROVIDER_SOURCES
+
+
+def is_command_shaped_api_key(value: Any) -> bool:
+    """Return True when an API-key input is clearly a copied CLI command.
+
+    This deliberately stays narrow: it only rejects Hermes/OpenClaw command
+    lines that also contain auth/setup/model/onboard markers or auth flags.
+    Normal secrets that merely contain words like "hermes" remain accepted.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return False
+    return bool(
+        _COMMAND_API_KEY_HEAD_RE.search(text)
+        and (
+            _COMMAND_API_KEY_AUTH_MARKER_RE.search(text)
+            or _COMMAND_API_KEY_CONFIG_SET_RE.search(text)
+        )
+    )
 
 
 def _is_secret_payload_key(key: Any) -> bool:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -18,6 +18,7 @@ from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
 from agent.secret_scope import get_secret as _get_secret
 from agent.credential_persistence import (
+    is_command_shaped_api_key,
     is_borrowed_credential_source,
     sanitize_borrowed_credential_payload,
 )
@@ -221,7 +222,10 @@ class PooledCredential:
                 ):
                     return token.strip()
             return ""
-        return str(self.access_token or "")
+        token = str(self.access_token or "").strip()
+        if is_command_shaped_api_key(token):
+            return ""
+        return token
 
     @property
     def runtime_base_url(self) -> Optional[str]:
@@ -1429,6 +1433,12 @@ class CredentialPool:
                 if refreshed is None:
                     continue
                 entry = refreshed
+            if (
+                entry.provider != "nous"
+                and entry.auth_type == "api_key"
+                and is_command_shaped_api_key(entry.access_token)
+            ):
+                continue
             available.append(entry)
         if entries_to_prune:
             pruned_ids = set(entries_to_prune)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -18,6 +18,7 @@ from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
 from agent.secret_scope import get_secret as _get_secret
 from agent.credential_persistence import (
+    is_command_shaped_api_key,
     is_borrowed_credential_source,
     sanitize_borrowed_credential_payload,
 )
@@ -280,7 +281,10 @@ class PooledCredential:
                 ):
                     return token.strip()
             return ""
-        return str(self.access_token or "")
+        token = str(self.access_token or "").strip()
+        if is_command_shaped_api_key(token):
+            return ""
+        return token
 
     @property
     def runtime_base_url(self) -> Optional[str]:
@@ -2381,6 +2385,13 @@ class CredentialPool:
             return None, None, f'No credential matching "{raw}".'
 
     def add_entry(self, entry: PooledCredential) -> PooledCredential:
+        if entry.auth_type == AUTH_TYPE_API_KEY and is_command_shaped_api_key(
+            entry.access_token
+        ):
+            raise ValueError(
+                "API key input looks like a Hermes/OpenClaw command. "
+                "Paste only the raw API key value."
+            )
         with self._lock:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -27,6 +27,7 @@ from agent.credential_pool import (
     list_custom_pool_providers,
     load_pool,
 )
+from agent.credential_persistence import is_command_shaped_api_key
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import PROVIDER_REGISTRY
 from hermes_constants import OPENROUTER_BASE_URL
@@ -200,6 +201,11 @@ def auth_add_command(args) -> None:
             token = masked_secret_prompt("Paste your API key: ").strip()
         if not token:
             raise SystemExit("No API key provided.")
+        if is_command_shaped_api_key(token):
+            raise SystemExit(
+                "API key input looks like a Hermes/OpenClaw command. "
+                "Paste only the raw API key value."
+            )
         default_label = _api_key_default_label(len(pool.entries()) + 1)
         label = (getattr(args, "label", None) or "").strip()
         if not label:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -102,6 +102,59 @@ def test_select_clears_expired_exhaustion(tmp_path, monkeypatch):
     assert entry.last_status == "ok"
 
 
+def test_command_shaped_api_key_values_are_not_runtime_credentials():
+    from agent.credential_persistence import is_command_shaped_api_key
+
+    assert is_command_shaped_api_key(
+        "hermes auth add openrouter --api-key sk-or-real"
+    )
+    assert is_command_shaped_api_key(
+        "openclaw onboard --non-interactive --auth-choice=zai-coding-global"
+    )
+    assert not is_command_shaped_api_key("sk-hermes-auth-add-openrouter")
+    assert not is_command_shaped_api_key("hermes-secret-token")
+
+
+def test_select_skips_command_shaped_api_key_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-bad",
+                        "label": "copied-command",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "hermes auth add openrouter --api-key sk-or-real",
+                    },
+                    {
+                        "id": "cred-good",
+                        "label": "good",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-good",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openrouter")
+    bad = next(entry for entry in pool.entries() if entry.id == "cred-bad")
+    selected = pool.select()
+
+    assert bad.runtime_api_key == ""
+    assert selected is not None
+    assert selected.id == "cred-good"
+
+
 def test_round_robin_strategy_rotates_priorities(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -24,6 +24,59 @@ def _jwt_with_claims(claims: dict) -> str:
     return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
 
 
+def test_command_shaped_api_key_values_are_not_runtime_credentials():
+    from agent.credential_persistence import is_command_shaped_api_key
+
+    assert is_command_shaped_api_key(
+        "hermes auth add openrouter --api-key sk-or-real"
+    )
+    assert is_command_shaped_api_key(
+        "openclaw onboard --non-interactive --auth-choice=zai-coding-global"
+    )
+    assert not is_command_shaped_api_key("sk-hermes-auth-add-openrouter")
+    assert not is_command_shaped_api_key("hermes-secret-token")
+
+
+def test_select_skips_command_shaped_api_key_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-bad",
+                        "label": "copied-command",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "openclaw config set models.providers.openai.apiKey sk-real",
+                    },
+                    {
+                        "id": "cred-good",
+                        "label": "good",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-good",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openrouter")
+    bad = next(entry for entry in pool.entries() if entry.id == "cred-bad")
+    selected = pool.select()
+
+    assert bad.runtime_api_key == ""
+    assert selected is not None
+    assert selected.id == "cred-good"
+
+
 
 
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -94,6 +94,25 @@ def test_auth_add_api_key_persists_manual_entry(tmp_path, monkeypatch):
     assert entry["access_token"] == "sk-or-manual"
 
 
+def test_auth_add_rejects_command_shaped_api_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openrouter"
+        auth_type = "api-key"
+        api_key = "hermes auth add openrouter --api-key sk-or-real"
+        label = "bad"
+
+    with pytest.raises(SystemExit, match="Paste only the raw API key value"):
+        auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert payload.get("credential_pool", {}).get("openrouter") in (None, [])
+
+
 def test_auth_add_anthropic_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -94,6 +94,25 @@ def test_auth_add_api_key_persists_manual_entry(tmp_path, monkeypatch):
     assert entry["access_token"] == "sk-or-manual"
 
 
+def test_auth_add_rejects_command_shaped_api_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openrouter"
+        auth_type = "api-key"
+        api_key = "hermes auth add openrouter --api-key sk-or-real"
+        label = "bad"
+
+    with pytest.raises(SystemExit, match="Paste only the raw API key value"):
+        auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert payload.get("credential_pool", {}).get("openrouter") in (None, [])
+
+
 def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -148,6 +148,22 @@ class TestCredentialPoolEndpoints:
         self.client, _ = _client()
 
 
+    def test_post_rejects_command_shaped_api_key_without_persisting(self):
+        from agent.credential_pool import load_pool
+
+        response = self.client.post(
+            "/api/credentials/pool",
+            json={
+                "provider": "openrouter",
+                "api_key": "openclaw config set models.providers.openai.apiKey sk-real",
+            },
+        )
+
+        assert response.status_code == 400
+        assert "raw API key" in response.json()["detail"]
+        assert load_pool("openrouter").entries() == []
+
+
 
     def test_env_seeded_delete_stays_deleted(self):
         """#55217: DELETE must suppress the source or load_pool() resurrects it.


### PR DESCRIPTION
Closes #54996

## Summary

- Add a narrow detector for API-key values that are clearly copied Hermes/OpenClaw CLI commands.
- Reject those values in `hermes auth add ... --api-key` before they are persisted.
- Skip existing command-shaped API-key pool entries during selection so a poisoned pool can recover by falling through to a valid credential.

## Context

This mirrors the input-guard class fixed in OpenClaw https://github.com/openclaw/openclaw/pull/97520, but applies it to Hermes' local auth command and credential pool paths.

The detector is deliberately narrow: it only matches values that begin like `hermes`/`openclaw` commands and also contain auth/setup/model/onboard markers or known auth flags. Normal secrets containing words such as `hermes` remain accepted.

## Duplicate Audit

Live GitHub searches found no matching open Hermes issue or PR for this credential-pool bug:

- `command shaped api key credential pool`
- `malformed API key auth command`
- `Paste only the raw API key`
- `api key command auth credential pool malformed`

The only broad-search issue returned was unrelated to this auth-input problem.

## Tests

- `uv run --extra dev python -m pytest tests\hermes_cli\test_auth_commands.py tests\agent\test_credential_pool.py -q --basetemp .pytest-tmp-auth-command-shaped-api-keys`
- `uv run --extra dev python -m ruff check agent\credential_persistence.py agent\credential_pool.py hermes_cli\auth_commands.py tests\agent\test_credential_pool.py tests\hermes_cli\test_auth_commands.py`
- `git diff --check`

Autoreview was not run because this worktree does not contain `.agents/skills/autoreview/scripts/autoreview`.
