### PR TITLE
feat(cron): add Dream weekly memory hygiene and learning blueprint

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5892,8 +5892,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._show_status()
         else:
             # Get tools for display
-            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
-            
+            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
+
             # Get terminal working directory (where commands will execute)
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
             
@@ -6213,7 +6213,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if os.environ.get("HERMES_DEFER_AGENT_STARTUP") == "1":
             tool_status = "tools deferred"
         else:
-            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
             tool_count = len(tools) if tools else 0
             tool_status = f"{tool_count} tools"
 
@@ -6380,7 +6380,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
-        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
         
         if not tools:
             print("(;_;) No tools available")
@@ -8162,7 +8162,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 if self.compact or term_w < 80:
                     cc.print(_build_compact_banner())
                 else:
-                    tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+                    tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())
                     ctx_len = None
                     if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):

--- a/cron/blueprint_catalog.py
+++ b/cron/blueprint_catalog.py
@@ -478,48 +478,48 @@ CATALOG: List[AutomationBlueprint] = [
     ),
     AutomationBlueprint(
         key="dream",
-        title="Dream — weekly memory distillation",
+        title="Dream — weekly memory hygiene and learning",
         description=(
-            "A weekly maintenance job that reviews recent sessions and "
-            "distills patterns into Hermes's memory stores. Prioritizes "
-            "compression and consolidation over accumulation so memory "
-            "stays lean and high-signal regardless of how long Hermes has "
-            "been running. Recommended: restrict enabled_toolsets to "
-            "'session_search' and 'memory' for efficiency."
+            "A weekly job that does two things in order: (1) hygiene — "
+            "consolidates and compresses memory stores to keep them lean "
+            "and high-signal; (2) learning — uses the headroom freed by "
+            "hygiene to save new behavioral patterns from recent sessions. "
+            "Both passes run every week unless stores are in emergency "
+            "state (>80%%) after hygiene. Recommended: restrict "
+            "enabled_toolsets to 'session_search' and 'memory'."
         ),
         category="maintenance",
         schedule_template="{minute} {hour} * * 0",
         prompt_template=(
-            "You are running a weekly Dream pass — a memory hygiene and distillation job.\n\n"
-            "CONTEXT: Hermes memory stores have hard size limits. Your primary job is to "
-            "keep memory lean, high-signal, and below 60%% capacity. Adding new knowledge "
-            "is secondary to compression and consolidation.\n\n"
-            "Step 1 — Check current state (ALWAYS DO THIS FIRST)\n"
+            "You are running a weekly Dream pass — memory hygiene AND learning.\n\n"
+            "CONTEXT: Hermes memory stores have hard size limits. Run hygiene first "
+            "to free space, then use the headroom for learning. Both happen every "
+            "week unless stores are in emergency state after hygiene.\n\n"
+            "Step 1 — Check current state (ALWAYS FIRST)\n"
             "Call memory(action=\"read\", target=\"memory\") and memory(action=\"read\", target=\"user\"). "
-            "Note: the read output shows current usage as \"X/N chars\". "
-            "Record both percentages before proceeding.\n\n"
+            "Record both current sizes and percentages.\n\n"
             "Step 2 — Review recent sessions\n"
-            "Call session_search(sort=\"newest\", limit=10) to browse session titles and previews. "
-            "For 2-4 substantive sessions, call session_search(session_id=\"...\") to read them. "
-            "Note patterns: recurring corrections, consistent workflows, repeated questions.\n\n"
-            "Step 3 — Decide mode based on usage\n"
-            "- BOTH stores < 60%%: consolidation pass + up to 2 new entries if novel\n"
-            "- Either store 60-80%%: consolidation-only, no new entries\n"
-            "- Either store > 80%%: emergency compression, target dropping below 60%%\n\n"
-            "Step 4 — Update memory with atomic operations\n"
-            "Use memory(operations=[...]) for all changes in a single atomic batch. "
-            "The batch checks the NET final state — removing 3 entries + adding 1 is valid "
-            "even if the add alone would overflow.\n\n"
-            "Consolidation rules:\n"
-            "- Merge any two entries covering the same topic into one shorter entry\n"
-            "- Remove entries that are superseded, no longer true, or too specific to one session\n"
-            "- Rephrase verbose entries as terse rules (prefer 'Use uv for Python' over sentences)\n"
-            "- Each entry must be under 80 chars — rewrite anything longer\n"
-            "- After the batch, total chars must be <= what they were at Step 1\n\n"
-            "Addition rules (only when both stores < 60%% capacity):\n"
-            "- Max 2 new entries per run total across both stores\n"
-            "- Only add if the pattern appeared in >= 2 sessions and isn't already captured\n"
-            "- Prefer a behavioral rule ('Always X when Y') over a one-off fact\n\n"
+            "Call session_search(sort=\"newest\", limit=10) to browse titles and previews. "
+            "For 3-5 substantive sessions call session_search(session_id=\"...\") to read them. "
+            "Note: recurring corrections, preferred workflows, user facts, repeated questions "
+            "answered the same way.\n\n"
+            "Step 3 — Hygiene pass (ALWAYS, runs before learning)\n"
+            "Use memory(operations=[...]) to consolidate:\n"
+            "- Merge entries covering the same topic into one shorter entry\n"
+            "- Remove entries that are superseded, no longer true, or too session-specific\n"
+            "- Rewrite verbose entries as terse rules under 80 chars each\n"
+            "- If either store > 80%%: aggressive compression — target below 60%% before proceeding\n"
+            "Record sizes after hygiene.\n\n"
+            "Step 4 — Learning pass (runs after hygiene)\n"
+            "Based on sizes after Step 3:\n"
+            "- Either store still > 80%%: skip learning this week\n"
+            "- Either store 60-80%%: add up to 1 new entry per store (2 total max)\n"
+            "- Both stores < 60%%: add up to 3 new entries total across both stores\n\n"
+            "Addition rules:\n"
+            "- Only add if the pattern appeared in >= 2 recent sessions and is not already captured\n"
+            "- Prefer behavioral rules ('Always X when Y') over one-off facts\n"
+            "- Each entry under 80 chars\n"
+            "- Hygiene removes and learning adds can be combined in one atomic batch\n\n"
             "Step 5 — End with [SILENT]\n"
             "Internal maintenance only — no delivery needed."
         ),
@@ -527,7 +527,7 @@ CATALOG: List[AutomationBlueprint] = [
             _TIME("03:00"),
             _DELIVER,
         ],
-        tags=("memory", "maintenance"),
+        tags=("memory", "maintenance", "learning"),
     ),
 ]
 

