### PR TITLE
feat(providers): add Cerebras model-provider plugin

### DIFF
--- a/plugins/model-providers/cerebras/__init__.py
+++ b/plugins/model-providers/cerebras/__init__.py
@@ -1,0 +1,33 @@
+"""Cerebras provider profile.
+
+Cerebras Inference is an OpenAI-compatible cloud endpoint backed by their
+wafer-scale hardware (very high tokens/sec). Auth is a ``csk-…`` bearer key
+on ``https://api.cerebras.ai/v1``; the standard ``/v1/models`` and
+``/v1/chat/completions`` routes apply, so the default ``chat_completions``
+transport handles it with no per-provider quirks.
+
+Model entitlement is per-account — ``GET /v1/models`` returns only the ids the
+key may use — so the live discovery path drives the picker; ``fallback_models``
+below is just the offline catalog (mirrors models.dev's Cerebras entry).
+"""
+
+from __future__ import annotations
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+cerebras = ProviderProfile(
+    name="cerebras",
+    env_vars=("CEREBRAS_API_KEY", "CEREBRAS_BASE_URL"),
+    base_url="https://api.cerebras.ai/v1",
+    display_name="Cerebras",
+    description="Cerebras — wafer-scale OpenAI-compatible inference",
+    signup_url="https://cloud.cerebras.ai/",
+    fallback_models=(
+        "gpt-oss-120b",
+        "zai-glm-4.7",
+    ),
+    default_aux_model="gpt-oss-120b",
+)
+
+register_provider(cerebras)

--- a/plugins/model-providers/cerebras/plugin.yaml
+++ b/plugins/model-providers/cerebras/plugin.yaml
@@ -1,0 +1,5 @@
+name: cerebras-provider
+kind: model-provider
+version: 1.0.0
+description: Cerebras — wafer-scale OpenAI-compatible inference
+author: TheStonedGamer

--- a/tests/providers/test_cerebras_profile.py
+++ b/tests/providers/test_cerebras_profile.py
@@ -1,0 +1,45 @@
+"""Cerebras provider profile wiring.
+
+Asserts the bundled ``plugins/model-providers/cerebras/`` profile registers
+with the expected OpenAI-compatible endpoint, API-key env var, and offline
+catalog. Registration itself is covered generically by test_plugin_discovery;
+this pins the Cerebras-specific values so a typo in the endpoint or env var
+fails CI rather than silently routing to the wrong place.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def _rediscover() -> None:
+    """Force providers/__init__.py to re-scan on the next lookup."""
+    import providers as _pkg
+
+    _pkg._REGISTRY.clear()
+    _pkg._ALIASES.clear()
+    _pkg._discovered = False
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("plugins.model_providers") or mod.startswith(
+            "_hermes_user_provider"
+        ):
+            del sys.modules[mod]
+
+
+def test_cerebras_profile_registered() -> None:
+    _rediscover()
+    from providers import get_provider_profile
+
+    p = get_provider_profile("cerebras")
+    assert p is not None, "cerebras profile not discovered"
+    assert p.name == "cerebras"
+    assert p.base_url == "https://api.cerebras.ai/v1"
+    assert p.api_mode == "chat_completions"
+    assert p.auth_type == "api_key"
+    assert "CEREBRAS_API_KEY" in p.env_vars
+    # Offline catalog mirrors models.dev's Cerebras entry; the live
+    # /v1/models probe (per-account entitlement) overrides it at runtime.
+    assert "gpt-oss-120b" in p.fallback_models
+    assert p.default_aux_model in p.fallback_models
+
+    _rediscover()


### PR DESCRIPTION
## What

Adds **Cerebras Inference** as a first-class model provider via a self-contained
`plugins/model-providers/cerebras/` profile (the same pattern as `deepseek/`,
`novita/`, etc.). Per the plugin README, this auto-wires into `auth.py`,
`config.py`, `models.py`, `doctor.py`, `runtime_provider.py`, the `/model`
picker, and the `chat_completions` transport — no core edits required.

Cerebras is a plain OpenAI-compatible endpoint (`https://api.cerebras.ai/v1`,
`csk-…` bearer key, standard `/v1/models` + `/v1/chat/completions`), so the
default transport handles it with no per-provider quirks.

## Why

Before this, Cerebras was only reachable by hand-writing a `providers:` /
`custom_providers:` block in `config.yaml` per machine. It's referenced in code
comments and tests but was never registered, so it didn't appear in the `/model`
picker or `hermes model`. This makes it a built-in option.

## Notes

- Model entitlement on Cerebras is **per-account** — `GET /v1/models` returns
  only the ids a key may use — so live discovery drives the picker. `fallback_models`
  mirrors the current models.dev Cerebras catalog (`gpt-oss-120b`, `zai-glm-4.7`)
  for the offline path.
- `CEREBRAS_API_KEY` (and optional `CEREBRAS_BASE_URL`) are the env vars.

## Test

`tests/providers/test_cerebras_profile.py` pins the Cerebras-specific wiring
(endpoint, env var, `api_mode`, fallback catalog). Generic registration is already
covered by `tests/providers/test_plugin_discovery.py`'s invariants. Verified the
profile discovers, lists its models live, and a model switch routes with the
correct `base_url` + key + `chat_completions` mode.
