### PR TITLE
fix(web): bound bundled provider JSON response reads

### DIFF
--- a/plugins/web/_bounded_json.py
+++ b/plugins/web/_bounded_json.py
@@ -1,0 +1,55 @@
+"""Bounded JSON response helpers for bundled web providers."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+
+DEFAULT_WEB_PROVIDER_JSON_MAX_BYTES = 2 * 1024 * 1024
+
+
+class WebProviderResponseTooLarge(RuntimeError):
+    """Raised when an upstream web-provider JSON response exceeds the cap."""
+
+
+def _response_byte_limit() -> int:
+    raw = os.getenv("HERMES_WEB_PROVIDER_JSON_MAX_BYTES", "").strip()
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            value = DEFAULT_WEB_PROVIDER_JSON_MAX_BYTES
+        if value > 0:
+            return value
+    return DEFAULT_WEB_PROVIDER_JSON_MAX_BYTES
+
+
+def _read_limited_response_bytes(response: httpx.Response, *, max_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_bytes():
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > max_bytes:
+            raise WebProviderResponseTooLarge(
+                f"web provider JSON response exceeded {max_bytes} bytes"
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def httpx_json_request(method: str, url: str, **kwargs: Any) -> Any:
+    """Send an httpx request and parse JSON while enforcing a response cap."""
+
+    max_bytes = int(kwargs.pop("max_bytes", _response_byte_limit()))
+    with httpx.stream(method, url, **kwargs) as response:
+        response.raise_for_status()
+        body = _read_limited_response_bytes(response, max_bytes=max_bytes)
+    if not body:
+        return {}
+    encoding = response.encoding or "utf-8"
+    return json.loads(body.decode(encoding, errors="replace"))

--- a/plugins/web/_bounded_json.py
+++ b/plugins/web/_bounded_json.py
@@ -1,0 +1,41 @@
+"""Bounded JSON response helpers for bundled web providers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+DEFAULT_WEB_PROVIDER_JSON_MAX_BYTES = 2 * 1024 * 1024
+
+
+class WebProviderResponseTooLarge(RuntimeError):
+    """Raised when an upstream web-provider JSON response exceeds the cap."""
+
+
+def _read_limited_response_bytes(response: httpx.Response, *, max_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_raw(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > max_bytes:
+            raise WebProviderResponseTooLarge(
+                f"web provider JSON response exceeded {max_bytes} bytes"
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def httpx_json_request(method: str, url: str, **kwargs: Any) -> Any:
+    """Send an httpx request and parse JSON while enforcing a response cap."""
+
+    max_bytes = int(kwargs.pop("max_bytes", DEFAULT_WEB_PROVIDER_JSON_MAX_BYTES))
+    headers = dict(kwargs.pop("headers", {}) or {})
+    headers.setdefault("Accept-Encoding", "identity")
+    with httpx.stream(method, url, headers=headers, **kwargs) as response:
+        response.raise_for_status()
+        body = _read_limited_response_bytes(response, max_bytes=max_bytes)
+    return json.loads(body)

--- a/plugins/web/brave_free/provider.py
+++ b/plugins/web/brave_free/provider.py
@@ -24,6 +24,10 @@ import os
 from typing import Any, Dict
 
 from agent.web_search_provider import WebSearchProvider
+from plugins.web._bounded_json import (
+    WebProviderResponseTooLarge,
+    httpx_json_request as _httpx_json_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +77,8 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
         count = max(1, min(int(limit), 20))
 
         try:
-            resp = httpx.get(
+            data = _httpx_json_request(
+                "GET",
                 _BRAVE_ENDPOINT,
                 params={"q": query, "count": count},
                 headers={
@@ -82,20 +87,19 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
                 },
                 timeout=15,
             )
-            resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             logger.warning("Brave Search HTTP error: %s", exc)
             return {
                 "success": False,
                 "error": f"Brave Search returned HTTP {exc.response.status_code}",
             }
+        except WebProviderResponseTooLarge as exc:
+            logger.warning("Brave Search response too large: %s", exc)
+            return {"success": False, "error": str(exc)}
         except httpx.RequestError as exc:
             logger.warning("Brave Search request error: %s", exc)
             return {"success": False, "error": f"Could not reach Brave Search: {exc}"}
-
-        try:
-            data = resp.json()
-        except Exception as exc:  # noqa: BLE001
+        except ValueError as exc:
             logger.warning("Brave Search response parse error: %s", exc)
             return {"success": False, "error": "Could not parse Brave Search response as JSON"}
 

--- a/plugins/web/brave_free/provider.py
+++ b/plugins/web/brave_free/provider.py
@@ -24,6 +24,10 @@ import os
 from typing import Any, Dict
 
 from agent.web_search_provider import WebSearchProvider
+from plugins.web._bounded_json import (
+    WebProviderResponseTooLarge,
+    httpx_json_request as _httpx_json_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +81,8 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
         count = max(1, min(int(limit), 20))
 
         try:
-            resp = httpx.get(
+            data = _httpx_json_request(
+                "GET",
                 _BRAVE_ENDPOINT,
                 params={"q": query, "count": count},
                 headers={
@@ -86,20 +91,19 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
                 },
                 timeout=15,
             )
-            resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             logger.warning("Brave Search HTTP error: %s", exc)
             return {
                 "success": False,
                 "error": f"Brave Search returned HTTP {exc.response.status_code}",
             }
+        except WebProviderResponseTooLarge as exc:
+            logger.warning("Brave Search response too large: %s", exc)
+            return {"success": False, "error": str(exc)}
         except httpx.RequestError as exc:
             logger.warning("Brave Search request error: %s", exc)
             return {"success": False, "error": f"Could not reach Brave Search: {exc}"}
-
-        try:
-            data = resp.json()
-        except Exception as exc:  # noqa: BLE001
+        except ValueError as exc:
             logger.warning("Brave Search response parse error: %s", exc)
             return {"success": False, "error": "Could not parse Brave Search response as JSON"}
 

--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -27,6 +27,10 @@ import os
 from typing import Any, Dict
 
 from agent.web_search_provider import WebSearchProvider
+from plugins.web._bounded_json import (
+    WebProviderResponseTooLarge,
+    httpx_json_request as _httpx_json_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,29 +84,29 @@ class SearXNGWebSearchProvider(WebSearchProvider):
         }
 
         try:
-            resp = httpx.get(
+            data = _httpx_json_request(
+                "GET",
                 f"{base_url}/search",
                 params=params,
                 timeout=15,
                 headers={"Accept": "application/json"},
             )
-            resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             logger.warning("SearXNG HTTP error: %s", exc)
             return {
                 "success": False,
                 "error": f"SearXNG returned HTTP {exc.response.status_code}",
             }
+        except WebProviderResponseTooLarge as exc:
+            logger.warning("SearXNG response too large: %s", exc)
+            return {"success": False, "error": str(exc)}
         except httpx.RequestError as exc:
             logger.warning("SearXNG request error: %s", exc)
             return {
                 "success": False,
                 "error": f"Could not reach SearXNG at {base_url}: {exc}",
             }
-
-        try:
-            data = resp.json()
-        except Exception as exc:  # noqa: BLE001
+        except ValueError as exc:
             logger.warning("SearXNG response parse error: %s", exc)
             return {
                 "success": False,

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -28,6 +28,10 @@ import os
 from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
+from plugins.web._bounded_json import (
+    WebProviderResponseTooLarge,
+    httpx_json_request as _httpx_json_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +43,6 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     when ``TAVILY_API_KEY`` is unset; the caller catches and surfaces as
     a typed error response.
     """
-    import httpx
-
     api_key = os.getenv("TAVILY_API_KEY")
     if not api_key:
         raise ValueError(
@@ -54,9 +56,7 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     url = f"{base_url}/{endpoint.lstrip('/')}"
     logger.info("Tavily %s request to %s", endpoint, url)
 
-    response = httpx.post(url, json=payload, timeout=60)
-    response.raise_for_status()
-    return response.json()
+    return _httpx_json_request("POST", url, json=payload, timeout=60)
 
 
 def _normalize_tavily_search_results(response: Dict[str, Any]) -> Dict[str, Any]:
@@ -167,6 +167,8 @@ class TavilyWebSearchProvider(WebSearchProvider):
             return _normalize_tavily_search_results(raw)
         except ValueError as exc:
             return {"success": False, "error": str(exc)}
+        except WebProviderResponseTooLarge as exc:
+            return {"success": False, "error": str(exc)}
         except Exception as exc:  # noqa: BLE001 — including httpx errors
             logger.warning("Tavily search error: %s", exc)
             return {"success": False, "error": f"Tavily search failed: {exc}"}
@@ -198,6 +200,11 @@ class TavilyWebSearchProvider(WebSearchProvider):
             )
         except ValueError as exc:
             return [{"url": u, "title": "", "content": "", "error": str(exc)} for u in urls]
+        except WebProviderResponseTooLarge as exc:
+            return [
+                {"url": u, "title": "", "content": "", "error": str(exc)}
+                for u in urls
+            ]
         except Exception as exc:  # noqa: BLE001
             logger.warning("Tavily extract error: %s", exc)
             return [

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -28,6 +28,10 @@ import os
 from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
+from plugins.web._bounded_json import (
+    WebProviderResponseTooLarge,
+    httpx_json_request as _httpx_json_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +43,6 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     when ``TAVILY_API_KEY`` is unset; the caller catches and surfaces as
     a typed error response.
     """
-    import httpx
-
     from agent.web_search_provider import get_provider_env
 
     api_key = get_provider_env("TAVILY_API_KEY")
@@ -56,9 +58,7 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     url = f"{base_url}/{endpoint.lstrip('/')}"
     logger.info("Tavily %s request to %s", endpoint, url)
 
-    response = httpx.post(url, json=payload, timeout=60)
-    response.raise_for_status()
-    return response.json()
+    return _httpx_json_request("POST", url, json=payload, timeout=60)
 
 
 def _normalize_tavily_search_results(response: Dict[str, Any]) -> Dict[str, Any]:
@@ -171,6 +171,8 @@ class TavilyWebSearchProvider(WebSearchProvider):
             return _normalize_tavily_search_results(raw)
         except ValueError as exc:
             return {"success": False, "error": str(exc)}
+        except WebProviderResponseTooLarge as exc:
+            return {"success": False, "error": str(exc)}
         except Exception as exc:  # noqa: BLE001 — including httpx errors
             logger.warning("Tavily search error: %s", exc)
             return {"success": False, "error": f"Tavily search failed: {exc}"}
@@ -202,6 +204,11 @@ class TavilyWebSearchProvider(WebSearchProvider):
             )
         except ValueError as exc:
             return [{"url": u, "title": "", "content": "", "error": str(exc)} for u in urls]
+        except WebProviderResponseTooLarge as exc:
+            return [
+                {"url": u, "title": "", "content": "", "error": str(exc)}
+                for u in urls
+            ]
         except Exception as exc:  # noqa: BLE001
             logger.warning("Tavily extract error: %s", exc)
             return [

--- a/plugins/web/xai/provider.py
+++ b/plugins/web/xai/provider.py
@@ -38,6 +38,10 @@ import re
 from typing import Any, Dict, List, Optional
 
 from agent.web_search_provider import WebSearchProvider
+from plugins.web._bounded_json import (
+    WebProviderResponseTooLarge,
+    httpx_json_request as _httpx_json_request,
+)
 from tools.xai_http import (
     has_xai_credentials,
     hermes_xai_user_agent,
@@ -251,16 +255,16 @@ class XAIWebSearchProvider(WebSearchProvider):
         # Env-var (`XAI_API_KEY`) credentials skip the retry entirely — we
         # can't refresh those and an immediate retry would just burn quota.
         is_oauth_path = (creds.get("provider") == "xai-oauth")
-        resp = None
+        data = None
         for attempt in range(2):
             try:
-                resp = httpx.post(
+                data = _httpx_json_request(
+                    "POST",
                     f"{base_url}/responses",
                     headers=headers,
                     json=payload,
                     timeout=timeout,
                 )
-                resp.raise_for_status()
                 break
             except httpx.HTTPStatusError as exc:
                 status = exc.response.status_code if exc.response is not None else 0
@@ -299,19 +303,19 @@ class XAIWebSearchProvider(WebSearchProvider):
             except httpx.RequestError as exc:
                 logger.warning("xAI web search request error: %s", exc)
                 return {"success": False, "error": f"Could not reach xAI: {exc}"}
+            except WebProviderResponseTooLarge as exc:
+                logger.warning("xAI web search response too large: %s", exc)
+                return {"success": False, "error": str(exc)}
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                logger.warning("xAI web search bad JSON: %s", exc)
+                return {
+                    "success": False,
+                    "error": "Could not parse xAI Responses API reply as JSON",
+                }
 
-        if resp is None:
+        if data is None:
             # Defensive — both attempts somehow exited the loop without resp.
             return {"success": False, "error": "xAI web search produced no response"}
-
-        try:
-            data = resp.json()
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("xAI web search bad JSON: %s", exc)
-            return {
-                "success": False,
-                "error": "Could not parse xAI Responses API reply as JSON",
-            }
 
         # xAI's Responses surface sometimes returns HTTP 200 with an error
         # envelope (model overloaded, content-policy refusal, etc.). Without

--- a/tests/plugins/web/test_bounded_json.py
+++ b/tests/plugins/web/test_bounded_json.py
@@ -1,0 +1,67 @@
+"""Tests for bounded web-provider JSON response reads."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeStreamResponse:
+    encoding = "utf-8"
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_bytes(self):
+        yield from self._chunks
+
+
+def test_httpx_json_request_streams_and_parses(monkeypatch):
+    from plugins.web import _bounded_json
+
+    captured = {}
+
+    def fake_stream(method, url, **kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return _FakeStreamResponse([b'{"ok": ', b"true}"])
+
+    monkeypatch.setattr(_bounded_json.httpx, "stream", fake_stream)
+
+    result = _bounded_json.httpx_json_request(
+        "GET",
+        "https://example.test/search",
+        params={"q": "hermes"},
+        max_bytes=32,
+    )
+
+    assert result == {"ok": True}
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://example.test/search"
+    assert captured["kwargs"]["params"] == {"q": "hermes"}
+
+
+def test_httpx_json_request_rejects_oversized_body(monkeypatch):
+    from plugins.web import _bounded_json
+
+    monkeypatch.setattr(
+        _bounded_json.httpx,
+        "stream",
+        lambda *a, **kw: _FakeStreamResponse([b'{"big":"', b"x" * 64, b'"}']),
+    )
+
+    with pytest.raises(_bounded_json.WebProviderResponseTooLarge):
+        _bounded_json.httpx_json_request(
+            "GET",
+            "https://example.test/search",
+            max_bytes=16,
+        )

--- a/tests/plugins/web/test_bounded_json.py
+++ b/tests/plugins/web/test_bounded_json.py
@@ -1,0 +1,82 @@
+"""Tests for bounded web-provider JSON response reads."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeStreamResponse:
+    encoding = "utf-8"
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_raw(self, chunk_size: int):
+        assert chunk_size == 64 * 1024
+        yield from self._chunks
+
+
+def test_httpx_json_request_streams_and_parses(monkeypatch):
+    from plugins.web import _bounded_json
+
+    captured = {}
+
+    def fake_stream(method, url, **kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return _FakeStreamResponse([b'{"ok": ', b"true}"])
+
+    monkeypatch.setattr(_bounded_json.httpx, "stream", fake_stream)
+
+    result = _bounded_json.httpx_json_request(
+        "GET",
+        "https://example.test/search",
+        params={"q": "hermes"},
+        max_bytes=32,
+    )
+
+    assert result == {"ok": True}
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://example.test/search"
+    assert captured["kwargs"]["params"] == {"q": "hermes"}
+    assert captured["kwargs"]["headers"]["Accept-Encoding"] == "identity"
+
+
+def test_httpx_json_request_rejects_oversized_body(monkeypatch):
+    from plugins.web import _bounded_json
+
+    monkeypatch.setattr(
+        _bounded_json.httpx,
+        "stream",
+        lambda *a, **kw: _FakeStreamResponse([b'{"big":"', b"x" * 64, b'"}']),
+    )
+
+    with pytest.raises(_bounded_json.WebProviderResponseTooLarge):
+        _bounded_json.httpx_json_request(
+            "GET",
+            "https://example.test/search",
+            max_bytes=16,
+        )
+
+
+def test_httpx_json_request_rejects_empty_success(monkeypatch):
+    from plugins.web import _bounded_json
+
+    monkeypatch.setattr(
+        _bounded_json.httpx,
+        "stream",
+        lambda *a, **kw: _FakeStreamResponse([]),
+    )
+
+    with pytest.raises(ValueError):
+        _bounded_json.httpx_json_request("GET", "https://example.test/search")

--- a/tests/tools/test_web_providers_brave_free.py
+++ b/tests/tools/test_web_providers_brave_free.py
@@ -74,7 +74,10 @@ class TestBraveFreeProviderSearch:
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
 
-        with patch("httpx.get", return_value=self._mock_resp(self._SAMPLE_RESPONSE)):
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            return_value=self._SAMPLE_RESPONSE,
+        ):
             result = BraveFreeWebSearchProvider().search("test query", limit=5)
 
         assert result["success"] is True
@@ -90,15 +93,20 @@ class TestBraveFreeProviderSearch:
 
         captured = {}
 
-        def fake_get(url, **kwargs):
+        def fake_request(method, url, **kwargs):
+            captured["method"] = method
             captured["url"] = url
             captured["headers"] = kwargs.get("headers", {})
             captured["params"] = kwargs.get("params", {})
-            return self._mock_resp({"web": {"results": []}})
+            return {"web": {"results": []}}
 
-        with patch("httpx.get", side_effect=fake_get):
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            side_effect=fake_request,
+        ):
             BraveFreeWebSearchProvider().search("q", limit=5)
 
+        assert captured["method"] == "GET"
         assert captured["url"] == "https://api.search.brave.com/res/v1/web/search"
         assert captured["headers"].get("X-Subscription-Token") == "BSAkey123"
         assert captured["params"].get("q") == "q"
@@ -111,11 +119,14 @@ class TestBraveFreeProviderSearch:
 
         captured = {}
 
-        def fake_get(url, **kwargs):
+        def fake_request(method, url, **kwargs):
             captured["params"] = kwargs.get("params", {})
-            return self._mock_resp({"web": {"results": []}})
+            return {"web": {"results": []}}
 
-        with patch("httpx.get", side_effect=fake_get):
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            side_effect=fake_request,
+        ):
             BraveFreeWebSearchProvider().search("q", limit=100)
 
         assert captured["params"].get("count") == 20
@@ -124,7 +135,10 @@ class TestBraveFreeProviderSearch:
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
 
-        with patch("httpx.get", return_value=self._mock_resp(self._SAMPLE_RESPONSE)):
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            return_value=self._SAMPLE_RESPONSE,
+        ):
             result = BraveFreeWebSearchProvider().search("q", limit=2)
 
         assert result["success"] is True
@@ -134,7 +148,10 @@ class TestBraveFreeProviderSearch:
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
 
-        with patch("httpx.get", return_value=self._mock_resp({"web": {"results": []}})):
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            return_value={"web": {"results": []}},
+        ):
             result = BraveFreeWebSearchProvider().search("nothing", limit=5)
 
         assert result["success"] is True
@@ -145,7 +162,10 @@ class TestBraveFreeProviderSearch:
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
 
-        with patch("httpx.get", return_value=self._mock_resp({})):
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            return_value={},
+        ):
             result = BraveFreeWebSearchProvider().search("q", limit=5)
 
         assert result["success"] is True
@@ -160,7 +180,7 @@ class TestBraveFreeProviderSearch:
         bad.status_code = 429
         err = httpx.HTTPStatusError("429", request=MagicMock(), response=bad)
 
-        with patch("httpx.get", side_effect=err):
+        with patch("plugins.web.brave_free.provider._httpx_json_request", side_effect=err):
             result = BraveFreeWebSearchProvider().search("q", limit=5)
 
         assert result["success"] is False
@@ -171,11 +191,28 @@ class TestBraveFreeProviderSearch:
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
 
-        with patch("httpx.get", side_effect=httpx.RequestError("boom")):
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            side_effect=httpx.RequestError("boom"),
+        ):
             result = BraveFreeWebSearchProvider().search("q", limit=5)
 
         assert result["success"] is False
         assert "boom" in result["error"] or "Brave" in result["error"]
+
+    def test_oversized_response_returns_failure(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from plugins.web._bounded_json import WebProviderResponseTooLarge
+        from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
+
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            side_effect=WebProviderResponseTooLarge("web provider JSON response exceeded 16 bytes"),
+        ):
+            result = BraveFreeWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "exceeded" in result["error"]
 
     def test_missing_key_returns_failure(self, monkeypatch):
         monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)

--- a/tests/tools/test_web_providers_brave_free.py
+++ b/tests/tools/test_web_providers_brave_free.py
@@ -61,7 +61,10 @@ class TestBraveFreeProviderSearch:
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
 
-        with patch("httpx.get", return_value=self._mock_resp(self._SAMPLE_RESPONSE)):
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            return_value=self._SAMPLE_RESPONSE,
+        ):
             result = BraveFreeWebSearchProvider().search("test query", limit=5)
 
         assert result["success"] is True
@@ -77,15 +80,20 @@ class TestBraveFreeProviderSearch:
 
         captured = {}
 
-        def fake_get(url, **kwargs):
+        def fake_request(method, url, **kwargs):
+            captured["method"] = method
             captured["url"] = url
             captured["headers"] = kwargs.get("headers", {})
             captured["params"] = kwargs.get("params", {})
-            return self._mock_resp({"web": {"results": []}})
+            return {"web": {"results": []}}
 
-        with patch("httpx.get", side_effect=fake_get):
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            side_effect=fake_request,
+        ):
             BraveFreeWebSearchProvider().search("q", limit=5)
 
+        assert captured["method"] == "GET"
         assert captured["url"] == "https://api.search.brave.com/res/v1/web/search"
         assert captured["headers"].get("X-Subscription-Token") == "BSAkey123"
         assert captured["params"].get("q") == "q"
@@ -97,11 +105,28 @@ class TestBraveFreeProviderSearch:
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
 
-        with patch("httpx.get", return_value=self._mock_resp({})):
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            return_value={},
+        ):
             result = BraveFreeWebSearchProvider().search("q", limit=5)
 
         assert result["success"] is True
         assert result["data"]["web"] == []
+
+
+    def test_oversized_response_returns_failure(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from plugins.web._bounded_json import WebProviderResponseTooLarge
+        from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
+
+        with patch(
+            "plugins.web.brave_free.provider._httpx_json_request",
+            side_effect=WebProviderResponseTooLarge("response exceeded cap"),
+        ):
+            result = BraveFreeWebSearchProvider().search("q", limit=5)
+
+        assert result == {"success": False, "error": "response exceeded cap"}
 
 
     def test_missing_key_returns_failure(self, monkeypatch):

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -71,9 +71,10 @@ class TestSearXNGSearchProviderSearch:
     def test_happy_path_returns_normalized_results(self, monkeypatch):
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
-        mock_resp = self._make_mock_response(self._SAMPLE_RESPONSE)
-
-        with patch("httpx.get", return_value=mock_resp):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            return_value=self._SAMPLE_RESPONSE,
+        ):
             result = SearXNGWebSearchProvider().search("test query", limit=5)
 
         assert result["success"] is True
@@ -95,9 +96,10 @@ class TestSearXNGSearchProviderSearch:
                 {"title": "Mid",  "url": "https://mid.example.com",  "content": "", "score": 0.5},
             ]
         }
