### PR TITLE
Cap Teams attachment downloads

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -806,7 +806,7 @@ class TeamsAdapter(BasePlatformAdapter):
         matching the cache_*_from_url helpers in gateway.platforms.base.
         """
         from tools.url_safety import is_safe_url
-        from gateway.platforms.base import _ssrf_redirect_guard
+        from gateway.platforms.base import _read_httpx_body_with_limit, _ssrf_redirect_guard
 
         if not is_safe_url(url):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
@@ -818,12 +818,16 @@ class TeamsAdapter(BasePlatformAdapter):
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(
+            async with client.stream(
+                "GET",
                 url,
                 headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
-            )
-            response.raise_for_status()
-            return response.content
+            ) as response:
+                response.raise_for_status()
+                return await _read_httpx_body_with_limit(
+                    response,
+                    media_type="teams attachment",
+                )
 
     async def _on_message(self, ctx: ActivityContext[MessageActivity]) -> None:
         """Process an incoming Teams message and dispatch to the gateway."""

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -33,6 +33,9 @@ from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
 from urllib.parse import quote
 
+
+_TEAMS_ATTACHMENT_MAX_REDIRECTS = 20
+
 # httpx is imported lazily — only the ``_write_summary_via_incoming_webhook``
 # code path actually constructs an ``AsyncClient``. Top-level import here
 # pulled in the entire httpx + httpcore stack (~37 ms, ~15 MB) on every
@@ -878,23 +881,49 @@ class TeamsAdapter(BasePlatformAdapter):
         SSRF guard and follows redirects through the shared redirect guard,
         matching the cache_*_from_url helpers in gateway.platforms.base.
         """
-        from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
-        from gateway.platforms.base import _ssrf_redirect_guard
+        from tools.url_safety import (
+            create_ssrf_safe_async_client,
+            is_safe_url,
+            redirect_target_from_response,
+        )
+        from gateway.platforms.base import (
+            _read_httpx_body_with_limit,
+        )
 
         if not is_safe_url(url):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
 
         async with create_ssrf_safe_async_client(
             timeout=timeout,
-            follow_redirects=True,
-            event_hooks={"response": [_ssrf_redirect_guard]},
+            follow_redirects=False,
         ) as client:
-            response = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
-            )
-            response.raise_for_status()
-            return response.content
+            current_url = url
+            for _ in range(_TEAMS_ATTACHMENT_MAX_REDIRECTS + 1):
+                async with client.stream(
+                    "GET",
+                    current_url,
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"
+                    },
+                ) as response:
+                    redirect_url = redirect_target_from_response(response)
+                    if redirect_url:
+                        if not is_safe_url(redirect_url):
+                            raise ValueError(
+                                "Blocked redirect to private/internal address"
+                            )
+                        # Leave the redirect body unread. The response context closes
+                        # it before the next SSRF-validated hop is opened.
+                        current_url = redirect_url
+                        continue
+
+                    response.raise_for_status()
+                    return await _read_httpx_body_with_limit(
+                        response,
+                        media_type="teams attachment",
+                    )
+
+            raise ValueError("Too many redirects fetching Teams attachment")
 
     async def _on_message(self, ctx: ActivityContext[MessageActivity]) -> None:
         """Process an incoming Teams message and dispatch to the gateway."""

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -864,6 +864,32 @@ class TestTeamsAttachmentClassification:
         assert event.media_urls == []
 
     @pytest.mark.anyio
+    async def test_fetch_attachment_rejects_oversized_content_length(self, monkeypatch):
+        import gateway.platforms.base as base_mod
+        import tools.url_safety as url_safety
+
+        adapter = self._make_adapter()
+        transport = httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                headers={"content-length": "9"},
+                content=b"123456789",
+            )
+        )
+        real_async_client = httpx.AsyncClient
+
+        def async_client_with_transport(*args, **kwargs):
+            kwargs["transport"] = transport
+            return real_async_client(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "AsyncClient", async_client_with_transport)
+        monkeypatch.setattr(base_mod, "get_inbound_media_max_bytes", lambda: 8)
+        monkeypatch.setattr(url_safety, "is_safe_url", lambda _url: True)
+
+        with pytest.raises(ValueError, match="Inbound teams attachment payload is too large"):
+            await adapter._fetch_attachment_bytes("https://contoso.sharepoint.com/download/x")
+
+    @pytest.mark.anyio
     async def test_image_only_still_photo(self):
         from gateway.platforms.base import MessageType
 

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -598,6 +598,136 @@ class TestTeamsAttachmentClassification:
         assert len(event.media_urls) == 2
 
 