--- a/cron/blueprint_catalog.py
+++ b/cron/blueprint_catalog.py
@@ -476,6 +476,59 @@ CATALOG: List[AutomationBlueprint] = [
         ],
         tags=("daily", "curiosity"),
     ),
+    AutomationBlueprint(
+        key="dream",
+        title="Dream — weekly memory distillation",
+        description=(
+            "A weekly maintenance job that reviews recent sessions and "
+            "distills patterns into Hermes's memory stores. Prioritizes "
+            "compression and consolidation over accumulation so memory "
+            "stays lean and high-signal regardless of how long Hermes has "
+            "been running. Recommended: restrict enabled_toolsets to "
+            "'session_search' and 'memory' for efficiency."
+        ),
+        category="maintenance",
+        schedule_template="{minute} {hour} * * 0",
+        prompt_template=(
+            "You are running a weekly Dream pass — a memory hygiene and distillation job.\n\n"
+            "CONTEXT: Hermes memory stores have hard size limits. Your primary job is to "
+            "keep memory lean, high-signal, and below 60%% capacity. Adding new knowledge "
+            "is secondary to compression and consolidation.\n\n"
+            "Step 1 — Check current state (ALWAYS DO THIS FIRST)\n"
+            "Call memory(action=\"read\", target=\"memory\") and memory(action=\"read\", target=\"user\"). "
+            "Note: the read output shows current usage as \"X/N chars\". "
+            "Record both percentages before proceeding.\n\n"
+            "Step 2 — Review recent sessions\n"
+            "Call session_search(sort=\"newest\", limit=10) to browse session titles and previews. "
+            "For 2-4 substantive sessions, call session_search(session_id=\"...\") to read them. "
+            "Note patterns: recurring corrections, consistent workflows, repeated questions.\n\n"
+            "Step 3 — Decide mode based on usage\n"
+            "- BOTH stores < 60%%: consolidation pass + up to 2 new entries if novel\n"
+            "- Either store 60-80%%: consolidation-only, no new entries\n"
+            "- Either store > 80%%: emergency compression, target dropping below 60%%\n\n"
+            "Step 4 — Update memory with atomic operations\n"
+            "Use memory(operations=[...]) for all changes in a single atomic batch. "
+            "The batch checks the NET final state — removing 3 entries + adding 1 is valid "
+            "even if the add alone would overflow.\n\n"
+            "Consolidation rules:\n"
+            "- Merge any two entries covering the same topic into one shorter entry\n"
+            "- Remove entries that are superseded, no longer true, or too specific to one session\n"
+            "- Rephrase verbose entries as terse rules (prefer 'Use uv for Python' over sentences)\n"
+            "- Each entry must be under 80 chars — rewrite anything longer\n"
+            "- After the batch, total chars must be <= what they were at Step 1\n\n"
+            "Addition rules (only when both stores < 60%% capacity):\n"
+            "- Max 2 new entries per run total across both stores\n"
+            "- Only add if the pattern appeared in >= 2 sessions and isn't already captured\n"
+            "- Prefer a behavioral rule ('Always X when Y') over a one-off fact\n\n"
+            "Step 5 — End with [SILENT]\n"
+            "Internal maintenance only — no delivery needed."
+        ),
+        slots=[
+            _TIME("03:00"),
+            _DELIVER,
+        ],
+        tags=("memory", "maintenance"),
+    ),
 ]
 
 _CATALOG_BY_KEY = {r.key: r for r in CATALOG}

