### PR TITLE
fix(hindsight): flush buffered turns on session end

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1919,13 +1919,24 @@ class HindsightMemoryProvider(MemoryProvider):
         if not self._session_turns:
             return
 
-        turns_to_flush = list(self._session_turns)
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+
+        # On append-capable APIs only send the unretained watermark delta —
+        # otherwise we'd re-ship turns that the periodic retain already sent.
+        # On legacy/overwrite APIs we must send everything because each
+        # retain replaces the document.
+        if update_mode == "append":
+            turns_to_flush = self._session_turns[self._last_retained_turn_count:]
+            if not turns_to_flush:
+                return
+        else:
+            turns_to_flush = list(self._session_turns)
+
         self._session_turns.clear()
         self._turn_counter = 0
         self._last_retained_turn_count = 0
 
         content = "[" + ",".join(turns_to_flush) + "]"
-        document_id, update_mode = self._resolve_retain_target(self._document_id)
 
         lineage_tags: list[str] = []
         if self._session_id:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1902,6 +1902,74 @@ class HindsightMemoryProvider(MemoryProvider):
             self._session_id, self._parent_session_id, reset, self._document_id,
         )
 
+    def on_session_end(self, messages: list[dict] | None = None) -> None:
+        """Flush buffered turns when the session ends (idle eviction, /reset, etc).
+
+        ``sync_turn`` only enqueues a retain every ``_retain_every_n_turns``
+        turns.  If the session ends before reaching the threshold, the
+        accumulated ``_session_turns`` would be lost.  This hook gives the
+        provider a chance to flush whatever is buffered so no conversation
+        data goes missing on idle TTL eviction, explicit /reset, or cap
+        enforcement.
+        """
+        if not self._auto_retain:
+            return
+        if self._shutting_down.is_set():
+            return
+        if not self._session_turns:
+            return
+
+        turns_to_flush = list(self._session_turns)
+        self._session_turns.clear()
+        self._turn_counter = 0
+        self._last_retained_turn_count = 0
+
+        content = "[" + ",".join(turns_to_flush) + "]"
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+
+        lineage_tags: list[str] = []
+        if self._session_id:
+            lineage_tags.append(f"session:{self._session_id}")
+        if self._parent_session_id:
+            lineage_tags.append(f"parent:{self._parent_session_id}")
+
+        metadata = self._build_metadata(
+            message_count=len(turns_to_flush) * 2,
+            turn_index=self._turn_index,
+        )
+
+        def _flush() -> None:
+            try:
+                item = self._build_retain_kwargs(
+                    content,
+                    context=self._retain_context,
+                    metadata=metadata,
+                    tags=lineage_tags or None,
+                )
+                item.pop("bank_id", None)
+                item.pop("retain_async", None)
+                if update_mode is not None:
+                    item["update_mode"] = update_mode
+                logger.debug(
+                    "Hindsight flush-on-end: bank=%s, doc=%s, mode=%s, num_turns=%d",
+                    self._bank_id, document_id, update_mode, len(turns_to_flush),
+                )
+                self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(
+                        bank_id=self._bank_id,
+                        items=[item],
+                        document_id=document_id,
+                        retain_async=self._retain_async,
+                    )
+                )
+                logger.debug("Hindsight flush-on-end succeeded, %d turns retained", len(turns_to_flush))
+            except Exception as e:
+                logger.warning("Hindsight flush-on-end failed: %s", e, exc_info=True)
+
+        self._ensure_writer()
+        self._register_atexit()
+        self._retain_queue.put(_flush)
+
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
         # Stop accepting new retain jobs first so anyone still calling

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1333,6 +1333,192 @@ class TestSessionSwitchBufferFlush:
 
 
 # ---------------------------------------------------------------------------
