### PR TITLE
fix(firecrawl): read firecrawl_api_url from config.yaml as fallback

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -35,12 +35,18 @@ Config keys this provider responds to::
 
 Env vars::
 
-    FIRECRAWL_API_KEY=...            # direct cloud auth
+    FIRECRAWL_API_KEY=***            # direct cloud auth
     FIRECRAWL_API_URL=...            # self-hosted Firecrawl
     FIRECRAWL_GATEWAY_URL=...        # Nous tool-gateway (subscribers)
     TOOL_GATEWAY_DOMAIN=...          # alternate gateway env
     TOOL_GATEWAY_SCHEME=...
-    TOOL_GATEWAY_USER_TOKEN=...
+    TOOL_GATEWAY_USER_TOKEN=***
+
+config.yaml fallbacks (when env vars are absent)::
+
+    web:
+      firecrawl_api_url: ...         # self-hosted Firecrawl URL
+      firecrawl_api_key: ***         # direct cloud auth
 """
 
 from __future__ import annotations
@@ -119,10 +125,34 @@ Firecrawl = _FirecrawlProxy()
 # :func:`_get_firecrawl_client` below.
 
 
+def _read_config_value(*path: str) -> Optional[str]:
+    """Resolve a dotted config key from ``config.yaml``.  Returns None on miss."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        cur: Any = cfg
+        for segment in path:
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(segment)
+        if isinstance(cur, str) and cur.strip():
+            return cur.strip()
+    except Exception:  # noqa: BLE001 — config read is best-effort
+        pass
+    return None
+
+
 def _get_direct_firecrawl_config() -> Optional[tuple]:
     """Return explicit direct Firecrawl kwargs + cache key, or None when unset."""
     api_key = os.getenv("FIRECRAWL_API_KEY", "").strip()
     api_url = os.getenv("FIRECRAWL_API_URL", "").strip().rstrip("/")
+
+    # Fall back to config.yaml when env vars are absent.
+    if not api_url:
+        api_url = (_read_config_value("web", "firecrawl_api_url") or "").rstrip("/")
+    if not api_key:
+        api_key = _read_config_value("web", "firecrawl_api_key") or ""
 
     if not api_key and not api_url:
         return None
@@ -191,8 +221,9 @@ def _raise_web_backend_configuration_error() -> None:
 
     message = (
         "Web tools are not configured. "
-        "Set FIRECRAWL_API_KEY for cloud Firecrawl or set FIRECRAWL_API_URL "
-        "for a self-hosted Firecrawl instance."
+        "Set FIRECRAWL_API_KEY for cloud Firecrawl, set FIRECRAWL_API_URL "
+        "for a self-hosted Firecrawl instance, or add "
+        "web.firecrawl_api_url to config.yaml."
     )
     if _wt.managed_nous_tools_enabled():
         message += (

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -219,6 +219,40 @@ class TestIsAvailable:
         monkeypatch.setenv("FIRECRAWL_API_URL", "http://localhost:3002")
         assert p.is_available() is True
 
+    def test_firecrawl_config_yaml_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """_get_direct_firecrawl_config reads config.yaml when env vars absent."""
+        from unittest.mock import patch
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        _clear_web_env(monkeypatch)
+
+        # Neither env var set → returns None.
+        assert firecrawl_provider._get_direct_firecrawl_config() is None
+
+        # config.yaml provides api_url → returns it.
+        with patch.object(
+            firecrawl_provider, "_read_config_value",
+            side_effect=lambda *p: (
+                "http://localhost:3002" if p == ("web", "firecrawl_api_url") else None
+            ),
+        ):
+            result = firecrawl_provider._get_direct_firecrawl_config()
+            assert result is not None
+            kwargs, cache_key = result
+            assert kwargs["api_url"] == "http://localhost:3002"
+            assert "api_key" not in kwargs
+
+        # Env var takes precedence over config.yaml.
+        monkeypatch.setenv("FIRECRAWL_API_URL", "http://env:9000")
+        with patch.object(
+            firecrawl_provider, "_read_config_value",
+            return_value="http://config:3002",
+        ):
+            result = firecrawl_provider._get_direct_firecrawl_config()
+            assert result is not None
+            kwargs, _ = result
+            assert kwargs["api_url"] == "http://env:9000"
+
     def test_ddgs_always_available_when_package_importable(self) -> None:
         """DDGS is the always-on fallback — no API key required.
 


### PR DESCRIPTION
## What does this PR do?

The Firecrawl plugin (`plugins/web/firecrawl/provider.py`) reads configuration exclusively from environment variables (`FIRECRAWL_API_KEY`, `FIRECRAWL_API_URL`), completely ignoring `web.firecrawl_api_url` / `web.firecrawl_api_key` in `config.yaml`. This creates a dangerous silent failure: when a user configures a self-hosted Firecrawl URL in `config.yaml` but has `FIRECRAWL_API_KEY` set from prior cloud usage, all `web_extract` calls silently route to the paid Firecrawl Cloud API.

This PR adds a `_read_config_value()` helper that reads from `config.yaml`, and falls back to it when the corresponding env var is absent. Env vars still take precedence for backward compatibility.

## Related Issue

Fixes #55065

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/web/firecrawl/provider.py`: Added `_read_config_value()` helper that reads dotted config keys from `config.yaml` (mirrors `_read_config_key` from `agent/web_search_registry.py`). Updated `_get_direct_firecrawl_config()` to fall back to `web.firecrawl_api_url` / `web.firecrawl_api_key` when env vars are absent. Updated error message to mention config.yaml option.
- `tests/plugins/web/test_web_search_provider_plugins.py`: Added `test_firecrawl_config_yaml_fallback` covering three scenarios: no config returns None, config.yaml provides api_url, env var takes precedence over config.yaml.

## How to Test

1. Run `pytest tests/plugins/web/test_web_search_provider_plugins.py -q -k 'firecrawl_config_yaml_fallback'` — should pass.
2. Run `pytest tests/plugins/web/test_web_search_provider_plugins.py -q -k 'firecrawl'` — all firecrawl tests should pass.
3. Manual verification: set `web.firecrawl_api_url: http://localhost:3002` in `config.yaml`, clear `FIRECRAWL_API_URL` env var, and confirm the plugin uses the config value.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