-        mock_resp = self._make_mock_response(unordered)
-
-        with patch("httpx.get", return_value=mock_resp):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            return_value=unordered,
+        ):
             result = SearXNGWebSearchProvider().search("query", limit=5)
 
         assert result["success"] is True
@@ -108,9 +110,10 @@ class TestSearXNGSearchProviderSearch:
     def test_limit_is_respected(self, monkeypatch):
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
-        mock_resp = self._make_mock_response(self._SAMPLE_RESPONSE)
-
-        with patch("httpx.get", return_value=mock_resp):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            return_value=self._SAMPLE_RESPONSE,
+        ):
             result = SearXNGWebSearchProvider().search("query", limit=2)
 
         assert result["success"] is True
@@ -119,9 +122,10 @@ class TestSearXNGSearchProviderSearch:
     def test_position_is_one_indexed(self, monkeypatch):
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
-        mock_resp = self._make_mock_response(self._SAMPLE_RESPONSE)
-
-        with patch("httpx.get", return_value=mock_resp):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            return_value=self._SAMPLE_RESPONSE,
+        ):
             result = SearXNGWebSearchProvider().search("query", limit=5)
 
         positions = [r["position"] for r in result["data"]["web"]]
@@ -130,9 +134,10 @@ class TestSearXNGSearchProviderSearch:
     def test_empty_results(self, monkeypatch):
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
-        mock_resp = self._make_mock_response({"results": []})
-
-        with patch("httpx.get", return_value=mock_resp):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            return_value={"results": []},
+        ):
             result = SearXNGWebSearchProvider().search("nothing", limit=5)
 
         assert result["success"] is True
