### PR TITLE
Add session-scoped context experiments

### DIFF
--- a/agent/context_experiments.py
+++ b/agent/context_experiments.py
@@ -1,0 +1,243 @@
+"""Session-scoped prompt context experiments.
+
+Context experiments let operators A/B test different project-context files and
+preloaded skills without changing the prompt mid-conversation. Assignment is
+resolved once per session id and then reused, preserving prefix-cache stability
+within that session.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import logging
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+fcntl: Any | None
+try:  # pragma: no cover - platform branch
+    import fcntl as _fcntl
+
+    fcntl = _fcntl
+except ImportError:  # pragma: no cover - non-Unix
+    fcntl = None
+
+msvcrt: Any | None
+try:  # pragma: no cover - platform branch
+    import msvcrt as _msvcrt
+
+    msvcrt = _msvcrt
+except ImportError:  # pragma: no cover - non-Windows
+    msvcrt = None
+
+_STATE_LOCK = threading.RLock()
+_SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+@dataclass(frozen=True)
+class ContextExperimentAssignment:
+    """Resolved experiment arm for a session."""
+
+    experiment_name: str
+    arm_name: str
+    arm: dict[str, Any]
+
+
+def _safe_state_name(name: str) -> str:
+    safe = _SAFE_NAME_RE.sub("-", name.strip()).strip(".-")
+    return safe or "context-experiment"
+
+
+def _state_path(experiment_name: str) -> Path:
+    return (
+        get_hermes_home()
+        / "context_experiments"
+        / f"{_safe_state_name(experiment_name)}.json"
+    )
+
+
+@contextlib.contextmanager
+def _locked_state(path: Path) -> Iterator[None]:
+    """Serialize round-robin assignment across gateway/CLI processes."""
+
+    with _STATE_LOCK:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lock_fd = None
+        try:
+            lock_fd = open(path.with_suffix(path.suffix + ".lock"), "a+", encoding="utf-8")
+            if fcntl is not None:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            elif msvcrt is not None:
+                getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+        except (OSError, IOError) as exc:
+            logger.warning("context experiment state lock unavailable: %s", exc)
+        try:
+            yield
+        finally:
+            if lock_fd is not None:
+                try:
+                    if fcntl is not None:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    elif msvcrt is not None:
+                        getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
+                except (OSError, IOError):
+                    pass
+                try:
+                    lock_fd.close()
+                except OSError:
+                    pass
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"assignments": {}, "next_index": 0}
+    if not isinstance(data, dict):
+        return {"assignments": {}, "next_index": 0}
+    assignments = data.get("assignments")
+    if not isinstance(assignments, dict):
+        data["assignments"] = {}
+    if not isinstance(data.get("next_index"), int):
+        data["next_index"] = 0
+    return data
+
+
+def _arm_names(spec: Mapping[str, Any]) -> list[str]:
+    arms = spec.get("arms")
+    if not isinstance(arms, dict):
+        return []
+    configured_order = spec.get("arm_order")
+    if isinstance(configured_order, list):
+        ordered = [str(name) for name in configured_order if str(name) in arms]
+        if ordered:
+            return ordered
+    return [str(name) for name in arms.keys()]
+
+
+def _session_allowed(spec: Mapping[str, Any], platform: str | None) -> bool:
+    unit = str(spec.get("unit") or "session").strip().lower()
+    if unit != "session":
+        return False
+
+    platform_key = (platform or "").strip().lower()
+    only = spec.get("platforms")
+    if isinstance(only, list) and only:
+        allowed = {str(item).strip().lower() for item in only if str(item).strip()}
+        if platform_key not in allowed:
+            return False
+    excluded = spec.get("exclude_platforms")
+    if isinstance(excluded, list) and excluded:
+        denied = {str(item).strip().lower() for item in excluded if str(item).strip()}
+        if platform_key in denied:
+            return False
+    return True
+
+
+def _iter_enabled_experiments(config: Mapping[str, Any]) -> list[tuple[str, Mapping[str, Any]]]:
+    experiments = config.get("context_experiments")
+    if not isinstance(experiments, dict) or not experiments:
+        return []
+
+    # Shorthand for a single unnamed experiment:
+    # context_experiments: {enabled: true, arms: {...}}
+    if isinstance(experiments.get("arms"), dict):
+        return [("default", experiments)] if experiments.get("enabled") else []
+
+    active = experiments.get("active")
+    if isinstance(active, str) and active in experiments:
+        spec = experiments.get(active)
+        if isinstance(spec, dict) and spec.get("enabled"):
+            return [(active, spec)]
+        return []
+
+    enabled: list[tuple[str, Mapping[str, Any]]] = []
+    for name, spec in experiments.items():
+        if name == "active" or not isinstance(spec, dict):
+            continue
+        if spec.get("enabled"):
+            enabled.append((str(name), spec))
+    return enabled
+
+
+def _hash_arm(experiment_name: str, session_id: str, arms: list[str]) -> str:
+    digest = hashlib.sha256(f"{experiment_name}:{session_id}".encode("utf-8")).digest()
+    return arms[int.from_bytes(digest[:8], "big") % len(arms)]
+
+
+def _round_robin_arm(experiment_name: str, session_id: str, arms: list[str]) -> str:
+    path = _state_path(experiment_name)
+    with _locked_state(path):
+        state = _load_state(path)
+        assignments = state.setdefault("assignments", {})
+        existing = assignments.get(session_id)
+        if existing in arms:
+            return str(existing)
+
+        idx = int(state.get("next_index", 0)) % len(arms)
+        arm = arms[idx]
+        state["next_index"] = idx + 1
+        assignments[session_id] = arm
+        atomic_json_write(path, state, mode=0o600)
+        return arm
+
+
+def resolve_context_experiment_assignment(
+    *,
+    session_id: str | None,
+    platform: str | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> ContextExperimentAssignment | None:
+    """Return the active context-experiment arm for *session_id*, if configured."""
+
+    sid = (session_id or "").strip()
+    if not sid:
+        return None
+
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            return None
+    if not isinstance(config, Mapping):
+        return None
+
+    for experiment_name, spec in _iter_enabled_experiments(config):
+        if not _session_allowed(spec, platform):
+            continue
+        arms_cfg = spec.get("arms")
+        if not isinstance(arms_cfg, dict):
+            continue
+        names = _arm_names(spec)
+        if not names:
+            continue
+        strategy = str(spec.get("assignment") or "hash").strip().lower()
+        if strategy in {"round_robin", "round-robin", "sequential"}:
+            arm_name = _round_robin_arm(experiment_name, sid, names)
+        else:
+            arm_name = _hash_arm(experiment_name, sid, names)
+        arm = arms_cfg.get(arm_name)
+        if isinstance(arm, dict):
+            return ContextExperimentAssignment(
+                experiment_name=experiment_name,
+                arm_name=arm_name,
+                arm=dict(arm),
+            )
+    return None
+
+
+__all__ = [
+    "ContextExperimentAssignment",
+    "resolve_context_experiment_assignment",
+]

--- a/agent/context_experiments.py
+++ b/agent/context_experiments.py
@@ -71,24 +71,49 @@ def _locked_state(path: Path) -> Iterator[None]:
 
     with _STATE_LOCK:
         path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = path.with_suffix(path.suffix + ".lock")
         lock_fd = None
+        lock_held = False
         try:
-            lock_fd = open(path.with_suffix(path.suffix + ".lock"), "a+", encoding="utf-8")
             if fcntl is not None:
+                lock_fd = open(lock_path, "a+", encoding="utf-8")
                 fcntl.flock(lock_fd, fcntl.LOCK_EX)
             elif msvcrt is not None:
-                getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+                # msvcrt.locking() locks from the current file position and
+                # requires that byte to already exist.  Seed the lock file
+                # before reopening it in r+ mode so the lock always starts at
+                # byte zero, including on the first use.
+                with open(lock_path, "ab") as seed_fd:
+                    if seed_fd.tell() == 0:
+                        seed_fd.write(b"\x00")
+                lock_fd = open(lock_path, "r+", encoding="utf-8")
+                lock_fd.seek(0)
+                getattr(msvcrt, "locking")(
+                    lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1
+                )
+            else:
+                raise OSError("context experiment state locking unavailable")
+            lock_held = True
         except (OSError, IOError) as exc:
             logger.warning("context experiment state lock unavailable: %s", exc)
+            if lock_fd is not None:
+                try:
+                    lock_fd.close()
+                except OSError:
+                    pass
+            raise
         try:
             yield
         finally:
             if lock_fd is not None:
                 try:
-                    if fcntl is not None:
+                    if lock_held and fcntl is not None:
                         fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                    elif msvcrt is not None:
-                        getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
+                    elif lock_held and msvcrt is not None:
+                        lock_fd.seek(0)
+                        getattr(msvcrt, "locking")(
+                            lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1
+                        )
                 except (OSError, IOError):
                     pass
                 try:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1989,11 +1989,112 @@ def _load_cursorrules(cwd_path: Path, context_length: Optional[int] = None) -> s
     )
 
 
+def _resolve_context_experiment_file(cwd_path: Path, raw_path: str) -> Path:
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        path = cwd_path / path
+    return path.resolve()
+
+
+def _load_context_experiment_sections(
+    cwd_path: Path,
+    *,
+    session_id: Optional[str],
+    platform: Optional[str],
+    context_length: Optional[int],
+) -> list[str] | None:
+    """Return context sections for an active context experiment.
+
+    ``None`` means no experiment is active, so normal project-context discovery
+    should proceed. An empty list means an experiment is active but its chosen
+    arm intentionally supplied no context material, so normal discovery should
+    stay suppressed for a clean A/B arm.
+    """
+    try:
+        from agent.context_experiments import resolve_context_experiment_assignment
+
+        assignment = resolve_context_experiment_assignment(
+            session_id=session_id,
+            platform=platform,
+        )
+    except Exception as exc:
+        logger.debug("Context experiment assignment failed: %s", exc)
+        return None
+
+    if assignment is None:
+        return None
+
+    arm = assignment.arm or {}
+    sections: list[str] = []
+    raw_files: list[str] = []
+    if arm.get("context_file"):
+        raw_files.append(str(arm.get("context_file")))
+    context_files = arm.get("context_files")
+    if isinstance(context_files, list):
+        raw_files.extend(str(item) for item in context_files if str(item).strip())
+
+    for raw in raw_files:
+        path = _resolve_context_experiment_file(cwd_path, raw)
+        try:
+            content = path.read_text(encoding="utf-8").strip()
+        except Exception as exc:
+            logger.debug("Could not read context experiment file %s: %s", path, exc)
+            sections.append(
+                f"## Context experiment {assignment.experiment_name}/{assignment.arm_name}: {path.name}\n\n"
+                f"[MISSING: configured context file {path} could not be read.]"
+            )
+            continue
+        if not content:
+            continue
+        content = _scan_context_content(content, path.name)
+        result = (
+            f"## Context experiment {assignment.experiment_name}/{assignment.arm_name}: {path.name}\n\n"
+            f"{content}"
+        )
+        sections.append(
+            _truncate_content(
+                result,
+                path.name,
+                context_length=context_length,
+                read_path=str(path),
+            )
+        )
+
+    skills = arm.get("skills")
+    if isinstance(skills, str):
+        skill_names = [skills]
+    elif isinstance(skills, list):
+        skill_names = [str(item) for item in skills if str(item).strip()]
+    else:
+        skill_names = []
+    if skill_names:
+        try:
+            from agent.skill_commands import build_preloaded_skills_prompt
+
+            skills_prompt, _loaded, missing = build_preloaded_skills_prompt(
+                skill_names,
+                task_id=session_id,
+            )
+            if skills_prompt:
+                sections.append(skills_prompt)
+            if missing:
+                sections.append(
+                    "[Context experiment missing skills: " + ", ".join(missing) + "]"
+                )
+        except Exception as exc:
+            logger.debug("Context experiment skill preload failed: %s", exc)
+            sections.append("[Context experiment skill preload failed; see logs.]")
+
+    return sections
+
+
 def build_context_files_prompt(
-    cwd: Optional[str] = None,
+    cwd: Optional[str | Path] = None,
     skip_soul: bool = False,
     context_length: Optional[int] = None,
     allow_install_tree_fallback: bool = False,
+    session_id: Optional[str] = None,
+    platform: Optional[str] = None,
 ) -> str:
     """Discover and load context files for the system prompt.
 
