### PR TITLE
fix(gateway): isolate multi-app Feishu sessions

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2501,3 +2501,5 @@ __all__ = [
     "_iter_pool_sockets",
     "force_close_tcp_sockets",
 ]
+
+

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -31,7 +31,50 @@ from gateway.whatsapp_identity import (
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
-    def _adapter_enforces_own_access_policy(self, platform: Optional[Platform]) -> bool:
+    def _platform_configs_for_auth(
+        self,
+        platform: Optional[Platform],
+        adapter_id: Optional[str] = None,
+    ) -> list:
+        """Return configs relevant to one inbound source.
+
+        Multi-instance platforms must scope config-driven authorization to the
+        concrete adapter that received the message. Falling back to every
+        config would let app A's allowlist authorize app B if platform IDs
+        collide.
+        """
+        if not platform:
+            return []
+        config = getattr(self, "config", None)
+        if config is None or not hasattr(config, "platforms"):
+            return []
+        platform_cfg = config.platforms.get(platform)
+        configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+        configs = [cfg for cfg in configs if cfg is not None]
+        if not adapter_id or str(adapter_id) == platform.value:
+            return configs
+
+        wanted = str(adapter_id)
+        for cfg in configs:
+            extra = getattr(cfg, "extra", None)
+            if not isinstance(extra, dict):
+                continue
+            configured_id = str(
+                extra.get("adapter_id")
+                or extra.get("app_id")
+                or extra.get("bot_id")
+                or extra.get("client_id")
+                or ""
+            ).strip()
+            if configured_id and wanted == f"{platform.value}:{configured_id}":
+                return [cfg]
+        return []
+
+    def _adapter_enforces_own_access_policy(
+        self,
+        platform: Optional[Platform],
+        adapter_id: Optional[str] = None,
+    ) -> bool:
         """Whether the adapter for *platform* gates access at intake itself.
 
         Mirrors ``BasePlatformAdapter.enforces_own_access_policy``. Adapters
@@ -50,12 +93,20 @@ class GatewayAuthorizationMixin:
         adapters = getattr(self, "adapters", None)
         if not adapters:
             return False
-        adapter = adapters.get(platform)
+        adapter = None
+        if adapter_id:
+            adapter = getattr(self, "adapters_by_id", {}).get(str(adapter_id))
+        if adapter is None:
+            adapter = adapters.get(platform)
         if adapter is None:
             return False
         return bool(getattr(adapter, "enforces_own_access_policy", False))
 
-    def _adapter_dm_policy(self, platform: Optional[Platform]) -> str:
+    def _adapter_dm_policy(
+        self,
+        platform: Optional[Platform],
+        adapter_id: Optional[str] = None,
+    ) -> str:
         """Best-effort read of an own-policy adapter's effective DM policy.
 
         Returns the lowercased ``dm_policy`` (``"open"`` / ``"allowlist"`` /
@@ -73,19 +124,15 @@ class GatewayAuthorizationMixin:
         if not platform:
             return ""
         adapters = getattr(self, "adapters", None) or {}
-        adapter = adapters.get(platform)
+        adapter = None
+        if adapter_id:
+            adapter = getattr(self, "adapters_by_id", {}).get(str(adapter_id))
+        if adapter is None:
+            adapter = adapters.get(platform)
         policy = getattr(adapter, "_dm_policy", None) if adapter is not None else None
         if policy is None:
-            config = getattr(self, "config", None)
-            platform_cfg = (
-                config.platforms.get(platform)
-                if config is not None and hasattr(config, "platforms")
-                else None
-            )
-            # Multi-app configs may store a list of PlatformConfig instances.
-            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
             extra = None
-            for cfg in _configs:
+            for cfg in self._platform_configs_for_auth(platform, adapter_id):
                 if cfg is not None:
                     extra = getattr(cfg, "extra", None)
                     break
@@ -208,6 +255,28 @@ class GatewayAuthorizationMixin:
             except Exception:
                 pass
 
+        config_allows_all = False
+        config_allowed_users = set()
+        for cfg in self._platform_configs_for_auth(
+            source.platform,
+            getattr(source, "adapter_id", None),
+        ):
+            extra = getattr(cfg, "extra", None)
+            if not isinstance(extra, dict):
+                continue
+            if str(extra.get("allow_all_users") or "").strip().lower() in {"true", "1", "yes", "on"}:
+                config_allows_all = True
+            allowed = extra.get("allowed_users")
+            if isinstance(allowed, str):
+                config_allowed_users.update(uid.strip() for uid in allowed.split(",") if uid.strip())
+            elif isinstance(allowed, (list, tuple, set)):
+                config_allowed_users.update(str(uid).strip() for uid in allowed if str(uid).strip())
+
+        if config_allows_all:
+            return True
+        if "*" in config_allowed_users:
+            return True
+
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
         if platform_allow_all_var and os.getenv(platform_allow_all_var, "").lower() in {"true", "1", "yes"}:
@@ -232,7 +301,13 @@ class GatewayAuthorizationMixin:
             group_chat_allowlist = os.getenv(platform_group_chat_env_map.get(source.platform, ""), "").strip()
         global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
 
-        if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
+        if (
+            not config_allowed_users
+            and not platform_allowlist
+            and not group_user_allowlist
+            and not group_chat_allowlist
+            and not global_allowlist
+        ):
             # No env allowlists configured. Adapters that own their own
             # config-driven access policy (dm_policy / group_policy /
             # allow_from / group_allow_from) already gated this message at
@@ -240,7 +315,10 @@ class GatewayAuthorizationMixin:
             # honor that decision instead of falling through to the
             # env-only default-deny below, which would silently break
             # `dm_policy: open` and config-only allowlists. (#34515)
-            if self._adapter_enforces_own_access_policy(source.platform):
+            if self._adapter_enforces_own_access_policy(
+                source.platform,
+                getattr(source, "adapter_id", None),
+            ):
                 # Exception: `dm_policy: pairing` does NOT authorize at intake.
                 # The adapter forwards the DM precisely so the gateway can run
                 # its pairing handshake (issue a code, consult the pairing
@@ -252,7 +330,10 @@ class GatewayAuthorizationMixin:
                 # traffic keeps the adapter-trust path.)
                 if not (
                     source.chat_type == "dm"
-                    and self._adapter_dm_policy(source.platform) == "pairing"
+                    and self._adapter_dm_policy(
+                        source.platform,
+                        getattr(source, "adapter_id", None),
+                    ) == "pairing"
                 ):
                     return True
             # No allowlists configured -- check global allow-all flag
@@ -303,6 +384,7 @@ class GatewayAuthorizationMixin:
         # imply DM access; TELEGRAM_ALLOWED_USERS remains the platform-wide
         # allowlist and still works everywhere for backward compatibility.
         allowed_ids = set()
+        allowed_ids.update(config_allowed_users)
         if platform_allowlist:
             allowed_ids.update(uid.strip() for uid in platform_allowlist.split(",") if uid.strip())
         if group_user_allowlist:

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -82,7 +82,13 @@ class GatewayAuthorizationMixin:
                 if config is not None and hasattr(config, "platforms")
                 else None
             )
-            extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+            # Multi-app configs may store a list of PlatformConfig instances.
+            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            extra = None
+            for cfg in _configs:
+                if cfg is not None:
+                    extra = getattr(cfg, "extra", None)
+                    break
             if isinstance(extra, dict):
                 policy = extra.get("dm_policy")
         return str(policy or "").strip().lower()
@@ -362,9 +368,11 @@ class GatewayAuthorizationMixin:
         # Check for an explicit per-platform override first.
         if config and hasattr(config, "get_unauthorized_dm_behavior") and platform:
             platform_cfg = config.platforms.get(platform) if hasattr(config, "platforms") else None
-            if platform_cfg and "unauthorized_dm_behavior" in getattr(platform_cfg, "extra", {}):
-                # Operator explicitly configured behavior for this platform — respect it.
-                return config.get_unauthorized_dm_behavior(platform)
+            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            for cfg in _configs:
+                if cfg and "unauthorized_dm_behavior" in getattr(cfg, "extra", {}):
+                    # Operator explicitly configured behavior for this platform — respect it.
+                    return config.get_unauthorized_dm_behavior(platform)
 
         # Check for an explicit global config override.
         if config and hasattr(config, "unauthorized_dm_behavior"):
@@ -377,7 +385,12 @@ class GatewayAuthorizationMixin:
         # with a pairing code. An explicit pairing policy opts back into codes.
         if platform and config and hasattr(config, "platforms"):
             platform_cfg = config.platforms.get(platform)
-            extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            extra = None
+            for cfg in _configs:
+                if cfg is not None:
+                    extra = getattr(cfg, "extra", None)
+                    break
             if isinstance(extra, dict):
                 dm_policy = str(extra.get("dm_policy") or "").strip().lower()
                 if dm_policy == "pairing":

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -13,7 +13,7 @@ import os
 import json
 from pathlib import Path
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Any, Callable
+from typing import Dict, List, Optional, Any, Callable, Union
 from enum import Enum
 
 from hermes_cli.config import get_hermes_home
@@ -463,7 +463,7 @@ class GatewayConfig:
     Manages all platform connections, session policies, and delivery settings.
     """
     # Platform configurations
-    platforms: Dict[Platform, PlatformConfig] = field(default_factory=dict)
+    platforms: Dict[Platform, Union[PlatformConfig, List[PlatformConfig]]] = field(default_factory=dict)
     
     # Session reset policies by type
     default_reset_policy: SessionResetPolicy = field(default_factory=SessionResetPolicy)
@@ -513,10 +513,13 @@ class GatewayConfig:
         """Return list of platforms that are enabled and configured."""
         connected = []
         for platform, config in self.platforms.items():
-            if not config.enabled:
-                continue
-            if self._is_platform_connected(platform, config):
-                connected.append(platform)
+            configs = config if isinstance(config, list) else [config]
+            for cfg in configs:
+                if not cfg.enabled:
+                    continue
+                if self._is_platform_connected(platform, cfg):
+                    connected.append(platform)
+                    break
         return connected
 
     def _is_platform_connected(self, platform: Platform, config: PlatformConfig) -> bool:
@@ -556,6 +559,11 @@ class GatewayConfig:
     def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
         """Get the home channel for a platform."""
         config = self.platforms.get(platform)
+        if isinstance(config, list):
+            for cfg in config:
+                if cfg.home_channel:
+                    return cfg.home_channel
+            return None
         if config:
             return config.home_channel
         return None
@@ -581,9 +589,13 @@ class GatewayConfig:
         return self.default_reset_policy
     
     def to_dict(self) -> Dict[str, Any]:
+        def _serialize_platform(cfg):
+            if isinstance(cfg, list):
+                return [c.to_dict() for c in cfg]
+            return cfg.to_dict()
         return {
             "platforms": {
-                p.value: c.to_dict() for p, c in self.platforms.items()
+                p.value: _serialize_platform(c) for p, c in self.platforms.items()
             },
             "default_reset_policy": self.default_reset_policy.to_dict(),
             "reset_by_type": {
@@ -611,7 +623,12 @@ class GatewayConfig:
         for platform_name, platform_data in data.get("platforms", {}).items():
             try:
                 platform = Platform(platform_name)
-                platforms[platform] = PlatformConfig.from_dict(platform_data)
+                if isinstance(platform_data, list):
+                    platforms[platform] = [
+                        PlatformConfig.from_dict(item) for item in platform_data if isinstance(item, dict)
+                    ]
+                elif isinstance(platform_data, dict):
+                    platforms[platform] = PlatformConfig.from_dict(platform_data)
             except ValueError:
                 pass  # Skip unknown platforms
         
@@ -680,22 +697,28 @@ class GatewayConfig:
         """Return the effective unauthorized-DM behavior for a platform."""
         if platform:
             platform_cfg = self.platforms.get(platform)
-            if platform_cfg and "unauthorized_dm_behavior" in platform_cfg.extra:
-                return _normalize_unauthorized_dm_behavior(
-                    platform_cfg.extra.get("unauthorized_dm_behavior"),
-                    self.unauthorized_dm_behavior,
-                )
+            # Multi-app configs may store a list of PlatformConfig instances.
+            configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            for cfg in configs:
+                if cfg and "unauthorized_dm_behavior" in cfg.extra:
+                    return _normalize_unauthorized_dm_behavior(
+                        cfg.extra.get("unauthorized_dm_behavior"),
+                        self.unauthorized_dm_behavior,
+                    )
         return self.unauthorized_dm_behavior
 
     def get_notice_delivery(self, platform: Optional[Platform] = None) -> str:
         """Return the effective notice-delivery mode for a platform."""
         if platform:
             platform_cfg = self.platforms.get(platform)
-            if platform_cfg and "notice_delivery" in platform_cfg.extra:
-                return _normalize_notice_delivery(
-                    platform_cfg.extra.get("notice_delivery"),
-                    "public",
-                )
+            # Multi-app configs may store a list of PlatformConfig instances.
+            configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            for cfg in configs:
+                if cfg and "notice_delivery" in cfg.extra:
+                    return _normalize_notice_delivery(
+                        cfg.extra.get("notice_delivery"),
+                        "public",
+                    )
         return "public"
 
 
@@ -801,6 +824,10 @@ def load_gateway_config() -> GatewayConfig:
                 if not isinstance(source_platforms, dict):
                     return
                 for plat_name, plat_block in source_platforms.items():
+                    # Multi-app configs may store a list of PlatformConfig dicts.
+                    if isinstance(plat_block, list):
+                        platforms_data[plat_name] = plat_block
+                        continue
                     if not isinstance(plat_block, dict):
                         continue
                     existing = platforms_data.get(plat_name, {})
@@ -1234,15 +1261,18 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
         Platform.WEIXIN: "WEIXIN_TOKEN",
     }
     for platform, pconfig in config.platforms.items():
-        if not pconfig.enabled:
-            continue
-        env_name = _token_env_names.get(platform)
-        if env_name and pconfig.token is not None and not pconfig.token.strip():
-            logger.warning(
-                "%s is enabled but %s is empty. "
-                "The adapter will likely fail to connect.",
-                platform.value, env_name,
-            )
+        # Multi-app configs may store a list of PlatformConfig instances.
+        configs = pconfig if isinstance(pconfig, list) else [pconfig]
+        for cfg in configs:
+            if not cfg.enabled:
+                continue
+            env_name = _token_env_names.get(platform)
+            if env_name and cfg.token is not None and not cfg.token.strip():
+                logger.warning(
+                    "%s is enabled but %s is empty. "
+                    "The adapter will likely fail to connect.",
+                    platform.value, env_name,
+                )
 
     # Reject known-weak placeholder tokens.
     # Ported from openclaw/openclaw#64586: users who copy .env.example
@@ -1255,20 +1285,22 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
 
     if has_usable_secret is not None:
         for platform, pconfig in config.platforms.items():
-            if not pconfig.enabled:
-                continue
-            env_name = _token_env_names.get(platform)
-            if not env_name:
-                continue
-            token = pconfig.token
-            if token and token.strip() and not has_usable_secret(token, min_length=4):
-                logger.error(
-                    "%s is enabled but %s is set to a placeholder value ('%s'). "
-                    "Set a real bot token before starting the gateway. "
-                    "The adapter will NOT be started.",
-                    platform.value, env_name, token.strip()[:6] + "...",
-                )
-                pconfig.enabled = False
+            configs = pconfig if isinstance(pconfig, list) else [pconfig]
+            for cfg in configs:
+                if not cfg.enabled:
+                    continue
+                env_name = _token_env_names.get(platform)
+                if not env_name:
+                    continue
+                token = cfg.token
+                if token and token.strip() and not has_usable_secret(token, min_length=4):
+                    logger.error(
+                        "%s is enabled but %s is set to a placeholder value ('%s'). "
+                        "Set a real bot token before starting the gateway. "
+                        "The adapter will NOT be started.",
+                        platform.value, env_name, token.strip()[:6] + "...",
+                    )
+                    cfg.enabled = False
 
 
 def _apply_env_overrides(config: GatewayConfig) -> None:
@@ -1280,6 +1312,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             return config.platforms[platform]
 
         platform_config = config.platforms[platform]
+        # Multi-app configs may store a list of PlatformConfig instances.
+        if isinstance(platform_config, list):
+            for cfg in platform_config:
+                enabled_was_explicit = bool(cfg.extra.pop("_enabled_explicit", False))
+                if not cfg.enabled and not enabled_was_explicit:
+                    cfg.enabled = True
+            return platform_config[0] if platform_config else PlatformConfig(enabled=True)
+
         enabled_was_explicit = bool(platform_config.extra.pop("_enabled_explicit", False))
         if not platform_config.enabled and not enabled_was_explicit:
             platform_config.enabled = True
@@ -1627,21 +1667,40 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     feishu_app_id = os.getenv("FEISHU_APP_ID")
     feishu_app_secret = os.getenv("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
-        if Platform.FEISHU not in config.platforms:
+        feishu_cfg = config.platforms.get(Platform.FEISHU)
+        if feishu_cfg is None:
             config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
-        config.platforms[Platform.FEISHU].extra.update({
-            "app_id": feishu_app_id,
-            "app_secret": feishu_app_secret,
-            "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
-            "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
-        })
-        feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
-        if feishu_encrypt_key:
-            config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key
-        feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
-        if feishu_verification_token:
-            config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
+            feishu_cfg = config.platforms[Platform.FEISHU]
+        # Multi-app configs may store a list of PlatformConfig instances.
+        if isinstance(feishu_cfg, list):
+            for cfg in feishu_cfg:
+                cfg.enabled = True
+                cfg.extra.update({
+                    "app_id": feishu_app_id,
+                    "app_secret": feishu_app_secret,
+                    "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
+                    "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
+                })
+                feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
+                if feishu_encrypt_key:
+                    cfg.extra["encrypt_key"] = feishu_encrypt_key
+                feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
+                if feishu_verification_token:
+                    cfg.extra["verification_token"] = feishu_verification_token
+        else:
+            feishu_cfg.enabled = True
+            feishu_cfg.extra.update({
+                "app_id": feishu_app_id,
+                "app_secret": feishu_app_secret,
+                "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
+                "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
+            })
+            feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
+            if feishu_encrypt_key:
+                feishu_cfg.extra["encrypt_key"] = feishu_encrypt_key
+            feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
+            if feishu_verification_token:
+                feishu_cfg.extra["verification_token"] = feishu_verification_token
         feishu_home = os.getenv("FEISHU_HOME_CHANNEL")
         if feishu_home:
             config.platforms[Platform.FEISHU].home_channel = HomeChannel(
@@ -2001,4 +2060,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         logger.debug("Plugin platform enable pass failed: %s", e)
 
     for platform_config in config.platforms.values():
-        platform_config.extra.pop("_enabled_explicit", None)
+        # Multi-app configs may store a list of PlatformConfig instances.
+        configs = platform_config if isinstance(platform_config, list) else [platform_config]
+        for cfg in configs:
+            cfg.extra.pop("_enabled_explicit", None)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -330,6 +330,20 @@ class PlatformConfig:
         if _grn is None:
             _grn = data.get("extra", {}).get("gateway_restart_notification")
 
+        reserved_keys = {
+            "enabled",
+            "token",
+            "api_key",
+            "home_channel",
+            "reply_to_mode",
+            "gateway_restart_notification",
+            "extra",
+        }
+        extra = dict(data.get("extra", {}) or {})
+        for key, value in data.items():
+            if key not in reserved_keys:
+                extra.setdefault(key, value)
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
@@ -337,7 +351,7 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
-            extra=data.get("extra", {}),
+            extra=extra,
         )
 
 
@@ -567,6 +581,40 @@ class GatewayConfig:
         if config:
             return config.home_channel
         return None
+
+    def iter_platform_configs(self, platform: Platform) -> list[PlatformConfig]:
+        """Return all configs for a platform, preserving multi-app entries."""
+        config = self.platforms.get(platform)
+        if isinstance(config, list):
+            return [cfg for cfg in config if cfg is not None]
+        if config:
+            return [config]
+        return []
+
+    def get_config_for_adapter_id(
+        self,
+        platform: Platform,
+        adapter_id: Optional[str],
+    ) -> Optional[PlatformConfig]:
+        """Find the platform config that produced a concrete adapter id."""
+        configs = self.iter_platform_configs(platform)
+        if not configs:
+            return None
+        if not adapter_id:
+            return configs[0]
+
+        for cfg in configs:
+            extra = cfg.extra if isinstance(cfg.extra, dict) else {}
+            configured_id = str(
+                extra.get("adapter_id")
+                or extra.get("app_id")
+                or extra.get("bot_id")
+                or extra.get("client_id")
+                or ""
+            ).strip()
+            if configured_id and str(adapter_id) == f"{platform.value}:{configured_id}":
+                return cfg
+        return configs[0]
     
     def get_reset_policy(
         self, 
@@ -1675,17 +1723,15 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if isinstance(feishu_cfg, list):
             for cfg in feishu_cfg:
                 cfg.enabled = True
-                cfg.extra.update({
-                    "app_id": feishu_app_id,
-                    "app_secret": feishu_app_secret,
-                    "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
-                    "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
-                })
+                cfg.extra.setdefault("app_id", feishu_app_id)
+                cfg.extra.setdefault("app_secret", feishu_app_secret)
+                cfg.extra.setdefault("domain", os.getenv("FEISHU_DOMAIN", "feishu"))
+                cfg.extra.setdefault("connection_mode", os.getenv("FEISHU_CONNECTION_MODE", "websocket"))
                 feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
-                if feishu_encrypt_key:
+                if feishu_encrypt_key and not cfg.extra.get("encrypt_key"):
                     cfg.extra["encrypt_key"] = feishu_encrypt_key
                 feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
-                if feishu_verification_token:
+                if feishu_verification_token and not cfg.extra.get("verification_token"):
                     cfg.extra["verification_token"] = feishu_verification_token
         else:
             feishu_cfg.enabled = True

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1803,6 +1803,7 @@ class BasePlatformAdapter(ABC):
     def __init__(self, config: PlatformConfig, platform: Platform):
         self.config = config
         self.platform = platform
+        self.adapter_id: Optional[str] = None
         self._message_handler: Optional[MessageHandler] = None
         # Optional hook (e.g. Telegram DM topic recovery) that rewrites
         # ``event.source.thread_id`` before session keying. Returns the
@@ -4221,7 +4222,13 @@ class BasePlatformAdapter(ABC):
 
                 # Send the text portion
                 if text_content and not _tts_caption_delivered:
-                    logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
+                    logger.info(
+                        "[%s] Sending response (%d chars) via adapter_id=%s to %s",
+                        self.name,
+                        len(text_content),
+                        getattr(event.source, "adapter_id", None) or getattr(self, "adapter_id", None) or "default",
+                        event.source.chat_id,
+                    )
                     _reply_anchor = _reply_anchor_for_event(event)
                     # Mark final response messages for notification delivery.
                     # Platform adapters that support per-message notification
@@ -4648,6 +4655,7 @@ class BasePlatformAdapter(ABC):
         guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
         message_id: Optional[str] = None,
+        adapter_id: Optional[str] = None,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform."""
         # Normalize empty topic to None
@@ -4668,6 +4676,7 @@ class BasePlatformAdapter(ABC):
             guild_id=str(guild_id) if guild_id else None,
             parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
             message_id=str(message_id) if message_id else None,
+            adapter_id=str(adapter_id or self.adapter_id) if (adapter_id or self.adapter_id) else None,
         )
     
     @abstractmethod

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1285,6 +1285,14 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
 