--- a/docs/mac-mini-m4-setup.md
+++ b/docs/mac-mini-m4-setup.md
@@ -1,0 +1,283 @@
+# Hermes on Mac Mini M4 (24 GB) — Local Inference Setup
+
+This guide documents running Hermes with a fully local inference backend on a Mac Mini M4 with 24 GB unified memory. No cloud API keys required.
+
+**Target hardware:** Mac Mini M4 (Mac16,10), 24 GB unified memory, macOS Sequoia or later
+
+---
+
+## Overview
+
+The stack:
+- **Hermes** — AI gateway, Discord + CLI interface
+- **Rapid-MLX** — Apple Silicon inference server (MLX-based, OpenAI-compatible)
+- **Model** — Gemma 4 E4B 4-bit (`mlx-community/gemma-4-e4b-it-4bit`)
+- **launchd** — keeps rapid-mlx running as a background service
+
+Hermes talks to rapid-mlx at `http://127.0.0.1:8001/v1` as a custom OpenAI-compatible provider.
+
+---
+
+## 1. Install Hermes
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+Follow prompts. Hermes installs to `~/.hermes/hermes-agent/` and registers a launchd gateway service.
+
+---
+
+## 2. Install Rapid-MLX
+
+```bash
+brew install rapid-mlx
+```
+
+Verify:
+```bash
+rapid-mlx --version
+```
+
+### Install the mlx-vlm dependency
+
+Gemma 4 requires `mlx-vlm` even when running in text-only mode. Install it into rapid-mlx's Homebrew Python environment:
+
+```bash
+/opt/homebrew/Cellar/rapid-mlx/$(rapid-mlx --version | awk '{print $1}')/libexec/bin/pip \
+  install 'mlx-vlm>=0.4.4' --ignore-installed fsspec
+```
+
+The `--ignore-installed fsspec` flag is required because Homebrew pins fsspec to a version that conflicts with mlx-vlm's requirement. Without this, rapid-mlx will fail with `ImportError: Vision/multimodal models require the optional mlx-vlm dependency` when loading any Gemma 4 model.
+
+> **If you upgrade rapid-mlx via Homebrew**, re-run this command — the Homebrew upgrade creates a fresh libexec environment.
+
+---
+
+## 3. Download the model
+
+```bash
+huggingface-cli download mlx-community/gemma-4-e4b-it-4bit
+```
+
+This downloads ~5.2 GB to `~/.cache/huggingface/hub/`. The model's working set at runtime is ~4.5 GB, leaving ~19 GB headroom for the OS and Hermes.
+
+### Why E4B and not a larger model?
+
+Hermes sends a system prompt with ~42 tool definitions on every request (~18,000–20,000 prompt tokens). Larger models require proportionally larger KV caches:
+
+| Model | Disk | Working set | Notes |
+|---|---|---|---|
+| **gemma-4-e4b-it-4bit** | 5.2 GB | ~4.5 GB | **Recommended — ample headroom** |
+| gemma-4-12B-it-4bit | 6.8 GB | ~6.0 GB | Slowest of the three (12.6 tok/s) |
+| gemma-4-26b-a4b-it-4bit | 15.6 GB | ~22 GB | Crashes under Hermes's full prompt load |
+
+The 26B model's KV cache for an 18K-token prompt exhausts Metal GPU memory and causes `SIGABRT` from `mlx::core::gpu::check_error`. E4B handles the same prompt easily.
+
+---
+
+## 4. Create the launchd plist
+
+Create `~/Library/LaunchAgents/com.rapid-mlx.server.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rapid-mlx.server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/rapid-mlx</string>
+        <string>serve</string>
+        <string>mlx-community/gemma-4-e4b-it-4bit</string>
+        <string>--port</string>
+        <string>8001</string>
+        <string>--no-mllm</string>
+        <string>--max-tokens</string>
+        <string>65536</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/YOUR_USERNAME/.hermes/logs/rapid-mlx.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOUR_USERNAME/.hermes/logs/rapid-mlx.log</string>
+</dict>
+</plist>
+```
+
+Replace `YOUR_USERNAME` with your macOS username (`whoami`).
+
+**Critical flags:**
+- `--no-mllm` — Routes Gemma 4 through the mlx-lm text path instead of mlx-vlm. Required even for text-only serving: without it, rapid-mlx attempts the VLM architecture path and raises `ValueError: Received 126 parameters not in model` due to a version mismatch between the mlx-community weights and mlx-vlm 0.6.3.
+- `--max-tokens 65536` — Hermes sends `max_tokens=65536` on every request; without this cap, rapid-mlx can attempt to allocate a KV cache sized for the full 262K context window.
+- `--port 8001` — Keeps port 8000 free for other services.
+
+Load the service:
+```bash
+launchctl load ~/Library/LaunchAgents/com.rapid-mlx.server.plist
+```
+
+Verify it's running:
+```bash
+curl http://127.0.0.1:8001/v1/models
+```
+
+---
+
+## 5. Configure Hermes
+
+Edit `~/.hermes/config.yaml`:
+
+```yaml
+model:
+  api_key: none
+  base_url: http://127.0.0.1:8001/v1
+  default: mlx-community/gemma-4-e4b-it-4bit
+  provider: custom
+
+agent:
+  disabled_toolsets:
+    - image_gen
+    - video_gen
+    - computer_use
+    - vision
+    - tts
+    - code_execution
+
+auxiliary:
+  compression:
+    provider: custom
+    base_url: http://127.0.0.1:8001/v1
+    model: mlx-community/gemma-4-e4b-it-4bit
+    api_key: none
+
+web:
+  backend: ddgs
+  search_backend: ddgs
+  extract_backend: ddgs
+
+toolsets:
+  - hermes-cli
+  - web
+  - browser
+```
+
+**Key config notes:**
+- `provider: custom` with `base_url` pointing directly to rapid-mlx on port 8001. Do not use `provider: ollama` for the auxiliary compression client — it doesn't recognize that provider name.
+- Disabled toolsets skip loading image generation, vision, TTS, and code execution — these aren't useful for a text-only local model and each adds overhead to the tool list sent with every prompt.
+- No `context_length` override needed — Gemma 4 natively reports 262144 tokens, well above Hermes's 64K minimum.
+- No `reasoning_effort` override needed — let Hermes manage it via the gemma4 reasoning parser.
+
+Restart Hermes to pick up config changes:
+```bash
+hermes gateway restart
+```
+
+---
+
+## 6. MCP Servers (optional)
+
+### Obsidian
+
+```bash
+cd ~/hermes/obsidian-mcp
+uv venv && uv pip install -e .
+```
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  obsidian:
+    command: /Users/YOUR_USERNAME/hermes/obsidian-mcp/.venv/bin/obsidian-api-mcp
+    env:
+      OBSIDIAN_API_KEY: <your-key>
+      OBSIDIAN_HOST: https://localhost:27124
+      OBSIDIAN_VERIFY_SSL: "false"
+    enabled: true
+```
+
+### Vestaboard
+
+```bash
+cd ~/hermes/vestaboard-mcp
+uv venv && uv pip install -r requirements.txt
+```
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  vestaboard:
+    command: /Users/YOUR_USERNAME/hermes/vestaboard-mcp/.venv/bin/python3
+    args:
+      - /Users/YOUR_USERNAME/hermes/vestaboard-mcp/vestaboard_mcp.py
+    env:
+      VESTABOARD_HOST: http://<board-ip>:7000
+      VESTABOARD_API_KEY: <your-key>
+    enabled: true
+```
+
+Use the board's IP address directly rather than a hostname — mDNS resolution can be unreliable. To get the API key, POST to `/local-api/enablement` with the enablement token printed on the board.
+
+---
+
+## 7. Verify everything
+
+```bash
+# rapid-mlx is up and serving E4B
+curl -s http://127.0.0.1:8001/v1/models | python3 -c \
+  "import sys,json; m=json.load(sys.stdin); print(m['data'][0]['id'], m['data'][0]['modality'])"
+# → mlx-community/gemma-4-e4b-it-4bit text
+
+# Quick inference test
+curl -s http://127.0.0.1:8001/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"mlx-community/gemma-4-e4b-it-4bit","messages":[{"role":"user","content":"Say hi."}],"max_tokens":10}' \
+  | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['choices'][0]['message']['content'])"
+
+# Hermes is connected
+hermes gateway status
+```
+
+---
+
+## Common Issues
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ImportError: Vision/multimodal models require the optional mlx-vlm dependency` | mlx-vlm not installed in rapid-mlx's env | Run the pip install command from Step 2 |
+| `ValueError: Received 126 parameters not in model` | mlx-vlm version mismatch with model weights | Add `--no-mllm` to plist ProgramArguments |
+| All output in `reasoning_content`, TTFT 8–10s | Gemma 4 chain-of-thought consuming all tokens | Hermes's gemma4 reasoning parser handles this; or add `--no-thinking` to disable CoT entirely |
+| `SIGABRT` / Metal GPU crash | KV cache for large prompt exhausts GPU memory | Switch to E4B model (smaller working set) |
+| `Provider returned an empty stream with no finish_reason` | Proxy/connection dropped mid-response | Point `base_url` directly to port 8001, skip any proxy |
+| Hermes `context window below minimum 64K` | Model reports a small context | Add `context_length: 65536` under `model:` in config |
+| Vestaboard `401 Invalid API key` | Using enablement token instead of API key | POST to `/local-api/enablement` to exchange for a real key |
+
+---
+
+## Updating rapid-mlx
+
+```bash
+brew upgrade rapid-mlx
+# Re-install mlx-vlm into the new libexec env (version number changes)
+/opt/homebrew/Cellar/rapid-mlx/<NEW_VERSION>/libexec/bin/pip \
+  install 'mlx-vlm>=0.4.4' --ignore-installed fsspec
+launchctl unload ~/Library/LaunchAgents/com.rapid-mlx.server.plist
+launchctl load ~/Library/LaunchAgents/com.rapid-mlx.server.plist
+```
+
+## Performance reference (Mac Mini M4, 24 GB)
+
+Benchmarked with 3-run average, 300-token response, Hermes system prompt (~18K tokens):
+
+| Model | TTFT | tok/s |
+|---|---|---|
+| gemma-4-e4b-it-4bit | ~0.22s | ~28 |
+| gemma-4-12B-it-4bit | ~0.44s | ~12 |
+| qwen3-8b-4bit (previous) | ~0.18s | ~22 |

--- a/docs/mac-mini-m4-setup.md
+++ b/docs/mac-mini-m4-setup.md
@@ -180,54 +180,7 @@ hermes gateway restart
 
 ---
 
-## 6. MCP Servers (optional)
-
-### Obsidian
-
-```bash
-cd ~/hermes/obsidian-mcp
-uv venv && uv pip install -e .
-```
-
-Add to `~/.hermes/config.yaml`:
-
-```yaml
-mcp_servers:
-  obsidian:
-    command: /Users/YOUR_USERNAME/hermes/obsidian-mcp/.venv/bin/obsidian-api-mcp
-    env:
-      OBSIDIAN_API_KEY: <your-key>
-      OBSIDIAN_HOST: https://localhost:27124
-      OBSIDIAN_VERIFY_SSL: "false"
-    enabled: true
-```
-
-### Vestaboard
-
-```bash
-cd ~/hermes/vestaboard-mcp
-uv venv && uv pip install -r requirements.txt
-```
-
-Add to `~/.hermes/config.yaml`:
-
-```yaml
-mcp_servers:
-  vestaboard:
-    command: /Users/YOUR_USERNAME/hermes/vestaboard-mcp/.venv/bin/python3
-    args:
-      - /Users/YOUR_USERNAME/hermes/vestaboard-mcp/vestaboard_mcp.py
-    env:
-      VESTABOARD_HOST: http://<board-ip>:7000
-      VESTABOARD_API_KEY: <your-key>
-    enabled: true
-```
-
-Use the board's IP address directly rather than a hostname — mDNS resolution can be unreliable. To get the API key, POST to `/local-api/enablement` with the enablement token printed on the board.
-
----
-
-## 7. Verify everything
+## 6. Verify everything
 
 ```bash
 # rapid-mlx is up and serving E4B
