### PR TITLE
fix(signal): bound JSON-RPC response reads

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -64,6 +64,14 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 SIGNAL_MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100 MB
+SIGNAL_RPC_RESPONSE_MAX_BYTES = 16 * 1024 * 1024
+# A max-size attachment expands to 4 * ceil(n / 3) bytes in base64. Leave a
+# bounded allowance for the JSON-RPC envelope and attachment metadata.
+SIGNAL_RPC_ATTACHMENT_JSON_OVERHEAD_BYTES = 64 * 1024
+SIGNAL_RPC_ATTACHMENT_RESPONSE_MAX_BYTES = (
+    4 * ((SIGNAL_MAX_ATTACHMENT_SIZE + 2) // 3)
+    + SIGNAL_RPC_ATTACHMENT_JSON_OVERHEAD_BYTES
+)
 MAX_MESSAGE_LENGTH = 8000  # Signal message size limit
 TYPING_INTERVAL = 8.0  # seconds between typing indicator refreshes
 SSE_RETRY_DELAY_INITIAL = 2.0
@@ -80,6 +88,36 @@ HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before conc
 def _parse_comma_list(value: str) -> List[str]:
     """Split a comma-separated string into a list, stripping whitespace."""
     return [v.strip() for v in value.split(",") if v.strip()]
+
+
+async def _read_signal_rpc_json_response(
+    response: httpx.Response,
+    *,
+    max_bytes: int,
+) -> Dict[str, Any]:
+    content_length = response.headers.get("content-length")
+    if content_length:
+        try:
+            declared_size = int(content_length)
+        except ValueError:
+            declared_size = None
+        if declared_size is not None and declared_size > max_bytes:
+            raise ValueError(f"Signal RPC response exceeds {max_bytes} bytes")
+
+    body = bytearray()
+    async for chunk in response.aiter_bytes(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        if len(body) + len(chunk) > max_bytes:
+            raise ValueError(f"Signal RPC response exceeds {max_bytes} bytes")
+        body.extend(chunk)
+
+    if not body:
+        return {}
+    data = json.loads(bytes(body).decode("utf-8", "replace"))
+    if not isinstance(data, dict):
+        raise ValueError("Signal RPC response JSON was not an object")
+    return data
 
 
 def _guess_extension(data: bytes) -> str:
@@ -964,13 +1002,22 @@ class SignalAdapter(BasePlatformAdapter):
         }
 
         try:
-            resp = await self.client.post(
+            async with self.client.stream(
+                "POST",
                 f"{self.http_url}/api/v1/rpc",
                 json=payload,
                 timeout=timeout,
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            ) as resp:
+                resp.raise_for_status()
+                max_response_bytes = (
+                    SIGNAL_RPC_ATTACHMENT_RESPONSE_MAX_BYTES
+                    if method == "getAttachment"
+                    else SIGNAL_RPC_RESPONSE_MAX_BYTES
+                )
+                data = await _read_signal_rpc_json_response(
+                    resp,
+                    max_bytes=max_response_bytes,
+                )
 
             if "error" in data:
                 err = data["error"]

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1,6 +1,7 @@
 """Tests for Signal messenger platform adapter."""
 import asyncio
 import base64
+import json
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -709,7 +710,6 @@ class TestSignalSendResultValidation:
         assert result.success is False
         assert result.error == "Some connection error"
 
-
 # ---------------------------------------------------------------------------
 # stop_typing() delegates to _stop_typing_indicator (#4647)
 # ---------------------------------------------------------------------------
@@ -895,8 +895,10 @@ class TestSignalQuoteExtraction:
 class _FakeHttpResponse:
     """Minimal stand-in for httpx.Response — only what _rpc touches."""
 
-    def __init__(self, json_data):
+    def __init__(self, json_data=None, *, body_chunks=None, headers=None):
         self._json = json_data
+        self._body_chunks = body_chunks
+        self.headers = headers or {}
 
     def raise_for_status(self):
         return None
@@ -904,20 +906,88 @@ class _FakeHttpResponse:
     def json(self):
         return self._json
 
+    async def aiter_bytes(self, chunk_size=None):
+        chunks = self._body_chunks
+        if chunks is None:
+            chunks = [json.dumps(self._json or {}).encode("utf-8")]
+        for chunk in chunks:
+            yield chunk
 
-def _install_fake_client(adapter, json_data):
-    """Replace adapter.client.post with an async fn returning json_data."""
+
+class _FakeHttpStream:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *args):
+        return None
+
+
+def _install_fake_client(adapter, json_data=None, *, body_chunks=None, headers=None):
+    """Replace adapter.client.stream with a fake response stream."""
     from types import SimpleNamespace
 
-    async def _post(url, json=None, timeout=None):
-        return _FakeHttpResponse(json_data)
+    def _stream(method, url, json=None, timeout=None):
+        return _FakeHttpStream(_FakeHttpResponse(
+            json_data,
+            body_chunks=body_chunks,
+            headers=headers,
+        ))
 
-    adapter.client = SimpleNamespace(post=_post)
+    adapter.client = SimpleNamespace(stream=_stream)
+
+
+class TestSignalRpcResponseBounds:
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_content_length(self, monkeypatch, caplog):
+        import gateway.platforms.signal as signal_module
+
+        adapter = _make_signal_adapter(monkeypatch)
+        monkeypatch.setattr(signal_module, "SIGNAL_RPC_RESPONSE_MAX_BYTES", 8)
+        _install_fake_client(
+            adapter,
+            {"result": "ok"},
+            headers={"content-length": "9"},
+        )
+
+        with caplog.at_level("WARNING"):
+            result = await adapter._rpc("send", {})
+
+        assert result is None
+        assert "Signal RPC response exceeds 8 bytes" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_streamed_body(self, monkeypatch, caplog):
+        import gateway.platforms.signal as signal_module
+
+        adapter = _make_signal_adapter(monkeypatch)
+        monkeypatch.setattr(signal_module, "SIGNAL_RPC_RESPONSE_MAX_BYTES", 8)
+        _install_fake_client(adapter, body_chunks=[b"x" * 9])
+
+        with caplog.at_level("WARNING"):
+            result = await adapter._rpc("send", {})
+
+        assert result is None
+        assert "Signal RPC response exceeds 8 bytes" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_allows_supported_attachment_above_normal_rpc_cap(self, monkeypatch):
+        from gateway.platforms.signal import SIGNAL_RPC_RESPONSE_MAX_BYTES
+
+        adapter = _make_signal_adapter(monkeypatch)
+        raw_attachment = b"a" * (SIGNAL_RPC_RESPONSE_MAX_BYTES + 1)
+        encoded_attachment = base64.b64encode(raw_attachment).decode("ascii")
+        _install_fake_client(adapter, {"result": {"data": encoded_attachment}})
+
+        result = await adapter._rpc("getAttachment", {"id": "attachment-123"})
+
+        assert result == {"data": encoded_attachment}
 
 
 class TestSignalRpcRateLimit:
     """_rpc opt-in 429 detection and SignalRateLimitError propagation."""
-
 
     @pytest.mark.asyncio
     async def test_default_swallows_rate_limit_returns_none(self, monkeypatch):
@@ -929,7 +999,6 @@ class TestSignalRpcRateLimit:
 
         result = await adapter._rpc("send", {})
         assert result is None
-
 
     @pytest.mark.asyncio
     async def test_raises_with_retry_after_from_v0_14_3_payload(self, monkeypatch):


### PR DESCRIPTION
﻿Fixes #55025

## Summary

- stream Signal JSON-RPC responses before parsing JSON
- keep ordinary RPC responses capped at 16 MiB
- give `getAttachment` a separate finite budget derived from the 100 MiB raw attachment limit, exact base64 expansion, and 64 KiB of JSON-RPC envelope allowance
- preserve the existing `_rpc()` failure contract for declared and streamed oversize responses

## Context

This mirrors the recent signal-cli REST response-boundary fix pattern from OpenClaw, scoped to Hermes' Signal JSON-RPC adapter. The branch is rebased on current `main` and now preserves Hermes' documented 100 MiB Signal attachment contract.

## Duplicate Audit

- `gh search prs --repo NousResearch/hermes-agent "Signal RPC response cap" --state open --limit 20` returned no matches.
- `gh search issues --repo NousResearch/hermes-agent "signal-cli response body cap" --state open --limit 20` returned no matches.
- Broad live scan of open PRs/issues containing Signal plus `response|body|read|bound|cap|rpc|cli` found no open body-cap duplicate.

## Validation

Exact head: `a9afef97da7ca6d63739f00332fb1f1c7ae0406d`

- `scripts/run_tests.sh tests/gateway/test_signal.py -q` - 55 passed
- `python -m ruff check gateway/platforms/signal.py tests/gateway/test_signal.py` - passed
- `git diff --check` - passed
- AutoReview (Codex, scoped branch closeout) - clean, no accepted/actionable findings; patch correct at 0.96 confidence

Regression coverage includes a raw attachment of 16 MiB + 1 byte, proving that `getAttachment` can exceed the ordinary RPC cap while remaining bounded below the supported 100 MiB limit.
