### PR TITLE
fix(matrix): stream inbound media under cap

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -139,6 +139,58 @@ _MATRIX_BANG_COMMAND_RE = re.compile(
 )
 
 
+class _MatrixInboundMediaTooLarge(ValueError):
+    """Raised when an inbound Matrix media response exceeds the configured cap."""
+
+
+async def _read_matrix_response_bytes_capped(resp: Any, limit: int) -> bytes:
+    raw_length = None
+    try:
+        headers = getattr(resp, "headers", {}) or {}
+        raw_length = headers.get("Content-Length") or headers.get("content-length")
+    except Exception:
+        raw_length = None
+    if raw_length is not None:
+        try:
+            content_length = int(raw_length)
+        except (TypeError, ValueError):
+            content_length = 0
+        if content_length > limit:
+            raise _MatrixInboundMediaTooLarge(
+                f"Matrix media response exceeds limit ({content_length} > {limit} bytes)"
+            )
+
+    content = getattr(resp, "content", None)
+    iter_chunked = getattr(content, "iter_chunked", None)
+    if callable(iter_chunked):
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in iter_chunked(65536):
+            data = bytes(chunk)
+            total += len(data)
+            if total > limit:
+                raise _MatrixInboundMediaTooLarge(
+                    f"Matrix media response exceeds limit (> {limit} bytes)"
+                )
+            chunks.append(data)
+        return b"".join(chunks)
+
+    read = getattr(resp, "read", None)
+    if callable(read):
+        try:
+            body = await read(limit + 1)
+        except TypeError:
+            body = await read()
+        body = bytes(body or b"")
+        if len(body) > limit:
+            raise _MatrixInboundMediaTooLarge(
+                f"Matrix media response exceeds limit ({len(body)} > {limit} bytes)"
+            )
+        return body
+
+    raise TypeError("Matrix media response body is not readable")
+
+
 def _resolve_matrix_bang_command(name: str) -> str | None:
     """Resolve a ``!command`` token to a dispatchable Hermes command token.
 
@@ -2768,7 +2820,7 @@ class MatrixAdapter(BasePlatformAdapter):
         } or is_voice_message or is_encrypted_media
         if should_cache_locally and url:
             try:
-                file_bytes = await self._client.download_media(ContentURI(url))
+                file_bytes = await self._download_mxc_media_with_cap(url)
                 if file_bytes is not None:
                     if is_encrypted_media:
                         from mautrix.crypto.attachments import decrypt_attachment
@@ -2846,6 +2898,9 @@ class MatrixAdapter(BasePlatformAdapter):
                             cached_path = cache_document_from_bytes(
                                 file_bytes, filename
                             )
+            except _MatrixInboundMediaTooLarge as e:
+                logger.warning("[Matrix] Rejecting oversized inbound media %s: %s", event_id, e)
+                return
             except Exception as e:
                 logger.warning("[Matrix] Failed to cache media: %s", e)
 
@@ -4057,6 +4112,70 @@ class MatrixAdapter(BasePlatformAdapter):
             return mxc_url
         parts = mxc_url[6:]  # strip mxc://
         return f"{self._homeserver}/_matrix/client/v1/media/download/{parts}"
+
+    async def _download_mxc_media_with_cap(self, url: str) -> Optional[bytes]:
+        client = self._client
+        api = getattr(client, "api", None)
+        api_type = type(api)
+        has_real_mautrix_api = (
+            api is not None
+            and api_type.__module__ != "unittest.mock"
+            and callable(getattr(api_type, "get_download_url", None))
+            and getattr(api, "session", None) is not None
+        )
+        if not has_real_mautrix_api:
+            data = await client.download_media(ContentURI(url))
+            if data is not None and len(data) > self._max_media_bytes:
+                raise _MatrixInboundMediaTooLarge(
+                    f"Matrix media response exceeds limit ({len(data)} > {self._max_media_bytes} bytes)"
+                )
+            return data
+
+        authenticated = False
+        try:
+            from mautrix.types import SpecVersions
+
+            authenticated = bool((await client.versions()).supports(SpecVersions.V111))
+        except Exception:
+            authenticated = False
+
+        download_url = api.get_download_url(ContentURI(url), authenticated=authenticated)
+        query_params: dict[str, Any] = {"allow_redirect": "true"}
+        headers: dict[str, str] = {}
+        if authenticated:
+            token = str(getattr(api, "token", "") or "")
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+            as_user_id = getattr(api, "as_user_id", None)
+            if as_user_id:
+                query_params["user_id"] = str(as_user_id)
+
+        req_id = None
+        start = time.monotonic()
+        log_download_request = getattr(api, "log_download_request", None)
+        if callable(log_download_request):
+            req_id = log_download_request(download_url, query_params)
+
+        async with api.session.get(
+            download_url,
+            params=query_params,
+            headers=headers,
+        ) as response:
+            try:
+                response.raise_for_status()
+                return await _read_matrix_response_bytes_capped(
+                    response,
+                    self._max_media_bytes,
+                )
+            finally:
+                log_download_done = getattr(api, "log_download_request_done", None)
+                if callable(log_download_done) and req_id is not None:
+                    log_download_done(
+                        download_url,
+                        req_id,
+                        time.monotonic() - start,
+                        getattr(response, "status", 0),
+                    )
 
     def _markdown_to_html(self, text: str) -> str:
         """Convert Markdown to Matrix-compatible HTML (org.matrix.custom.html).

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -281,6 +281,58 @@ _MATRIX_BANG_COMMAND_RE = re.compile(
 )
 
 
