### PR TITLE
fix(dashboard): preserve inline chat history without spacer flood

### DIFF
--- a/ui-tui/src/__tests__/usePet.test.ts
+++ b/ui-tui/src/__tests__/usePet.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { derivePetState, isPetCellsUnsupportedError } from '../app/usePet.js'
+
+describe('derivePetState', () => {
+  it('prioritizes user-blocked state over busy/tool/reasoning states', () => {
+    expect(
+      derivePetState({
+        awaitingInput: true,
+        busy: true,
+        reasoning: true,
+        toolRunning: true
+      })
+    ).toBe('waiting')
+  })
+
+  it('maps normal agent activity to pet animation states', () => {
+    expect(derivePetState({ awaitingInput: false, busy: false, reasoning: false, toolRunning: true })).toBe('run')
+    expect(derivePetState({ awaitingInput: false, busy: false, reasoning: true, toolRunning: false })).toBe('review')
+    expect(derivePetState({ awaitingInput: false, busy: true, reasoning: false, toolRunning: false })).toBe('run')
+    expect(derivePetState({ awaitingInput: false, busy: false, reasoning: false, toolRunning: false })).toBe('idle')
+  })
+})
+
+describe('isPetCellsUnsupportedError', () => {
+  it('recognizes version-skew unknown-method errors for pet.cells', () => {
+    expect(isPetCellsUnsupportedError(new Error('unknown method: pet.cells'))).toBe(true)
+    expect(isPetCellsUnsupportedError(new Error('Unknown method:  PET.CELLS'))).toBe(true)
+  })
+
+  it('does not match unrelated RPC failures', () => {
+    expect(isPetCellsUnsupportedError(new Error('unknown method: pet.gallery'))).toBe(false)
+    expect(isPetCellsUnsupportedError(new Error('timeout: pet.cells'))).toBe(false)
+    expect(isPetCellsUnsupportedError('unknown method: pet.cells')).toBe(false)
+  })
+})

--- a/ui-tui/src/app/usePet.ts
+++ b/ui-tui/src/app/usePet.ts
@@ -81,6 +81,9 @@ type CacheEntry =
 const FRAME_MS = 160
 const POLL_MS = 2500
 
+export const isPetCellsUnsupportedError = (err: unknown): boolean =>
+  err instanceof Error && /unknown method:\s*pet\.cells/i.test(err.message)
+
 // Only the standalone TUI owns a real terminal it can splat image escapes into;
 // when piped (or running under the dashboard PTY the gateway resolves to
 // half-blocks anyway) we never ask for graphics.
