### PR TITLE
feat: add Website Toolbox community forum MCP to catalog

### DIFF
--- a/optional-mcps/websitetoolbox/manifest.yaml
+++ b/optional-mcps/websitetoolbox/manifest.yaml
@@ -1,0 +1,36 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: websitetoolbox
+description: Manage your Website Toolbox community forum — categories, topics, posts, users, groups, conversations, messages, moderators, tags, and page views via the Forum REST API.
+source: https://github.com/webtoolbox/websitetoolbox-mcp
+
+transport:
+  type: stdio
+  command: "npx"
+  args:
+    - "-y"
+    - "websitetoolbox-mcp"
+
+auth:
+  type: api_key
+  env:
+    - name: WEBSITETOOLBOX_API_KEY
+      prompt: "Website Toolbox API key (from your forum's Integrate → API settings)"
+      required: true
+      secret: true
+    - name: WEBSITETOOLBOX_USERNAME
+      prompt: "Username to act as (optional — leave blank for default)"
+      required: false
+      secret: false
+    - name: WEBSITETOOLBOX_EMAIL
+      prompt: "Email for the user (optional)"
+      required: false
+      secret: false
+
+post_install: |
+  Get your API key from your forum's admin panel under Integrate → API.
+
+  The server connects to your Website Toolbox community forum via the REST API.
+  Start a new Hermes session to load the community forum tools.

--- a/optional-mcps/websitetoolbox/manifest.yaml
+++ b/optional-mcps/websitetoolbox/manifest.yaml
@@ -11,7 +11,7 @@ transport:
   command: "npx"
   args:
     - "-y"
-    - "websitetoolbox-mcp"
+    - "websitetoolbox-mcp@1.1.2"
 
 auth:
   type: api_key


### PR DESCRIPTION
Adds [websitetoolbox-mcp](https://github.com/webtoolbox/websitetoolbox-mcp) to the MCP catalog.

## What it does

MCP server for the Website Toolbox **community forum** platform. Manages categories, topics, posts, users, user groups, conversations, messages, moderators, tags, and page views via the Forum REST API.

## Transport

stdio via `npx -y websitetoolbox-mcp` — no local clone needed.

## Auth

Requires a Website Toolbox API key (obtained from the forum's admin panel under Integrate → API). Optional username and email for acting as a specific user.

## npm

Published as `websitetoolbox-mcp` on npm.

## Why it belongs in the catalog

Website Toolbox hosts thousands of community forums. This MCP server lets Hermes users manage their community forum directly — moderation, content management, user administration, and analytics — all through natural language.