### PR TITLE
feat(models): show /v1/models display_name in picker & status line

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -884,6 +884,23 @@ def fetch_endpoint_model_metadata(
     return {}
 
 
+def get_cached_endpoint_model_metadata(base_url: str) -> Dict[str, Dict[str, Any]]:
+    """Return already-cached ``/models`` metadata for ``base_url`` without fetching.
+
+    Cache-only counterpart to :func:`fetch_endpoint_model_metadata` for hot paths
+    (e.g. session-info polling) that must never issue a blocking network call.
+    Returns ``{}`` on a cache miss or when the cached entry has expired.
+    """
+    normalized = _normalize_base_url(base_url)
+    if not normalized or _is_openrouter_base_url(normalized):
+        return {}
+    cached = _endpoint_model_metadata_cache.get(normalized)
+    cached_at = _endpoint_model_metadata_cache_time.get(normalized, 0)
+    if cached is not None and (time.time() - cached_at) < _ENDPOINT_MODEL_CACHE_TTL:
+        return cached
+    return {}
+
+
 def _resolve_endpoint_context_length(
     model: str,
     base_url: str,

--- a/cli.py
+++ b/cli.py
@@ -7523,6 +7523,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Only fall back to the live provider catalog when the curated
             # list is empty (e.g. user-defined endpoints with no curated list).
             model_list = provider_data.get("models", [])
+            model_labels = {}
             if not model_list:
                 try:
                     from hermes_cli.models import provider_model_ids
@@ -7531,9 +7532,36 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         model_list = live
                 except Exception:
                     pass
+            # Fetch display names from /v1/models for custom providers
+            _base = provider_data.get("base_url") or getattr(self, "base_url", "")
+            if _base and model_list:
+                try:
+                    import urllib.request, json as _j
+                    _url = _base.rstrip("/").removesuffix("/v1") + "/v1/models"
+                    _req = urllib.request.Request(_url, headers={"Accept": "application/json"})
+                    _api_key = provider_data.get("api_key") or getattr(self, "api_key", "")
+                    if _api_key:
+                        _req.add_header("Authorization", f"Bearer {_api_key}")
+                    with urllib.request.urlopen(_req, timeout=3) as _resp:
+                        _data = _j.loads(_resp.read().decode())
+                        for _m in _data.get("data", []):
+                            _mid = _m.get("id", "")
+                            _label = _m.get("display_name") or _m.get("name")
+                            if _mid and _label and _label != _mid:
+                                model_labels[_mid] = _label
+                except Exception:
+                    pass
+            if model_labels:
+                import re as _re
+                def _size_key(mid):
+                    _l = model_labels.get(mid, "")
+                    _match = _re.search(r'\((\d+)GB\)', _l)
+                    return -(int(_match.group(1))) if _match else 0
+                model_list = sorted(model_list, key=_size_key)
             state["stage"] = "model"
             state["provider_data"] = provider_data
             state["model_list"] = model_list
+            state["model_labels"] = model_labels
             state["selected"] = 0
             self._invalidate(min_interval=0.0)
             return
@@ -14130,8 +14158,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             else:
                 provider_data = state.get("provider_data") or {}
                 model_list = state.get("model_list") or []
+                _ml = state.get("model_labels") or {}
                 title = f"⚙ Model Picker — {provider_data.get('name', provider_data.get('slug', 'Provider'))}"
-                choices = list(model_list) + ["← Back", "Cancel"]
+                choices = [_ml.get(m, m) for m in model_list] + ["← Back", "Cancel"]
                 if model_list:
                     hint = f"Select a model ({len(model_list)} available)"
                 else:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1979,10 +1979,13 @@ def list_authenticated_providers(
             should_probe = bool(api_url) and discover and (
                 bool(api_key) or not has_explicit_models
             )
+            live_labels: dict[str, str] = {}
             if should_probe:
                 try:
-                    from hermes_cli.models import fetch_api_models
-                    live_models = fetch_api_models(api_key, api_url)
+                    from hermes_cli.models import probe_api_models
+                    probe = probe_api_models(api_key, api_url)
+                    live_models = probe.get("models")
+                    live_labels = probe.get("model_labels") or {}
                     if live_models:
                         models_list = live_models
                 except Exception:
@@ -1994,6 +1997,7 @@ def list_authenticated_providers(
                 "is_current": ep_name == current_provider,
                 "is_user_defined": True,
                 "models": models_list,
+                "model_labels": live_labels,
                 "total_models": len(models_list) if models_list else 0,
                 "source": "user-config",
                 "api_url": api_url,
@@ -2225,11 +2229,14 @@ def list_authenticated_providers(
                 and (bool(api_key) or not grp["models"])
                 and grp.get("discover_models", True)
             )
+            live_labels: dict[str, str] = {}
             if should_probe:
                 try:
-                    from hermes_cli.models import fetch_api_models
+                    from hermes_cli.models import probe_api_models
 
-                    live_models = fetch_api_models(api_key, api_url)
+                    probe = probe_api_models(api_key, api_url)
+                    live_models = probe.get("models")
+                    live_labels = probe.get("model_labels") or {}
                     if live_models:
                         grp["models"] = live_models
                         grp["total_models"] = len(live_models)
@@ -2246,6 +2253,7 @@ def list_authenticated_providers(
                 ),
                 "is_user_defined": True,
                 "models": grp["models"],
+                "model_labels": live_labels,
                 "total_models": len(grp["models"]),
                 "source": "user-config",
                 "api_url": grp["api_url"],

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3460,8 +3460,16 @@ def probe_api_models(
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
+                _entries = data.get("data", [])
+                _labels: dict[str, str] = {}
+                for _m in _entries:
+                    _mid = _m.get("id", "")
+                    _label = _m.get("display_name") or _m.get("name")
+                    if _mid and _label and _label != _mid:
+                        _labels[_mid] = _label
                 return {
-                    "models": [m.get("id", "") for m in data.get("data", [])],
+                    "models": [m.get("id", "") for m in _entries],
+                    "model_labels": _labels,
                     "probed_url": url,
                     "resolved_base_url": candidate_base.rstrip("/"),
                     "suggested_base_url": alternate_base if alternate_base != candidate_base else normalized,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3091,6 +3091,24 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "profile_name": _current_profile_name(),
     }
     try:
+        # Opportunistic server-driven model label: read the memo-cached
+        # /v1/models metadata for the agent's endpoint and prefer the
+        # human-readable ``name`` when it differs from the raw model id.
+        _model_id = str(getattr(agent, "model", "") or "")
+        _base_url = str(getattr(agent, "base_url", "") or "")
+        if _model_id and _base_url:
+            from agent.model_metadata import fetch_endpoint_model_metadata
+
+            _meta = fetch_endpoint_model_metadata(
+                _base_url, getattr(agent, "api_key", "") or ""
+            )
+            _entry = (_meta or {}).get(_model_id) or {}
+            _name = str(_entry.get("name") or "")
+            if _name and _name != _model_id:
+                info["model_label"] = _name
+    except Exception:
+        pass
+    try:
         from hermes_cli import __version__, __release_date__
 
         info["version"] = __version__

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3097,11 +3097,12 @@ def _session_info(agent, session: dict | None = None) -> dict:
         _model_id = str(getattr(agent, "model", "") or "")
         _base_url = str(getattr(agent, "base_url", "") or "")
         if _model_id and _base_url:
-            from agent.model_metadata import fetch_endpoint_model_metadata
+            from agent.model_metadata import get_cached_endpoint_model_metadata
 
-            _meta = fetch_endpoint_model_metadata(
-                _base_url, getattr(agent, "api_key", "") or ""
-            )
+            # Cache-only: session.info is a hot path, so never trigger a
+            # blocking network fetch here. On a cache miss we omit
+            # ``model_label`` and the TUI falls back to the raw model id.
+            _meta = get_cached_endpoint_model_metadata(_base_url)
             _entry = (_meta or {}).get(_model_id) or {}
             _name = str(_entry.get("name") or "")
             if _name and _name != _model_id:

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -374,8 +374,10 @@ const shortModelLabel = (model: string) =>
     .replace(/\b(\d+)\s+(\d+)\b/g, '$1.$2')
     .trim()
 
-const modelLabel = (model: string, effort?: string, fast?: boolean) =>
-  [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
+const modelLabel = (model: string, effort?: string, fast?: boolean, serverLabel?: string) =>
+  // Prefer the server-provided /v1/models label verbatim when present;
+  // otherwise prettify the raw id via shortModelLabel.
+  [serverLabel?.trim() || shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
 
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
@@ -410,6 +412,7 @@ export function StatusRule({
   statusColor,
   model,
   modelFast,
+  modelLabelOverride,
   modelReasoningEffort,
   indicatorStyle = 'kaomoji',
   notice,
@@ -438,7 +441,7 @@ export function StatusRule({
       : ''
 
   const bar = !segs.compactCtx && usage.context_max ? ctxBar(pct) : ''
-  const modelText = modelLabel(model, modelReasoningEffort, modelFast)
+  const modelText = modelLabel(model, modelReasoningEffort, modelFast, modelLabelOverride)
 
   // A credits notice replaces the status/verb slot, but only when idle —
   // while busy the FaceTicker always wins (R1 render priority). The notice
@@ -778,6 +781,7 @@ interface StatusRuleProps {
   cwdLabel: string
   model: string
   modelFast?: boolean
+  modelLabelOverride?: string
   modelReasoningEffort?: string
   indicatorStyle?: IndicatorStyle
   notice?: Notice | null

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -405,6 +405,7 @@ const StatusRulePane = memo(function StatusRulePane({
         liveSessionCount={ui.liveSessionCount}
         model={ui.info?.model ?? ''}
         modelFast={ui.info?.fast || ui.info?.service_tier === 'priority'}
+        modelLabelOverride={ui.info?.model_label}
         modelReasoningEffort={ui.info?.reasoning_effort}
         notice={ui.notice}
         onSessionCountClick={() => patchOverlayState({ sessions: true })}

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -103,8 +103,8 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
       return allModels
     }
 
-    return fuzzyRank(allModels, filter, m => m).map(r => r.item)
-  }, [allModels, filter, stage])
+    return fuzzyRank(allModels, filter, m => `${m} ${provider?.model_labels?.[m] ?? ''}`).map(r => r.item)
+  }, [allModels, filter, stage, provider])
 
   const models = filteredModels
 
@@ -606,6 +606,7 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
         }
 
         const prefix = modelIdx === idx ? '▸ ' : row === currentModel ? '* ' : '  '
+        const label = provider?.model_labels?.[row] ?? row
 
         return (
           <Text
@@ -616,7 +617,7 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
             wrap="truncate-end"
           >
             {prefix}
-            {idx + 1}. {row}
+            {idx + 1}. {label}
           </Text>
         )
       })}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -475,6 +475,7 @@ export interface ModelOptionProvider {
   is_current?: boolean
   key_env?: string
   models?: string[]
+  model_labels?: Record<string, string>
   name: string
   slug: string
   total_models?: number

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -153,6 +153,7 @@ export interface SessionInfo {
   lazy?: boolean
   mcp_servers?: McpServerStatus[]
   model: string
+  model_label?: string
   profile_name?: string
   reasoning_effort?: string
   release_date?: string


### PR DESCRIPTION
Opportunistic, backward-compatible: providers expose a parallel `model_labels` map (id→label) sourced from each `/v1/models` entry's `display_name`/`name`; the picker and status line prefer the label and fall back to `id`. No hardcoded model→label map, no config flag, fully server-driven. `providers[].models` stays `string[]` so existing consumers are unaffected. `tsc` typecheck + StatusRule tests pass. Draft for discussion.