### PR TITLE
fix(gateway): bound proxy error response reads

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,6 +68,7 @@ _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
+_PROXY_ERROR_RESPONSE_MAX_BYTES = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
@@ -104,6 +105,34 @@ _GATEWAY_RAW_TEXT_PLATFORMS = frozenset(
 def _gateway_surface_passes_raw_text(platform: Any) -> bool:
     """True only for programmatic/local surfaces that must keep raw text."""
     return _gateway_platform_value(platform) in _GATEWAY_RAW_TEXT_PLATFORMS
+
+
+async def _read_proxy_error_text_with_limit(resp: Any) -> str:
+    headers = getattr(resp, "headers", {}) or {}
+    content_length = None
+    try:
+        content_length = int(str(headers.get("content-length", "")).strip())
+    except (TypeError, ValueError):
+        content_length = None
+    if (
+        content_length is not None
+        and content_length > _PROXY_ERROR_RESPONSE_MAX_BYTES
+    ):
+        raise ValueError(
+            f"Proxy error response exceeds {_PROXY_ERROR_RESPONSE_MAX_BYTES} bytes"
+        )
+
+    body = bytearray()
+    async for chunk in resp.content.iter_chunked(64 * 1024):
+        if not chunk:
+            continue
+        chunk_bytes = bytes(chunk)
+        if len(body) + len(chunk_bytes) > _PROXY_ERROR_RESPONSE_MAX_BYTES:
+            raise ValueError(
+                f"Proxy error response exceeds {_PROXY_ERROR_RESPONSE_MAX_BYTES} bytes"
+            )
+        body.extend(chunk_bytes)
+    return bytes(body).decode("utf-8", "replace")
 
 
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
@@ -16278,7 +16307,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     headers=headers,
                 ) as resp:
                     if resp.status != 200:
-                        error_text = await resp.text()
+                        try:
+                            error_text = await _read_proxy_error_text_with_limit(resp)
+                        except ValueError as e:
+                            error_text = str(e)
                         logger.warning(
                             "Proxy error (%d) from %s: %s",
                             resp.status, proxy_url, error_text[:500],

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -104,6 +104,7 @@ _USER_BOUNDARY_END_REASONS = (
 # on timeout the latch stays clear and the next tick retries).
 _STALL_NOTIFY_SEND_TIMEOUT_SECONDS = 15.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
+_PROXY_ERROR_RESPONSE_MAX_BYTES = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
 
@@ -358,6 +359,34 @@ _GATEWAY_RAW_TEXT_PLATFORMS = frozenset(
 def _gateway_surface_passes_raw_text(platform: Any) -> bool:
     """True only for programmatic/local surfaces that must keep raw text."""
     return _gateway_platform_value(platform) in _GATEWAY_RAW_TEXT_PLATFORMS
+
+
+async def _read_proxy_error_text_with_limit(resp: Any) -> str:
+    headers = getattr(resp, "headers", {}) or {}
+    content_length = None
+    try:
+        content_length = int(str(headers.get("content-length", "")).strip())
+    except (TypeError, ValueError):
+        content_length = None
+    if (
+        content_length is not None
+        and content_length > _PROXY_ERROR_RESPONSE_MAX_BYTES
+    ):
+        raise ValueError(
+            f"Proxy error response exceeds {_PROXY_ERROR_RESPONSE_MAX_BYTES} bytes"
+        )
+
+    body = bytearray()
+    async for chunk in resp.content.iter_chunked(64 * 1024):
+        if not chunk:
+            continue
+        chunk_bytes = bytes(chunk)
+        if len(body) + len(chunk_bytes) > _PROXY_ERROR_RESPONSE_MAX_BYTES:
+            raise ValueError(
+                f"Proxy error response exceeds {_PROXY_ERROR_RESPONSE_MAX_BYTES} bytes"
+            )
+        body.extend(chunk_bytes)
+    return bytes(body).decode("utf-8", "replace")
 
 
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
@@ -25112,7 +25141,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     headers=headers,
                 ) as resp:
                     if resp.status != 200:
-                        error_text = await resp.text()
+                        try:
+                            error_text = await _read_proxy_error_text_with_limit(resp)
+                        except ValueError as e:
+                            error_text = str(e)
                         logger.warning(
                             "Proxy error (%d) from %s: %s",
                             resp.status, proxy_url, error_text[:500],

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -39,17 +39,37 @@ def _make_source(platform=Platform.MATRIX):
 class _FakeSSEResponse:
     """Simulates an aiohttp response with SSE streaming."""
 
-    def __init__(self, status=200, sse_chunks=None, error_text=""):
+    def __init__(
+        self,
+        status=200,
+        sse_chunks=None,
+        error_text="",
+        error_chunks=None,
+        headers=None,
+    ):
         self.status = status
         self._sse_chunks = sse_chunks or []
         self._error_text = error_text
+        self._error_chunks = error_chunks
+        self.headers = headers or {}
         self.content = self
+        self.text_called = False
 
     async def text(self):
+        self.text_called = True
         return self._error_text
 
     async def iter_any(self):
         for chunk in self._sse_chunks:
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+            yield chunk
+
+    async def iter_chunked(self, _size):
+        chunks = self._error_chunks
+        if chunks is None:
+            chunks = [self._error_text.encode("utf-8")]
+        for chunk in chunks:
             if isinstance(chunk, str):
                 chunk = chunk.encode("utf-8")
             yield chunk
@@ -303,6 +323,32 @@ class TestRunAgentViaProxy:
 
         assert "Proxy error (401)" in result["final_response"]
         assert result["api_calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_bounds_http_error_response_body(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        monkeypatch.setattr("gateway.run._PROXY_ERROR_RESPONSE_MAX_BYTES", 8)
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(status=502, error_chunks=[b"x" * 9])
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert "Proxy error (502)" in result["final_response"]
+        assert "Proxy error response exceeds 8 bytes" in result["final_response"]
+        assert resp.text_called is False
 
     @pytest.mark.asyncio
     async def test_handles_connection_error(self, monkeypatch):

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -39,17 +39,37 @@ def _make_source(platform=Platform.MATRIX):
 class _FakeSSEResponse:
     """Simulates an aiohttp response with SSE streaming."""
 
-    def __init__(self, status=200, sse_chunks=None, error_text=""):
+    def __init__(
+        self,
+        status=200,
+        sse_chunks=None,
+        error_text="",
+        error_chunks=None,
+        headers=None,
+    ):
         self.status = status
         self._sse_chunks = sse_chunks or []
         self._error_text = error_text
+        self._error_chunks = error_chunks
+        self.headers = headers or {}
         self.content = self
+        self.text_called = False
 
     async def text(self):
+        self.text_called = True
         return self._error_text
 
     async def iter_any(self):
         for chunk in self._sse_chunks:
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+            yield chunk
+
+    async def iter_chunked(self, _size):
+        chunks = self._error_chunks
+        if chunks is None:
+            chunks = [self._error_text.encode("utf-8")]
+        for chunk in chunks:
             if isinstance(chunk, str):
                 chunk = chunk.encode("utf-8")
             yield chunk
@@ -222,6 +242,44 @@ class TestRunAgentViaProxy:
         # Verify response was assembled
         assert result["final_response"] == "Hello world"
 
+
+    @pytest.mark.asyncio
+    async def test_bounds_http_error_response_body(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        monkeypatch.setattr("gateway.run._PROXY_ERROR_RESPONSE_MAX_BYTES", 8)
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(status=502, error_chunks=[b"x" * 9])
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert "Proxy error (502)" in result["final_response"]
+        assert "Proxy error response exceeds 8 bytes" in result["final_response"]
+        assert resp.text_called is False
+
+    @pytest.mark.asyncio
+    async def test_rejects_declared_oversize_without_reading(self, monkeypatch):
+        from gateway.run import _read_proxy_error_text_with_limit
+
+        monkeypatch.setattr("gateway.run._PROXY_ERROR_RESPONSE_MAX_BYTES", 8)
+        resp = _FakeSSEResponse(headers={"content-length": "9"})
+        resp.iter_chunked = MagicMock(side_effect=AssertionError("body was consumed"))
+
+        with pytest.raises(ValueError, match="Proxy error response exceeds 8 bytes"):
+            await _read_proxy_error_text_with_limit(resp)
+        resp.iter_chunked.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_handles_connection_error(self, monkeypatch):


### PR DESCRIPTION
## Summary

- Bound gateway proxy-mode non-200 error response reads at 16 MiB.
- Check `Content-Length` before reading and enforce the same cap while streaming chunks.
- Keep existing small-error behavior and leave successful SSE streaming unchanged.

Closes #55015.

## Context

This is the Hermes gateway-proxy analogue of the upstream proxy error-response boundary class: the previous code truncated diagnostics only after `await resp.text()` had already buffered the full error body.

## Duplicate Audit

Live GitHub checks before opening:

- `gh search prs --repo NousResearch/hermes-agent "gateway proxy error response cap" --state open` -> no results
- `gh search prs --repo NousResearch/hermes-agent "Proxy error response exceeds" --state open` -> no results
- `gh search issues --repo NousResearch/hermes-agent "gateway proxy error response cap" --state open` -> no results
- `gh search issues --repo NousResearch/hermes-agent "Proxy error response exceeds" --state open` -> no results

Broad open PR/issue scan showed other gateway and response-cap work, but no gateway proxy-mode error response duplicate.

## Validation

- `uv run --extra dev --extra messaging python -m pytest tests\gateway\test_proxy_mode.py -q --basetemp .pytest-tmp-gateway-proxy-error-response-cap` -> `23 passed`
- `uv run --extra dev python -m ruff check gateway\run.py tests\gateway\test_proxy_mode.py` -> passed
- `git diff --check` -> passed

`autoreview` was not run because `.agents/skills/autoreview/scripts/autoreview` is not present in this worktree.