+class _MatrixInboundMediaTooLarge(ValueError):
+    """Raised when an inbound Matrix media response exceeds the configured cap."""
+
+
+async def _read_matrix_response_bytes_capped(resp: Any, limit: int) -> bytes:
+    raw_length = None
+    try:
+        headers = getattr(resp, "headers", {}) or {}
+        raw_length = headers.get("Content-Length") or headers.get("content-length")
+    except Exception:
+        raw_length = None
+    if raw_length is not None:
+        try:
+            content_length = int(raw_length)
+        except (TypeError, ValueError):
+            content_length = 0
+        if content_length > limit:
+            raise _MatrixInboundMediaTooLarge(
+                f"Matrix media response exceeds limit ({content_length} > {limit} bytes)"
+            )
+
+    content = getattr(resp, "content", None)
+    iter_chunked = getattr(content, "iter_chunked", None)
+    if callable(iter_chunked):
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in iter_chunked(65536):
+            data = bytes(chunk)
+            total += len(data)
+            if total > limit:
+                raise _MatrixInboundMediaTooLarge(
+                    f"Matrix media response exceeds limit (> {limit} bytes)"
+                )
+            chunks.append(data)
+        return b"".join(chunks)
+
+    read = getattr(resp, "read", None)
+    if callable(read):
+        try:
+            body = await read(limit + 1)
+        except TypeError:
+            body = await read()
+        body = bytes(body or b"")
+        if len(body) > limit:
+            raise _MatrixInboundMediaTooLarge(
+                f"Matrix media response exceeds limit ({len(body)} > {limit} bytes)"
+            )
+        return body
+
+    raise TypeError("Matrix media response body is not readable")
+
+
 def _resolve_matrix_bang_command(name: str) -> str | None:
     """Resolve a ``!command`` token to a dispatchable Hermes command token.
 
@@ -3599,7 +3651,7 @@ class MatrixAdapter(BasePlatformAdapter):
         } or is_voice_message or is_encrypted_media
         if should_cache_locally and url:
             try:
-                file_bytes = await self._client.download_media(ContentURI(url))
+                file_bytes = await self._download_mxc_media_with_cap(url)
                 if file_bytes is not None:
                     if is_encrypted_media:
                         from mautrix.crypto.attachments import decrypt_attachment
@@ -3677,6 +3729,9 @@ class MatrixAdapter(BasePlatformAdapter):
                             cached_path = cache_document_from_bytes(
                                 file_bytes, filename
                             )
+            except _MatrixInboundMediaTooLarge as e:
+                logger.warning("[Matrix] Rejecting oversized inbound media %s: %s", event_id, e)
+                return
             except Exception as e:
                 logger.warning("[Matrix] Failed to cache media: %s", e)
 
@@ -4960,6 +5015,70 @@ class MatrixAdapter(BasePlatformAdapter):
             return mxc_url
         parts = mxc_url[6:]  # strip mxc://
         return f"{self._homeserver}/_matrix/client/v1/media/download/{parts}"
+
+    async def _download_mxc_media_with_cap(self, url: str) -> Optional[bytes]:
+        client = self._client
+        api = getattr(client, "api", None)
+        api_type = type(api)
+        has_real_mautrix_api = (
+            api is not None
+            and api_type.__module__ != "unittest.mock"
+            and callable(getattr(api_type, "get_download_url", None))
+            and getattr(api, "session", None) is not None
+        )
+        if not has_real_mautrix_api:
+            data = await client.download_media(ContentURI(url))
+            if data is not None and len(data) > self._max_media_bytes:
+                raise _MatrixInboundMediaTooLarge(
+                    f"Matrix media response exceeds limit ({len(data)} > {self._max_media_bytes} bytes)"
+                )
+            return data
+
+        authenticated = False
+        try:
+            from mautrix.types import SpecVersions
+
+            authenticated = bool((await client.versions()).supports(SpecVersions.V111))
+        except Exception:
+            authenticated = False
+
+        download_url = api.get_download_url(ContentURI(url), authenticated=authenticated)
+        query_params: dict[str, Any] = {"allow_redirect": "true"}
+        headers: dict[str, str] = {}
+        if authenticated:
+            token = str(getattr(api, "token", "") or "")
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+            as_user_id = getattr(api, "as_user_id", None)
+            if as_user_id:
+                query_params["user_id"] = str(as_user_id)
+
+        req_id = None
+        start = time.monotonic()
+        log_download_request = getattr(api, "log_download_request", None)
+        if callable(log_download_request):
+            req_id = log_download_request(download_url, query_params)
+
+        async with api.session.get(
+            download_url,
+            params=query_params,
+            headers=headers,
+        ) as response:
+            try:
+                response.raise_for_status()
+                return await _read_matrix_response_bytes_capped(
+                    response,
+                    self._max_media_bytes,
+                )
+            finally:
+                log_download_done = getattr(api, "log_download_request_done", None)
+                if callable(log_download_done) and req_id is not None:
+                    log_download_done(
+                        download_url,
+                        req_id,
+                        time.monotonic() - start,
+                        getattr(response, "status", 0),
+                    )
 
     def _markdown_to_html(self, text: str) -> str:
         """Convert Markdown to Matrix-compatible HTML (org.matrix.custom.html).

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3273,6 +3273,78 @@ class TestMatrixReadReceipts:
 # Media normalization
 # ---------------------------------------------------------------------------
 
