### PR TITLE
feat: add 1Password secret source backend

### DIFF
--- a/agent/secret_sources/__init__.py
+++ b/agent/secret_sources/__init__.py
@@ -10,4 +10,7 @@ Currently shipped:
   - ``bitwarden`` — Bitwarden Secrets Manager (`bws` CLI).  See
     ``agent.secret_sources.bitwarden`` for the integration and
     ``hermes_cli.secrets_cli`` for the user-facing setup wizard.
+  - ``onepassword`` — 1Password CLI (`op`) secret references.  See
+    ``agent.secret_sources.onepassword`` for the integration and
+    ``hermes_cli.onepassword_secrets_cli`` for the user-facing setup wizard.
 """

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -1,0 +1,310 @@
+"""1Password CLI (`op`) integration for Hermes secret sources.
+
+Hermes can pull API keys from 1Password at process startup so provider
+credentials do not have to live in plaintext in ``~/.hermes/.env``.
+
+Design summary
+--------------
+
+* Users keep a small references file (default:
+  ``~/.hermes/secrets/1password.env``) that maps environment variable
+  names to 1Password secret references, for example::
+
+      OPENROUTER_API_KEY=op://Private/OpenRouter API Key/credential
+
+* The only optional bootstrap secret is ``OP_SERVICE_ACCOUNT_TOKEN`` (or a
+  configured alternative) in ``~/.hermes/.env`` / the shell.  Users can
+  also rely on an already authenticated 1Password app / CLI session.
+* Fetching is subprocess-driven via ``op read <reference>``.  We do not
+  depend on a Python SDK and we do not print secret values.
+* Failures NEVER block Hermes startup.  Missing ``op``, unauthenticated
+  sessions, invalid references, etc. all emit warnings and continue with
+  credentials already present in the environment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+_OP_RUN_TIMEOUT = 20
+_CacheKey = Tuple[str, str]  # (env_file_fingerprint, op_path)
+_CACHE: Dict[_CacheKey, "_CachedFetch"] = {}
+
+
+@dataclass
+class FetchResult:
+    """Outcome of a single 1Password pull."""
+
+    secrets: Dict[str, str] = field(default_factory=dict)
+    applied: List[str] = field(default_factory=list)
+    skipped: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+    binary_path: Optional[Path] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+@dataclass
+class _CachedFetch:
+    secrets: Dict[str, str]
+    warnings: List[str]
+    fetched_at: float
+
+    def is_fresh(self, ttl_seconds: float) -> bool:
+        if ttl_seconds <= 0:
+            return False
+        return (time.time() - self.fetched_at) < ttl_seconds
+
+
+def find_op(*, op_path: str = "") -> Optional[Path]:
+    """Return a usable ``op`` binary path, or None.
+
+    Resolution order:
+      1. explicit ``op_path`` from config / CLI
+      2. ``shutil.which("op")`` / ``op.exe`` on PATH
+    """
+    configured = str(op_path or "").strip()
+    if configured:
+        candidate = Path(configured).expanduser()
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+        return None
+
+    system = shutil.which(_platform_binary_name()) or shutil.which("op")
+    if system:
+        return Path(system)
+    return None
+
+
+def _platform_binary_name() -> str:
+    return "op.exe" if os.name == "nt" else "op"
+
+
+def _is_valid_env_name(name: str) -> bool:
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _resolve_env_file(env_file: str, home_path: Optional[Path] = None) -> Path:
+    raw = str(env_file or "").strip() or "~/.hermes/secrets/1password.env"
+    home = home_path or Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    if raw == "~/.hermes" or raw.startswith("~/.hermes/"):
+        suffix = raw.removeprefix("~/.hermes").lstrip("/")
+        return home / suffix
+    if raw.startswith("~"):
+        return Path(raw).expanduser()
+    path = Path(raw)
+    if path.is_absolute():
+        return path
+    return home / path
+
+
+def parse_reference_file(path: Path) -> Tuple[Dict[str, str], List[str]]:
+    """Parse an env-style file of ``NAME=op://...`` references.
+
+    Plaintext-looking values are skipped with a warning.  This keeps the
+    native 1Password backend honest: the file is for references, not final
+    secret values.
+    """
+    references: Dict[str, str] = {}
+    warnings: List[str] = []
+    try:
+        lines = path.read_text(encoding="utf-8-sig").splitlines()
+    except OSError as exc:
+        raise RuntimeError(f"1Password references file not readable: {path}: {exc}") from exc
+
+    for line_no, raw_line in enumerate(lines, 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        if "=" not in line:
+            warnings.append(f"Skipping line {line_no}: expected NAME=op:// reference")
+            continue
+        name, value = line.split("=", 1)
+        name = name.strip()
+        value = value.strip()
+        if not _is_valid_env_name(name):
+            warnings.append(f"Skipping line {line_no}: {name!r} is not a valid env-var name")
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        if not value.startswith("op://"):
+            warnings.append(
+                f"Skipping {name}: value is not a 1Password secret reference (op://...)"
+            )
+            continue
+        references[name] = value
+    return references, warnings
+
+
+def _fingerprint_references(references: Dict[str, str], env_file: Path) -> str:
+    h = hashlib.sha256()
+    h.update(str(env_file.resolve()).encode("utf-8", errors="replace"))
+    for name in sorted(references):
+        h.update(b"\0")
+        h.update(name.encode("utf-8"))
+        h.update(b"=")
+        h.update(references[name].encode("utf-8"))
+    return h.hexdigest()[:24]
+
+
+def fetch_onepassword_secrets(
+    *,
+    env_file: str = "~/.hermes/secrets/1password.env",
+    binary: Optional[Path] = None,
+    op_path: str = "",
+    cache_ttl_seconds: float = 300,
+    use_cache: bool = True,
+    home_path: Optional[Path] = None,
+) -> Tuple[Dict[str, str], List[str]]:
+    """Resolve all ``op://`` references in ``env_file`` via ``op read``.
+
+    Returns ``(secrets_dict, warnings_list)``.  Secret values are never
+    included in warnings or exceptions.
+    """
+    path = _resolve_env_file(env_file, home_path)
+    if not path.exists():
+        raise RuntimeError(
+            f"1Password references file does not exist: {path}. "
+            "Run `hermes secrets onepassword setup`."
+        )
+
+    references, warnings = parse_reference_file(path)
+    if not references:
+        return {}, warnings + ["1Password references file contains no op:// entries"]
+
+    op = binary or find_op(op_path=op_path)
+    if op is None:
+        raise RuntimeError(
+            "1Password CLI `op` is not available. Install it from "
+            "https://developer.1password.com/docs/cli/get-started/ "
+            "or set secrets.onepassword.op_path."
+        )
+
+    cache_key = (_fingerprint_references(references, path), str(op))
+    if use_cache:
+        cached = _CACHE.get(cache_key)
+        if cached and cached.is_fresh(cache_ttl_seconds):
+            return cached.secrets, cached.warnings
+
+    secrets: Dict[str, str] = {}
+    for name, reference in references.items():
+        try:
+            secrets[name] = _op_read(op, reference)
+        except RuntimeError as exc:
+            warnings.append(f"Skipping {name}: {exc}")
+            continue
+
+    entry = _CachedFetch(secrets=secrets, warnings=list(warnings), fetched_at=time.time())
+    _CACHE[cache_key] = entry
+    return secrets, warnings
+
+
+def _op_read(op: Path, reference: str) -> str:
+    try:
+        proc = subprocess.run(  # noqa: S603 — op path is either user configured or PATH-resolved
+            [str(op), "read", reference],
+            capture_output=True,
+            text=True,
+            timeout=_OP_RUN_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"op timed out after {_OP_RUN_TIMEOUT}s") from exc
+    except OSError as exc:
+        raise RuntimeError(f"failed to invoke op: {exc}") from exc
+
+    if proc.returncode != 0:
+        err = _sanitize_op_error(proc.stderr or proc.stdout or "")
+        raise RuntimeError(f"op exited {proc.returncode}: {err}")
+    return (proc.stdout or "").rstrip("\r\n")
+
+
+def _sanitize_op_error(text: str) -> str:
+    """Keep op errors useful without echoing references or credential-like data."""
+    cleaned = text.strip().replace("\x1b", "")
+    for token in cleaned.split():
+        if token.startswith("op://"):
+            cleaned = cleaned.replace(token, "op://[REDACTED]")
+    return cleaned[:200] or "unknown error"
+
+
+def apply_onepassword_secrets(
+    *,
+    enabled: bool,
+    env_file: str = "~/.hermes/secrets/1password.env",
+    service_account_token_env: str = "OP_SERVICE_ACCOUNT_TOKEN",
+    override_existing: bool = False,
+    cache_ttl_seconds: float = 300,
+    op_path: str = "",
+    home_path: Optional[Path] = None,
+) -> FetchResult:
+    """Pull secrets from 1Password and set them on ``os.environ``.
+
+    Defensive by design: returns a :class:`FetchResult` and never raises,
+    because external secret sources must not block Hermes startup.
+    """
+    result = FetchResult()
+    if not enabled:
+        return result
+
+    binary = find_op(op_path=op_path)
+    result.binary_path = binary
+    if binary is None:
+        result.error = (
+            "1Password CLI `op` is not available. Run `hermes secrets "
+            "onepassword setup` after installing op."
+        )
+        return result
+
+    # service_account_token_env is optional: `op` can also use an already
+    # authenticated desktop-app / CLI session.  If the env var is present,
+    # subprocesses inherit it via os.environ.
+    _ = service_account_token_env
+
+    try:
+        secrets, warnings = fetch_onepassword_secrets(
+            env_file=env_file,
+            binary=binary,
+            op_path=op_path,
+            cache_ttl_seconds=cache_ttl_seconds,
+            home_path=home_path,
+        )
+    except RuntimeError as exc:
+        result.error = str(exc)
+        return result
+
+    result.secrets = secrets
+    result.warnings.extend(warnings)
+
+    for key, value in secrets.items():
+        if key == service_account_token_env:
+            result.skipped.append(key)
+            continue
+        if not override_existing and os.environ.get(key):
+            result.skipped.append(key)
+            continue
+        os.environ[key] = value
+        result.applied.append(key)
+
+    return result
+
+
+def _reset_cache_for_tests() -> None:
+    """Clear in-process cache for hermetic tests."""
+    _CACHE.clear()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2959,6 +2959,22 @@ DEFAULT_CONFIG = {
             # `hermes secrets bitwarden setup`.
             "server_url": "",
         },
+        "onepassword": {
+            # Master switch.  When false, the op CLI is never contacted.
+            "enabled": False,
+            # Env-style file with NAME=op://vault/item/field references.
+            # This file should contain references only, not plaintext secrets.
+            "env_file": "~/.hermes/secrets/1password.env",
+            # Optional bootstrap token env var for 1Password Service Accounts.
+            # Users can also rely on an already authenticated op/app session.
+            "service_account_token_env": "OP_SERVICE_ACCOUNT_TOKEN",
+            # Seconds to cache resolved references in-process.  0 disables.
+            "cache_ttl_seconds": 300,
+            # When True, 1Password values overwrite existing env vars.
+            "override_existing": True,
+            # Optional explicit op CLI path.  Empty string means resolve from PATH.
+            "op_path": "",
+        },
     },
 
     # Paste collapse thresholds (TUI + CLI).

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -33,21 +33,22 @@ _SECRET_SOURCES: dict[str, str] = {}
 # process.  ``load_hermes_dotenv()`` is called at module-import time from
 # several hot modules (cli.py, hermes_cli/main.py, run_agent.py,
 # trajectory_compressor.py, gateway/run.py, ...), so without this guard the
