### PR TITLE
fix(cli): add REMAINDER passthrough for provider-specific flags in memory setup

### DIFF
--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -6,6 +6,8 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import argparse
+
 from typing import Callable
 
 
@@ -31,6 +33,12 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         nargs="?",
         default=None,
         help="Provider to configure directly (e.g. honcho), skipping the picker",
+    )
+    _setup_parser.add_argument(
+        "provider_args",
+        nargs=argparse.REMAINDER,
+        default=[],
+        help=argparse.SUPPRESS,
     )
     memory_sub.add_parser("status", help="Show current memory provider config")
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")


### PR DESCRIPTION
## Description

Fix #54945 — documented Mem0 OSS setup flags like `--mode oss`, `--oss-llm`, etc. are rejected by top-level argparse before the Mem0 plugin can parse them.

## Root Cause

`hermes memory setup` subparser only defined a positional `provider` argument (`nargs="?"`). When provider-specific flags follow the provider name, argparse rejects them as unrecognized before the handler ever executes.

## Fix

Added a second argument with `nargs=argparse.REMAINDER` to the `setup` subparser. This captures all remaining unrecognized arguments into a `provider_args` list instead of erroring. Since argparse never modifies `sys.argv`, the Mem0 plugin's existing `parse_flags(sys.argv[1:])` continues to work correctly.

## Testing

Verified all parse paths:

| Input | Result |
|-------|--------|
| `memory setup` | `provider=None, provider_args=[]` |
| `memory setup honcho` | `provider='honcho', provider_args=[]` |
| `memory setup mem0 --mode oss --oss-llm openai --dry-run` | `provider='mem0', provider_args=['--mode','oss','--oss-llm','openai','--dry-run']` |

Closes #54945