### PR TITLE
fix(video): bound xAI generation response reads

### DIFF
--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import mimetypes
 import os
@@ -52,6 +53,7 @@ DEFAULT_RESOLUTION = "720p"
 DEFAULT_TIMEOUT_SECONDS = 240
 DEFAULT_POLL_INTERVAL_SECONDS = 5
 DEFAULT_EXTEND_DURATION = 6
+_XAI_VIDEO_RESPONSE_MAX_BYTES = 16 * 1024 * 1024
 
 VALID_ASPECT_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"}
 VALID_RESOLUTIONS = {"480p", "720p"}
@@ -84,6 +86,13 @@ _IMAGE_TO_VIDEO_COMPAT_MODEL_IDS = {
 # ---------------------------------------------------------------------------
 # HTTP helpers
 # ---------------------------------------------------------------------------
+
+
+class _XAIVideoHTTPError(RuntimeError):
+    def __init__(self, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"xAI video HTTP {status_code}: {detail}")
 
 
 def _resolve_xai_credentials() -> Tuple[str, str]:
@@ -141,6 +150,40 @@ def _raise_if_blocked_local_input(ref: str) -> None:
         logger.debug("xAI media input read guard unavailable: %s", exc)
         return
     raise_if_read_blocked(ref)
+
+
+async def _read_xai_video_response_text(response: httpx.Response) -> str:
+    content_length = response.headers.get("content-length")
+    if content_length:
+        try:
+            declared_size = int(content_length)
+        except ValueError:
+            declared_size = None
+        if declared_size is not None and declared_size > _XAI_VIDEO_RESPONSE_MAX_BYTES:
+            raise ValueError(
+                f"xAI video response exceeds {_XAI_VIDEO_RESPONSE_MAX_BYTES} bytes"
+            )
+
+    body = bytearray()
+    async for chunk in response.aiter_bytes(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        if len(body) + len(chunk) > _XAI_VIDEO_RESPONSE_MAX_BYTES:
+            raise ValueError(
+                f"xAI video response exceeds {_XAI_VIDEO_RESPONSE_MAX_BYTES} bytes"
+            )
+        body.extend(chunk)
+    return bytes(body).decode("utf-8", "replace")
+
+
+async def _read_xai_video_response_json(response: httpx.Response) -> Dict[str, Any]:
+    text = await _read_xai_video_response_text(response)
+    if not text.strip():
+        return {}
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        raise ValueError("xAI video response JSON was not an object")
+    return payload
 
 
 def _image_ref_to_xai_url(value: str) -> str:
@@ -312,14 +355,19 @@ async def _submit(
     endpoint: str = "generations",
 ) -> str:
     """POST to one of xAI's async video endpoints and return request_id."""
-    response = await client.post(
+    """POST to /videos/generations — xAI's only public endpoint for our
+    text-to-video and image-to-video surface."""
+    async with client.stream(
+        "POST",
         f"{base_url}/videos/{endpoint}",
         headers={**_xai_headers(api_key), "x-idempotency-key": str(uuid.uuid4())},
         json=payload,
         timeout=60,
-    )
-    response.raise_for_status()
-    body = response.json()
+    ) as response:
+        if response.status_code >= 400:
+            detail = await _read_xai_video_response_text(response)
+            raise _XAIVideoHTTPError(response.status_code, detail[:500])
+        body = await _read_xai_video_response_json(response)
     request_id = body.get("request_id")
     if not request_id:
         raise RuntimeError("xAI video response did not include request_id")
@@ -338,13 +386,16 @@ async def _poll(
     elapsed = 0.0
     last_status = "queued"
     while elapsed < timeout_seconds:
-        response = await client.get(
+        async with client.stream(
+            "GET",
             f"{base_url}/videos/{request_id}",
             headers=_xai_headers(api_key),
             timeout=30,
-        )
-        response.raise_for_status()
-        body = response.json()
+        ) as response:
+            if response.status_code >= 400:
+                detail = await _read_xai_video_response_text(response)
+                raise _XAIVideoHTTPError(response.status_code, detail[:500])
+            body = await _read_xai_video_response_json(response)
         last_status = (body.get("status") or "").lower()
 
         if last_status == "done":
@@ -817,6 +868,14 @@ async def _submit_xai_video_payload(
                 client, payload, api_key=api_key, base_url=base_url,
                 endpoint=endpoint,
             )
+        except _XAIVideoHTTPError as exc:
+            return error_response(
+                error=f"xAI submit failed ({exc.status_code}): {exc.detail or exc}",
+                error_type="api_error",
+                provider="xai",
+                model=resolved_model,
+                prompt=prompt,
+            )
         except httpx.HTTPStatusError as exc:
             detail = ""
             try:
@@ -830,13 +889,38 @@ async def _submit_xai_video_payload(
                 model=resolved_model,
                 prompt=prompt,
             )
+        except ValueError as exc:
+            return error_response(
+                error=f"xAI submit failed: {exc}",
+                error_type="api_error",
+                provider="xai",
+                model=resolved_model,
+                prompt=prompt,
+            )
 
-        poll_result = await _poll(
-            client, request_id,
-            api_key=api_key, base_url=base_url,
-            timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
-            poll_interval=DEFAULT_POLL_INTERVAL_SECONDS,
-        )
+        try:
+            poll_result = await _poll(
+                client, request_id,
+                api_key=api_key, base_url=base_url,
+                timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
+                poll_interval=DEFAULT_POLL_INTERVAL_SECONDS,
+            )
+        except _XAIVideoHTTPError as exc:
+            return error_response(
+                error=f"xAI poll failed ({exc.status_code}): {exc.detail or exc}",
+                error_type="api_error",
+                provider="xai",
+                model=resolved_model,
+                prompt=prompt,
+            )
+        except ValueError as exc:
+            return error_response(
+                error=f"xAI poll failed: {exc}",
+                error_type="api_error",
+                provider="xai",
+                model=resolved_model,
+                prompt=prompt,
+            )
 
     status = poll_result["status"]
     body = poll_result["body"]

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import mimetypes
 import os
@@ -52,6 +53,7 @@ DEFAULT_RESOLUTION = "720p"
 DEFAULT_TIMEOUT_SECONDS = 240
 DEFAULT_POLL_INTERVAL_SECONDS = 5
 DEFAULT_EXTEND_DURATION = 6
+_XAI_VIDEO_RESPONSE_MAX_BYTES = 16 * 1024 * 1024
 
 VALID_ASPECT_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"}
 VALID_RESOLUTIONS = {"480p", "720p"}
@@ -84,6 +86,13 @@ _IMAGE_TO_VIDEO_COMPAT_MODEL_IDS = {
 # ---------------------------------------------------------------------------
 # HTTP helpers
 # ---------------------------------------------------------------------------
+
+
+class _XAIVideoHTTPError(RuntimeError):
+    def __init__(self, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"xAI video HTTP {status_code}: {detail}")
 
 
 def _resolve_xai_credentials() -> Tuple[str, str]:
@@ -122,6 +131,7 @@ def _xai_user_agent() -> str:
 def _xai_headers(api_key: str) -> Dict[str, str]:
     return {
         "Authorization": f"Bearer {api_key}",
+        "Accept-Encoding": "identity",
         "Content-Type": "application/json",
         "User-Agent": _xai_user_agent(),
     }
@@ -141,6 +151,52 @@ def _raise_if_blocked_local_input(ref: str) -> None:
         logger.debug("xAI media input read guard unavailable: %s", exc)
         return
     raise_if_read_blocked(ref)
+
+
+async def _read_xai_video_response_body(response: httpx.Response) -> bytes:
+    content_encoding = response.headers.get("content-encoding", "identity").strip().lower()
+    if content_encoding not in {"", "identity"}:
+        raise ValueError(
+            f"xAI video response used unsupported content encoding: {content_encoding}"
+        )
+
+    content_length = response.headers.get("content-length")
+    if content_length:
+        try:
+            declared_size = int(content_length)
+        except ValueError:
+            declared_size = None
+        if declared_size is not None and declared_size > _XAI_VIDEO_RESPONSE_MAX_BYTES:
+            raise ValueError(
+                f"xAI video response exceeds {_XAI_VIDEO_RESPONSE_MAX_BYTES} bytes"
+            )
+
+    body = bytearray()
+    async for chunk in response.aiter_raw(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        if len(body) + len(chunk) > _XAI_VIDEO_RESPONSE_MAX_BYTES:
+            raise ValueError(
+                f"xAI video response exceeds {_XAI_VIDEO_RESPONSE_MAX_BYTES} bytes"
+            )
+        body.extend(chunk)
+    return bytes(body)
+
+
+async def _read_xai_video_response_json(response: httpx.Response) -> Dict[str, Any]:
+    payload = json.loads(await _read_xai_video_response_body(response))
+    if not isinstance(payload, dict):
+        raise ValueError("xAI video response JSON was not an object")
+    return payload
+
+
+async def _xai_video_http_error(response: httpx.Response) -> _XAIVideoHTTPError:
+    try:
+        body = await _read_xai_video_response_body(response)
+        detail = body.decode("utf-8", "replace")
+    except Exception as exc:
+        detail = f"response body unavailable: {exc}"
+    return _XAIVideoHTTPError(response.status_code, detail[:500])
 
 
 def _image_ref_to_xai_url(value: str) -> str:
@@ -312,14 +368,18 @@ async def _submit(
     endpoint: str = "generations",
 ) -> str:
     """POST to one of xAI's async video endpoints and return request_id."""
-    response = await client.post(
+    """POST to /videos/generations — xAI's only public endpoint for our
+    text-to-video and image-to-video surface."""
+    async with client.stream(
+        "POST",
         f"{base_url}/videos/{endpoint}",
         headers={**_xai_headers(api_key), "x-idempotency-key": str(uuid.uuid4())},
         json=payload,
         timeout=60,
-    )
-    response.raise_for_status()
-    body = response.json()
+    ) as response:
+        if not 200 <= response.status_code < 300:
+            raise await _xai_video_http_error(response)
+        body = await _read_xai_video_response_json(response)
     request_id = body.get("request_id")
     if not request_id:
         raise RuntimeError("xAI video response did not include request_id")
@@ -338,13 +398,15 @@ async def _poll(
     elapsed = 0.0
     last_status = "queued"
     while elapsed < timeout_seconds:
-        response = await client.get(
+        async with client.stream(
+            "GET",
             f"{base_url}/videos/{request_id}",
             headers=_xai_headers(api_key),
             timeout=30,
-        )
-        response.raise_for_status()
-        body = response.json()
+        ) as response:
+            if not 200 <= response.status_code < 300:
+                raise await _xai_video_http_error(response)
+            body = await _read_xai_video_response_json(response)
         last_status = (body.get("status") or "").lower()
 
         if last_status == "done":
@@ -817,6 +879,14 @@ async def _submit_xai_video_payload(
                 client, payload, api_key=api_key, base_url=base_url,
                 endpoint=endpoint,
             )
+        except _XAIVideoHTTPError as exc:
+            return error_response(
+                error=f"xAI submit failed ({exc.status_code}): {exc.detail or exc}",
+                error_type="api_error",
+                provider="xai",
+                model=resolved_model,
+                prompt=prompt,
+            )
         except httpx.HTTPStatusError as exc:
             detail = ""
             try:
@@ -830,13 +900,38 @@ async def _submit_xai_video_payload(
                 model=resolved_model,
                 prompt=prompt,
             )
+        except ValueError as exc:
+            return error_response(
+                error=f"xAI submit failed: {exc}",
+                error_type="api_error",
+                provider="xai",
+                model=resolved_model,
+                prompt=prompt,
+            )
 
-        poll_result = await _poll(
-            client, request_id,
-            api_key=api_key, base_url=base_url,
-            timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
-            poll_interval=DEFAULT_POLL_INTERVAL_SECONDS,
-        )
+        try:
+            poll_result = await _poll(
+                client, request_id,
+                api_key=api_key, base_url=base_url,
+                timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
+                poll_interval=DEFAULT_POLL_INTERVAL_SECONDS,
+            )
+        except _XAIVideoHTTPError as exc:
+            return error_response(
+                error=f"xAI poll failed ({exc.status_code}): {exc.detail or exc}",
+                error_type="api_error",
+                provider="xai",
+                model=resolved_model,
+                prompt=prompt,
+            )
+        except ValueError as exc:
+            return error_response(
+                error=f"xAI poll failed: {exc}",
+                error_type="api_error",
+                provider="xai",
+                model=resolved_model,
+                prompt=prompt,
+            )
 
     status = poll_result["status"]
     body = poll_result["body"]

--- a/tests/plugins/video_gen/test_xai_plugin_integration.py
+++ b/tests/plugins/video_gen/test_xai_plugin_integration.py
@@ -24,9 +24,17 @@ def _reset_registry():
 
 
 class _FakeResponse:
-    def __init__(self, status: int = 200, payload: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        status: int = 200,
+        payload: Optional[Dict[str, Any]] = None,
+        body_chunks: Optional[List[bytes]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ):
         self.status_code = status
         self._payload = payload or {}
+        self._body_chunks = body_chunks
+        self.headers = headers or {}
         self.text = json.dumps(self._payload)
 
     def raise_for_status(self):
@@ -36,6 +44,24 @@ class _FakeResponse:
 
     def json(self):
         return self._payload
+
+    async def aiter_bytes(self, chunk_size=None):
+        chunks = self._body_chunks
+        if chunks is None:
+            chunks = [self.text.encode("utf-8")]
+        for chunk in chunks:
+            yield chunk
+
+
+class _FakeStream:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *args):
+        return None
 
 
 class _FakeAsyncClient:
@@ -58,6 +84,16 @@ class _FakeAsyncClient:
             "video": {"url": "https://xai-cdn/out.mp4", "duration": 8},
             "model": self.posts[-1]["json"]["model"],
         })
+
+    def stream(self, method, url, headers=None, json=None, timeout=None):
+        if method == "POST":
+            self.posts.append({"url": url, "json": json})
+            return _FakeStream(_FakeResponse(200, {"request_id": "req-123"}))
+        return _FakeStream(_FakeResponse(200, {
+            "status": "done",
+            "video": {"url": "https://xai-cdn/out.mp4", "duration": 8},
+            "model": self.posts[-1]["json"]["model"],
+        }))
 
 
 @pytest.fixture
@@ -106,6 +142,106 @@ class TestXAIEndpoint:
         assert result["success"] is True
         assert _last_post(captured)["url"].endswith("/videos/generations")
         assert result["modality"] == "image"
+
+    @pytest.mark.asyncio
+    async def test_submit_rejects_oversized_content_length(self, monkeypatch):
+        import plugins.video_gen.xai as xai_plugin
+
+        monkeypatch.setattr(xai_plugin, "_XAI_VIDEO_RESPONSE_MAX_BYTES", 8)
+
+        class _Client:
+            def stream(self, *args, **kwargs):
+                return _FakeStream(_FakeResponse(
+                    200,
+                    body_chunks=[b"{}"],
+                    headers={"content-length": "9"},
+                ))
+
+        with pytest.raises(ValueError, match="xAI video response exceeds 8 bytes"):
+            await xai_plugin._submit(
+                _Client(),  # type: ignore[arg-type]
+                {"model": "grok-imagine-video", "prompt": "dog"},
+                api_key="key",
+                base_url="https://api.x.ai/v1",
+            )
+
+    @pytest.mark.asyncio
+    async def test_poll_rejects_oversized_streamed_body(self, monkeypatch):
+        import plugins.video_gen.xai as xai_plugin
+
+        monkeypatch.setattr(xai_plugin, "_XAI_VIDEO_RESPONSE_MAX_BYTES", 8)
+
+        class _Client:
+            def stream(self, *args, **kwargs):
+                return _FakeStream(_FakeResponse(200, body_chunks=[b"x" * 9]))
+
+        with pytest.raises(ValueError, match="xAI video response exceeds 8 bytes"):
+            await xai_plugin._poll(
+                _Client(),  # type: ignore[arg-type]
+                "req-123",
+                api_key="key",
+                base_url="https://api.x.ai/v1",
+                timeout_seconds=5,
+                poll_interval=1,
+            )
+
+    def test_generate_reports_oversized_submit_response(self, monkeypatch):
+        import plugins.video_gen.xai as xai_plugin
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+        monkeypatch.setattr(xai_plugin, "_XAI_VIDEO_RESPONSE_MAX_BYTES", 8)
+
+        class _Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            def stream(self, *args, **kwargs):
+                return _FakeStream(_FakeResponse(
+                    200,
+                    body_chunks=[b"{}"],
+                    headers={"content-length": "9"},
+                ))
+
+        monkeypatch.setattr(xai_plugin.httpx, "AsyncClient", lambda: _Client())
+
+        result = xai_plugin.XAIVideoGenProvider().generate("a dog on a skateboard")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "xAI submit failed: xAI video response exceeds 8 bytes" in result["error"]
+
+    def test_generate_reports_oversized_poll_response(self, monkeypatch):
+        import plugins.video_gen.xai as xai_plugin
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+        monkeypatch.setattr(xai_plugin, "_XAI_VIDEO_RESPONSE_MAX_BYTES", 32)
+
+        class _Client:
+            def __init__(self):
+                self._calls = 0
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            def stream(self, method, *args, **kwargs):
+                self._calls += 1
+                if method == "POST":
+                    return _FakeStream(_FakeResponse(200, {"request_id": "req-123"}))
+                return _FakeStream(_FakeResponse(200, body_chunks=[b"x" * 33]))
+
+        monkeypatch.setattr(xai_plugin.httpx, "AsyncClient", lambda: _Client())
+
+        result = xai_plugin.XAIVideoGenProvider().generate("a dog on a skateboard")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "xAI poll failed: xAI video response exceeds 32 bytes" in result["error"]
 
 
 class TestXAIPayload:

--- a/tests/plugins/video_gen/test_xai_plugin_integration.py
+++ b/tests/plugins/video_gen/test_xai_plugin_integration.py
@@ -24,9 +24,17 @@ def _reset_registry():
 
 
 class _FakeResponse:
-    def __init__(self, status: int = 200, payload: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        status: int = 200,
+        payload: Optional[Dict[str, Any]] = None,
+        body_chunks: Optional[List[bytes]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ):
         self.status_code = status
         self._payload = payload or {}
+        self._body_chunks = body_chunks
+        self.headers = headers or {}
         self.text = json.dumps(self._payload)
 
     def raise_for_status(self):
@@ -36,6 +44,24 @@ class _FakeResponse:
 
     def json(self):
         return self._payload
+
+    async def aiter_raw(self, chunk_size=None):
+        chunks = self._body_chunks
+        if chunks is None:
+            chunks = [self.text.encode("utf-8")]
+        for chunk in chunks:
+            yield chunk
+
+
+class _FakeStream:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *args):
+        return None
 
 
 class _FakeAsyncClient:
@@ -58,6 +84,16 @@ class _FakeAsyncClient:
             "video": {"url": "https://xai-cdn/out.mp4", "duration": 8},
             "model": self.posts[-1]["json"]["model"],
         })
+
+    def stream(self, method, url, headers=None, json=None, timeout=None):
+        if method == "POST":
+            self.posts.append({"url": url, "json": json})
+            return _FakeStream(_FakeResponse(200, {"request_id": "req-123"}))
+        return _FakeStream(_FakeResponse(200, {
+            "status": "done",
+            "video": {"url": "https://xai-cdn/out.mp4", "duration": 8},
+            "model": self.posts[-1]["json"]["model"],
+        }))
 
 
 @pytest.fixture
@@ -106,6 +142,161 @@ class TestXAIEndpoint:
         assert result["success"] is True
         assert _last_post(captured)["url"].endswith("/videos/generations")
         assert result["modality"] == "image"
+
+    @pytest.mark.asyncio
+    async def test_submit_rejects_oversized_content_length(self, monkeypatch):
+        import plugins.video_gen.xai as xai_plugin
+
+        monkeypatch.setattr(xai_plugin, "_XAI_VIDEO_RESPONSE_MAX_BYTES", 8)
+
+        class _Client:
+            def stream(self, *args, **kwargs):
+                return _FakeStream(_FakeResponse(
+                    200,
+                    body_chunks=[b"{}"],
+                    headers={"content-length": "9"},
+                ))
+
+        with pytest.raises(ValueError, match="xAI video response exceeds 8 bytes"):
+            await xai_plugin._submit(
+                _Client(),  # type: ignore[arg-type]
+                {"model": "grok-imagine-video", "prompt": "dog"},
+                api_key="key",
+                base_url="https://api.x.ai/v1",
+            )
+
+    @pytest.mark.asyncio
+    async def test_poll_rejects_oversized_streamed_body(self, monkeypatch):
+        import plugins.video_gen.xai as xai_plugin
+
+        monkeypatch.setattr(xai_plugin, "_XAI_VIDEO_RESPONSE_MAX_BYTES", 8)
+
+        class _Client:
+            def stream(self, *args, **kwargs):
+                return _FakeStream(_FakeResponse(200, body_chunks=[b"x" * 9]))
+
+        with pytest.raises(ValueError, match="xAI video response exceeds 8 bytes"):
+            await xai_plugin._poll(
+                _Client(),  # type: ignore[arg-type]
+                "req-123",
+                api_key="key",
+                base_url="https://api.x.ai/v1",
+                timeout_seconds=5,
+                poll_interval=1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_submit_rejects_compressed_response(self):
+        import plugins.video_gen.xai as xai_plugin
+
+        response = _FakeResponse(200, headers={"content-encoding": "gzip"})
+        assert xai_plugin._xai_headers("key")["Accept-Encoding"] == "identity"
+        with pytest.raises(ValueError, match="unsupported content encoding: gzip"):
+            await xai_plugin._read_xai_video_response_json(response)
+        assert await xai_plugin._read_xai_video_response_json(
+            _FakeResponse(200, body_chunks=[b'\xef\xbb\xbf{"request_id":"req-123"}'])
+        ) == {"request_id": "req-123"}
+        with pytest.raises(UnicodeDecodeError):
+            await xai_plugin._read_xai_video_response_json(
+                _FakeResponse(200, body_chunks=[b'{"request_id":"req-\xff"}'])
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("operation", "status", "chunks", "error_type"),
+        [
+            ("submit", 302, [b'{}'], "http"),
+            ("poll", 302, [b'{}'], "http"),
+            ("poll", 200, [b" "], "json"),
+        ],
+    )
+    async def test_response_error_semantics_remain_strict(
+        self, operation, status, chunks, error_type
+    ):
+        import json
+        import plugins.video_gen.xai as xai_plugin
+
+        class _Client:
+            def stream(self, *args, **kwargs):
+                headers = {"content-encoding": "gzip"} if error_type == "http" else None
+                return _FakeStream(_FakeResponse(status, body_chunks=chunks, headers=headers))
+
+        expected = xai_plugin._XAIVideoHTTPError if error_type == "http" else json.JSONDecodeError
+        with pytest.raises(expected):
+            if operation == "submit":
+                await xai_plugin._submit(
+                    _Client(),  # type: ignore[arg-type]
+                    {"model": "grok-imagine-video", "prompt": "dog"},
+                    api_key="key",
+                    base_url="https://api.x.ai/v1",
+                )
+            else:
+                await xai_plugin._poll(
+                    _Client(),  # type: ignore[arg-type]
+                    "req-123",
+                    api_key="key",
+                    base_url="https://api.x.ai/v1",
+                    timeout_seconds=5,
+                    poll_interval=1,
+                )
+
+    def test_generate_reports_oversized_submit_response(self, monkeypatch):
+        import plugins.video_gen.xai as xai_plugin
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+        monkeypatch.setattr(xai_plugin, "_XAI_VIDEO_RESPONSE_MAX_BYTES", 8)
+
+        class _Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            def stream(self, *args, **kwargs):
+                return _FakeStream(_FakeResponse(
+                    200,
+                    body_chunks=[b"{}"],
+                    headers={"content-length": "9"},
+                ))
+
+        monkeypatch.setattr(xai_plugin.httpx, "AsyncClient", lambda: _Client())
+
+        result = xai_plugin.XAIVideoGenProvider().generate("a dog on a skateboard")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "xAI submit failed: xAI video response exceeds 8 bytes" in result["error"]
+
+    def test_generate_reports_oversized_poll_response(self, monkeypatch):
+        import plugins.video_gen.xai as xai_plugin
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+        monkeypatch.setattr(xai_plugin, "_XAI_VIDEO_RESPONSE_MAX_BYTES", 32)
+
+        class _Client:
+            def __init__(self):
+                self._calls = 0
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            def stream(self, method, *args, **kwargs):
+                self._calls += 1
+                if method == "POST":
+                    return _FakeStream(_FakeResponse(200, {"request_id": "req-123"}))
+                return _FakeStream(_FakeResponse(200, body_chunks=[b"x" * 33]))
+
+        monkeypatch.setattr(xai_plugin.httpx, "AsyncClient", lambda: _Client())
+
+        result = xai_plugin.XAIVideoGenProvider().generate("a dog on a skateboard")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "xAI poll failed: xAI video response exceeds 32 bytes" in result["error"]
 
 
 class TestXAIPayload:

--- a/tests/tools/test_video_generation_tool_surface_matrix.py
+++ b/tests/tools/test_video_generation_tool_surface_matrix.py
@@ -67,11 +67,22 @@ def matrix_env(tmp_path, monkeypatch):
             self.status_code = s
             self._p = p
             self.text = json.dumps(p)
+            self.headers = {}
         def raise_for_status(self):
             if self.status_code >= 400:
                 raise httpx.HTTPStatusError("err", request=None, response=self)  # type: ignore
         def json(self):
             return self._p
+        async def aiter_raw(self, chunk_size=None):
+            yield self.text.encode("utf-8")
+
+    class _Stream:
+        def __init__(self, response):
+            self._response = response
+        async def __aenter__(self):
+            return self._response
+        async def __aexit__(self, *args):
+            return None
     class _Client:
         async def __aenter__(self): return self
         async def __aexit__(self, *a): return None
@@ -95,6 +106,28 @@ def matrix_env(tmp_path, monkeypatch):
                 },
                 "model": payload.get("model", "grok-imagine-video"),
             })