@@ -148,9 +153,10 @@ class TestSearXNGSearchProviderSearch:
                 {"title": "Has score", "url": "https://scored.example.com", "content": "", "score": 0.8},
             ]
         }
-        mock_resp = self._make_mock_response(data)
-
-        with patch("httpx.get", return_value=mock_resp):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            return_value=data,
+        ):
             result = SearXNGWebSearchProvider().search("query", limit=5)
 
         assert result["success"] is True
@@ -166,7 +172,7 @@ class TestSearXNGSearchProviderSearch:
         mock_resp.status_code = 500
         http_err = httpx.HTTPStatusError("500", request=MagicMock(), response=mock_resp)
 
-        with patch("httpx.get", side_effect=http_err):
+        with patch("plugins.web.searxng.provider._httpx_json_request", side_effect=http_err):
             result = SearXNGWebSearchProvider().search("query", limit=5)
 
         assert result["success"] is False
@@ -177,11 +183,28 @@ class TestSearXNGSearchProviderSearch:
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
 
-        with patch("httpx.get", side_effect=httpx.RequestError("connection refused")):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            side_effect=httpx.RequestError("connection refused"),
+        ):
             result = SearXNGWebSearchProvider().search("query", limit=5)
 
         assert result["success"] is False
         assert "localhost:8080" in result["error"] or "connection" in result["error"].lower()
