### PR TITLE
[codex] Fix Kanban worker workspace dispatch

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -313,6 +313,7 @@ def init_agent(
     # would mangle the escape sequences.  None = use builtins.print.
     agent._print_fn = None
     agent.background_review_callback = None  # Optional sync callback for gateway delivery
+    agent.background_review_event_callback = None  # Optional structured lifecycle callback for UI surfaces
     agent.memory_notifications = "on"  # Memory update notifications: "off", "on", "verbose"
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -22,9 +22,36 @@ import contextlib
 import json
 import logging
 import os
+import time
+import uuid
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _emit_review_event(agent: Any, review_id: str, phase: str, **payload: Any) -> None:
+    """Best-effort structured event for UI surfaces.
+
+    The existing ``background_review_callback`` remains the human-facing text
+    hook used by gateway/chat adapters.  This structured hook lets browser
+    surfaces show review lifecycle state without parsing that text or changing
+    gateway behavior.
+    """
+    cb = getattr(agent, "background_review_event_callback", None)
+    if not cb:
+        return
+    event = {
+        "source": "background_review",
+        "phase": str(phase or ""),
+        "review_id": review_id,
+        "event_id": uuid.uuid4().hex,
+        "created_at": time.time(),
+    }
+    event.update(payload)
+    try:
+        cb(event)
+    except Exception:
+        logger.debug("background_review_event_callback failed", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -572,6 +599,8 @@ def _run_review_in_thread(
     agent: Any,
     messages_snapshot: List[Dict],
     prompt: str,
+    review_memory: bool = False,
+    review_skills: bool = False,
 ) -> None:
     """Worker function executed in the background-review daemon thread.
 
@@ -601,6 +630,20 @@ def _run_review_in_thread(
 
     review_agent = None
     review_messages: List[Dict] = []
+    review_id = uuid.uuid4().hex
+    scopes = []
+    if review_memory:
+        scopes.append("memory")
+    if review_skills:
+        scopes.append("skills")
+    _emit_review_event(
+        agent,
+        review_id,
+        "started",
+        review_memory=bool(review_memory),
+        review_skills=bool(review_skills),
+        scopes=scopes,
+    )
     try:
         with open(os.devnull, "w", encoding="utf-8") as _devnull, \
              contextlib.redirect_stdout(_devnull), \
@@ -803,9 +846,42 @@ def _run_review_in_thread(
                     )
                 except Exception:
                     pass
+            _emit_review_event(
+                agent,
+                review_id,
+                "completed",
+                status="changed",
+                review_memory=bool(review_memory),
+                review_skills=bool(review_skills),
+                scopes=scopes,
+                actions=actions,
+                summary=summary,
+            )
+        else:
+            _emit_review_event(
+                agent,
+                review_id,
+                "completed",
+                status="unchanged",
+                review_memory=bool(review_memory),
+                review_skills=bool(review_skills),
+                scopes=scopes,
+                actions=[],
+                summary="No memory or skill changes.",
+            )
 
     except Exception as e:
         logger.warning("Background memory/skill review failed: %s", e)
+        _emit_review_event(
+            agent,
+            review_id if "review_id" in locals() else uuid.uuid4().hex,
+            "failed",
+            status="failed",
+            review_memory=bool(review_memory),
+            review_skills=bool(review_skills),
+            scopes=scopes if "scopes" in locals() else [],
+            error=str(e),
+        )
         agent._emit_auxiliary_failure("background review", e)
     finally:
         # Safety-net cleanup for the exception path.  Normal
@@ -859,7 +935,13 @@ def spawn_background_review_thread(
         prompt = getattr(agent, "_SKILL_REVIEW_PROMPT", _SKILL_REVIEW_PROMPT)
 
     def _target() -> None:
-        _run_review_in_thread(agent, messages_snapshot, prompt)
+        _run_review_in_thread(
+            agent,
+            messages_snapshot,
+            prompt,
+            review_memory=review_memory,
+            review_skills=review_skills,
+        )
 
     return _target, prompt
 

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -72,8 +72,10 @@ class CodexAppServerClient:
         codex_home: Optional[str] = None,
         extra_args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
+        cwd: Optional[str] = None,
     ) -> None:
         self._codex_bin = codex_bin
+        self._cwd = cwd
         spawn_env = os.environ.copy()
         if env:
             spawn_env.update(env)
@@ -116,6 +118,7 @@ class CodexAppServerClient:
 
         self._proc = subprocess.Popen(
             cmd,
+            cwd=cwd or None,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -244,7 +244,9 @@ class CodexAppServerSession:
             return self._thread_id
         if self._client is None:
             self._client = self._client_factory(
-                codex_bin=self._codex_bin, codex_home=self._codex_home
+                codex_bin=self._codex_bin,
+                codex_home=self._codex_home,
+                cwd=self._cwd,
             )
         self._client.initialize(
             client_name="hermes",

--- a/cli.py
+++ b/cli.py
@@ -651,7 +651,16 @@ def load_cli_config() -> Dict[str, Any]:
                     os.environ[env_var] = json.dumps(val)
                 else:
                     os.environ[env_var] = str(val)
-    
+
+    # Kanban dispatcher-spawned workers carry a resolved task workspace in
+    # HERMES_KANBAN_WORKSPACE. Keep that workspace authoritative even when
+    # local CLI startup bridges profile terminal config to TERMINAL_CWD.
+    _kanban_workspace = os.environ.get("HERMES_KANBAN_WORKSPACE", "").strip()
+    if _kanban_workspace:
+        _kw_path = Path(_kanban_workspace).expanduser()
+        if _kw_path.is_dir():
+            os.environ["TERMINAL_CWD"] = str(_kw_path.resolve())
+
     # Apply browser config to environment variables
     browser_config = defaults.get("browser", {})
     browser_env_mappings = {

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3842,6 +3842,15 @@ def resolve_codex_runtime_credentials(
                 "last_refresh": None,
                 "auth_mode": "chatgpt",
             }
+        if (
+            read_error is not None
+            and getattr(read_error, "relogin_required", False)
+            and getattr(read_error, "code", None) == "codex_auth_missing"
+        ):
+            imported = _recover_codex_tokens_from_cli(str(getattr(read_error, "code", None) or "auth_error"))
+            if imported:
+                data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
+    if data is None:
         pool_rate_limit = _codex_pool_rate_limit_status()
         if pool_rate_limit:
             reset_at = pool_rate_limit.get("reset_at")

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2168,6 +2168,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "crashed": res.crashed,
             "timed_out": res.timed_out,
             "stale": res.stale,
+            "skipped_locked": res.skipped_locked,
             "auto_blocked": res.auto_blocked,
             "promoted": res.promoted,
             "spawned": [
@@ -2183,6 +2184,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "auto_assigned_default": res.auto_assigned_default,
         }, indent=2))
         return 0
+    if res.skipped_locked:
+        print(
+            "Skipped:      dispatch lock already held by another dispatcher "
+            "(no DB writes from this process)"
+        )
     print(f"Reclaimed:    {res.reclaimed}")
     print(f"Crashed:      {len(res.crashed)}")
     if res.crashed:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7681,6 +7681,23 @@ def _default_spawn(
     if not task.assignee:
         raise ValueError(f"task {task.id} has no assignee")
 
+    workspace_path = Path(workspace).expanduser()
+    if not workspace_path.is_absolute():
+        raise RuntimeError(
+            f"resolved workspace for task {task.id} is not absolute: {workspace!r}"
+        )
+    try:
+        workspace_path = workspace_path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"resolved workspace for task {task.id} does not exist: {workspace!r}"
+        ) from exc
+    if not workspace_path.is_dir():
+        raise RuntimeError(
+            f"resolved workspace for task {task.id} is not a directory: {workspace!r}"
+        )
+    workspace = str(workspace_path)
+
     from hermes_cli.profiles import normalize_profile_name
 
     profile_arg = normalize_profile_name(task.assignee)
@@ -7719,11 +7736,10 @@ def _default_spawn(
     # build_context_files_prompt (#34619 — workers loaded the dispatching
     # gateway's AGENTS.md instead of the task's). Setting it to the workspace
     # fixes both: the workspace is where the task's work actually happens.
-    # Only pin a real, absolute directory — file_tools rejects relative /
-    # sentinel TERMINAL_CWD values, so a non-dir workspace must NOT be set
-    # here (leave the inherited value rather than write a meaningless one).
-    if workspace and os.path.isabs(workspace) and os.path.isdir(workspace):
-        env["TERMINAL_CWD"] = workspace
+    # `_default_spawn` validates the resolved workspace before building the
+    # worker env. The task workspace is now authoritative; never inherit the
+    # dispatcher cwd for a Kanban worker.
+    env["TERMINAL_CWD"] = workspace
     if task.branch_name:
         env["HERMES_KANBAN_BRANCH"] = task.branch_name
     if task.current_run_id is not None:
@@ -7810,7 +7826,7 @@ def _default_spawn(
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
             cmd,
-            cwd=workspace if os.path.isdir(workspace) else None,
+            cwd=workspace,
             stdin=subprocess.DEVNULL,
             stdout=log_f,
             stderr=subprocess.STDOUT,

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -295,3 +295,40 @@ class TestSpawnEnvIsolation:
         )
         assert "sandbox_workspace_write.network_access=false" in cmd
         assert all("danger" not in part for part in cmd)
+
+    def test_spawn_uses_explicit_cwd_when_provided(self, monkeypatch, tmp_path):
+        """Codex app-server must start in the Hermes session workspace."""
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cwd"] = kwargs.get("cwd")
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+        client = cas.CodexAppServerClient(codex_bin="codex", cwd=str(workspace))
+        client._closed = True
+
+        assert captured["cwd"] == str(workspace)

--- a/tests/cli/test_cwd_env_respect.py
+++ b/tests/cli/test_cwd_env_respect.py
@@ -28,6 +28,10 @@ def _resolve_cwd(terminal_config: dict, defaults: dict, env: dict):
         else:
             env["TERMINAL_CWD"] = str(terminal_config["cwd"])
 
+    kanban_workspace = env.get("HERMES_KANBAN_WORKSPACE", "").strip()
+    if kanban_workspace and env.get("_KANBAN_WORKSPACE_EXISTS") == "1":
+        env["TERMINAL_CWD"] = kanban_workspace
+
     return env.get("TERMINAL_CWD", "")
 
 
@@ -97,3 +101,14 @@ class TestGatewayLazyImport:
         d = {"terminal": {"cwd": "/home/user"}}
         result = _resolve_cwd(tc, d, env)
         assert result == "/fake/getcwd"
+
+    def test_kanban_workspace_overrides_local_cli_bridge(self):
+        env = {
+            "TERMINAL_CWD": "/opt/axis",
+            "HERMES_KANBAN_WORKSPACE": "/opt/axis/.worktrees/t_fix",
+            "_KANBAN_WORKSPACE_EXISTS": "1",
+        }
+        tc = {"cwd": "/opt/axis", "env_type": "local"}
+        d = {"terminal": {"cwd": "/opt/axis"}}
+        result = _resolve_cwd(tc, d, env)
+        assert result == "/opt/axis/.worktrees/t_fix"

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -209,10 +209,54 @@ def test_resolve_codex_runtime_credentials_pool_fallback_no_usable_entry(tmp_pat
     }
     (hermes_home / "auth.json").write_text(json.dumps(auth_store))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex"))
 
     with pytest.raises(AuthError) as exc:
         resolve_codex_runtime_credentials()
     assert exc.value.code == "codex_auth_missing"
+
+
+def test_resolve_codex_runtime_credentials_missing_singleton_prefers_cli_before_exhausted_pool(tmp_path, monkeypatch):
+    """A stale exhausted pool entry must not block recovery from current Codex CLI auth."""
+    hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    codex_home.mkdir(parents=True, exist_ok=True)
+    future_reset = time.time() + 3600
+    auth_store = {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "source": "device_code",
+                    "access_token": "exhausted-pool-token",
+                    "refresh_token": "exhausted-pool-refresh",
+                    "last_status": "exhausted",
+                    "last_error_code": 429,
+                    "last_error_reason": "usage_limit_reached",
+                    "last_error_reset_at": future_reset,
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": "fresh-cli-access",
+            "refresh_token": "fresh-cli-refresh",
+        },
+        "last_refresh": "2026-07-08T00:00:00Z",
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == "fresh-cli-access"
+    assert resolved["source"] == "hermes-auth-store"
+    stored = json.loads((hermes_home / "auth.json").read_text())
+    assert stored["providers"]["openai-codex"]["tokens"]["access_token"] == "fresh-cli-access"
 
 
 def test_resolve_provider_explicit_codex_does_not_fallback(monkeypatch):

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -8,6 +8,7 @@ operator footgun that only manifests in long-running setups.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 import tempfile
@@ -114,6 +115,25 @@ def test_cli_invalid_max_in_progress_silently_disables(isolated_kanban_home, mon
             f"invalid max_in_progress={bad_val!r} should fall through to None, "
             f"got {captured.get('max_in_progress')!r}"
         )
+
+
+def test_cli_dispatch_json_reports_lock_skip(isolated_kanban_home, monkeypatch, capsys):
+    """A losing dispatcher must report that the lock was held elsewhere."""
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"kanban": {}})
+
+    def fake_dispatch_once(conn, **kwargs):
+        return kanban_db.DispatchResult(skipped_locked=True)
+
+    monkeypatch.setattr(kanban_db, "dispatch_once", fake_dispatch_once)
+
+    args = argparse.Namespace(dry_run=False, max=None, failure_limit=2, json=True)
+    assert kb_cli._cmd_dispatch(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["skipped_locked"] is True
 
 
 def test_kanban_swarm_uses_existing_humanizer_skill():

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2923,6 +2923,8 @@ class TestSharedBoardPaths:
                 self.pid = 4242
 
         monkeypatch.setattr("subprocess.Popen", _FakePopen)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
 
         task = kb.Task(
             id="t_dispatch_env",
@@ -2936,13 +2938,13 @@ class TestSharedBoardPaths:
             started_at=None,
             completed_at=None,
             workspace_kind="worktree",
-            workspace_path=str(tmp_path / "ws"),
+            workspace_path=str(workspace),
             claim_lock=None,
             claim_expires=None,
             tenant=None,
             branch_name="wt/t_dispatch_env",
         )
-        kb._default_spawn(task, str(tmp_path / "ws"))
+        kb._default_spawn(task, str(workspace))
 
         env = captured["env"]
         assert env["HERMES_KANBAN_DB"] == str(default_home / "kanban.db")

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -78,12 +78,7 @@ def test_terminal_cwd_pinned_to_workspace(monkeypatch, tmp_path):
 
 
 def test_terminal_cwd_not_pinned_for_nonexistent_workspace(monkeypatch, tmp_path):
-    """A non-directory workspace must NOT clobber the inherited TERMINAL_CWD.
-
-    file_tools rejects relative / sentinel TERMINAL_CWD values, so writing a
-    meaningless (nonexistent) path would be worse than leaving the inherited
-    one. The guard requires an existing absolute dir.
-    """
+    """A non-directory workspace must fail before worker launch."""
     root = tmp_path / ".hermes"
     (root / "profiles" / "w").mkdir(parents=True)
     (root / "profiles" / "w" / "config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
@@ -95,7 +90,27 @@ def test_terminal_cwd_not_pinned_for_nonexistent_workspace(monkeypatch, tmp_path
 
     missing = tmp_path / "does-not-exist"
 
-    captured = _capture_spawn_env(kb, monkeypatch, str(missing))
+    try:
+        _capture_spawn_env(kb, monkeypatch, str(missing))
+    except RuntimeError as exc:
+        assert "does not exist" in str(exc)
+    else:
+        raise AssertionError("missing workspace should fail before Popen")
 
-    # Inherited value is preserved (not overwritten with a bogus path).
-    assert captured["env"]["TERMINAL_CWD"] == "/pre/existing/anchor"
+
+def test_terminal_cwd_rejects_relative_workspace(monkeypatch, tmp_path):
+    """Kanban workers must never inherit dispatcher cwd from a relative path."""
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "w").mkdir(parents=True)
+    (root / "profiles" / "w" / "config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    root.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    try:
+        _capture_spawn_env(kb, monkeypatch, "relative-workspace")
+    except RuntimeError as exc:
+        assert "not absolute" in str(exc)
+    else:
+        raise AssertionError("relative workspace should fail before Popen")

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -313,6 +313,92 @@ def test_background_review_summary_is_attributed_to_self_improvement_loop(monkey
     )
 
 
+def test_background_review_emits_structured_changed_lifecycle(monkeypatch):
+    import json
+
+    captured_events: list = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = [
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_bg",
+                    "content": json.dumps(
+                        {"success": True, "message": "Entry added", "target": "memory"}
+                    ),
+                }
+            ]
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent.background_review_event_callback = lambda event: captured_events.append(event)
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hi"}],
+        review_memory=True,
+    )
+
+    assert [event["phase"] for event in captured_events] == ["started", "completed"]
+    started, completed = captured_events
+    assert started["review_id"] == completed["review_id"]
+    assert started["event_id"] != completed["event_id"]
+    assert started["review_memory"] is True
+    assert started["scopes"] == ["memory"]
+    assert completed["status"] == "changed"
+    assert completed["actions"] == ["Memory updated"]
+    assert completed["summary"] == "Memory updated"
+
+
+def test_background_review_emits_structured_unchanged_lifecycle(monkeypatch):
+    captured_events: list = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent.background_review_event_callback = lambda event: captured_events.append(event)
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hi"}],
+        review_skills=True,
+    )
+
+    assert [event["phase"] for event in captured_events] == ["started", "completed"]
+    started, completed = captured_events
+    assert started["review_id"] == completed["review_id"]
+    assert started["scopes"] == ["skills"]
+    assert completed["status"] == "unchanged"
+    assert completed["actions"] == []
+    assert completed["summary"] == "No memory or skill changes."
+
+
 def test_background_review_fork_skips_external_memory_plugins(monkeypatch):
     """The background review fork must NOT touch external memory plugins.
 


### PR DESCRIPTION
## Summary

- emit structured background-review lifecycle events for UI surfaces while keeping the existing text callback intact
- require Hermes Kanban workers to launch from a resolved absolute task workspace and pin TERMINAL_CWD accordingly
- pass the Hermes session cwd into Codex app-server subprocesses and expose skipped_locked in dispatch JSON

## Root Cause

Kanban dispatch could spawn a worker while still letting downstream Codex/runtime startup inherit the dispatcher cwd or a profile-derived TERMINAL_CWD. In dogfood this allowed worker execution to escape the intended task workspace. Dispatch JSON also hid the lock-lost case, which made orchestration failures harder to distinguish from no-op dispatches.

## Validation

- `venv/bin/pytest tests/run_agent/test_background_review.py tests/hermes_cli/test_kanban_worker_terminal_cwd.py tests/agent/transports/test_codex_app_server_runtime.py tests/cli/test_cwd_env_respect.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_dispatch_lock.py tests/agent/transports/test_codex_app_server_session.py -q` -> 121 passed
- `python3 -m py_compile ...` for changed Python modules/tests
- `git diff --check`

## Notes

This was dogfooded through Axis Hermes Kanban after the local hotfix. The worker completed in the disposable task workspace and active source stayed unchanged from baseline.