+class _ChunkedMatrixContent:
+    def __init__(self, chunks):
+        self.chunks = chunks
+        self.iter_chunked_sizes = []
+
+    async def iter_chunked(self, size):
+        self.iter_chunked_sizes.append(size)
+        for chunk in self.chunks:
+            yield chunk
+
+
+class _ChunkedMatrixResponse:
+    status = 200
+
+    def __init__(self, chunks, headers=None):
+        self.headers = headers or {}
+        self.content = _ChunkedMatrixContent(chunks)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    def raise_for_status(self):
+        return None
+
+
+class _ChunkedMatrixSession:
+    def __init__(self, response):
+        self.response = response
+        self.get_calls = []
+
+    def get(self, *args, **kwargs):
+        self.get_calls.append((args, kwargs))
+        return self.response
+
+
+class _ChunkedMatrixApi:
+    token = "syt_test_token"
+    as_user_id = None
+
+    def __init__(self, response):
+        self.session = _ChunkedMatrixSession(response)
+        self.download_urls = []
+        self.log_done_calls = []
+
+    def get_download_url(self, url, authenticated=False):
+        self.download_urls.append((url, authenticated))
+        return f"https://matrix.example.org/_matrix/media/v3/download/{str(url)[6:]}"
+
+    def log_download_request(self, url, query_params):
+        return 42
+
+    def log_download_request_done(self, url, req_id, duration, status):
+        self.log_done_calls.append((url, req_id, status))
+
+
+class _ChunkedMatrixVersions:
+    def supports(self, _version):
+        return False
+
+
+class _ChunkedMatrixClient:
+    def __init__(self, response):
+        self.api = _ChunkedMatrixApi(response)
+        self.download_media = AsyncMock()
+
+    async def versions(self):
+        return _ChunkedMatrixVersions()
+
+
 class TestMatrixImageOnlyMediaNormalization:
     def setup_method(self):
         self.adapter = _make_adapter()
