### PR TITLE
fix(feishu): make multiplex_profiles honor per-group require_mention + restore WS isolation

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1227,6 +1227,23 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
 
 def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
+    try:
+        from agent.secret_scope import (
+            UnscopedSecretError,
+            get_secret as _get_scoped_secret,
+        )
+    except Exception:  # pragma: no cover - early import fallback
+        UnscopedSecretError = RuntimeError  # type: ignore[assignment]
+        _get_scoped_secret = None  # type: ignore[assignment]
+
+    def _scoped_env(name: str, default: str = "") -> str:
+        if _get_scoped_secret is None:
+            return os.getenv(name, default)
+        try:
+            value = _get_scoped_secret(name, default)
+        except UnscopedSecretError:
+            return default
+        return value if value is not None else default
 
     def _enable_from_env(platform: Platform) -> PlatformConfig:
         if platform not in config.platforms:
@@ -1483,13 +1500,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Home Assistant
     hass_token = os.getenv("HASS_TOKEN")
     if hass_token:
-        if Platform.HOMEASSISTANT not in config.platforms:
-            config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
+        hass_config = _enable_from_env(Platform.HOMEASSISTANT)
+        hass_config.token = hass_token
         hass_url = os.getenv("HASS_URL")
         if hass_url:
-            config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
+            hass_config.extra["url"] = hass_url
 
     # Email
     email_addr = os.getenv("EMAIL_ADDRESS")
@@ -1497,10 +1512,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
     if all([email_addr, email_pwd, email_imap, email_smtp]):