+    async def _run_manual_ws_client() -> None:
+        await ws_client._connect()
+        ping_loop = getattr(ws_client, "_ping_loop", None)
+        if callable(ping_loop):
+            loop.create_task(ping_loop())
+        while getattr(adapter, "_running", False):
+            await asyncio.sleep(60)
+
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     ws_client_module.loop = loop
@@ -1322,6 +1330,13 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     _apply_runtime_ws_overrides()
     try:
         ws_client.start()
+    except RuntimeError as e:
+        if "no running event loop" in str(e).lower():
+            logger.warning("[Feishu] lark_oapi.start() requires running loop — retrying with loop.run_until_complete")
+            try:
+                loop.run_until_complete(_run_manual_ws_client())
+            except Exception:
+                pass
     except Exception:
         pass
     finally:
@@ -1681,7 +1696,12 @@ class FeishuAdapter(BasePlatformAdapter):
             self._loop = asyncio.get_running_loop()
             await self._connect_with_retry()
             self._mark_connected()
-            logger.info("[Feishu] Connected in %s mode (%s)", self._connection_mode, self._domain_name)
+            logger.info(
+                "[Feishu] Connected in %s mode (%s, adapter_id=%s)",
+                self._connection_mode,
+                self._domain_name,
+                getattr(self, "adapter_id", None) or "pending",
+            )
             return True
         except Exception as exc:
             await self._release_app_lock()
@@ -3138,8 +3158,9 @@ class FeishuAdapter(BasePlatformAdapter):
             or "<unknown>"
         )
         logger.info(
-            "[Feishu] Inbound %s message received: id=%s type=%s chat_id=%s sender=%s:%s text=%r media=%d",
+            "[Feishu] Inbound %s message received: adapter_id=%s id=%s type=%s chat_id=%s sender=%s:%s text=%r media=%d",
             "dm" if chat_type == "p2p" else "group",
+            getattr(self, "adapter_id", None) or "unknown",
             message_id,
             inbound_type.value,
             getattr(message, "chat_id", "") or "",

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1286,12 +1286,29 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     import lark_oapi.ws.client as ws_client_module
 
     async def _run_manual_ws_client() -> None:
+        disconnected_since: Optional[float] = None
+        stale_after = max(
+            30.0,
+            float(getattr(adapter, "_ws_reconnect_nonce", 30) or 0)
+            + float(getattr(adapter, "_ws_reconnect_interval", 120) or 120)
+            + 15.0,
+        )
         await ws_client._connect()
         ping_loop = getattr(ws_client, "_ping_loop", None)
         if callable(ping_loop):
             loop.create_task(ping_loop())
         while getattr(adapter, "_running", False):
-            await asyncio.sleep(60)
+            if getattr(ws_client, "_conn", None) is None:
+                now = time.monotonic()
+                disconnected_since = disconnected_since or now
+                if now - disconnected_since >= stale_after:
+                    raise RuntimeError(
+                        "Feishu websocket receive loop exited and did not reconnect "
+                        f"within {stale_after:.0f}s"
+                    )
+            else:
+                disconnected_since = None
+            await asyncio.sleep(5)
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
@@ -1335,10 +1352,15 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             logger.warning("[Feishu] lark_oapi.start() requires running loop — retrying with loop.run_until_complete")
             try:
                 loop.run_until_complete(_run_manual_ws_client())
-            except Exception:
-                pass
-    except Exception:
-        pass
+            except Exception as exc:
+                logger.error("[Feishu] websocket client exited: %s", exc, exc_info=True)
+                raise
+        else:
+            logger.error("[Feishu] websocket client exited: %s", e, exc_info=True)
+            raise
+    except Exception as exc:
+        logger.error("[Feishu] websocket client exited: %s", exc, exc_info=True)
+        raise
     finally:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
@@ -1492,6 +1514,15 @@ class FeishuAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
+        def _iter_allowed_users(raw: Any):
+            if isinstance(raw, str):
+                yield from (item.strip() for item in raw.split(",") if item.strip())
+            elif isinstance(raw, (list, tuple, set)):
+                for item in raw:
+                    text = str(item).strip()
+                    if text:
+                        yield text
+
         # Parse per-group rules from config
         raw_group_rules = extra.get("group_rules", {})
         group_rules: Dict[str, FeishuGroupRule] = {}
@@ -1541,9 +1572,8 @@ class FeishuAdapter(BasePlatformAdapter):
             ).strip(),
             group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
             allowed_group_users=frozenset(
-                item.strip()
-                for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")
-                if item.strip()
+                set(_iter_allowed_users(os.getenv("FEISHU_ALLOWED_USERS", "")))
+                | set(_iter_allowed_users(extra.get("allowed_users")))
             ),
             bot_open_id=os.getenv("FEISHU_BOT_OPEN_ID", "").strip(),
             bot_user_id=os.getenv("FEISHU_BOT_USER_ID", "").strip(),
@@ -4610,6 +4640,7 @@ class FeishuAdapter(BasePlatformAdapter):
             self._ws_client,
             self,
         )
+        self._ws_future.add_done_callback(self._on_websocket_thread_done)
 
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:
@@ -4636,6 +4667,36 @@ class FeishuAdapter(BasePlatformAdapter):
             .log_level(lark.LogLevel.WARNING)
             .build()
         )
