### PR TITLE
fix(zai): stream endpoint probes without reading bodies

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -627,7 +627,8 @@ def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str
     for ep_id, base_url, probe_models, label in ZAI_ENDPOINTS:
         for model in probe_models:
             try:
-                resp = httpx.post(
+                with httpx.stream(
+                    "POST",
                     f"{base_url}/chat/completions",
                     headers={
                         "Authorization": f"Bearer {api_key}",
@@ -640,8 +641,9 @@ def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str
                         "messages": [{"role": "user", "content": "ping"}],
                     },
                     timeout=timeout,
-                )
-                if resp.status_code == 200:
+                ) as resp:
+                    status_code = resp.status_code
+                if status_code == 200:
                     logger.debug("Z.AI endpoint probe: %s (%s) model=%s OK", ep_id, base_url, model)
                     return {
                         "id": ep_id,
@@ -649,7 +651,7 @@ def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str
                         "model": model,
                         "label": label,
                     }
-                logger.debug("Z.AI endpoint probe: %s model=%s returned %s", ep_id, model, resp.status_code)
+                logger.debug("Z.AI endpoint probe: %s model=%s returned %s", ep_id, model, status_code)
             except Exception as exc:
                 logger.debug("Z.AI endpoint probe: %s model=%s failed: %s", ep_id, model, exc)
     return None

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -741,7 +741,8 @@ def _probe_single_zai_endpoint(
     ep_id, base_url, probe_models, label = endpoint
     for model in probe_models:
         try:
-            resp = httpx.post(
+            with httpx.stream(
+                "POST",
                 f"{base_url}/chat/completions",
                 headers={
                     "Authorization": f"Bearer {api_key}",
@@ -754,8 +755,9 @@ def _probe_single_zai_endpoint(
                     "messages": [{"role": "user", "content": "ping"}],
                 },
                 timeout=timeout,
-            )
-            if resp.status_code == 200:
+            ) as resp:
+                status_code = resp.status_code
+            if status_code == 200:
                 logger.debug("Z.AI endpoint probe: %s (%s) model=%s OK", ep_id, base_url, model)
                 return {
                     "id": ep_id,
@@ -763,7 +765,7 @@ def _probe_single_zai_endpoint(
                     "model": model,
                     "label": label,
                 }
-            logger.debug("Z.AI endpoint probe: %s model=%s returned %s", ep_id, model, resp.status_code)
+            logger.debug("Z.AI endpoint probe: %s model=%s returned %s", ep_id, model, status_code)
         except Exception as exc:
             logger.debug("Z.AI endpoint probe: %s model=%s failed: %s", ep_id, model, exc)
     return None

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -747,6 +747,16 @@ class TestZaiParallelProbe:
     winner is chosen by ZAI_ENDPOINTS priority order (not completion order).
     """
 
+    @pytest.fixture(autouse=True)
+    def _stream_via_mock_post(self, monkeypatch):
+        from contextlib import nullcontext
+        from hermes_cli import auth
+
+        def _stream(_method, url, **kwargs):
+            return nullcontext(auth.httpx.post(url, **kwargs))
+
+        monkeypatch.setattr(auth.httpx, "stream", _stream)
+
     def _mock_post(self, ok):
         """Return an httpx.post replacement; `ok` maps (base_url, model) -> bool."""
         import httpx as _httpx

--- a/tests/hermes_cli/test_zai_endpoint_probe.py
+++ b/tests/hermes_cli/test_zai_endpoint_probe.py
@@ -1,0 +1,57 @@
+from hermes_cli import auth
+
+
+class _ProbeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def iter_bytes(self, *args, **kwargs):
+        raise AssertionError("Z.AI endpoint probe should not read response bodies")
+
+
+def test_detect_zai_endpoint_streams_probe_without_reading_body(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        auth,
+        "ZAI_ENDPOINTS",
+        [("global", "https://api.z.ai/api/paas/v4", ["glm-5"], "Global")],
+    )
+
+    def _fake_stream(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        return _ProbeResponse(200)
+
+    monkeypatch.setattr(auth.httpx, "stream", _fake_stream)
+
+    result = auth.detect_zai_endpoint("zai-key", timeout=3.5)
+
+    assert result == {
+        "id": "global",
+        "base_url": "https://api.z.ai/api/paas/v4",
+        "model": "glm-5",
+        "label": "Global",
+    }
+    assert calls
+    method, url, kwargs = calls[0]
+    assert method == "POST"
+    assert url == "https://api.z.ai/api/paas/v4/chat/completions"
+    assert kwargs["timeout"] == 3.5
+    assert kwargs["json"]["model"] == "glm-5"
+    assert kwargs["headers"]["Authorization"] == "Bearer zai-key"
+
+
+def test_detect_zai_endpoint_ignores_non_200_without_reading_body(monkeypatch):
+    monkeypatch.setattr(
+        auth,
+        "ZAI_ENDPOINTS",
+        [("global", "https://api.z.ai/api/paas/v4", ["glm-5"], "Global")],
+    )
+    monkeypatch.setattr(auth.httpx, "stream", lambda *_args, **_kwargs: _ProbeResponse(401))
+
+    assert auth.detect_zai_endpoint("zai-key") is None

--- a/tests/hermes_cli/test_zai_endpoint_probe.py
+++ b/tests/hermes_cli/test_zai_endpoint_probe.py
@@ -1,0 +1,60 @@
+from hermes_cli import auth
+
+
+class _ProbeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        raise AssertionError("Z.AI endpoint probe should not read response bodies")
+
+    def iter_bytes(self, *args, **kwargs):
+        raise AssertionError("Z.AI endpoint probe should not read response bodies")
+
+
+def test_detect_zai_endpoint_streams_probe_without_reading_body(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        auth,
+        "ZAI_ENDPOINTS",
+        [("global", "https://api.z.ai/api/paas/v4", ["glm-5"], "Global")],
+    )
+
+    def _fake_stream(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        return _ProbeResponse(200)
+
+    monkeypatch.setattr(auth.httpx, "stream", _fake_stream)
+
+    result = auth.detect_zai_endpoint("zai-key", timeout=3.5)
+
+    assert result == {
+        "id": "global",
+        "base_url": "https://api.z.ai/api/paas/v4",
+        "model": "glm-5",
+        "label": "Global",
+    }
+    assert calls
+    method, url, kwargs = calls[0]
+    assert method == "POST"
+    assert url == "https://api.z.ai/api/paas/v4/chat/completions"
+    assert kwargs["timeout"] == 3.5
+    assert kwargs["json"]["model"] == "glm-5"
+    assert kwargs["headers"]["Authorization"] == "Bearer zai-key"
+
+
+def test_detect_zai_endpoint_ignores_non_200_without_reading_body(monkeypatch):
+    monkeypatch.setattr(
+        auth,
+        "ZAI_ENDPOINTS",
+        [("global", "https://api.z.ai/api/paas/v4", ["glm-5"], "Global")],
+    )
+    monkeypatch.setattr(auth.httpx, "stream", lambda *_args, **_kwargs: _ProbeResponse(401))
+
+    assert auth.detect_zai_endpoint("zai-key") is None


### PR DESCRIPTION
Closes #55006

## Summary

- Switch `detect_zai_endpoint()` from non-streaming `httpx.post(...)` to `httpx.stream(...)`.
- Keep the existing status-only endpoint detection behavior while closing probe responses without reading bodies.
- Add focused tests proving successful and non-200 probes do not consume response bodies.

## Context

This mirrors the endpoint-probe boundary fixed in OpenClaw https://github.com/openclaw/openclaw/pull/97540, adapted to Hermes' simpler Z.AI detection path.

Hermes only needs `status_code` for this probe. It does not parse error JSON, so the safest and smallest fix is to avoid response-body reads entirely rather than add a body parser/cap.

## Duplicate Audit

Live GitHub searches found no matching open Hermes issue or PR for Z.AI endpoint-probe response-body reads:

- `ZAI endpoint probe response`
- `Z.AI endpoint probe body`
- broad open PR/issue scans containing `zai|z.ai|probe|endpoint|response|body|read|bound|cap`

Related response-cap PRs exist for other providers and surfaces; #54723/#54671 is xAI OAuth fallback activation and unrelated to Z.AI endpoint probing.

## Tests

- `uv run --extra dev python -m pytest tests\hermes_cli\test_zai_endpoint_probe.py -q --basetemp .pytest-tmp-zai-endpoint-probe-stream`
- `uv run --extra dev python -m ruff check hermes_cli\auth.py tests\hermes_cli\test_zai_endpoint_probe.py`
- `git diff --check`

Autoreview was not run because this worktree does not contain `.agents/skills/autoreview/scripts/autoreview`.
