### PR TITLE
fix(matrix): bound standalone sender response reads

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import logging
 import mimetypes
 import os
@@ -133,10 +134,47 @@ from gateway.platforms.helpers import ThreadParticipationTracker
 
 logger = logging.getLogger(__name__)
 
+_MATRIX_API_RESPONSE_MAX_BYTES = 16 * 1024 * 1024
+
 _MATRIX_BANG_COMMAND_RE = re.compile(
     r"^!([A-Za-z][A-Za-z0-9_-]*)(?=$|\s)(.*)$",
     re.DOTALL,
 )
+
+
+async def _read_matrix_api_response_text(resp: Any) -> str:
+    headers = getattr(resp, "headers", {}) or {}
+    content_length = None
+    try:
+        content_length = int(str(headers.get("content-length", "")).strip())
+    except (TypeError, ValueError):
+        content_length = None
+    if content_length is not None and content_length > _MATRIX_API_RESPONSE_MAX_BYTES:
+        raise ValueError(
+            f"Matrix API response exceeds {_MATRIX_API_RESPONSE_MAX_BYTES} bytes"
+        )
+
+    body = bytearray()
+    async for chunk in resp.content.iter_chunked(64 * 1024):
+        if not chunk:
+            continue
+        chunk_bytes = bytes(chunk)
+        if len(body) + len(chunk_bytes) > _MATRIX_API_RESPONSE_MAX_BYTES:
+            raise ValueError(
+                f"Matrix API response exceeds {_MATRIX_API_RESPONSE_MAX_BYTES} bytes"
+            )
+        body.extend(chunk_bytes)
+    return bytes(body).decode("utf-8", "replace")
+
+
+async def _read_matrix_api_response_json(resp: Any) -> Dict[str, Any]:
+    text = await _read_matrix_api_response_text(resp)
+    if not text.strip():
+        return {}
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        raise ValueError("Matrix API JSON response was not an object")
+    return payload
 
 
 def _resolve_matrix_bang_command(name: str) -> str | None:
@@ -4306,9 +4344,9 @@ async def _standalone_send(
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
             async with session.put(url, headers=headers, json=payload) as resp:
                 if resp.status not in {200, 201}:
-                    body = await resp.text()
+                    body = await _read_matrix_api_response_text(resp)
                     return {"error": f"Matrix API error ({resp.status}): {body}"}
-                data = await resp.json()
+                data = await _read_matrix_api_response_json(resp)
         return {"success": True, "platform": "matrix", "chat_id": chat_id, "message_id": data.get("event_id")}
     except Exception as e:
         return {"error": f"Matrix send failed: {e}"}

--- a/tests/tools/test_send_message_missing_platforms.py
+++ b/tests/tools/test_send_message_missing_platforms.py
@@ -1,6 +1,7 @@
 """Tests for _send_mattermost, _send_matrix, _send_homeassistant, _send_dingtalk."""
 
 import asyncio
+import json
 import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -67,12 +68,31 @@ async def _send_homeassistant(token, extra, chat_id, message):
 # ---------------------------------------------------------------------------
 
 
-def _make_aiohttp_resp(status, json_data=None, text_data=None):
+class _AiohttpContent:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def iter_chunked(self, _size):
+        async def _iter():
+            for chunk in self._chunks:
+                yield chunk
+
+        return _iter()
+
+
+def _make_aiohttp_resp(status, json_data=None, text_data=None, *, headers=None, body_bytes=None):
     """Build a minimal async-context-manager mock for an aiohttp response."""
     resp = AsyncMock()
     resp.status = status
     resp.json = AsyncMock(return_value=json_data or {})
     resp.text = AsyncMock(return_value=text_data or "")
+    resp.headers = dict(headers or {})
+    if body_bytes is None:
+        if json_data is not None:
+            body_bytes = json.dumps(json_data).encode("utf-8")
+        else:
+            body_bytes = (text_data or "").encode("utf-8")
+    resp.content = _AiohttpContent([body_bytes])
     return resp
 
 
@@ -191,6 +211,38 @@ class TestSendMatrix:
         assert "error" in result
         assert "403" in result["error"]
         assert "Forbidden" in result["error"]
+
+    def test_http_error_response_body_is_capped(self, monkeypatch):
+        from plugins.platforms.matrix import adapter as matrix_adapter
+
+        monkeypatch.setattr(matrix_adapter, "_MATRIX_API_RESPONSE_MAX_BYTES", 8)
+        resp = _make_aiohttp_resp(403, body_bytes=b"x" * 9)
+        session_ctx, _ = _make_aiohttp_session(resp)
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx):
+            result = asyncio.run(_send_matrix(
+                "tok", {"homeserver": "https://matrix.example.com"},
+                "!room:example.com", "hi"
+            ))
+
+        assert "error" in result
+        assert "Matrix API response exceeds 8 bytes" in result["error"]
+
+    def test_success_response_body_is_capped(self, monkeypatch):
+        from plugins.platforms.matrix import adapter as matrix_adapter
+
+        monkeypatch.setattr(matrix_adapter, "_MATRIX_API_RESPONSE_MAX_BYTES", 8)
+        resp = _make_aiohttp_resp(200, body_bytes=b"x" * 9)
+        session_ctx, _ = _make_aiohttp_session(resp)
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx):
+            result = asyncio.run(_send_matrix(
+                "tok", {"homeserver": "https://matrix.example.com"},
+                "!room:example.com", "hi"
+            ))
+
+        assert "error" in result
+        assert "Matrix API response exceeds 8 bytes" in result["error"]
 
     def test_missing_config(self):
         with patch.dict(os.environ, {"MATRIX_HOMESERVER": "", "MATRIX_ACCESS_TOKEN": ""}, clear=False):


### PR DESCRIPTION
## Summary

- Add a 16 MiB cap for Matrix standalone sender API response reads.
- Apply the cap to both non-2xx error text and success JSON response parsing.
- Extend the existing missing-platform sender tests with oversized Matrix response coverage.

Closes #55009.

## Context

This follows the same response-boundary class as recent provider/platform response cap fixes, but is intentionally scoped to `plugins/platforms/matrix/adapter.py::_standalone_send`.

## Duplicate Audit

Live GitHub checks before opening:

- `gh search prs --repo NousResearch/hermes-agent "Matrix homeserver response cap" --state open` -> no results
- `gh search prs --repo NousResearch/hermes-agent "Matrix API response body" --state open` -> no results
- `gh search issues --repo NousResearch/hermes-agent "Matrix homeserver response cap" --state open` -> no results
- `gh search issues --repo NousResearch/hermes-agent "Matrix API response body" --state open` -> no results

Broad open PR/issue scan showed related response-cap work for other providers, but no Matrix standalone sender duplicate.

## Validation

- `uv run --extra dev --extra messaging python -m pytest tests\tools\test_send_message_missing_platforms.py -q --basetemp .pytest-tmp-matrix-standalone-response-cap` -> `21 passed`
- `uv run --extra dev python -m ruff check plugins\platforms\matrix\adapter.py tests\tools\test_send_message_missing_platforms.py` -> passed
- `git diff --check` -> passed

`autoreview` was not run because `.agents/skills/autoreview/scripts/autoreview` is not present in this worktree.