+
+    def _on_websocket_thread_done(self, future: asyncio.Future) -> None:
+        """Escalate an unexpected Feishu websocket thread exit to the runner."""
+        if not getattr(self, "_running", False):
+            return
+        try:
+            exc = future.exception()
+        except asyncio.CancelledError:
+            return
+        except Exception as callback_exc:
+            exc = callback_exc
+
+        if exc is None:
+            message = "Feishu websocket thread exited while adapter was still running"
+        else:
+            message = f"Feishu websocket thread exited: {exc}"
+        logger.error(
+            "[Feishu] %s",
+            message,
+            exc_info=(type(exc), exc, exc.__traceback__) if exc else None,
+        )
+        self._set_fatal_error("feishu_ws_disconnected", message, retryable=True)
+
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        try:
+            asyncio.run_coroutine_threadsafe(self._notify_fatal_error(), loop)
+        except RuntimeError:
+            logger.debug("[Feishu] Could not schedule websocket fatal-error handler", exc_info=True)
 
     async def _feishu_send_with_retry(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1655,7 +1655,7 @@ def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
     Session keys follow the format
-    ``agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
+    ``agent:main:{platform}[:adapter={adapter_id}]:{chat_type}:{chat_id}[:{extra}...]``.
     Returns a dict with ``platform``, ``chat_type``, ``chat_id``, and
     optionally ``thread_id`` keys, or None if the key doesn't match.
 
@@ -1665,6 +1665,8 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
+    if len(parts) >= 6 and parts[3].startswith("adapter="):
+        parts = parts[:3] + parts[4:]
     if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
         result = {
             "platform": parts[2],

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3829,7 +3829,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
 
                 platform_cfg = self.config.platforms.get(platform)
-                if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+                _grn = any(
+                    getattr(cfg, "gateway_restart_notification", True) for cfg in _configs if cfg is not None
+                )
+                if platform_cfg is not None and not _grn:
                     logger.info(
                         "Shutdown notification suppressed for active session: %s has gateway_restart_notification=false",
                         platform_str,
@@ -3892,7 +3896,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
 
             platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            _grn = any(
+                getattr(cfg, "gateway_restart_notification", True) for cfg in _configs if cfg is not None
+            )
+            if platform_cfg is not None and not _grn:
                 logger.info(
                     "Shutdown notification suppressed for home channel: %s has gateway_restart_notification=false",
                     platform.value,
@@ -4634,122 +4642,125 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # Initialize and connect each configured platform
         for platform, platform_config in self.config.platforms.items():
-            if not platform_config.enabled:
-                continue
-            enabled_platform_count += 1
-            
-            adapter = self._create_adapter(platform, platform_config)
-            if not adapter:
-                # Distinguish between missing builtin deps and missing plugin
-                _pval = platform.value
-                _builtin_names = {m.value for m in Platform.__members__.values()}
-                if _pval not in _builtin_names:
-                    logger.warning(
-                        "No adapter for '%s' — is the plugin installed? "
-                        "(platform is enabled in config.yaml but no plugin registered it)",
-                        _pval,
-                    )
-                else:
-                    logger.warning("No adapter available for %s", _pval)
-                continue
-            
-            # Set up message + fatal error handlers
-            adapter.set_message_handler(self._handle_message)
-            adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
-            adapter.set_session_store(self.session_store)
-            adapter.set_busy_session_handler(self._handle_active_session_busy_message)
-            adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
-            adapter._busy_text_mode = self._busy_text_mode
-            
-            # Try to connect
-            logger.info("Connecting to %s...", platform.value)
-            self._update_platform_runtime_status(
-                platform.value,
-                platform_state="connecting",
-                error_code=None,
-                error_message=None,
-            )
-            try:
-                success = await self._connect_adapter_with_timeout(adapter, platform)
-                if success:
-                    self.adapters[platform] = adapter
-                    self._sync_voice_mode_state_to_adapter(adapter)
-                    connected_count += 1
-                    self._update_platform_runtime_status(
-                        platform.value,
-                        platform_state="connected",
-                        error_code=None,
-                        error_message=None,
-                    )
-                    logger.info("✓ %s connected", platform.value)
-                else:
-                    logger.warning("✗ %s failed to connect", platform.value)
-                    # Defensive cleanup: a failed connect() may have
-                    # allocated resources (aiohttp.ClientSession, poll
-                    # tasks, bridge subprocesses) before giving up.
-                    # Without this call, those resources are orphaned
-                    # and Python logs "Unclosed client session" at
-                    # process exit. Adapter disconnect() implementations
-                    # are expected to be idempotent and tolerate
-                    # partial-init state.
-                    await self._safe_adapter_disconnect(adapter, platform)
-                    if adapter.has_fatal_error:
+            # Multi-app configs may store a list of PlatformConfig instances.
+            configs = platform_config if isinstance(platform_config, list) else [platform_config]
+            for cfg in configs:
+                if not cfg.enabled:
+                    continue
+                enabled_platform_count += 1
+                
+                adapter = self._create_adapter(platform, cfg)
+                if not adapter:
+                    # Distinguish between missing builtin deps and missing plugin
+                    _pval = platform.value
+                    _builtin_names = {m.value for m in Platform.__members__.values()}
+                    if _pval not in _builtin_names:
+                        logger.warning(
+                            "No adapter for '%s' — is the plugin installed? "
+                            "(platform is enabled in config.yaml but no plugin registered it)",
+                            _pval,
+                        )
+                    else:
+                        logger.warning("No adapter available for %s", _pval)
+                    continue
+                
+                # Set up message + fatal error handlers
+                adapter.set_message_handler(self._handle_message)
+                adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+                adapter.set_session_store(self.session_store)
+                adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+                adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
+                adapter._busy_text_mode = self._busy_text_mode
+                
+                # Try to connect
+                logger.info("Connecting to %s...", platform.value)
+                self._update_platform_runtime_status(
+                    platform.value,
+                    platform_state="connecting",
+                    error_code=None,
+                    error_message=None,
+                )
+                try:
+                    success = await self._connect_adapter_with_timeout(adapter, platform)
+                    if success:
+                        self.adapters[platform] = adapter
+                        self._sync_voice_mode_state_to_adapter(adapter)
+                        connected_count += 1
                         self._update_platform_runtime_status(
                             platform.value,
-                            platform_state="retrying" if adapter.fatal_error_retryable else "fatal",
-                            error_code=adapter.fatal_error_code,
-                            error_message=adapter.fatal_error_message,
+                            platform_state="connected",
+                            error_code=None,
+                            error_message=None,
                         )
-                        target = (
-                            startup_retryable_errors
-                            if adapter.fatal_error_retryable
-                            else startup_nonretryable_errors
-                        )
-                        target.append(
-                            f"{platform.value}: {adapter.fatal_error_message}"
-                        )
-                        # Queue for reconnection if the error is retryable
-                        if adapter.fatal_error_retryable:
+                        logger.info("✓ %s connected", platform.value)
+                    else:
+                        logger.warning("✗ %s failed to connect", platform.value)
+                        # Defensive cleanup: a failed connect() may have
+                        # allocated resources (aiohttp.ClientSession, poll
+                        # tasks, bridge subprocesses) before giving up.
+                        # Without this call, those resources are orphaned
+                        # and Python logs "Unclosed client session" at
+                        # process exit. Adapter disconnect() implementations
+                        # are expected to be idempotent and tolerate
+                        # partial-init state.
+                        await self._safe_adapter_disconnect(adapter, platform)
+                        if adapter.has_fatal_error:
+                            self._update_platform_runtime_status(
+                                platform.value,
+                                platform_state="retrying" if adapter.fatal_error_retryable else "fatal",
+                                error_code=adapter.fatal_error_code,
+                                error_message=adapter.fatal_error_message,
+                            )
+                            target = (
+                                startup_retryable_errors
+                                if adapter.fatal_error_retryable
+                                else startup_nonretryable_errors
+                            )
+                            target.append(
+                                f"{platform.value}: {adapter.fatal_error_message}"
+                            )
+                            # Queue for reconnection if the error is retryable
+                            if adapter.fatal_error_retryable:
+                                self._failed_platforms[platform] = {
+                                    "config": cfg,
+                                    "attempts": 1,
+                                    "next_retry": time.monotonic() + 30,
+                                }
+                        else:
+                            self._update_platform_runtime_status(
+                                platform.value,
+                                platform_state="retrying",
+                                error_code=None,
+                                error_message="failed to connect",
+                            )
+                            startup_retryable_errors.append(
+                                f"{platform.value}: failed to connect"
+                            )
+                            # No fatal error info means likely a transient issue — queue for retry
                             self._failed_platforms[platform] = {
-                                "config": platform_config,
+                                "config": cfg,
                                 "attempts": 1,
                                 "next_retry": time.monotonic() + 30,
                             }
-                    else:
-                        self._update_platform_runtime_status(
-                            platform.value,
-                            platform_state="retrying",
-                            error_code=None,
-                            error_message="failed to connect",
-                        )
-                        startup_retryable_errors.append(
-                            f"{platform.value}: failed to connect"
-                        )
-                        # No fatal error info means likely a transient issue — queue for retry
-                        self._failed_platforms[platform] = {
-                            "config": platform_config,
-                            "attempts": 1,
-                            "next_retry": time.monotonic() + 30,
-                        }
-            except Exception as e:
-                logger.error("✗ %s error: %s", platform.value, e)
-                # Same defensive cleanup path for exceptions — an adapter
-                # that raised mid-connect may still have a live
-                # aiohttp.ClientSession or child subprocess.
-                await self._safe_adapter_disconnect(adapter, platform)
-                self._update_platform_runtime_status(
-                    platform.value,
-                    platform_state="retrying",
-                    error_code=None,
-                    error_message=str(e),
-                )
-                startup_retryable_errors.append(f"{platform.value}: {e}")
-                # Unexpected exceptions are typically transient — queue for retry
-                self._failed_platforms[platform] = {
-                    "config": platform_config,
-                    "attempts": 1,
-                    "next_retry": time.monotonic() + 30,
-                }
+                except Exception as e:
+                    logger.error("✗ %s error: %s", platform.value, e)
+                    # Same defensive cleanup path for exceptions — an adapter
+                    # that raised mid-connect may still have a live
+                    # aiohttp.ClientSession or child subprocess.
+                    await self._safe_adapter_disconnect(adapter, platform)
+                    self._update_platform_runtime_status(
+                        platform.value,
+                        platform_state="retrying",
+                        error_code=None,
+                        error_message=str(e),
+                    )
+                    startup_retryable_errors.append(f"{platform.value}: {e}")
+                    # Unexpected exceptions are typically transient — queue for retry
+                    self._failed_platforms[platform] = {
+                        "config": cfg,
+                        "attempts": 1,
+                        "next_retry": time.monotonic() + 30,
+                    }
         
         if connected_count == 0:
             if startup_nonretryable_errors:
@@ -5063,7 +5074,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # user_id (thread_sessions_per_user defaults to False) — so the
         # next real user message in the thread shares this same session.
         platform_cfg = self.config.platforms.get(platform)
-        extra = platform_cfg.extra if platform_cfg else {}
+        # Multi-app configs may return a list of PlatformConfig instances.
+        _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+        extra = {}
+        for cfg in _configs:
+            if cfg is not None:
+                extra = cfg.extra
+                break
         session_key = build_session_key(
             dest_source,
             group_sessions_per_user=extra.get("group_sessions_per_user", True),
@@ -11059,7 +11076,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return None
 
             platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            _grn = any(
+                getattr(cfg, "gateway_restart_notification", True) for cfg in _configs if cfg is not None
+            )
+            if platform_cfg is not None and not _grn:
                 logger.info(
                     "Restart notification suppressed: %s has gateway_restart_notification=false",
                     platform_str,
@@ -11125,7 +11146,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
 
             platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            _grn = any(
+                getattr(cfg, "gateway_restart_notification", True) for cfg in _configs if cfg is not None
+            )
+            if platform_cfg is not None and not _grn:
                 logger.info(
                     "Home-channel startup notification suppressed: %s has gateway_restart_notification=false",
                     platform.value,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1892,6 +1892,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         global _gateway_runner_ref
         self.config = config or load_gateway_config()
         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
+        self.adapters_by_id: Dict[str, BasePlatformAdapter] = {}
+        self._platform_adapter_ids: Dict[Platform, list[str]] = {}
         self._warn_if_docker_media_delivery_is_risky()
         _gateway_runner_ref = _weakref.ref(self)
 
@@ -2147,6 +2149,71 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Teams pipeline runtime unavailable: %s",
                 self._teams_pipeline_runtime_error,
             )
+
+
+    def _adapter_instance_id(self, platform: Platform, adapter: BasePlatformAdapter) -> str:
+        """Return a stable per-config adapter id for multi-instance platforms."""
+        existing = getattr(adapter, "adapter_id", None)
+        if existing:
+            return str(existing)
+        extra = getattr(getattr(adapter, "config", None), "extra", None)
+        configured_id = ""
+        if isinstance(extra, dict):
+            configured_id = str(
+                extra.get("adapter_id")
+                or extra.get("app_id")
+                or extra.get("bot_id")
+                or extra.get("client_id")
+                or ""
+            ).strip()
+        base = f"{platform.value}:{configured_id}" if configured_id else platform.value
+        adapter_id = base
+        suffix = 2
+        while adapter_id in self.adapters_by_id and self.adapters_by_id[adapter_id] is not adapter:
+            adapter_id = f"{base}:{suffix}"
+            suffix += 1
+        setattr(adapter, "adapter_id", adapter_id)
+        return adapter_id
+
+    def _register_connected_adapter(self, platform: Platform, adapter: BasePlatformAdapter) -> None:
+        adapter_id = self._adapter_instance_id(platform, adapter)
+        self.adapters_by_id[adapter_id] = adapter
+        ids = self._platform_adapter_ids.setdefault(platform, [])
+        if adapter_id not in ids:
+            ids.append(adapter_id)
+        self.adapters.setdefault(platform, adapter)
+
+    def _adapter_for_source(self, source: Optional[SessionSource]) -> Optional[BasePlatformAdapter]:
+        """Resolve the concrete adapter for a source, falling back to platform."""
+        if source is None:
+            return None
+        adapter_id = getattr(source, "adapter_id", None)
+        if adapter_id:
+            adapter = getattr(self, "adapters_by_id", {}).get(str(adapter_id))
+            if adapter is not None:
+                return adapter
+        return getattr(self, "adapters", {}).get(source.platform)
+
+    def _adapter_for_event(self, event: Optional[MessageEvent]) -> Optional[BasePlatformAdapter]:
+        return self._adapter_for_source(getattr(event, "source", None))
+
+    def _iter_connected_adapters(self) -> list[tuple[Platform, BasePlatformAdapter]]:
+        """Return all connected adapter instances, including multi-app platforms."""
+        seen: set[int] = set()
+        items: list[tuple[Platform, BasePlatformAdapter]] = []
+        for adapter in getattr(self, "adapters_by_id", {}).values():
+            ident = id(adapter)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            items.append((adapter.platform, adapter))
+        for platform, adapter in getattr(self, "adapters", {}).items():
+            ident = id(adapter)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            items.append((platform, adapter))
+        return items
 
 
     def _warn_if_docker_media_delivery_is_risky(self) -> None:
@@ -2829,6 +2896,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             finally:
                 self.adapters.pop(adapter.platform, None)
                 self.delivery_router.adapters = self.adapters
+        else:
+            try:
+                await adapter.disconnect()
+            finally:
+                pass
+        adapter_id = getattr(adapter, "adapter_id", None)
+        if adapter_id:
+            self.adapters_by_id.pop(str(adapter_id), None)
+            ids = self._platform_adapter_ids.get(adapter.platform)
+            if ids and str(adapter_id) in ids:
+                ids.remove(str(adapter_id))
+            if self.adapters.get(adapter.platform) is None and ids:
+                replacement = self.adapters_by_id.get(ids[0])
+                if replacement is not None:
+                    self.adapters[adapter.platform] = replacement
+                    self.delivery_router.adapters = self.adapters
 
         # Queue retryable failures for background reconnection
         if adapter.fatal_error_retryable:
@@ -3437,7 +3520,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _BUSY_QUEUE_MAX_PENDING = 32
 
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._adapter_for_event(event)
         if not adapter:
             return
         # #28503 — Previously this called ``merge_pending_message_event``
@@ -3494,7 +3577,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
-            adapter = self.adapters.get(event.source.platform)
+            adapter = self._adapter_for_event(event)
             if not adapter:
                 return True
 
@@ -3521,7 +3604,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return True
 
         # Normal busy case (agent actively running a task)
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._adapter_for_event(event)
         if not adapter:
             return False  # let default path handle it
 
@@ -3890,20 +3973,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # elsewhere), which would otherwise trigger
         # ``RuntimeError: dictionary changed size during iteration`` —
         # observed in a user report during gateway shutdown.
-        for platform, adapter in list(self.adapters.items()):
-            home = self.config.get_home_channel(platform)
+        for platform, adapter in self._iter_connected_adapters():
+            adapter_id = getattr(adapter, "adapter_id", None)
+            cfg = self.config.get_config_for_adapter_id(platform, adapter_id)
+            home = cfg.home_channel if cfg else self.config.get_home_channel(platform)
             if not home or not home.chat_id:
                 continue
 
-            platform_cfg = self.config.platforms.get(platform)
-            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
-            _grn = any(
-                getattr(cfg, "gateway_restart_notification", True) for cfg in _configs if cfg is not None
-            )
-            if platform_cfg is not None and not _grn:
+            if cfg is not None and not getattr(cfg, "gateway_restart_notification", True):
                 logger.info(
-                    "Shutdown notification suppressed for home channel: %s has gateway_restart_notification=false",
+                    "Shutdown notification suppressed for home channel: %s adapter_id=%s has gateway_restart_notification=false",
                     platform.value,
+                    adapter_id,
                 )
                 continue
 
@@ -4354,7 +4435,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
 
             source = entry.origin
-            adapter = self.adapters.get(source.platform)
+            adapter = self._adapter_for_source(source)
             if adapter is None:
                 logger.debug(
                     "Skipping auto-resume for %s: adapter not ready for %s",
@@ -4671,6 +4752,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                 adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
                 adapter._busy_text_mode = self._busy_text_mode
+                self._adapter_instance_id(platform, adapter)
                 
                 # Try to connect
                 logger.info("Connecting to %s...", platform.value)
@@ -4683,7 +4765,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                     if success:
-                        self.adapters[platform] = adapter
+                        self._register_connected_adapter(platform, adapter)
+                        adapter_id = getattr(adapter, "adapter_id", None)
                         self._sync_voice_mode_state_to_adapter(adapter)
                         connected_count += 1
                         self._update_platform_runtime_status(
@@ -4692,7 +4775,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             error_code=None,
                             error_message=None,
                         )
-                        logger.info("✓ %s connected", platform.value)
+                        if adapter_id:
+                            logger.info("✓ %s connected (adapter_id=%s)", platform.value, adapter_id)
+                        else:
+                            logger.info("✓ %s connected", platform.value)
                     else:
                         logger.warning("✗ %s failed to connect", platform.value)
                         # Defensive cleanup: a failed connect() may have
@@ -4862,20 +4948,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Notify the chat that initiated /restart that the gateway is back.
         planned_restart_notification_pending = _planned_restart_notification_pending()
-        await self._send_restart_notification()
+        restart_target = await self._send_restart_notification()
 
-        # Broadcast a lightweight "gateway is back" message to configured home
-        # channels only for non-chat planned restarts (terminal/SIGUSR1/service
-        # paths). Chat-originated /restart already has a precise reply target
-        # in .restart_notify.json, so keep that lifecycle in the originating
-        # chat/topic instead of also leaking it to the configured home channel.
-        if planned_restart_notification_pending:
+        # Broadcast a lightweight "gateway is back" message to configured
+        # home channels on startup/restart. Chat-originated /restart already
+        # has a precise reply target in .restart_notify.json, so skip that
+        # one destination while still notifying any other configured homes.
+        if connected_count > 0:
             try:
                 await self._send_home_channel_startup_notifications(
-                    skip_targets=None,
+                    skip_targets={restart_target} if restart_target else None,
                 )
             finally:
-                _clear_planned_restart_notification()
+                if planned_restart_notification_pending:
+                    _clear_planned_restart_notification()
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
@@ -5413,10 +5499,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
                     adapter._busy_text_mode = self._busy_text_mode
+                    self._adapter_instance_id(platform, adapter)
 
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                     if success:
-                        self.adapters[platform] = adapter
+                        self._register_connected_adapter(platform, adapter)
                         self._sync_voice_mode_state_to_adapter(adapter)
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]
@@ -5736,7 +5823,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     self._cleanup_agent_resources(_agent)
 
-            for platform, adapter in list(self.adapters.items()):
+            for platform, adapter in self._iter_connected_adapters():
                 _adapter_started_at = time.monotonic()
                 try:
                     await adapter.cancel_background_tasks()
@@ -5768,6 +5855,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._background_tasks.clear()
 
             self.adapters.clear()
+            self.adapters_by_id.clear()
+            self._platform_adapter_ids.clear()
             self._running_agents.clear()
             self._running_agents_ts.clear()
             self._pending_messages.clear()
@@ -6101,7 +6190,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _deliver_platform_notice(self, source, content: str) -> None:
         """Deliver a setup/operational notice using platform-specific privacy rules."""
-        adapter = self.adapters.get(source.platform)
+        adapter = self._adapter_for_source(source)
         if not adapter:
             return
 
@@ -6216,7 +6305,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     platform_name, source.user_id, source.user_name or ""
                 )
                 if code:
-                    adapter = self.adapters.get(source.platform)
+                    adapter = self._adapter_for_source(source)
                     if adapter:
                         await adapter.send(
                             source.chat_id,
@@ -6226,7 +6315,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             f"`hermes pairing approve {platform_name} {code}`"
                         )
                 else:
-                    adapter = self.adapters.get(source.platform)
+                    adapter = self._adapter_for_source(source)
                     if adapter:
                         await adapter.send(
                             source.chat_id,
@@ -6523,7 +6612,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 queued_text = event.get_command_args().strip()
                 if not queued_text:
                     return "Usage: /queue <prompt>"
-                adapter = self.adapters.get(source.platform)
+                adapter = self._adapter_for_source(source)
                 if adapter:
                     queued_event = MessageEvent(
                         text=queued_text,
@@ -6533,7 +6622,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         channel_prompt=event.channel_prompt,
                     )
                     self._enqueue_fifo(_quick_key, queued_event, adapter)
-                depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
+                depth = self._queue_depth(_quick_key, adapter=self._adapter_for_source(source))
                 if depth <= 1:
                     return "Queued for the next turn."
                 return f"Queued for the next turn. ({depth} queued)"
@@ -6550,7 +6639,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 running_agent = self._running_agents.get(_quick_key)
                 if running_agent is _AGENT_PENDING_SENTINEL:
                     # Agent hasn't started yet — queue as turn-boundary fallback.
-                    adapter = self.adapters.get(source.platform)
+                    adapter = self._adapter_for_source(source)
                     if adapter:
                         queued_event = MessageEvent(
                             text=steer_text,
@@ -6572,7 +6661,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         return f"⏩ Steer queued — arrives after the next tool call: '{preview}'"
                     return "Steer rejected (empty payload)."
                 # Running agent is missing or lacks steer() — fall back to queue.
-                adapter = self.adapters.get(source.platform)
+                adapter = self._adapter_for_source(source)
                 if adapter:
                     queued_event = MessageEvent(
                         text=steer_text,
@@ -6686,7 +6775,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
-                adapter = self.adapters.get(source.platform)
+                adapter = self._adapter_for_source(source)
                 if adapter:
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
@@ -6707,7 +6796,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     time.time() - _started_at,
                     _quick_key,
                 )
-                adapter = self.adapters.get(source.platform)
+                adapter = self._adapter_for_source(source)
                 if adapter:
                     if self._busy_input_mode == "queue":
                         self._enqueue_fifo(_quick_key, event, adapter)
@@ -6730,7 +6819,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return EphemeralReply("⚡ Force-stopped. The agent was still starting — session unlocked.")
                 # Queue the message so it will be picked up after the
                 # agent starts.
-                adapter = self.adapters.get(source.platform)
+                adapter = self._adapter_for_source(source)
                 if adapter:
                     merge_pending_message_event(
                         adapter._pending_messages,
@@ -7400,7 +7489,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # before the agent loop runs. Lets the user verify STT quality
                 # in real-time and see the raw whisper output verbatim.
                 if _successful_transcripts:
-                    _echo_adapter = self.adapters.get(source.platform)
+                    _echo_adapter = self._adapter_for_source(source)
                     _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
                     if _echo_adapter:
                         for _tx in _successful_transcripts:
@@ -7421,7 +7510,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "VOICE_TOOLS_OPENAI_KEY",
                 )
                 if any(marker in message_text for marker in _stt_fail_markers):
-                    _stt_adapter = self.adapters.get(source.platform)
+                    _stt_adapter = self._adapter_for_source(source)
                     _stt_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
                     if _stt_adapter:
                         try:
@@ -7541,7 +7630,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     allowed_root=_msg_cwd,
                 )
                 if _ctx_result.blocked:
-                    _adapter = self.adapters.get(source.platform)
+                    _adapter = self._adapter_for_source(source)
                     if _adapter:
                         await _adapter.send(
                             source.chat_id,
@@ -7758,7 +7847,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and platform_name not in policy.notify_exclude_platforms
                 )
                 if should_notify:
-                    adapter = self.adapters.get(source.platform)
+                    adapter = self._adapter_for_source(source)
                     if adapter:
                         if reset_reason == "suspended":
                             reason_text = "previous session was stopped or interrupted"
@@ -8104,7 +8193,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             "configuration."
                                         )
                                         try:
-                                            _adapter = self.adapters.get(source.platform)
+                                            _adapter = self._adapter_for_source(source)
                                             if _adapter and source.chat_id:
                                                 await _adapter.send(source.chat_id, _warn_msg, metadata=_hyg_meta)
                                         except Exception as _werr:
@@ -8128,7 +8217,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             "check `auxiliary.compression.model` in config.yaml."
                                         )
                                         try:
-                                            _adapter = self.adapters.get(source.platform)
+                                            _adapter = self._adapter_for_source(source)
                                             if _adapter and source.chat_id:
                                                 await _adapter.send(source.chat_id, _aux_msg, metadata=_hyg_meta)
                                         except Exception as _werr:
@@ -8246,7 +8335,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # event so deferred post-delivery callbacks can be released by the
         # same run that registered them.
         self._bind_adapter_run_generation(
-            self.adapters.get(source.platform),
+            self._adapter_for_source(source),
             session_key,
             run_generation,
         )
@@ -8279,7 +8368,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Stop persistent typing indicator now that the agent is done
             try:
-                _typing_adapter = self.adapters.get(source.platform)
+                _typing_adapter = self._adapter_for_source(source)
                 if _typing_adapter and hasattr(_typing_adapter, "stop_typing"):
                     await _typing_adapter.stop_typing(source.chat_id)
             except Exception:
@@ -8291,7 +8380,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _quick_key or "?",
                     run_generation,
                 )
-                _stale_adapter = self.adapters.get(source.platform)
+                _stale_adapter = self._adapter_for_source(source)
                 if getattr(type(_stale_adapter), "pop_post_delivery_callback", None) is not None:
                     _stale_adapter.pop_post_delivery_callback(
                         _quick_key,
@@ -8319,8 +8408,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)
             logger.info(
-                "response ready: platform=%s chat=%s time=%.1fs api_calls=%d response=%d chars",
-                _platform_name, source.chat_id or "unknown",
+                "response ready: platform=%s adapter_id=%s chat=%s time=%.1fs api_calls=%d response=%d chars",
+                _platform_name, getattr(source, "adapter_id", None) or "default", source.chat_id or "unknown",
                 _response_time, _api_calls, _resp_len,
             )
 
@@ -8633,7 +8722,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # users see the agent "stop responding without explanation."
             if agent_result.get("already_sent") and not agent_result.get("failed"):
                 if response:
-                    _media_adapter = self.adapters.get(source.platform)
+                    _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
@@ -8644,7 +8733,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # still surface the runtime metadata on the final reply.
                 if _footer_line:
                     try:
-                        _foot_adapter = self.adapters.get(source.platform)
+                        _foot_adapter = self._adapter_for_source(source)
                         if _foot_adapter:
                             await _foot_adapter.send(
                                 source.chat_id,
@@ -8660,7 +8749,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             # Stop typing indicator on error too
             try:
-                _err_adapter = self.adapters.get(source.platform)
+                _err_adapter = self._adapter_for_source(source)
                 if _err_adapter and hasattr(_err_adapter, "stop_typing"):
                     await _err_adapter.stop_typing(source.chat_id)
             except Exception:
@@ -9070,7 +9159,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _send_goal_status_notice(self, source: Any, message: str) -> None:
         """Send a /goal judge status line back to the originating chat/thread."""
-        adapter = self.adapters.get(source.platform)
+        adapter = self._adapter_for_source(source)
         if not adapter:
             logger.debug("goal continuation: no adapter for %s", getattr(source, "platform", None))
             return
@@ -9097,7 +9186,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         exactly this boundary; when unavailable, fall back to direct awaited
         delivery rather than silently dropping the notice.
         """
-        adapter = self.adapters.get(source.platform)
+        adapter = self._adapter_for_source(source)
         if not adapter:
             logger.debug("goal continuation: no adapter for %s", getattr(source, "platform", None))
             return
@@ -9185,7 +9274,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Enqueue via the adapter's FIFO so a user message already in
         # flight preempts the continuation naturally.
         try:
-            adapter = self.adapters.get(source.platform)
+            adapter = self._adapter_for_source(source)
             _quick_key = self._session_key_for_source(source)
             if adapter and _quick_key:
                 cont_event = MessageEvent(
@@ -9218,7 +9307,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         """Join the user's current Discord voice channel."""
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._adapter_for_event(event)
         if not hasattr(adapter, "join_voice_channel"):
             return "Voice channels are not supported on this platform."
 
@@ -9269,7 +9358,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _handle_voice_channel_leave(self, event: MessageEvent) -> str:
         """Leave the Discord voice channel."""
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._adapter_for_event(event)
         guild_id = self._get_guild_id(event)
 
         if not guild_id or not hasattr(adapter, "leave_voice_channel"):
@@ -9499,7 +9588,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
                 return
 
-            adapter = self.adapters.get(event.source.platform)
+            adapter = self._adapter_for_event(event)
 
             # If connected to a voice channel, play there instead of sending a file
             guild_id = self._get_guild_id(event)
@@ -9677,7 +9766,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         media_urls = media_urls or []
         media_types = media_types or []
 
-        adapter = self.adapters.get(source.platform)
+        adapter = self._adapter_for_source(source)
         if not adapter:
             logger.warning("No adapter for platform %s in background task %s", source.platform, task_id)
             return
@@ -9872,7 +9961,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _get_telegram_topic_capabilities(self, source: SessionSource) -> dict:
         """Read Telegram private-topic capability flags via Bot API getMe."""
-        adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None
+        adapter = self._adapter_for_source(source) if getattr(self, "adapters", None) else None
         bot = getattr(adapter, "_bot", None)
         if bot is None or not hasattr(bot, "get_me"):
             return {"checked": False}
@@ -9900,7 +9989,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _ensure_telegram_system_topic(self, source: SessionSource) -> None:
         """Create/pin the managed System topic after /topic activation when possible."""
-        adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None
+        adapter = self._adapter_for_source(source) if getattr(self, "adapters", None) else None
         if adapter is None or not source.chat_id:
             return
 
@@ -9941,7 +10030,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _send_telegram_topic_setup_image(self, source: SessionSource) -> None:
         """Send the bundled BotFather Threads Settings screenshot when available."""
-        adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None
+        adapter = self._adapter_for_source(source) if getattr(self, "adapters", None) else None
         if adapter is None or not source.chat_id or not hasattr(adapter, "send_image_file"):
             return
         image_path = Path(__file__).resolve().parent / "assets" / "telegram-botfather-threads-settings.jpg"
@@ -9993,7 +10082,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Check the class, not the instance — getattr() on MagicMock
         # auto-creates attributes, so `hasattr(adapter, "_get_dm_topic_info")`
         # would return True for every test double.
-        adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None
+        adapter = self._adapter_for_source(source) if getattr(self, "adapters", None) else None
         if adapter is not None:
             get_info = getattr(type(adapter), "_get_dm_topic_info", None)
             if callable(get_info):
@@ -10550,7 +10639,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # cannot race the send_slash_confirm return.
         _slash_confirm_mod.register(session_key, confirm_id, command, handler)
 
-        adapter = self.adapters.get(source.platform)
+        adapter = self._adapter_for_source(source)
         metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
 
         used_buttons = False
@@ -11140,20 +11229,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         skipped = skip_targets or set()
         message = "♻️ Gateway online — Hermes is back and ready."
 
-        for platform, adapter in self.adapters.items():
-            home = self.config.get_home_channel(platform)
+        for platform, adapter in self._iter_connected_adapters():
+            adapter_id = getattr(adapter, "adapter_id", None)
+            cfg = self.config.get_config_for_adapter_id(platform, adapter_id)
+            home = cfg.home_channel if cfg else self.config.get_home_channel(platform)
             if not home or not home.chat_id:
                 continue
 
-            platform_cfg = self.config.platforms.get(platform)
-            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
-            _grn = any(
-                getattr(cfg, "gateway_restart_notification", True) for cfg in _configs if cfg is not None
-            )
-            if platform_cfg is not None and not _grn:
+            if cfg is not None and not getattr(cfg, "gateway_restart_notification", True):
                 logger.info(
-                    "Home-channel startup notification suppressed: %s has gateway_restart_notification=false",
+                    "Home-channel startup notification suppressed: %s adapter_id=%s has gateway_restart_notification=false",
                     platform.value,
+                    adapter_id,
                 )
                 continue
 
@@ -11468,7 +11555,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Echo raw transcripts back to the user so voice interrupts
             # feel identical to fresh voice messages.
             if successful_transcripts:
-                echo_adapter = self.adapters.get(source.platform)
+                echo_adapter = self._adapter_for_source(source)
                 echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
                 if echo_adapter:
                     for tx in successful_transcripts:
@@ -12120,7 +12207,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             running_agent.interrupt(interrupt_reason)
         self._invalidate_session_run_generation(session_key, reason=invalidation_reason)
-        adapter = self.adapters.get(source.platform)
+        adapter = self._adapter_for_source(source)
         if adapter and hasattr(adapter, "interrupt_session_activity"):
             await adapter.interrupt_session_activity(session_key, source.chat_id)
         if adapter and hasattr(adapter, "get_pending_message"):
@@ -12494,7 +12581,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if _streaming_enabled:
             try:
                 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
-                _adapter = self.adapters.get(source.platform)
+                _adapter = self._adapter_for_source(source)
                 if _adapter:
                     _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
                     _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
@@ -12536,7 +12623,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             stream_task = asyncio.create_task(_stream_consumer.run())
 
         # Send typing indicator
-        _adapter = self.adapters.get(source.platform)
+        _adapter = self._adapter_for_source(source)
         if _adapter:
             try:
                 await _adapter.send_typing(source.chat_id, metadata=_thread_metadata)
@@ -12839,7 +12926,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _cleanup_progress = bool(
             resolve_display_setting(user_config, platform_key, "cleanup_progress")
         )
-        _cleanup_adapter = self.adapters.get(source.platform) if _cleanup_progress else None
+        _cleanup_adapter = self._adapter_for_source(source) if _cleanup_progress else None
         if _cleanup_adapter is not None and (
             type(_cleanup_adapter).delete_message is BasePlatformAdapter.delete_message
         ):
@@ -12924,7 +13011,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # it, while plain-text platforms keep the compact line.
             _bash_block = None
             try:
-                _progress_adapter = self.adapters.get(source.platform)
+                _progress_adapter = self._adapter_for_source(source)
             except Exception:
                 _progress_adapter = None
             if (
@@ -13015,7 +13102,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not progress_queue:
                 return
 
-            adapter = self.adapters.get(source.platform)
+            adapter = self._adapter_for_source(source)
             if not adapter:
                 return
 
@@ -13377,7 +13464,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
         # Bridge sync status_callback → async adapter.send for context pressure
-        _status_adapter = self.adapters.get(source.platform)
+        _status_adapter = self._adapter_for_source(source)
         _status_chat_id = source.chat_id
         if source.platform == Platform.FEISHU and source.thread_id and event_message_id:
             # Feishu topics only keep messages inside the topic when they are
@@ -13511,7 +13598,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _want_stream_deltas or _want_interim_consumer:
                 try:
                     from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
-                    _adapter = self.adapters.get(source.platform)
+                    _adapter = self._adapter_for_source(source)
                     if _adapter:
                         # Platforms that don't support editing sent messages
                         # (e.g. QQ, WeChat) should skip streaming entirely —
@@ -14379,7 +14466,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     # Re-resolve adapter each iteration so reconnects don't
                     # leave us holding a stale reference.
-                    _adapter = self.adapters.get(source.platform)
+                    _adapter = self._adapter_for_source(source)
                     if not _adapter:
                         continue
                     # Check if adapter has a pending interrupt for this session.
@@ -14476,7 +14563,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         async def _notify_long_running():
             if _NOTIFY_INTERVAL is None:
                 return  # Notifications disabled (gateway_notify_interval: 0)
-            _notify_adapter = self.adapters.get(source.platform)
+            _notify_adapter = self._adapter_for_source(source)
             if not _notify_adapter:
                 return
             # Track the heartbeat message id so we can edit-in-place on
@@ -14583,7 +14670,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Backup interrupt check: if the monitor task died or
                     # missed the interrupt, catch it here.
                     if not _interrupt_detected.is_set() and session_key:
-                        _backup_adapter = self.adapters.get(source.platform)
+                        _backup_adapter = self._adapter_for_source(source)
                         _backup_agent = agent_holder[0]
                         if (_backup_adapter and _backup_agent
                                 and hasattr(_backup_adapter, 'has_pending_interrupt')
@@ -14623,7 +14710,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if (not _warning_fired and _agent_warning is not None
                             and _idle_secs >= _agent_warning):
                         _warning_fired = True
-                        _warn_adapter = self.adapters.get(source.platform)
+                        _warn_adapter = self._adapter_for_source(source)
                         if _warn_adapter:
                             _elapsed_warn = int(_agent_warning // 60) or 1
                             _remaining_mins = int((_agent_timeout - _agent_warning) // 60) or 1
@@ -14643,7 +14730,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         break
                     # Backup interrupt check (same as unlimited path).
                     if not _interrupt_detected.is_set() and session_key:
-                        _backup_adapter = self.adapters.get(source.platform)
+                        _backup_adapter = self._adapter_for_source(source)
                         _backup_agent = agent_holder[0]
                         if (_backup_adapter and _backup_agent
                                 and hasattr(_backup_adapter, 'has_pending_interrupt')
@@ -14742,7 +14829,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Check if we were interrupted OR have a queued message (/queue).
             result = result_holder[0]
-            adapter = self.adapters.get(source.platform)
+            adapter = self._adapter_for_source(source)
             
             # Get pending message from adapter.
             # Use session_key (not source.chat_id) to match adapter's storage keys.
@@ -14873,7 +14960,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "queueing message instead of recursing.",
                         _interrupt_depth, session_key,
                     )
-                    adapter = self.adapters.get(source.platform)
+                    adapter = self._adapter_for_source(source)
                     if adapter and pending_event:
                         merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
                     elif adapter and hasattr(adapter, 'queue_message'):
@@ -14977,7 +15064,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
                 # typing task is still alive but may be stale.
-                _followup_adapter = self.adapters.get(source.platform)
+                _followup_adapter = self._adapter_for_source(source)
                 if _followup_adapter:
                     try:
                         await _followup_adapter.send_typing(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -601,6 +601,23 @@ def is_shared_multi_user_session(
     return not group_sessions_per_user
 
 
+def _session_key_prefix_parts(source: SessionSource) -> list[str]:
+    """Return the namespace prefix for a source's session key.
+
+    Single-instance platforms keep their historical ``agent:main:<platform>``
+    prefix. Multi-instance adapters, such as multiple Feishu apps, include the
+    concrete adapter id so colliding app-scoped chat/user ids cannot share an
+    agent cache or transcript.
+    """
+    platform = source.platform.value
+    parts = ["agent:main", platform]
+    adapter_id = str(getattr(source, "adapter_id", "") or "").strip()
+    if adapter_id and adapter_id != platform:
+        escaped = adapter_id.replace("%", "%25").replace(":", "%3A")
+        parts.append(f"adapter={escaped}")
+    return parts
+
+
 def build_session_key(
     source: SessionSource,
     group_sessions_per_user: bool = True,
@@ -629,7 +646,7 @@ def build_session_key(
         shared session per chat.
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
-    platform = source.platform.value
+    prefix_parts = _session_key_prefix_parts(source)
     if source.chat_type == "dm":
         dm_chat_id = source.chat_id
         if source.platform == Platform.WHATSAPP:
@@ -637,8 +654,8 @@ def build_session_key(
 
         if dm_chat_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{dm_chat_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{dm_chat_id}"
+                return ":".join([*prefix_parts, "dm", dm_chat_id, str(source.thread_id)])
+            return ":".join([*prefix_parts, "dm", dm_chat_id])
         # No chat_id — fall back to the sender's own identifier before the
         # bare per-platform sink.  Without this, every DM from every user that
         # arrives without a chat_id (non-standard adapters / synthetic sources)
@@ -653,11 +670,11 @@ def build_session_key(
             )
         if dm_participant_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{dm_participant_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{dm_participant_id}"
+                return ":".join([*prefix_parts, "dm", str(dm_participant_id), str(source.thread_id)])
+            return ":".join([*prefix_parts, "dm", str(dm_participant_id)])
         if source.thread_id:
-            return f"agent:main:{platform}:dm:{source.thread_id}"
-        return f"agent:main:{platform}:dm"
+            return ":".join([*prefix_parts, "dm", str(source.thread_id)])
+        return ":".join([*prefix_parts, "dm"])
 
     participant_id = source.user_id_alt or source.user_id
     if participant_id and source.platform == Platform.WHATSAPP:
@@ -665,7 +682,7 @@ def build_session_key(
         # single group member gets two isolated per-user sessions when the
         # bridge reshuffles alias forms.
         participant_id = canonical_whatsapp_identifier(str(participant_id)) or participant_id
-    key_parts = ["agent:main", platform, source.chat_type]
+    key_parts = [*prefix_parts, source.chat_type]
 
     if source.chat_id:
         key_parts.append(source.chat_id)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -91,6 +91,7 @@ class SessionSource:
     guild_id: Optional[str] = None  # Discord guild / Slack workspace / Matrix server scope
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
+    adapter_id: Optional[str] = None  # Concrete adapter instance that received the message
     
     @property
     def description(self) -> str:
@@ -134,6 +135,8 @@ class SessionSource:
             d["parent_chat_id"] = self.parent_chat_id
         if self.message_id:
             d["message_id"] = self.message_id
+        if self.adapter_id:
+            d["adapter_id"] = self.adapter_id
         return d
 
     @classmethod
@@ -152,6 +155,7 @@ class SessionSource:
             guild_id=data.get("guild_id"),
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
+            adapter_id=data.get("adapter_id"),
         )
     
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,6 +7,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -126,27 +127,17 @@ def _get_service_pids() -> set:
 
     # --- launchd (macOS) ---
     if is_macos():
-        try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
+        loaded = _launchd_print_loaded_service()
+        if loaded:
+            _domain, output = loaded
+            match = re.search(r"^\s*pid\s*=\s*(\d+)\s*$", output, re.MULTILINE)
+            if match:
+                try:
+                    pid = int(match.group(1))
+                    if pid > 0:
+                        pids.add(pid)
+                except ValueError:
+                    pass
 
     return pids
 
@@ -1067,16 +1058,7 @@ def _recover_pending_systemd_restart(
 def _probe_launchd_service_running() -> bool:
     if not get_launchd_plist_path().exists():
         return False
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired:
-        return False
-    return result.returncode == 0
+    return _launchd_print_loaded_service() is not None
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -3075,6 +3057,33 @@ def _launchd_domain() -> str:
     return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
+def _launchd_domain_candidates() -> list[str]:
+    """Return launchd domains worth probing for an already-loaded job."""
+    domains = [_launchd_domain(), f"gui/{os.getuid()}"]
+    return list(dict.fromkeys(domains))
+
+
+def _launchd_print_loaded_service(label: str | None = None) -> tuple[str, str] | None:
+    """Return (domain, output) for a loaded launchd service, if discoverable."""
+    label = label or get_launchd_label()
+    for domain in _launchd_domain_candidates():
+        target = f"{domain}/{label}"
+        try:
+            result = subprocess.run(
+                ["launchctl", "print", target],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0:
+            if not result.stdout.strip():
+                continue
+            return domain, result.stdout
+    return None
+
+
 # On macOS, exit code 125 ("Domain does not support specified action") and
 # 3/113 ("Could not find service") all mean the job isn't currently loaded in
 # the target domain, so start/restart should re-bootstrap the plist and retry.
@@ -3374,6 +3383,7 @@ def launchd_uninstall():
 def launchd_start():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
+    target = f"{_launchd_domain()}/{label}"
 
     # Self-heal if the plist is missing entirely (e.g., manual cleanup, failed upgrade)
     if not plist_path.exists():
@@ -3402,11 +3412,21 @@ def launchd_start():
     refresh_launchd_plist_if_needed()
     try:
         subprocess.run(
-            ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
+            ["launchctl", "kickstart", target],
             check=True,
             timeout=30,
         )
     except subprocess.CalledProcessError as e:
+        loaded = _launchd_print_loaded_service(label)
+        if loaded:
+            loaded_target = f"{loaded[0]}/{label}"
+            subprocess.run(
+                ["launchctl", "kickstart", loaded_target],
+                check=True,
+                timeout=30,
+            )
+            print("✓ Service started")
+            return
         if not _launchd_error_indicates_unloaded(e):
             raise
         # Job not loaded in this domain — re-bootstrap the plist and retry.
@@ -3418,7 +3438,7 @@ def launchd_start():
                 timeout=30,
             )
             subprocess.run(
-                ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
+                ["launchctl", "kickstart", target],
                 check=True,
                 timeout=30,
             )
@@ -3547,6 +3567,12 @@ def launchd_restart():
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:
+        loaded = _launchd_print_loaded_service(label)
+        if loaded:
+            loaded_target = f"{loaded[0]}/{label}"
+            subprocess.run(["launchctl", "kickstart", "-k", loaded_target], check=True, timeout=90)
+            print("✓ Service restarted")
+            return
         if not _launchd_error_indicates_unloaded(e):
             # Not a "job unloaded" code. If the domain is fundamentally
             # unmanageable (error 5), degrade to detached; the old process was
@@ -3567,6 +3593,12 @@ def launchd_restart():
             )
             subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         except subprocess.CalledProcessError as e2:
+            loaded = _launchd_print_loaded_service(label)
+            if loaded:
+                loaded_target = f"{loaded[0]}/{label}"
+                subprocess.run(["launchctl", "kickstart", "-k", loaded_target], check=True, timeout=90)
+                print("✓ Service restarted")
+                return
             if not _launchctl_domain_unsupported(e2.returncode):
                 raise
             _ensure_detached_restart_can_take_over()
@@ -3578,18 +3610,10 @@ def launchd_restart():
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        loaded = result.returncode == 0
-        loaded_output = result.stdout
-    except subprocess.TimeoutExpired:
-        loaded = False
-        loaded_output = ""
+    loaded_service = _launchd_print_loaded_service(label)
+    loaded = loaded_service is not None
+    loaded_domain = loaded_service[0] if loaded_service else None
+    loaded_output = loaded_service[1] if loaded_service else ""
 
     print(f"Launchd plist: {plist_path}")
     if launchd_plist_is_current():
@@ -3599,7 +3623,7 @@ def launchd_status(deep: bool = False):
         print("  Run: hermes gateway start")
 
     if loaded:
-        print("✓ Gateway service is loaded")
+        print(f"✓ Gateway service is loaded ({loaded_domain})")
         print(loaded_output)
     else:
         print("✗ Gateway service is not loaded")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3521,6 +3521,13 @@ def launchd_restart():
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
+    def _ensure_detached_restart_can_take_over() -> None:
+        # When launchd cannot manage this host and we fall back to a detached
+        # process, there is no supervisor to serialize the replacement. Make
+        # one final PID-file-based pass so the new gateway does not overlap the
+        # old websocket clients and lose the Feishu app locks.
+        _wait_for_gateway_exit(timeout=5.0, force_after=0.0)
+
     try:
         pid = get_running_pid()
         if pid is not None and _request_gateway_self_restart(pid):
@@ -3545,6 +3552,7 @@ def launchd_restart():
             # unmanageable (error 5), degrade to detached; the old process was
             # already drained/terminated above. Otherwise re-raise.
             if _launchctl_domain_unsupported(e.returncode):
+                _ensure_detached_restart_can_take_over()
                 _launchd_fallback_to_detached(f"launchctl kickstart exit {e.returncode}")
                 return
             raise
@@ -3561,6 +3569,7 @@ def launchd_restart():
         except subprocess.CalledProcessError as e2:
             if not _launchctl_domain_unsupported(e2.returncode):
                 raise
+            _ensure_detached_restart_can_take_over()
             _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
             return
         print("✓ Service restarted")

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -530,6 +530,13 @@ def test_parse_session_key_with_extra_parts():
     assert result == {"platform": "discord", "chat_type": "group", "chat_id": "chan123"}
 
 
+def test_parse_session_key_with_adapter_namespace():
+    result = _parse_session_key(
+        "agent:main:feishu:adapter=feishu%3Acli_app2:dm:oc_same"
+    )
+    assert result == {"platform": "feishu", "chat_type": "dm", "chat_id": "oc_same"}
+
+
 def test_parse_session_key_with_user_id_part():
     """Group keys with per-user isolation have user_id as 6th part — don't return as thread_id."""
     result = _parse_session_key("agent:main:telegram:group:chat1:user99")

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -48,6 +48,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "QQ_GROUP_ALLOWED_USERS",
         "WHATSAPP_ALLOWED_USERS",
         "TELEGRAM_ALLOWED_USERS",
+        "FEISHU_ALLOWED_USERS",
         "GATEWAY_ALLOWED_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
         "WECOM_ALLOW_ALL_USERS",
@@ -55,6 +56,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "YUANBAO_ALLOW_ALL_USERS",
         "QQ_ALLOW_ALL_USERS",
         "WHATSAPP_ALLOW_ALL_USERS",
+        "FEISHU_ALLOW_ALL_USERS",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -164,6 +166,85 @@ def test_non_owning_platform_still_default_denies(monkeypatch):
     runner, _adapter = _make_runner(Platform.TELEGRAM, config, enforces=False)
 
     assert runner._is_user_authorized(_source(Platform.TELEGRAM)) is False
+
+
+def test_config_allowed_users_authorize_non_owning_platform(monkeypatch):
+    """Config-level allowed_users is a first-class allowlist source."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={"allowed_users": ["allowed-user"]},
+            )
+        }
+    )
+    runner, _adapter = _make_runner(Platform.FEISHU, config, enforces=False)
+
+    listed = SessionSource(
+        platform=Platform.FEISHU,
+        user_id="allowed-user",
+        chat_id="c",
+        user_name="t",
+        chat_type="dm",
+    )
+    stranger = SessionSource(
+        platform=Platform.FEISHU,
+        user_id="stranger",
+        chat_id="c",
+        user_name="t",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(listed) is True
+    assert runner._is_user_authorized(stranger) is False
+
+
+def test_config_allowed_users_are_scoped_to_source_adapter_id(monkeypatch):
+    """A Feishu app must not inherit another app's config allowlist."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: [
+                PlatformConfig(
+                    enabled=True,
+                    extra={"app_id": "cli_app1", "allowed_users": ["same-user"]},
+                ),
+                PlatformConfig(
+                    enabled=True,
+                    extra={"app_id": "cli_app2", "allowed_users": ["other-user"]},
+                ),
+            ]
+        }
+    )
+    runner, _adapter = _make_runner(Platform.FEISHU, config, enforces=False)
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        user_id="same-user",
+        chat_id="c",
+        user_name="t",
+        chat_type="dm",
+        adapter_id="feishu:cli_app2",
+    )
+
+    assert runner._is_user_authorized(source) is False
+
+
+def test_config_allow_all_users_authorizes_non_owning_platform(monkeypatch):
+    """Config-level allow_all_users mirrors the platform allow-all env flag."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={"allow_all_users": True},
+            )
+        }
+    )
+    runner, _adapter = _make_runner(Platform.FEISHU, config, enforces=False)
+
+    assert runner._is_user_authorized(_source(Platform.FEISHU)) is True
 
 
 def test_env_allowlist_still_takes_precedence_for_own_policy_platform(monkeypatch):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -559,6 +559,62 @@ class TestAdapterModule(unittest.TestCase):
         self.assertEqual(fake_client._reconnect_interval, 3)
         self.assertEqual(fake_client._ping_interval, 4)
 
+    def test_ws_client_no_running_loop_fallback_stays_alive_until_adapter_stops(self):
+        import sys
+        from types import ModuleType
+
+        calls = []
+
+        class _FakeWSClient:
+            def start(self):
+                raise RuntimeError("no running event loop")
+
+            async def _connect(self):
+                calls.append("connect")
+
+            async def _ping_loop(self):
+                calls.append("ping")
+                await asyncio.Event().wait()
+
+        fake_client = _FakeWSClient()
+        fake_adapter = SimpleNamespace(
+            _running=True,
+            _ws_thread_loop=None,
+            _ws_reconnect_nonce=2,
+            _ws_reconnect_interval=3,
+            _ws_ping_interval=4,
+            _ws_ping_timeout=5,
+        )
+        fake_client_module = ModuleType("lark_oapi.ws.client")
+        fake_client_module.loop = None
+        fake_client_module.websockets = SimpleNamespace(connect=AsyncMock())
+        fake_ws_module = ModuleType("lark_oapi.ws")
+        fake_ws_module.client = fake_client_module
+        fake_root_module = ModuleType("lark_oapi")
+        fake_root_module.ws = fake_ws_module
+
+        async def _stop_after_first_idle(_delay):
+            calls.append("sleep")
+            fake_adapter._running = False
+
+        original_modules = sys.modules.copy()
+        sys.modules["lark_oapi"] = fake_root_module
+        sys.modules["lark_oapi.ws"] = fake_ws_module
+        sys.modules["lark_oapi.ws.client"] = fake_client_module
+        try:
+            from gateway.platforms import feishu as feishu_module
+
+            with patch.object(feishu_module.asyncio, "sleep", side_effect=_stop_after_first_idle):
+                feishu_module._run_official_feishu_ws_client(fake_client, fake_adapter)
+        finally:
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+        self.assertIn("connect", calls)
+        self.assertIn("ping", calls)
+        self.assertIn("sleep", calls)
+        self.assertIsNone(fake_adapter._ws_thread_loop)
+
 
 def _admits_group(adapter, message, sender_id, chat_id=""):
     """Group-path shim: run a message through ``_admit`` and return a bool."""
@@ -1596,6 +1652,7 @@ class TestAdapterBehavior(unittest.TestCase):
         )
         sender = SimpleNamespace(sender_type="user", sender_id=sender_id)
         data = SimpleNamespace(event=SimpleNamespace(message=message, sender=sender))
+        adapter.adapter_id = "feishu:cli_test_app"
 
         asyncio.run(
             adapter._process_inbound_message(
@@ -1614,6 +1671,7 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.source.user_name, "张三")
         self.assertEqual(event.source.user_id_alt, "on_union")
         self.assertEqual(event.source.chat_name, "Feishu DM")
+        self.assertEqual(event.source.adapter_id, "feishu:cli_test_app")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_text_batch_merges_rapid_messages_into_single_event(self):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -549,7 +549,8 @@ class TestAdapterModule(unittest.TestCase):
         try:
             from gateway.platforms.feishu import _run_official_feishu_ws_client
 
-            _run_official_feishu_ws_client(fake_client, fake_adapter)
+            with self.assertRaisesRegex(RuntimeError, "stop test client"):
+                _run_official_feishu_ws_client(fake_client, fake_adapter)
         finally:
             sys.modules.clear()
             sys.modules.update(original_modules)
@@ -614,6 +615,95 @@ class TestAdapterModule(unittest.TestCase):
         self.assertIn("ping", calls)
         self.assertIn("sleep", calls)
         self.assertIsNone(fake_adapter._ws_thread_loop)
+
+    def test_ws_client_no_running_loop_fallback_exits_when_disconnected_stale(self):
+        import sys
+        from types import ModuleType
+
+        class _FakeWSClient:
+            def start(self):
+                raise RuntimeError("no running event loop")
+
+            async def _connect(self):
+                self._conn = None
+
+        fake_client = _FakeWSClient()
+        fake_adapter = SimpleNamespace(
+            _running=True,
+            _ws_thread_loop=None,
+            _ws_reconnect_nonce=2,
+            _ws_reconnect_interval=3,
+            _ws_ping_interval=4,
+            _ws_ping_timeout=5,
+        )
+        fake_client_module = ModuleType("lark_oapi.ws.client")
+        fake_client_module.loop = None
+        fake_client_module.websockets = SimpleNamespace(connect=AsyncMock())
+        fake_ws_module = ModuleType("lark_oapi.ws")
+        fake_ws_module.client = fake_client_module
+        fake_root_module = ModuleType("lark_oapi")
+        fake_root_module.ws = fake_ws_module
+
+        async def _fast_sleep(_delay):
+            return None
+
+        clock = [-31.0]
+
+        def _tick():
+            clock[0] += 31.0
+            return clock[0]
+
+        original_modules = sys.modules.copy()
+        sys.modules["lark_oapi"] = fake_root_module
+        sys.modules["lark_oapi.ws"] = fake_ws_module
+        sys.modules["lark_oapi.ws.client"] = fake_client_module
+        try:
+            from gateway.platforms import feishu as feishu_module
+
+            with (
+                patch.object(feishu_module.asyncio, "sleep", side_effect=_fast_sleep),
+                patch.object(feishu_module.time, "monotonic", side_effect=_tick),
+                self.assertRaisesRegex(RuntimeError, "receive loop exited"),
+            ):
+                feishu_module._run_official_feishu_ws_client(fake_client, fake_adapter)
+        finally:
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+        self.assertIsNone(fake_adapter._ws_thread_loop)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_websocket_thread_done_marks_retryable_fatal(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        callback_loop = SimpleNamespace(is_closed=lambda: False)
+        future_loop = asyncio.new_event_loop()
+        scheduled = []
+
+        def _run_threadsafe(coro, loop):
+            scheduled.append((coro, loop))
+            return SimpleNamespace()
+
+        try:
+            future = future_loop.create_future()
+            future.set_exception(RuntimeError("ws lost"))
+            adapter._running = True
+            adapter._loop = callback_loop
+
+            with patch("gateway.platforms.feishu.asyncio.run_coroutine_threadsafe", side_effect=_run_threadsafe):
+                adapter._on_websocket_thread_done(future)
+
+            self.assertFalse(adapter._running)
+            self.assertEqual(adapter.fatal_error_code, "feishu_ws_disconnected")
+            self.assertTrue(adapter.fatal_error_retryable)
+            self.assertIn("ws lost", adapter.fatal_error_message)
+            self.assertEqual(scheduled[0][1], callback_loop)
+        finally:
+            for coro, _loop in scheduled:
+                coro.close()
+            future_loop.close()
 
 
 def _admits_group(adapter, message, sender_id, chat_id=""):

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -72,6 +72,27 @@ def test_feishu_load_settings_falls_back_to_env_when_extra_missing(monkeypatch):
     assert settings.allow_bots == "mentions"
 
 
+@pytest.mark.parametrize(
+    "extra_allowed_users",
+    [
+        "ou_alice, u_bob",
+        ["ou_alice", "u_bob"],
+    ],
+)
+def test_feishu_load_settings_merges_extra_allowed_users(monkeypatch, extra_allowed_users):
+    from gateway.platforms.feishu import FeishuAdapter
+
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_test")
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_carol")
+
+    settings = FeishuAdapter._load_settings(
+        extra={"allowed_users": extra_allowed_users}
+    )
+
+    assert settings.allowed_group_users == frozenset({"ou_alice", "u_bob", "ou_carol"})
+
+
 def test_feishu_load_settings_warns_on_unknown_allow_bots(monkeypatch, caplog):
     import logging
 

--- a/tests/gateway/test_feishu_multi_app.py
+++ b/tests/gateway/test_feishu_multi_app.py
@@ -16,7 +16,7 @@ from gateway.config import (
 )
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.run import GatewayRunner
-from gateway.session import SessionSource
+from gateway.session import SessionSource, build_session_key
 from gateway.platforms.base import BasePlatformAdapter
 
 
@@ -259,6 +259,30 @@ class TestMultiAppListConfig:
         source = adapter.build_source(chat_id="chat-1", user_id="user-1")
 
         assert source.adapter_id == "feishu:cli_app1"
+
+    def test_session_key_isolates_matching_chat_ids_across_feishu_apps(self):
+        """Different Feishu apps must not share agent/session state."""
+        first = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_same",
+            chat_type="dm",
+            user_id="ou_same",
+            adapter_id="feishu:cli_app1",
+        )
+        second = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_same",
+            chat_type="dm",
+            user_id="ou_same",
+            adapter_id="feishu:cli_app2",
+        )
+
+        first_key = build_session_key(first)
+        second_key = build_session_key(second)
+
+        assert first_key == "agent:main:feishu:adapter=feishu%3Acli_app1:dm:oc_same"
+        assert second_key == "agent:main:feishu:adapter=feishu%3Acli_app2:dm:oc_same"
+        assert first_key != second_key
 
     def test_runner_routes_source_to_matching_feishu_app_adapter(self):
         runner = GatewayRunner.__new__(GatewayRunner)

--- a/tests/gateway/test_feishu_multi_app.py
+++ b/tests/gateway/test_feishu_multi_app.py
@@ -5,9 +5,19 @@ raise AttributeError: 'list' object has no attribute 'extra'.
 """
 
 import pytest
+from unittest.mock import patch
 
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import (
+    GatewayConfig,
+    HomeChannel,
+    Platform,
+    PlatformConfig,
+    _apply_env_overrides,
+)
 from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from gateway.platforms.base import BasePlatformAdapter
 
 
 class DummyMixin(GatewayAuthorizationMixin):
@@ -16,6 +26,25 @@ class DummyMixin(GatewayAuthorizationMixin):
     def __init__(self, config):
         self.config = config
         self.adapters = {}
+
+
+class DummyAdapter(BasePlatformAdapter):
+    """Small concrete adapter for runner routing tests."""
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, **kwargs):
+        calls = getattr(self, "send_calls", None)
+        if calls is not None:
+            calls.append((chat_id, content, kwargs))
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"name": chat_id, "type": "dm"}
 
 
 class TestMultiAppListConfig:
@@ -155,6 +184,60 @@ class TestMultiAppListConfig:
         assert feishu_cfgs[0].extra["app_id"] == "cli_app1"
         assert feishu_cfgs[1].extra["app_id"] == "cli_app2"
 
+    def test_from_dict_preserves_top_level_platform_specific_keys_in_extra(self):
+        restored = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "feishu": [
+                        {"enabled": True, "app_id": "cli_app1", "app_secret": "secret1"},
+                        {"enabled": True, "app_id": "cli_app2", "app_secret": "secret2"},
+                    ]
+                }
+            }
+        )
+
+        feishu_cfgs = restored.platforms[Platform.FEISHU]
+
+        assert isinstance(feishu_cfgs, list)
+        assert feishu_cfgs[0].extra["app_id"] == "cli_app1"
+        assert feishu_cfgs[0].extra["app_secret"] == "secret1"
+        assert feishu_cfgs[1].extra["app_id"] == "cli_app2"
+        assert feishu_cfgs[1].extra["app_secret"] == "secret2"
+
+    def test_env_overrides_do_not_clobber_explicit_multi_app_credentials(self):
+        config = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "feishu": [
+                        {"enabled": True, "app_id": "cli_app1", "app_secret": "secret1"},
+                        {"enabled": True, "app_id": "cli_app2", "app_secret": "secret2"},
+                    ]
+                }
+            }
+        )
+
+        with patch.dict(
+            "os.environ",
+            {
+                "FEISHU_APP_ID": "cli_env",
+                "FEISHU_APP_SECRET": "secret_env",
+                "FEISHU_DOMAIN": "lark",
+                "FEISHU_CONNECTION_MODE": "websocket",
+            },
+            clear=False,
+        ):
+            _apply_env_overrides(config)
+
+        feishu_cfgs = config.platforms[Platform.FEISHU]
+
+        assert isinstance(feishu_cfgs, list)
+        assert feishu_cfgs[0].extra["app_id"] == "cli_app1"
+        assert feishu_cfgs[0].extra["app_secret"] == "secret1"
+        assert feishu_cfgs[1].extra["app_id"] == "cli_app2"
+        assert feishu_cfgs[1].extra["app_secret"] == "secret2"
+        assert feishu_cfgs[0].extra["domain"] == "lark"
+        assert feishu_cfgs[1].extra["domain"] == "lark"
+
     def test_get_home_channel_list(self, multi_config):
         """get_home_channel should iterate list and return first match."""
         # Default home_channel is None; test that it doesn't crash
@@ -165,3 +248,88 @@ class TestMultiAppListConfig:
         # No real connection, but ensure it doesn't crash on list
         connected = multi_config.get_connected_platforms()
         assert isinstance(connected, list)
+
+    def test_build_source_carries_adapter_id(self):
+        adapter = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app1"}),
+            Platform.FEISHU,
+        )
+        adapter.adapter_id = "feishu:cli_app1"
+
+        source = adapter.build_source(chat_id="chat-1", user_id="user-1")
+
+        assert source.adapter_id == "feishu:cli_app1"
+
+    def test_runner_routes_source_to_matching_feishu_app_adapter(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {}
+        runner.adapters_by_id = {}
+        runner._platform_adapter_ids = {}
+
+        app1 = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app1"}),
+            Platform.FEISHU,
+        )
+        app2 = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app2"}),
+            Platform.FEISHU,
+        )
+
+        runner._register_connected_adapter(Platform.FEISHU, app1)
+        runner._register_connected_adapter(Platform.FEISHU, app2)
+
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="chat-from-app2",
+            adapter_id="feishu:cli_app2",
+        )
+
+        assert runner.adapters[Platform.FEISHU] is app1
+        assert runner._adapter_for_source(source) is app2
+
+    @pytest.mark.asyncio
+    async def test_startup_notifications_use_each_feishu_app_home_channel(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: [
+                    PlatformConfig(
+                        enabled=True,
+                        extra={"app_id": "cli_app1"},
+                        home_channel=HomeChannel(
+                            platform=Platform.FEISHU,
+                            chat_id="chat-app1",
+                            name="App 1",
+                        ),
+                    ),
+                    PlatformConfig(
+                        enabled=True,
+                        extra={"app_id": "cli_app2"},
+                        home_channel=HomeChannel(
+                            platform=Platform.FEISHU,
+                            chat_id="chat-app2",
+                            name="App 2",
+                        ),
+                    ),
+                ],
+            }
+        )
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = config
+        runner.adapters = {}
+        runner.adapters_by_id = {}
+        runner._platform_adapter_ids = {}
+
+        app1 = DummyAdapter(config.platforms[Platform.FEISHU][0], Platform.FEISHU)
+        app1.send_calls = []
+        app2 = DummyAdapter(config.platforms[Platform.FEISHU][1], Platform.FEISHU)
+        app2.send_calls = []
+
+        runner._register_connected_adapter(Platform.FEISHU, app1)
+        runner._register_connected_adapter(Platform.FEISHU, app2)
+
+        delivered = await runner._send_home_channel_startup_notifications()
+
+        assert ("feishu", "chat-app1", None) in delivered
+        assert ("feishu", "chat-app2", None) in delivered
+        assert [call[0] for call in app1.send_calls] == ["chat-app1"]
+        assert [call[0] for call in app2.send_calls] == ["chat-app2"]