-# Bitwarden status line gets printed 3-5x per startup.  Bitwarden's own
-# in-process cache prevents redundant network calls, but the print, the
-# config re-parse, and the ASCII sanitization sweep still ran every time.
+# external-source status line gets printed 3-5x per startup.  Backend caches
+# prevent redundant CLI/network calls, but the print, config re-parse, and
+# ASCII sanitization sweep still ran every time.
 _APPLIED_HOMES: set[str] = set()
 
 
 def get_secret_source(env_var: str) -> str | None:
     """Return the label of the secret source that supplied ``env_var``, if any.
 
-    Returns ``"bitwarden"`` for keys pulled from Bitwarden Secrets Manager
-    during the current process's ``load_hermes_dotenv()`` call.  Returns
-    ``None`` for keys that came from ``.env``, the shell environment, or
-    aren't tracked.  The returned label is metadata only: credential-pool
-    persistence may store it to explain the origin of a borrowed secret, but
-    must never treat it as authorization to persist the raw value.
+    Returns labels like ``"bitwarden"`` or ``"onepassword"`` for keys pulled
+    from an external secret source during the current process's
+    ``load_hermes_dotenv()`` call.  Returns ``None`` for keys that came from
+    ``.env``, the shell environment, or aren't tracked.  The returned label is
+    metadata only: credential-pool persistence may store it to explain the
+    origin of a borrowed secret, but must never treat it as authorization to
+    persist the raw value.
     """
     return _SECRET_SOURCES.get(env_var)
 