@@ -2045,15 +2146,25 @@ def build_context_files_prompt(
         )
         project_context = ""
     else:
-        # Priority-based project context: first match wins
-        project_context = (
-            _load_hermes_md(cwd_path, context_length)
-            or _load_agents_md(cwd_path, context_length)
-            or _load_claude_md(cwd_path, context_length)
-            or _load_cursorrules(cwd_path, context_length)
+        experiment_sections = _load_context_experiment_sections(
+            cwd_path,
+            session_id=session_id,
+            platform=platform,
+            context_length=context_length,
         )
-    if project_context:
-        sections.append(project_context)
+
+        if experiment_sections is None:
+            # Priority-based project context: first match wins
+            project_context = (
+                _load_hermes_md(cwd_path, context_length)
+                or _load_agents_md(cwd_path, context_length)
+                or _load_claude_md(cwd_path, context_length)
+                or _load_cursorrules(cwd_path, context_length)
+            )
+            if project_context:
+                sections.append(project_context)
+        else:
+            sections.extend(experiment_sections)
 
     # SOUL.md from HERMES_HOME only — skip when already loaded as identity
     if not skip_soul:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -473,7 +473,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         context_files_prompt = _r.build_context_files_prompt(
             cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
             context_length=_ctx_len,
-            allow_install_tree_fallback=agent.platform in ("cli", "tui"))
+            allow_install_tree_fallback=agent.platform in ("cli", "tui"),
+            session_id=getattr(agent, "session_id", None),
+            platform=getattr(agent, "platform", None),
+        )
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1001,6 +1001,11 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    # Optional prompt-context A/B experiments. Disabled by default.
+    # When enabled, Hermes assigns each session to one configured arm before
+    # prompt assembly and loads that arm's context files / preloaded skills in
+    # place of the normal cwd project context. See agent/context_experiments.py.
+    "context_experiments": {},
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,

