### PR TITLE
fix(video): stream downloads with size cap

### DIFF
--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -4,9 +4,11 @@ import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 from tools.vision_tools import (
     _detect_video_mime_type,
+    _download_video,
     _video_to_base64_data_url,
     _handle_video_analyze,
     _MAX_VIDEO_BASE64_BYTES,
@@ -95,6 +97,107 @@ class TestVideoToBase64DataUrl:
         result = _video_to_base64_data_url(p)
         # Falls back to video/mp4
         assert result.startswith("data:video/mp4;base64,")
+
+
+# ---------------------------------------------------------------------------
+# _download_video
+# ---------------------------------------------------------------------------
+
+
+class _FakeVideoResponse:
+    def __init__(self, *, chunks, headers=None, url="https://example.com/clip.mp4"):
+        self._chunks = chunks
+        self.headers = headers or {}
+        self.url = url
+        self.is_redirect = False
+        self.next_request = None
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_bytes(self, chunk_size=None):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeVideoStream:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *args):
+        return None
+
+
+class _FakeVideoClient:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    def stream(self, *args, **kwargs):
+        return _FakeVideoStream(self._response)
+
+
+class TestDownloadVideo:
+    def _install_client(self, monkeypatch, response):
+        monkeypatch.setattr("tools.vision_tools.check_website_access", lambda url: None)
+        monkeypatch.setattr(
+            "tools.vision_tools.httpx.AsyncClient",
+            lambda *args, **kwargs: _FakeVideoClient(response),
+        )
+
+    def test_rejects_oversized_content_length(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.vision_tools._MAX_VIDEO_BASE64_BYTES", 8)
+        self._install_client(
+            monkeypatch,
+            _FakeVideoResponse(chunks=[b"ok"], headers={"content-length": "9"}),
+        )
+
+        destination = tmp_path / "clip.mp4"
+        with pytest.raises(ValueError, match="Video too large"):
+            asyncio.get_event_loop().run_until_complete(
+                _download_video("https://example.com/clip.mp4", destination, max_retries=1)
+            )
+
+        assert not destination.exists()
+        assert not list(tmp_path.glob("*.part"))
+
+    def test_rejects_oversized_streamed_body(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.vision_tools._MAX_VIDEO_BASE64_BYTES", 8)
+        self._install_client(
+            monkeypatch,
+            _FakeVideoResponse(chunks=[b"1234", b"56789"]),
+        )
+
+        destination = tmp_path / "clip.mp4"
+        with pytest.raises(ValueError, match="Video too large"):
+            asyncio.get_event_loop().run_until_complete(
+                _download_video("https://example.com/clip.mp4", destination, max_retries=1)
+            )
+
+        assert not destination.exists()
+        assert not list(tmp_path.glob("*.part"))
+
+    def test_writes_streamed_video_chunks(self, tmp_path, monkeypatch):
+        self._install_client(
+            monkeypatch,
+            _FakeVideoResponse(chunks=[b"abc", b"def"]),
+        )
+
+        destination = tmp_path / "clip.mp4"
+        result = asyncio.get_event_loop().run_until_complete(
+            _download_video("https://example.com/clip.mp4", destination, max_retries=1)
+        )
+
+        assert result == destination
+        assert destination.read_bytes() == b"abcdef"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1432,32 +1432,47 @@ async def _download_video(video_url: str, destination: Path, max_retries: int = 
                 follow_redirects=True,
                 event_hooks={"response": [_ssrf_redirect_guard]},
             ) as client:
-                response = await client.get(
-                    video_url,
-                    headers={
-                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                        "Accept": "video/*,*/*;q=0.8",
-                    },
+                temp_destination = destination.with_name(
+                    f"{destination.name}.{uuid.uuid4().hex}.part"
                 )
-                response.raise_for_status()
+                try:
+                    async with client.stream(
+                        "GET",
+                        video_url,
+                        headers={
+                            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                            "Accept": "video/*,*/*;q=0.8",
+                        },
+                    ) as response:
+                        response.raise_for_status()
 
-                cl = response.headers.get("content-length")
-                if cl and int(cl) > _MAX_VIDEO_BASE64_BYTES:
-                    raise ValueError(
-                        f"Video too large ({int(cl)} bytes, max {_MAX_VIDEO_BASE64_BYTES})"
-                    )
+                        cl = response.headers.get("content-length")
+                        if cl and int(cl) > _MAX_VIDEO_BASE64_BYTES:
+                            raise ValueError(
+                                f"Video too large ({int(cl)} bytes, max {_MAX_VIDEO_BASE64_BYTES})"
+                            )
 
-                final_url = str(response.url)
-                blocked = check_website_access(final_url)
-                if blocked:
-                    raise PermissionError(blocked["message"])
+                        final_url = str(response.url)
+                        blocked = check_website_access(final_url)
+                        if blocked:
+                            raise PermissionError(blocked["message"])
 
-                body = response.content
-                if len(body) > _MAX_VIDEO_BASE64_BYTES:
-                    raise ValueError(
-                        f"Video too large ({len(body)} bytes, max {_MAX_VIDEO_BASE64_BYTES})"
-                    )
-                destination.write_bytes(body)
+                        downloaded = 0
+                        with temp_destination.open("wb") as fh:
+                            async for chunk in response.aiter_bytes(chunk_size=64 * 1024):
+                                if not chunk:
+                                    continue
+                                downloaded += len(chunk)
+                                if downloaded > _MAX_VIDEO_BASE64_BYTES:
+                                    raise ValueError(
+                                        f"Video too large ({downloaded} bytes, max {_MAX_VIDEO_BASE64_BYTES})"
+                                    )
+                                fh.write(chunk)
+                    temp_destination.replace(destination)
+                except Exception:
+                    with contextlib.suppress(OSError):
+                        temp_destination.unlink()
+                    raise
 
             return destination
         except Exception as e:


### PR DESCRIPTION
Fixes #55027

## Summary

- stream remote `video_analyze` downloads instead of reading `response.content`
- enforce `_MAX_VIDEO_BASE64_BYTES` while chunks arrive
- write to a temporary `.part` file and replace the destination only after success
- add focused coverage for declared oversize, streamed oversize, and normal chunked downloads

## Context

This mirrors the recent video-download response-boundary fix pattern from OpenClaw, scoped to Hermes' `video_analyze` remote download path.

## Duplicate Audit

- `gh search prs --repo NousResearch/hermes-agent "video download response cap" --state open --limit 20` returned no matches.
- `gh search issues --repo NousResearch/hermes-agent "video download body cap" --state open --limit 20` returned no matches.
- Broad live scan of open PRs/issues containing video plus `download|body|response|read|bound|cap|stream` found the existing xAI video JSON response PR, but no remote video download duplicate.

## Validation

- `uv run --extra dev python -m pytest tests\tools\test_video_analyze.py -q --basetemp .pytest-tmp-video-download-response-cap`
- `uv run --extra dev python -m ruff check tools\vision_tools.py tests\tools\test_video_analyze.py`
- `git diff --check`

## Autoreview

Not run: `.agents\skills\autoreview` is not present in this worktree.