@@ -78,9 +79,10 @@ def format_secret_source_suffix(env_var: str) -> str:
         return ""
     if source == "bitwarden":
         return " (from Bitwarden)"
+    if source == "onepassword":
+        return " (from 1Password)"
     # Generic fallback — future-proofing for additional secret sources
-    # (e.g. 1Password, HashiCorp Vault) without having to update every
-    # call site.
+    # (e.g. HashiCorp Vault) without having to update every call site.
     return f" (from {source})"
 
 
@@ -281,21 +283,16 @@ def _apply_managed_env() -> None:
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:
-    """Pull secrets from external sources (currently Bitwarden) into env.
+    """Pull secrets from configured external sources into env.
 
-    Runs AFTER dotenv loads so .env values are visible (we use them to
-    locate the access token) but BEFORE the rest of Hermes reads
-    ``os.environ`` for credentials.  Any failure here is logged and
-    swallowed — external secret sources must never block startup.
+    Runs AFTER dotenv loads so bootstrap credentials / references are visible
+    but BEFORE the rest of Hermes reads ``os.environ`` for provider keys.  Any
+    failure here is logged and swallowed — external secret sources must never
+    block startup.
 
-    Idempotent within a process: subsequent calls for the same
-    ``home_path`` are no-ops.  ``load_hermes_dotenv()`` runs at import
-    time from several hot modules (cli.py, hermes_cli/main.py,
-    run_agent.py, trajectory_compressor.py, ...), so without this guard
-    the Bitwarden status line would print 3-5x per CLI startup.  Use
-    ``reset_secret_source_cache()`` if you need to force a re-pull
-    (tests, future ``hermes secrets bitwarden sync`` from a long-running
-    process).
+    Idempotent within a process: subsequent calls for the same ``home_path``
+    are no-ops.  Use ``reset_secret_source_cache()`` if you need to force a
+    re-pull (tests, or future sync flows from a long-running process).
     """
     home_key = str(Path(home_path).resolve())
     if home_key in _APPLIED_HOMES:
@@ -308,52 +305,72 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         return
 
     bw_cfg = (cfg or {}).get("bitwarden") or {}
-    if not bw_cfg.get("enabled"):
-        return
+    if bw_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.bitwarden import apply_bitwarden_secrets
+        except ImportError:
+            apply_bitwarden_secrets = None  # type: ignore[assignment]
+        if apply_bitwarden_secrets is not None:
+            result = apply_bitwarden_secrets(
+                enabled=True,
+                access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
+                project_id=bw_cfg.get("project_id", ""),
+                override_existing=bool(bw_cfg.get("override_existing", False)),
+                cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
+                auto_install=bool(bw_cfg.get("auto_install", True)),
+                server_url=str(bw_cfg.get("server_url", "") or "").strip(),
+                home_path=home_path,
+            )
+            _report_secret_source_result(
+                label="Bitwarden Secrets Manager",
+                source_key="bitwarden",
+                result=result,
+            )
 
-    try:
-        from agent.secret_sources.bitwarden import apply_bitwarden_secrets
-    except ImportError:
-        return
+    op_cfg = (cfg or {}).get("onepassword") or {}
+    if op_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.onepassword import apply_onepassword_secrets
+        except ImportError:
+            apply_onepassword_secrets = None  # type: ignore[assignment]
+        if apply_onepassword_secrets is not None:
+            result = apply_onepassword_secrets(
+                enabled=True,
+                env_file=op_cfg.get("env_file", "~/.hermes/secrets/1password.env"),
+                service_account_token_env=op_cfg.get(
+                    "service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN"
+                ),
+                override_existing=bool(op_cfg.get("override_existing", False)),
+                cache_ttl_seconds=float(op_cfg.get("cache_ttl_seconds", 300)),
+                op_path=str(op_cfg.get("op_path", "") or ""),
+                home_path=home_path,
+            )
+            _report_secret_source_result(
+                label="1Password Secrets",
+                source_key="onepassword",
+                result=result,
+            )
 
-    result = apply_bitwarden_secrets(
-        enabled=True,
-        access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
-        project_id=bw_cfg.get("project_id", ""),
-        override_existing=bool(bw_cfg.get("override_existing", False)),
-        cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
-        auto_install=bool(bw_cfg.get("auto_install", True)),
-        server_url=str(bw_cfg.get("server_url", "") or "").strip(),
-        home_path=home_path,
-    )
 
+def _report_secret_source_result(*, label: str, source_key: str, result) -> None:  # noqa: ANN001
+    """Record and print a backend fetch result without exposing values."""
     if result.applied:
-        # Re-run the ASCII sanitization pass: BSM values are user-supplied
-        # and might have the same copy-paste corruption as a manually
-        # edited .env (see #6843).
+        # Re-run the ASCII sanitization pass: external secret values are
+        # user-supplied and might have the same copy-paste corruption as a
+        # manually edited .env (see #6843).
         _sanitize_loaded_credentials()
-        # Remember where these came from so the setup / `hermes model`
-        # flows can label detected credentials with "(from Bitwarden)" —
-        # otherwise users see "credentials ✓" with no hint that the value
-        # came from BSM rather than .env.
         for name in result.applied:
-            _SECRET_SOURCES[name] = "bitwarden"
+            _SECRET_SOURCES[name] = source_key
         print(
-            f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
+            f"  {label}: applied {len(result.applied)} "
             f"secret{'s' if len(result.applied) != 1 else ''} "
             f"({', '.join(sorted(result.applied))})",
             file=sys.stderr,
         )
     if result.error:
-        print(
-            f"  Bitwarden Secrets Manager: {result.error}",
-            file=sys.stderr,
-        )
+        print(f"  {label}: {result.error}", file=sys.stderr)
     for warn in result.warnings:
-        print(
-            f"  Bitwarden Secrets Manager: {warn}",
-            file=sys.stderr,
-        )
+        print(f"  {label}: {warn}", file=sys.stderr)
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12506,12 +12506,12 @@ def main():
     # =========================================================================
     secrets_parser = subparsers.add_parser(
         "secrets",
-        help="Manage external secret sources (Bitwarden Secrets Manager)",
+        help="Manage external secret sources (Bitwarden, 1Password)",
         description=(
             "Pull API keys from an external secret manager at process startup "
             "instead of storing them in ~/.hermes/.env.  Currently supports "
-            "Bitwarden Secrets Manager.  See: "
-            "https://hermes-agent.nousresearch.com/docs/user-guide/secrets/bitwarden"
+            "Bitwarden Secrets Manager and 1Password CLI references.  See: "
+            "https://hermes-agent.nousresearch.com/docs/user-guide/secrets/"
         ),
     )
     secrets_subparsers = secrets_parser.add_subparsers(dest="secrets_command")
@@ -12522,15 +12522,26 @@ def main():
         help="Bitwarden Secrets Manager integration",
     )
 
-    # Lazy import — only pays for itself when this subcommand is actually used.
+    secrets_op = secrets_subparsers.add_parser(
+        "onepassword",
+        aliases=["op", "1password"],
+        help="1Password CLI secret references integration",
+    )
+
+    # Lazy imports — only pay for themselves when this command group is built.
+    from hermes_cli import onepassword_secrets_cli as _op_secrets_cli
     from hermes_cli import secrets_cli as _secrets_cli
 
     _secrets_cli.register_cli(secrets_bw)
+    _op_secrets_cli.register_cli(secrets_op)
 
     def _dispatch_secrets(args):  # noqa: ANN001
         sub = getattr(args, "secrets_command", None)
         bw_sub = getattr(args, "secrets_bw_command", None)
+        op_sub = getattr(args, "secrets_op_command", None)
         if sub in ("bitwarden", "bw") and bw_sub is not None:
+            return args.func(args)
+        if sub in ("onepassword", "op", "1password") and op_sub is not None:
             return args.func(args)
         secrets_parser.print_help()
         return 0

--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -1,0 +1,295 @@
+"""CLI handlers for ``hermes secrets onepassword ...``."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import subprocess
+from pathlib import Path
+from typing import Tuple
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from agent.secret_sources import onepassword as op_source
+from hermes_cli.config import load_config, save_config
+
+_DEFAULT_ENV_FILE = "~/.hermes/secrets/1password.env"
+_EXAMPLE_LINES = """# Hermes + 1Password secret references
+#
+# Replace placeholders with your actual 1Password secret references.
+# Keep op:// references here, not plaintext API keys.
+#
+# Example format:
+#   OPENROUTER_API_KEY=op://Private/OpenRouter API Key/credential
+#
+# Uncomment and replace these placeholders:
+# OPENROUTER_API_KEY=op://<vault>/<item-openrouter>/<field>
+# RUNWARE_API_KEY=op://<vault>/<item-runware>/<field>
+# FAL_KEY=op://<vault>/<item-fal>/<field>
+"""
+
+
+def register_cli(parent_parser: argparse.ArgumentParser) -> None:
+    """Attach the ``onepassword`` subcommand tree to a parent parser."""
+    sub = parent_parser.add_subparsers(dest="secrets_op_command")
+
+    setup = sub.add_parser(
+        "setup",
+        help="Configure Hermes to pull secrets from 1Password CLI references",
+    )
+    setup.add_argument(
+        "--env-file",
+        default=_DEFAULT_ENV_FILE,
+        help="Env-style file containing NAME=op://vault/item/field references",
+    )
+    setup.add_argument(
+        "--service-account-token-env",
+        default="OP_SERVICE_ACCOUNT_TOKEN",
+        help="Env var that may hold a 1Password Service Account token",
+    )
+    setup.add_argument(
+        "--op-path",
+        default="",
+        help="Explicit path to the op binary (default: resolve from PATH)",
+    )
+    setup.add_argument(
+        "--no-create-env-file",
+        action="store_true",
+        help="Do not create the references file if it is missing",
+    )
+    setup.set_defaults(func=cmd_setup)
+
+    status = sub.add_parser("status", help="Show 1Password config and readiness")
+    status.set_defaults(func=cmd_status)
+
+    sync = sub.add_parser("sync", help="Resolve references now and report actions")
+    sync.add_argument(
+        "--apply",
+        action="store_true",
+        help="Export resolved secrets into this process (default: dry-run)",
+    )
+    sync.set_defaults(func=cmd_sync)
+
+    disable = sub.add_parser("disable", help="Turn off the 1Password integration")
+    disable.set_defaults(func=cmd_disable)
+
+
+def cmd_setup(args: argparse.Namespace) -> int:
+    console = Console()
+    console.print(
+        Panel.fit(
+            "[bold]1Password Secrets setup[/bold]\n\n"
+            "Hermes will read API keys from 1Password via [cyan]op read[/cyan].\n"
+            "The references file stores only [cyan]op://...[/cyan] references, "
+            "not plaintext secrets.",
+            border_style="cyan",
+        )
+    )
+
+    binary = op_source.find_op(op_path=args.op_path)
+    if binary:
+        console.print(f"  [green]✓[/green] op binary: {binary} ({_op_version(binary)})")
+    else:
+        console.print(
+            "  [yellow]op binary not found.[/yellow] Install 1Password CLI or "
+            "pass --op-path. Setup can still write config."
+        )
+
+    env_file = _resolve_env_file(args.env_file)
+    if not env_file.exists() and not args.no_create_env_file:
+        env_file.parent.mkdir(parents=True, exist_ok=True)
+        env_file.write_text(_EXAMPLE_LINES, encoding="utf-8")
+        os.chmod(env_file, stat.S_IRUSR | stat.S_IWUSR)
+        console.print(f"  [green]✓[/green] created references file: {env_file}")
+    elif env_file.exists():
+        try:
+            os.chmod(env_file, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+        console.print(f"  [green]✓[/green] references file: {env_file}")
+    else:
+        console.print(f"  [yellow]references file missing:[/yellow] {env_file}")
+
+    cfg = load_config()
+    secrets_cfg = cfg.setdefault("secrets", {}).setdefault("onepassword", {})
+    secrets_cfg["enabled"] = True
+    secrets_cfg["env_file"] = args.env_file
+    secrets_cfg["service_account_token_env"] = args.service_account_token_env
+    secrets_cfg["op_path"] = args.op_path
+    secrets_cfg.setdefault("override_existing", True)
+    secrets_cfg.setdefault("cache_ttl_seconds", 300)
+    save_config(cfg)
+
+    console.print()
+    console.print(
+        "[green]✓ 1Password secret source is enabled.[/green]\n"
+        "  Edit the references file with real op:// references, then run:\n"
+        "  [cyan]hermes secrets onepassword sync[/cyan]"
+    )
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    op_cfg = (cfg.get("secrets") or {}).get("onepassword") or {}
+
+    enabled = bool(op_cfg.get("enabled"))
+    env_file_cfg = op_cfg.get("env_file", _DEFAULT_ENV_FILE)
+    env_file = _resolve_env_file(env_file_cfg)
+    service_env = op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+    op_path = str(op_cfg.get("op_path", "") or "")
+    binary = op_source.find_op(op_path=op_path)
+    ref_count, warn_count = _reference_counts(env_file)
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("", style="bold")
+    table.add_column("")
+    table.add_row("Enabled", _yn(enabled))
+    table.add_row("References file", str(env_file))
+    table.add_row("References file exists", _yn(env_file.exists()))
+    table.add_row("op:// references", str(ref_count))
+    table.add_row("Reference warnings", str(warn_count))
+    table.add_row("Service token env var", service_env)
+    table.add_row("Service token in env", _yn(bool(os.environ.get(service_env))))
+    table.add_row("Override existing", _yn(bool(op_cfg.get("override_existing", False))))
+    table.add_row("Cache TTL (s)", str(op_cfg.get("cache_ttl_seconds", 300)))
+    table.add_row("Configured op path", op_path or "[dim](PATH)[/dim]")
+    table.add_row("op binary", f"{binary} ({_op_version(binary)})" if binary else "[yellow]not found[/yellow]")
+    console.print(Panel(table, title="1Password Secrets", border_style="cyan"))
+
+    if not enabled:
+        console.print("\n  Run [cyan]hermes secrets onepassword setup[/cyan] to enable.")
+    elif not binary:
+        console.print("\n  [yellow]Enabled but op is not available.[/yellow]")
+    elif not env_file.exists():
+        console.print("\n  [yellow]Enabled but the references file does not exist.[/yellow]")
+    return 0
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    op_cfg = (cfg.get("secrets") or {}).get("onepassword") or {}
+    if not op_cfg.get("enabled"):
+        console.print(
+            "[yellow]1Password integration is disabled. Run "
+            "`hermes secrets onepassword setup` first.[/yellow]"
+        )
+        return 1
+
+    try:
+        secrets, warnings = op_source.fetch_onepassword_secrets(
+            env_file=op_cfg.get("env_file", _DEFAULT_ENV_FILE),
+            op_path=str(op_cfg.get("op_path", "") or ""),
+            cache_ttl_seconds=float(op_cfg.get("cache_ttl_seconds", 300)),
+            use_cache=False,
+        )
+    except RuntimeError as exc:
+        console.print(f"[red]Fetch failed: {exc}[/red]")
+        return 1
+
+    if not secrets:
+        console.print("[yellow]No secrets resolved.[/yellow]")
+        for w in warnings:
+            console.print(f"[yellow]warning:[/yellow] {w}")
+        return 0
+
+    override = bool(op_cfg.get("override_existing", False)) or args.apply
+    service_env = op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name", style="cyan")
+    table.add_column("Action")
+    applied = 0
+    for key in sorted(secrets):
+        if key == service_env:
+            table.add_row(key, "[dim]skip (bootstrap token)[/dim]")
+            continue
+        already = bool(os.environ.get(key))
+        if already and not override:
+            table.add_row(key, "[dim]skip (already set)[/dim]")
+            continue
+        if args.apply:
+            os.environ[key] = secrets[key]
+            applied += 1
+            table.add_row(key, "[green]exported[/green]" + (" (overrode)" if already else ""))
+        else:
+            table.add_row(key, "[green]would export[/green]" + (" (overrides)" if already else ""))
+
+    console.print(table)
+    for w in warnings:
+        console.print(f"[yellow]warning:[/yellow] {w}")
+
+    if args.apply:
+        console.print(f"\n  [green]Exported {applied} secret(s) into current process.[/green]")
+    else:
+        console.print(
+            "\n  This was a dry-run — secrets are picked up automatically on the "
+            "next [cyan]hermes[/cyan] invocation. Re-run with [cyan]--apply[/cyan] "
+            "to export into the current process instead."
+        )
+    return 0
+
+
+def cmd_disable(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    op_cfg = cfg.setdefault("secrets", {}).setdefault("onepassword", {})
+    op_cfg["enabled"] = False
+    save_config(cfg)
+    console.print(
+        "[green]Disabled.[/green]  1Password secrets will NOT be pulled on the next "
+        "Hermes invocation. The references file is left untouched."
+    )
+    return 0
+
+
+def _resolve_env_file(path: str) -> Path:
+    raw = str(path or _DEFAULT_ENV_FILE).strip()
+    try:
+        from hermes_constants import get_hermes_home
+        home = get_hermes_home()
+    except Exception:  # noqa: BLE001 — CLI status should stay best-effort
+        home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    if raw == "~/.hermes" or raw.startswith("~/.hermes/"):
+        suffix = raw.removeprefix("~/.hermes").lstrip("/")
+        return home / suffix
+    if raw.startswith("~"):
+        return Path(raw).expanduser()
+    resolved = Path(raw)
+    if resolved.is_absolute():
+        return resolved
+    return home / resolved
+
+
+def _reference_counts(path: Path) -> Tuple[int, int]:
+    if not path.exists():
+        return 0, 0
+    try:
+        references, warnings = op_source.parse_reference_file(path)
+    except RuntimeError:
+        return 0, 1
+    return len(references), len(warnings)
+
+
+def _op_version(binary: Path) -> str:
+    try:
+        res = subprocess.run(
+            [str(binary), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+        )
+        if res.returncode == 0:
+            return (res.stdout or res.stderr).strip().splitlines()[0]
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return "version unknown"
+
+
+def _yn(value: bool) -> str:
+    return "[green]yes[/green]" if value else "[dim]no[/dim]"

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -53,6 +53,14 @@ def test_format_secret_source_suffix_bitwarden_uses_proper_name():
     )
 
 
+def test_format_secret_source_suffix_onepassword_uses_proper_name():
+    env_loader._SECRET_SOURCES["OPENROUTER_API_KEY"] = "onepassword"
+    assert (
+        env_loader.format_secret_source_suffix("OPENROUTER_API_KEY")
+        == " (from 1Password)"
+    )
+
+
 def test_format_secret_source_suffix_generic_label_for_future_sources():
     # Future-proofing: a new secret source (e.g. "vault") should still
     # produce a sensible label without needing to edit every call site.
@@ -119,6 +127,42 @@ def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch)
     env_loader._apply_external_secret_sources(tmp_path)
 
     assert env_loader.get_secret_source("ANTHROPIC_API_KEY") is None
+
+
+def test_apply_external_secret_sources_records_onepassword_origin(tmp_path, monkeypatch):
+    """When 1Password returns applied keys, source tracking labels them."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    enabled: true\n"
+        "    env_file: ~/.hermes/secrets/1password.env\n",
+        encoding="utf-8",
+    )
+
+    from agent.secret_sources.onepassword import FetchResult
+
+    fake_result = FetchResult(
+        secrets={"OPENROUTER_API_KEY": "test-openrouter-secret"},
+        applied=["OPENROUTER_API_KEY"],
+    )
+
+    def _fake_apply(**_kwargs):
+        return fake_result
+
+    import agent.secret_sources.onepassword as op_module
+
+    monkeypatch.setattr(op_module, "apply_onepassword_secrets", _fake_apply)
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert env_loader.get_secret_source("OPENROUTER_API_KEY") == "onepassword"
+    assert (
+        env_loader.format_secret_source_suffix("OPENROUTER_API_KEY")
+        == " (from 1Password)"
+    )
 
 
 def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypatch):

--- a/tests/test_onepassword_secret_source.py
+++ b/tests/test_onepassword_secret_source.py
@@ -1,0 +1,148 @@
+"""Tests for the 1Password secret-source backend."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.secret_sources import onepassword  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    onepassword._reset_cache_for_tests()
+    yield
+    onepassword._reset_cache_for_tests()
+
+
+def test_parse_reference_file_accepts_only_op_references(tmp_path):
+    env_file = tmp_path / "1password.env"
+    env_file.write_text(
+        "# comment\n"
+        "OPENROUTER_API_KEY=op://Private/OpenRouter API Key/credential\n"
+        "export RUNWARE_API_KEY='op://Private/Runware API Key/credential'\n"
+        "PLAINTEXT_API_KEY=sk-plaintext\n"
+        "1BAD=op://Private/Bad/credential\n"
+        "BROKEN_LINE\n",
+        encoding="utf-8",
+    )
+
+    refs, warnings = onepassword.parse_reference_file(env_file)
+
+    assert refs == {
+        "OPENROUTER_API_KEY": "op://Private/OpenRouter API Key/credential",
+        "RUNWARE_API_KEY": "op://Private/Runware API Key/credential",
+    }
+    assert len(warnings) == 3
+    assert any("PLAINTEXT_API_KEY" in warning for warning in warnings)
+    assert any("1BAD" in warning for warning in warnings)
+    assert any("expected NAME=op://" in warning for warning in warnings)
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="fake executable uses POSIX shebang/chmod")
+def test_fetch_onepassword_secrets_resolves_references_with_op_read(tmp_path):
+    env_file = tmp_path / "1password.env"
+    env_file.write_text(
+        "OPENROUTER_API_KEY=op://Private/OpenRouter/credential\n"
+        "RUNWARE_API_KEY=op://Private/Runware/credential\n"
+        "MISSING_API_KEY=op://Private/Missing/credential\n",
+        encoding="utf-8",
+    )
+    fake_op = tmp_path / "op"
+    fake_op.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "if sys.argv[1] == '--version':\n"
+        "    print('2.30.0')\n"
+        "    raise SystemExit(0)\n"
+        "if sys.argv[1] == 'read':\n"
+        "    ref = sys.argv[2]\n"
+        "    values = {\n"
+        "        'op://Private/OpenRouter/credential': 'test-openrouter-secret',\n"
+        "        'op://Private/Runware/credential': 'test-runware-secret',\n"
+        "    }\n"
+        "    if ref not in values:\n"
+        "        print('could not read op://Private/Missing/credential', file=sys.stderr)\n"
+        "        raise SystemExit(1)\n"
+        "    print(values[ref])\n"
+        "    raise SystemExit(0)\n"
+        "raise SystemExit(2)\n",
+        encoding="utf-8",
+    )
+    fake_op.chmod(0o700)
+
+    secrets, warnings = onepassword.fetch_onepassword_secrets(
+        env_file=str(env_file),
+        binary=fake_op,
+        use_cache=False,
+    )
+
+    assert secrets == {
+        "OPENROUTER_API_KEY": "test-openrouter-secret",
+        "RUNWARE_API_KEY": "test-runware-secret",
+    }
+    assert len(warnings) == 1
+    assert "MISSING_API_KEY" in warnings[0]
+    assert "op://[REDACTED]" in warnings[0]
+    assert "op://Private/Missing/credential" not in warnings[0]
+
+
+def test_apply_onepassword_secrets_respects_override_existing(tmp_path, monkeypatch):
+    env_file = tmp_path / "1password.env"
+    env_file.write_text("OPENROUTER_API_KEY=op://Private/OpenRouter/credential\n", encoding="utf-8")
+    fake_op = tmp_path / "op"
+    fake_op.write_text("placeholder", encoding="utf-8")
+    fake_op.chmod(0o700)
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "existing")
+    monkeypatch.setattr(onepassword, "find_op", lambda *, op_path="": fake_op)
+    monkeypatch.setattr(
+        onepassword,
+        "fetch_onepassword_secrets",
+        lambda **_kwargs: ({"OPENROUTER_API_KEY": "from-1password"}, []),
+    )
+
+    result = onepassword.apply_onepassword_secrets(
+        enabled=True,
+        env_file=str(env_file),
+        override_existing=False,
+    )
+
+    assert result.applied == []
+    assert result.skipped == ["OPENROUTER_API_KEY"]
+    assert os.environ["OPENROUTER_API_KEY"] == "existing"
+
+    result = onepassword.apply_onepassword_secrets(
+        enabled=True,
+        env_file=str(env_file),
+        override_existing=True,
+    )
+
+    assert result.applied == ["OPENROUTER_API_KEY"]
+    assert os.environ["OPENROUTER_API_KEY"] == "from-1password"
+
+
+def test_apply_onepassword_secrets_missing_op_is_nonfatal():
+    result = onepassword.apply_onepassword_secrets(
+        enabled=True,
+        env_file="/does/not/matter.env",
+        op_path="/definitely/missing/op",
+    )
+
+    assert result.applied == []
+    assert result.error
+    assert "op" in result.error
+
+
+def test_default_references_file_respects_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    resolved = onepassword._resolve_env_file("~/.hermes/secrets/1password.env")
+
+    assert resolved == tmp_path / "secrets" / "1password.env"

