### PR TITLE
fix(wecom): harden content-disposition filenames

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -40,6 +40,7 @@ import re
 import time
 import uuid
 from datetime import datetime, timezone
+from email.message import Message
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote, urlparse
@@ -138,6 +139,41 @@ def _entry_matches(entries: List[str], target: str) -> bool:
         if normalized == "*" or normalized == normalized_target:
             return True
     return False
+
+
+def _safe_filename_candidate(value: Any, *, decode_percent: bool = False) -> str:
+    if isinstance(value, tuple):
+        value = value[-1] if value else ""
+    candidate = str(value or "")
+    if decode_percent:
+        candidate = unquote(candidate)
+    candidate = candidate.replace("\x00", "").strip()
+    candidate = Path(candidate.replace("\\", "/")).name.strip()
+    return "" if not candidate or candidate in {".", ".."} else candidate
+
+
+def _filename_from_content_disposition(content_disposition: Optional[str]) -> str:
+    if not content_disposition:
+        return ""
+    msg = Message()
+    msg["Content-Disposition"] = content_disposition
+    params = msg.get_params(header="content-disposition", unquote=True) or []
+
+    filename_star_values: List[Any] = []
+    filename_values: List[Any] = []
+    for key, value in params:
+        if str(key or "").lower() != "filename":
+            continue
+        if isinstance(value, tuple):
+            filename_star_values.append(value)
+        else:
+            filename_values.append(value)
+
+    for value in filename_star_values + filename_values:
+        candidate = _safe_filename_candidate(value, decode_percent=isinstance(value, tuple))
+        if candidate:
+            return candidate
+    return ""
 
 
 class WeComAdapter(BasePlatformAdapter):
@@ -830,12 +866,9 @@ class WeComAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _guess_filename(url: str, content_disposition: Optional[str], content_type: str) -> str:
-        if content_disposition:
-            match = re.search(r'filename="?([^";]+)"?', content_disposition)
-            if match:
-                return match.group(1)
-
-        name = Path(urlparse(url).path).name or "document"
+        name = _filename_from_content_disposition(content_disposition)
+        if not name:
+            name = _safe_filename_candidate(Path(urlparse(url).path).name) or "document"
         if "." not in name:
             ext = mimetypes.guess_extension(content_type) or ".bin"
             name = f"{name}{ext}"

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -40,6 +40,8 @@ import re
 import time
 import uuid
 from datetime import datetime, timezone
+from email.message import Message
+from email.utils import collapse_rfc2231_value
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote, urlparse
@@ -162,6 +164,39 @@ def _entry_matches(entries: List[str], target: str) -> bool:
         if normalized == "*" or normalized == normalized_target:
             return True
     return False
+
+
+def _safe_filename_candidate(value: Any) -> str:
+    if isinstance(value, tuple):
+        value = collapse_rfc2231_value(value)
+    candidate = str(value or "")
+    candidate = candidate.replace("\x00", "").strip()
+    candidate = Path(candidate.replace("\\", "/")).name.strip()
+    return "" if not candidate or candidate in {".", ".."} else candidate
+
+
+def _filename_from_content_disposition(content_disposition: Optional[str]) -> str:
+    if not content_disposition:
+        return ""
+    msg = Message()
+    msg["Content-Disposition"] = content_disposition
+    params = msg.get_params(header="content-disposition", unquote=True) or []
+
+    filename_star_values: List[Any] = []
+    filename_values: List[Any] = []
+    for key, value in params:
+        if str(key or "").lower() != "filename":
+            continue
+        if isinstance(value, tuple):
+            filename_star_values.append(value)
+        else:
+            filename_values.append(value)
+
+    for value in filename_star_values + filename_values:
+        candidate = _safe_filename_candidate(value)
+        if candidate:
+            return candidate
+    return ""
 
 
 class WeComAdapter(BasePlatformAdapter):
@@ -861,12 +896,9 @@ class WeComAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _guess_filename(url: str, content_disposition: Optional[str], content_type: str) -> str:
-        if content_disposition:
-            match = re.search(r'filename="?([^";]+)"?', content_disposition)
-            if match:
-                return match.group(1)
-
-        name = Path(urlparse(url).path).name or "document"
+        name = _filename_from_content_disposition(content_disposition)
+        if not name:
+            name = _safe_filename_candidate(Path(urlparse(url).path).name) or "document"
         if "." not in name:
             ext = mimetypes.guess_extension(content_type) or ".bin"
             name = f"{name}{ext}"

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -378,6 +378,56 @@ class TestMediaHelpers:
 
         assert decrypted == plaintext
 
