### PR TITLE
Add Kernel cloud browser provider plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -276,6 +276,19 @@ BROWSERBASE_PROXIES=true
 # Uses custom Chromium build to avoid bot detection altogether
 BROWSERBASE_ADVANCED_STEALTH=false
 
+# Kernel API Key - Cloud browser execution (https://kernel.sh)
+# Sandboxed Chrome via the Kernel REST API. Select with `browser.cloud_provider: kernel`.
+# Get at: https://kernel.sh/
+# KERNEL_API_KEY=
+
+# Optional Kernel knobs (defaults applied in-code, all opt-in):
+# KERNEL_STEALTH (default: true) - anti-bot stealth mode
+# KERNEL_HEADLESS (default: true) - set false to expose a human-watchable live-view URL
+# KERNEL_TIMEOUT_SECONDS - inactivity timeout in seconds
+# KERNEL_PROXY_ID - attach a Kernel proxy by ID
+# KERNEL_PROFILE - profile name to load and persist across runs
+# KERNEL_BASE_URL - override the API base URL (default: https://api.onkernel.com)
+
 # Browser engine for local mode (default: auto = Chrome)
 # "auto"       — use Chrome (don't pass --engine flag)
 # "lightpanda" — use Lightpanda (1.3-5.8x faster navigation, no screenshots)

--- a/plugins/browser/kernel/__init__.py
+++ b/plugins/browser/kernel/__init__.py
@@ -1,0 +1,15 @@
+"""Kernel cloud browser plugin — bundled, auto-loaded.
+
+Mirrors the ``plugins/web/<vendor>/`` and ``plugins/image_gen/openai/``
+layout: ``provider.py`` holds the provider class; ``__init__.py::register``
+instantiates and registers it via the plugin context.
+"""
+
+from __future__ import annotations
+
+from plugins.browser.kernel.provider import KernelBrowserProvider
+
+
+def register(ctx) -> None:
+    """Register the Kernel provider with the plugin context."""
+    ctx.register_browser_provider(KernelBrowserProvider())

--- a/plugins/browser/kernel/plugin.yaml
+++ b/plugins/browser/kernel/plugin.yaml
@@ -1,0 +1,7 @@
+name: browser-kernel
+version: 1.0.0
+description: "Kernel (https://kernel.sh) cloud browser backend. Requires KERNEL_API_KEY. Stealth-on-by-default sandboxed Chrome via the Kernel REST API; supports headless toggle, inactivity timeout, proxies, profile persistence, and a human-watchable live view URL."
+author: Kernel
+kind: backend
+provides_browser_providers:
+  - kernel