@@ -3373,6 +3445,50 @@ class TestMatrixImageOnlyMediaNormalization:
 
         assert captured_event is None
         self.adapter._client.download_media.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mxc_media_download_streams_under_cap(self):
+        response = _ChunkedMatrixResponse([b"abc", b"def"])
+        self.adapter._client = _ChunkedMatrixClient(response)
+        self.adapter._max_media_bytes = 10
+
+        data = await self.adapter._download_mxc_media_with_cap("mxc://example/small.png")
+
+        assert data == b"abcdef"
+        assert response.content.iter_chunked_sizes == [65536]
+        self.adapter._client.download_media.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_inbound_mxc_media_rejects_oversized_stream_without_fallback(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        response = _ChunkedMatrixResponse([b"12345", b"67890", b"!"])
+        self.adapter._client = _ChunkedMatrixClient(response)
+        self.adapter._max_media_bytes = 10
+        self.adapter.handle_message = capture
+
+        await self.adapter._handle_media_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$image-stream-big",
+            event_ts=0.0,
+            source_content={
+                "msgtype": "m.image",
+                "body": "huge.png",
+                "url": "mxc://example/huge.png",
+                "info": {"mimetype": "image/png"},
+            },
+            relates_to={},
+            msgtype="m.image",
+        )
+
+        assert captured_event is None
+        self.adapter._client.download_media.assert_not_called()
+        assert response.content.iter_chunked_sizes == [65536]
 
     @pytest.mark.asyncio
     async def test_external_media_download_rejects_oversized_content_length(self, monkeypatch):

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1937,6 +1937,80 @@ class TestMatrixReadReceipts:
 # Media normalization
 # ---------------------------------------------------------------------------
 
+class _ChunkedMatrixContent:
+    def __init__(self, chunks):
+        self.chunks = chunks
+        self.iter_chunked_sizes = []
+
+    async def iter_chunked(self, size):
+        self.iter_chunked_sizes.append(size)
+        for chunk in self.chunks:
+            yield chunk
+
+
+class _ChunkedMatrixResponse:
+    status = 200
+
+    def __init__(self, chunks, headers=None):
+        self.headers = headers or {}
+        self.content = _ChunkedMatrixContent(chunks)
+        self.exited = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        self.exited = True
+        return None
+
+    def raise_for_status(self):
+        return None
+
+
+class _ChunkedMatrixSession:
+    def __init__(self, response):
+        self.response = response
+        self.get_calls = []
+
+    def get(self, *args, **kwargs):
+        self.get_calls.append((args, kwargs))
+        return self.response
+
+
+class _ChunkedMatrixApi:
+    token = "syt_test_token"
+    as_user_id = None
+
+    def __init__(self, response):
+        self.session = _ChunkedMatrixSession(response)
+        self.download_urls = []
+        self.log_done_calls = []
+
+    def get_download_url(self, url, authenticated=False):
+        self.download_urls.append((url, authenticated))
+        return f"https://matrix.example.org/_matrix/media/v3/download/{str(url)[6:]}"
+
+    def log_download_request(self, url, query_params):
+        return 42
+
+    def log_download_request_done(self, url, req_id, duration, status):
+        self.log_done_calls.append((url, req_id, status))
+
+
+class _ChunkedMatrixVersions:
+    def supports(self, _version):
+        return False
+
+
+class _ChunkedMatrixClient:
+    def __init__(self, response):
+        self.api = _ChunkedMatrixApi(response)
+        self.download_media = AsyncMock()
+
+    async def versions(self):
+        return _ChunkedMatrixVersions()
+
+
 class TestMatrixImageOnlyMediaNormalization:
     def setup_method(self):
         self.adapter = _make_adapter()