--- a/tests/agent/test_context_experiments.py
+++ b/tests/agent/test_context_experiments.py
@@ -1,0 +1,78 @@
+"""Tests for session-scoped context experiments."""
+
+from pathlib import Path
+
+from agent.prompt_builder import build_context_files_prompt
+
+
+def _experiment_config(old_file: Path, new_file: Path, *, new_skills=None):
+    return {
+        "context_experiments": {
+            "agentsmd-split": {
+                "enabled": True,
+                "assignment": "round_robin",
+                "arms": {
+                    "old": {"context_file": str(old_file)},
+                    "new": {
+                        "context_file": str(new_file),
+                        "skills": list(new_skills or []),
+                    },
+                },
+            }
+        }
+    }
+
+
+def test_context_experiment_round_robin_replaces_default_project_context(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (tmp_path / "AGENTS.md").write_text("DEFAULT AGENTS", encoding="utf-8")
+    old_file = tmp_path / "AGENTS.old.md"
+    new_file = tmp_path / "AGENTS.slim.md"
+    old_file.write_text("OLD RULES", encoding="utf-8")
+    new_file.write_text("NEW RULES", encoding="utf-8")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: _experiment_config(old_file, new_file),
+    )
+
+    first = build_context_files_prompt(cwd=str(tmp_path), session_id="session-a")
+    second = build_context_files_prompt(cwd=str(tmp_path), session_id="session-b")
+    first_again = build_context_files_prompt(cwd=str(tmp_path), session_id="session-a")
+
+    assert "OLD RULES" in first
+    assert "NEW RULES" not in first
+    assert "NEW RULES" in second
+    assert "OLD RULES" not in second
+    assert first_again == first
+    assert "DEFAULT AGENTS" not in first + second
+
+
+def test_context_experiment_arm_can_preload_skills(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    old_file = tmp_path / "AGENTS.old.md"
+    new_file = tmp_path / "AGENTS.slim.md"
+    old_file.write_text("OLD RULES", encoding="utf-8")
+    new_file.write_text("NEW RULES", encoding="utf-8")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: _experiment_config(old_file, new_file, new_skills=["eval-skill"]),
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands.build_preloaded_skills_prompt",
+        lambda skills, task_id=None: (
+            "[loaded skill body]",
+            ["eval-skill"],
+            [],
+        ),
+    )
+
+    # First new session receives old; second receives new + skill preload.
+    build_context_files_prompt(cwd=str(tmp_path), session_id="session-a")
+    prompt = build_context_files_prompt(cwd=str(tmp_path), session_id="session-b")
+
+    assert "NEW RULES" in prompt
+    assert "[loaded skill body]" in prompt

