### PR TITLE
fix(telegram): bound DoH discovery JSON response reads

### DIFF
--- a/agent/httpx_bounded_response.py
+++ b/agent/httpx_bounded_response.py
@@ -1,0 +1,66 @@
+"""Compression-safe bounded reads for streamed HTTPX responses.
+
+HTTPX's decoded iterators apply ``Content-Encoding`` before yielding bytes. A
+small gzip or Brotli chunk can therefore expand into a large allocation before
+a caller gets a chance to count it. This module takes the deliberately simpler
+identity-only path: callers request ``Accept-Encoding: identity``, and the
+reader consumes the raw stream while rejecting servers that ignore that
+negotiation.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+class HTTPXResponseBodyTooLarge(ValueError):
+    """Raised when a streamed response exceeds its byte cap."""
+
+
+class HTTPXUnsupportedContentEncoding(ValueError):
+    """Raised when an identity-only response uses a content coding."""
+
+
+async def read_httpx_response_bytes_limited(
+    response: httpx.Response,
+    *,
+    max_bytes: int,
+) -> bytes:
+    """Read a complete identity-encoded response without exceeding ``max_bytes``.
+
+    The response must come from an HTTPX streaming request whose caller sent
+    ``Accept-Encoding: identity``. A non-identity ``Content-Encoding`` fails
+    closed before the body is read, so decompression cannot happen ahead of the
+    cap. The client's own timeout remains responsible for stalled streams.
+    """
+    if max_bytes < 0:
+        raise ValueError("max_bytes must be non-negative")
+
+    content_encoding = response.headers.get("content-encoding", "").strip().lower()
+    if content_encoding not in {"", "identity"}:
+        raise HTTPXUnsupportedContentEncoding(
+            f"response used unsupported Content-Encoding: {content_encoding}"
+        )
+
+    content_length = response.headers.get("content-length")
+    if content_length is not None:
+        try:
+            declared_bytes = int(content_length)
+        except ValueError:
+            pass
+        else:
+            if declared_bytes > max_bytes:
+                raise HTTPXResponseBodyTooLarge(
+                    f"response exceeds {max_bytes} bytes"
+                )
+
+    body = bytearray()
+    async for chunk in response.aiter_raw():
+        if not chunk:
+            continue
+        if len(chunk) > max_bytes - len(body):
+            raise HTTPXResponseBodyTooLarge(
+                f"response exceeds {max_bytes} bytes"
+            )
+        body.extend(chunk)
+    return bytes(body)

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import ipaddress
+import json
 import logging
 import socket
 from typing import Iterable, Optional
@@ -24,6 +25,8 @@ _TELEGRAM_API_HOST = "api.telegram.org"
 # DNS-over-HTTPS providers used to discover Telegram API IPs that may differ
 # from the (potentially unreachable) IP returned by the local system resolver.
 _DOH_TIMEOUT = 4.0  # seconds — bounded so connect() isn't noticeably delayed
+
+_DOH_JSON_MAX_BYTES = 1_048_576  # DoH A-record JSON is tiny; 1 MiB is defensive.
 
 _DOH_PROVIDERS: list[dict] = [
     {
@@ -171,11 +174,14 @@ async def _query_doh_provider(
 ) -> list[str]:
     """Query one DoH provider and return A-record IPs."""
     try:
-        resp = await client.get(
-            provider["url"], params=provider["params"], headers=provider["headers"]
-        )
-        resp.raise_for_status()
-        data = resp.json()
+        async with client.stream(
+            "GET",
+            provider["url"],
+            params=provider["params"],
+            headers=provider["headers"],
+        ) as resp:
+            resp.raise_for_status()
+            data = await _read_doh_json_response(resp)
         ips: list[str] = []
         for answer in data.get("Answer", []):
             if answer.get("type") != 1:  # A record
@@ -190,6 +196,25 @@ async def _query_doh_provider(
     except Exception as exc:
         logger.debug("DoH query to %s failed: %s", provider["url"], exc)
         return []
+
+
+async def _read_doh_json_response(
+    resp: httpx.Response,
+    *,
+    max_bytes: int = _DOH_JSON_MAX_BYTES,
+) -> dict:
+    """Read a small DoH JSON response without buffering unbounded bodies."""
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in resp.aiter_bytes():
+        total += len(chunk)
+        if total > max_bytes:
+            raise ValueError(f"DoH JSON response exceeds {max_bytes} bytes")
+        chunks.append(chunk)
+    if not chunks:
+        return {}
+    data = json.loads(b"".join(chunks).decode("utf-8"))
+    return data if isinstance(data, dict) else {}
 
 
 async def discover_fallback_ips() -> list[str]:

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 
 import asyncio
 import ipaddress
+import json
 import logging
 import socket
 from typing import Iterable, Optional
 
 import httpx
+
+from agent.httpx_bounded_response import read_httpx_response_bytes_limited
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +27,7 @@ _TELEGRAM_API_HOST = "api.telegram.org"
 # DNS-over-HTTPS providers used to discover Telegram API IPs that may differ
 # from the (potentially unreachable) IP returned by the local system resolver.
 _DOH_TIMEOUT = 4.0  # seconds — bounded so connect() isn't noticeably delayed
+_DOH_JSON_MAX_BYTES = 1_048_576
 
 _DOH_PROVIDERS: list[dict] = [
     {
@@ -225,11 +229,19 @@ async def _query_doh_provider(
 ) -> list[str]:
     """Query one DoH provider and return A-record IPs."""
     try:
-        resp = await client.get(
-            provider["url"], params=provider["params"], headers=provider["headers"]
-        )
-        resp.raise_for_status()
-        data = resp.json()
+        headers = httpx.Headers(provider["headers"])
+        headers["Accept-Encoding"] = "identity"
+        async with client.stream(
+            "GET",
+            provider["url"],
+            params=provider["params"],
+            headers=headers,
+        ) as resp:
+            resp.raise_for_status()
+            body = await read_httpx_response_bytes_limited(
+                resp, max_bytes=_DOH_JSON_MAX_BYTES
+            )
+        data = json.loads(body) if body else {}
         ips: list[str] = []
         for answer in data.get("Answer", []):
             if answer.get("type") != 1:  # A record

--- a/tests/agent/test_httpx_bounded_response.py
+++ b/tests/agent/test_httpx_bounded_response.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from agent.httpx_bounded_response import (
+    HTTPXResponseBodyTooLarge,
+    HTTPXUnsupportedContentEncoding,
+    read_httpx_response_bytes_limited,
+)
+
+
+class _TrackedStream(httpx.AsyncByteStream):
+    def __init__(self, *chunks: bytes):
+        self.chunks = chunks
+        self.yielded = 0
+
+    async def __aiter__(self):
+        for chunk in self.chunks:
+            self.yielded += 1
+            yield chunk
+
+    async def aclose(self):
+        pass
+
+
+def _response(stream: _TrackedStream, **headers: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers=headers,
+        request=httpx.Request("GET", "https://provider.invalid/data"),
+        stream=stream,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reads_complete_identity_response():
+    stream = _TrackedStream(b'{"ok":', b"true}")
+    response = _response(
+        stream,
+        **{"Content-Encoding": "identity", "Content-Length": "11"},
+    )
+
+    assert await read_httpx_response_bytes_limited(response, max_bytes=11) == (
+        b'{"ok":true}'
+    )
+    assert stream.yielded == 2
+
+
+@pytest.mark.asyncio
+async def test_stops_when_stream_crosses_limit():
+    stream = _TrackedStream(b"abcd", b"efgh", b"unread")
+    response = _response(stream)
+
+    with pytest.raises(HTTPXResponseBodyTooLarge, match="exceeds 6 bytes"):
+        await read_httpx_response_bytes_limited(response, max_bytes=6)
+
+    assert stream.yielded == 2
+
+
+@pytest.mark.asyncio
+async def test_rejects_declared_oversize_without_reading_body():
+    stream = _TrackedStream(b"unread")
+    response = _response(stream, **{"Content-Length": "7"})
+
+    with pytest.raises(HTTPXResponseBodyTooLarge, match="exceeds 6 bytes"):
+        await read_httpx_response_bytes_limited(response, max_bytes=6)
+
+    assert stream.yielded == 0
+
+
+@pytest.mark.asyncio
+async def test_rejects_encoded_response_without_decoding_body():
+    stream = _TrackedStream(b"compressed bytes stay unread")
+    response = _response(stream, **{"Content-Encoding": "gzip"})
+
+    with pytest.raises(
+        HTTPXUnsupportedContentEncoding,
+        match="unsupported Content-Encoding: gzip",
+    ):
+        await read_httpx_response_bytes_limited(response, max_bytes=1024)
+
+    assert stream.yielded == 0

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -488,7 +488,19 @@ class FakeDoHClient:
     def _make_response(status, body, url):
         """Build an httpx.Response with a request attached (needed for raise_for_status)."""
         request = httpx.Request("GET", url)
+        if isinstance(body, bytes):
+            return httpx.Response(status, content=body, request=request)
         return httpx.Response(status, json=body, request=request)
+
+    class _Stream:
+        def __init__(self, response):
+            self.response = response
+
+        async def __aenter__(self):
+            return self.response
+
+        async def __aexit__(self, *args):
+            await self.response.aclose()
 
     async def get(self, url, *, params=None, headers=None, **kwargs):
         self.requests_made.append({"url": url, "params": params, "headers": headers})
@@ -499,6 +511,21 @@ class FakeDoHClient:
                 status, body = action
                 return self._make_response(status, body, url)
         return self._make_response(200, {}, url)
+
+    def stream(self, method, url, *, params=None, headers=None, **kwargs):
+        self.requests_made.append({
+            "method": method,
+            "url": url,
+            "params": params,
+            "headers": headers,
+        })
+        for prefix, action in self._responses.items():
+            if url.startswith(prefix):
+                if isinstance(action, Exception):
+                    raise action
+                status, body = action
+                return self._Stream(self._make_response(status, body, url))
+        return self._Stream(self._make_response(200, {}, url))
 
     async def __aenter__(self):
         return self
@@ -590,6 +617,23 @@ class TestDiscoverFallbackIps:
 
         ips = await tnet.discover_fallback_ips()
         assert ips == tnet._SEED_FALLBACK_IPS
+
+    @pytest.mark.asyncio
+    async def test_oversized_doh_json_is_ignored(self, monkeypatch):
+        oversized = (
+            b'{"Answer":['
+            + b'{"type":1,"data":"149.154.167.220"},' * 80_000
+            + b'{"type":1,"data":"149.154.167.221"}]}'
+        )
+        assert len(oversized) > tnet._DOH_JSON_MAX_BYTES
+
+        self._patch_doh(monkeypatch, {
+            "https://dns.google": (200, oversized),
+            "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.222")),
+        }, system_dns_ips=["149.154.166.110"])
+
+        ips = await tnet.discover_fallback_ips()
+        assert ips == ["149.154.167.222"]
 
     @pytest.mark.asyncio
     async def test_one_provider_fails_other_succeeds(self, monkeypatch):

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -15,6 +15,9 @@ path first, and on ConnectTimeout / ConnectError fall through to configured
 fallback IPs in order, then "stick" to whichever IP works.
 """
 
