### PR TITLE
feat(whatsapp): honor channel_skill_bindings and channel_prompts (LID…

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1022,7 +1022,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
-                if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
+                if plat in {Platform.DISCORD, Platform.SLACK, Platform.WHATSAPP} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1309,6 +1309,45 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
+            # Per-channel auto-loaded skill(s) and ephemeral prompt.
+            # Mirrors Slack/Discord -- whatsapp.py previously dropped both, so
+            # channel_skill_bindings / channel_prompts never reached the agent.
+            # WhatsApp delivers the same person under either a phone-JID
+            # ("<num>@s.whatsapp.net") or a LID ("<lid>@lid"); config binds by the
+            # phone number. Resolve against EVERY alias form (same identity model
+            # as gateway.session.build_session_key) so a LID-delivered DM still
+            # matches. Wrapped so a resolver hiccup never drops the user's message.
+            _wa_extra = getattr(self.config, "extra", None) or {}
+            _channel_prompt = None
+            _auto_skill = None
+            try:
+                from gateway.platforms.base import (
+                    resolve_channel_prompt,
+                    resolve_channel_skills,
+                )
+                from gateway.whatsapp_identity import (
+                    canonical_whatsapp_identifier,
+                    expand_whatsapp_aliases,
+                )
+                _wa_chat_id = data.get("chatId", "") or ""
+                _wa_candidates: list[str] = []
+                for _c in (
+                    _wa_chat_id,
+                    canonical_whatsapp_identifier(_wa_chat_id),
+                    *sorted(expand_whatsapp_aliases(_wa_chat_id)),
+                ):
+                    if _c and _c not in _wa_candidates:
+                        _wa_candidates.append(_c)
+                for _cand in _wa_candidates:
+                    if _channel_prompt is None:
+                        _channel_prompt = resolve_channel_prompt(_wa_extra, _cand, None)
+                    if _auto_skill is None:
+                        _auto_skill = resolve_channel_skills(_wa_extra, _cand, None)
+                    if _channel_prompt is not None and _auto_skill is not None:
+                        break
+            except Exception as _e:
+                print(f"[{self.name}] channel skill/prompt resolution failed: {_e}", flush=True)
+
             return MessageEvent(
                 text=body,
                 message_type=msg_type,
@@ -1317,6 +1356,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                channel_prompt=_channel_prompt,
+                auto_skill=_auto_skill,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")


### PR DESCRIPTION
…-robust)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

