### PR TITLE
fix(teams): authenticate inbound image attachment downloads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -710,7 +710,7 @@ def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
     return str(filepath)
 
 
-async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2) -> str:
+async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2, headers=None) -> str:
     """
     Download an image from a URL and save it to the local cache.
 
@@ -721,6 +721,9 @@ async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2) ->
         url: The HTTP/HTTPS URL to download from.
         ext: File extension including the dot (e.g. ".jpg", ".png").
         retries: Number of retry attempts on transient failures.
+        headers: Optional extra request headers merged over the defaults — e.g. an
+            ``Authorization: Bearer`` for endpoints that require auth (Teams attachment
+            URLs on Bot Framework hosts). Public CDNs pass ``None``.
 
     Returns:
         Absolute path to the cached image file as a string.
@@ -742,13 +745,16 @@ async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2) ->
     ) as client:
         for attempt in range(retries + 1):
             try:
+                _req_headers = {
+                    "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+                    "Accept": "image/*,*/*;q=0.8",
+                }
+                if headers:
+                    _req_headers.update(headers)
                 async with client.stream(
                     "GET",
                     url,
-                    headers={
-                        "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
-                        "Accept": "image/*,*/*;q=0.8",
-                    },
+                    headers=_req_headers,
                 ) as response:
                     response.raise_for_status()
                     content = await _read_httpx_body_with_limit(

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -708,6 +708,53 @@ class TeamsAdapter(BasePlatformAdapter):
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+        # Cached Bot Framework bearer token for downloading inbound image attachments.
+        self._bf_token: Optional[str] = None
+        self._bf_token_exp: float = 0.0
+
+    async def _bot_framework_token(self) -> Optional[str]:
+        """Mint (and briefly cache) a Bot Framework bearer token for downloading
+        inbound image attachments from Bot Framework hosts (smba.*), whose URLs
+        require auth.
+
+        Uses the same client-credentials flow + ``api.botframework.com`` scope the
+        adapter already uses to send activities. **Fail-soft:** returns ``None`` on
+        any error so the caller falls back to an unauthenticated fetch — a token
+        hiccup must never break message handling.
+        """
+        import time
+
+        now = time.monotonic()
+        if self._bf_token and self._bf_token_exp > now:
+            return self._bf_token
+        if not (self._client_id and self._client_secret and self._tenant_id):
+            return None
+        token_url = f"https://login.microsoftonline.com/{self._tenant_id}/oauth2/v2.0/token"
+        try:
+            import httpx
+
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.post(
+                    token_url,
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": self._client_id,
+                        "client_secret": self._client_secret,
+                        "scope": "https://api.botframework.com/.default",
+                    },
+                )
+                resp.raise_for_status()
+                payload = resp.json()
+            token = payload.get("access_token")
+            if not token:
+                return None
+            expires_in = float(payload.get("expires_in", 3600) or 3600)
+            self._bf_token = token
+            self._bf_token_exp = now + max(60.0, expires_in - 60.0)  # refresh ~1 min early
+            return token
+        except Exception as e:  # noqa: BLE001 — must not propagate; fall back to no-auth
+            logger.warning("[teams] Could not acquire Bot Framework token for attachment download: %s", e)
+            return None
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
@@ -924,8 +971,23 @@ class TeamsAdapter(BasePlatformAdapter):
                 continue
 
             if content_url and content_type.startswith("image/"):
+                # Bot Framework image URLs (smba.*) require the bot's bearer token;
+                # without it the download 401s and the image is silently dropped.
+                # Attach the token, but only for allowlisted Bot Framework hosts so
+                # it can never leak to an attacker-controlled contentUrl. Non-BF
+                # hosts (and any token failure) fall back to an unauthenticated GET.
+                _dl_headers = None
                 try:
-                    cached = await cache_image_from_url(content_url)
+                    from urllib.parse import urlparse
+
+                    if urlparse(content_url).hostname in _ALLOWED_TEAMS_SERVICE_HOSTS:
+                        _tok = await self._bot_framework_token()
+                        if _tok:
+                            _dl_headers = {"Authorization": f"Bearer {_tok}"}
+                except Exception:  # noqa: BLE001 — gating is best-effort; fall back to no-auth
+                    _dl_headers = None
+                try:
+                    cached = await cache_image_from_url(content_url, headers=_dl_headers)
                     if cached:
                         media_urls.append(cached)
                         media_types.append(content_type)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "rod@rodnavarro.com": "rodnavarro",  # Teams inbound image attachment auth fix
     "telos@apex-z.com": "telos-oc",  # PR #14353 salvage (propagate custom_providers key_env into ProviderDef.api_key_env_vars; named + bare-custom self-heal paths)
     "256073454+Kolektori@users.noreply.github.com": "Kolektori",  # PR #6436 salvage (require approval for host-bound Docker commands; container guard fast-path)
     "41764686+LIC99@users.noreply.github.com": "LIC99",  # PR #4682 salvage (warn + default to manual on unknown approvals.mode; #4261)

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -1125,3 +1125,125 @@ class TestTeamsMediaAttachments:
         result = await adapter.send_document("19:abc@thread.v2", "/no/such/file.pdf")
         assert not result.success
         adapter._app.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Inbound image attachment auth (Bot Framework bearer token)
+#
+# Teams serves message attachments from Bot Framework hosts (smba.*) whose URLs
+# require the bot's bearer token; the shared image downloader sends none, so the
+# download 401s and the image is silently dropped. Regression coverage for the
+# fix: the adapter mints the token (same client-credentials flow it uses to send
+# activities) and the cache forwards it — gated to allowlisted BF hosts.
+# ---------------------------------------------------------------------------
+
+
+class _FakeHttpxResponse:
+    def __init__(self, payload=None):
+        self._payload = payload or {}
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeStreamCtx:
+    async def __aenter__(self):
+        return _FakeHttpxResponse()
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeHttpxClient:
+    """Async-context ``httpx.AsyncClient`` stand-in recording the last request."""
+
+    last: dict = {}
+    token_payload: dict = {"access_token": "tok-abc", "expires_in": 3600}
+    post_error = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, url, **kwargs):
+        _FakeHttpxClient.last = {"method": "post", "url": url, "kwargs": kwargs}
+        if _FakeHttpxClient.post_error is not None:
+            raise _FakeHttpxClient.post_error
+        return _FakeHttpxResponse(payload=_FakeHttpxClient.token_payload)
+
+    def stream(self, method, url, headers=None):
+        _FakeHttpxClient.last = {"method": method, "url": url, "headers": headers}
+        return _FakeStreamCtx()
+
+
+class TestTeamsAttachmentAuth:
+    def _adapter(self):
+        return TeamsAdapter(
+            _make_config(client_id="cid", client_secret="csec", tenant_id="tid")
+        )
+
+    @pytest.mark.asyncio
+    async def test_token_minted_with_botframework_scope(self, monkeypatch):
+        _FakeHttpxClient.post_error = None
+        _FakeHttpxClient.token_payload = {"access_token": "tok-abc", "expires_in": 3600}
+        monkeypatch.setattr(httpx, "AsyncClient", _FakeHttpxClient)
+        token = await self._adapter()._bot_framework_token()
+        assert token == "tok-abc"
+        data = _FakeHttpxClient.last["kwargs"]["data"]
+        assert data["grant_type"] == "client_credentials"
+        assert data["scope"] == "https://api.botframework.com/.default"
+        assert "login.microsoftonline.com/tid/" in _FakeHttpxClient.last["url"]
+
+    @pytest.mark.asyncio
+    async def test_token_cached_between_calls(self, monkeypatch):
+        _FakeHttpxClient.post_error = None
+        _FakeHttpxClient.token_payload = {"access_token": "tok-1", "expires_in": 3600}
+        monkeypatch.setattr(httpx, "AsyncClient", _FakeHttpxClient)
+        adapter = self._adapter()
+        assert await adapter._bot_framework_token() == "tok-1"
+        # A fresh mint would now return tok-2; the cached value must persist.
+        _FakeHttpxClient.token_payload = {"access_token": "tok-2", "expires_in": 3600}
+        _FakeHttpxClient.last = {}
+        assert await adapter._bot_framework_token() == "tok-1"
+        assert _FakeHttpxClient.last == {}  # no second network call
+
+    @pytest.mark.asyncio
+    async def test_token_fail_soft_returns_none(self, monkeypatch):
+        _FakeHttpxClient.post_error = httpx.ConnectError("down")
+        monkeypatch.setattr(httpx, "AsyncClient", _FakeHttpxClient)
+        try:
+            assert await self._adapter()._bot_framework_token() is None
+        finally:
+            _FakeHttpxClient.post_error = None
+
+    @pytest.mark.asyncio
+    async def test_token_none_without_credentials(self, monkeypatch):
+        for var in ("TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"):
+            monkeypatch.delenv(var, raising=False)
+        assert await TeamsAdapter(_make_config())._bot_framework_token() is None
+
+    @pytest.mark.asyncio
+    async def test_cache_image_from_url_forwards_auth_header(self, monkeypatch):
+        from unittest.mock import AsyncMock
+        from gateway.platforms import base as base_mod
+
+        _FakeHttpxClient.last = {}
+        monkeypatch.setattr(httpx, "AsyncClient", _FakeHttpxClient)
+        monkeypatch.setattr(base_mod, "_read_httpx_body_with_limit", AsyncMock(return_value=b"\x89PNG\r\n\x1a\n"))
+        monkeypatch.setattr(base_mod, "cache_image_from_bytes", lambda data, ext=".jpg": "/tmp/cached.png")
+        out = await base_mod.cache_image_from_url(
+            "https://smba.trafficmanager.net/amer/x/v3/attachments/abc/views/original",
+            headers={"Authorization": "Bearer T"},
+        )
+        assert out == "/tmp/cached.png"
+        sent = _FakeHttpxClient.last["headers"]
+        assert sent["Authorization"] == "Bearer T"
+        assert "User-Agent" in sent  # default headers preserved alongside the override


### PR DESCRIPTION
## What does this PR do?

Inbound **image attachments in Microsoft Teams never reach the model** — the agent silently ignores screenshots and photos users send.

Teams serves message attachments from Bot Framework hosts (`smba.trafficmanager.net/.../v3/attachments/<id>/views/original`) whose URLs **require the bot's bearer token**. The Teams adapter downloads them through the shared `cache_image_from_url()` helper, which sends only `User-Agent`/`Accept` and **no `Authorization` header**. Every inbound image therefore returns **401 Unauthorized**, the download is caught and dropped (`[teams] Failed to cache image attachment: 401`), and the now-empty media path then fails downstream in `vision_analyze` (`Invalid image source`).

The fix mints a Bot Framework token using the **same client-credentials flow the adapter already uses to send activities** (`scope=https://api.botframework.com/.default`), caches it for its lifetime, and passes it to the downloader — **gated to the existing `_ALLOWED_TEAMS_SERVICE_HOSTS` allowlist** so the token can never be sent to an attacker-controlled `contentUrl`. Public-CDN media on other platforms (Telegram/Discord/etc.) is unaffected. Token-mint failures fall back to the previous unauthenticated fetch, so a token hiccup can never break message handling.

## Related Issue

No existing issue found; happy to open one to track if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` — `cache_image_from_url()` gains an optional `headers` argument, merged over the existing defaults. Backward compatible (default `None`).
- `plugins/platforms/teams/adapter.py` —
  - new `TeamsAdapter._bot_framework_token()`: mints + caches a Bot Framework bearer (client-credentials, `api.botframework.com/.default`); returns `None` on any failure (fail-soft).
  - `_on_message()`: for image attachments whose host is in `_ALLOWED_TEAMS_SERVICE_HOSTS`, attaches `Authorization: Bearer <token>` to the download; non-allowlisted hosts and token failures fall back to the prior no-auth fetch.
- `tests/gateway/test_teams.py` — `TestTeamsAttachmentAuth`: token minting (correct scope/endpoint), caching, fail-soft, and `Authorization` header forwarding.

## How to Test

**Reproduction (before):** Send an image to a Teams-connected Hermes bot. Logs show:
```
WARNING [teams] Failed to cache image attachment: Client error '401 Unauthorized'
  for url 'https://smba.trafficmanager.net/.../v3/attachments/.../views/original'
ERROR  tools.vision_tools: Invalid image source ...
```
The agent does not see the image.

**After the fix:** Send an image containing readable text/numbers and ask "what does this show?" — the 401 is gone, the image downloads, and the agent describes its contents. Verified on a live Microsoft Teams tenant against a Bedrock-backed agent.

**Unit tests:**
```
pytest tests/gateway/test_teams.py -q       # 49 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(teams): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass (`pytest tests/gateway/test_teams.py` → 49 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (container) + live Microsoft Teams tenant

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing config/docs change)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — considered; pure network/auth, no OS-specific calls (`scripts/check-windows-footguns.py` clean)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before (download leg fails):
```
WARNING [teams] Failed to cache image attachment: Client error '401 Unauthorized' for url 'https://smba.trafficmanager.net/.../views/original'
ERROR  tools.vision_tools: Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path.
```
After: no 401, attachment cached, agent reads the image content back to the user.
