### PR TITLE
fix(dashboard_auth): allow any http:// host in self-hosted OIDC redirect_uri

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -610,20 +610,16 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         """Fast-fail obviously-broken redirect_uris before bouncing to the IDP.
 
         The IDP's own allowlist is authoritative; this just catches the common
-        operator-error case with a clear message. Mirrors the nous provider.
+        operator-error case with a clear message. We allow any ``http://`` host
+        (not just localhost) so self-hosted dashboards reached over plain HTTP —
+        LAN IPs, internal hostnames, reverse proxies that terminate TLS upstream
+        — are not rejected here; the IDP makes the final call on which
+        redirect_uris are permitted. Mirrors the nous provider.
         """
         parsed = urllib.parse.urlparse(redirect_uri)
         if parsed.scheme not in ("https", "http"):
             raise ProviderError(
                 f"redirect_uri must be http(s), got {redirect_uri!r}"
-            )
-        if parsed.scheme == "http" and parsed.hostname not in (
-            "localhost",
-            "127.0.0.1",
-        ):
-            raise ProviderError(
-                "redirect_uri may only use http:// for localhost/127.0.0.1, "
-                f"got {redirect_uri!r}"
             )
         if not parsed.path or not parsed.path.endswith("/auth/callback"):
             raise ProviderError(

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -496,6 +496,16 @@ class TestStartLogin:
         with pytest.raises(ProviderError, match="/auth/callback"):
             provider.start_login(redirect_uri="https://x.example/oauth/cb")
 
+    def test_allows_http_with_arbitrary_host(self, provider):
+        # http:// is permitted for any host now, not just localhost — the
+        # IDP-side allowlist is authoritative on which redirect_uris are
+        # accepted; this client-side fast-fail must not reject self-hosted
+        # dashboards reached over plain HTTP (LAN IPs, internal hostnames,
+        # TLS-terminating reverse proxies). Should not raise.
+        provider.start_login(redirect_uri="http://hermes.example/auth/callback")
+        provider.start_login(redirect_uri="http://192.168.1.50:9119/auth/callback")
+        provider.start_login(redirect_uri="http://my-internal-host/auth/callback")
+
     def test_allows_http_localhost_redirect(self, provider):
         provider.start_login(redirect_uri="http://localhost:8080/auth/callback")
         provider.start_login(redirect_uri="http://127.0.0.1:8080/auth/callback")


### PR DESCRIPTION
## What does this PR do?

Fixes the self-hosted OIDC dashboard login rejecting any `http://` redirect URI whose host is not `localhost`/`127.0.0.1`. The login surfaces:

> {"detail":"Provider unreachable: redirect_uri may only use http:// for localhost/127.0.0.1, got 'http://[ip]:9119/auth/callback'"}

before the request ever reaches the IDP. This breaks legitimate self-hosted dashboards reached over plain HTTP (including LAN IPs, internal hostnames, and reverse proxies that terminate TLS upstream).

`_validate_redirect_uri` is only a **fast-fail for obvious operator error** — the IDP's own allowlist is authoritative on which redirect URIs are permitted, so the client-side check shouldn't second-guess valid `http://` deployments. #38827 already relaxed this for the **nous** provider. The generic **self-hosted** provider copied the old localhost-only branch and reintroduced the bug for `HERMES_DASHBOARD_OIDC_ISSUER` setups. This PR applies the same relaxation there.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/dashboard_auth/self_hosted/__init__.py`: dropped the localhost-only branch on the `http` scheme in `_validate_redirect_uri`. Validation now enforces only that the scheme is `http(s)` and the path ends with `/auth/callback`. Updated the docstring to explain the relaxed contract.
- `tests/plugins/dashboard_auth/test_self_hosted_provider.py`: added `test_allows_http_with_arbitrary_host` covering an internal hostname and a LAN IP, alongside the existing localhost case.

## How to Test

1. Configure the dashboard with a self-hosted OIDC issuer over plain HTTP on a non-loopback host, e.g. `HERMES_DASHBOARD_OIDC_ISSUER=https://id.example.online` and `HERMES_DASHBOARD_PUBLIC_URL=http://[ip]:9119`.
2. Before this change: starting login fails with `redirect_uri may only use http:// for localhost/127.0.0.1`. After: the redirect URI passes the client-side check and the request proceeds to the IDP.
3. Run the suite: `python -m pytest tests/plugins/dashboard_auth/test_self_hosted_provider.py -q` → all green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Unraid (Linux) v7.2.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