+class _TrackingAsyncByteStream(httpx.AsyncByteStream):
+    def __init__(self, chunks):
+        self._chunks = chunks
+        self.chunks_read = 0
+        self.closed = False
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            self.chunks_read += 1
+            yield chunk
+
+    async def aclose(self):
+        self.closed = True
+
+
+class TestTeamsAttachmentDownloadLimits:
+    def _make_adapter(self):
+        return TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+
+    def _install_transport(self, monkeypatch, handler):
+        import tools.url_safety as url_safety
+
+        transport = httpx.MockTransport(handler)
+
+        def client_factory(**kwargs):
+            kwargs["transport"] = transport
+            return httpx.AsyncClient(**kwargs)
+
+        monkeypatch.setattr(url_safety, "create_ssrf_safe_async_client", client_factory)
+        monkeypatch.setattr(url_safety, "is_safe_url", lambda _url: True)
+
+    @pytest.mark.anyio
+    async def test_fetch_attachment_enforces_declared_streamed_and_decoded_limits(
+        self,
+        monkeypatch,
+    ):
+        import gzip
+        import gateway.platforms.base as base_mod
+
+        compressed = gzip.compress(b"x" * 256)
+        assert len(compressed) < 64
+        cases = [
+            ([b"1234", b"5678"], {}, 8, 2, b"12345678"),
+            ([b"123456789"], {"content-length": "9"}, 8, 0, None),
+            ([b"1234", b"5678", b"9"], {}, 8, 3, None),
+            (
+                [compressed],
+                {
+                    "content-encoding": "gzip",
+                    "content-length": str(len(compressed)),
+                },
+                64,
+                1,
+                None,
+            ),
+        ]
+
+        for chunks, headers, limit, expected_reads, expected_data in cases:
+            stream = _TrackingAsyncByteStream(chunks)
+            responses = []
+
+            def handler(_request):
+                response = httpx.Response(200, headers=headers, stream=stream)
+                responses.append(response)
+                return response
+
+            with monkeypatch.context() as case_patch:
+                self._install_transport(case_patch, handler)
+                case_patch.setattr(
+                    base_mod,
+                    "get_inbound_media_max_bytes",
+                    lambda: limit,
+                )
+                download = self._make_adapter()._fetch_attachment_bytes(
+                    "https://contoso.sharepoint.com/download/x"
+                )
+                if expected_data is None:
+                    with pytest.raises(
+                        ValueError,
+                        match="Inbound teams attachment payload is too large",
+                    ):
+                        await download
+                else:
+                    assert await download == expected_data
+
+            assert stream.chunks_read == expected_reads
+            assert stream.closed and responses[0].is_closed
+
+    @pytest.mark.anyio
+    async def test_fetch_attachment_does_not_read_safe_redirect_body(
+        self,
+        monkeypatch,
+    ):
+        redirect_stream = _TrackingAsyncByteStream([b"x" * (1024 * 1024)])
+        final_stream = _TrackingAsyncByteStream([b"attachment"])
+        responses = []
+        requested_urls = []
+
+        def handler(request):
+            requested_urls.append(str(request.url))
+            if len(requested_urls) == 1:
+                response = httpx.Response(
+                    302,
+                    headers={"location": "https://cdn.example.test/file"},
+                    stream=redirect_stream,
+                )
+            else:
+                response = httpx.Response(200, stream=final_stream)
+            responses.append(response)
+            return response
+
+        self._install_transport(monkeypatch, handler)
+
+        data = await self._make_adapter()._fetch_attachment_bytes(
+            "https://contoso.sharepoint.com/download/x"
+        )
+
+        assert data == b"attachment"
+        assert requested_urls == [
+            "https://contoso.sharepoint.com/download/x",
+            "https://cdn.example.test/file",
+        ]
+        assert redirect_stream.chunks_read == 0
+        assert final_stream.chunks_read == 1
+        assert all(response.is_closed for response in responses)
+        assert redirect_stream.closed and final_stream.closed
+
+
 # ── _standalone_send (out-of-process cron delivery) ──────────────────────
 
 


### PR DESCRIPTION
## Summary

- stream existing Teams attachment downloads through the shared inbound-media size limiter
- follow redirects manually so every target is SSRF-validated and every intermediate response is closed without reading its body
- cap declared, lengthless, and decoded compressed final bodies before aggregation

Fixes #55061.

## Why this boundary

- This PR owns the existing generic Teams attachment download lifecycle.
- It is independently correct and revertible: its two current consumers become bounded without changing authentication or routing.
- Authenticated pasted-image handling has separate token, retry, origin, and cache policy; #72977 is the preferred follow-up and should reuse this foundation after it lands.

## Dependency and merge order

- Depends on: none
- Merge order: #55063 first; then refresh #72977 on current `main` and retain only its authenticated-image changes.

## Deliberately excluded

- Bot Framework bearer acquisition, token caching, protected inline-image routing, retries, Graph downloads, cache policy, or global HTTPX/decompression redesign

## Series status

- [x] #55063 — generic Teams bounded-download foundation
- [ ] #72977 — authenticated pasted-image consumer

## Validation

- six related test files — 113 passed
- Ruff, py_compile, and `git diff --check` — passed
- structured AutoReview round 1 found the automatic-redirect body bypass; fixed in the same lifecycle
- structured AutoReview round 2 — no findings; patch correct (0.98)

The redirect regression uses a safe 302 with a 1 MiB body and proves that zero redirect-body chunks are read, the final attachment is returned, and both response streams are closed.