+
+        def stream(self, method, url, headers=None, json=None, timeout=None):
+            if method == "POST":
+                xai_calls.append({"url": url, "json": json})
+                return _Stream(_Resp({"request_id": "req-1"}))
+
+            payload = xai_calls[-1]["json"]
+            storage_options = payload.get("storage_options") or {}
+            return _Stream(_Resp({
+                "status": "done",
+                "video": {
+                    "url": "https://xai-cdn/out.mp4",
+                    "duration": 8,
+                    "file_output": {
+                        "file_id": "file-123",
+                        "filename": storage_options.get("filename", "out.mp4"),
+                        "public_url": "https://xai-files.example/out.mp4",
+                        "public_url_expires_at": 1234567890,
+                    },
+                },
+                "model": payload.get("model", "grok-imagine-video"),
+            }))
     import plugins.video_gen.xai as xai_plugin
     monkeypatch.setattr(xai_plugin.httpx, "AsyncClient", lambda: _Client())
     async def _no_sleep(*a, **k): return None


### PR DESCRIPTION
Fixes #55021

## Summary

- stream xAI video submit and poll responses before parsing JSON
- reject declared or streamed response bodies over 16 MiB
- return structured `api_error` results for oversized submit/poll responses
- add focused coverage for content-length and streamed-body overflow

## Context

This follows the same external-provider response-boundary pattern as recent response cap fixes, scoped specifically to the xAI video generation plugin.

## Duplicate Audit

- `gh search prs --repo NousResearch/hermes-agent "xAI video response cap" --state open --limit 20` returned no matches.
- `gh search issues --repo NousResearch/hermes-agent "xAI video generation JSON" --state open --limit 20` returned no matches.
- Broad live scan of open PRs/issues containing `xai|video|generation|response|body|read|bound|cap` found related response-cap work, but no open xAI video generation response-body cap duplicate.

## Validation

- `uv run --extra dev python -m pytest tests\plugins\video_gen\test_xai_plugin.py tests\plugins\video_gen\test_xai_plugin_integration.py -q --basetemp .pytest-tmp-xai-video-response-cap`
- `uv run --extra dev python -m ruff check plugins\video_gen\xai\__init__.py tests\plugins\video_gen\test_xai_plugin_integration.py`
- `git diff --check`

## Autoreview

Not run: `.agents\skills\autoreview` is not present in this worktree.