@@ -119,6 +122,7 @@ export function usePet(): PetRender {
   const imageIdRef = useRef(0)
   const stateRef = useRef<PetState>('idle')
   const frameRef = useRef(0)
+  const unsupportedRef = useRef(false)
 
   const [petState, setPetState] = useState<PetState>('idle')
 
@@ -193,6 +197,10 @@ export function usePet(): PetRender {
   // config, so its `slug`/`enabled` are the source of truth.
   const sync = useCallback(
     async (state: PetState) => {
+      if (unsupportedRef.current) {
+        return
+      }
+
       try {
         const res = (await rpc('pet.cells', { graphics: IS_TTY, state })) as PetCellsResult | null
 
@@ -243,7 +251,20 @@ export function usePet(): PetRender {
         }
 
         setEnabled(true)
-      } catch {
+      } catch (err) {
+        if (isPetCellsUnsupportedError(err)) {
+          // Version-skew guard: a freshly built TUI can run against an older
+          // dashboard / sidecar gateway that does not know the pet RPCs yet.
+          // The pet is cosmetic, so disable it for this process instead of
+          // polling every 2.5s and surfacing repeated "unknown method" errors.
+          unsupportedRef.current = true
+          releaseKitty()
+          slugRef.current = ''
+          cache.current.clear()
+          setGrid(null)
+          setKitty(null)
+          setEnabled(false)
+        }
         // cosmetic — ignore RPC failures
       }
     },

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -106,6 +106,18 @@ const TranscriptPane = memo(function TranscriptPane({
     [transcript.historyItems]
   )
 
+  // Inline dashboard chat renders into the host terminal's primary screen so
+  // xterm.js native scrollback can retain transcript rows.  Virtual-history
+  // spacers are only valid in the finite-height alt-screen ScrollBox; in
+  // inline mode those spacers become thousands of physical blank rows and can
+  // roll the real transcript out of xterm's scrollback, leaving resumed long
+  // sessions visually blank.  Do not "fix" that by capping to the last N
+  // items: that makes older text genuinely absent.  In inline mode render the
+  // actual transcript rows and suppress only the synthetic spacer rows.
+  const visibleRows = INLINE_MODE
+    ? transcript.virtualRows
+    : transcript.virtualRows.slice(transcript.virtualHistory.start, transcript.virtualHistory.end)
+
   return (
     <>
       <ScrollBox
@@ -121,9 +133,9 @@ const TranscriptPane = memo(function TranscriptPane({
         stickyScroll
       >
         <Box flexDirection="column" paddingX={1}>
-          {transcript.virtualHistory.topSpacer > 0 ? <Box height={transcript.virtualHistory.topSpacer} /> : null}
+          {!INLINE_MODE && transcript.virtualHistory.topSpacer > 0 ? <Box height={transcript.virtualHistory.topSpacer} /> : null}
 
-          {transcript.virtualRows.slice(transcript.virtualHistory.start, transcript.virtualHistory.end).map(row => (
+          {visibleRows.map(row => (
             <Box flexDirection="column" key={row.key} ref={transcript.virtualHistory.measureRef(row.key)}>
               {row.msg.role === 'user' && firstUserIdx >= 0 && row.index > firstUserIdx && (
                 <Box marginTop={1}>
@@ -167,7 +179,7 @@ const TranscriptPane = memo(function TranscriptPane({
             </Box>
           ))}
 
-          {transcript.virtualHistory.bottomSpacer > 0 ? <Box height={transcript.virtualHistory.bottomSpacer} /> : null}
+          {!INLINE_MODE && transcript.virtualHistory.bottomSpacer > 0 ? <Box height={transcript.virtualHistory.bottomSpacer} /> : null}
 
           <StreamingAssistant
             cols={composer.cols}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -500,21 +500,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     fitRef.current = fit;
     term.loadAddon(fit);
 
-    // Dashboard chat should scroll the browser-side transcript, not send
-    // mouse-wheel protocol bytes through the PTY.
-    term.attachCustomWheelEventHandler((ev) => {
-      const delta = ev.deltaY;
-      if (!delta) {
-        return false;
-      }
-
-      const step = Math.max(1, Math.round(Math.abs(delta) / 50));
-      term.scrollLines(delta > 0 ? step : -step);
-
-      ev.preventDefault();
-      ev.stopPropagation();
-      return false;
-    });
+    // Dashboard chat is an embedded Ink app.  The transcript scroll position
+    // lives inside Ink's ScrollBox, not in xterm's native scrollback.  Let
+    // xterm encode wheel input as mouse protocol bytes so the TUI can scroll
+    // its own virtualized transcript.  Non-wheel SGR mouse traffic is still
+    // filtered below before it reaches the PTY; that keeps the old stray
+    // `102;71M5;104;62M` input-corruption class out while fixing long final
+    // replies that looked cut off in the browser.
+    term.attachCustomWheelEventHandler(() => true);
 
     const unicode11 = new Unicode11Addon();
     term.loadAddon(unicode11);
@@ -799,10 +792,18 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // behave normally.
       // eslint-disable-next-line no-control-regex -- intentional ESC byte in xterm SGR mouse report parser
       const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
+      const isWheelSgrMouseReport = (data: string): boolean => {
+        const match = data.match(SGR_MOUSE_RE);
+        if (!match) return false;
+        const button = Number(match[1]);
+        // SGR protocol: 64 = wheel up, 65 = wheel down.  Forward only these
+        // so Ink's ScrollBox receives scroll intent; drop click/move reports.
+        return button === 64 || button === 65;
+      };
       onDataDisposable = term.onData((data) => {
         if (ws.readyState !== WebSocket.OPEN) return;
 
-        if (SGR_MOUSE_RE.test(data)) {
+        if (SGR_MOUSE_RE.test(data) && !isWheelSgrMouseReport(data)) {
           return;
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes dashboard embedded Chat missing-text/blank-resume behavior for long sessions without introducing a hard transcript cap, and makes the new cosmetic pet renderer fail closed when the dashboard sidecar is older than the TUI bundle.

There are three related failure modes here:

1. The browser Chat tab was swallowing wheel events into xterm's native scrollback instead of forwarding scroll intent to the embedded Ink TUI transcript. Long assistant replies could look cut off even though the response existed.
2. PR #31430 correctly identified that inline dashboard mode must not render virtual-history spacer boxes: those spacer boxes become thousands of physical blank CR/LF rows and can roll real content out of xterm.js scrollback, leaving resumed long sessions blank. But its proposed `INLINE_MAX_ITEMS = 200` workaround makes older transcript rows genuinely absent.
3. A freshly built TUI can run against an older dashboard `/api/ws` sidecar that does not know the new `pet.cells` RPC yet. Because the pet is cosmetic, this should silently disable pet rendering instead of surfacing repeated `unknown method: pet.cells` errors.

This PR preserves the intent of the spacer-flood fix while avoiding new missing-text/noise bugs:

- in inline mode, suppress only synthetic virtual-history spacer rows;
- render the actual transcript rows instead of slicing to the last N items;
- keep normal alt-screen behavior unchanged;
- forward wheel SGR reports to the TUI while filtering non-wheel mouse reports so old input-corruption remains blocked;
- stop polling `pet.cells` after an unknown-method response and disable the pet for that TUI process.

## Why this shape

Inline dashboard Chat intentionally renders on the primary screen so the browser terminal can retain transcript rows in native scrollback. The spacer rows are synthetic implementation details for finite-height `ScrollBox` virtualization; they should not be emitted into xterm.js as real rows. But capping to 200 transcript items is worse for the user: it turns a rendering bug into data invisibility.

Likewise, the pet renderer is decorative. It should never spam the transcript or force a dashboard restart during frontend/backend version skew.

## Verification

Ran locally after rebasing on current `origin/main`:

```text
cd web && npm run typecheck
cd web && npm run build
cd web && npm test
cd ui-tui && npm run typecheck
cd ui-tui && npm run build
cd ui-tui && npm run build --prefix packages/hermes-ink
cd ui-tui && npx vitest run virtualHistory
cd ui-tui && npx vitest run src/__tests__/usePet.test.ts
git diff --check origin/main...HEAD
```

Results:

- web typecheck passed
- web build passed
- web tests passed: 5 files / 31 tests
- ui-tui typecheck passed
- ui-tui build passed
- hermes-ink build passed
- virtualHistory tests passed: 3 files / 13 tests
- usePet tests passed: 1 file / 4 tests
- diff check passed

Related: #31430
