### PR TITLE
fix(cron): allow profile-scoped jobs to run scripts from the default-profile scripts dir (#40801)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -38,7 +38,7 @@ from typing import List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
@@ -1545,12 +1545,24 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
+def _path_within(candidate: Path, root: Path) -> bool:
+    """True if ``candidate`` resolves inside ``root`` (path-traversal guard)."""
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
 def _run_job_script(script_path: str) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
-    Scripts must reside within HERMES_HOME/scripts/.  Both relative and
-    absolute paths are resolved and validated against this directory to
-    prevent arbitrary script execution via path traversal or absolute
+    Scripts must reside within the active scripts directory
+    (``HERMES_HOME/scripts/``) or, for profile-scoped jobs, the canonical
+    default-profile scripts directory (``~/.hermes/scripts/``) so shared
+    scripts referenced across profiles keep working (#40801).  Both relative
+    and absolute paths are resolved and validated against these directories
+    to prevent arbitrary script execution via path traversal or absolute
     path injection.
 
     Supported interpreters (chosen by file extension):
@@ -1569,8 +1581,10 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     Args:
         script_path: Path to the script.  Relative paths are resolved
-            against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
-            are also validated to ensure they stay within the scripts dir.
+            against ``HERMES_HOME/scripts/`` first, then the canonical
+            ``~/.hermes/scripts/`` directory (so profile-scoped jobs can run
+            shared scripts).  Absolute and ~-prefixed paths are validated to
+            ensure they stay within one of these directories.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -1578,23 +1592,59 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     """
     scripts_dir = _get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
-    scripts_dir_resolved = scripts_dir.resolve()
+
+    # Allowed script roots: the active (possibly profile-scoped) scripts
+    # directory, plus the canonical root scripts directory so that
+    # profile-scoped jobs can run shared scripts kept under the default-profile
+    # scripts dir (``~/.hermes/scripts/``) (#40801).  ``get_default_hermes_root()``
+    # returns ``~/.hermes`` even when the active ``HERMES_HOME`` points at a
+    # profile subdir (``~/.hermes/profiles/<name>``) and honours custom/Docker
+    # ``HERMES_HOME`` layouts — more correct than hardcoding ``Path.home()``.
+    active_scripts_dir = scripts_dir.resolve()
+    root_scripts_dir = (get_default_hermes_root() / "scripts").resolve()
+    allowed_roots: list[Path] = [active_scripts_dir]
+    if root_scripts_dir != active_scripts_dir:
+        allowed_roots.append(root_scripts_dir)
 
     raw = Path(script_path).expanduser()
-    if raw.is_absolute():
-        path = raw.resolve()
-    else:
-        path = (scripts_dir / raw).resolve()
 
-    # Guard against path traversal, absolute path injection, and symlink
-    # escape — scripts MUST reside within HERMES_HOME/scripts/.
-    try:
-        path.relative_to(scripts_dir_resolved)
-    except ValueError:
-        return False, (
-            f"Blocked: script path resolves outside the scripts directory "
-            f"({scripts_dir_resolved}): {script_path!r}"
-        )
+    if raw.is_absolute():
+        # An absolute path resolves to a single location; accept it only if it
+        # sits inside one of the allowed roots (guards against path-traversal
+        # and absolute-path injection).
+        resolved = raw.resolve()
+        if not any(_path_within(resolved, r) for r in allowed_roots):
+            checked = " or ".join(str(d) for d in allowed_roots)
+            return False, (
+                f"Blocked: script path resolves outside the scripts directory "
+                f"({checked}): {script_path!r}"
+            )
+        path = resolved
+    else:
+        # Relative names are searched across every allowed root so a shared
+        # script resolves whether it lives in the profile-local or the root
+        # scripts directory.  Each candidate's realpath (symlinks followed) is
+        # validated against ANY root, so a profile-local symlink whose target
+        # is in the root dir is accepted while symlink-escape stays blocked.
+        valid_candidates: list[Path] = []
+        for root in allowed_roots:
+            resolved = (root / raw).resolve()
+            if any(_path_within(resolved, r) for r in allowed_roots):
+                valid_candidates.append(resolved)
+        existing = [c for c in valid_candidates if c.exists()]
+        if existing:
+            # Profile-local roots come first, so per-profile overrides win.
+            path = existing[0]
+        elif valid_candidates:
+            # In-bounds name with no existing copy in any root — report
+            # "not found" rather than "blocked".
+            path = valid_candidates[0]
+        else:
+            checked = " or ".join(str(d) for d in allowed_roots)
+            return False, (
+                f"Blocked: script path resolves outside the scripts directory "
+                f"({checked}): {script_path!r}"
+            )
 
     if not path.exists():
         return False, f"Script not found: {path}"

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -565,3 +565,138 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+
+@pytest.fixture
+def profile_cron_env(tmp_path, monkeypatch):
+    """Profile-scoped cron environment.
+
+    ``HERMES_HOME`` points at a profile subdir (``<root>/profiles/work``), so
+    ``_get_hermes_home()`` returns the profile-local home.  Shared/"canonical"
+    scripts live under the default-profile root scripts dir (``<root>/scripts``),
+    exactly like ``~/.hermes/scripts/`` in a real multi-profile deployment.
+
+    Returns ``(root, profile_home)`` where ``root`` is the
+    ``get_default_hermes_root()`` equivalent.
+    """
+    root = tmp_path / ".hermes"
+    root.mkdir()
+    (root / "scripts").mkdir()  # default-profile (shared) scripts
+    (root / "profiles").mkdir()
+    profile_home = root / "profiles" / "work"
+    profile_home.mkdir()
+    (profile_home / "cron").mkdir()
+    (profile_home / "cron" / "output").mkdir()
+    (profile_home / "scripts").mkdir()  # profile-local scripts
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    # The scheduler caches a module-level home; keep it unset so the env var
+    # path is exercised (the production code path for profile-scoped jobs).
+    from cron import scheduler as sched_mod
+    monkeypatch.setattr(sched_mod, "_hermes_home", None)
+
+    import cron.jobs as jobs_mod
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", profile_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", profile_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", profile_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", profile_home / "cron" / "output")
+    return root, profile_home
+
+
+class TestProfileScopedSharedScripts:
+    """Regression tests for #40801: profile-scoped jobs must be able to run
+    scripts that live in the default-profile (root) scripts directory.
+
+    Before the fix, the guard only accepted the profile-local scripts dir and
+    hard-rejected any reference to the shared/default-profile scripts dir,
+    breaking the most common multi-profile pattern (shared canonical scripts).
+    """
+
+    def test_absolute_path_to_root_script_runs(self, profile_cron_env):
+        """Layer 2: absolute path to a shared script in the root scripts dir."""
+        root, profile_home = profile_cron_env
+        from cron.scheduler import _run_job_script
+
+        shared = root / "scripts" / "shared.py"
+        shared.write_text('print("root shared")\n')
+
+        success, output = _run_job_script(str(shared))
+        assert success is True
+        assert output == "root shared"
+
+    def test_relative_name_resolves_to_root_script(self, profile_cron_env):
+        """Layer 1: a relative name whose only copy is in the root scripts dir."""
+        root, profile_home = profile_cron_env
+        from cron.scheduler import _run_job_script
+
+        (root / "scripts" / "collector.py").write_text('print("collected")\n')
+
+        success, output = _run_job_script("collector.py")
+        assert success is True
+        assert output == "collected"
+
+    def test_profile_local_relative_takes_precedence(self, profile_cron_env):
+        """A relative name present in BOTH dirs resolves to the profile-local copy."""
+        root, profile_home = profile_cron_env
+        from cron.scheduler import _run_job_script
+
+        (profile_home / "scripts" / "dup.py").write_text('print("local")\n')
+        (root / "scripts" / "dup.py").write_text('print("root")\n')
+
+        success, output = _run_job_script("dup.py")
+        assert success is True
+        assert output == "local"
+
+    def test_symlink_to_root_script_runs(self, profile_cron_env):
+        """Layer 3: a profile-local symlink whose realpath is in the root dir."""
+        root, profile_home = profile_cron_env
+        from cron.scheduler import _run_job_script
+
+        (root / "scripts" / "real.py").write_text('print("via symlink")\n')
+        link = profile_home / "scripts" / "link.py"
+        link.symlink_to(root / "scripts" / "real.py")
+
+        success, output = _run_job_script("link.py")
+        assert success is True
+        assert output == "via symlink"
+
+    def test_absolute_path_outside_both_dirs_still_blocked(self, profile_cron_env, tmp_path):
+        """Layer 4: a path outside BOTH roots must still be rejected."""
+        root, profile_home = profile_cron_env
+        from cron.scheduler import _run_job_script
+
+        outside = tmp_path / "evil.py"
+        outside.write_text('print("pwned")\n')
+
+        success, output = _run_job_script(str(outside))
+        assert success is False
+        assert "blocked" in output.lower() or "outside" in output.lower()
+
+    def test_traversal_escape_still_blocked(self, profile_cron_env):
+        """Layer 4: relative traversal escaping both roots must be blocked."""
+        root, profile_home = profile_cron_env
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script("../../../../../etc/passwd")
+        assert success is False
+        assert "blocked" in output.lower() or "outside" in output.lower()
+
+    def test_missing_relative_reports_not_found_not_blocked(self, profile_cron_env):
+        """A missing relative name should report 'not found', not 'blocked'."""
+        root, profile_home = profile_cron_env
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script("does_not_exist_anywhere.py")
+        assert success is False
+        assert "not found" in output.lower()
+
+    def test_default_profile_single_root_unchanged(self, cron_env):
+        """Layer 5: with no profile scoping (root == active), behaviour is unchanged."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "plain.py"
+        script.write_text('print("plain ok")\n')
+
+        success, output = _run_job_script("plain.py")
+        assert success is True
+        assert output == "plain ok"


### PR DESCRIPTION
## Summary

A profile-scoped cron job (`profile: <name>`) fires with profile-switched context, so `_get_hermes_home()` returns the profile-local home (`~/.hermes/profiles/<name>`). The script-path guard in `_run_job_script` only knew about `~/.hermes/profiles/<name>/scripts/` and hard-rejected any reference to a shared script living in the canonical default-profile scripts dir (`~/.hermes/scripts/`) — for relative names, absolute paths, **and** profile-local symlinks whose realpath lands in the root dir. This is the inverse of #32091: routing `profile: <name>` jobs through the default scheduler narrowed script resolution to the profile-local dir, silently breaking every shared-script reference on every tick.

## Root cause

`cron/scheduler.py::_run_job_script` built a single `scripts_dir = _get_hermes_home()/scripts` and rejected any resolved path not `relative_to()` it. Under profile switch `_get_hermes_home()` is `~/.hermes/profiles/<name>`, so the canonical `~/.hermes/scripts/` was always "outside".

## Fix

Allow scripts that resolve within **either** the active (profile-scoped) scripts dir **or** the canonical root scripts dir (`get_default_hermes_root()/scripts`). Relative names search the profile-local dir first (per-profile overrides win), then the root dir. The resolved realpath (symlinks followed) is validated against **any** allowed root, so a profile-local symlink whose target is in the root dir is accepted while symlink-escape to outside both roots stays blocked. `get_default_hermes_root()` honours custom/Docker `HERMES_HOME` layouts and walks a profile home up to its root — more correct than hardcoding `Path.home()`.

### Behaviour table

| `script` field | Before | After |
|---|---|---|
| `collector.py` (relative, only in root dir) | ❌ Blocked | ✅ Runs |
| `/home/USER/.hermes/scripts/collector.py` (absolute, in root dir) | ❌ Blocked | ✅ Runs |
| `link.py` (profile-local symlink → root script) | ❌ Blocked | ✅ Runs |
| `dup.py` (in both dirs) | profile-local | profile-local (precedence preserved) |
| `/tmp/evil.py` (outside both) | ❌ Blocked | ❌ Blocked |
| `../../etc/passwd` (traversal) | ❌ Blocked | ❌ Blocked |

## How verified

- **RED phase**: 3 of 8 new regression tests FAIL on pristine upstream/main (commit 929dd9c0d), proving the bug.
- **GREEN phase**: all 8 pass after the fix.
- **Security regression**: all 9 existing `TestScriptPathContainment` tests still pass (absolute-outside, `/tmp`, `~` expansion, `~` traversal, `../../` traversal, subdirs, symlink-escape).
- 1 pre-existing failure (`test_script_timeout`) — conftest live-system guard blocks `os.kill`; identical on pristine upstream/main, unrelated to this change (touches only path resolution, before any subprocess/timeout logic).

```
tests/cron/test_cron_script.py: 44 passed, 1 failed (pre-existing test_script_timeout)
```

Auto-published by Moonsong via Path B automated pipeline.