+
+    def test_oversized_response_returns_failure(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web._bounded_json import WebProviderResponseTooLarge
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            side_effect=WebProviderResponseTooLarge("web provider JSON response exceeded 16 bytes"),
+        ):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result["success"] is False
+        assert "exceeded" in result["error"]
 
     def test_missing_url_returns_failure(self, monkeypatch):
         monkeypatch.delenv("SEARXNG_URL", raising=False)
@@ -195,14 +218,16 @@ class TestSearXNGSearchProviderSearch:
         """Base URL trailing slash should not produce double-slash in endpoint."""
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080/")
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
-        mock_resp = self._make_mock_response({"results": []})
-
         calls = []
-        def capture_get(url, **kwargs):
+        def capture_request(method, url, **kwargs):
+            assert method == "GET"
             calls.append(url)
-            return mock_resp
+            return {"results": []}
 
-        with patch("httpx.get", side_effect=capture_get):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            side_effect=capture_request,
+        ):
             SearXNGWebSearchProvider().search("query", limit=5)
 
         assert calls[0] == "http://localhost:8080/search", f"Got: {calls[0]}"

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -58,9 +58,10 @@ class TestSearXNGSearchProviderSearch:
     def test_happy_path_returns_normalized_results(self, monkeypatch):
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
-        mock_resp = self._make_mock_response(self._SAMPLE_RESPONSE)
-
-        with patch("httpx.get", return_value=mock_resp):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            return_value=self._SAMPLE_RESPONSE,
+        ):
             result = SearXNGWebSearchProvider().search("test query", limit=5)
 
         assert result["success"] is True