--- a/tests/gateway/test_feishu_multi_app.py
+++ b/tests/gateway/test_feishu_multi_app.py
@@ -1,0 +1,167 @@
+"""Tests for multi-app Feishu list-config compatibility.
+
+Regression guard: when platforms.feishu is a list, several code paths used to
+raise AttributeError: 'list' object has no attribute 'extra'.
+"""
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.authz_mixin import GatewayAuthorizationMixin
+
+
+class DummyMixin(GatewayAuthorizationMixin):
+    """Minimal mixin instance for testing list-config paths."""
+
+    def __init__(self, config):
+        self.config = config
+        self.adapters = {}
+
+
+class TestMultiAppListConfig:
+    """Cover the list-config branches introduced in PR #42499."""
+
+    @pytest.fixture
+    def multi_config(self):
+        return GatewayConfig(
+            platforms={
+                Platform.FEISHU: [
+                    PlatformConfig(
+                        enabled=True,
+                        token="app1-token",
+                        extra={
+                            "dm_policy": "open",
+                            "unauthorized_dm_behavior": "ignore",
+                            "notice_delivery": "private",
+                            "app_id": "cli_app1",
+                        },
+                    ),
+                    PlatformConfig(
+                        enabled=True,
+                        token="app2-token",
+                        extra={
+                            "dm_policy": "pairing",
+                            "app_id": "cli_app2",
+                        },
+                    ),
+                ],
+            }
+        )
+
+    @pytest.fixture
+    def single_config(self):
+        return GatewayConfig(
+            platforms={
+                Platform.FEISHU: PlatformConfig(
+                    enabled=True,
+                    token="single-token",
+                    extra={
+                        "dm_policy": "open",
+                        "unauthorized_dm_behavior": "pair",
+                        "notice_delivery": "public",
+                    },
+                ),
+            }
+        )
+
+    # --- GatewayConfig ---
+
+    def test_get_unauthorized_dm_behavior_list_first_wins(self, multi_config):
+        """First config in the list with the key wins."""
+        assert multi_config.get_unauthorized_dm_behavior(Platform.FEISHU) == "ignore"
+
+    def test_get_unauthorized_dm_behavior_single(self, single_config):
+        assert single_config.get_unauthorized_dm_behavior(Platform.FEISHU) == "pair"
+
+    def test_get_unauthorized_dm_behavior_missing_platform(self, single_config):
+        assert single_config.get_unauthorized_dm_behavior(Platform.SLACK) == "pair"
+
+    def test_get_notice_delivery_list_first_wins(self, multi_config):
+        assert multi_config.get_notice_delivery(Platform.FEISHU) == "private"
+
+    def test_get_notice_delivery_single(self, single_config):
+        assert single_config.get_notice_delivery(Platform.FEISHU) == "public"
+
+    def test_get_notice_delivery_missing_platform(self, single_config):
+        assert single_config.get_notice_delivery(Platform.SLACK) == "public"
+
+    # --- GatewayAuthorizationMixin._adapter_dm_policy ---
+
+    def test_adapter_dm_policy_list(self, multi_config):
+        mixin = DummyMixin(multi_config)
+        assert mixin._adapter_dm_policy(Platform.FEISHU) == "open"
+
+    def test_adapter_dm_policy_single(self, single_config):
+        mixin = DummyMixin(single_config)
+        assert mixin._adapter_dm_policy(Platform.FEISHU) == "open"
+
+    def test_adapter_dm_policy_no_config(self):
+        mixin = DummyMixin(GatewayConfig())
+        assert mixin._adapter_dm_policy(Platform.FEISHU) == ""
+
+    # --- GatewayAuthorizationMixin._get_unauthorized_dm_behavior ---
+
+    def test_get_unauthorized_dm_behavior_list_explicit(self, multi_config):
+        mixin = DummyMixin(multi_config)
+        # First list item has explicit unauthorized_dm_behavior
+        assert mixin._get_unauthorized_dm_behavior(Platform.FEISHU) == "ignore"
+
+    def test_get_unauthorized_dm_behavior_single_explicit(self, single_config):
+        mixin = DummyMixin(single_config)
+        assert mixin._get_unauthorized_dm_behavior(Platform.FEISHU) == "pair"
+
+    def test_get_unauthorized_dm_behavior_list_dm_policy_pairing(self):
+        """When no explicit unauthorized_dm_behavior but dm_policy == pairing."""
+        config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: [
+                    PlatformConfig(
+                        enabled=True,
+                        extra={"dm_policy": "pairing"},
+                    ),
+                ],
+            }
+        )
+        mixin = DummyMixin(config)
+        assert mixin._get_unauthorized_dm_behavior(Platform.FEISHU) == "pair"
+
+    def test_get_unauthorized_dm_behavior_list_dm_policy_disabled(self):
+        """When dm_policy is disabled, default to ignore."""
+        config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: [
+                    PlatformConfig(
+                        enabled=True,
+                        extra={"dm_policy": "disabled"},
+                    ),
+                ],
+            }
+        )
+        mixin = DummyMixin(config)
+        assert mixin._get_unauthorized_dm_behavior(Platform.FEISHU) == "ignore"
+
+    def test_get_unauthorized_dm_behavior_no_platform(self):
+        mixin = DummyMixin(GatewayConfig())
+        assert mixin._get_unauthorized_dm_behavior(Platform.FEISHU) == "pair"
+
+    # --- GatewayConfig roundtrip with list ---
+
+    def test_to_dict_from_dict_preserves_list(self, multi_config):
+        d = multi_config.to_dict()
+        restored = GatewayConfig.from_dict(d)
+        feishu_cfgs = restored.platforms[Platform.FEISHU]
+        assert isinstance(feishu_cfgs, list)
+        assert len(feishu_cfgs) == 2
+        assert feishu_cfgs[0].extra["app_id"] == "cli_app1"
+        assert feishu_cfgs[1].extra["app_id"] == "cli_app2"
+
+    def test_get_home_channel_list(self, multi_config):
+        """get_home_channel should iterate list and return first match."""
+        # Default home_channel is None; test that it doesn't crash
+        assert multi_config.get_home_channel(Platform.FEISHU) is None
+
+    def test_connected_platforms_list(self, multi_config):
+        """connected_platforms should include platform if any list item is connected."""
+        # No real connection, but ensure it doesn't crash on list
+        connected = multi_config.get_connected_platforms()
+        assert isinstance(connected, list)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -508,6 +508,7 @@ class TestLaunchdServiceRecovery:
         calls = []
         domain = gateway_cli._launchd_domain()
         target = f"{domain}/{label}"
