### PR TITLE
fix(gateway): sanitize unexpected-status auth errors

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -377,6 +377,7 @@ _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
     r"|non-retryable\s+error"
     r"|rate\s+limited\s+after\s+\d+\s+retries"
     r"|error\s+code\s*:"
+    r"|unexpected\s+status\s+\d{3}\b"
     r"|http\s*\d{3}\b"
     r"|incorrect\s+api\s+key"
     r"|invalid\s+api\s+key"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -685,6 +685,7 @@ _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
     r"|non-retryable\s+error"
     r"|rate\s+limited\s+after\s+\d+\s+retries"
     r"|error\s+code\s*:"
+    r"|unexpected\s+status\s+401\s+unauthorized:\s+missing\s+bearer\s+or\s+basic\s+authentication\s+in\s+header\b"
     r"|http\s*\d{3}\b"
     r"|incorrect\s+api\s+key"
     r"|invalid\s+api\s+key"

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -175,6 +175,31 @@ def test_telegram_final_response_sanitizes_raw_provider_errors():
     assert "req_abc" not in sanitized
 
 
+def test_telegram_final_response_sanitizes_unexpected_status_auth_error():
+    """Provider 401 envelopes that start with "unexpected status" are errors."""
+    raw = (
+        "unexpected status 401 Unauthorized: Missing bearer or basic "
+        "authentication in header"
+    )
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "authentication failed" in sanitized.lower()
+    assert "Missing bearer" not in sanitized
+    assert "401 Unauthorized" not in sanitized
+
+
+def test_telegram_final_response_keeps_prose_about_unexpected_status():
+    """Long explanatory prose mentioning unexpected status codes is normal text."""
+    answer = (
+        "If a service says unexpected status 401, it usually means the request "
+        "was not authenticated. Check whether your Authorization header was sent "
+        "and whether the token has expired before retrying the request."
+    )
+
+    assert _sanitize_gateway_final_response(Platform.TELEGRAM, answer) == answer
+
+
 def test_telegram_final_response_redacts_auth_secrets():
     """Authentication errors should be useful without leaking key material."""
     raw = (

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -286,6 +286,31 @@ def test_telegram_final_response_sanitizes_raw_provider_errors():
     assert "req_abc" not in sanitized
 
 
+def test_telegram_final_response_sanitizes_unexpected_status_auth_error():
+    """Provider 401 envelopes that start with "unexpected status" are errors."""
+    raw = (
+        "unexpected status 401 Unauthorized: Missing bearer or basic "
+        "authentication in header"
+    )
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "authentication failed" in sanitized.lower()
+    assert "Missing bearer" not in sanitized
+    assert "401 Unauthorized" not in sanitized
+
+
+def test_telegram_final_response_keeps_prose_about_unexpected_status():
+    """Long explanatory prose mentioning unexpected status codes is normal text."""
+    answer = (
+        "Unexpected status 401 Unauthorized: this means the supplied credentials "
+        "were rejected. Check whether your Authorization header was sent and "
+        "whether the token has expired before retrying the request."
+    )
+
+    assert _sanitize_gateway_final_response(Platform.TELEGRAM, answer) == answer
+
+
 def test_telegram_final_response_redacts_auth_secrets():
     """Authentication errors should be useful without leaking key material."""
     raw = (


### PR DESCRIPTION
﻿## Summary

- recognize short `unexpected status <code>` provider envelopes in the gateway chat sanitizer
- route `unexpected status 401 Unauthorized` through the existing safe auth guidance
- add regression coverage that keeps longer explanatory prose unchanged

Fixes #55071.

Inspired by the channel-visible provider-auth failure class fixed in openclaw/openclaw#96599.

## Validation

- `TMP=.tmp-pytest TEMP=.tmp-pytest TMPDIR=.tmp-pytest C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests/gateway/test_telegram_noise_filter.py -q` (197 passed)
- `TMP=.tmp-pytest TEMP=.tmp-pytest TMPDIR=.tmp-pytest C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check gateway/run.py tests/gateway/test_telegram_noise_filter.py`
- `git diff --check`