@@ -82,9 +83,10 @@ class TestSearXNGSearchProviderSearch:
                 {"title": "Mid",  "url": "https://mid.example.com",  "content": "", "score": 0.5},
             ]
         }
-        mock_resp = self._make_mock_response(unordered)
-
-        with patch("httpx.get", return_value=mock_resp):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            return_value=unordered,
+        ):
             result = SearXNGWebSearchProvider().search("query", limit=5)
 
         assert result["success"] is True
@@ -97,17 +99,32 @@ class TestSearXNGSearchProviderSearch:
         """Base URL trailing slash should not produce double-slash in endpoint."""
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080/")
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
-        mock_resp = self._make_mock_response({"results": []})
-
         calls = []
-        def capture_get(url, **kwargs):
+        def capture_request(method, url, **kwargs):
+            assert method == "GET"
             calls.append(url)
-            return mock_resp
+            return {"results": []}
 
-        with patch("httpx.get", side_effect=capture_get):
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            side_effect=capture_request,
+        ):
             SearXNGWebSearchProvider().search("query", limit=5)
 
         assert calls[0] == "http://localhost:8080/search", f"Got: {calls[0]}"
+
+    def test_oversized_response_returns_failure(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web._bounded_json import WebProviderResponseTooLarge
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        with patch(
+            "plugins.web.searxng.provider._httpx_json_request",
+            side_effect=WebProviderResponseTooLarge("response exceeded cap"),
+        ):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result == {"success": False, "error": "response exceeded cap"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_web_providers_xai.py
+++ b/tests/tools/test_web_providers_xai.py
@@ -15,6 +15,9 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import httpx
+import pytest
+
 
 def _creds(api_key: str = "xai-test-key", base_url: str = "https://api.x.ai/v1") -> dict:
     return {"provider": "xai", "api_key": api_key, "base_url": base_url}
@@ -26,6 +29,18 @@ def _mock_resp(json_data, status_code: int = 200):
     m.json.return_value = json_data
     m.raise_for_status = MagicMock()
     return m
+
+
+@pytest.fixture(autouse=True)
+def _route_streams_through_existing_httpx_mocks(monkeypatch):
+    from plugins.web.xai import provider as xai_provider
+
+    def legacy_mock_adapter(method, url, **kwargs):
+        response = httpx.post(url, **kwargs)
+        response.raise_for_status()
+        return response.json()
+
+    monkeypatch.setattr(xai_provider, "_httpx_json_request", legacy_mock_adapter)
 
 
 def _responses_payload(text: str, annotations=None, citations=None) -> dict:
@@ -294,6 +309,34 @@ class TestXAIProviderSearchErrors:
         assert result["success"] is False
         assert "cannot both be set" in result["error"]
         posted.assert_not_called()
+
+    def test_oversized_success_returns_failure(self):
+        from plugins.web import _bounded_json
+        from plugins.web.xai import provider as xai_provider
+
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+        response.iter_raw.return_value = [b"x" * (2 * 1024 * 1024 + 1)]
+        with patch.object(xai_provider, "resolve_xai_http_credentials", return_value=_creds()), \
+             patch.object(xai_provider, "_load_xai_web_config", return_value={}), \
+             patch.object(xai_provider, "_httpx_json_request", _bounded_json.httpx_json_request), \
+             patch("httpx.stream", return_value=response):
+            result = xai_provider.XAIWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "exceeded" in result["error"]
+
+    def test_malformed_success_returns_parse_failure(self):
+        from plugins.web.xai import provider as xai_provider
+
+        with patch.object(xai_provider, "resolve_xai_http_credentials", return_value=_creds()), \
+             patch.object(xai_provider, "_load_xai_web_config", return_value={}), \
+             patch.object(xai_provider, "_httpx_json_request", side_effect=json.JSONDecodeError("bad", "x", 0)):
+            result = xai_provider.XAIWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "parse" in result["error"]
 
 
     def test_401_on_oauth_path_triggers_force_refresh_and_retry(self):

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -31,34 +31,48 @@ class TestTavilyRequest:
 
     def test_posts_with_api_key_in_body(self):
         """api_key is injected into the JSON payload."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"results": []}
-        mock_response.raise_for_status = MagicMock()
-
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test-key"}):
-            with patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post:
+            with patch(
+                "plugins.web.tavily.provider._httpx_json_request",
+                return_value={"results": []},
+            ) as mock_request:
                 from tools.web_tools import _tavily_request
                 result = _tavily_request("search", {"query": "hello"})
 
-                mock_post.assert_called_once()
-                call_kwargs = mock_post.call_args
+                mock_request.assert_called_once()
+                call_kwargs = mock_request.call_args
+                assert call_kwargs.args[0] == "POST"
                 payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
                 assert payload["api_key"] == "tvly-test-key"
                 assert payload["query"] == "hello"
-                assert "api.tavily.com/search" in call_kwargs.args[0]
+                assert "api.tavily.com/search" in call_kwargs.args[1]
 
     def test_raises_on_http_error(self):
         """Non-2xx responses propagate as httpx.HTTPStatusError."""
         import httpx as _httpx
-        mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = _httpx.HTTPStatusError(
-            "401 Unauthorized", request=MagicMock(), response=mock_response
+        http_error = _httpx.HTTPStatusError(
+            "401 Unauthorized", request=MagicMock(), response=MagicMock()
         )
 
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-bad-key"}):
-            with patch("tools.web_tools.httpx.post", return_value=mock_response):
+            with patch(
+                "plugins.web.tavily.provider._httpx_json_request",
+                side_effect=http_error,
+            ):
                 from tools.web_tools import _tavily_request
                 with pytest.raises(_httpx.HTTPStatusError):
+                    _tavily_request("search", {"query": "test"})
+
+    def test_raises_on_oversized_response(self):
+        from plugins.web._bounded_json import WebProviderResponseTooLarge
+
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test-key"}):
+            with patch(
+                "plugins.web.tavily.provider._httpx_json_request",
+                side_effect=WebProviderResponseTooLarge("web provider JSON response exceeded 16 bytes"),
+            ):
+                from tools.web_tools import _tavily_request
+                with pytest.raises(WebProviderResponseTooLarge):
                     _tavily_request("search", {"query": "test"})
 
 
@@ -175,15 +189,13 @@ class TestWebSearchTavily:
         _reset_for_tests()
 
     def test_search_dispatches_to_tavily(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
+        payload = {
             "results": [{"title": "Result", "url": "https://r.com", "content": "desc", "score": 0.9}]
         }
-        mock_response.raise_for_status = MagicMock()
 
         with patch("tools.web_tools._get_backend", return_value="tavily"), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
-             patch("tools.web_tools.httpx.post", return_value=mock_response), \
+             patch("plugins.web.tavily.provider._httpx_json_request", return_value=payload), \
              patch("tools.interrupt.is_interrupted", return_value=False):
             from tools.web_tools import web_search_tool
             result = json.loads(web_search_tool("test query", limit=3))
@@ -207,15 +219,13 @@ class TestWebExtractTavily:
         _reset_for_tests()
 
     def test_extract_dispatches_to_tavily(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
+        payload = {
             "results": [{"url": "https://example.com", "raw_content": "Extracted content", "title": "Page"}]
         }
-        mock_response.raise_for_status = MagicMock()
 
         with patch("tools.web_tools._get_backend", return_value="tavily"), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
-             patch("tools.web_tools.httpx.post", return_value=mock_response):
+             patch("plugins.web.tavily.provider._httpx_json_request", return_value=payload):
             from tools.web_tools import web_extract_tool
             result = json.loads(asyncio.get_event_loop().run_until_complete(
                 web_extract_tool(["https://example.com"])
@@ -224,4 +234,3 @@ class TestWebExtractTavily:
             assert len(result["results"]) == 1
             assert result["results"][0]["url"] == "https://example.com"
             assert "Extracted content" in result["results"][0]["content"]
-

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -31,34 +31,48 @@ class TestTavilyRequest:
 
     def test_posts_with_api_key_in_body(self):
         """api_key is injected into the JSON payload."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"results": []}
-        mock_response.raise_for_status = MagicMock()
-
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test-key"}):
-            with patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post:
+            with patch(
+                "plugins.web.tavily.provider._httpx_json_request",
+                return_value={"results": []},
+            ) as mock_request:
                 from tools.web_tools import _tavily_request
                 result = _tavily_request("search", {"query": "hello"})
 
-                mock_post.assert_called_once()
-                call_kwargs = mock_post.call_args
+                mock_request.assert_called_once()
+                call_kwargs = mock_request.call_args
+                assert call_kwargs.args[0] == "POST"
                 payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
                 assert payload["api_key"] == "tvly-test-key"
                 assert payload["query"] == "hello"
-                assert "api.tavily.com/search" in call_kwargs.args[0]
+                assert "api.tavily.com/search" in call_kwargs.args[1]
 
     def test_raises_on_http_error(self):
         """Non-2xx responses propagate as httpx.HTTPStatusError."""
         import httpx as _httpx
-        mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = _httpx.HTTPStatusError(
-            "401 Unauthorized", request=MagicMock(), response=mock_response
+        http_error = _httpx.HTTPStatusError(
+            "401 Unauthorized", request=MagicMock(), response=MagicMock()
         )
 
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-bad-key"}):
-            with patch("tools.web_tools.httpx.post", return_value=mock_response):
+            with patch(
+                "plugins.web.tavily.provider._httpx_json_request",
+                side_effect=http_error,
+            ):
                 from tools.web_tools import _tavily_request
                 with pytest.raises(_httpx.HTTPStatusError):
+                    _tavily_request("search", {"query": "test"})
+
+    def test_raises_on_oversized_response(self):
+        from plugins.web._bounded_json import WebProviderResponseTooLarge
+
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test-key"}):
+            with patch(
+                "plugins.web.tavily.provider._httpx_json_request",
+                side_effect=WebProviderResponseTooLarge("web provider JSON response exceeded 16 bytes"),
+            ):
+                from tools.web_tools import _tavily_request
+                with pytest.raises(WebProviderResponseTooLarge):
                     _tavily_request("search", {"query": "test"})
 
 
@@ -140,15 +154,13 @@ class TestWebSearchTavily:
         _reset_for_tests()
 
     def test_search_dispatches_to_tavily(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
+        payload = {
             "results": [{"title": "Result", "url": "https://r.com", "content": "desc", "score": 0.9}]
         }
-        mock_response.raise_for_status = MagicMock()
 
         with patch("tools.web_tools._get_backend", return_value="tavily"), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
-             patch("tools.web_tools.httpx.post", return_value=mock_response), \
+             patch("plugins.web.tavily.provider._httpx_json_request", return_value=payload), \
              patch("tools.interrupt.is_interrupted", return_value=False):
             from tools.web_tools import web_search_tool
             result = json.loads(web_search_tool("test query", limit=3))
@@ -172,15 +184,13 @@ class TestWebExtractTavily:
         _reset_for_tests()
 
     def test_extract_dispatches_to_tavily(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
+        payload = {
             "results": [{"url": "https://example.com", "raw_content": "Extracted content", "title": "Page"}]
         }
-        mock_response.raise_for_status = MagicMock()
 
         with patch("tools.web_tools._get_backend", return_value="tavily"), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
-             patch("tools.web_tools.httpx.post", return_value=mock_response):
+             patch("plugins.web.tavily.provider._httpx_json_request", return_value=payload):
             from tools.web_tools import web_extract_tool
             result = json.loads(asyncio.get_event_loop().run_until_complete(
                 web_extract_tool(["https://example.com"])
@@ -189,4 +199,3 @@ class TestWebExtractTavily:
             assert len(result["results"]) == 1
             assert result["results"][0]["url"] == "https://example.com"
             assert "Extracted content" in result["results"][0]["content"]
-


### PR DESCRIPTION
﻿Fixes #55079.

## Summary

- add a shared bounded JSON response helper for direct `httpx` web-provider calls
- switch Tavily, SearXNG, and Brave web providers from eager `response.json()` reads to streamed capped reads
- return normal provider/tool errors when an upstream web-provider JSON response exceeds the cap

## Why

Recent OpenClaw bounded response-read fixes surfaced the same bug class in Hermes' bundled direct-HTTP web providers. These providers reduce upstream JSON to a small normalized result list, but currently buffer the entire upstream body before parsing.

This keeps the scope narrow to direct `httpx` JSON providers. SDK-backed providers such as Firecrawl and Parallel are unchanged.

## Validation

- `TMP=.tmp-pytest TEMP=.tmp-pytest TMPDIR=.tmp-pytest C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests/plugins/web/test_bounded_json.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_tools_tavily.py -q` -> 65 passed
- `TMP=.tmp-pytest TEMP=.tmp-pytest TMPDIR=.tmp-pytest C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check plugins/web/_bounded_json.py plugins/web/tavily/provider.py plugins/web/searxng/provider.py plugins/web/brave_free/provider.py tests/plugins/web/test_bounded_json.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_tools_tavily.py` -> All checks passed
- `git diff --check` -> passed