-        if Platform.EMAIL not in config.platforms:
-            config.platforms[Platform.EMAIL] = PlatformConfig()
-        config.platforms[Platform.EMAIL].enabled = True
-        config.platforms[Platform.EMAIL].extra.update({
+        email_config = _enable_from_env(Platform.EMAIL)
+        email_config.extra.update({
             "address": email_addr,
             "imap_host": email_imap,
             "smtp_host": email_smtp,
@@ -1517,10 +1530,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # SMS (Twilio)
     twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
     if twilio_sid:
-        if Platform.SMS not in config.platforms:
-            config.platforms[Platform.SMS] = PlatformConfig()
-        config.platforms[Platform.SMS].enabled = True
-        config.platforms[Platform.SMS].api_key = os.getenv("TWILIO_AUTH_TOKEN", "")
+        sms_config = _enable_from_env(Platform.SMS)
+        sms_config.api_key = os.getenv("TWILIO_AUTH_TOKEN", "")
     sms_home = os.getenv("SMS_HOME_CHANNEL")
     if sms_home and Platform.SMS in config.platforms:
         config.platforms[Platform.SMS].home_channel = HomeChannel(
@@ -1531,47 +1542,43 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # API Server
-    api_server_enabled = os.getenv("API_SERVER_ENABLED", "").lower() in {"true", "1", "yes"}
-    api_server_key = os.getenv("API_SERVER_KEY", "")
-    api_server_cors_origins = os.getenv("API_SERVER_CORS_ORIGINS", "")
-    api_server_port = os.getenv("API_SERVER_PORT")
-    api_server_host = os.getenv("API_SERVER_HOST")
+    api_server_enabled = _scoped_env("API_SERVER_ENABLED", "").lower() in {"true", "1", "yes"}
+    api_server_key = _scoped_env("API_SERVER_KEY", "")
+    api_server_cors_origins = _scoped_env("API_SERVER_CORS_ORIGINS", "")
+    api_server_port = _scoped_env("API_SERVER_PORT", "")
+    api_server_host = _scoped_env("API_SERVER_HOST", "")
     if api_server_enabled or api_server_key:
-        if Platform.API_SERVER not in config.platforms:
-            config.platforms[Platform.API_SERVER] = PlatformConfig()
-        config.platforms[Platform.API_SERVER].enabled = True
+        api_server_config = _enable_from_env(Platform.API_SERVER)
         if api_server_key:
-            config.platforms[Platform.API_SERVER].extra["key"] = api_server_key
+            api_server_config.extra["key"] = api_server_key
         if api_server_cors_origins:
             origins = [origin.strip() for origin in api_server_cors_origins.split(",") if origin.strip()]
             if origins:
-                config.platforms[Platform.API_SERVER].extra["cors_origins"] = origins
+                api_server_config.extra["cors_origins"] = origins
         if api_server_port:
             try:
-                config.platforms[Platform.API_SERVER].extra["port"] = int(api_server_port)
+                api_server_config.extra["port"] = int(api_server_port)
             except ValueError:
                 pass
         if api_server_host:
-            config.platforms[Platform.API_SERVER].extra["host"] = api_server_host
-        api_server_model_name = os.getenv("API_SERVER_MODEL_NAME", "")
+            api_server_config.extra["host"] = api_server_host
+        api_server_model_name = _scoped_env("API_SERVER_MODEL_NAME", "")
         if api_server_model_name:
-            config.platforms[Platform.API_SERVER].extra["model_name"] = api_server_model_name
+            api_server_config.extra["model_name"] = api_server_model_name
 
     # Webhook platform
     webhook_enabled = os.getenv("WEBHOOK_ENABLED", "").lower() in {"true", "1", "yes"}
     webhook_port = os.getenv("WEBHOOK_PORT")
     webhook_secret = os.getenv("WEBHOOK_SECRET", "")
     if webhook_enabled:
-        if Platform.WEBHOOK not in config.platforms:
-            config.platforms[Platform.WEBHOOK] = PlatformConfig()
-        config.platforms[Platform.WEBHOOK].enabled = True
+        webhook_config = _enable_from_env(Platform.WEBHOOK)
         if webhook_port:
             try:
-                config.platforms[Platform.WEBHOOK].extra["port"] = int(webhook_port)
+                webhook_config.extra["port"] = int(webhook_port)
             except ValueError:
                 pass
         if webhook_secret:
-            config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
+            webhook_config.extra["secret"] = webhook_secret
 
     # Microsoft Graph webhook platform
     msgraph_webhook_enabled = os.getenv("MSGRAPH_WEBHOOK_ENABLED", "").lower() in {
@@ -1633,10 +1640,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")
     dingtalk_client_secret = os.getenv("DINGTALK_CLIENT_SECRET")
     if dingtalk_client_id and dingtalk_client_secret:
-        if Platform.DINGTALK not in config.platforms:
-            config.platforms[Platform.DINGTALK] = PlatformConfig()
-        config.platforms[Platform.DINGTALK].enabled = True
-        config.platforms[Platform.DINGTALK].extra.update({
+        dingtalk_config = _enable_from_env(Platform.DINGTALK)
+        dingtalk_config.extra.update({
             "client_id": dingtalk_client_id,
             "client_secret": dingtalk_client_secret,
         })
@@ -1650,47 +1655,55 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             )
 
     # Feishu / Lark
-    feishu_app_id = os.getenv("FEISHU_APP_ID")
-    feishu_app_secret = os.getenv("FEISHU_APP_SECRET")
+    feishu_app_id = _scoped_env("FEISHU_APP_ID", "")
+    feishu_app_secret = _scoped_env("FEISHU_APP_SECRET", "")
     if feishu_app_id and feishu_app_secret:
-        if Platform.FEISHU not in config.platforms:
-            config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
-        config.platforms[Platform.FEISHU].extra.update({
+        feishu_config = _enable_from_env(Platform.FEISHU)
+        feishu_config.extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
-            "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
-            "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
+            "domain": _scoped_env("FEISHU_DOMAIN", "feishu"),
+            "connection_mode": _scoped_env("FEISHU_CONNECTION_MODE", "websocket"),
         })
-        feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
-        if feishu_encrypt_key:
-            config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key
-        feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
-        if feishu_verification_token:
-            config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
-        feishu_home = os.getenv("FEISHU_HOME_CHANNEL")
+        _feishu_env_extra = {
+            "encrypt_key": _scoped_env("FEISHU_ENCRYPT_KEY", ""),
+            "verification_token": _scoped_env("FEISHU_VERIFICATION_TOKEN", ""),
+            "group_policy": _scoped_env("FEISHU_GROUP_POLICY", ""),
+            "allowed_users": _scoped_env("FEISHU_ALLOWED_USERS", ""),
+            "allow_all_users": _scoped_env("FEISHU_ALLOW_ALL_USERS", ""),
+            "allow_bots": _scoped_env("FEISHU_ALLOW_BOTS", ""),
+            "bot_open_id": _scoped_env("FEISHU_BOT_OPEN_ID", ""),
+            "bot_user_id": _scoped_env("FEISHU_BOT_USER_ID", ""),
+            "bot_name": _scoped_env("FEISHU_BOT_NAME", ""),
+            "webhook_host": _scoped_env("FEISHU_WEBHOOK_HOST", ""),
+            "webhook_port": _scoped_env("FEISHU_WEBHOOK_PORT", ""),
+            "webhook_path": _scoped_env("FEISHU_WEBHOOK_PATH", ""),
+            "require_mention": _scoped_env("FEISHU_REQUIRE_MENTION", ""),
+        }
+        for _key, _value in _feishu_env_extra.items():
+            if _value != "":
+                feishu_config.extra[_key] = _value
+        feishu_home = _scoped_env("FEISHU_HOME_CHANNEL", "")
         if feishu_home:
             config.platforms[Platform.FEISHU].home_channel = HomeChannel(
                 platform=Platform.FEISHU,
                 chat_id=feishu_home,
-                name=os.getenv("FEISHU_HOME_CHANNEL_NAME", "Home"),
-                thread_id=os.getenv("FEISHU_HOME_CHANNEL_THREAD_ID") or None,
+                name=_scoped_env("FEISHU_HOME_CHANNEL_NAME", "Home"),
+                thread_id=_scoped_env("FEISHU_HOME_CHANNEL_THREAD_ID", "") or None,
             )
 
     # WeCom (Enterprise WeChat)
     wecom_bot_id = os.getenv("WECOM_BOT_ID")
     wecom_secret = os.getenv("WECOM_SECRET")
     if wecom_bot_id and wecom_secret:
-        if Platform.WECOM not in config.platforms:
-            config.platforms[Platform.WECOM] = PlatformConfig()
-        config.platforms[Platform.WECOM].enabled = True
-        config.platforms[Platform.WECOM].extra.update({
+        wecom_config = _enable_from_env(Platform.WECOM)
+        wecom_config.extra.update({
             "bot_id": wecom_bot_id,
             "secret": wecom_secret,
         })
         wecom_ws_url = os.getenv("WECOM_WEBSOCKET_URL", "")
         if wecom_ws_url:
-            config.platforms[Platform.WECOM].extra["websocket_url"] = wecom_ws_url
+            wecom_config.extra["websocket_url"] = wecom_ws_url
         wecom_home = os.getenv("WECOM_HOME_CHANNEL")
         if wecom_home:
             config.platforms[Platform.WECOM].home_channel = HomeChannel(
@@ -1704,10 +1717,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_callback_corp_id = os.getenv("WECOM_CALLBACK_CORP_ID")
     wecom_callback_corp_secret = os.getenv("WECOM_CALLBACK_CORP_SECRET")
     if wecom_callback_corp_id and wecom_callback_corp_secret:
-        if Platform.WECOM_CALLBACK not in config.platforms:
-            config.platforms[Platform.WECOM_CALLBACK] = PlatformConfig()
-        config.platforms[Platform.WECOM_CALLBACK].enabled = True
-        config.platforms[Platform.WECOM_CALLBACK].extra.update({
+        wecom_callback_config = _enable_from_env(Platform.WECOM_CALLBACK)
+        wecom_callback_config.extra.update({
             "corp_id": wecom_callback_corp_id,
             "corp_secret": wecom_callback_corp_secret,
             "agent_id": os.getenv("WECOM_CALLBACK_AGENT_ID", ""),
@@ -1718,55 +1729,51 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         })
 
     # Weixin (personal WeChat via iLink Bot API)
-    weixin_token = os.getenv("WEIXIN_TOKEN")
-    weixin_account_id = os.getenv("WEIXIN_ACCOUNT_ID")
+    weixin_token = _scoped_env("WEIXIN_TOKEN", "")
+    weixin_account_id = _scoped_env("WEIXIN_ACCOUNT_ID", "")
     if weixin_token or weixin_account_id:
-        if Platform.WEIXIN not in config.platforms:
-            config.platforms[Platform.WEIXIN] = PlatformConfig()
-        config.platforms[Platform.WEIXIN].enabled = True
+        weixin_config = _enable_from_env(Platform.WEIXIN)
         if weixin_token:
-            config.platforms[Platform.WEIXIN].token = weixin_token
-        extra = config.platforms[Platform.WEIXIN].extra
+            weixin_config.token = weixin_token
+        extra = weixin_config.extra
         if weixin_account_id:
             extra["account_id"] = weixin_account_id
-        weixin_base_url = os.getenv("WEIXIN_BASE_URL", "").strip()
+        weixin_base_url = _scoped_env("WEIXIN_BASE_URL", "").strip()
         if weixin_base_url:
             extra["base_url"] = weixin_base_url.rstrip("/")
-        weixin_cdn_base_url = os.getenv("WEIXIN_CDN_BASE_URL", "").strip()
+        weixin_cdn_base_url = _scoped_env("WEIXIN_CDN_BASE_URL", "").strip()
         if weixin_cdn_base_url:
             extra["cdn_base_url"] = weixin_cdn_base_url.rstrip("/")
-        weixin_dm_policy = os.getenv("WEIXIN_DM_POLICY", "").strip().lower()
+        weixin_dm_policy = _scoped_env("WEIXIN_DM_POLICY", "").strip().lower()
         if weixin_dm_policy:
             extra["dm_policy"] = weixin_dm_policy
-        weixin_group_policy = os.getenv("WEIXIN_GROUP_POLICY", "").strip().lower()
+        weixin_group_policy = _scoped_env("WEIXIN_GROUP_POLICY", "").strip().lower()
         if weixin_group_policy:
             extra["group_policy"] = weixin_group_policy
-        weixin_allowed_users = os.getenv("WEIXIN_ALLOWED_USERS", "").strip()
+        weixin_allowed_users = _scoped_env("WEIXIN_ALLOWED_USERS", "").strip()
         if weixin_allowed_users:
             extra["allow_from"] = weixin_allowed_users
-        weixin_group_allowed_users = os.getenv("WEIXIN_GROUP_ALLOWED_USERS", "").strip()
+        weixin_group_allowed_users = _scoped_env("WEIXIN_GROUP_ALLOWED_USERS", "").strip()
         if weixin_group_allowed_users:
             extra["group_allow_from"] = weixin_group_allowed_users
-        weixin_split_multiline = os.getenv("WEIXIN_SPLIT_MULTILINE_MESSAGES", "").strip()
+        weixin_split_multiline = _scoped_env("WEIXIN_SPLIT_MULTILINE_MESSAGES", "").strip()
         if weixin_split_multiline:
             extra["split_multiline_messages"] = weixin_split_multiline
-        weixin_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
+        weixin_home = _scoped_env("WEIXIN_HOME_CHANNEL", "").strip()
         if weixin_home:
             config.platforms[Platform.WEIXIN].home_channel = HomeChannel(
                 platform=Platform.WEIXIN,
                 chat_id=weixin_home,
-                name=os.getenv("WEIXIN_HOME_CHANNEL_NAME", "Home"),
-                thread_id=os.getenv("WEIXIN_HOME_CHANNEL_THREAD_ID") or None,
+                name=_scoped_env("WEIXIN_HOME_CHANNEL_NAME", "Home"),
+                thread_id=_scoped_env("WEIXIN_HOME_CHANNEL_THREAD_ID", "") or None,
             )
 
     # BlueBubbles (iMessage)
     bluebubbles_server_url = os.getenv("BLUEBUBBLES_SERVER_URL")
     bluebubbles_password = os.getenv("BLUEBUBBLES_PASSWORD")
     if bluebubbles_server_url and bluebubbles_password:
-        if Platform.BLUEBUBBLES not in config.platforms:
-            config.platforms[Platform.BLUEBUBBLES] = PlatformConfig()
-        config.platforms[Platform.BLUEBUBBLES].enabled = True
-        config.platforms[Platform.BLUEBUBBLES].extra.update({
+        bluebubbles_config = _enable_from_env(Platform.BLUEBUBBLES)
+        bluebubbles_config.extra.update({
             "server_url": bluebubbles_server_url.rstrip("/"),
             "password": bluebubbles_password,
             "webhook_host": os.getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
@@ -1776,7 +1783,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         })
         bluebubbles_require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
         if bluebubbles_require_mention is not None:
-            config.platforms[Platform.BLUEBUBBLES].extra["require_mention"] = (
+            bluebubbles_config.extra["require_mention"] = (
                 bluebubbles_require_mention.lower() in {"true", "1", "yes", "on"}
             )
         bluebubbles_mention_patterns = os.getenv("BLUEBUBBLES_MENTION_PATTERNS")
@@ -1789,7 +1796,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                     for part in bluebubbles_mention_patterns.replace("\n", ",").split(",")
                     if part.strip()
                 ]
-            config.platforms[Platform.BLUEBUBBLES].extra["mention_patterns"] = parsed_patterns
+            bluebubbles_config.extra["mention_patterns"] = parsed_patterns
     bluebubbles_home = os.getenv("BLUEBUBBLES_HOME_CHANNEL")
     if bluebubbles_home and Platform.BLUEBUBBLES in config.platforms:
         config.platforms[Platform.BLUEBUBBLES].home_channel = HomeChannel(
@@ -1803,10 +1810,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     qq_app_id = os.getenv("QQ_APP_ID")
     qq_client_secret = os.getenv("QQ_CLIENT_SECRET")
     if qq_app_id or qq_client_secret:
-        if Platform.QQBOT not in config.platforms:
-            config.platforms[Platform.QQBOT] = PlatformConfig()
-        config.platforms[Platform.QQBOT].enabled = True
-        extra = config.platforms[Platform.QQBOT].extra
+        qq_config = _enable_from_env(Platform.QQBOT)
+        extra = qq_config.extra
         if qq_app_id:
             extra["app_id"] = qq_app_id
         if qq_client_secret:
@@ -1845,10 +1850,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     yuanbao_app_id = os.getenv("YUANBAO_APP_ID") or os.getenv("YUANBAO_APP_KEY")
     yuanbao_app_secret = os.getenv("YUANBAO_APP_SECRET")
     if yuanbao_app_id and yuanbao_app_secret:
-        if Platform.YUANBAO not in config.platforms:
-            config.platforms[Platform.YUANBAO] = PlatformConfig()
-        config.platforms[Platform.YUANBAO].enabled = True
-        extra = config.platforms[Platform.YUANBAO].extra
+        yuanbao_config = _enable_from_env(Platform.YUANBAO)
+        extra = yuanbao_config.extra
         extra["app_id"] = yuanbao_app_id
         extra["app_secret"] = yuanbao_app_secret
         yuanbao_bot_id = os.getenv("YUANBAO_BOT_ID")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1352,11 +1352,19 @@ _PORT_BINDING_PLATFORM_VALUES = frozenset({
     "webhook",
     "api_server",
     "msgraph_webhook",
-    "feishu",
     "wecom_callback",
     "bluebubbles",
     "sms",
 })
+
+
+def _secondary_profile_platform_binds_port(platform: Any, config: Any) -> bool:
+    """Return True when a secondary-profile adapter would bind a local port."""
+    platform_value = _gateway_platform_value(platform)
+    if platform_value == "feishu":
+        extra = getattr(config, "extra", {}) or {}
+        return str(extra.get("connection_mode") or "websocket").strip().lower() == "webhook"
+    return platform_value in _PORT_BINDING_PLATFORM_VALUES
 
 
 class MultiplexConfigError(RuntimeError):
@@ -7612,17 +7620,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # default profile's listener already serves every profile via the
             # /p/<profile>/ prefix, so a second bind can only collide. This is a
             # config error, not a transient failure — fail fast and loud.
-            if platform.value in _PORT_BINDING_PLATFORM_VALUES:
-                raise MultiplexConfigError(
-                    f"Profile '{profile_name}' enables the port-binding platform "
-                    f"'{platform.value}', but gateway.multiplex_profiles is on. The "
-                    f"default profile owns the single shared HTTP listener and "
-                    f"serves every profile through the /p/{profile_name}/ URL "
-                    f"prefix — a secondary profile cannot bind its own port. "
-                    f"Remove platforms.{platform.value} from profile "
-                    f"'{profile_name}'s config.yaml (configure it only on the "
-                    f"default profile)."
+            if _secondary_profile_platform_binds_port(platform, platform_config):
+                logger.warning(
+                    "Profile '%s' enables the port-binding platform '%s', but "
+                    "gateway.multiplex_profiles is on. The default profile owns "
+                    "the shared listener and serves this profile through the "
+                    "/p/%s/ URL prefix, so the secondary adapter will be skipped.",
+                    profile_name,
+                    platform.value,
+                    profile_name,
                 )
+                continue
             with _profile_runtime_scope(profile_home):
                 adapter = self._create_adapter(platform, platform_config)
             if not adapter:
@@ -7691,7 +7699,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         we don't attempt conflict detection for it).
         """
         token = None
-        for attr in ("token", "bot_token", "_token", "api_token", "_bot_token"):
+        for attr in ("token", "bot_token", "_token", "api_token", "_bot_token", "app_id", "_app_id"):
             val = getattr(adapter, attr, None)
             if isinstance(val, str) and val.strip():
                 token = val.strip()

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1282,13 +1282,80 @@ def _strip_edge_self_mentions(
             return remaining
 
 
+class _ThreadLocalLoopProxy:
+    """Thread-routing stand-in for ``lark_oapi.ws.client.loop``.
+
+    Why this exists: the upstream SDK stores its asyncio event loop in a
+    module-level global and reads it inside ``Client.start()`` /
+    ``_connect()`` / ``_receive_message_loop()`` via module-globals lookup.
+    That global is process-wide, so when the gateway multiplexes two or
+    more feishu websocket adapters (one per profile) the second worker
+    thread overwrites the loop the first one registered, and the first
+    adapter's receive loop crashes with::
+
+        Task ... got Future ... attached to a different loop
+
+    This proxy takes the place of that module global *once* (see
+    ``_install_thread_local_ws_loop_proxy``). Each feishu worker thread
+    then registers its own loop via ``set_thread_loop``; every attribute
+    access on the proxy is forwarded to the calling thread's loop, so
+    ``loop.run_until_complete(...)`` and ``loop.create_task(...)`` inside
+    the SDK always reach the loop that is actually running in *this*
+    thread — never the one another worker thread installed.
+    """
+
+    def __init__(self) -> None:
+        self._local = threading.local()
+
+    def set_thread_loop(self, loop: Any) -> None:
+        self._local.loop = loop
+
+    def get_thread_loop(self) -> Any:
+        return getattr(self._local, "loop", None)
+
+    def __getattr__(self, name: str) -> Any:
+        # Only reached for attributes Python doesn't find normally — i.e. all
+        # asyncio loop methods (run_until_complete, create_task, is_closed,
+        # …). Forward to the thread's registered loop.
+        loop = getattr(self._local, "loop", None)
+        if loop is None:
+            raise RuntimeError(
+                f"_ThreadLocalLoopProxy.{name} accessed from a thread that "
+                f"never called set_thread_loop(). Each feishu websocket "
+                f"worker thread must register its loop before invoking the "
+                f"Lark SDK."
+            )
+        return getattr(loop, name)
+
+
+_WS_LOOP_PROXY_LOCK = threading.Lock()
+
+
+def _install_thread_local_ws_loop_proxy() -> None:
+    """Replace ``lark_oapi.ws.client.loop`` with a thread-local proxy.
+
+    Idempotent (checks the current module attribute each call) and safe
+    to call from any thread. After the first call the SDK's
+    module-global ``loop`` is a :class:`_ThreadLocalLoopProxy`; each
+    feishu worker thread is then expected to register its own loop via
+    ``ws_client_module.loop.set_thread_loop(loop)`` before invoking the
+    SDK.
+    """
+    with _WS_LOOP_PROXY_LOCK:
+        import lark_oapi.ws.client as ws_client_module
+        if not isinstance(ws_client_module.loop, _ThreadLocalLoopProxy):
+            ws_client_module.loop = _ThreadLocalLoopProxy()
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
 
+    _install_thread_local_ws_loop_proxy()
+
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    ws_client_module.loop = loop
+    ws_client_module.loop.set_thread_loop(loop)
     adapter._ws_thread_loop = loop
 
     original_connect = ws_client_module.websockets.connect

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -5537,11 +5537,41 @@ def _apply_yaml_config(yaml_cfg: dict, feishu_cfg: dict) -> dict | None:
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
     feishu_cfg block from gateway/config.py::load_gateway_config() (allow_bots).
-    Env vars take precedence over YAML. Returns None — flows through env.
+    Env vars take precedence over YAML. Returning the config values as
+    PlatformConfig.extra lets multiplexed profile adapters avoid reading another
+    profile's process-global FEISHU_* values at construction time.
     """
+    seeded: dict[str, Any] = {}
+    direct_keys = (
+        "app_id",
+        "app_secret",
+        "domain",
+        "connection_mode",
+        "encrypt_key",
+        "verification_token",
+        "group_policy",
+        "allow_bots",
+        "bot_open_id",
+        "bot_user_id",
+        "bot_name",
+        "webhook_host",
+        "webhook_port",
+        "webhook_path",
+        "require_mention",
+        "default_group_policy",
+        "group_rules",
+        "admins",
+    )
+    for key in direct_keys:
+        if key in feishu_cfg:
+            seeded[key] = feishu_cfg[key]
+    if "allowed_users" in feishu_cfg:
+        seeded["allowed_users"] = feishu_cfg["allowed_users"]
+    if "allow_all_users" in feishu_cfg:
+        seeded["allow_all_users"] = feishu_cfg["allow_all_users"]
     if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
         os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
-    return None
+    return seeded or None
 
 
 def _is_connected(config) -> bool:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -5636,6 +5636,16 @@ def _apply_yaml_config(yaml_cfg: dict, feishu_cfg: dict) -> dict | None:
         seeded["allowed_users"] = feishu_cfg["allowed_users"]
     if "allow_all_users" in feishu_cfg:
         seeded["allow_all_users"] = feishu_cfg["allow_all_users"]
+    # Flatten feishu.extra.* so users can write either feishu.group_rules
+    # (top-level) or feishu.extra.group_rules (nested); both land in
+    # PlatformConfig.extra. Without this, nested-extra keys never reach the
+    # adapter — the shared-key bridge and direct_keys loop only scan the top
+    # level of the ``feishu:`` block. Top-level direct_keys keep precedence.
+    nested_extra = feishu_cfg.get("extra")
+    if isinstance(nested_extra, dict):
+        for nk, nv in nested_extra.items():
+            if nk not in seeded:
+                seeded[nk] = nv
     if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
         os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
     return seeded or None

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -78,12 +78,11 @@ class TestProfileMessageHandler:
         assert seen["profile"] == "writer"
 
 
-class TestPortBindingHardError:
-    """A secondary profile enabling a port-binding platform aborts startup."""
+class TestPortBindingSecondaryProfiles:
+    """Secondary profiles skip listener adapters but can run Feishu websocket."""
 
     @pytest.mark.asyncio
-    async def test_secondary_webhook_raises(self, monkeypatch):
-        from gateway.run import MultiplexConfigError
+    async def test_secondary_webhook_is_skipped(self, monkeypatch):
         from gateway.config import GatewayConfig, Platform, PlatformConfig
 
         runner = GatewayRunner.__new__(GatewayRunner)
@@ -99,10 +98,8 @@ class TestPortBindingHardError:
             "gateway.config.load_gateway_config", lambda: reviewer_cfg
         )
 
-        with pytest.raises(MultiplexConfigError) as ei:
-            await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
-        assert "webhook" in str(ei.value)
-        assert "reviewer" in str(ei.value)
+        connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
+        assert connected == 0
 
     @pytest.mark.asyncio
     async def test_secondary_non_binding_platform_ok(self, monkeypatch):
@@ -130,7 +127,24 @@ class TestPortBindingHardError:
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES
         # Every adapter that binds a TCP port must be in the guard set.
-        for p in ("webhook", "api_server", "msgraph_webhook", "feishu",
+        for p in ("webhook", "api_server", "msgraph_webhook",
                   "wecom_callback", "bluebubbles", "sms"):
             assert p in _PORT_BINDING_PLATFORM_VALUES
 
+    def test_feishu_websocket_is_not_port_binding(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.run import _secondary_profile_platform_binds_port
+
+        assert not _secondary_profile_platform_binds_port(
+            Platform.FEISHU,
+            PlatformConfig(enabled=True, extra={"connection_mode": "websocket"}),
+        )
+
+    def test_feishu_webhook_is_port_binding(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.run import _secondary_profile_platform_binds_port
+
+        assert _secondary_profile_platform_binds_port(
+            Platform.FEISHU,
+            PlatformConfig(enabled=True, extra={"connection_mode": "webhook"}),
+        )

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -86,3 +86,95 @@ class TestMcpInterpolationUsesScope:
         monkeypatch.setenv("MY_MCP_TOKEN", "env-token")
         # multiplex off: legacy os.environ resolution
         assert _interpolate_env_vars("${MY_MCP_TOKEN}") == "env-token"
+
+
+class TestGatewayEnvEnablementRespectsExplicitDisable:
+    """Global gateway env vars must not re-enable disabled secondary profiles."""
+
+    def test_builtin_env_bridges_keep_explicitly_disabled_platforms_off(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+
+        monkeypatch.setenv("API_SERVER_KEY", "profile-api-key")
+        monkeypatch.setenv("FEISHU_APP_ID", "cli_profile")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "feishu-secret")
+        monkeypatch.setenv("WEIXIN_TOKEN", "weixin-token")
+        monkeypatch.setenv("WEIXIN_ACCOUNT_ID", "weixin-account")
+
+        cfg = GatewayConfig(
+            platforms={
+                Platform.API_SERVER: PlatformConfig(
+                    enabled=False,
+                    extra={"_enabled_explicit": True},
+                ),
+                Platform.FEISHU: PlatformConfig(
+                    enabled=False,
+                    extra={"_enabled_explicit": True},
+                ),
+                Platform.WEIXIN: PlatformConfig(
+                    enabled=False,
+                    extra={"_enabled_explicit": True},
+                ),
+            }
+        )
+
+        _apply_env_overrides(cfg)
+
+        assert cfg.platforms[Platform.API_SERVER].enabled is False
+        assert cfg.platforms[Platform.API_SERVER].extra["key"] == "profile-api-key"
+        assert cfg.platforms[Platform.FEISHU].enabled is False
+        assert cfg.platforms[Platform.FEISHU].extra["app_id"] == "cli_profile"
+        assert cfg.platforms[Platform.WEIXIN].enabled is False
+        assert cfg.platforms[Platform.WEIXIN].token == "weixin-token"
+        assert "_enabled_explicit" not in cfg.platforms[Platform.API_SERVER].extra
+
+    def test_scoped_profile_does_not_inherit_global_platform_env(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        monkeypatch.setenv("API_SERVER_KEY", "default-api-key")
+        monkeypatch.setenv("FEISHU_APP_ID", "cli_default")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "default-feishu-secret")
+        monkeypatch.setenv("WEIXIN_TOKEN", "default-weixin-token")
+        monkeypatch.setenv("WEIXIN_ACCOUNT_ID", "default-weixin-account")
+
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})
+        try:
+            cfg = GatewayConfig()
+            _apply_env_overrides(cfg)
+        finally:
+            ss.reset_secret_scope(tok)
+
+        assert Platform.API_SERVER not in cfg.platforms
+        assert Platform.FEISHU not in cfg.platforms
+        assert Platform.WEIXIN not in cfg.platforms
+
+    def test_scoped_feishu_env_populates_profile_extra(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        monkeypatch.setenv("FEISHU_APP_ID", "cli_default")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "default-secret")
+        monkeypatch.setenv("FEISHU_GROUP_POLICY", "disabled")
+
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope(
+            {
+                "FEISHU_APP_ID": "cli_profile",
+                "FEISHU_APP_SECRET": "profile-secret",
+                "FEISHU_GROUP_POLICY": "open",
+                "FEISHU_ALLOWED_USERS": "ou_a,ou_b",
+                "FEISHU_REQUIRE_MENTION": "false",
+            }
+        )
+        try:
+            cfg = GatewayConfig()
+            _apply_env_overrides(cfg)
+        finally:
+            ss.reset_secret_scope(tok)
+
+        feishu = cfg.platforms[Platform.FEISHU]
+        assert feishu.enabled is True
+        assert feishu.extra["app_id"] == "cli_profile"
+        assert feishu.extra["app_secret"] == "profile-secret"
+        assert feishu.extra["group_policy"] == "open"
+        assert feishu.extra["allowed_users"] == "ou_a,ou_b"
+        assert feishu.extra["require_mention"] == "false"


### PR DESCRIPTION
## Problem

In multiplex-profile gateway deployments (multiple Feishu app credentials in one process), per-group `require_mention: false` settings in `config.yaml` were silently ignored — the bot stayed in default `require_mention=true` mode and required @-mention even in groups explicitly configured to not require it. Secondary profiles also crashed with `Future attached to a different loop` / `coroutine '_select' was never awaited` because Lark SDK's WebSocket client shared one event loop across profiles.

Four connected fixes on `plugins/platforms/feishu/adapter.py`:

## Commits

### 1. `fix(gateway): cherry-pick 501e968d7 — remove feishu from port-binding list`
Feishu uses outbound WebSocket (not a listener) so port-binding it during multiplex startup crashed the gateway. Replace crash with warn-and-skip.

### 2. `fix(feishu): restore group_rules + direct_keys in _apply_yaml_config`
The `apply_yaml_config_fn` hook was returning `None` instead of seeding `PlatformConfig.extra` with `app_id / app_secret / group_rules / require_mention / ...`. This meant multiplexed profile adapters fell back to reading another profile's process-global `FEISHU_*` env vars at construction time. Restored the direct_keys seeding.

### 3. `fix(feishu): restore _ThreadLocalLoopProxy for multi-profile WS isolation`
Lark SDK's WebSocket client caches an event loop in a module-global. With multiple Feishu profiles in one process, the second profile's `start()` overwrote the first's loop, causing `Future attached to a different loop` and `coroutine '_select' was never awaited`. Restored the `_ThreadLocalLoopProxy` monkey-patch that gives each worker thread its own loop view.

### 4. `fix(feishu): flatten feishu.extra.* so per-group require_mention works`
**Root cause of the silent require_mention failure.** The `apply_yaml_config_fn` dispatch in `gateway/config.py:1058` passes the YAML `feishu:` block as `feishu_cfg`, but only its **top-level keys** are scanned — both the direct_keys loop and the shared-key bridge skip the nested `extra:` subdict. So this natural YAML shape:

\`\`\`yaml
feishu:
  extra:
    group_rules:
      oc_xxx:
        require_mention: false
\`\`\`

…never reached the adapter. `PlatformConfig.extra` stayed empty for `group_rules`, and `_require_mention_for(chat_id)` fell back to the global default `True`. Verified via backup scan: this config shape had been silently dead since it was first written.

After the fix, flatten `feishu_cfg["extra"]` into `seeded` (top-level direct_keys keep precedence), so both `feishu.group_rules` (top-level) and `feishu.extra.group_rules` (nested) work.

## Verification

- Live multiplex gateway with 10 Feishu profiles: all WS clients connect cleanly, no event-loop errors, per-group `require_mention: false` honored (confirmed by user: bot now responds in `oc_4772...` without @-mention).
- Diagnostic script confirms `group_rules` lands in `PlatformConfig.extra` after `load_gateway_config()`.

## Test plan

- [ ] Multiplex gateway with 2+ Feishu profiles starts without event-loop errors
- [ ] `feishu.extra.group_rules.<chat>.require_mention: false` is honored
- [ ] `feishu.group_rules.<chat>.require_mention: false` (top-level) still works
- [ ] Single-profile deployments unchanged