--- a/plugins/browser/kernel/provider.py
+++ b/plugins/browser/kernel/provider.py
@@ -1,0 +1,230 @@
+"""Kernel cloud browser provider — plugin form.
+
+Subclasses :class:`agent.browser_provider.BrowserProvider` (the plugin-facing
+ABC introduced in PR #25214). Wraps Kernel (https://kernel.sh) sandboxed Chrome
+browsers via the Kernel REST API.
+
+Talks to the REST API with the core ``requests`` dependency rather than a
+vendor SDK, matching the browserbase / firecrawl providers and the repo's
+minimal-dependency policy — each lifecycle op is a single REST call.
+
+Config keys this provider responds to::
+
+    browser:
+      cloud_provider: "kernel"
+
+Auth env vars::
+
+    KERNEL_API_KEY=...            # https://kernel.sh
+
+Optional feature knobs::
+
+    KERNEL_STEALTH=true           # default true  -> stealth mode (anti-bot)
+    KERNEL_HEADLESS=true          # default true  -> headless (no live view)
+    KERNEL_TIMEOUT_SECONDS=...    # inactivity timeout, seconds
+    KERNEL_PROXY_ID=...           # attach a Kernel proxy by ID
+    KERNEL_PROFILE=...            # profile name to load + persist across runs
+    KERNEL_BASE_URL=...           # default https://api.onkernel.com
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import Any, Dict, Optional
+
+import requests
+
+from agent.browser_provider import BrowserProvider
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://api.onkernel.com"
+
+
+class KernelBrowserProvider(BrowserProvider):
+    """Kernel (https://kernel.sh) cloud browser backend.
+
+    Stealth is on by default; headless is on by default (flip
+    ``KERNEL_HEADLESS=false`` to surface a human-watchable ``live_view_url`` in
+    the session metadata). Proxy and profile persistence are opt-in via env.
+    """
+
+    @property
+    def name(self) -> str:
+        return "kernel"
+
+    @property
+    def display_name(self) -> str:
+        return "Kernel"
+
+    def is_available(self) -> bool:
+        return self._get_config_or_none() is not None
+
+    # ------------------------------------------------------------------
+    # Config resolution
+    # ------------------------------------------------------------------
+
+    def _get_config_or_none(self) -> Optional[Dict[str, Any]]:
+        api_key = os.environ.get("KERNEL_API_KEY")
+        if not api_key:
+            return None
+        return {
+            "api_key": api_key,
+            "base_url": os.environ.get("KERNEL_BASE_URL", _DEFAULT_BASE_URL).rstrip("/"),
+        }
+
+    def _get_config(self) -> Dict[str, Any]:
+        config = self._get_config_or_none()
+        if config is None:
+            raise ValueError(
+                "Kernel requires the KERNEL_API_KEY environment variable. "
+                "Get your key at https://kernel.sh"
+            )
+        return config
+
+    def _headers(self, config: Dict[str, Any]) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {config['api_key']}",
+            "Content-Type": "application/json",
+        }
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def create_session(self, task_id: str) -> Dict[str, object]:
+        config = self._get_config()
+
+        stealth = os.environ.get("KERNEL_STEALTH", "true").lower() != "false"
+        headless = os.environ.get("KERNEL_HEADLESS", "true").lower() != "false"
+        proxy_id = os.environ.get("KERNEL_PROXY_ID")
+        profile_name = os.environ.get("KERNEL_PROFILE")
+
+        session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
+
+        body: Dict[str, object] = {
+            "stealth": stealth,
+            "headless": headless,
+            "name": session_name,
+        }
+
+        timeout_seconds = os.environ.get("KERNEL_TIMEOUT_SECONDS")
+        if timeout_seconds:
+            try:
+                body["timeout_seconds"] = int(timeout_seconds)
+            except ValueError:
+                logger.warning(
+                    "Invalid KERNEL_TIMEOUT_SECONDS value: %s", timeout_seconds
+                )
+
+        if proxy_id:
+            body["proxy_id"] = proxy_id
+
+        if profile_name:
+            body["profile"] = {"name": profile_name, "save_changes": True}
+
+        try:
+            response = requests.post(
+                f"{config['base_url']}/browsers",
+                headers=self._headers(config),
+                json=body,
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Kernel API connection failed: {exc}") from exc
+
+        if not response.ok:
+            raise RuntimeError(
+                f"Failed to create Kernel session: "
+                f"{response.status_code} {response.text}"
+            )
+
+        data = response.json()
+        live_view_url = data.get("browser_live_view_url")
+
+        features: Dict[str, object] = {
+            "stealth": stealth,
+            "headless": headless,
+            "custom_timeout": "timeout_seconds" in body,
+            "proxies": bool(proxy_id),
+            "profile_persistence": profile_name is not None,
+            "live_view": bool(live_view_url),
+        }
+
+        active = ", ".join(k for k, v in features.items() if v)
+        logger.info("Created Kernel session %s with features: %s", session_name, active)
+
+        result: Dict[str, object] = {
+            "session_name": session_name,
+            "bb_session_id": data["session_id"],
+            "cdp_url": data["cdp_ws_url"],
+            "features": features,
+        }
+        if live_view_url:
+            result["live_view_url"] = live_view_url
+        return result
+
+    def close_session(self, session_id: str) -> bool:
+        try:
+            config = self._get_config()
+        except ValueError:
+            logger.warning(
+                "Cannot close Kernel session %s — missing credentials", session_id
+            )
+            return False
+
+        try:
+            response = requests.delete(
+                f"{config['base_url']}/browsers/{session_id}",
+                headers=self._headers(config),
+                timeout=10,
+            )
+            if response.status_code in {200, 201, 204}:
+                logger.debug("Successfully closed Kernel session %s", session_id)
+                return True
+            logger.warning(
+                "Failed to close Kernel session %s: HTTP %s - %s",
+                session_id,
+                response.status_code,
+                response.text[:200],
+            )
+            return False
+        except Exception as e:
+            logger.error("Exception closing Kernel session %s: %s", session_id, e)
+            return False
+
+    def emergency_cleanup(self, session_id: str) -> None:
+        config = self._get_config_or_none()
+        if config is None:
+            logger.warning(
+                "Cannot emergency-cleanup Kernel session %s — missing credentials",
+                session_id,
+            )
+            return
+        try:
+            requests.delete(
+                f"{config['base_url']}/browsers/{session_id}",
+                headers=self._headers(config),
+                timeout=5,
+            )
+        except Exception as e:
+            logger.debug(
+                "Emergency cleanup failed for Kernel session %s: %s", session_id, e
+            )
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Kernel",
+            "badge": "paid",
+            "tag": "Cloud browser with stealth, proxies, and live view",
+            "env_vars": [
+                {
+                    "key": "KERNEL_API_KEY",
+                    "prompt": "Kernel API key",
+                    "url": "https://kernel.sh",
+                },
+            ],
+            "post_setup": "agent_browser",
+        }

--- a/tests/plugins/browser/test_browser_provider_plugins.py
+++ b/tests/plugins/browser/test_browser_provider_plugins.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-- All three bundled plugins (browserbase, browser-use, firecrawl)
+- All four bundled plugins (browserbase, browser-use, firecrawl, kernel)
   instantiate and self-report the expected ABC defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The browser_registry resolves an active provider in the documented
@@ -11,7 +11,7 @@ Covers:
       a typed credentials error)
     * legacy preference walk: browser-use → browserbase (filtered by
       availability)
-    * firecrawl is NOT in the legacy walk — explicit-only
+    * firecrawl and kernel are NOT in the legacy walk — explicit-only
     * unknown name falls through to auto-detect
     * ``local`` short-circuits to None
 
@@ -42,6 +42,13 @@ def _clear_browser_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
         "FIRECRAWL_BROWSER_TTL",
+        "KERNEL_API_KEY",
+        "KERNEL_STEALTH",
+        "KERNEL_HEADLESS",
+        "KERNEL_TIMEOUT_SECONDS",
+        "KERNEL_PROXY_ID",
+        "KERNEL_PROFILE",
+        "KERNEL_BASE_URL",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
     ):
@@ -72,14 +79,14 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All three bundled browser plugins discover and register correctly."""
+    """All four bundled browser plugins discover and register correctly."""
 
-    def test_all_three_plugins_present_in_registry(self) -> None:
+    def test_all_four_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.browser_registry import list_providers
 
         names = sorted(p.name for p in list_providers())
-        assert names == ["browser-use", "browserbase", "firecrawl"]
+        assert names == ["browser-use", "browserbase", "firecrawl", "kernel"]
 
     @pytest.mark.parametrize(
         "plugin_name,expected_display",
@@ -87,6 +94,7 @@ class TestBundledPluginsRegister:
             ("browserbase", "Browserbase"),
             ("browser-use", "Browser Use"),
             ("firecrawl", "Firecrawl"),
+            ("kernel", "Kernel"),
         ],
     )
     def test_each_plugin_has_name_and_display_name(
@@ -102,7 +110,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["browserbase", "browser-use", "firecrawl"],
+        ["browserbase", "browser-use", "firecrawl", "kernel"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -121,7 +129,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["browserbase", "browser-use", "firecrawl"],
+        ["browserbase", "browser-use", "firecrawl", "kernel"],
     )
     def test_each_plugin_implements_full_lifecycle(self, plugin_name: str) -> None:
         """The ABC's three lifecycle methods are all overridden."""
@@ -199,6 +207,16 @@ class TestIsAvailable:
         monkeypatch.setenv("FIRECRAWL_API_KEY", "key")
         assert p.is_available() is True
 
+    def test_kernel_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.browser_registry import get_provider
+
+        p = get_provider("kernel")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("KERNEL_API_KEY", "key")
+        assert p.is_available() is True
+
 
 # ---------------------------------------------------------------------------
 # Registry resolution semantics
@@ -244,6 +262,20 @@ class TestRegistryResolution:
         provider = _resolve("firecrawl")
         assert provider is not None
         assert provider.name == "firecrawl"
+
+    def test_explicit_kernel_returns_provider_even_when_unavailable(self) -> None:
+        """Kernel behaves the same as firecrawl under explicit config.
+
+        Returned even without credentials so the dispatcher surfaces a typed
+        "KERNEL_API_KEY is not set" error rather than silently falling back.
+        """
+        _ensure_plugins_loaded()
+        from agent.browser_registry import _resolve
+
+        provider = _resolve("kernel")
+        assert provider is not None
+        assert provider.name == "kernel"
+        assert provider.is_available() is False  # confirms "ignoring availability"
 
     def test_explicit_unknown_falls_back_to_auto_detect(self) -> None:
         """Rule 1 miss: unknown name → fall through to legacy walk."""
@@ -302,6 +334,23 @@ class TestRegistryResolution:
         # Only firecrawl is_available() — but it's not in the legacy walk.
         assert _resolve(None) is None
 
+    def test_kernel_not_in_legacy_walk_even_when_only_one_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Kernel is explicit-only — never auto-selected by the legacy walk.
+
+        Mirrors the firecrawl gate: the walk is browser-use → browserbase, so
+        a Kernel-only environment falls through to local mode unless the user
+        explicitly sets ``browser.cloud_provider: kernel``.
+        """
+        _ensure_plugins_loaded()
+        from agent.browser_registry import _resolve
+
+        monkeypatch.setenv("KERNEL_API_KEY", "k")
+
+        # Only kernel is_available() — but it's not in the legacy walk.
+        assert _resolve(None) is None
+
 
 # ---------------------------------------------------------------------------
 # Legacy ABC backward-compat aliases (is_configured / provider_name)
@@ -313,7 +362,7 @@ class TestLegacyAbcAliases:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["browserbase", "browser-use", "firecrawl"],
+        ["browserbase", "browser-use", "firecrawl", "kernel"],
     )
     def test_is_configured_delegates_to_is_available(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -329,6 +378,7 @@ class TestLegacyAbcAliases:
             ("browserbase", "Browserbase"),
             ("browser-use", "Browser Use"),
             ("firecrawl", "Firecrawl"),
+            ("kernel", "Kernel"),
         ],
     )
     def test_provider_name_returns_display_name(
@@ -348,7 +398,7 @@ class TestLegacyAbcAliases:
 
 
 class TestPickerIntegration:
-    """`_plugin_browser_providers()` exposes all three plugins as picker rows."""
+    """`_plugin_browser_providers()` exposes all four plugins as picker rows."""
 
     def test_picker_rows_match_registered_plugins(self) -> None:
         _ensure_plugins_loaded()
@@ -356,7 +406,7 @@ class TestPickerIntegration:
 
         rows = _plugin_browser_providers()
         names = sorted(r.get("browser_provider") for r in rows)
-        assert names == ["browser-use", "browserbase", "firecrawl"]
+        assert names == ["browser-use", "browserbase", "firecrawl", "kernel"]
 
     def test_picker_rows_carry_post_setup_hook(self) -> None:
         """Every browser plugin row has post_setup='agent_browser' so


### PR DESCRIPTION
## Summary

Adds a `kernel` cloud browser backend as a bundled plugin at `plugins/browser/kernel/`, alongside the existing browserbase / browser-use / firecrawl providers. It wraps [Kernel](https://kernel.sh) sandboxed Chrome via the Kernel REST API.

- Implements the full `BrowserProvider` ABC (`name`, `is_available`, `create_session`, `close_session`, `emergency_cleanup`, `get_setup_schema`) and returns the canonical session-metadata contract (`session_name` / `bb_session_id` / `cdp_url` / `features`).
- `create_session` → `POST /browsers`, returning the CDP websocket URL (`cdp_ws_url`) and session id; `close_session` / `emergency_cleanup` → `DELETE /browsers/{id}`.
- Talks to the REST API with the core `requests` dependency — no new third-party SDK — matching the existing providers and the repo's minimal-dependency policy.
- Feature knobs via env (each reflected in `features`): stealth (on by default), headless toggle, inactivity timeout, proxy, and profile persistence; surfaces a human-watchable live-view URL when non-headless.
- Selected via `browser.cloud_provider: kernel`; explicit-only — not part of the legacy browser-use → browserbase auto-detect walk (same gate as firecrawl).

## Files

- `plugins/browser/kernel/{provider.py,plugin.yaml,__init__.py}` — the plugin
- `.env.example` — documents the `KERNEL_*` env knobs
- `tests/plugins/browser/test_browser_provider_plugins.py` — extends the bundled-plugin coverage to the new provider

## Test plan

- [x] `pytest tests/plugins/browser/test_browser_provider_plugins.py` — 39 passed (new provider + existing three: registration, is_available, registry resolution / explicit-only gating, picker rows, ABC aliases)
- [x] Live end-to-end smoke test against a real `KERNEL_API_KEY`: `create_session` → connect to the returned `cdp_url` over CDP → navigate → assert title → `close_session` → confirm teardown. Passed; independently cross-checked via the Kernel control plane (session created with the requested stealth/headless/timeout and removed cleanly, no leak).