--- a/tests/agent/test_context_experiments.py
+++ b/tests/agent/test_context_experiments.py
@@ -1,8 +1,163 @@
 """Tests for session-scoped context experiments."""
 
+import json
+import os
 from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import time
 
+import pytest
+
+from agent import context_experiments
 from agent.prompt_builder import build_context_files_prompt
+
+
+class _FakeMsvcrt:
+    LK_LOCK = 1
+    LK_UNLCK = 2
+
+    def __init__(self, *, fail_lock=False):
+        self.fail_lock = fail_lock
+        self.calls = []
+
+    def locking(self, fd, mode, size):
+        self.calls.append((mode, size, os.lseek(fd, 0, os.SEEK_CUR)))
+        if self.fail_lock and mode == self.LK_LOCK:
+            raise OSError("lock unavailable")
+
+
+def test_msvcrt_lock_seeds_one_byte_and_uses_offset_zero(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    fake_msvcrt = _FakeMsvcrt()
+    monkeypatch.setattr(context_experiments, "fcntl", None)
+    monkeypatch.setattr(context_experiments, "msvcrt", fake_msvcrt)
+
+    context_experiments._round_robin_arm("experiment", "session-a", ["old", "new"])
+
+    lock_path = home / "context_experiments" / "experiment.json.lock"
+    assert lock_path.read_bytes() == b"\x00"
+    assert [call[0] for call in fake_msvcrt.calls] == [
+        fake_msvcrt.LK_LOCK,
+        fake_msvcrt.LK_UNLCK,
+    ]
+    assert [call[2] for call in fake_msvcrt.calls] == [0, 0]
+
+
+def test_msvcrt_lock_rewinds_existing_lock_file_before_locking(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / "home"
+    lock_dir = home / "context_experiments"
+    lock_dir.mkdir(parents=True)
+    lock_path = lock_dir / "experiment.json.lock"
+    lock_path.write_bytes(b"\x00")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    fake_msvcrt = _FakeMsvcrt()
+    monkeypatch.setattr(context_experiments, "fcntl", None)
+    monkeypatch.setattr(context_experiments, "msvcrt", fake_msvcrt)
+
+    context_experiments._round_robin_arm("experiment", "session-a", ["old", "new"])
+
+    assert [call[2] for call in fake_msvcrt.calls] == [0, 0]
+
+
+def test_msvcrt_lock_failure_does_not_read_modify_write(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    fake_msvcrt = _FakeMsvcrt(fail_lock=True)
+    monkeypatch.setattr(context_experiments, "fcntl", None)
+    monkeypatch.setattr(context_experiments, "msvcrt", fake_msvcrt)
+
+    with pytest.raises(OSError, match="lock unavailable"):
+        context_experiments._round_robin_arm(
+            "experiment", "session-a", ["old", "new"]
+        )
+
+    state_path = home / "context_experiments" / "experiment.json"
+    assert not state_path.exists()
+    assert [call[0] for call in fake_msvcrt.calls] == [fake_msvcrt.LK_LOCK]
+
+
+@pytest.mark.skipif(
+    context_experiments.fcntl is None,
+    reason="POSIX fcntl/flock required",
+)
+def test_round_robin_assignment_is_cross_process_safe(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    ready = tmp_path / "first-writing"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    repo_root = Path(__file__).resolve().parents[2]
+    worker = textwrap.dedent(
+        f"""
+        import os
+        from pathlib import Path
+        import sys
+        import time
+
+        sys.path.insert(0, {str(repo_root)!r})
+        from agent import context_experiments
+        from utils import atomic_json_write as real_atomic_json_write
+
+        if sys.argv[1] == "session-a":
+            def delayed_atomic_json_write(*args, **kwargs):
+                Path(os.environ["READY"]).write_text("1")
+                time.sleep(0.5)
+                return real_atomic_json_write(*args, **kwargs)
+
+            context_experiments.atomic_json_write = delayed_atomic_json_write
+
+        arm = context_experiments._round_robin_arm(
+            "experiment", sys.argv[1], ["old", "new"]
+        )
+        print(arm, flush=True)
+        """
+    )
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["READY"] = str(ready)
+
+    first = subprocess.Popen(
+        [sys.executable, "-c", worker, "session-a"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    second = None
+    try:
+        deadline = time.monotonic() + 5
+        while not ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ready.exists(), "first process never entered the write"
+
+        second = subprocess.Popen(
+            [sys.executable, "-c", worker, "session-b"],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        first_output, first_error = first.communicate(timeout=10)
+        second_output, second_error = second.communicate(timeout=10)
+    finally:
+        for process in (first, second):
+            if process is not None and process.poll() is None:
+                process.kill()
+                process.wait()
+
+    assert first.returncode == 0, first_error
+    assert second.returncode == 0, second_error
+    assert first_output.strip() == "old"
+    assert second_output.strip() == "new"
+    state = json.loads(
+        (home / "context_experiments" / "experiment.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert state["assignments"] == {"session-a": "old", "session-b": "new"}
 
 
 def _experiment_config(old_file: Path, new_file: Path, *, new_skills=None):

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -27,15 +27,20 @@ def _make_agent(**overrides):
     return SimpleNamespace(**base)
 
 
-def _captured_context_cwd(agent):
-    """The cwd build_system_prompt_parts hands to build_context_files_prompt."""
+def _captured_context_args(agent):
+    """The context args build_system_prompt_parts hands to build_context_files_prompt."""
     captured = {}
 
     def fake_context_files(
         cwd=None, skip_soul=False, context_length=None,
         allow_install_tree_fallback=False,
+        session_id=None,
+        platform=None,
     ):
         captured["cwd"] = cwd
+        captured["allow_install_tree_fallback"] = allow_install_tree_fallback
+        captured["session_id"] = session_id
+        captured["platform"] = platform
         return ""
 
     with (
@@ -45,7 +50,12 @@ def _captured_context_cwd(agent):
         patch("run_agent.build_context_files_prompt", side_effect=fake_context_files),
     ):
         build_system_prompt_parts(agent)
-    return captured["cwd"]
+    return captured
+
+
+def _captured_context_cwd(agent):
+    """The cwd build_system_prompt_parts hands to build_context_files_prompt."""
+    return _captured_context_args(agent)["cwd"]
 
 
 class TestContextFileCwd:
@@ -58,6 +68,14 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+    def test_passes_session_context_to_context_file_builder(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        args = _captured_context_args(
+            _make_agent(session_id="session-123", platform="slack")
+        )
+        assert args["session_id"] == "session-123"
+        assert args["platform"] == "slack"
 
 
 def _stable_prompt(agent):

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -235,6 +235,43 @@ All context files are:
 - **Truncated** — capped at `context_file_max_chars` characters (default 20,000) using 70/20 head/tail ratio with a truncation marker
 - **YAML frontmatter stripped** — `.hermes.md` frontmatter is removed (reserved for future config overrides)
 
+### Session-scoped context experiments
+
+Operators who want to compare prompt layouts across real sessions can enable a
+`context_experiments` block in `config.yaml`. Hermes assigns each session to one
+arm before system-prompt assembly, then loads that arm's `context_file` /
+`context_files` and optional preloaded `skills` instead of the normal cwd project
+context. The assignment is fixed for the session, so the system prompt remains
+byte-stable after the session starts.
+
+```yaml
+context_experiments:
+  active: agentsmd_split
+  agentsmd_split:
+    enabled: true
+    assignment: round_robin   # or hash
+    unit: session             # currently the only supported unit
+    platforms: [slack]        # optional; omit to include every platform
+    arms:
+      old:
+        context_file: /opt/hermes-prompts/AGENTS.old.md
+      new:
+        context_file: /opt/hermes-prompts/AGENTS.slim.md
+        skills:
+          - workflow-capture
+          - agent-tool-selection
+```
+
+Notes:
+
+- `round_robin` persists `session_id -> arm` under
+  `~/.hermes/context_experiments/<experiment>.json` so Slack/gateway restarts do
+  not reshuffle existing sessions.
+- `hash` is deterministic and does not require shared state.
+- Relative `context_file` paths resolve against the session cwd.
+- If an experiment is active, the default `.hermes.md` / `AGENTS.md` /
+  `CLAUDE.md` discovery is intentionally suppressed for that session arm.
+
 ## API-call-time-only layers
 
 These are intentionally *not* persisted as part of the cached system prompt:


### PR DESCRIPTION
## Summary
- add a session-scoped `context_experiments` config block for A/B testing prompt context arms before system-prompt assembly
- support deterministic hash or persisted round-robin assignment by session id, with optional platform filters
- load experiment arm context files and optional preloaded skills in place of normal project context
- document the config shape in prompt assembly docs

## Tests
- `scripts/run_tests.sh tests/agent/test_context_experiments.py tests/agent/test_system_prompt.py tests/agent/test_prompt_builder.py tests/hermes_cli/test_prompt_size.py tests/hermes_cli/test_prompt_compose_command.py -q`
- `.venv/bin/python -m ruff check agent/context_experiments.py agent/prompt_builder.py agent/system_prompt.py tests/agent/test_context_experiments.py tests/agent/test_system_prompt.py`
- `.venv/bin/ty check agent/context_experiments.py tests/agent/test_context_experiments.py tests/agent/test_system_prompt.py`

## Notes
- A full `scripts/run_tests.sh` attempt initially failed because the newly created local `.venv` lacked pytest; after syncing the dev extra, the targeted canonical suite above passed.