### PR TITLE
fix(zai): bound in-flight model calls to Z.AI under subagent swarms

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -886,6 +886,7 @@ def init_agent(
         agent.client = MoAClient(
             agent.model or "default",
             reference_callback=_moa_reference_relay,
+            interrupt_check=lambda: bool(agent._interrupt_requested),
         )
         agent._client_kwargs = {}
         agent.api_key = api_key or "moa-virtual-provider"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1324,11 +1324,20 @@ def run_conversation(
                             allow_stream=False,
                             is_github_responses=agent._is_copilot_url(),
                         )
-                    if _use_streaming:
-                        return agent._interruptible_streaming_api_call(
-                            next_api_kwargs, on_first_delta=_stop_spinner
-                        )
-                    return agent._interruptible_api_call(next_api_kwargs)
+
+                    from agent.zai_concurrency import acquire_zai_slot
+
+                    with acquire_zai_slot(
+                        provider=agent.provider,
+                        model=agent.model,
+                        base_url=agent.base_url,
+                        interrupt_check=lambda: bool(agent._interrupt_requested),
+                    ):
+                        if _use_streaming:
+                            return agent._interruptible_streaming_api_call(
+                                next_api_kwargs, on_first_delta=_stop_spinner
+                            )
+                        return agent._interruptible_api_call(next_api_kwargs)
 
                 from hermes_cli.middleware import run_llm_execution_middleware
 

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -173,6 +174,51 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
     return out
 
 
+def _call_moa_model(
+    *,
+    runtime: dict[str, Any],
+    interrupt_check: Callable[[], bool] | None = None,
+    **call_kwargs: Any,
+) -> Any:
+    """Call one resolved MoA model under the shared Z.AI gate when needed.
+
+    Non-Z.AI routes call ``call_llm`` directly. A Z.AI streaming call keeps
+    the slot for the full iterator lifetime, not merely until the SDK returns
+    the stream object.
+    """
+    from agent.zai_concurrency import acquire_zai_slot, is_zai_request
+
+    target = {
+        "provider": runtime.get("provider"),
+        "model": runtime.get("model"),
+        "base_url": runtime.get("base_url"),
+    }
+    if not is_zai_request(**target):
+        return call_llm(**call_kwargs, **runtime)
+
+    def _slot():
+        return acquire_zai_slot(
+            **target,
+            interrupt_check=interrupt_check,
+        )
+
+    if not call_kwargs.get("stream"):
+        with _slot():
+            return call_llm(**call_kwargs, **runtime)
+
+    def _gated_stream():
+        with _slot():
+            stream = call_llm(**call_kwargs, **runtime)
+            try:
+                yield from stream
+            finally:
+                close = getattr(stream, "close", None)
+                if callable(close):
+                    close()
+
+    return _gated_stream()
+
+
 def _maybe_apply_moa_cache_control(
     messages: list[dict[str, Any]],
     runtime: dict[str, Any],
@@ -223,6 +269,7 @@ def _run_reference(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    interrupt_check: Callable[[], bool] | None = None,
 ) -> tuple[str, str, Any]:
     """Call one reference model and return ``(label, text, usage)``.
 
@@ -270,12 +317,13 @@ def _run_reference(
         # (their caching is automatic; markers are ignored harmlessly, but we
         # only decorate when the policy says the route honors them).
         messages = _maybe_apply_moa_cache_control(messages, runtime)
-        response = call_llm(
+        response = _call_moa_model(
+            runtime=runtime,
+            interrupt_check=interrupt_check,
             task="moa_reference",
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
-            **runtime,
         )
         usage = CanonicalUsage()
         raw_usage = getattr(response, "usage", None)
@@ -339,6 +387,7 @@ def _run_references_parallel(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    interrupt_check: Callable[[], bool] | None = None,
 ) -> list[tuple[str, str, Any]]:
     """Fan out all reference models in parallel, returning outputs in order.
 
@@ -375,6 +424,7 @@ def _run_references_parallel(
                     ref_messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
+                    interrupt_check=interrupt_check,
                 )
             ] = idx
         # Collect every reference before returning — the aggregator needs the
@@ -633,12 +683,12 @@ def aggregate_moa_context(
         agg_messages = _maybe_apply_moa_cache_control(
             [{"role": "user", "content": synth_prompt}], agg_runtime
         )
-        response = call_llm(
+        response = _call_moa_model(
+            runtime=agg_runtime,
             task="moa_aggregator",
             messages=agg_messages,
             temperature=aggregator_temperature,
             max_tokens=max_tokens,
-            **agg_runtime,
         )
         synthesis = _extract_text(response)
     except Exception as exc:
@@ -683,7 +733,12 @@ def _attach_reference_guidance(agg_messages: list[dict[str, Any]], guidance: str
 class MoAChatCompletions:
     """OpenAI-chat-compatible facade where the aggregator is the acting model."""
 
-    def __init__(self, preset_name: str, reference_callback: Any = None):
+    def __init__(
+        self,
+        preset_name: str,
+        reference_callback: Any = None,
+        interrupt_check: Callable[[], bool] | None = None,
+    ):
         self.preset_name = preset_name or "default"
         # Optional display hook. Called as reference outputs become available so
         # frontends can show each reference model's answer as a labelled block
@@ -694,6 +749,7 @@ class MoAChatCompletions:
         #   "moa.aggregating" kwargs: aggregator (label), ref_count
         # Never raises into the model call — display is best-effort.
         self.reference_callback = reference_callback
+        self.interrupt_check = interrupt_check
         # State-scoped reference cache. The agent loop calls create() once per
         # tool-loop iteration; references should re-run whenever the task STATE
         # advances — i.e. on every new user message AND every new tool result —
@@ -902,6 +958,7 @@ class MoAChatCompletions:
                 ref_messages,
                 temperature=temperature,
                 max_tokens=reference_max_tokens,
+                interrupt_check=self.interrupt_check,
             )
             self._ref_cache_key = _cache_key
             self._ref_cache_outputs = list(reference_outputs)
@@ -1010,7 +1067,9 @@ class MoAChatCompletions:
             # actually governs the aggregator stream, not just call_llm's default.
             if api_kwargs.get("timeout") is not None:
                 stream_kwargs["timeout"] = api_kwargs["timeout"]
-        _agg_response = call_llm(
+        _agg_response = _call_moa_model(
+            runtime=_slot_runtime(aggregator),
+            interrupt_check=self.interrupt_check,
             task="moa_aggregator",
             messages=agg_messages,
             temperature=aggregator_temperature,
@@ -1018,7 +1077,6 @@ class MoAChatCompletions:
             tools=agg_kwargs.get("tools"),
             extra_body=agg_kwargs.get("extra_body"),
             **stream_kwargs,
-            **_slot_runtime(aggregator),
         )
         # Non-streaming path (quiet mode / eval / subagents): the aggregator
         # output is available inline, so capture it into the pending trace now.
@@ -1039,9 +1097,18 @@ class MoAChatCompletions:
 
 
 class MoAClient:
-    def __init__(self, preset_name: str, reference_callback: Any = None):
+    def __init__(
+        self,
+        preset_name: str,
+        reference_callback: Any = None,
+        interrupt_check: Callable[[], bool] | None = None,
+    ):
         self.chat = type("_MoAChat", (), {})()
-        self.chat.completions = MoAChatCompletions(preset_name, reference_callback=reference_callback)
+        self.chat.completions = MoAChatCompletions(
+            preset_name,
+            reference_callback=reference_callback,
+            interrupt_check=interrupt_check,
+        )
 
     def consume_reference_usage(self) -> Any:
         """Pop the pending reference-fan-out usage from the completions facade.

--- a/agent/zai_concurrency.py
+++ b/agent/zai_concurrency.py
@@ -1,0 +1,185 @@
+"""Process-local concurrency gate for Z.AI / GLM model calls.
+
+Z.AI Coding Plan can return HTTP 429 / code 1305 under concurrent load.
+Subagent and Mixture-of-Agents fan-out can otherwise keep several long-lived
+requests and their retries in flight at once. This module applies one strict
+process-local bound to calls that resolve to the Z.AI endpoint.
+
+The gate deliberately does not use the model name alone: GLM models can be
+served by local or third-party endpoints that should not be throttled. A call
+is gated only when its resolved provider or base URL identifies Z.AI.
+
+Scope and limitations
+---------------------
+- The semaphore is process-local. Separate Hermes processes that share one API
+  key each have their own limit, so fleet operators may need a lower
+  per-process value.
+- Non-Z.AI providers and a disabled gate pass through unchanged.
+- Saturated calls queue instead of bypassing the cap. Interactive waits poll
+  for an interrupt. A positive acquire timeout raises locally without sending
+  a request; the default timeout of zero waits until a slot or an interrupt.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from typing import Any, Optional
+
+from utils import env_float, env_int
+
+# Field reports show the Coding Plan endpoint remains stable at two concurrent
+# calls while four can still trigger 1305 overload responses.
+# 0 disables the gate entirely.
+_ZAI_MAX_CONCURRENT = max(0, env_int("HERMES_ZAI_MAX_CONCURRENT", 2))
+
+# 0 waits until a slot becomes available. A positive value raises
+# ZaiConcurrencyTimeout after the configured number of seconds.
+_ZAI_ACQUIRE_TIMEOUT = max(0.0, env_float("HERMES_ZAI_ACQUIRE_TIMEOUT_S", 0.0))
+_ZAI_ACQUIRE_POLL_INTERVAL = 0.1
+
+_ZAI_HOST_MARKERS = ("api.z.ai", "bigmodel.cn")
+
+
+class ZaiConcurrencyTimeout(TimeoutError):
+    """Raised when a configured Z.AI slot wait expires."""
+
+
+class _ZaiConcurrencyGate:
+    """Lazy, thread-safe holder for the process-wide Z.AI semaphore."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sem: Optional[threading.BoundedSemaphore] = None
+        self._configured_max = _ZAI_MAX_CONCURRENT
+
+    def _semaphore(self) -> Optional[threading.BoundedSemaphore]:
+        if self._configured_max <= 0:
+            return None
+        if self._sem is None:
+            with self._lock:
+                if self._sem is None:
+                    self._sem = threading.BoundedSemaphore(self._configured_max)
+        return self._sem
+
+    def is_zai(self, *, provider: Any, model: Any, base_url: Any) -> bool:
+        """Return whether the resolved destination is Z.AI / Zhipu."""
+        host = str(base_url or "").lower()
+        if any(marker in host for marker in _ZAI_HOST_MARKERS):
+            return True
+        provider_name = str(provider or "").lower()
+        return provider_name in {"zai", "zhipu", "glm", "z-ai", "z.ai"}
+
+
+_gate = _ZaiConcurrencyGate()
+
+
+def is_zai_request(*, provider: Any, model: Any, base_url: Any) -> bool:
+    """Return whether a model call targets Z.AI / Zhipu."""
+    return _gate.is_zai(provider=provider, model=model, base_url=base_url)
+
+
+def acquire_zai_slot(
+    *,
+    provider: Any,
+    model: Any,
+    base_url: Any,
+    interrupt_check: Optional[Callable[[], bool]] = None,
+) -> "_SlotHandle":
+    """Return a context manager that acquires a Z.AI slot on entry.
+
+    Creating a handle without entering it never consumes capacity. Non-Z.AI
+    requests and a disabled gate receive a no-op context manager.
+    """
+    if not is_zai_request(provider=provider, model=model, base_url=base_url):
+        return _NoopHandle()
+    sem = _gate._semaphore()
+    if sem is None:
+        return _NoopHandle()
+    return _SlotHandle(
+        sem,
+        timeout=_ZAI_ACQUIRE_TIMEOUT,
+        interrupt_check=interrupt_check,
+    )
+
+
+class _SlotHandle:
+    """Acquire one semaphore slot on entry and release it on exit."""
+
+    __slots__ = ("_acquired", "_entered", "_interrupt_check", "_sem", "_timeout")
+
+    def __init__(
+        self,
+        sem: threading.BoundedSemaphore,
+        *,
+        timeout: float,
+        interrupt_check: Optional[Callable[[], bool]],
+    ) -> None:
+        self._sem = sem
+        self._timeout = timeout
+        self._interrupt_check = interrupt_check
+        self._entered = False
+        self._acquired = False
+
+    def __enter__(self) -> "_SlotHandle":
+        if self._entered:
+            raise RuntimeError("Z.AI concurrency slot handle cannot be re-entered")
+        self._entered = True
+
+        deadline = time.monotonic() + self._timeout if self._timeout > 0 else None
+        while True:
+            if self._interrupt_check is not None and self._interrupt_check():
+                raise InterruptedError(
+                    "Agent interrupted while waiting for a Z.AI concurrency slot"
+                )
+
+            wait_for = _ZAI_ACQUIRE_POLL_INTERVAL
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ZaiConcurrencyTimeout(
+                        f"Timed out after {self._timeout:g}s waiting for a "
+                        "Z.AI concurrency slot"
+                    )
+                wait_for = min(wait_for, remaining)
+
+            if self._sem.acquire(timeout=wait_for):
+                self._acquired = True
+                if self._interrupt_check is not None and self._interrupt_check():
+                    self._acquired = False
+                    self._sem.release()
+                    raise InterruptedError(
+                        "Agent interrupted while waiting for a Z.AI concurrency slot"
+                    )
+                return self
+
+    def __exit__(self, *exc: Any) -> None:
+        if self._acquired:
+            self._acquired = False
+            self._sem.release()
+
+
+class _NoopHandle:
+    """Pass-through context manager for non-Z.AI or disabled calls."""
+
+    __slots__ = ()
+
+    def __enter__(self) -> "_NoopHandle":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+
+def configured_max_concurrent() -> int:
+    """Return the configured Z.AI in-flight cap; zero means disabled."""
+    return _ZAI_MAX_CONCURRENT
+
+
+def _reset_for_tests(max_concurrent: int, timeout: float) -> None:
+    """Rebuild the process-local gate with explicit settings."""
+    global _ZAI_MAX_CONCURRENT, _ZAI_ACQUIRE_TIMEOUT, _gate
+    _ZAI_MAX_CONCURRENT = max(0, max_concurrent)
+    _ZAI_ACQUIRE_TIMEOUT = max(0.0, timeout)
+    _gate = _ZaiConcurrencyGate()

--- a/tests/agent/test_moa_zai_concurrency.py
+++ b/tests/agent/test_moa_zai_concurrency.py
@@ -1,0 +1,138 @@
+"""Integration tests for Z.AI gating inside Mixture-of-Agents calls."""
+
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent import moa_loop, zai_concurrency
+
+
+def _response(content="ok"):
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="glm-5.2")
+
+
+def _zai_runtime(slot):
+    return {
+        "provider": "zai",
+        "model": slot.get("model") or "glm-5.2",
+        "base_url": "https://api.z.ai/api/coding/paas/v4",
+        "api_key": "test-key",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _stable_gate():
+    zai_concurrency._reset_for_tests(2, 0.0)
+    yield
+    zai_concurrency._reset_for_tests(2, 0.0)
+
+
+def test_parallel_moa_references_share_process_cap(monkeypatch):
+    in_flight = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def fake_call_llm(**kwargs):
+        nonlocal in_flight, peak
+        with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        time.sleep(0.03)
+        with lock:
+            in_flight -= 1
+        return _response(kwargs["model"])
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(moa_loop, "_slot_runtime", _zai_runtime)
+    monkeypatch.setattr(
+        "agent.usage_pricing.estimate_usage_cost",
+        lambda *args, **kwargs: SimpleNamespace(
+            amount_usd=None,
+            status="unknown",
+            source=None,
+        ),
+    )
+
+    refs = [{"provider": "zai", "model": f"glm-{index}"} for index in range(6)]
+    out = moa_loop._run_references_parallel(
+        refs,
+        [{"role": "user", "content": "review"}],
+    )
+
+    assert len(out) == 6
+    assert peak == 2
+
+
+def test_zai_stream_holds_slot_until_iterator_finishes(monkeypatch):
+    zai_concurrency._reset_for_tests(1, 0.0)
+    release_first = threading.Event()
+    first_created = threading.Event()
+    calls = []
+    lock = threading.Lock()
+
+    class _Stream:
+        def __init__(self, index):
+            self.index = index
+            self.done = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.done:
+                raise StopIteration
+            self.done = True
+            if self.index == 1:
+                release_first.wait(timeout=2)
+            return self.index
+
+    def fake_call_llm(**kwargs):
+        with lock:
+            calls.append(kwargs)
+            index = len(calls)
+        if index == 1:
+            first_created.set()
+        return _Stream(index)
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    runtime = _zai_runtime({"model": "glm-5.2"})
+    outputs = []
+
+    def consume():
+        outputs.append(
+            list(
+                moa_loop._call_moa_model(
+                    runtime=runtime,
+                    task="moa_aggregator",
+                    messages=[],
+                    stream=True,
+                )
+            )
+        )
+
+    first = threading.Thread(target=consume)
+    second = threading.Thread(target=consume)
+    first.start()
+    assert first_created.wait(timeout=1)
+    second.start()
+    time.sleep(0.05)
+
+    assert len(calls) == 1
+    release_first.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert len(calls) == 2
+    assert sorted(outputs) == [[1], [2]]
+
+
+def test_moa_client_preserves_interrupt_check():
+    interrupt_check = lambda: True
+    client = moa_loop.MoAClient("review", interrupt_check=interrupt_check)
+    assert client.chat.completions.interrupt_check is interrupt_check

--- a/tests/agent/test_zai_concurrency.py
+++ b/tests/agent/test_zai_concurrency.py
@@ -1,0 +1,235 @@
+"""Tests for the process-local Z.AI concurrency gate."""
+
+import importlib
+import threading
+import time
+
+import pytest
+
+from agent import zai_concurrency
+
+
+def _reset(max_concurrent=2, timeout=0.0):
+    zai_concurrency._reset_for_tests(max_concurrent, timeout)
+
+
+@pytest.fixture(autouse=True)
+def _stable_gate():
+    _reset()
+    yield
+    _reset()
+
+
+class TestDetection:
+    @pytest.mark.parametrize(
+        ("provider", "base_url"),
+        [
+            ("zai", ""),
+            ("ZAI", ""),
+            ("zhipu", ""),
+            ("glm", ""),
+            ("z-ai", ""),
+            ("Z.AI", ""),
+            ("custom", "https://api.z.ai/api/coding/paas/v4"),
+            ("custom", "https://open.bigmodel.cn/api/paas/v4"),
+        ],
+    )
+    def test_zai_provider_and_host_markers(self, provider, base_url):
+        assert zai_concurrency.is_zai_request(
+            provider=provider,
+            model="glm-5.2",
+            base_url=base_url,
+        )
+
+    @pytest.mark.parametrize(
+        ("provider", "model", "base_url"),
+        [
+            ("openai", "gpt-5", "https://api.openai.com/v1"),
+            ("anthropic", "claude-opus-4", "https://api.anthropic.com"),
+            ("custom", "glm-5.2", "http://localhost:8080/v1"),
+            (None, None, None),
+        ],
+    )
+    def test_non_zai_routes_are_not_gated(self, provider, model, base_url):
+        assert not zai_concurrency.is_zai_request(
+            provider=provider,
+            model=model,
+            base_url=base_url,
+        )
+
+
+class TestLifecycle:
+    def test_non_zai_and_disabled_gate_pass_through(self):
+        with zai_concurrency.acquire_zai_slot(
+            provider="openai",
+            model="gpt-5",
+            base_url="https://api.openai.com/v1",
+        ):
+            pass
+
+        _reset(0)
+        with zai_concurrency.acquire_zai_slot(
+            provider="zai",
+            model="glm-5.2",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        ):
+            pass
+
+    def test_slot_is_acquired_on_enter_not_handle_creation(self):
+        _reset(1)
+        sem = zai_concurrency._gate._semaphore()
+        handle = zai_concurrency.acquire_zai_slot(
+            provider="zai",
+            model="glm-5.2",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+
+        assert sem.acquire(blocking=False)
+        sem.release()
+
+        with handle:
+            assert not sem.acquire(blocking=False)
+        assert sem.acquire(blocking=False)
+        sem.release()
+
+    def test_slot_is_released_after_exception(self):
+        _reset(1)
+        sem = zai_concurrency._gate._semaphore()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with zai_concurrency.acquire_zai_slot(
+                provider="zai",
+                model="glm-5.2",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+            ):
+                raise RuntimeError("boom")
+
+        assert sem.acquire(blocking=False)
+        sem.release()
+
+    def test_handle_cannot_be_reentered(self):
+        handle = zai_concurrency.acquire_zai_slot(
+            provider="zai",
+            model="glm-5.2",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+        with handle:
+            pass
+        with pytest.raises(RuntimeError, match="cannot be re-entered"):
+            with handle:
+                pass
+
+
+class TestStrictBound:
+    def test_parallel_calls_never_exceed_cap(self):
+        _reset(2)
+        observed_peak = 0
+        in_flight = 0
+        lock = threading.Lock()
+
+        def _worker():
+            nonlocal observed_peak, in_flight
+            with zai_concurrency.acquire_zai_slot(
+                provider="zai",
+                model="glm-5.2",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+            ):
+                with lock:
+                    in_flight += 1
+                    observed_peak = max(observed_peak, in_flight)
+                time.sleep(0.03)
+                with lock:
+                    in_flight -= 1
+
+        threads = [threading.Thread(target=_worker) for _ in range(10)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=2)
+            assert not thread.is_alive()
+
+        assert observed_peak == 2
+
+    def test_timeout_raises_instead_of_proceeding_uncapped(self):
+        _reset(1, timeout=0.03)
+        sem = zai_concurrency._gate._semaphore()
+        assert sem.acquire()
+
+        with pytest.raises(zai_concurrency.ZaiConcurrencyTimeout):
+            with zai_concurrency.acquire_zai_slot(
+                provider="zai",
+                model="glm-5.2",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+            ):
+                pytest.fail("a timed-out caller must never enter uncapped")
+
+        assert not sem.acquire(blocking=False)
+        sem.release()
+
+    def test_interrupt_stops_wait_without_releasing_foreign_slot(self):
+        _reset(1)
+        sem = zai_concurrency._gate._semaphore()
+        assert sem.acquire()
+
+        with pytest.raises(InterruptedError):
+            with zai_concurrency.acquire_zai_slot(
+                provider="zai",
+                model="glm-5.2",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+                interrupt_check=lambda: True,
+            ):
+                pytest.fail("an interrupted caller must not enter")
+
+        assert not sem.acquire(blocking=False)
+        sem.release()
+
+    def test_interrupt_racing_with_acquire_returns_newly_granted_slot(self):
+        interrupted = False
+
+        class _RaceSemaphore:
+            releases = 0
+
+            def acquire(self, timeout):
+                nonlocal interrupted
+                interrupted = True
+                return True
+
+            def release(self):
+                self.releases += 1
+
+        sem = _RaceSemaphore()
+        handle = zai_concurrency._SlotHandle(
+            sem,
+            timeout=0.0,
+            interrupt_check=lambda: interrupted,
+        )
+
+        with pytest.raises(InterruptedError):
+            with handle:
+                pytest.fail("an interrupt that races with acquire must win")
+
+        assert sem.releases == 1
+
+
+class TestConfiguration:
+    def test_defaults_are_strict_cap_two_with_unbounded_wait(self, monkeypatch):
+        monkeypatch.delenv("HERMES_ZAI_MAX_CONCURRENT", raising=False)
+        monkeypatch.delenv("HERMES_ZAI_ACQUIRE_TIMEOUT_S", raising=False)
+        reloaded = importlib.reload(zai_concurrency)
+        try:
+            assert reloaded.configured_max_concurrent() == 2
+            assert reloaded._ZAI_ACQUIRE_TIMEOUT == 0.0
+        finally:
+            reloaded._reset_for_tests(2, 0.0)
+
+    def test_environment_overrides_cap_and_fractional_timeout(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ZAI_MAX_CONCURRENT", "7")
+        monkeypatch.setenv("HERMES_ZAI_ACQUIRE_TIMEOUT_S", "0.5")
+        reloaded = importlib.reload(zai_concurrency)
+        try:
+            assert reloaded.configured_max_concurrent() == 7
+            assert reloaded._ZAI_ACQUIRE_TIMEOUT == pytest.approx(0.5)
+        finally:
+            monkeypatch.delenv("HERMES_ZAI_MAX_CONCURRENT", raising=False)
+            monkeypatch.delenv("HERMES_ZAI_ACQUIRE_TIMEOUT_S", raising=False)
+            importlib.reload(zai_concurrency)._reset_for_tests(2, 0.0)

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -280,6 +280,12 @@ Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_U
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
 :::
 
+:::note Z.AI Concurrency Bound
+Hermes limits direct-agent and MoA calls to Z.AI to two simultaneous in-flight requests per process by default. This prevents a subagent or MoA fan-out from sustaining code 1305 overload retries and repeatedly re-sending a large context. Set `HERMES_ZAI_MAX_CONCURRENT` to tune the cap, or `0` to disable it.
+
+The bound is process-local. If several CLI or gateway processes share one Coding Plan key, their effective combined ceiling is the number of processes multiplied by the per-process value; fleet operators should usually keep the value at `1` or `2`. `HERMES_ZAI_ACQUIRE_TIMEOUT_S` optionally bounds how long a caller waits for a slot (default `0`, meaning wait until a slot is available). This gate does not change the separate rolling usage quota or its "Usage limit reached for 5 hour" response.
+:::
+
 ### xAI (Grok) — Responses API + Prompt Caching
 
 xAI is wired through the Responses API (`codex_responses` transport) for automatic reasoning support on Grok 4 models — no `reasoning_effort` parameter needed, the server reasons by default. Set `XAI_API_KEY` in `~/.hermes/.env` and pick xAI in `hermes model`, or drop `grok` as a shortcut into `/model grok-4-fast-reasoning`.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -759,6 +759,8 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_AGENT_HELP_GUIDANCE` | Append additional guidance text to the system prompt for custom deployments. |
 | `HERMES_AGENT_LOGO` | Override the ASCII banner logo at CLI startup. |
 | `DELEGATION_MAX_CONCURRENT_CHILDREN` | Max parallel subagents per `delegate_task` batch (default: `3`, floor of 1, no ceiling). Also configurable via `delegation.max_concurrent_children` in `config.yaml` — the config value takes priority. |
+| `HERMES_ZAI_MAX_CONCURRENT` | Strict process-local cap for simultaneous Z.AI / Zhipu model calls from the agent and MoA paths (default: `2`; `0` disables the gate). Separate processes have separate caps. |
+| `HERMES_ZAI_ACQUIRE_TIMEOUT_S` | Seconds to wait for a Z.AI concurrency slot before raising locally without contacting the provider. Accepts fractional seconds. Default: `0` (wait until a slot is available; interactive waits remain interruptible). |
 
 ## Interface
 


### PR DESCRIPTION
## Summary

Adds a strict, process-local concurrency bound for Z.AI / Zhipu model calls made by direct agents, delegated subagents, and Mixture-of-Agents (MoA). The goal is to stop a fan-out from sustaining `HTTP 429 / code 1305` overload retries against the Coding Plan endpoint.

The important correction in this revision is that saturation now **queues** instead of silently proceeding uncapped. The previous best-effort timeout path could exceed the configured ceiling exactly when the provider was already overloaded.

## Why this matters

A 1305 retry storm is more than a latency problem. In the field report on this PR, overloaded Coding Plan calls carried roughly 130k tokens and could be attempted up to six times, repeatedly re-sending the same large context and consuming the rolling quota. A five-profile deployment sharing one key reported zero 1305 responses in its active observation window after setting the cap to `2`, while MoA continued to run normally.

MoA makes the bound especially important: reference models fan out in parallel and the acting aggregator uses its resolved provider route on every relevant iteration. If that aggregator is GLM on Z.AI, the outer virtual `moa` provider is not enough to identify or limit the real requests.

## What changed

- Added one lazy, process-wide `BoundedSemaphore` for resolved Z.AI destinations.
- Changed the default cap from `4` to `2`; `HERMES_ZAI_MAX_CONCURRENT=0` disables it.
- Moved acquisition into context entry so an unused handle cannot leak a slot.
- Made the cap strict: a positive `HERMES_ZAI_ACQUIRE_TIMEOUT_S` raises locally without contacting the provider; the default `0` waits for a slot.
- Made waiting interruptible and closed the race where an interrupt arrives at the same instant a slot is granted.
- Preserved the current `codex_responses` preflight while rebasing the main call path.
- Applied the same shared gate to MoA reference calls and the resolved acting aggregator.
- Kept a Z.AI streaming slot for the stream's full iterator lifetime, not only until the SDK returns the stream object.
- Added operator documentation, including the multi-process fleet caveat and the separate five-hour usage quota.

Non-Z.AI providers still take the direct no-op path. A bare `glm-*` model name is intentionally insufficient for detection because local and third-party endpoints can serve GLM models without being Z.AI.

## Scope and limitations

The semaphore is process-local. If several CLI or gateway processes share one key, the effective ceiling is:

`process count × HERMES_ZAI_MAX_CONCURRENT`

Fleet operators should normally keep the per-process value at `1` or `2`. Cross-process coordination remains separate work.

This patch does not reinterpret the hard `Usage limit reached for 5 hour` response; that is a rolling spend quota, not concurrency overload. The adjacent client-identity concern raised in the field report is also separate from concurrency and is intentionally not mixed into this focused patch.

## Verification

Three independent verification layers passed on the rebased final commit:

1. **Focused gate and MoA tests:** 25 passed, including acquire-on-enter, strict timeout, foreign-slot safety, interrupt races, six parallel MoA references, and full streaming-lifetime ownership.
2. **Behavioral integration:** 152 related MoA/retry/interrupt/system-prompt tests passed; the complete streaming suite passed with 44 tests.
3. **Broad regression pass:** 729 agent, auxiliary-client, compression-timeout, and run-agent tests passed.

Additional checks:

- 100-thread stress simulation held the peak at exactly 2 and restored full capacity after injected exceptions.
- `ruff`, `py_compile`, and `git diff --check` passed.
- Manual diff/security review found no secret handling, persistence, command execution, or network destination changes outside the intended provider calls.
- Added lines and commit metadata contain no personal name, email, or local filesystem path; the commit uses the pseudonymous GitHub noreply identity.