### PR TITLE
fix(gateway): call on_session_end before evicting cached agent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14772,6 +14772,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if id(agent) in running_ids:
             return
 
+        # Notify memory providers that the session is ending (idle eviction,
+        # /new, /reset, cap enforcement) so they can flush buffered data
+        # that hasn't been retained yet (e.g. auto-retain tail buffer).
+        try:
+            mm = getattr(agent, "_memory_manager", None)
+            if mm is not None:
+                msgs = list(getattr(agent, "_session_messages", None) or [])
+                mm.on_session_end(msgs)
+        except Exception:
+            pass
+
         try:
             threading.Thread(
                 target=self._release_evicted_agent_soft,


### PR DESCRIPTION
## Problem

When the gateway evicts a cached AIAgent (idle TTL expiry, /new, /reset, cache-cap enforcement), memory providers lose their in-memory buffer without any notification.  Providers like Hindsight accumulate conversation turns in `_session_turns` and only flush them periodically (every N turns via `sync_turn`) or on `on_session_switch`.  If the session ends with fewer than N buffered turns, those turns are silently discarded.

## Fix

Call `agent._memory_manager.on_session_end(messages)` in `_evict_cached_agent` before releasing the evicted agent's resources.  This mirrors the existing `on_session_end` call in the CLI shutdown path (`run_agent.py:3054`) and gives memory providers a hook to flush unsaved data when the session ends.

## Scope

This covers:
- `_session_expiry_watcher` → `_sweep_idle_cached_agents` → `_evict_cached_agent` (idle TTL eviction)
- `_evict_cached_agent` (explicit /new, /reset, /model, CLI handoff)

Note: `_enforce_agent_cache_cap` currently pops cache entries directly without going through `_evict_cached_agent`; a follow-up should align it to also call `on_session_end`.