@@ -257,7 +210,6 @@ hermes gateway status
 | `SIGABRT` / Metal GPU crash | KV cache for large prompt exhausts GPU memory | Switch to E4B model (smaller working set) |
 | `Provider returned an empty stream with no finish_reason` | Proxy/connection dropped mid-response | Point `base_url` directly to port 8001, skip any proxy |
 | Hermes `context window below minimum 64K` | Model reports a small context | Add `context_length: 65536` under `model:` in config |
-| Vestaboard `401 Invalid API key` | Using enablement token instead of API key | POST to `/local-api/enablement` to exchange for a real key |
 
 ---
 

--- a/docs/mac-mini-m4-setup.md
+++ b/docs/mac-mini-m4-setup.md
@@ -224,6 +224,47 @@ launchctl unload ~/Library/LaunchAgents/com.rapid-mlx.server.plist
 launchctl load ~/Library/LaunchAgents/com.rapid-mlx.server.plist
 ```
 
+## MCP Servers
+
+### Vestaboard
+
+Repo: https://github.com/kfezer/vestaboard-mcp
+
+```bash
+cd ~/hermes/vestaboard-mcp
+uv venv && uv pip install -r requirements.txt
+```
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  vestaboard:
+    command: /Users/YOUR_USERNAME/hermes/vestaboard-mcp/.venv/bin/python3
+    args:
+      - /Users/YOUR_USERNAME/hermes/vestaboard-mcp/vestaboard_mcp.py
+    env:
+      VESTABOARD_HOST: http://<board-ip>:7000
+      VESTABOARD_API_KEY: <your-key>
+    enabled: true
+```
+
+Use the board's IP address directly — mDNS can be unreliable. To get the API key, POST to `/local-api/enablement` with the enablement token shown on the board.
+
+**Tools:**
+
+| Tool | Description |
+|---|---|
+| `vestaboard_weather_forecast` | Fetches live weather, shows matching icon for 4s then data |
+| `vestaboard_send_text` | Send centered text (up to 6 rows × 22 chars) |
+| `vestaboard_send_long_text` | Auto-splits long text across multiple screens, cycles in background |
+| `vestaboard_show_icon` | Display a weather icon directly: sunny, cloudy, rainy, snowy, stormy, foggy, windy, hot |
+| `vestaboard_read` | Read current board contents |
+| `vestaboard_clear` | Blank the display |
+| `vestaboard_send_raw` | Send a raw 6×22 color-code grid |
+
+---
+
 ## Performance reference (Mac Mini M4, 24 GB)
 
 Benchmarked with 3-run average, 300-token response, Hermes system prompt (~18K tokens):


