### PR TITLE
Fix Telegram multipart first replies

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3001,6 +3001,9 @@ class TelegramAdapter(BasePlatformAdapter):
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
+            suppress_multipart_first_reply = (
+                len(chunks) > 1 and self._reply_to_mode not in {"all", "off"}
+            )
             used_thread_fallback = False
             
             try:
@@ -3040,6 +3043,12 @@ class TelegramAdapter(BasePlatformAdapter):
                         reply_to_source is not None
                         and self._reply_to_mode != "off"
                     )
+                elif suppress_multipart_first_reply:
+                    # Telegram Desktop/TDLib can render the first long native
+                    # reply chunk as unsupported. Keep single-chunk first
+                    # replies intact, but avoid attaching reply metadata to a
+                    # multipart "first" reply.
+                    should_thread = False
                 else:
                     should_thread = self._should_thread_reply(reply_to_source, i)
                 reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4586,6 +4586,9 @@ class TelegramAdapter(BasePlatformAdapter):
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
+            suppress_multipart_first_reply = (
+                len(chunks) > 1 and self._reply_to_mode not in {"all", "off"}
+            )
             used_thread_fallback = False
             
             try:
@@ -4625,6 +4628,12 @@ class TelegramAdapter(BasePlatformAdapter):
                         reply_to_source is not None
                         and self._reply_to_mode != "off"
                     )
+                elif suppress_multipart_first_reply:
+                    # Telegram Desktop/TDLib can render the first long native
+                    # reply chunk as unsupported. Keep single-chunk first
+                    # replies intact, but avoid attaching reply metadata to a
+                    # multipart "first" reply.
+                    should_thread = False
                 else:
                     should_thread = self._should_thread_reply(reply_to_source, i)
                 reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None

--- a/tests/gateway/test_telegram_reply_mode.py
+++ b/tests/gateway/test_telegram_reply_mode.py
@@ -2,7 +2,7 @@
 
 Covers the threading behavior control for multi-chunk replies:
 - "off": Never thread replies to original message
-- "first": Only first chunk threads (default)
+- "first": Single-chunk replies thread; multi-chunk sends suppress native reply metadata
 - "all": All chunks thread to original message
 """
 import os
@@ -129,7 +129,7 @@ class TestSendWithReplyToMode:
             assert call.kwargs.get("reply_to_message_id") is None
 
     @pytest.mark.asyncio
-    async def test_first_mode_only_first_chunk_threads(self, adapter_factory):
+    async def test_first_mode_multipart_reply_suppresses_native_reply(self, adapter_factory):
         adapter = adapter_factory(reply_to_mode="first")
         adapter._bot = MagicMock()
         adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
@@ -139,7 +139,7 @@ class TestSendWithReplyToMode:
 
         calls = adapter._bot.send_message.call_args_list
         assert len(calls) == 3
-        assert calls[0].kwargs.get("reply_to_message_id") == 999
+        assert calls[0].kwargs.get("reply_to_message_id") is None
         assert calls[1].kwargs.get("reply_to_message_id") is None
         assert calls[2].kwargs.get("reply_to_message_id") is None
 

--- a/tests/gateway/test_telegram_reply_mode.py
+++ b/tests/gateway/test_telegram_reply_mode.py
@@ -2,7 +2,7 @@
 
 Covers the threading behavior control for multi-chunk replies:
 - "off": Never thread replies to original message
-- "first": Only first chunk threads (default)
+- "first": Single-chunk replies thread; multi-chunk sends suppress native reply metadata
 - "all": All chunks thread to original message
 """
 import os
@@ -86,7 +86,7 @@ class TestSendWithReplyToMode:
             assert call.kwargs.get("reply_to_message_id") is None
 
     @pytest.mark.asyncio
-    async def test_first_mode_only_first_chunk_threads(self, adapter_factory):
+    async def test_first_mode_multipart_reply_suppresses_native_reply(self, adapter_factory):
         adapter = adapter_factory(reply_to_mode="first")
         adapter._bot = MagicMock()
         adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
@@ -96,7 +96,7 @@ class TestSendWithReplyToMode:
 
         calls = adapter._bot.send_message.call_args_list
         assert len(calls) == 3
-        assert calls[0].kwargs.get("reply_to_message_id") == 999
+        assert calls[0].kwargs.get("reply_to_message_id") is None
         assert calls[1].kwargs.get("reply_to_message_id") is None
         assert calls[2].kwargs.get("reply_to_message_id") is None
 


### PR DESCRIPTION
﻿## Summary

- suppress native `reply_to_message_id` for ordinary Telegram multi-chunk sends when `reply_to_mode` behaves like `first`
- preserve single-chunk first replies and `reply_to_mode="all"` behavior
- leave DM-topic fallback anchoring unchanged because that path requires the reply anchor for topic delivery

Fixes #55059.
Related pattern: openclaw/openclaw#97304.

## Validation

- `uv run --extra dev --extra messaging python -m pytest tests\gateway\test_telegram_reply_mode.py -q --basetemp .pytest-tmp-telegram-reply-mode-only`
- `uv run --extra dev --extra messaging python -m pytest tests\gateway\test_telegram_thread_fallback.py -q --basetemp .pytest-tmp-thread-fallback-new-only`
- `uv run --extra dev --extra messaging python -m ruff check plugins\platforms\telegram\adapter.py tests\gateway\test_telegram_reply_mode.py`
- `git diff --check`

Note: running `tests\gateway\test_telegram_reply_mode.py tests\gateway\test_telegram_thread_fallback.py` together currently fails the same three `chat_type` assertions on untouched `origin/main`, due to Telegram mock/module-order pollution. Each file passes independently.
