### PR TITLE
feat(telegram): implement rich message support and enhance platform h…

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -53,7 +53,7 @@ from hermes_cli.config import cfg_get
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
 from model_tools import check_toolset_requirements, get_tool_definitions
-from utils import base_url_host_matches
+from utils import base_url_host_matches, is_truthy_value
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
 # capture our warnings.  (run_agent.py also does
@@ -1041,6 +1041,26 @@ def init_agent(
         _agent_cfg = _load_agent_config()
     except Exception:
         _agent_cfg = {}
+    if not isinstance(_agent_cfg, dict):
+        _agent_cfg = {}
+
+    # Session-stable platform prompt controls. These are intentionally read
+    # once at agent construction so live config edits do not mutate a cached
+    # prompt mid-conversation.
+    _platform_hint_overrides = _agent_cfg.get("platform_hints", {})
+    agent._platform_hint_overrides = (
+        _platform_hint_overrides if isinstance(_platform_hint_overrides, dict) else {}
+    )
+    agent._telegram_rich_messages_enabled = is_truthy_value(
+        cfg_get(
+            _agent_cfg,
+            "platforms",
+            "telegram",
+            "extra",
+            "rich_messages",
+        ),
+        default=False,
+    )
     try:
         agent._tool_guardrails = ToolCallGuardrailController(
             ToolCallGuardrailConfig.from_mapping(

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -404,6 +404,33 @@ COMPUTER_USE_GUIDANCE = (
 # message representation stays consistent ("system" everywhere).
 DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")
 
+TELEGRAM_MEDIA_GUIDANCE = (
+    "You can send media files natively: to deliver a file to the user, "
+    "include MEDIA:/absolute/path/to/file in your response. Images "
+    "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "
+    "bubbles, and videos (.mp4) play inline. You can also include image "
+    "URLs in markdown format ![alt](url) and they will be sent as native photos."
+)
+
+TELEGRAM_RICH_PLATFORM_HINT = (
+    "You are on a text messaging communication platform, Telegram. "
+    "Standard Markdown is automatically converted to Telegram formatting. "
+    "Supported: **bold**, *italic*, ~~strikethrough~~, ||spoiler||, "
+    "`inline code`, ```code blocks```, [links](url), and ## headers. "
+    "This Telegram gateway has rich messages enabled, so lean into rich Markdown "
+    "when it makes the answer clearer or easier to scan: real Markdown tables, "
+    "bullet and numbered lists, task lists, headings, nested blockquotes, "
+    "collapsible details, footnotes/references, math/formulas, underline, "
+    "subscript/superscript, marked/highlighted text, and anchors. "
+    "Default to structured formatting over dense paragraphs for comparisons, "
+    "steps, key/value summaries, and tabular data. For status/update summaries, "
+    "investigations, QA/results, confirmations of changed items, and multi-part "
+    "answers, include a compact table and/or task-list checklist unless the "
+    "answer is truly a one-sentence reply. Prefer real Markdown tables and task "
+    "lists over hand-built substitutes. "
+    f"{TELEGRAM_MEDIA_GUIDANCE}"
+)
+
 PLATFORM_HINTS = {
     "whatsapp": (
         "You are on a text messaging communication platform, WhatsApp. "
@@ -424,11 +451,7 @@ PLATFORM_HINTS = {
         "key: value pairs over pipe tables (any tables you do emit are "
         "auto-rewritten into row-group bullets, which you can produce "
         "directly for cleaner output). "
-        "You can send media files natively: to deliver a file to the user, "
-        "include MEDIA:/absolute/path/to/file in your response. Images "
-        "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "
-        "bubbles, and videos (.mp4) play inline. You can also include image "
-        "URLs in markdown format ![alt](url) and they will be sent as native photos."
+        f"{TELEGRAM_MEDIA_GUIDANCE}"
     ),
     "discord": (
         "You are in a Discord server or group chat communicating with your user. "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -37,6 +37,7 @@ from agent.prompt_builder import (
     PLATFORM_HINTS,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
+    TELEGRAM_RICH_PLATFORM_HINT,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
 )
@@ -55,6 +56,27 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _resolve_platform_hint(agent: Any, platform_key: str, default_hint: str) -> str:
+    """Apply optional per-platform hint replacement/appends to a default hint."""
+    overrides = getattr(agent, "_platform_hint_overrides", None)
+    if not isinstance(overrides, dict):
+        return default_hint
+
+    platform_override = overrides.get(platform_key)
+    if not isinstance(platform_override, dict):
+        return default_hint
+
+    replace = platform_override.get("replace")
+    if isinstance(replace, str) and replace.strip():
+        return replace.strip()
+
+    append = platform_override.get("append")
+    if isinstance(append, str) and append.strip():
+        return f"{default_hint.rstrip()}\n\n{append.strip()}"
+
+    return default_hint
 
 
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
@@ -241,7 +263,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     platform_key = (agent.platform or "").lower().strip()
     if platform_key in PLATFORM_HINTS:
-        stable_parts.append(PLATFORM_HINTS[platform_key])
+        default_hint = (
+            TELEGRAM_RICH_PLATFORM_HINT
+            if platform_key == "telegram"
+            and getattr(agent, "_telegram_rich_messages_enabled", False)
+            else PLATFORM_HINTS[platform_key]
+        )
+        stable_parts.append(_resolve_platform_hint(agent, platform_key, default_hint))
     elif platform_key:
         # Check plugin registry for platform-specific LLM guidance
         try:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -208,6 +208,18 @@ def _strip_mdv2(text: str) -> str:
 _TABLE_SEPARATOR_RE = re.compile(
     r'^\s*\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*){1,}\|?\s*$'
 )
+_TASK_LIST_RE = re.compile(r"(?m)^\s*[-*]\s+\[[ xX]\]\s+")
+_HEADING_RE = re.compile(r"(?m)^\s{0,3}#{1,6}\s+\S")
+_LIST_RE = re.compile(r"(?m)^\s{0,3}(?:[-+*]\s+|\d+[.)]\s+)\S")
+_BLOCKQUOTE_RE = re.compile(r"(?m)^\s{0,3}>\s*\S")
+_FENCE_RE = re.compile(r"(?m)^\s*```")
+_DIVIDER_RE = re.compile(r"(?m)^\s*---+\s*$")
+_FOOTNOTE_RE = re.compile(r"\[\^[^\]]+\](?::)?")
+_HTML_RICH_TAG_RE = re.compile(r"</?(?:u|sub|sup)\b", re.IGNORECASE)
+_INLINE_MATH_RE = re.compile(r"(?<!\\)\$[^$\n]+(?<!\\)\$")
+_CJK_RE = re.compile(
+    r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff00-\uffef]"
+)
 
 
 def _is_table_row(line: str) -> bool:
@@ -344,6 +356,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     # Telegram message limits
     MAX_MESSAGE_LENGTH = 4096
+    RICH_MESSAGE_MAX_CHARS = 32768
     # Threshold for detecting Telegram client-side message splits.
     # When a chunk is near this limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 4000
@@ -409,6 +422,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
+        self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
@@ -859,6 +873,185 @@ class TelegramAdapter(BasePlatformAdapter):
         if LinkPreviewOptions is not None:
             return {"link_preview_options": LinkPreviewOptions(is_disabled=True)}
         return {"disable_web_page_preview": True}
+
+    def _rich_delivery_enabled(self) -> bool:
+        """Return True only when rich Telegram delivery is explicitly enabled."""
+        return bool(getattr(self, "_rich_messages_enabled", False))
+
+    def _rich_safety_allows(self, content: str) -> bool:
+        if utf16_len(content) > self.RICH_MESSAGE_MAX_CHARS:
+            return False
+        lowered = content.lower()
+        if "<details" in lowered and "$$" in content:
+            return False
+        # Keep legacy MarkdownV2 safer for CJK-heavy content until the rich
+        # endpoint's escaping/segmentation behavior is proven across clients.
+        if _CJK_RE.search(content):
+            return False
+        return True
+
+    def _needs_rich_rendering(self, content: str) -> bool:
+        """Return whether content should use Telegram rich-message delivery.
+
+        Rich delivery changes both endpoint routing and Markdown semantics, so
+        it is strictly opt-in via ``platforms.telegram.extra.rich_messages``.
+        """
+        if not content:
+            return False
+        if not self._rich_delivery_enabled():
+            return False
+        if not self._rich_safety_allows(content):
+            return False
+
+        if utf16_len(content) > self.MAX_MESSAGE_LENGTH:
+            return True
+        if any(_TABLE_SEPARATOR_RE.match(line) for line in content.splitlines()):
+            return True
+        if _TASK_LIST_RE.search(content):
+            return True
+        lowered = content.lower()
+        if "<details" in lowered:
+            return True
+        if "$$" in content:
+            return True
+        if _HEADING_RE.search(content):
+            return True
+        if _LIST_RE.search(content):
+            return True
+        if _BLOCKQUOTE_RE.search(content):
+            return True
+        if _FENCE_RE.search(content):
+            return True
+        if _DIVIDER_RE.search(content):
+            return True
+        if _FOOTNOTE_RE.search(content):
+            return True
+        if "==" in content:
+            return True
+        if _HTML_RICH_TAG_RE.search(content):
+            return True
+        if _INLINE_MATH_RE.search(content):
+            return True
+        return False
+
+    @staticmethod
+    def _clean_rich_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {key: value for key, value in payload.items() if value is not None}
+
+    @staticmethod
+    def _extract_message_id(response: Any) -> Optional[str]:
+        if response is None:
+            return None
+        if isinstance(response, dict):
+            message_id = response.get("message_id")
+            if message_id is None and isinstance(response.get("result"), dict):
+                message_id = response["result"].get("message_id")
+            return str(message_id) if message_id is not None else None
+        message_id = getattr(response, "message_id", None)
+        return str(message_id) if message_id is not None else None
+
+    async def _rich_api_request(self, method: str, payload: Dict[str, Any]) -> Any:
+        api_request = getattr(self._bot, "do_api_request", None)
+        if not callable(api_request):
+            raise RuntimeError("Telegram Bot does not expose do_api_request")
+        payload = self._clean_rich_payload(payload)
+        try:
+            return await api_request(method, data=payload)
+        except TypeError:
+            return await api_request(method, payload)
+
+    def _rich_link_preview_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {}
+        for key, value in self._link_preview_kwargs().items():
+            if key == "link_preview_options" and hasattr(value, "to_dict"):
+                payload[key] = value.to_dict()
+            else:
+                payload[key] = value
+        return payload
+
+    async def _send_rich_message(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        thread_id = self._metadata_thread_id(metadata)
+        metadata_reply_to = self._metadata_reply_to_message_id(metadata)
+        private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)
+        dm_topic_reply_to_off = (
+            private_dm_topic_send
+            and self._reply_to_mode == "off"
+            and bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
+        )
+        reply_to_source = reply_to or (
+            str(metadata_reply_to)
+            if private_dm_topic_send and metadata_reply_to is not None
+            else None
+        )
+        if private_dm_topic_send:
+            should_thread = reply_to_source is not None and self._reply_to_mode != "off"
+        else:
+            should_thread = self._should_thread_reply(reply_to_source, 0)
+        reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
+        if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
+            return SendResult(
+                success=False,
+                error=self._dm_topic_missing_anchor_error(),
+                retryable=False,
+            )
+
+        thread_kwargs = self._thread_kwargs_for_send(
+            chat_id,
+            thread_id,
+            metadata,
+            reply_to_message_id=reply_to_id,
+            reply_to_mode=self._reply_to_mode,
+        )
+        payload = {
+            "chat_id": int(chat_id),
+            "text": content,
+            "reply_to_message_id": reply_to_id,
+            **thread_kwargs,
+            **self._rich_link_preview_payload(),
+            **self._notification_kwargs(metadata),
+        }
+        try:
+            response = await self._rich_api_request("sendRichMessage", payload)
+        except Exception as exc:
+            logger.debug("[%s] Rich Telegram send failed, falling back: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc), retryable=False)
+
+        return SendResult(
+            success=True,
+            message_id=self._extract_message_id(response),
+            raw_response={"rich": True, "response": response},
+        )
+
+    async def _edit_rich_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        payload = {
+            "chat_id": int(chat_id),
+            "message_id": int(message_id),
+            "text": content,
+            **self._rich_link_preview_payload(),
+            **self._notification_kwargs(metadata),
+        }
+        try:
+            response = await self._rich_api_request("editRichMessage", payload)
+        except Exception as exc:
+            logger.debug("[%s] Rich Telegram edit failed, falling back: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc), retryable=False)
+        return SendResult(
+            success=True,
+            message_id=self._extract_message_id(response) or message_id,
+            raw_response={"rich": True, "response": response},
+        )
 
     async def _drain_polling_connections(self) -> None:
         """Reset the httpx connection pool used for getUpdates polling.
@@ -1820,6 +2013,17 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+
+        if self._needs_rich_rendering(content):
+            rich_result = await self._send_rich_message(
+                chat_id, content, reply_to=reply_to, metadata=metadata,
+            )
+            if rich_result.success:
+                try:
+                    await self.send_typing(chat_id, metadata=metadata)
+                except Exception:
+                    pass
+                return rich_result
         
         try:
             # Format and split message if needed
@@ -2128,6 +2332,13 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+
+        if finalize and self._needs_rich_rendering(content):
+            rich_result = await self._edit_rich_message(
+                chat_id, message_id, content, metadata=metadata,
+            )
+            if rich_result.success:
+                return rich_result
 
         # Pre-flight: if content already exceeds the limit, split-and-deliver
         # without round-tripping a doomed edit.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1385,6 +1385,19 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _append_progress_repeat_counter(message: str, repeat_count: int) -> str:
+    """Append a repeat counter without corrupting fenced code blocks."""
+    text = str(message)
+    suffix = f" (×{repeat_count})"
+    lines = text.splitlines()
+    if lines and lines[-1].strip() == "```":
+        if lines[0].strip() and not lines[0].lstrip().startswith("```"):
+            lines[0] = f"{lines[0]}{suffix}"
+            return "\n".join(lines)
+        return f"{text}\n{suffix.strip()}"
+    return f"{text}{suffix}"
+
+
 def _teams_pipeline_plugin_enabled() -> bool:
     """Return True when the standalone Teams pipeline plugin is enabled."""
     config = _load_gateway_config()
@@ -16169,7 +16182,7 @@ class GatewayRunner:
                     if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                         _, base_msg, count = raw
                         if progress_lines:
-                            progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                            progress_lines[-1] = _append_progress_repeat_counter(base_msg, count + 1)
                         msg = progress_lines[-1] if progress_lines else base_msg
                     elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                         # Content bubble just landed on the platform — close off
@@ -16291,7 +16304,7 @@ class GatewayRunner:
                             if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                                 _, base_msg, count = raw
                                 if progress_lines:
-                                    progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                                    progress_lines[-1] = _append_progress_repeat_counter(base_msg, count + 1)
                                     await _roll_progress_overflow_if_needed()
                             elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                                 # Content-bubble marker during drain: close off

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -27,6 +27,7 @@ from agent.prompt_builder import (
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
+    TELEGRAM_RICH_PLATFORM_HINT,
     WSL_ENVIRONMENT_HINT,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
@@ -790,6 +791,17 @@ class TestPromptBuilderConstants:
         assert "cli" in PLATFORM_HINTS
         assert "api_server" in PLATFORM_HINTS
         assert "webui" in PLATFORM_HINTS
+
+    def test_telegram_rich_hint_is_not_default(self):
+        default_hint = PLATFORM_HINTS["telegram"]
+        assert "Telegram has NO table syntax" in default_hint
+        assert "rich messages enabled" not in default_hint
+        assert "status/update" not in default_hint
+
+        assert "rich messages enabled" in TELEGRAM_RICH_PLATFORM_HINT
+        assert "status/update" in TELEGRAM_RICH_PLATFORM_HINT
+        assert "task-list checklist" in TELEGRAM_RICH_PLATFORM_HINT
+        assert "MEDIA:/absolute/path/to/file" in TELEGRAM_RICH_PLATFORM_HINT
 
     def test_cli_hint_does_not_suggest_media_tags(self):
         # Regression: MEDIA:/path tags are intercepted only by messaging

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent import system_prompt
+
+
+@pytest.fixture(autouse=True)
+def _stub_prompt_dependencies(monkeypatch):
+    monkeypatch.setattr(
+        system_prompt,
+        "_ra",
+        lambda: SimpleNamespace(
+            load_soul_md=lambda: None,
+            build_nous_subscription_prompt=lambda tool_names: "",
+            build_environment_hints=lambda: "",
+            build_context_files_prompt=lambda cwd=None, skip_soul=False: "",
+            build_skills_system_prompt=lambda **kwargs: "",
+            get_toolset_for_tool=lambda tool_name: None,
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.file_safety._resolve_active_profile_name",
+        lambda: "default",
+        raising=False,
+    )
+
+
+def _agent(*, platform="telegram", rich_messages=False, overrides=None):
+    return SimpleNamespace(
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names=set(),
+        _kanban_worker_guidance=False,
+        _tool_use_enforcement="auto",
+        provider="test",
+        model="test-model",
+        platform=platform,
+        _telegram_rich_messages_enabled=rich_messages,
+        _platform_hint_overrides=overrides or {},
+        _memory_store=None,
+        _memory_enabled=False,
+        _user_profile_enabled=False,
+        _memory_manager=None,
+        pass_session_id=False,
+        session_id=None,
+    )
+
+
+def _stable_prompt(agent):
+    return system_prompt.build_system_prompt_parts(agent)["stable"]
+
+
+def test_telegram_missing_or_false_rich_uses_legacy_hint():
+    prompt = _stable_prompt(_agent(rich_messages=False))
+
+    assert "Telegram has NO table syntax" in prompt
+    assert "rich messages enabled" not in prompt
+    assert "status/update" not in prompt
+    assert "task-list checklist" not in prompt
+
+
+def test_telegram_rich_enabled_uses_rich_hint_with_media_guidance():
+    prompt = _stable_prompt(_agent(rich_messages=True))
+
+    assert "rich messages enabled" in prompt
+    assert "status/update" in prompt
+    assert "task-list checklist" in prompt
+    assert "MEDIA:/absolute/path/to/file" in prompt
+    assert "Telegram has NO table syntax" not in prompt
+
+
+def test_platform_hint_replace_overrides_selected_telegram_default():
+    prompt = _stable_prompt(
+        _agent(
+            rich_messages=True,
+            overrides={"telegram": {"replace": "CUSTOM TELEGRAM HINT"}},
+        )
+    )
+
+    assert "CUSTOM TELEGRAM HINT" in prompt
+    assert "rich messages enabled" not in prompt
+    assert "Telegram has NO table syntax" not in prompt
+
+
+def test_platform_hint_append_extends_selected_telegram_default():
+    prompt = _stable_prompt(
+        _agent(
+            rich_messages=True,
+            overrides={"telegram": {"append": "CUSTOM APPEND"}},
+        )
+    )
+
+    assert "rich messages enabled" in prompt
+    assert "CUSTOM APPEND" in prompt
+
+
+def test_non_telegram_platform_hint_unaffected_by_telegram_rich_flag():
+    prompt = _stable_prompt(_agent(platform="discord", rich_messages=True))
+
+    assert "Discord" in prompt
+    assert "rich messages enabled" not in prompt
+    assert "Telegram has NO table syntax" not in prompt

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -21,6 +21,7 @@ import pytest
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.run import _append_progress_repeat_counter
 from gateway.session import SessionSource
 
 
@@ -109,6 +110,24 @@ class ProgressAgent:
         return {"final_response": "done", "messages": [], "api_calls": 1}
 
 
+class RepeatedTerminalAgent:
+    """Emits the same terminal progress event twice to exercise dedup."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            args = {"command": "cd /tmp/hermes-agent"}
+            cb("tool.started", "terminal", "cd /tmp/hermes-agent", args)
+            time.sleep(0.35)
+            cb("tool.started", "terminal", "cd /tmp/hermes-agent", args)
+            time.sleep(0.1)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
 class FailingAgent:
     def __init__(self, **kwargs):
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
@@ -186,6 +205,65 @@ def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool):
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def test_progress_repeat_counter_stays_outside_headered_code_fence():
+    message = "💻 terminal\n```\ncd /tmp/hermes-agent\n```"
+
+    rendered = _append_progress_repeat_counter(message, 2)
+
+    assert rendered.splitlines()[0] == "💻 terminal (×2)"
+    assert "``` (×2)" not in rendered
+    assert not any(
+        line.lstrip().startswith("```") and "(×" in line
+        for line in rendered.splitlines()
+    )
+
+
+def test_progress_repeat_counter_stays_after_bare_code_fence():
+    message = "```\ncd /tmp/hermes-agent\n```"
+
+    rendered = _append_progress_repeat_counter(message, 2)
+
+    assert rendered == "```\ncd /tmp/hermes-agent\n```\n(×2)"
+    assert "``` (×2)" not in rendered
+    assert not any(
+        line.lstrip().startswith("```") and "(×" in line
+        for line in rendered.splitlines()
+    )
+
+
+@pytest.mark.asyncio
+async def test_repeated_terminal_progress_counter_stays_outside_code_fence(monkeypatch, tmp_path):
+    adapter = CleanupCaptureAdapter()
+    adapter.supports_code_blocks = True
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(monkeypatch, RepeatedTerminalAgent, cleanup_on=False)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    session_key = "agent:main:telegram:group:-1001"
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-repeat-terminal",
+        session_key=session_key,
+    )
+
+    rendered = "\n".join(
+        [entry["content"] for entry in adapter.sent]
+        + [entry["content"] for entry in adapter.edits]
+    )
+    assert result["final_response"] == "done"
+    assert "(×2)" in rendered
+    assert "``` (×2)" not in rendered
+    assert not any(
+        line.lstrip().startswith("```") and "(×" in line
+        for line in rendered.splitlines()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -1,0 +1,158 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+class FakeTelegramBot:
+    def __init__(self):
+        self.rich_calls = []
+        self.send_messages = []
+        self.edit_messages = []
+        self._next_id = 100
+
+    def _message(self):
+        self._next_id += 1
+        return SimpleNamespace(message_id=self._next_id)
+
+    async def do_api_request(self, method, data=None):
+        self.rich_calls.append({"method": method, "data": data or {}})
+        return {"message_id": f"rich-{len(self.rich_calls)}"}
+
+    async def send_message(self, **kwargs):
+        self.send_messages.append(kwargs)
+        return self._message()
+
+    async def edit_message_text(self, **kwargs):
+        self.edit_messages.append(kwargs)
+        return True
+
+
+def _adapter(*, rich_messages=None):
+    extra = {}
+    if rich_messages is not None:
+        extra["rich_messages"] = rich_messages
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***", extra=extra))
+    bot = FakeTelegramBot()
+    adapter._bot = bot
+    return adapter, bot
+
+
+@pytest.mark.asyncio
+async def test_short_ordinary_markdown_stays_legacy_when_rich_enabled():
+    adapter, bot = _adapter(rich_messages=True)
+
+    result = await adapter.send("123", "A **short** reply.")
+
+    assert result.success is True
+    assert bot.rich_calls == []
+    assert len(bot.send_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_heading_and_bullet_list_use_rich_when_enabled():
+    adapter, bot = _adapter(rich_messages=True)
+    content = "# Summary\n- First item\n- Second item"
+
+    result = await adapter.send("123", content)
+
+    assert result.success is True
+    assert bot.send_messages == []
+    assert bot.rich_calls == [
+        {
+            "method": "sendRichMessage",
+            "data": {"chat_id": 123, "text": content, "disable_notification": True},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_heading_and_bullet_list_stay_legacy_when_rich_false():
+    adapter, bot = _adapter(rich_messages=False)
+
+    result = await adapter.send("123", "# Summary\n- First item\n- Second item")
+
+    assert result.success is True
+    assert bot.rich_calls == []
+    assert len(bot.send_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_heading_and_bullet_list_stay_legacy_when_rich_missing():
+    adapter, bot = _adapter()
+
+    result = await adapter.send("123", "# Summary\n- First item\n- Second item")
+
+    assert result.success is True
+    assert bot.rich_calls == []
+    assert len(bot.send_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_long_plain_content_uses_single_rich_send_when_enabled():
+    adapter, bot = _adapter(rich_messages=True)
+    content = "x" * (adapter.MAX_MESSAGE_LENGTH + 100)
+
+    result = await adapter.send("123", content)
+
+    assert result.success is True
+    assert bot.send_messages == []
+    assert [call["method"] for call in bot.rich_calls] == ["sendRichMessage"]
+    assert bot.rich_calls[0]["data"]["text"] == content
+
+
+@pytest.mark.asyncio
+async def test_long_plain_content_uses_legacy_split_when_rich_missing():
+    adapter, bot = _adapter()
+    content = "x" * (adapter.MAX_MESSAGE_LENGTH + 100)
+
+    result = await adapter.send("123", content)
+
+    assert result.success is True
+    assert bot.rich_calls == []
+    assert len(bot.send_messages) > 1
+
+
+@pytest.mark.asyncio
+async def test_final_long_plain_edit_uses_rich_edit_when_enabled():
+    adapter, bot = _adapter(rich_messages=True)
+    content = "x" * (adapter.MAX_MESSAGE_LENGTH + 100)
+
+    result = await adapter.edit_message("123", "10", content, finalize=True)
+
+    assert result.success is True
+    assert bot.edit_messages == []
+    assert bot.rich_calls == [
+        {
+            "method": "editRichMessage",
+            "data": {
+                "chat_id": 123,
+                "message_id": 10,
+                "text": content,
+                "disable_notification": True,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_final_long_plain_edit_uses_legacy_split_when_rich_false():
+    adapter, bot = _adapter(rich_messages=False)
+    content = "x" * (adapter.MAX_MESSAGE_LENGTH + 100)
+
+    result = await adapter.edit_message("123", "10", content, finalize=True)
+
+    assert result.success is True
+    assert bot.rich_calls == []
+    assert bot.edit_messages
+    assert bot.send_messages
+
+
+def test_needs_rich_rendering_empty_and_disabled_are_false():
+    adapter, _ = _adapter(rich_messages=True)
+    assert adapter._needs_rich_rendering("") is False
+
+    adapter, _ = _adapter(rich_messages=False)
+    assert adapter._needs_rich_rendering("# Heading\n- item") is False


### PR DESCRIPTION
## Summary

- Keep Telegram rich Markdown generation/delivery strictly gated by `platforms.telegram.extra.rich_messages`.
- Preserve default/legacy Telegram behavior when `rich_messages` is missing or false.
- Use richer Telegram prompt guidance and rich delivery routing only when rich messages are enabled.
- Prevent tool-progress repeat counters from corrupting terminal code-block closing fences.

## Why

Rich Telegram messages are useful but should remain opt-in because they change output style and delivery behavior. Users who have not enabled `rich_messages` should see the same default behavior as before.

Separately, repeated terminal progress blocks could produce malformed closing fences like ``` (×2), causing Telegram to swallow later progress lines into copyable code blocks. That is a plain bug in existing progress rendering, so the fence fix applies regardless of rich-message config.

## Behavior

| Scenario | Behavior |
|---|---|
| `rich_messages` false/missing | Legacy Telegram prompt and send/edit behavior preserved. |
| `rich_messages: true` | Rich Telegram prompt guidance and rich endpoint routing are enabled for supported structured/long content. |
| Repeated terminal progress | Repeat counter is placed on the header or a separate post-fence line, never on the closing ``` fence. |

## Tests

```text
python -m pytest tests/gateway/test_run_cleanup_progress.py::test_repeated_terminal_progress_counter_stays_outside_code_fence -q -o "addopts=" -p no:cacheprovider --basetemp .pytest_tmp_progress
1 passed in 3.51s

python -m pytest tests/gateway/test_telegram_rich_messages.py tests/agent/test_prompt_builder.py::TestPromptBuilderConstants::test_telegram_rich_hint_is_not_default tests/agent/test_system_prompt.py -q -o "addopts=" -p no:cacheprovider --basetemp .pytest_tmp_rich
15 passed in 1.01s

python -m pytest tests/gateway/test_run_cleanup_progress.py tests/gateway/test_run_progress_topics.py tests/gateway/test_run_progress_interrupt.py tests/gateway/test_telegram_progress_edit_transient.py -q -o "addopts=" -p no:cacheprovider --basetemp .pytest_tmp_progress_suite
60 passed in 20.37s

python -m pytest tests/gateway/test_telegram_rich_messages.py tests/gateway/test_stream_consumer_draft.py tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py -q -o "addopts=" -p no:cacheprovider --basetemp .pytest_tmp_prompt_suite
150 passed, 1 skipped in 6.04s

python -m pytest tests/gateway/test_run_cleanup_progress.py tests/gateway/test_run_progress_topics.py tests/gateway/test_run_progress_interrupt.py tests/gateway/test_telegram_progress_edit_transient.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_stream_consumer_draft.py tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py -q -o "addopts=" -p no:cacheprovider --basetemp .pytest_tmp_combined
210 passed, 1 skipped in 23.95s

git diff --check
exit 0; only Windows LF→CRLF warnings

python -m py_compile agent/prompt_builder.py agent/system_prompt.py agent/agent_init.py gateway/platforms/telegram.py gateway/run.py
exit 0