--- a/website/docs/user-guide/secrets/index.md
+++ b/website/docs/user-guide/secrets/index.md
@@ -5,5 +5,6 @@ Hermes can pull API keys from external secret managers at process startup instea
 Supported:
 
 - [Bitwarden Secrets Manager](./bitwarden) — `bws` CLI, lazy-installed, free tier works.
+- [1Password CLI](./onepassword) — `op` CLI, `op://` secret references, works with app sessions or Service Accounts.
 
-More backends (Vault, AWS Secrets Manager, 1Password CLI) are easy to add behind the same interface — the lift is one module in `agent/secret_sources/` and one CLI handler. File a request if you have a specific one in mind.
+More backends (Vault, AWS Secrets Manager) are easy to add behind the same interface — the lift is one module in `agent/secret_sources/` and one CLI handler. File a request if you have a specific one in mind.

--- a/website/docs/user-guide/secrets/onepassword.md
+++ b/website/docs/user-guide/secrets/onepassword.md
@@ -1,0 +1,160 @@
+# 1Password CLI
+
+Pull API keys from [1Password](https://1password.com/) at process startup instead of storing every provider key in plaintext inside `~/.hermes/.env`. Hermes uses the `op` CLI to resolve `op://...` secret references and sets the resulting values in `os.environ` for the current process.
+
+## How it works
+
+1. You install and authenticate the [1Password CLI](https://developer.1password.com/docs/cli/get-started/), or provide a 1Password Service Account token via an env var such as `OP_SERVICE_ACCOUNT_TOKEN`.
+2. You create a references file, by default `~/.hermes/secrets/1password.env`, with lines like:
+
+   ```bash
+   OPENROUTER_API_KEY=op://Private/OpenRouter API Key/credential
+   RUNWARE_API_KEY=op://Private/Runware API Key/credential
+   ```
+
+   This file stores **references only**, not plaintext API keys.
+3. Every time `hermes` (or the gateway, or a cron job) starts, after `~/.hermes/.env` has loaded, Hermes calls `op read <reference>` for each entry and sets the returned keys into `os.environ`.
+4. By default Hermes **overrides** values already in your environment, so rotation in 1Password takes effect on the next Hermes process start. Flip `override_existing: false` in config if you want `.env` / shell exports to win locally.
+
+## Setup
+
+### 1. Install and authenticate `op`
+
+Install the CLI from the official docs:
+
+```text
+https://developer.1password.com/docs/cli/get-started/
+```
+
+Then verify:
+
+```bash
+op --version
+op whoami
+```
+
+For non-interactive servers, prefer a [1Password Service Account](https://developer.1password.com/docs/service-accounts/). Store only that bootstrap token in your shell or `~/.hermes/.env`:
+
+```bash
+OP_SERVICE_ACCOUNT_TOKEN=...
+```
+
+You can rename that env var with `secrets.onepassword.service_account_token_env`.
+
+### 2. Run the wizard
+
+```bash
+hermes secrets onepassword setup
+```
+
+It will:
+
+1. Check whether `op` is available.
+2. Create `~/.hermes/secrets/1password.env` if it does not exist.
+3. Set file mode `0600` on the references file.
+4. Enable `secrets.onepassword.enabled: true` in `config.yaml`.
+
+The generated file contains placeholders. Replace them with real `op://...` references copied from the 1Password app, CLI, or browser extension.
+
+Non-interactive setup is also supported:
+
+```bash
+hermes secrets onepassword setup \
+  --env-file ~/.hermes/secrets/1password.env \
+  --service-account-token-env OP_SERVICE_ACCOUNT_TOKEN \
+  --op-path /usr/local/bin/op
+```
+
+### 3. Confirm
+
+```bash
+hermes secrets onepassword status
+hermes secrets onepassword sync
+```
+
+`sync` is a dry-run by default. It resolves references and shows which env var names would be exported, but it never prints secret values.
+
+## CLI
+
+| Command | What it does |
+|---|---|
+| `hermes secrets onepassword setup` | Configure the backend and create the references file if missing |
+| `hermes secrets onepassword status` | Show config, `op` availability, reference count, and bootstrap-token presence |
+| `hermes secrets onepassword sync` | Dry-run: resolve references now and show what would be applied |
+| `hermes secrets onepassword sync --apply` | Resolve and export into the current process's environment |
+| `hermes secrets onepassword disable` | Flip `enabled: false`; leaves the references file untouched |
+
+Aliases:
+
+```bash
+hermes secrets op status
+hermes secrets 1password status
+```
+
+## Configuration
+
+Defaults in `~/.hermes/config.yaml`:
+
+```yaml
+secrets:
+  onepassword:
+    enabled: false
+    env_file: ~/.hermes/secrets/1password.env
+    service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN
+    cache_ttl_seconds: 300
+    override_existing: true
+    op_path: ""
+```
+
+| Key | Default | What it does |
+|---|---|---|
+| `enabled` | `false` | Master switch. When false, 1Password is never contacted. |
+| `env_file` | `~/.hermes/secrets/1password.env` | Env-style file containing `NAME=op://vault/item/field` references. |
+| `service_account_token_env` | `OP_SERVICE_ACCOUNT_TOKEN` | Optional env var name that holds a 1Password Service Account token. If unset, `op` can still use an authenticated app/CLI session. |
+| `cache_ttl_seconds` | `300` | How long resolved references are reused in-process. Set to `0` to disable caching. |
+| `override_existing` | `true` | When true, 1Password values overwrite anything already in env. Flip to `false` if `.env` / shell exports should win locally. |
+| `op_path` | `""` | Optional explicit path to the `op` binary. Empty = resolve from `PATH`. |
+
+## References file format
+
+```bash
+# comments are allowed
+OPENROUTER_API_KEY=op://Private/OpenRouter API Key/credential
+RUNWARE_API_KEY='op://Private/Runware API Key/credential'
+export FAL_KEY=op://Private/FAL API Key/credential
+```
+
+Rules:
+
+- Keys must be valid environment variable names.
+- Values must start with `op://`.
+- Plaintext-looking values are skipped with a warning.
+- Secret values are never printed in status, sync output, startup warnings, or errors.
+
+## Failure modes
+
+1Password never blocks Hermes startup. If anything goes wrong, Hermes prints a one-line warning to stderr and continues with whatever credentials `.env` already had.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `op is not available` | 1Password CLI not installed or not on PATH | Install `op`, or set `secrets.onepassword.op_path` |
+| `references file does not exist` | Enabled but `env_file` has not been created | Run `hermes secrets onepassword setup` |
+| `references file contains no op:// entries` | File has only comments/placeholders/plaintext values | Replace placeholders with real 1Password references |
+| `op exited ...` | Not signed in, service account token missing/invalid, or reference cannot be read | Run `op whoami`, check `OP_SERVICE_ACCOUNT_TOKEN`, and verify item/vault access |
+| A key is skipped as already set | `override_existing: false` and env already has that key | Remove the local env var or set `override_existing: true` |
+
+## Security notes
+
+- The references file should contain `op://...` references only, not plaintext API keys.
+- Hermes sets the references file mode to `0600` during setup.
+- For shared servers and gateways, use a 1Password Service Account with least-privilege vault access rather than a personal interactive session.
+- The bootstrap token, if you use one, is still a secret. Store it in `~/.hermes/.env` or the service manager's secret mechanism, not in `config.yaml`.
+- Hermes refuses to let 1Password overwrite the configured bootstrap-token env var itself.
+
+## When NOT to use this
+
+- Single-machine setups where `~/.hermes/.env` is sufficient and centralized rotation is unnecessary.
+- Air-gapped environments where `op` cannot reach 1Password.
+- CI/CD systems that already have a mature secret-injection mechanism.
+
+The good case is a gateway VPS, shared dev box, or multi-machine setup where you want central rotation and revocation in 1Password while keeping Hermes config free of provider keys.


### PR DESCRIPTION
## Summary

Adds a native 1Password CLI secret-source backend alongside the existing Bitwarden Secrets Manager integration.

### What changed

- Add `agent.secret_sources.onepassword` backend using `op read` over `op://...` references.
- Add `hermes secrets onepassword` / `hermes secrets op` CLI commands:
  - `setup`
  - `status`
  - `sync`
  - `disable`
- Add `secrets.onepassword` defaults in `config.yaml` schema.
- Extend `env_loader` to apply multiple external secret sources and label 1Password-provided credentials as `(from 1Password)`.
- Add user docs at `website/docs/user-guide/secrets/onepassword.md` and link from the Secrets overview.
- Add unit tests for parsing, fake `op read`, override behavior, startup source tracking, and `HERMES_HOME`/profile-aware references-file resolution.

## Design notes

The backend stores only references in the configured env-style file, for example:

```bash
OPENROUTER_API_KEY=op://Private/OpenRouter API Key/credential
```

Secret values are resolved at Hermes startup via `op read` and are never printed in status, sync output, warnings, or errors. Missing `op`, missing references files, invalid references, or auth failures are fail-open and do not block Hermes startup.

## Verification

Ran locally on branch `feat/onepassword-secrets-backend`:

```bash
uv run --extra dev python -m pytest \
  tests/test_onepassword_secret_source.py \
  tests/test_env_loader_secret_sources.py \
  -o 'addopts=' -q
# 15 passed

uv run --extra dev ruff check \
  agent/secret_sources/onepassword.py \
  hermes_cli/onepassword_secrets_cli.py \
  hermes_cli/env_loader.py \
  tests/test_onepassword_secret_source.py \
  tests/test_env_loader_secret_sources.py
# All checks passed

git diff --check
# no output
```

Also manually verified with temporary `HERMES_HOME`:

- `hermes secrets onepassword --help`
- `hermes secrets onepassword status`
- `hermes secrets onepassword setup`
- `hermes secrets onepassword sync` with a fake `op` binary

## Security

- No plaintext provider keys are stored in config or docs.
- The references file is created with mode `0600`.
- Plaintext-looking entries in the references file are skipped with warnings.
- `op://...` references in error output are redacted.
- External source failures remain fail-open, consistent with Bitwarden.
