### PR TITLE
fix(agent): classify upstream provider errors for fallback

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1187,6 +1187,13 @@ def _classify_by_error_code(
             should_fallback=True,
         )
 
+    if code_lower == "upstream_error":
+        return result_fn(
+            FailoverReason.server_error,
+            retryable=True,
+            should_fallback=True,
+        )
+
     if code_lower in {"context_length_exceeded", "max_tokens_exceeded"}:
         return result_fn(
             FailoverReason.context_overflow,

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1517,6 +1517,13 @@ def _classify_by_error_code(
             should_fallback=True,
         )
 
+    if code_lower == "upstream_error":
+        return result_fn(
+            FailoverReason.server_error,
+            retryable=True,
+            should_fallback=True,
+        )
+
     if code_lower in {"context_length_exceeded", "max_tokens_exceeded"}:
         return result_fn(
             FailoverReason.context_overflow,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -956,6 +956,16 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.model_not_found
 
+    def test_error_type_upstream_error_is_server_error(self):
+        e = MockAPIError(
+            "Upstream request failed",
+            body={"error": {"message": "Upstream request failed", "type": "upstream_error"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_fallback is True
+
     def test_error_code_context_length_exceeded(self):
         e = MockAPIError(
             "Context too large",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -534,6 +534,15 @@ class TestClassifyApiError:
 
 
 
+    def test_error_type_upstream_error_is_server_error(self):
+        e = MockAPIError(
+            "Upstream request failed",
+            body={"error": {"message": "Upstream request failed", "type": "upstream_error"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_fallback is True
 
 
     # ── Message-only patterns (no status code) ──


### PR DESCRIPTION
﻿Fixes #55096

## Summary

Classify structured provider payloads with `error.type = "upstream_error"` as Hermes' existing `server_error` failover reason instead of letting them fall through to `unknown`.

## Why

Hermes already extracts `error.type` in `_extract_error_code()`, but `_classify_by_error_code()` did not map `upstream_error`. Providers can surface transient upstream failures in this structured body shape without a reliable HTTP status code, so the classifier lost provider-error semantics and did not mark the failure as fallback-worthy.

## Scope

This only adds the `upstream_error` mapping. It does not change `model_not_found`, typo handling, 400 validation errors, or the broader retry/fallback policy.

## Validation

```powershell
New-Item -ItemType Directory -Force -Path .tmp-pytest | Out-Null
$env:TMP=(Resolve-Path .tmp-pytest).Path
$env:TEMP=$env:TMP
$env:TMPDIR=$env:TMP
C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests\agent\test_error_classifier.py -q
```

Result: `167 passed in 4.76s`

```powershell
C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check agent\error_classifier.py tests\agent\test_error_classifier.py
```

Result: `All checks passed!`

`git diff --check` also passed.