@@ -2011,6 +2085,51 @@ class TestMatrixImageOnlyMediaNormalization:
         assert captured_event is None
         self.adapter._client.download_media.assert_not_called()
 
+
+    @pytest.mark.asyncio
+    async def test_mxc_media_download_streams_under_cap(self):
+        response = _ChunkedMatrixResponse([b"abc", b"def"])
+        self.adapter._client = _ChunkedMatrixClient(response)
+        self.adapter._max_media_bytes = 10
+
+        data = await self.adapter._download_mxc_media_with_cap("mxc://example/small.png")
+
+        assert data == b"abcdef"
+        assert response.content.iter_chunked_sizes == [65536]
+        self.adapter._client.download_media.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_inbound_mxc_media_rejects_oversized_stream_without_fallback(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        response = _ChunkedMatrixResponse([b"12345", b"67890", b"!"])
+        self.adapter._client = _ChunkedMatrixClient(response)
+        self.adapter._max_media_bytes = 10
+        self.adapter.handle_message = capture
+
+        await self.adapter._handle_media_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$image-stream-big",
+            event_ts=0.0,
+            source_content={
+                "msgtype": "m.image",
+                "body": "huge.png",
+                "url": "mxc://example/huge.png",
+                "info": {"mimetype": "image/png"},
+            },
+            relates_to={},
+            msgtype="m.image",
+        )
+
+        assert captured_event is None
+        self.adapter._client.download_media.assert_not_called()
+        assert response.content.iter_chunked_sizes == [65536]
+        assert response.exited is True
 
     @pytest.mark.asyncio
     async def test_external_media_download_follows_safe_redirect(self, monkeypatch):


### PR DESCRIPTION
﻿Fixes #55041.

## Summary

- stream inbound Matrix `mxc://` media through `MATRIX_MAX_MEDIA_BYTES` instead of calling `mautrix.download_media()`'s unbounded `response.read()` path
- reject oversized MXC media as soon as the streamed response crosses the cap, without forwarding the HTTP fallback downstream
- keep the old `download_media()` path only for test/fake clients, with a defensive post-read size check
- add regression tests for under-cap streaming and over-cap stream rejection

## Relation to Existing Work

Related but not a duplicate of #52354:

- #52354 gates pre-auth Matrix media downloads and checks the real downloaded byte length before cache/use.
- This PR closes the remaining earlier boundary: avoid buffering an oversized media response before that length check can run.

This mirrors the response-boundary class from openclaw/openclaw#97855, adapted to Hermes' Python `mautrix` client path.

## Duplicate Audit

Live checks before opening:

- Existing #55009/#55011 covers Matrix standalone sender REST responses, not inbound MXC media downloads.
- Existing #52354 covers media authorization and post-download real length checks, but still uses `download_media()`'s full-buffer read.
- No open PR/issue found for inbound Matrix MXC streaming caps before #55041.

## Validation

- `python -m pytest tests\gateway\test_matrix.py -q -k "MediaNormalization or mxc_media" --basetemp .pytest-tmp-matrix-inbound-media-cap` (`17 passed, 218 deselected`)
- `python -m ruff check plugins\platforms\matrix\adapter.py tests\gateway\test_matrix.py` (passed)
- `git diff --check` (passed)

I also ran the full `tests\gateway\test_matrix.py` on Windows: `233 passed, 2 failed`. The two failures are pre-existing on untouched `origin/main` in this environment: POSIX `0600` mode assertion on Windows and default-GBK decoding of `website/docs/user-guide/messaging/matrix.md`.