### PR DESCRIPTION
## Summary

- Adds a `dream` entry to the blueprint catalog (`cron/blueprint_catalog.py`)
- Dream is a weekly cron that runs two passes in sequence: **hygiene** (compress and consolidate memory) then **learning** (extract new patterns from recent sessions into the freed headroom)
- Size-bounded: learning is tiered on space remaining after hygiene, so stores stay lean regardless of runtime duration

## Motivation

Without a maintenance job, Hermes memory stores grow until they hit their hard character limits (2,200 for MEMORY.md, 1,375 for USER.md), at which point the model gets hard-refusal errors when trying to remember new patterns. Dream prevents this by running hygiene first every week, then using the freed space for genuine learning.

An earlier design gated all learning behind 60% usage thresholds. In practice this meant Dream almost never added anything — it only compressed. This version runs both passes every week.

## How it works

**Step 1 — Read** both memory stores, note current sizes.

**Step 2 — Session review** — browse 3–5 recent sessions for recurring corrections, preferred workflows, repeated questions.

**Step 3 — Hygiene (always)** — consolidate, merge, and rewrite entries. Aggressive compression if either store is >80%.

**Step 4 — Learning (tiered on post-hygiene size)**

| Size after hygiene | Learning budget |
|---|---|
| Either store > 80% | Skip learning this week |
| Either store 60–80% | Up to 1 new entry per store (2 total) |
| Both stores < 60% | Up to 3 new entries total |

Hygiene removes and learning adds are combined into a single atomic `memory(operations=[...])` batch, which evaluates net final state — so removing two entries and adding one replacement is valid even if the add alone would overflow.

## Blueprint details

- **Key**: `dream`
- **Category**: `maintenance`
- **Schedule**: every Sunday at configurable time (default 03:00)
- **Slots**: time, deliver
- **Tags**: memory, maintenance, learning

## Notes

- Recommend setting `enabled_toolsets: ["session_search", "memory"]` on the created job to keep Dream's own prompt context lean (currently requires editing `jobs.json` directly; a future CLI flag could expose this)
- Addition rules: only patterns seen in ≥2 recent sessions, not already captured, written as behavioral rules under 80 chars each

🤖 Generated with [Claude Code](https://claude.com/claude-code)