### PR TITLE
fix(auth): cap password-login rate limiter buckets

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from collections import defaultdict, deque
+from collections import OrderedDict, deque
 from typing import Any, Deque, Dict, Tuple
 
 from fastapi import APIRouter, HTTPException, Request
@@ -415,8 +415,22 @@ def _validate_post_login_target(raw: str) -> str:
 
 _PW_RATE_MAX_ATTEMPTS = 10
 _PW_RATE_WINDOW_SEC = 60.0
-_pw_attempts: Dict[str, Deque[float]] = defaultdict(deque)
+_PW_RATE_MAX_BUCKETS = 4096
+_pw_attempts: "OrderedDict[str, Deque[float]]" = OrderedDict()
 _pw_attempts_lock = threading.Lock()
+
+
+def _prune_password_rate_buckets_locked(cutoff: float) -> None:
+    """Drop expired/empty password-login limiter buckets.
+
+    Must be called with ``_pw_attempts_lock`` held.
+    """
+    for bucket_key in list(_pw_attempts.keys()):
+        bucket = _pw_attempts[bucket_key]
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if not bucket:
+            _pw_attempts.pop(bucket_key, None)
 
 
 def _password_rate_limited(ip: str) -> bool:
@@ -432,7 +446,18 @@ def _password_rate_limited(ip: str) -> bool:
     cutoff = now - _PW_RATE_WINDOW_SEC
     key = ip or "_unknown_"
     with _pw_attempts_lock:
-        bucket = _pw_attempts[key]
+        max_buckets = max(1, int(_PW_RATE_MAX_BUCKETS))
+        if key not in _pw_attempts and len(_pw_attempts) >= max_buckets:
+            _prune_password_rate_buckets_locked(cutoff)
+        while key not in _pw_attempts and len(_pw_attempts) >= max_buckets:
+            _pw_attempts.popitem(last=False)
+
+        bucket = _pw_attempts.get(key)
+        if bucket is None:
+            bucket = deque()
+            _pw_attempts[key] = bucket
+        else:
+            _pw_attempts.move_to_end(key)
         while bucket and bucket[0] < cutoff:
             bucket.popleft()
         if len(bucket) >= _PW_RATE_MAX_ATTEMPTS:

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from collections import defaultdict, deque
+from collections import OrderedDict, deque
 from typing import Any, Deque, Dict
 
 from fastapi import APIRouter, HTTPException, Request
@@ -625,8 +625,22 @@ def _validate_post_login_target(raw: str) -> str:
 
 _PW_RATE_MAX_ATTEMPTS = 10
 _PW_RATE_WINDOW_SEC = 60.0
-_pw_attempts: Dict[str, Deque[float]] = defaultdict(deque)
+_PW_RATE_MAX_BUCKETS = 4096
+_pw_attempts: "OrderedDict[str, Deque[float]]" = OrderedDict()
 _pw_attempts_lock = threading.Lock()
+
+
+def _prune_password_rate_buckets_locked(cutoff: float) -> None:
+    """Drop expired/empty password-login limiter buckets.
+
+    Must be called with ``_pw_attempts_lock`` held.
+    """
+    for bucket_key in list(_pw_attempts.keys()):
+        bucket = _pw_attempts[bucket_key]
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if not bucket:
+            _pw_attempts.pop(bucket_key, None)
 
 
 def _password_rate_limited(ip: str) -> bool:
@@ -642,7 +656,18 @@ def _password_rate_limited(ip: str) -> bool:
     cutoff = now - _PW_RATE_WINDOW_SEC
     key = ip or "_unknown_"
     with _pw_attempts_lock:
-        bucket = _pw_attempts[key]
+        max_buckets = max(1, int(_PW_RATE_MAX_BUCKETS))
+        if key not in _pw_attempts and len(_pw_attempts) >= max_buckets:
+            _prune_password_rate_buckets_locked(cutoff)
+        while key not in _pw_attempts and len(_pw_attempts) >= max_buckets:
+            _pw_attempts.popitem(last=False)
+
+        bucket = _pw_attempts.get(key)
+        if bucket is None:
+            bucket = deque()
+            _pw_attempts[key] = bucket
+        else:
+            _pw_attempts.move_to_end(key)
         while bucket and bucket[0] < cutoff:
             bucket.popleft()
         if len(bucket) >= _PW_RATE_MAX_ATTEMPTS:

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -28,6 +28,7 @@ from hermes_cli.dashboard_auth import (
     clear_providers,
     register_provider,
 )