+import gzip
+import json
+
 import httpx
 import pytest
 
@@ -359,6 +362,19 @@ def _doh_answer(*ips: str) -> dict:
     return {"Answer": [{"type": 1, "data": ip} for ip in ips]}
 
 
+class _TrackedDoHStream(httpx.AsyncByteStream):
+    def __init__(self, body: bytes):
+        self.body = body
+        self.yielded = 0
+
+    async def __aiter__(self):
+        self.yielded += 1
+        yield self.body
+
+    async def aclose(self):
+        pass
+
+
 class FakeDoHClient:
     """Mock httpx.AsyncClient for DoH queries."""
 
@@ -371,17 +387,38 @@ class FakeDoHClient:
     def _make_response(status, body, url):
         """Build an httpx.Response with a request attached (needed for raise_for_status)."""
         request = httpx.Request("GET", url)
-        return httpx.Response(status, json=body, request=request)
+        raw = body if isinstance(body, bytes) else json.dumps(body).encode()
+        return httpx.Response(
+            status,
+            headers={"Content-Type": "application/json"},
+            request=request,
+            stream=_TrackedDoHStream(raw),
+        )
 
-    async def get(self, url, *, params=None, headers=None, **kwargs):
-        self.requests_made.append({"url": url, "params": params, "headers": headers})
+    class _Stream:
+        def __init__(self, response):
+            self.response = response
+
+        async def __aenter__(self):
+            return self.response
+
+        async def __aexit__(self, *args):
+            await self.response.aclose()
+
+    def stream(self, method, url, *, params=None, headers=None, **kwargs):
+        self.requests_made.append({
+            "method": method,
+            "url": url,
+            "params": params,
+            "headers": headers,
+        })
         for prefix, action in self._responses.items():
             if url.startswith(prefix):
                 if isinstance(action, Exception):
                     raise action
                 status, body = action
