### PR TITLE
fix(env-loader): preserve .env file permissions during startup sanitize

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -189,7 +189,17 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         stripped = [line.replace("\x00", "") for line in original]
         sanitized = _sanitize_env_lines(stripped)
         if sanitized != original:
+            import stat
             import tempfile
+
+            # Preserve original permissions so Docker volume mounts
+            # aren't clobbered (mirrors save_env_value / remove_env_value).
+            original_mode = None
+            try:
+                original_mode = stat.S_IMODE(path.stat().st_mode)
+            except OSError:
+                pass
+
             fd, tmp = tempfile.mkstemp(
                 dir=str(path.parent), suffix=".tmp", prefix=".env_"
             )
@@ -199,6 +209,14 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
                     f.flush()
                     os.fsync(f.fileno())
                 atomic_replace(tmp, path)
+                # Restore the original file mode instead of relying on
+                # mkstemp's default (0600).  For new files without a
+                # prior mode, _secure_file tightens to 0600.
+                if original_mode is not None:
+                    try:
+                        os.chmod(path, original_mode)
+                    except OSError:
+                        pass
             except BaseException:
                 try:
                     os.unlink(tmp)

--- a/tests/hermes_cli/test_env_sanitize_on_load.py
+++ b/tests/hermes_cli/test_env_sanitize_on_load.py
@@ -89,3 +89,42 @@ def test_env_loader_sanitizes_before_dotenv():
         assert parsed_token == token
     finally:
         env_path.unlink(missing_ok=True)
+
+
+def test_sanitize_env_file_if_needed_preserves_permissions():
+    """_sanitize_env_file_if_needed preserves the original file mode.
+
+    Mirrors the sanitize_env_file permission-preservation tests in
+    test_config.py.  When a .env file has an operator-set mode (e.g.
+    0o640 for Docker volume mounts), the sanitize rewrite must not
+    clobber it to 0o600 (mkstemp default).
+    """
+    import os
+    import stat
+
+    from hermes_cli.env_loader import _sanitize_env_file_if_needed
+
+    token = "0123456789:test"
+    # Concatenated line that triggers sanitization
+    corrupted = f"TELEGRAM_BOT_TOKEN={token}ANTHROPIC_API_KEY=sk-ant-test\n"
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".env", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(corrupted)
+        env_path = Path(f.name)
+
+    try:
+        # Set a non-default mode (simulates Docker volume mount at 0640)
+        target_mode = 0o640
+        os.chmod(env_path, target_mode)
+
+        _sanitize_env_file_if_needed(env_path)
+
+        actual_mode = stat.S_IMODE(env_path.stat().st_mode)
+        assert actual_mode == target_mode, (
+            f"Expected mode {oct(target_mode)}, got {oct(actual_mode)} — "
+            "permissions were clobbered by sanitize"
+        )
+    finally:
+        env_path.unlink(missing_ok=True)


### PR DESCRIPTION
Closing as stale — 10+ days old, 0 reviews, 0 maintainer engagement. Not worth further effort.