+    def test_guess_filename_preserves_quoted_semicolon(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        assert (
+            WeComAdapter._guess_filename(
+                "https://example.com/download",
+                'attachment; filename="quarter; summary.txt"',
+                "text/plain",
+            )
+            == "quarter; summary.txt"
+        )
+
+    def test_guess_filename_prefers_filename_star(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        assert (
+            WeComAdapter._guess_filename(
+                "https://example.com/fallback.txt",
+                "attachment; filename=wrong.txt; filename*=UTF-8''quarter%3B%20summary.pdf",
+                "application/pdf",
+            )
+            == "quarter; summary.pdf"
+        )
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            'attachment; filename="../secret.bin"',
+            'attachment; filename="..\\secret.bin"',
+            "attachment; filename*=UTF-8''..%2Fsecret.bin",
+        ],
+    )
+    def test_guess_filename_strips_disposition_path_segments(self, header):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        assert WeComAdapter._guess_filename("https://example.com/fallback.bin", header, "") == "secret.bin"
+
+    @pytest.mark.parametrize("header", ['attachment; filename=".."', 'attachment; filename="."'])
+    def test_guess_filename_ignores_dot_segment_disposition(self, header):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        assert (
+            WeComAdapter._guess_filename(
+                "https://example.com/reports/fallback",
+                header,
+                "application/pdf",
+            )
+            == "fallback.pdf"
+        )
+
     @pytest.mark.asyncio
     async def test_load_outbound_media_rejects_placeholder_path(self):
         from plugins.platforms.wecom.adapter import WeComAdapter

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -221,6 +221,67 @@ class TestMediaHelpers:
         assert result["downgraded"] is True
         assert "AMR" in (result["downgrade_note"] or "")
 
+    def test_guess_filename_preserves_quoted_semicolon(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        assert (
+            WeComAdapter._guess_filename(
+                "https://example.com/download",
+                'attachment; filename="quarter; summary.txt"',
+                "text/plain",
+            )
+            == "quarter; summary.txt"
+        )
+
+    def test_guess_filename_prefers_filename_star(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        assert (
+            WeComAdapter._guess_filename(
+                "https://example.com/fallback.txt",
+                "attachment; filename=wrong.txt; filename*=UTF-8''quarter%3B%20summary.pdf",
+                "application/pdf",
+            )
+            == "quarter; summary.pdf"
+        )
+
+    def test_guess_filename_decodes_non_ascii_filename_star(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        assert (
+            WeComAdapter._guess_filename(
+                "https://example.com/fallback.txt",
+                "attachment; filename=wrong.txt; filename*=UTF-8''caf%C3%A9.pdf",
+                "application/pdf",
+            )
+            == "café.pdf"
+        )
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            'attachment; filename="../secret.bin"',
+            'attachment; filename="..\\secret.bin"',
+            "attachment; filename*=UTF-8''..%2Fsecret.bin",
+        ],
+    )
+    def test_guess_filename_strips_disposition_path_segments(self, header):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        assert WeComAdapter._guess_filename("https://example.com/fallback.bin", header, "") == "secret.bin"
+
+    @pytest.mark.parametrize("header", ['attachment; filename=".."', 'attachment; filename="."'])
+    def test_guess_filename_ignores_dot_segment_disposition(self, header):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        assert (
+            WeComAdapter._guess_filename(
+                "https://example.com/reports/fallback",
+                header,
+                "application/pdf",
+            )
+            == "fallback.pdf"
+        )
 
 class TestMediaUpload:
 


### PR DESCRIPTION
﻿## Summary

Fixes #55049.

WeCom remote media filename guessing now parses `Content-Disposition` with quote-aware stdlib parsing instead of the previous semicolon-fragile regex. It also:

- preserves quoted filenames such as `filename="quarter; summary.txt"`;
- prefers RFC 5987 / RFC 2231-style `filename*` values over fallback `filename` values;
- strips slash and backslash path segments before using a header-provided filename;
- ignores `.` / `..` disposition filenames and falls back to the URL-derived name plus MIME extension.

## Why

This mirrors the bug class fixed in openclaw/openclaw#96555. Hermes has the analogous parser in `plugins.platforms.wecom.adapter.WeComAdapter._guess_filename()`, where malformed parsing can truncate user-visible upload/cache filenames or pass path-bearing names into outbound media preparation before downstream cache helpers sanitize their own paths.

## Duplicate / Scope Check

- New issue: #55049.
- I searched existing Hermes issues/PRs for `wecom filename content-disposition`, `WeCom remote filename`, and related path traversal terms and did not find a duplicate.
- Scope is limited to WeCom filename derivation and focused tests. No download-size logic or shared document cache behavior is changed.

## Validation

Base: `origin/main` at `929dd9c0d`
Environment: Windows, Python 3.11.15

- `uv run --extra dev --extra messaging python -m pytest tests\gateway\test_wecom.py -q --basetemp .pytest-tmp-wecom-filename` -> `53 passed`
- `uv run --extra dev --extra messaging python -m ruff check plugins\platforms\wecom\adapter.py tests\gateway\test_wecom.py` -> `All checks passed!`
- `git diff --check`