-                return self._make_response(status, body, url)
-        return self._make_response(200, {}, url)
+                return self._Stream(self._make_response(status, body, url))
+        return self._Stream(self._make_response(200, {}, url))
 
     async def __aenter__(self):
         return self
@@ -443,6 +480,48 @@ class TestDiscoverFallbackIps:
 
         ips = await tnet.discover_fallback_ips()
         assert ips == ["149.154.167.220"]
+
+    @pytest.mark.asyncio
+    async def test_oversized_provider_does_not_block_healthy_provider(self, monkeypatch):
+        oversized = b"x" * (tnet._DOH_JSON_MAX_BYTES + 1)
+        self._patch_doh(monkeypatch, {
+            "https://dns.google": (200, oversized),
+            "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.222")),
+        }, system_dns_ips=["149.154.166.110"])
+
+        assert await tnet.discover_fallback_ips() == ["149.154.167.222"]
+
+    @pytest.mark.asyncio
+    async def test_gzip_bomb_is_rejected_without_decoding(self):
+        expanded = json.dumps(
+            {"Answer": [], "padding": "x" * (tnet._DOH_JSON_MAX_BYTES + 1)}
+        ).encode()
+        compressed = gzip.compress(expanded, compresslevel=9)
+        assert len(compressed) < 2_000
+        assert len(expanded) > tnet._DOH_JSON_MAX_BYTES
+
+        stream = _TrackedDoHStream(compressed)
+        requests: list[httpx.Request] = []
+
+        async def respond(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(
+                200,
+                headers={"Content-Encoding": "gzip"},
+                request=request,
+                stream=stream,
+            )
+
+        provider = {
+            "url": "https://doh.invalid/query",
+            "params": {},
+            "headers": {},
+        }
+        async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+            assert await tnet._query_doh_provider(client, provider) == []
+
+        assert stream.yielded == 0
+        assert requests[0].headers["Accept-Encoding"] == "identity"
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a shared async HTTPX bounded-response primitive that requests identity encoding, rejects encoded responses before body reads, and caps raw bytes
- migrate Telegram DoH discovery to that primitive with a 1 MiB JSON limit
- preserve the existing Google/Cloudflare fallback behavior when one provider is malformed, oversized, or compressed

Fixes #55087.

## Why this boundary

- This PR owns the async HTTPX identity/raw bounded-read contract and its first concrete consumer.
- It is independently correct: Telegram DoH discovery is bounded end to end and retains its existing provider fallback behavior.
- Signal RPC (#55026) and MS Graph token reads (#55281) are separate consumers with independent runtime, tests, and rollback boundaries. They should reuse this primitive rather than duplicate it here.

## Dependency and merge order

- Depends on: none
- Merge order: this PR first; then rebase the consumer PRs onto current `main` and keep only their consumer-specific commits.

## Deliberately excluded

- sync HTTPX and Requests response readers
- redirects, retries, message delivery, and provider-selection policy
- migrations of unrelated HTTPX callers

## Series status

- [x] #55089 — async HTTPX foundation + Telegram DoH first consumer
- [ ] #55026 — Signal RPC consumer
- [ ] #55281 — MS Graph consumer

## Validation

- `bash scripts/run_tests.sh tests/agent/test_httpx_bounded_response.py tests/gateway/test_telegram_network.py -q` — 25 passed
- `python -m ruff check` on the four changed files — passed
- `python -m compileall -q` on the four changed files — passed
- `git diff --check` — passed
- structured AutoReview — no findings; patch correct (0.97)

The regression proof uses a 1,048,611-byte JSON response compressed to 1,096 bytes: the old path advertises compression and inflates it before the cap; this branch requests identity and rejects a non-identity response before consuming the body.