+from hermes_cli.dashboard_auth import routes as auth_routes
 from hermes_cli.dashboard_auth.cookies import SESSION_AT_COOKIE, SESSION_RT_COOKIE
 from hermes_cli.dashboard_auth.login_page import render_login_html
 from hermes_cli.dashboard_auth.routes import _reset_password_rate_limit
@@ -392,6 +393,34 @@ class TestRateLimit:
             json={"provider": "testpw", "username": "admin", "password": "hunter2"},
         )
         assert good.status_code == 429
+
+    def test_distinct_ip_buckets_are_capped(self, monkeypatch):
+        _reset_password_rate_limit()
+        monkeypatch.setattr(auth_routes, "_PW_RATE_MAX_BUCKETS", 3)
+
+        for i in range(5):
+            assert auth_routes._password_rate_limited(f"192.0.2.{i}") is False
+
+        assert list(auth_routes._pw_attempts.keys()) == [
+            "192.0.2.2",
+            "192.0.2.3",
+            "192.0.2.4",
+        ]
+
+    def test_expired_buckets_pruned_before_evicting_live_bucket(self, monkeypatch):
+        _reset_password_rate_limit()
+        monkeypatch.setattr(auth_routes, "_PW_RATE_MAX_BUCKETS", 2)
+        now = time.monotonic()
+        auth_routes._pw_attempts["expired"] = auth_routes.deque([
+            now - auth_routes._PW_RATE_WINDOW_SEC - 1,
+        ])
+        auth_routes._pw_attempts["live"] = auth_routes.deque([now])
+
+        assert auth_routes._password_rate_limited("192.0.2.99") is False
+
+        assert "expired" not in auth_routes._pw_attempts
+        assert "live" in auth_routes._pw_attempts
+        assert "192.0.2.99" in auth_routes._pw_attempts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -28,6 +28,7 @@ from hermes_cli.dashboard_auth import (
     clear_providers,
     register_provider,
 )
+from hermes_cli.dashboard_auth import routes as auth_routes
 from hermes_cli.dashboard_auth.cookies import SESSION_AT_COOKIE, SESSION_RT_COOKIE
 from hermes_cli.dashboard_auth.login_page import render_login_html
 from hermes_cli.dashboard_auth.routes import _reset_password_rate_limit
@@ -336,6 +337,34 @@ class TestRateLimit:
             json={"provider": "testpw", "username": "admin", "password": "hunter2"},
         )
         assert good.status_code == 429
+
+    def test_distinct_ip_buckets_are_capped(self, monkeypatch):
+        _reset_password_rate_limit()
+        monkeypatch.setattr(auth_routes, "_PW_RATE_MAX_BUCKETS", 3)
+
+        for i in range(5):
+            assert auth_routes._password_rate_limited(f"192.0.2.{i}") is False
+
+        assert list(auth_routes._pw_attempts.keys()) == [
+            "192.0.2.2",
+            "192.0.2.3",
+            "192.0.2.4",
+        ]
+
+    def test_expired_buckets_pruned_before_evicting_live_bucket(self, monkeypatch):
+        _reset_password_rate_limit()
+        monkeypatch.setattr(auth_routes, "_PW_RATE_MAX_BUCKETS", 2)
+        now = time.monotonic()
+        auth_routes._pw_attempts["expired"] = auth_routes.deque([
+            now - auth_routes._PW_RATE_WINDOW_SEC - 1,
+        ])
+        auth_routes._pw_attempts["live"] = auth_routes.deque([now])
+
+        assert auth_routes._password_rate_limited("192.0.2.99") is False
+
+        assert "expired" not in auth_routes._pw_attempts
+        assert "live" in auth_routes._pw_attempts
+        assert "192.0.2.99" in auth_routes._pw_attempts
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
﻿## Summary

Fixes #55101.

Caps the in-process `/auth/password-login` rate-limiter bookkeeping so distinct client IPs cannot grow `_pw_attempts` without bound.

## What changed

- Replaced the password-login limiter bucket map with an `OrderedDict`.
- Added a 4096-bucket cap.
- Before evicting, prune expired/empty buckets across the table.
- When still at capacity, evict the oldest bucket only for new client keys.
- Keep the existing 10 attempts / 60 seconds per-IP behavior unchanged.

## Validation

- `python -m pytest tests\hermes_cli\test_dashboard_auth_password_login.py -q`
  - `21 passed in 4.37s`
- `python -m ruff check hermes_cli\dashboard_auth\routes.py tests\hermes_cli\test_dashboard_auth_password_login.py`
  - `All checks passed!`
- `git diff --check`
  - passed

## Non-goals

This does not add a persistent/distributed rate limiter, change cookie/session behavior, or alter the password provider contract. It only bounds the existing process-local limiter's memory footprint.
