### PR TITLE
fix(tools): add tool runtime env vars (BUN_INSTALL, NODE_OPTIONS, DENO_INSTALL) to _SAFE_ENV_KEYS

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1379,6 +1379,32 @@ class TestBuildSafeEnv:
         assert "DATABASE_URL" not in result
         assert "API_SECRET" not in result
 
+    def test_tool_runtime_vars_passed(self):
+        """Tool runtime env vars (BUN_INSTALL, NODE_OPTIONS, DENO_INSTALL) pass through.
+
+        These are install-prefix and runtime-flag variables — not credentials.
+        MCP servers that shell out to Bun/Node/Deno need them to locate WASM
+        runtimes, native addons, and globally-installed tools.
+        """
+        from tools.mcp_tool import _build_safe_env
+
+        fake_env = {
+            "PATH": "/usr/bin",
+            "HOME": "/home/test",
+            "BUN_INSTALL": "/opt/bun",
+            "NODE_OPTIONS": "--experimental-wasm-simd",
+            "DENO_INSTALL": "/opt/deno",
+            "OPENAI_API_KEY": "sk-should-not-leak",
+        }
+        with patch.dict("os.environ", fake_env, clear=True):
+            result = _build_safe_env(None)
+
+        assert result["BUN_INSTALL"] == "/opt/bun"
+        assert result["NODE_OPTIONS"] == "--experimental-wasm-simd"
+        assert result["DENO_INSTALL"] == "/opt/deno"
+        # Secret still excluded
+        assert "OPENAI_API_KEY" not in result
+
 
 # ---------------------------------------------------------------------------
 # _sanitize_error

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -263,9 +263,23 @@ _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
 
-# Environment variables that are safe to pass to stdio subprocesses
+# Environment variables that are safe to pass to stdio subprocesses.
+# These are tool runtime paths and platform environment variables — not
+# credentials or secrets.  Tool runtimes like Bun, Node, and Deno need
+# their install-prefix variables to locate WASM runtimes, native
+# addons, and global packages.  Without them, MCP servers that shell
+# out to these runtimes can crash with opaque WASM aborts or fail to
+# find globally-installed tools.
+#
+# If you add a key here it must be a runtime/platform variable whose
+# value does not contain secrets (no API keys, tokens, or passwords).
 _SAFE_ENV_KEYS = frozenset({
+    # Platform baseline
     "PATH", "HOME", "USER", "LANG", "LC_ALL", "TERM", "SHELL", "TMPDIR",
+    # Tool runtime paths — needed by MCP servers that shell out to these runtimes
+    "BUN_INSTALL",
+    "NODE_OPTIONS",
+    "DENO_INSTALL",
 })
 
 # Regex for credential patterns to strip from error messages


### PR DESCRIPTION
## What

Adds `BUN_INSTALL`, `NODE_OPTIONS`, and `DENO_INSTALL` to
`_build_safe_env()` allowlist (in addition to the existing 9 baseline
vars). These are tool runtime paths/flags — not credentials.

## Why

Without `BUN_INSTALL`, Bun-based MCP servers (e.g. gbrain) cannot locate
their WASM runtime or globally-installed packages, causing opaque
`PGLite failed to initialize its WASM runtime` crashes.

## Test plan

```bash
python -m pytest tests/tools/test_mcp_tool.py::TestBuildSafeEnv -v
```

New test `test_tool_runtime_vars_passed` verifies all three vars pass
through while secrets are still excluded.

## Related

- Closes #44548