### PR TITLE
fix(desktop): seed reasoning effort from config.yaml on boot (#55062)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -1,10 +1,10 @@
 import { type QueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
 
-import { getGlobalModelInfo } from '@/hermes'
+import { getGlobalModelInfo, getHermesConfigRecord } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
-import { $activeSessionId, $currentModel, $currentProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
+import { $activeSessionId, $currentModel, $currentProvider, setCurrentModel, setCurrentProvider, setCurrentReasoningEffort } from '@/store/session'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelSelection {
@@ -44,6 +44,26 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
     try {
       if ($activeSessionId.get()) {
         return
+      }
+
+      // Seed reasoning effort from config.yaml when no session is active.
+      // This prevents stale session-level overrides stored in localStorage
+      // (hermes.desktop.composer.reasoning-effort) from persisting across app
+      // restarts. The Settings page reads agent.reasoning_effort from
+      // config.yaml, so this keeps the composer and Settings in sync. (#55062)
+      try {
+        const cfg = await getHermesConfigRecord()
+        // Re-check: a session may have become active while we were fetching.
+        if ($activeSessionId.get()) {
+          return
+        }
+        const agent = (cfg.agent ?? {}) as Record<string, unknown>
+        const effort = String(agent.reasoning_effort ?? '').trim().toLowerCase()
+        if (effort) {
+          setCurrentReasoningEffort(effort)
+        }
+      } catch {
+        // Best-effort: keep the last known value rather than blocking model refresh.
       }
 
       if (!force && $currentModel.get()) {


### PR DESCRIPTION
## Summary

The chat bar model pill reads reasoning effort from localStorage (`hermes.desktop.composer.reasoning-effort`), while the Settings page reads from config.yaml (`agent.reasoning_effort`). These two sources desync after an Electron update because localStorage persists stale session-level overrides that were never written to config.yaml.

This fix seeds `$currentReasoningEffort` from config.yaml in `refreshCurrentModel` when no session is active, matching the existing pattern for model/provider seeding. This keeps the composer and Settings in sync on boot.

## Root Cause

When reasoning is changed via the model edit submenu (chat bar), two things happen:
1. `setCurrentReasoningEffort(next)` → writes to localStorage
2. `config.set('reasoning', session_id, value)` → sets a session-scoped override on the gateway

This does NOT write to `config.yaml`. After an Electron update, localStorage persists the stale `"xhigh"` value while config.yaml retains `"medium"`.

## Changes

- `apps/desktop/src/app/session/hooks/use-model-controls.ts`: Add config.yaml read in `refreshCurrentModel` to seed reasoning effort when no session is active. Includes a re-check after the async fetch to avoid overwriting a session that became active during the fetch.

## Testing

- TypeScript compiles cleanly (`tsc --noEmit` passes)
- Pre-existing test failures (vitest path alias resolution for desktop app) are unrelated
- Verified the config fetch follows the same pattern as the existing model/provider seeding

## Follow-up

Stage 2 (separate PR): Remove localStorage persistence for reasoning effort entirely — change `atom(storedString(COMPOSER_EFFORT_KEY) ?? '')` to `atom('')` and remove the `persistString` call from `setCurrentReasoningEffort`. This eliminates the desync class at the root.

Closes #55062
