### PR TITLE
Guard empty Bedrock Converse tool results against empty text blocks

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -644,6 +644,14 @@ def convert_messages_to_converse(
             # Tool result messages → merge into the preceding user turn
             tool_call_id = msg.get("tool_call_id", "")
             result_content = content if isinstance(content, str) else json.dumps(content)
+            # Bedrock Converse rejects empty text blocks (ValidationException:
+            # "text content blocks must be non-empty"), the same constraint
+            # _convert_content_to_converse already guards for user/assistant
+            # content (issue #9486). A tool that returns an empty string would
+            # otherwise 400 the entire request with no retry path, since the
+            # empty block is baked into every replay of the history.
+            if not result_content.strip():
+                result_content = " "
             tool_result_block = {
                 "toolResult": {
                     "toolUseId": tool_call_id,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -221,6 +221,26 @@ class TestConvertMessagesToConverse:
 # Response normalization: Converse → OpenAI
 # ---------------------------------------------------------------------------
 
+    def test_empty_tool_result_gets_placeholder(self):
+        """A tool that returns an empty string must not produce an empty text
+        block - Bedrock Converse rejects those with "text content blocks must
+        be non-empty", the same guard already applied to user/assistant
+        content (issue #9486)."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "Run it"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "call_1", "type": "function",
+                "function": {"name": "run", "arguments": "{}"},
+            }]},
+            {"role": "tool", "tool_call_id": "call_1", "content": ""},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        tr = [b for m in msgs for b in m["content"] if "toolResult" in b][0]
+        text = tr["toolResult"]["content"][0]["text"]
+        assert text != "", "empty tool result must not yield an empty text block"
+
+
 class TestNormalizeConverseResponse:
     """Test Bedrock Converse response → OpenAI format conversion."""
 


### PR DESCRIPTION
Fixes #55092

`convert_messages_to_converse` built the `toolResult` text block directly from the raw tool content with no empty-content guard:

```python
result_content = content if isinstance(content, str) else json.dumps(content)
tool_result_block = {"toolResult": {"toolUseId": ..., "content": [{"text": result_content}]}}
```

When a tool returns an empty string, this is a `{"text": ""}` block. Bedrock Converse rejects empty text blocks (`ValidationException: ... text content blocks must be non-empty`). Because the block is part of the persisted history, every replay and retry fails identically, wedging the conversation.

`_convert_content_to_converse` already guards this for user and assistant content (issue #9486), but the tool-result branch does not go through that helper and was left unguarded.

### Change

- Substitute the same non-empty placeholder the user/assistant path uses when the serialized tool result is empty or whitespace-only.

### Test

`test_empty_tool_result_gets_placeholder` converts a tool message with empty content and asserts the resulting `toolResult` text block is non-empty. It fails on the current code (the block is `{"text": ""}`) and passes with this change. The rest of `tests/agent/test_bedrock_adapter.py` continues to pass.

```
$ python -m pytest tests/agent/test_bedrock_adapter.py -q
133 passed
```
