### PR TITLE
feat(skills): support renaming skills

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -15,6 +15,7 @@ from tools.skill_manager_tool import (
     _create_skill,
     _edit_skill,
     _patch_skill,
+    _rename_skill,
     _delete_skill,
     _write_file,
     _remove_file,
@@ -366,6 +367,91 @@ word word
         assert outside_file.read_text() == "old text here"
 
 
+class TestRenameSkill:
+    def test_rename_updates_directory_frontmatter_and_support_files(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            _write_file("old-skill", "references/note.md", "kept")
+            result = _rename_skill("old-skill", "new-skill")
+
+        assert result["success"] is True, result
+        assert not (tmp_path / "old-skill").exists()
+        new_dir = tmp_path / "new-skill"
+        assert (new_dir / "SKILL.md").exists()
+        assert (new_dir / "references" / "note.md").read_text() == "kept"
+        content = (new_dir / "SKILL.md").read_text()
+        assert 'name: "new-skill"' in content
+        assert "name: old-skill" not in content
+
+    def test_rename_rejects_existing_target_and_preserves_source(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            _create_skill("new-skill", _skill_content("new-skill"))
+            result = _rename_skill("old-skill", "new-skill")
+
+        assert result["success"] is False
+        assert "already exists" in result["error"]
+        assert (tmp_path / "old-skill" / "SKILL.md").exists()
+        assert (tmp_path / "new-skill" / "SKILL.md").exists()
+
+    def test_rename_refuses_pinned_skill(self, tmp_path):
+        def _fake_get_record(skill_name):
+            return {"pinned": True} if skill_name == "old-skill" else {"pinned": False}
+
+        with _skill_dir(tmp_path):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            with patch("tools.skill_usage.get_record", side_effect=_fake_get_record):
+                result = _rename_skill("old-skill", "new-skill")
+
+        assert result["success"] is False
+        assert "pinned" in result["error"].lower()
+        assert (tmp_path / "old-skill" / "SKILL.md").exists()
+        assert not (tmp_path / "new-skill").exists()
+
+    def test_rename_refuses_frontmatter_pinned_skill(self, tmp_path):
+        def _fake_get_record(skill_name):
+            return {"pinned": True} if skill_name == "front-skill" else {"pinned": False}
+
+        with _skill_dir(tmp_path):
+            _create_skill("dir-skill", _skill_content("front-skill"))
+            with patch("tools.skill_usage.get_record", side_effect=_fake_get_record):
+                result = _rename_skill("dir-skill", "new-skill")
+
+        assert result["success"] is False
+        assert "front-skill" in result["error"]
+        assert "pinned" in result["error"].lower()
+        assert (tmp_path / "dir-skill" / "SKILL.md").exists()
+        assert not (tmp_path / "new-skill").exists()
+
+    def test_rename_rejects_existing_frontmatter_name_and_preserves_source(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            _create_skill("alias-dir", _skill_content("target-skill"))
+            result = _rename_skill("old-skill", "target-skill")
+
+        assert result["success"] is False
+        assert "already exists" in result["error"]
+        assert "alias-dir" in result["error"]
+        assert (tmp_path / "old-skill" / "SKILL.md").exists()
+        assert (tmp_path / "alias-dir" / "SKILL.md").exists()
+        assert not (tmp_path / "target-skill").exists()
+
+    @pytest.mark.parametrize("scalar_like_name", ["123", "true", "null", "2024-01-01"])
+    def test_rename_quotes_yaml_scalar_like_new_name(self, tmp_path, scalar_like_name):
+        import yaml
+
+        with _skill_dir(tmp_path):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            result = _rename_skill("old-skill", scalar_like_name)
+
+        assert result["success"] is True, result
+        content = (tmp_path / scalar_like_name / "SKILL.md").read_text()
+        frontmatter = content.split("---", 2)[1]
+        parsed = yaml.safe_load(frontmatter)
+        assert parsed["name"] == scalar_like_name
+        assert isinstance(parsed["name"], str)
+
+
 class TestDeleteSkill:
     def test_delete_existing(self, tmp_path):
         with _skill_dir(tmp_path):
@@ -600,6 +686,27 @@ class TestSkillManageDispatcher:
         assert result["success"] is False
         assert "does not exist" in result["error"]
 
+    def test_rename_via_dispatcher_threads_new_name(self, tmp_path):
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="old-skill", content=_skill_content("old-skill"))
+            raw = skill_manage(action="rename", name="old-skill", new_name="new-skill")
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert result["old_name"] == "old-skill"
+        assert result["new_name"] == "new-skill"
+        assert (tmp_path / "new-skill" / "SKILL.md").exists()
+        assert not (tmp_path / "old-skill").exists()
+
+    def test_rename_via_dispatcher_moves_frontmatter_usage_alias(self, tmp_path):
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="dir-skill", content=_skill_content("front-skill"))
+            with patch("tools.skill_usage.rename_record") as rename_record:
+                raw = skill_manage(action="rename", name="dir-skill", new_name="new-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        rename_record.assert_called_once_with("dir-skill", "new-skill", aliases=["front-skill"])
+
     def test_background_review_delete_refuses_bundled_even_with_absorbed_into(self, tmp_path):
         from tools.skill_provenance import (
             BACKGROUND_REVIEW,
@@ -824,6 +931,22 @@ class TestExternalSkillMutations:
 
         assert result["success"] is True, result
         assert not (skill_dir / "references" / "notes.md").exists()
+
+    def test_rename_external_skill_writes_in_place(self, tmp_path):
+        local = tmp_path / "local"
+        external = tmp_path / "vault"
+        local.mkdir(); external.mkdir()
+        skill_dir = _write_external_skill(external)
+
+        with _two_roots(local, external):
+            result = _rename_skill("ext-skill", "better-ext-skill")
+
+        assert result["success"] is True, result
+        assert not skill_dir.exists()
+        renamed = external / "better-ext-skill"
+        assert renamed.exists()
+        assert 'name: "better-ext-skill"' in (renamed / "SKILL.md").read_text()
+        assert not (local / "better-ext-skill").exists()
 
     def test_delete_external_skill_removes_skill_not_root(self, tmp_path):
         local = tmp_path / "local"

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -383,6 +383,22 @@ class TestRenameSkill:
         assert 'name: "new-skill"' in content
         assert "name: old-skill" not in content
 
+    def test_rename_rolls_back_when_cron_reference_rewrite_fails(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            with patch(
+                "cron.jobs.rewrite_skill_refs",
+                side_effect=OSError("jobs.json write failed"),
+            ):
+                result = _rename_skill("old-skill", "new-skill")
+
+        assert result["success"] is False
+        assert "jobs.json write failed" in result["error"]
+        assert not (tmp_path / "new-skill").exists()
+        old_skill_md = tmp_path / "old-skill" / "SKILL.md"
+        assert old_skill_md.exists()
+        assert "name: old-skill" in old_skill_md.read_text()
+
     def test_rename_rejects_existing_target_and_preserves_source(self, tmp_path):
         with _skill_dir(tmp_path):
             _create_skill("old-skill", _skill_content("old-skill"))

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -33,6 +33,26 @@ def _skill_dir(tmp_path):
         yield
 
 
+def _cron_store_with_legacy_refs(monkeypatch, tmp_path):
+    """Create a real cron store whose plural and legacy refs use old-skill."""
+
+    import cron.jobs as jobs_mod
+
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+    job = jobs_mod.create_job(
+        prompt="",
+        schedule="every 1h",
+        skills=["old-skill", "keep-skill"],
+    )
+    before = jobs_mod.JOBS_FILE.read_text()
+    return jobs_mod, job["id"], before
+
+
 VALID_SKILL_CONTENT = """\
 ---
 name: test-skill
@@ -383,11 +403,20 @@ class TestRenameSkill:
         assert 'name: "new-skill"' in content
         assert "name: old-skill" not in content
 
-    def test_rename_rolls_back_when_cron_reference_rewrite_fails(self, tmp_path):
+    def test_rename_rolls_back_when_cron_reference_rewrite_fails(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        jobs_mod, job_id, cron_before = _cron_store_with_legacy_refs(
+            monkeypatch,
+            tmp_path,
+        )
         with _skill_dir(tmp_path):
             _create_skill("old-skill", _skill_content("old-skill"))
-            with patch(
-                "cron.jobs.rewrite_skill_refs",
+            with patch.object(
+                jobs_mod,
+                "save_jobs",
                 side_effect=OSError("jobs.json write failed"),
             ):
                 result = _rename_skill("old-skill", "new-skill")
@@ -398,13 +427,22 @@ class TestRenameSkill:
         old_skill_md = tmp_path / "old-skill" / "SKILL.md"
         assert old_skill_md.exists()
         assert "name: old-skill" in old_skill_md.read_text()
+        assert jobs_mod.JOBS_FILE.read_text() == cron_before
+        stored_job = jobs_mod.get_job(job_id)
+        assert stored_job["skills"] == ["old-skill", "keep-skill"]
+        assert stored_job["skill"] == "old-skill"
 
     def test_rename_reports_inconsistent_state_when_frontmatter_rollback_fails(
         self,
         tmp_path,
+        monkeypatch,
     ):
         import tools.skill_manager_tool as manager
 
+        jobs_mod, _job_id, cron_before = _cron_store_with_legacy_refs(
+            monkeypatch,
+            tmp_path,
+        )
         with _skill_dir(tmp_path):
             _create_skill("old-skill", _skill_content("old-skill"))
             original = (tmp_path / "old-skill" / "SKILL.md").read_text()
@@ -416,8 +454,9 @@ class TestRenameSkill:
                 return real_write(path, content)
 
             with (
-                patch(
-                    "cron.jobs.rewrite_skill_refs",
+                patch.object(
+                    jobs_mod,
+                    "save_jobs",
                     side_effect=OSError("jobs.json write failed"),
                 ),
                 patch(
@@ -433,6 +472,7 @@ class TestRenameSkill:
         assert result["inconsistent_state"]["new_path_exists"] is False
         assert any("frontmatter restore failed" in item for item in result["rollback_errors"])
         assert "_change" not in result
+        assert jobs_mod.JOBS_FILE.read_text() == cron_before
         assert 'name: "new-skill"' in (
             tmp_path / "old-skill" / "SKILL.md"
         ).read_text()
@@ -440,9 +480,14 @@ class TestRenameSkill:
     def test_rename_reports_inconsistent_state_when_directory_rollback_fails(
         self,
         tmp_path,
+        monkeypatch,
     ):
         import tools.skill_manager_tool as manager
 
+        jobs_mod, _job_id, cron_before = _cron_store_with_legacy_refs(
+            monkeypatch,
+            tmp_path,
+        )
         with _skill_dir(tmp_path):
             _create_skill("old-skill", _skill_content("old-skill"))
             real_move = manager._move_skill_dir
@@ -453,8 +498,9 @@ class TestRenameSkill:
                 return real_move(src, dest)
 
             with (
-                patch(
-                    "cron.jobs.rewrite_skill_refs",
+                patch.object(
+                    jobs_mod,
+                    "save_jobs",
                     side_effect=OSError("jobs.json write failed"),
                 ),
                 patch(
@@ -470,6 +516,7 @@ class TestRenameSkill:
         assert result["inconsistent_state"]["new_path_exists"] is True
         assert any("directory restore failed" in item for item in result["rollback_errors"])
         assert "_change" not in result
+        assert jobs_mod.JOBS_FILE.read_text() == cron_before
         assert "name: old-skill" in (
             tmp_path / "new-skill" / "SKILL.md"
         ).read_text()

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -707,6 +707,96 @@ class TestSkillManageDispatcher:
         assert result["success"] is True, result
         rename_record.assert_called_once_with("dir-skill", "new-skill", aliases=["front-skill"])
 
+    def test_rename_rewrites_cron_skill_and_legacy_references(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        skills_root = hermes_home / "skills"
+        cron_root = hermes_home / "cron"
+        (cron_root / "output").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import cron.jobs as jobs_mod
+
+        monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+        monkeypatch.setattr(jobs_mod, "CRON_DIR", cron_root)
+        monkeypatch.setattr(jobs_mod, "JOBS_FILE", cron_root / "jobs.json")
+        monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", cron_root / "output")
+
+        with _skill_dir(skills_root):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            skills_job = jobs_mod.create_job(
+                prompt="",
+                schedule="every 1h",
+                skills=["old-skill", "keep"],
+            )
+            legacy_job = jobs_mod.create_job(
+                prompt="",
+                schedule="every 1h",
+                skill="old-skill",
+            )
+            with patch.object(
+                jobs_mod,
+                "rewrite_skill_refs",
+                wraps=jobs_mod.rewrite_skill_refs,
+            ) as rewrite_skill_refs:
+                raw = skill_manage(
+                    action="rename",
+                    name="old-skill",
+                    new_name="new-skill",
+                )
+
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        rewrite_skill_refs.assert_called_once_with(
+            consolidated={"old-skill": "new-skill"},
+            pruned=[],
+        )
+        assert jobs_mod.get_job(skills_job["id"])["skills"] == ["new-skill", "keep"]
+        legacy = jobs_mod.get_job(legacy_job["id"])
+        assert legacy["skills"] == ["new-skill"]
+        assert legacy["skill"] == "new-skill"
+
+    def test_background_review_rename_requires_skill_view_first(self, tmp_path, monkeypatch):
+        from tools.skill_manager_tool import _reset_background_review_read_marks
+        from tools.skills_tool import skill_view
+
+        _reset_background_review_read_marks()
+        try:
+            with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+                created = json.loads(
+                    skill_manage(
+                        action="create",
+                        name="reviewed",
+                        content=_skill_content("reviewed"),
+                    )
+                )
+                assert created["success"] is True, created
+
+                blocked = json.loads(
+                    skill_manage(
+                        action="rename",
+                        name="reviewed",
+                        new_name="renamed",
+                    )
+                )
+                assert blocked["success"] is False
+                assert blocked.get("_read_before_write_required") is True
+                assert (tmp_path / ".hermes" / "skills" / "reviewed").exists()
+                assert not (tmp_path / ".hermes" / "skills" / "renamed").exists()
+
+                viewed = json.loads(skill_view("reviewed"))
+                assert viewed["success"] is True
+
+                allowed = json.loads(
+                    skill_manage(
+                        action="rename",
+                        name="reviewed",
+                        new_name="renamed",
+                    )
+                )
+                assert allowed["success"] is True, allowed
+        finally:
+            _reset_background_review_read_marks()
+
     def test_background_review_delete_refuses_bundled_even_with_absorbed_into(self, tmp_path):
         from tools.skill_provenance import (
             BACKGROUND_REVIEW,

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -399,6 +399,81 @@ class TestRenameSkill:
         assert old_skill_md.exists()
         assert "name: old-skill" in old_skill_md.read_text()
 
+    def test_rename_reports_inconsistent_state_when_frontmatter_rollback_fails(
+        self,
+        tmp_path,
+    ):
+        import tools.skill_manager_tool as manager
+
+        with _skill_dir(tmp_path):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            original = (tmp_path / "old-skill" / "SKILL.md").read_text()
+            real_write = manager._atomic_write_text
+
+            def fail_original_restore(path, content):
+                if path == tmp_path / "new-skill" / "SKILL.md" and content == original:
+                    raise OSError("frontmatter restore failed")
+                return real_write(path, content)
+
+            with (
+                patch(
+                    "cron.jobs.rewrite_skill_refs",
+                    side_effect=OSError("jobs.json write failed"),
+                ),
+                patch(
+                    "tools.skill_manager_tool._atomic_write_text",
+                    side_effect=fail_original_restore,
+                ),
+            ):
+                result = _rename_skill("old-skill", "new-skill")
+
+        assert result["success"] is False
+        assert result["rollback_failed"] is True
+        assert result["inconsistent_state"]["old_path_exists"] is True
+        assert result["inconsistent_state"]["new_path_exists"] is False
+        assert any("frontmatter restore failed" in item for item in result["rollback_errors"])
+        assert "_change" not in result
+        assert 'name: "new-skill"' in (
+            tmp_path / "old-skill" / "SKILL.md"
+        ).read_text()
+
+    def test_rename_reports_inconsistent_state_when_directory_rollback_fails(
+        self,
+        tmp_path,
+    ):
+        import tools.skill_manager_tool as manager
+
+        with _skill_dir(tmp_path):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            real_move = manager._move_skill_dir
+
+            def fail_reverse_move(src, dest):
+                if src == tmp_path / "new-skill" and dest == tmp_path / "old-skill":
+                    raise OSError("directory restore failed")
+                return real_move(src, dest)
+
+            with (
+                patch(
+                    "cron.jobs.rewrite_skill_refs",
+                    side_effect=OSError("jobs.json write failed"),
+                ),
+                patch(
+                    "tools.skill_manager_tool._move_skill_dir",
+                    side_effect=fail_reverse_move,
+                ),
+            ):
+                result = _rename_skill("old-skill", "new-skill")
+
+        assert result["success"] is False
+        assert result["rollback_failed"] is True
+        assert result["inconsistent_state"]["old_path_exists"] is False
+        assert result["inconsistent_state"]["new_path_exists"] is True
+        assert any("directory restore failed" in item for item in result["rollback_errors"])
+        assert "_change" not in result
+        assert "name: old-skill" in (
+            tmp_path / "new-skill" / "SKILL.md"
+        ).read_text()
+
     def test_rename_rejects_existing_target_and_preserves_source(self, tmp_path):
         with _skill_dir(tmp_path):
             _create_skill("old-skill", _skill_content("old-skill"))

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -403,6 +403,32 @@ class TestRenameSkill:
         assert 'name: "new-skill"' in content
         assert "name: old-skill" not in content
 
+    def test_background_rename_requires_reading_skill_md(self, tmp_path):
+        import tools.skill_manager_tool as manager
+
+        with _skill_dir(tmp_path):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            manager._reset_background_review_read_marks()
+            with patch("tools.skill_provenance.is_background_review", return_value=True):
+                result = _rename_skill("old-skill", "new-skill")
+
+        assert result["success"] is False
+        assert result["_read_before_write_required"] is True
+        assert "skill_view" in result["error"]
+        assert (tmp_path / "old-skill" / "SKILL.md").exists()
+        assert not (tmp_path / "new-skill").exists()
+
+    def test_rename_rewrites_plural_and_legacy_cron_references(self, tmp_path, monkeypatch):
+        jobs_mod, job_id, _cron_before = _cron_store_with_legacy_refs(monkeypatch, tmp_path)
+        with _skill_dir(tmp_path):
+            _create_skill("old-skill", _skill_content("old-skill"))
+            result = _rename_skill("old-skill", "new-skill")
+
+        assert result["success"] is True, result
+        stored_job = jobs_mod.get_job(job_id)
+        assert stored_job["skills"] == ["new-skill", "keep-skill"]
+        assert stored_job["skill"] == "new-skill"
+
     def test_rename_rolls_back_when_cron_reference_rewrite_fails(
         self,
         tmp_path,

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -229,6 +229,27 @@ def test_forget_removes_record(skills_home):
     assert "x" not in load_usage()
 
 
+def test_rename_record_moves_frontmatter_alias_without_double_counting(skills_home):
+    from tools.skill_usage import get_record, rename_record, save_usage, load_usage
+
+    save_usage({
+        "front-name": {
+            "view_count": 3,
+            "patch_count": 4,
+            "pinned": False,
+        }
+    })
+
+    rename_record("dir-name", "new-name", aliases=["front-name"])
+
+    data = load_usage()
+    assert "dir-name" not in data
+    assert "front-name" not in data
+    rec = get_record("new-name")
+    assert rec["view_count"] == 3
+    assert rec["patch_count"] == 5
+
+
 # ---------------------------------------------------------------------------
 # Provenance filter — the load-bearing safety check
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -221,6 +221,33 @@ def test_skill_create_diff_is_full_content(hermes_home):
     assert "name: test-skill" in diff
 
 
+def test_skill_rename_gate_on_then_apply_renames_skill(hermes_home):
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from tools import write_approval as wa
+
+    old_content = _SKILL.replace("name: test-skill", "name: old-skill")
+    created = json.loads(smt.skill_manage("create", "old-skill", content=old_content))
+    assert created["success"] is True
+
+    _set_approval("skills", True)
+    staged = json.loads(smt.skill_manage("rename", "old-skill", new_name="new-skill"))
+    assert staged.get("staged") is True
+    assert "rename skill 'old-skill' to 'new-skill'" in staged.get("gist", "")
+
+    rec = wa.get_pending("skills", staged["pending_id"])
+    assert rec is not None
+    assert rec["payload"]["new_name"] == "new-skill"
+    diff = wa.skill_pending_diff(rec)
+    assert "rename skill 'old-skill' to 'new-skill'" in diff
+
+    applied = json.loads(smt.apply_skill_pending(rec["payload"]))
+    assert applied["success"] is True, applied
+    assert smt._find_skill("old-skill") is None
+    assert smt._find_skill("new-skill") is not None
+
+
 # ---------------------------------------------------------------------------
 # Pending store CRUD
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -15,6 +15,7 @@ Actions:
   create     -- Create a new skill (SKILL.md + directory structure)
   edit       -- Replace the SKILL.md content of a user skill (full rewrite)
   patch      -- Targeted find-and-replace within SKILL.md or any supporting file
+  rename     -- Rename a skill directory and its frontmatter name
   delete     -- Remove a user skill entirely
   write_file -- Add/overwrite a supporting file (reference, template, script, asset)
   remove_file-- Remove a supporting file from a user skill
@@ -267,6 +268,148 @@ def _validate_delete_target(skill_dir: Path) -> Optional[str]:
     )
 
 
+def _validate_rename_target(skill_dir: Path, target_dir: Path) -> Optional[str]:
+    """Guard a skill directory rename against poisoned paths.
+
+    Rename is not recursive deletion, but it still changes skill identity and
+    writes SKILL.md after the move. Refuse the same dangerous shapes as delete:
+    source symlink/junctions, a source that resolves to a skills root, and
+    targets whose parent is not strictly inside a known skills root.
+    """
+    from agent.skill_utils import get_all_skills_dirs
+
+    if _is_path_redirect(skill_dir):
+        return (
+            f"Refusing to rename '{skill_dir}': the skill directory is a "
+            "symlink/junction. Rename the link manually if intended."
+        )
+
+    try:
+        resolved_source = skill_dir.resolve()
+        resolved_parent = target_dir.parent.resolve()
+    except OSError as exc:
+        return f"Refusing to rename '{skill_dir}': could not resolve path ({exc})."
+
+    for root in get_all_skills_dirs():
+        try:
+            resolved_root = root.resolve()
+        except OSError:
+            continue
+        if resolved_source == resolved_root:
+            return (
+                f"Refusing to rename '{skill_dir}': resolves to the skills root "
+                "itself, which would rename every installed skill."
+            )
+        try:
+            rel_source = resolved_source.relative_to(resolved_root)
+            rel_parent = resolved_parent.relative_to(resolved_root)
+        except ValueError:
+            continue
+        if rel_source.parts and (resolved_parent == resolved_root or rel_parent.parts):
+            return None
+
+    return (
+        f"Refusing to rename '{skill_dir}': source or target does not resolve "
+        "inside any known skills root."
+    )
+
+
+def _read_frontmatter_name(content: str) -> Tuple[Optional[str], Optional[str]]:
+    """Return the parsed string frontmatter name from SKILL.md content."""
+    if not content.startswith("---"):
+        return None, "SKILL.md must start with YAML frontmatter (---)."
+    end_match = re.search(r'\n---\s*\n', content[3:])
+    if not end_match:
+        return None, "SKILL.md frontmatter is not closed."
+
+    yaml_content = content[3:end_match.start() + 3]
+    try:
+        parsed = yaml.safe_load(yaml_content)
+    except yaml.YAMLError as exc:
+        return None, f"YAML frontmatter parse error: {exc}"
+    if not isinstance(parsed, dict):
+        return None, "Frontmatter must be a YAML mapping (key: value pairs)."
+    if "name" not in parsed:
+        return None, "Frontmatter must include 'name' field."
+    value = parsed["name"]
+    if not isinstance(value, str):
+        return None, "Frontmatter 'name' must be a string."
+    return value, None
+
+
+def _find_frontmatter_name_collision(name: str, exclude_dir: Path) -> Optional[Path]:
+    """Find a different skill whose parsed frontmatter name equals *name*."""
+    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+
+    try:
+        resolved_exclude = exclude_dir.resolve()
+    except OSError:
+        resolved_exclude = exclude_dir
+
+    for skills_dir in get_all_skills_dirs():
+        if not skills_dir.exists():
+            continue
+        for skill_md in skills_dir.rglob("SKILL.md"):
+            if is_excluded_skill_path(skill_md):
+                continue
+            try:
+                if skill_md.parent.resolve() == resolved_exclude:
+                    continue
+                frontmatter_name, _ = _read_frontmatter_name(skill_md.read_text(encoding="utf-8"))
+            except OSError:
+                continue
+            if frontmatter_name == name:
+                return skill_md.parent
+    return None
+
+
+def _rename_pinned_guard(names: List[Optional[str]]) -> Optional[str]:
+    """Return a rename refusal if any current skill identity is pinned."""
+    seen = set()
+    try:
+        from tools import skill_usage
+        for candidate in names:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            if skill_usage.get_record(candidate).get("pinned"):
+                return (
+                    f"Skill '{candidate}' is pinned and cannot be renamed by skill_manage. "
+                    f"Ask the user to run `hermes curator unpin {candidate}` if they want "
+                    "to rename it. Patches and edits are allowed on pinned skills; "
+                    "renaming changes the skill identity."
+                )
+    except Exception:
+        logger.debug("rename pinned-guard lookup failed for %s", names, exc_info=True)
+    return None
+
+
+def _replace_frontmatter_name(content: str, new_name: str) -> Tuple[Optional[str], Optional[str]]:
+    """Return SKILL.md content with the YAML frontmatter name replaced."""
+    if not content.startswith("---"):
+        return None, "SKILL.md must start with YAML frontmatter (---)."
+    end_match = re.search(r'\n---\s*\n', content[3:])
+    if not end_match:
+        return None, "SKILL.md frontmatter is not closed."
+
+    yaml_start = 3
+    yaml_end = 3 + end_match.start()
+    frontmatter = content[yaml_start:yaml_end]
+    replacement = f"name: {json.dumps(new_name)}"
+    updated, count = re.subn(r"(?m)^name\s*:.*$", replacement, frontmatter, count=1)
+    if count != 1:
+        return None, "Frontmatter must include 'name' field."
+    return content[:yaml_start] + updated + content[yaml_end:], None
+
+
+def _move_skill_dir(src: Path, dest: Path) -> None:
+    """Move a skill directory, falling back for cross-device moves."""
+    try:
+        src.rename(dest)
+    except OSError:
+        shutil.move(str(src), str(dest))
+
+
 def _pinned_guard(name: str) -> Optional[str]:
     """Return a refusal message if *name* is pinned, else None.
 
@@ -427,7 +570,7 @@ def _background_review_read_before_write_guard(
 
 
 def _background_review_preflight(action: str, name: str) -> Optional[Dict[str, Any]]:
-    if action not in {"edit", "patch", "delete", "write_file", "remove_file"}:
+    if action not in {"edit", "patch", "rename", "delete", "write_file", "remove_file"}:
         return None
     existing = _find_skill(name)
     if not existing:
@@ -1044,6 +1187,98 @@ def _patch_skill(
     return result
 
 
+def _rename_skill(name: str, new_name: str) -> Dict[str, Any]:
+    """Rename a skill directory and update its SKILL.md frontmatter name."""
+    err = _validate_name(new_name)
+    if err:
+        return {"success": False, "error": err}
+    if name == new_name:
+        return {"success": False, "error": "new_name must be different from name."}
+
+    existing = _find_skill(name)
+    if not existing:
+        return {"success": False, "error": _skill_not_found_error(name)}
+    if _find_skill(new_name):
+        return {"success": False, "error": f"A skill named '{new_name}' already exists."}
+
+    skill_dir = existing["path"]
+    guard = _background_review_write_guard(name, skill_dir, "rename")
+    if guard:
+        return guard
+
+    target_dir = skill_dir.with_name(new_name)
+    if target_dir.exists():
+        return {"success": False, "error": f"A skill directory already exists at {target_dir}."}
+
+    unsafe = _validate_rename_target(skill_dir, target_dir)
+    if unsafe:
+        return {"success": False, "error": unsafe}
+
+    skill_md = skill_dir / "SKILL.md"
+    try:
+        original_content = skill_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {"success": False, "error": f"Failed to read SKILL.md for '{name}': {exc}"}
+
+    old_frontmatter_name, name_err = _read_frontmatter_name(original_content)
+    if name_err:
+        logger.debug("could not read frontmatter name for %s before rename: %s", name, name_err)
+
+    pinned_err = _rename_pinned_guard([name, old_frontmatter_name])
+    if pinned_err:
+        return {"success": False, "error": pinned_err}
+
+    collision = _find_frontmatter_name_collision(new_name, exclude_dir=skill_dir)
+    if collision:
+        return {
+            "success": False,
+            "error": f"A skill with frontmatter name '{new_name}' already exists at {collision}.",
+        }
+
+    new_content, err = _replace_frontmatter_name(original_content, new_name)
+    if err:
+        return {"success": False, "error": err}
+
+    err = _validate_frontmatter(new_content or "")
+    if err:
+        return {"success": False, "error": f"Renamed SKILL.md would be invalid: {err}"}
+    err = _validate_content_size(new_content or "")
+    if err:
+        return {"success": False, "error": err}
+
+    moved = False
+    try:
+        _move_skill_dir(skill_dir, target_dir)
+        moved = True
+        _atomic_write_text(target_dir / "SKILL.md", new_content or "")
+
+        scan_error = _security_scan_skill(target_dir)
+        if scan_error:
+            _atomic_write_text(target_dir / "SKILL.md", original_content)
+            _move_skill_dir(target_dir, skill_dir)
+            moved = False
+            return {"success": False, "error": scan_error}
+    except Exception as exc:
+        if moved:
+            try:
+                _atomic_write_text(target_dir / "SKILL.md", original_content)
+                if not skill_dir.exists():
+                    _move_skill_dir(target_dir, skill_dir)
+            except Exception:
+                logger.error("Failed to roll back skill rename %s -> %s", name, new_name, exc_info=True)
+        return {"success": False, "error": f"Failed to rename skill '{name}' to '{new_name}': {exc}"}
+
+    return {
+        "success": True,
+        "message": f"Skill '{name}' renamed to '{new_name}'.",
+        "old_name": name,
+        "old_frontmatter_name": old_frontmatter_name,
+        "new_name": new_name,
+        "path": str(target_dir),
+        "_change": {"old": name, "new": new_name},
+    }
+
+
 def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, Any]:
     """Delete a skill.
 
@@ -1281,7 +1516,7 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     write should NOT proceed (blocked or staged), or None to perform the real
     write. Bypassed during approved-pending replay.
     """
-    if action not in {"create", "edit", "patch", "delete", "write_file", "remove_file"}:
+    if action not in {"create", "edit", "patch", "rename", "delete", "write_file", "remove_file"}:
         return None
     if _skill_gate_bypass.get():
         return None
@@ -1306,6 +1541,7 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
         file_path=payload_kwargs.get("file_path") or "",
         old_string=payload_kwargs.get("old_string") or "",
         new_string=payload_kwargs.get("new_string") or "",
+        new_name=payload_kwargs.get("new_name") or "",
     )
     record = wa.stage_write(wa.SKILLS, payload, summary=gist, origin=wa.current_origin())
     return json.dumps(
@@ -1330,6 +1566,7 @@ def apply_skill_pending(payload: Dict[str, Any]) -> str:
             file_content=payload.get("file_content"),
             old_string=payload.get("old_string"),
             new_string=payload.get("new_string"),
+            new_name=payload.get("new_name"),
             replace_all=payload.get("replace_all", False),
             absorbed_into=payload.get("absorbed_into"),
         )
@@ -1346,6 +1583,7 @@ def skill_manage(
     file_content: str = None,
     old_string: str = None,
     new_string: str = None,
+    new_name: str = None,
     replace_all: bool = False,
     absorbed_into: str = None,
 ) -> str:
@@ -1365,7 +1603,7 @@ def skill_manage(
     gate_result = _apply_skill_write_gate(
         action, name, content=content, category=category,
         file_path=file_path, file_content=file_content,
-        old_string=old_string, new_string=new_string,
+        old_string=old_string, new_string=new_string, new_name=new_name,
         replace_all=replace_all, absorbed_into=absorbed_into,
     )
     if gate_result is not None:
@@ -1388,6 +1626,11 @@ def skill_manage(
             return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
         result = _patch_skill(name, old_string, new_string, file_path, replace_all)
 
+    elif action == "rename":
+        if not new_name:
+            return tool_error("new_name is required for 'rename'. Provide the corrected skill name.", success=False)
+        result = _rename_skill(name, new_name)
+
     elif action == "delete":
         result = _delete_skill(name, absorbed_into=absorbed_into)
 
@@ -1404,7 +1647,7 @@ def skill_manage(
         result = _remove_file(name, file_path)
 
     else:
-        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
+        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, rename, delete, write_file, remove_file"}
 
     if result.get("success"):
         try:
@@ -1419,11 +1662,15 @@ def skill_manage(
         # user-directed, and those skills belong to the user (the curator must
         # not touch them). Best-effort; telemetry failures never break the tool.
         try:
-            from tools.skill_usage import bump_patch, forget, mark_agent_created
+            from tools.skill_usage import bump_patch, forget, mark_agent_created, rename_record
             from tools.skill_provenance import is_background_review
             if action == "create":
                 if is_background_review():
                     mark_agent_created(name)
+            elif action == "rename":
+                old_frontmatter_name = result.get("old_frontmatter_name")
+                aliases = [old_frontmatter_name] if old_frontmatter_name and old_frontmatter_name != name else None
+                rename_record(name, result.get("new_name") or new_name or "", aliases=aliases)
             elif action in {"patch", "edit", "write_file", "remove_file"}:
                 bump_patch(name)
             elif action == "delete":
@@ -1445,12 +1692,13 @@ def skill_manage(
 SKILL_MANAGE_SCHEMA = {
     "name": "skill_manage",
     "description": (
-        "Manage skills (create, update, delete). Skills are your procedural "
+        "Manage skills (create, update, rename, delete). Skills are your procedural "
         "memory — reusable approaches for recurring task types. "
         f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified wherever they live.\n\n"
         "Actions: create (full SKILL.md + optional category), "
         "patch (old_string/new_string — preferred for fixes), "
         "edit (full SKILL.md rewrite — major overhauls only), "
+        "rename (change a skill's directory name and frontmatter name), "
         "delete, write_file, remove_file.\n\n"
         "On delete, pass `absorbed_into=<umbrella>` when you're merging this "
         "skill's content into another one, or `absorbed_into=\"\"` when you're "
@@ -1466,27 +1714,28 @@ SKILL_MANAGE_SCHEMA = {
         "missing steps or pitfalls found during use. "
         "If you used a skill and hit issues not covered by it, patch it immediately.\n\n"
         "After difficult/iterative tasks, offer to save as a skill. "
-        "Skip for simple one-offs. Confirm with user before creating/deleting.\n\n"
+        "Skip for simple one-offs. Confirm with user before creating/renaming/deleting.\n\n"
         "Good skills: trigger conditions, numbered steps with exact commands, "
         "pitfalls section, verification steps. Use skill_view() to see format examples.\n\n"
-        "Pinned skills are protected from deletion only — skill_manage(action='delete') "
+        "Pinned skills are protected from deletion and rename — "
+        "skill_manage(action='delete') or action='rename' "
         "will refuse with a message pointing the user to `hermes curator unpin <name>`. "
         "Patches and edits go through on pinned skills so you can still improve them as "
-        "pitfalls come up; pin only guards against irrecoverable loss."
+        "pitfalls come up; pin only guards against identity/loss actions."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["create", "patch", "edit", "delete", "write_file", "remove_file"],
+                "enum": ["create", "patch", "edit", "rename", "delete", "write_file", "remove_file"],
                 "description": "The action to perform."
             },
             "name": {
                 "type": "string",
                 "description": (
                     "Skill name (lowercase, hyphens/underscores, max 64 chars). "
-                    "Must match an existing skill for patch/edit/delete/write_file/remove_file."
+                    "Must match an existing skill for patch/edit/rename/delete/write_file/remove_file."
                 )
             },
             "content": {
@@ -1510,6 +1759,13 @@ SKILL_MANAGE_SCHEMA = {
                 "description": (
                     "Replacement text (required for 'patch'). Can be empty string "
                     "to delete the matched text."
+                )
+            },
+            "new_name": {
+                "type": "string",
+                "description": (
+                    "For 'rename': the corrected skill name. Renames the skill "
+                    "directory and updates the SKILL.md frontmatter name."
                 )
             },
             "replace_all": {
@@ -1573,6 +1829,7 @@ registry.register(
         file_content=args.get("file_content"),
         old_string=args.get("old_string"),
         new_string=args.get("new_string"),
+        new_name=args.get("new_name"),
         replace_all=args.get("replace_all", False),
         absorbed_into=args.get("absorbed_into")),
     emoji="📝",

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -420,17 +420,9 @@ def _rewrite_cron_skill_refs_after_rename(
     if old_frontmatter_name and old_frontmatter_name != old_name:
         consolidated[old_frontmatter_name] = new_name
 
-    try:
-        from cron.jobs import rewrite_skill_refs
+    from cron.jobs import rewrite_skill_refs
 
-        rewrite_skill_refs(consolidated=consolidated, pruned=[])
-    except Exception as exc:
-        logger.warning(
-            "Failed to rewrite cron skill references after renaming %s to %s: %s",
-            old_name,
-            new_name,
-            exc,
-        )
+    rewrite_skill_refs(consolidated=consolidated, pruned=[])
 
 
 def _pinned_guard(name: str) -> Optional[str]:
@@ -1294,6 +1286,17 @@ def _rename_skill(name: str, new_name: str) -> Dict[str, Any]:
             _move_skill_dir(target_dir, skill_dir)
             moved = False
             return {"success": False, "error": scan_error}
+
+        # Cron references are part of the rename transaction.  Returning
+        # success with stale refs would make scheduled jobs silently run
+        # without the skill they were configured to load.  Keep this inside
+        # the rollback boundary so a failed jobs.json save restores both the
+        # directory name and the original frontmatter.
+        _rewrite_cron_skill_refs_after_rename(
+            name,
+            new_name,
+            old_frontmatter_name,
+        )
     except Exception as exc:
         if moved:
             try:
@@ -1303,8 +1306,6 @@ def _rename_skill(name: str, new_name: str) -> Dict[str, Any]:
             except Exception:
                 logger.error("Failed to roll back skill rename %s -> %s", name, new_name, exc_info=True)
         return {"success": False, "error": f"Failed to rename skill '{name}' to '{new_name}': {exc}"}
-
-    _rewrite_cron_skill_refs_after_rename(name, new_name, old_frontmatter_name)
 
     return {
         "success": True,

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1298,14 +1298,63 @@ def _rename_skill(name: str, new_name: str) -> Dict[str, Any]:
             old_frontmatter_name,
         )
     except Exception as exc:
+        rollback_errors: list[str] = []
         if moved:
             try:
                 _atomic_write_text(target_dir / "SKILL.md", original_content)
+            except Exception as rollback_exc:
+                rollback_errors.append(f"frontmatter restore failed: {rollback_exc}")
+                logger.error(
+                    "Failed to restore SKILL.md while rolling back %s -> %s",
+                    name,
+                    new_name,
+                    exc_info=True,
+                )
+
+            try:
                 if not skill_dir.exists():
                     _move_skill_dir(target_dir, skill_dir)
-            except Exception:
-                logger.error("Failed to roll back skill rename %s -> %s", name, new_name, exc_info=True)
-        return {"success": False, "error": f"Failed to rename skill '{name}' to '{new_name}': {exc}"}
+            except Exception as rollback_exc:
+                rollback_errors.append(f"directory restore failed: {rollback_exc}")
+                logger.error(
+                    "Failed to restore skill directory while rolling back %s -> %s",
+                    name,
+                    new_name,
+                    exc_info=True,
+                )
+
+            try:
+                restored = (
+                    skill_dir.exists()
+                    and not target_dir.exists()
+                    and (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+                    == original_content
+                )
+            except Exception as rollback_exc:
+                restored = False
+                rollback_errors.append(f"rollback verification failed: {rollback_exc}")
+            if not restored and not rollback_errors:
+                rollback_errors.append("rollback verification found inconsistent paths or content")
+
+        result: Dict[str, Any] = {
+            "success": False,
+            "error": f"Failed to rename skill '{name}' to '{new_name}': {exc}",
+        }
+        if rollback_errors:
+            result.update(
+                {
+                    "rollback_failed": True,
+                    "inconsistent_state": {
+                        "old_path": str(skill_dir),
+                        "old_path_exists": skill_dir.exists(),
+                        "new_path": str(target_dir),
+                        "new_path_exists": target_dir.exists(),
+                    },
+                    "rollback_errors": rollback_errors,
+                }
+            )
+            result["error"] += "; rollback incomplete: " + "; ".join(rollback_errors)
+        return result
 
     return {
         "success": True,

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -410,6 +410,29 @@ def _move_skill_dir(src: Path, dest: Path) -> None:
         shutil.move(str(src), str(dest))
 
 
+def _rewrite_cron_skill_refs_after_rename(
+    old_name: str,
+    new_name: str,
+    old_frontmatter_name: Optional[str] = None,
+) -> None:
+    """Keep scheduled jobs aligned with a successfully renamed skill."""
+    consolidated = {old_name: new_name}
+    if old_frontmatter_name and old_frontmatter_name != old_name:
+        consolidated[old_frontmatter_name] = new_name
+
+    try:
+        from cron.jobs import rewrite_skill_refs
+
+        rewrite_skill_refs(consolidated=consolidated, pruned=[])
+    except Exception as exc:
+        logger.warning(
+            "Failed to rewrite cron skill references after renaming %s to %s: %s",
+            old_name,
+            new_name,
+            exc,
+        )
+
+
 def _pinned_guard(name: str) -> Optional[str]:
     """Return a refusal message if *name* is pinned, else None.
 
@@ -575,7 +598,14 @@ def _background_review_preflight(action: str, name: str) -> Optional[Dict[str, A
     existing = _find_skill(name)
     if not existing:
         return None
-    return _background_review_write_guard(name, existing["path"], action)
+    write_guard = _background_review_write_guard(name, existing["path"], action)
+    if write_guard:
+        return write_guard
+    if action == "rename":
+        return _background_review_read_before_write_guard(
+            name, existing["path"] / "SKILL.md", action, "SKILL.md"
+        )
+    return None
 
 
 def _curator_consolidation_delete_guard(
@@ -1215,6 +1245,12 @@ def _rename_skill(name: str, new_name: str) -> Dict[str, Any]:
         return {"success": False, "error": unsafe}
 
     skill_md = skill_dir / "SKILL.md"
+    read_guard = _background_review_read_before_write_guard(
+        name, skill_md, "rename", "SKILL.md"
+    )
+    if read_guard:
+        return read_guard
+
     try:
         original_content = skill_md.read_text(encoding="utf-8")
     except OSError as exc:
@@ -1267,6 +1303,8 @@ def _rename_skill(name: str, new_name: str) -> Dict[str, Any]:
             except Exception:
                 logger.error("Failed to roll back skill rename %s -> %s", name, new_name, exc_info=True)
         return {"success": False, "error": f"Failed to rename skill '{name}' to '{new_name}': {exc}"}
+
+    _rewrite_cron_skill_refs_after_rename(name, new_name, old_frontmatter_name)
 
     return {
         "success": True,

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -689,6 +689,89 @@ def forget(skill_name: str) -> None:
         logger.debug("skill_usage.forget(%s) failed: %s", skill_name, e, exc_info=True)
 
 
+def _merge_usage_record(target: Dict[str, Any], source: Dict[str, Any]) -> None:
+    """Merge two sidecar records that refer to the same renamed skill."""
+    count_fields = ("use_count", "view_count", "patch_count")
+    for field in count_fields:
+        target[field] = int(target.get(field) or 0) + int(source.get(field) or 0)
+
+    timestamp_fields = (
+        "last_used_at",
+        "last_viewed_at",
+        "last_patched_at",
+        "archived_at",
+    )
+    for field in timestamp_fields:
+        values = [v for v in (target.get(field), source.get(field)) if v]
+        if values:
+            target[field] = max(values)
+
+    created_values = [v for v in (target.get("created_at"), source.get("created_at")) if v]
+    if created_values:
+        target["created_at"] = min(created_values)
+
+    if source.get("created_by") and not target.get("created_by"):
+        target["created_by"] = source.get("created_by")
+    if source.get("agent_created") is True:
+        target["agent_created"] = True
+    target["pinned"] = bool(target.get("pinned")) or bool(source.get("pinned"))
+
+    source_state = source.get("state")
+    if target.get("state") == STATE_ACTIVE and source_state and source_state != STATE_ACTIVE:
+        target["state"] = source_state
+
+
+def rename_record(old_name: str, new_name: str, aliases: Optional[List[str]] = None) -> None:
+    """Move a skill's usage entry when skill_manage renames the skill.
+
+    The filesystem and frontmatter rename make old keys stop resolving; keep
+    counters, pin state, and curator provenance attached to the new name instead
+    of silently orphaning them. ``aliases`` covers skills whose directory name
+    and frontmatter name differed before the rename. If no old record exists,
+    create the same minimal patch telemetry that bump_patch(new_name) would have
+    produced.
+    """
+    if not old_name or not new_name:
+        return
+    names: List[str] = []
+    for candidate in [old_name, *(aliases or [])]:
+        if candidate and candidate != new_name and candidate not in names:
+            names.append(candidate)
+    try:
+        with _usage_file_lock():
+            data = load_usage()
+            rec = data.get(new_name)
+            if isinstance(rec, dict):
+                merged = {**_empty_record(), **rec}
+            else:
+                merged = _empty_record()
+
+            found_old_record = False
+            for candidate in names:
+                old_rec = data.pop(candidate, None)
+                if isinstance(old_rec, dict):
+                    found_old_record = True
+                    _merge_usage_record(merged, {**_empty_record(), **old_rec})
+
+            if not names and old_name == new_name and new_name not in data:
+                return
+            if not found_old_record and new_name not in data:
+                merged = _empty_record()
+
+            merged["patch_count"] = int(merged.get("patch_count") or 0) + 1
+            merged["last_patched_at"] = _now_iso()
+            data[new_name] = merged
+            save_usage(data)
+    except Exception as e:
+        logger.debug(
+            "skill_usage.rename_record(%s -> %s) failed: %s",
+            old_name,
+            new_name,
+            e,
+            exc_info=True,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Archive / restore
 # ---------------------------------------------------------------------------

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -387,7 +387,7 @@ def _prompt_inline_memory_approval(summary: str, detail: str) -> Optional[bool]:
 
 def skill_gist(action: str, name: str, *, content: str = "",
                file_path: str = "", old_string: str = "",
-               new_string: str = "") -> str:
+               new_string: str = "", new_name: str = "") -> str:
     """Build a one-line human gist for a pending skill write.
 
     Heuristic, no model call — the gist surfaces enough to decide approve/reject
@@ -407,6 +407,8 @@ def skill_gist(action: str, name: str, *, content: str = "",
         removed = old_string.count("\n") + 1 if old_string else 0
         added = new_string.count("\n") + 1 if new_string else 0
         return f"patch '{name}' {target} (+{added}/-{removed} lines)"
+    if action == "rename":
+        return f"rename skill '{name}' to '{new_name}'"
     if action == "write_file":
         return f"write {file_path} in '{name}'"
     if action == "remove_file":
@@ -478,6 +480,8 @@ def skill_pending_diff(record: Dict[str, Any]) -> str:
         new = payload.get("file_content") or ""
     elif action == "remove_file":
         return f"remove file: {payload.get('file_path')} from skill '{name}'"
+    elif action == "rename":
+        return f"rename skill '{name}' to '{payload.get('new_name')}'"
     elif action == "delete":
         return f"delete skill '{name}'"
     else:


### PR DESCRIPTION
## Summary
- Add `skill_manage(action="rename", name=..., new_name=...)` to rename a skill directory and update the `SKILL.md` frontmatter `name`.
- Route skill rename through the existing write-approval staging/replay path.
- Preserve skill usage/provenance telemetry by moving the usage record to the new name, including mismatched old frontmatter aliases.
- Refuse renaming pinned skills by checking both directory and frontmatter identities.
- Reject target names that collide with any existing skill frontmatter name, not only directory names.
- Quote rewritten YAML names so scalar-like valid skill names such as `123`, `true`, `null`, and `2024-01-01` remain strings.
- Guard against symlink/root/path poisoning, matching the delete safety model.

## Tests
- ✅ `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py tests/tools/test_write_approval.py tests/tools/test_skill_usage.py -- -q -o addopts=` — 193 passed
- ✅ `python -m py_compile tools/skill_manager_tool.py tools/skill_usage.py tools/write_approval.py tests/tools/test_skill_manager_tool.py tests/tools/test_skill_usage.py tests/tools/test_write_approval.py`
- ✅ `git diff --check`
- ✅ `python scripts/check-windows-footguns.py tools/skill_manager_tool.py tools/skill_usage.py tools/write_approval.py tests/tools/test_skill_manager_tool.py tests/tools/test_skill_usage.py tests/tools/test_write_approval.py`
- ✅ Static added-line scan for hardcoded secrets, shell=True/os.system, eval/exec, pickle loads, simple SQL string formatting
- ✅ `uvx code-review-graph detect-changes --base origin/main --brief` — risk score 0.00, no detected test gaps
- ⚠️ `scripts/run_tests.sh tests/tools -- -q -o addopts=` has unrelated existing macOS failures:
  - `tests/tools/test_base_environment.py::TestAtomicSnapshotConcurrencyBehavioral::test_concurrent_writes_never_tear_the_snapshot`
  - `tests/tools/test_file_tools.py::{test_writes_content,test_replace_mode_calls_patch_replace,test_replace_mode_replace_all_flag}` due `/tmp` resolving as `/private/tmp`
  - Verified `test_base_environment.py::...` also fails on `origin/main` at `929dd9c0d` in a detached worktree.
  - Verified the `/tmp` file tool assertions also fail on `origin/main`.
- ℹ️ `ruff` is not installed in the repo venv, so no ruff run was available.

## Review follow-up
Addressed independent review blockers:
- frontmatter-name pinned skills now block rename.
- target frontmatter-name collisions now block rename.
- YAML scalar-like names are written quoted and parse back as strings.
- usage telemetry aliases for old frontmatter names are migrated without double-counting the patch bump.