+# on_session_end — flush buffered turns at session boundary
+# ---------------------------------------------------------------------------
+
+
+class TestSessionEndBufferFlush:
+    def test_sub_threshold_turns_flushed_on_session_end(
+        self, provider_with_config,
+    ) -> None:
+        """Turns buffered below _retain_every_n_turns must flush on session end."""
+        import json as _json
+
+        p = provider_with_config(retain_every_n_turns=5, retain_async=False)
+        old_doc = p._document_id
+
+        # Buffer 2 turns — well below the 5-turn boundary.
+        p.sync_turn("t1-user", "t1-asst")
+        p.sync_turn("t2-user", "t2-asst")
+        assert len(p._session_turns) == 2
+        p._client.aretain_batch.assert_not_called()
+
+        p.on_session_end()
+        p._retain_queue.join()
+
+        p._client.aretain_batch.assert_called_once()
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == old_doc
+        item = kw["items"][0]
+        content = _json.loads(item["content"])
+        flat = _json.dumps(content)
+        assert "t1-user" in flat
+        assert "t2-user" in flat
+        assert "session:test-session" in item["tags"]
+
+        # Buffer must be cleared after flush.
+        assert p._session_turns == []
+        assert p._turn_counter == 0
+
+    def test_no_op_when_buffer_empty(self, provider) -> None:
+        """Session end with no buffered turns must not fire a spurious retain."""
+        assert provider._session_turns == []
+        provider.on_session_end()
+        provider._retain_queue.join()
+        provider._client.aretain_batch.assert_not_called()
+
+    def test_no_op_when_auto_retain_disabled(
+        self, provider_with_config,
+    ) -> None:
+        """If auto_retain is off, on_session_end is a silent no-op."""
+        import json as _json
+
+        p = provider_with_config(retain_every_n_turns=5, retain_async=False)
+        p._auto_retain = False
+        # When auto_retain is off, sync_turn does not buffer; simulate a
+        # buffered turn to prove on_session_end still guards correctly.
+        p._session_turns.append(_json.dumps({"role": "user", "content": "test"}))
+        assert len(p._session_turns) == 1
+
+        p.on_session_end()
+        p._retain_queue.join()
+        p._client.aretain_batch.assert_not_called()
+
+    def test_append_mode_tail_only_after_periodic_flush(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """After a periodic batch retain (append mode), on_session_end must
+        only ship the unretained watermark delta, not the full buffer."""
+        import json as _json
+
+        p = provider_with_config(retain_every_n_turns=5, retain_async=False)
+
+        # Simulate a post-batch state: watermark at 3, buffer still has all
+        # 5 turns (the periodic flush in append mode doesn't clear the
+        # buffer, just advances the watermark).
+        p._session_turns = [
+            _json.dumps({"role": "user", "content": "User: batch1-u"}),
+            _json.dumps({"role": "user", "content": "User: batch2-u"}),
+            _json.dumps({"role": "user", "content": "User: batch3-u"}),
+            _json.dumps({"role": "user", "content": "User: tail1-u"}),
+            _json.dumps({"role": "user", "content": "User: tail2-u"}),
+        ]
+        p._last_retained_turn_count = 3  # batch turns 0-2 already retained
+        p._turn_counter = 5
+
+        # Replace _resolve_retain_target inline to force append mode.
+        _orig = p._resolve_retain_target
+        p._resolve_retain_target = lambda fallback: (fallback, "append")  # type: ignore[method-assign]
+
+        try:
+            p.on_session_end()
+            p._retain_queue.join()
+
+            # Must have sent exactly one flush.
+            assert p._client.aretain_batch.call_count == 1
+            kw = p._client.aretain_batch.call_args.kwargs
+            content = _json.loads(kw["items"][0]["content"])
+            flat = _json.dumps(content)
+
+            # Tail turns must be present.
+            assert "tail1-u" in flat
+            assert "tail2-u" in flat
+            # Already-retained batch must NOT appear.
+            assert "batch1-u" not in flat
+            assert "batch2-u" not in flat
+            assert "batch3-u" not in flat
+
+            # Buffer must be cleared.
+            assert p._session_turns == []
+            assert p._turn_counter == 0
+        finally:
+            p._resolve_retain_target = _orig
+
+    def test_overwrite_mode_flushes_all_turns(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """Legacy overwrite mode must send the full buffer on session end."""
+        import json as _json
+
+        p = provider_with_config(retain_every_n_turns=5, retain_async=False)
+
+        # Simulate 4 buffered turns.
+        p._session_turns = [
+            _json.dumps({"role": "user", "content": "User: t1-u"}),
+            _json.dumps({"role": "user", "content": "User: t2-u"}),
+            _json.dumps({"role": "user", "content": "User: t3-u"}),
+            _json.dumps({"role": "user", "content": "User: t4-u"}),
+        ]
+        p._turn_counter = 4
+
+        # Force overwrite mode (update_mode=None).
+        _orig = p._resolve_retain_target
+        p._resolve_retain_target = lambda fallback: (fallback, None)  # type: ignore[method-assign]
+
+        try:
+            p.on_session_end()
+            p._retain_queue.join()
+
+            assert p._client.aretain_batch.call_count == 1
+            kw = p._client.aretain_batch.call_args.kwargs
+            content = _json.loads(kw["items"][0]["content"])
+            flat = _json.dumps(content)
+            assert "t1-u" in flat
+            assert "t4-u" in flat
+        finally:
+            p._resolve_retain_target = _orig
+
+    def test_flush_serializes_behind_pending_retains(
+        self, provider_with_config,
+    ) -> None:
+        """The end-of-session flush must land behind any still-queued
+        periodic retains via the shared writer queue."""
+        import threading as _threading
+
+        p = provider_with_config(retain_every_n_turns=2, retain_async=False)
+
+        gate = _threading.Event()
+        call_order: list[str] = []
+
+        def _aretain_batch_tracking(**kw):
+            idx = kw["items"][0]["metadata"].get("turn_index", "")
+            call_order.append(str(idx))
+            if idx == "2":
+                gate.wait(timeout=5.0)
+
+        p._client.aretain_batch = AsyncMock(side_effect=_aretain_batch_tracking)
+
+        # Turns 1-2: boundary hit → periodic retain enqueued (blocks on gate).
+        p.sync_turn("t1-u", "t1-a")
+        p.sync_turn("t2-u", "t2-a")
+
+        # Turn 3: buffered, below next boundary.
+        p.sync_turn("t3-u", "t3-a")
+
+        # Fire on_session_end while periodic retain is still blocked.
+        p.on_session_end()
+
+        # Release the gate — periodic retain runs first, then flush.
+        gate.set()
+        p._retain_queue.join()
+
+        # Order: periodic retain (turn 2) first, then session-end flush (turn 3).
+        assert len(call_order) >= 2
+        assert call_order[0] == "2"
+        assert call_order[1] == "3"
+
+
+# ---------------------------------------------------------------------------
 # update_mode='append' capability probe + retain dispatch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`HindsightMemoryProvider` accumulates conversation turns in `_session_turns` and only flushes them to the Hindsight API every `_retain_every_n_turns` turns (default 5).  If a session ends (idle TTL eviction, /reset, cap enforcement) before reaching the threshold, the buffered turns are silently discarded — the message content is lost forever.

The base `MemoryProvider.on_session_end()` is a no-op, and Hindsight does not override it, so session boundaries never trigger a flush.

## Fix

Override `on_session_end(messages)` to flush any remaining `_session_turns` into the Hindsight API via the same `aretain_batch` + writer queue path used by the periodic flush and `on_session_switch` flush.

The implementation:
- Snapshots current `_session_turns`, then clears the buffer (re-entrancy safe)
- Resolves the document target (append-mode for v0.5.0+, fallback to per-process document for legacy)
- Enqueues a `_flush` job to the existing serial writer queue, so it's ordered behind any in-flight retains
- Logs success/failure at INFO/WARNING level

## Related

Depends on the gateway-side change in PR #55045 which calls `on_session_end` before evicting cached agents. Without that PR, this hook would never be reached on idle TTL eviction (only on explicit /reset and the existing shutdown path).