+        gui_target = f"gui/{os.getuid()}/{label}"
 
         def fake_run(cmd, check=False, **kwargs):
             if cmd and cmd[0] == "launchctl":
@@ -523,6 +524,8 @@ class TestLaunchdServiceRecovery:
 
         assert calls == [
             ["launchctl", "kickstart", target],
+            ["launchctl", "print", target],
+            ["launchctl", "print", gui_target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
         ]
@@ -536,6 +539,7 @@ class TestLaunchdServiceRecovery:
         calls = []
         domain = gateway_cli._launchd_domain()
         target = f"{domain}/{label}"
+        gui_target = f"gui/{os.getuid()}/{label}"
 
         def fake_run(cmd, check=False, **kwargs):
             if cmd and cmd[0] == "launchctl":
@@ -551,6 +555,8 @@ class TestLaunchdServiceRecovery:
 
         assert calls == [
             ["launchctl", "kickstart", target],
+            ["launchctl", "print", target],
+            ["launchctl", "print", gui_target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
         ]
@@ -684,6 +690,61 @@ class TestLaunchdServiceRecovery:
         # non-Aqua/background sessions on macOS 26+ (issue #23387).
         assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
 
+    def test_launchd_status_detects_service_loaded_in_gui_domain(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+        user_target = f"user/{os.getuid()}/{label}"
+        gui_target = f"gui/{os.getuid()}/{label}"
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd == ["launchctl", "print", user_target]:
+                return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+            if cmd == ["launchctl", "print", gui_target]:
+                return SimpleNamespace(returncode=0, stdout="state = running\npid = 123\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "Gateway service is loaded (gui/" in output
+        assert "pid = 123" in output
+
+    def test_launchd_restart_uses_gui_domain_when_service_is_loaded_there(self, monkeypatch):
+        label = gateway_cli.get_launchd_label()
+        user_target = f"user/{os.getuid()}/{label}"
+        gui_target = f"gui/{os.getuid()}/{label}"
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", "-k", user_target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    5, cmd, stderr="Input/output error"
+                )
+            if cmd == ["launchctl", "print", user_target]:
+                return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+            if cmd == ["launchctl", "print", gui_target]:
+                return SimpleNamespace(returncode=0, stdout="state = running\npid = 321\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli, "_spawn_detached_gateway", lambda: (_ for _ in ()).throw(AssertionError("unexpected detached fallback")))
+
+        gateway_cli.launchd_restart()
+
+        assert ["launchctl", "kickstart", "-k", gui_target] in calls
+
     def test_launchctl_domain_unsupported_recognizes_macos26_codes(self):
         # Codes that persist after a fresh bootstrap → launchd truly unavailable.
         assert gateway_cli._launchctl_domain_unsupported(5) is True
@@ -701,6 +762,7 @@ class TestLaunchdServiceRecovery:
         calls = []
         domain = gateway_cli._launchd_domain()
         target = f"{domain}/{label}"
+        gui_target = f"gui/{os.getuid()}/{label}"
 
         def fake_run(cmd, check=False, **kwargs):
             if cmd and cmd[0] == "launchctl":
@@ -718,6 +780,8 @@ class TestLaunchdServiceRecovery:
 
         assert calls == [
             ["launchctl", "kickstart", target],
+            ["launchctl", "print", target],
+            ["launchctl", "print", gui_target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
         ]

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -809,6 +809,47 @@ class TestLaunchdServiceRecovery:
 
         assert spawned == [True]
 
+    def test_launchd_restart_waits_again_before_unloaded_fallback(self, tmp_path, monkeypatch):
+        """Detached fallback must not overlap a still-running old gateway."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+
+        waits = []
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda timeout, force_after=None: waits.append((timeout, force_after)) or True,
+        )
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd == ["launchctl", "kickstart", "-k", target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    113, cmd, stderr="Could not find service"
+                )
+            if cmd[:2] == ["launchctl", "bootstrap"]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    5, cmd, stderr="Input/output error"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        spawned = []
+        monkeypatch.setattr(
+            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert waits == [(5.0, None), (5.0, 0.0)]
+        assert spawned == [True]
+
     def test_launchd_stop_tolerates_domain_unsupported_bootout(self, monkeypatch, capsys):
         """bootout exit 125 (macOS 26) must fall through to PID-based kill, not raise."""
         def fake_run(cmd, check=False, **kwargs):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -25,7 +25,7 @@ def _reset_signal_scheduler():
     yield
     _reset_scheduler()
 
-from gateway.config import Platform
+from gateway.config import HomeChannel, Platform, PlatformConfig
 from tools.send_message_tool import (
     _is_telegram_thread_not_found,
     _parse_target_ref,
@@ -169,6 +169,48 @@ class TestSendMessageTool:
         assert chat_id == "alerts-channel"
         assert thread_id is None
         assert is_explicit is True
+
+    def test_feishu_multi_app_config_selects_matching_home_channel(self):
+        first = PlatformConfig(
+            enabled=True,
+            home_channel=HomeChannel(Platform.FEISHU, "oc_first", "First"),
+            extra={"app_id": "cli_first", "app_secret": "secret"},
+        )
+        second = PlatformConfig(
+            enabled=True,
+            home_channel=HomeChannel(Platform.FEISHU, "oc_second", "Second"),
+            extra={"app_id": "cli_second", "app_secret": "secret"},
+        )
+        config = SimpleNamespace(
+            platforms={Platform.FEISHU: [first, second]},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "feishu:oc_second",
+                        "message": "done",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.FEISHU,
+            second,
+            "oc_second",
+            "done",
+            thread_id=None,
+            media_files=[],
+            force_document=False,
+        )
 
     def test_ntfy_topic_target_bypasses_channel_directory(self):
         ntfy_platform = Platform("ntfy")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -174,6 +174,27 @@ def _handle_list():
         return json.dumps(_error(f"Failed to load channel directory: {e}"))
 
 
+def _enabled_platform_configs(pconfig):
+    """Return enabled configs from a single- or multi-app platform config."""
+    configs = pconfig if isinstance(pconfig, list) else [pconfig]
+    return [cfg for cfg in configs if cfg is not None and getattr(cfg, "enabled", False)]
+
+
+def _select_platform_config(platform, configs, chat_id):
+    """Pick the best config for a target, preserving Feishu multi-app fallback."""
+    if not configs:
+        return None
+    if platform.value == "feishu":
+        for cfg in configs:
+            home = getattr(cfg, "home_channel", None)
+            if home and chat_id and str(home.chat_id) == str(chat_id):
+                return cfg
+        # Unknown Feishu chats may belong to any configured app. Let _send_feishu
+        # try each enabled app instead of failing before it reaches the adapter.
+        return configs if len(configs) > 1 else configs[0]
+    return configs[0]
+
+
 def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
@@ -228,7 +249,8 @@ def _handle_send(args):
         return tool_error(f"Unknown platform: {platform_name}")
 
     pconfig = config.platforms.get(platform)
-    if not pconfig or not pconfig.enabled:
+    enabled_configs = _enabled_platform_configs(pconfig)
+    if not enabled_configs:
         # Weixin can be configured purely via .env; synthesize a pconfig so
         # send_message and cron delivery work without a gateway.yaml entry.
         if platform_name == "weixin":
@@ -245,6 +267,7 @@ def _handle_send(args):
                         "cdn_base_url": os.getenv("WEIXIN_CDN_BASE_URL", "").strip(),
                     },
                 )
+                enabled_configs = [pconfig]
             else:
                 return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
         else:
@@ -264,16 +287,29 @@ def _handle_send(args):
 
     used_home_channel = False
     if not chat_id:
-        home = config.get_home_channel(platform)
-        if not home and platform_name == "weixin":
-            wx_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
-            if wx_home:
-                from gateway.config import HomeChannel
-                home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
-        if home:
-            chat_id = home.chat_id
-            used_home_channel = True
-        else:
+        enabled_configs = _enabled_platform_configs(pconfig)
+        if enabled_configs:
+            for cfg in enabled_configs:
+                home = getattr(cfg, "home_channel", None)
+                if home:
+                    chat_id = home.chat_id
+                    used_home_channel = True
+                    break
+        if not chat_id and hasattr(config, "get_home_channel"):
+            home = config.get_home_channel(platform)
+            if home:
+                chat_id = home.chat_id
+                used_home_channel = True
+        if not chat_id:
+            if platform_name == "weixin":
+                wx_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
+                if wx_home:
+                    from gateway.config import HomeChannel
+                    home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
+                    if home:
+                        chat_id = home.chat_id
+                        used_home_channel = True
+        if not chat_id:
             home_env = _HOME_CHANNEL_ENV_OVERRIDES.get(
                 platform_name, f"{platform_name.upper()}_HOME_CHANNEL"
             )
@@ -286,6 +322,10 @@ def _handle_send(args):
     duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
     if duplicate_skip:
         return json.dumps(duplicate_skip)
+
+    pconfig = _select_platform_config(platform, enabled_configs, chat_id)
+    if not pconfig:
+        return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
 
     # Slack: resolve user IDs (U...) to DM channel IDs via conversations.open
     if platform_name == "slack" and chat_id and chat_id.startswith("U"):
@@ -1594,61 +1634,105 @@ async def _send_bluebubbles(extra, chat_id, message):
         return _error(f"BlueBubbles send failed: {e}")
 
 
+def normalize_feishu_configs(extra):
+    """Normalize Feishu multi-app config to a list of enabled configs."""
+    if extra is None:
+        return []
+    if isinstance(extra, list):
+        return [item for item in extra if item and _feishu_config_enabled(item)]
+    if isinstance(extra, dict):
+        if isinstance(extra.get("apps"), list):
+            return [item for item in extra["apps"] if item and _feishu_config_enabled(item)]
+        if extra.get("enabled", True):
+            return [extra]
+    elif _feishu_config_enabled(extra):
+        return [extra]
+    return []
+
+
+def _feishu_config_enabled(config):
+    if isinstance(config, dict):
+        return bool(config.get("enabled", True))
+    return bool(getattr(config, "enabled", True))
+
+
 async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=None):
     """Send via Feishu/Lark using the adapter's send pipeline."""
+    configs = normalize_feishu_configs(pconfig)
+    if not configs:
+        return {"error": "No enabled Feishu config found"}
+
     try:
         from gateway.platforms.feishu import FeishuAdapter, FEISHU_AVAILABLE
         if not FEISHU_AVAILABLE:
             return {"error": "Feishu dependencies not installed. Run: pip install 'hermes-agent[feishu]'"}
         from gateway.platforms.feishu import FEISHU_DOMAIN, LARK_DOMAIN
+        from gateway.config import PlatformConfig
     except ImportError:
         return {"error": "Feishu dependencies not installed. Run: pip install 'hermes-agent[feishu]'"}
 
     media_files = media_files or []
+    errors = []
 
-    try:
-        adapter = FeishuAdapter(pconfig)
-        domain_name = getattr(adapter, "_domain_name", "feishu")
-        domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
-        adapter._client = adapter._build_lark_client(domain)
-        metadata = {"thread_id": thread_id} if thread_id else None
+    for candidate in configs:
+        try:
+            feishu_config = (
+                PlatformConfig.from_dict(candidate)
+                if isinstance(candidate, dict)
+                else candidate
+            )
+            adapter = FeishuAdapter(feishu_config)
+            domain_name = getattr(adapter, "_domain_name", "feishu")
+            domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
+            adapter._client = adapter._build_lark_client(domain)
+            metadata = {"thread_id": thread_id} if thread_id else None
 
-        last_result = None
-        if message.strip():
-            last_result = await adapter.send(chat_id, message, metadata=metadata)
-            if not last_result.success:
-                return _error(f"Feishu send failed: {last_result.error}")
+            last_result = None
+            delivered_any = False
+            if message.strip():
+                last_result = await adapter.send(chat_id, message, metadata=metadata)
+                if not last_result.success:
+                    errors.append(str(last_result.error))
+                    continue
+                delivered_any = True
 
-        for media_path, is_voice in media_files:
-            if not os.path.exists(media_path):
-                return _error(f"Media file not found: {media_path}")
+            for media_path, is_voice in media_files:
+                if not os.path.exists(media_path):
+                    return _error(f"Media file not found: {media_path}")
 
-            ext = os.path.splitext(media_path)[1].lower()
-            if ext in _IMAGE_EXTS:
-                last_result = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
-            elif ext in _VIDEO_EXTS:
-                last_result = await adapter.send_video(chat_id, media_path, metadata=metadata)
-            elif ext in _VOICE_EXTS and is_voice:
-                last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
-            elif ext in _AUDIO_EXTS:
-                last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+                ext = os.path.splitext(media_path)[1].lower()
+                if ext in _IMAGE_EXTS:
+                    last_result = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
+                elif ext in _VIDEO_EXTS:
+                    last_result = await adapter.send_video(chat_id, media_path, metadata=metadata)
+                elif ext in _VOICE_EXTS and is_voice:
+                    last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+                elif ext in _AUDIO_EXTS:
+                    last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+                else:
+                    last_result = await adapter.send_document(chat_id, media_path, metadata=metadata)
+
+                if not last_result.success:
+                    if delivered_any:
+                        return _error(f"Feishu media send failed: {last_result.error}")
+                    errors.append(str(last_result.error))
+                    break
+                delivered_any = True
             else:
-                last_result = await adapter.send_document(chat_id, media_path, metadata=metadata)
+                if last_result is None:
+                    return {"error": "No deliverable text or media remained after processing MEDIA tags"}
 
-            if not last_result.success:
-                return _error(f"Feishu media send failed: {last_result.error}")
+                return {
+                    "success": True,
+                    "platform": "feishu",
+                    "chat_id": chat_id,
+                    "message_id": last_result.message_id,
+                }
+        except Exception as e:
+            errors.append(str(e))
 
-        if last_result is None:
-            return {"error": "No deliverable text or media remained after processing MEDIA tags"}
-
-        return {
-            "success": True,
-            "platform": "feishu",
-            "chat_id": chat_id,
-            "message_id": last_result.message_id,
-        }
-    except Exception as e:
-        return _error(f"Feishu send failed: {e}")
+    detail = "; ".join(error for error in errors if error) or "all configured Feishu apps failed"
+    return _error(f"Feishu send failed: {detail}")
 
 
 def _check_send_message():


### PR DESCRIPTION
## Summary
- isolate Feishu sessions by concrete adapter/app id so chats from different orgs/apps cannot share agent state
- scope config-driven allowlists and allow-all flags to the source adapter id
- preserve multi-app send/home-channel routing and launchd recovery fixes

## Tests
- pytest tests/gateway/test_feishu_multi_app.py tests/gateway/test_session.py tests/gateway/test_background_process_notifications.py tests/gateway/test_config_driven_access_policy.py tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py tests/tools/test_send_message_tool.py tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery -q
