### PR TITLE
Add native non-dispatched Kanban task capability

### DIFF
--- a/docs/native-non-dispatched-kanban-task-capability.md
+++ b/docs/native-non-dispatched-kanban-task-capability.md
@@ -1,0 +1,49 @@
+# Native non-dispatched Kanban task capability
+
+This document records the native implementation of the local contract proven in AION governance PR #598 / issue #595.
+
+## Capability
+
+`hermes_kanban_create_non_dispatched_task` is exposed through the structured `kanban_create` tool when callers set:
+
+- `initial_status: todo` or `initial_status: ready`
+- `no_dispatch: true`
+- `correlation_key: <stable exactly-one key>`
+- `body` or `metadata` carrying `audit_task_contract.v1`
+
+The ordinary `kanban_create` behavior for `running` / `blocked` remains unchanged.
+
+## Native proof returned
+
+The no-dispatch path returns a `proof` object containing:
+
+- `task_id`
+- `assignee`
+- `status`
+- `metadata`
+- `no_dispatch`
+- `correlation_key`
+- `read_after_create_verified`
+- `worker_execution_started: false`
+- `dispatcher_pickup_count: 0`
+
+## Fail-closed rules
+
+The native path rejects:
+
+- `running` as a substitute for `ready`
+- `blocked` as a substitute for `todo`
+- missing or false `no_dispatch`
+- missing `correlation_key`
+- duplicate non-archived `correlation_key`
+- GitHub comment / regex / timeout verdict sources
+- direct DB write markers as a contract-satisfying integration path
+- dispatch leakage observed during read-after-create
+
+## Dispatch suppression
+
+The dispatcher claim path refuses to transition tasks with `no_dispatch=1` from `ready` to `running`; this preserves `ready` as a non-dispatched audit-queue state for this capability.
+
+## Boundary
+
+This implementation does not itself authorize live task creation by any AION workflow, Batch 9 retry, deployment, dispatcher/controller/cron startup, production readiness claims, or Flow OS DONE.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -101,6 +101,25 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+VALID_NON_DISPATCHED_INITIAL_STATUSES = {"todo", "ready"}
+NON_DISPATCHED_CAPABILITY_NAME = "hermes_kanban_create_non_dispatched_task"
+FORBIDDEN_NON_DISPATCHED_STATUS_SUBSTITUTES = {
+    "running": "running cannot be used or interpreted as ready",
+    "blocked": "blocked cannot be used or interpreted as todo",
+}
+FORBIDDEN_NON_DISPATCHED_VERDICT_SOURCES = {
+    "github_comment_regex",
+    "github_comment",
+    "regex",
+    "timeout",
+    "fallback_request",
+    "owner_nudge",
+}
+FORBIDDEN_NON_DISPATCHED_INTEGRATION_PATHS = {
+    "direct_db_write",
+    "kanban_db_direct_write",
+    "db_write_primary_path",
+}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -914,6 +933,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    task_metadata: Optional[dict] = None
+    no_dispatch: bool = False
+    correlation_key: Optional[str] = None
+    dispatcher_pickup_count: int = 0
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -927,6 +950,14 @@ class Task:
                     skills_value = [str(s) for s in parsed if s]
             except Exception:
                 skills_value = None
+        task_metadata_value: Optional[dict] = None
+        if "task_metadata" in keys and row["task_metadata"]:
+            try:
+                parsed_metadata = json.loads(row["task_metadata"])
+                if isinstance(parsed_metadata, dict):
+                    task_metadata_value = parsed_metadata
+            except Exception:
+                task_metadata_value = None
         return cls(
             id=row["id"],
             title=row["title"],
@@ -996,6 +1027,14 @@ class Task:
             block_recurrences=(
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
+                else 0
+            ),
+            task_metadata=task_metadata_value,
+            no_dispatch=(bool(row["no_dispatch"]) if "no_dispatch" in keys and row["no_dispatch"] else False),
+            correlation_key=(row["correlation_key"] if "correlation_key" in keys and row["correlation_key"] else None),
+            dispatcher_pickup_count=(
+                int(row["dispatcher_pickup_count"])
+                if "dispatcher_pickup_count" in keys and row["dispatcher_pickup_count"] is not None
                 else 0
             ),
         )
@@ -1175,7 +1214,14 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Native non-dispatched task capability (#595): optional metadata used
+    -- only when no_dispatch=1. Normal running/blocked task creation remains
+    -- unchanged and leaves these NULL/0.
+    task_metadata       TEXT,
+    no_dispatch         INTEGER NOT NULL DEFAULT 0,
+    correlation_key     TEXT,
+    dispatcher_pickup_count INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1867,6 +1913,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
         )
+    if "task_metadata" not in cols:
+        _add_column_if_missing(conn, "tasks", "task_metadata", "task_metadata TEXT")
+    if "no_dispatch" not in cols:
+        _add_column_if_missing(conn, "tasks", "no_dispatch", "no_dispatch INTEGER NOT NULL DEFAULT 0")
+    if "correlation_key" not in cols:
+        _add_column_if_missing(conn, "tasks", "correlation_key", "correlation_key TEXT")
+    if "dispatcher_pickup_count" not in cols:
+        _add_column_if_missing(conn, "tasks", "dispatcher_pickup_count", "dispatcher_pickup_count INTEGER NOT NULL DEFAULT 0")
     # ``idx_tasks_idempotency`` is created unconditionally below alongside
     # the other additive-column indexes — see the block after the
     # legacy-column migration. Creating it here too would be redundant.
@@ -1996,6 +2050,9 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_tenant ON tasks(tenant)")
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_correlation_key ON tasks(correlation_key)"
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
@@ -2687,6 +2744,173 @@ def create_task(
             # Retry with a fresh id.
             continue
     raise RuntimeError("unreachable")
+
+
+def _normalize_task_metadata(metadata: Optional[dict]) -> dict:
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, dict):
+        raise ValueError("metadata must be an object")
+    return json.loads(json.dumps(metadata))
+
+
+def _carries_audit_task_contract(body: Optional[str], metadata: dict) -> bool:
+    contract_from_metadata = metadata.get("audit_task_contract")
+    return (
+        isinstance(contract_from_metadata, dict)
+        and contract_from_metadata.get("schema_version") == "audit_task_contract.v1"
+    ) or (isinstance(body, str) and "audit_task_contract.v1" in body)
+
+
+def create_non_dispatched_task(
+    conn: sqlite3.Connection,
+    *,
+    title: str,
+    body: Optional[str],
+    assignee: str,
+    initial_status: str,
+    no_dispatch: bool,
+    correlation_key: str,
+    metadata: Optional[dict] = None,
+    created_by: Optional[str] = None,
+    tenant: Optional[str] = None,
+    priority: int = 0,
+    audit_verdict_source: Optional[str] = None,
+    created_via: Optional[str] = None,
+    direct_db_write: bool = False,
+    session_id: Optional[str] = None,
+) -> dict:
+    """Create a native non-dispatched task and return read-after-create proof.
+
+    This is the production wiring for the #595 / PR #598 contract. It is a
+    separate path from ordinary ``create_task`` so legacy running/blocked
+    dispatch semantics remain unchanged.
+    """
+    if not title or not str(title).strip():
+        raise ValueError("title is required")
+    assignee = _canonical_assignee(assignee)
+    if not assignee:
+        raise ValueError("assignee is required")
+    if initial_status in FORBIDDEN_NON_DISPATCHED_STATUS_SUBSTITUTES:
+        raise ValueError(FORBIDDEN_NON_DISPATCHED_STATUS_SUBSTITUTES[initial_status])
+    if initial_status not in VALID_NON_DISPATCHED_INITIAL_STATUSES:
+        raise ValueError("initial_status must be exactly todo or ready for non-dispatched capability")
+    if no_dispatch is not True:
+        raise ValueError("no_dispatch must be true for non-dispatched capability")
+    if not correlation_key or not str(correlation_key).strip():
+        raise ValueError("correlation_key is required for exactly-one-task guard")
+    correlation_key = str(correlation_key).strip()
+    if direct_db_write or created_via in FORBIDDEN_NON_DISPATCHED_INTEGRATION_PATHS:
+        raise ValueError("direct Kanban DB write cannot satisfy native integration contract")
+    if audit_verdict_source in FORBIDDEN_NON_DISPATCHED_VERDICT_SOURCES:
+        raise ValueError("GitHub comment / regex / timeout cannot produce audit verdict")
+    if body is not None and not isinstance(body, str):
+        raise ValueError("body must be a string when provided")
+    normalized_metadata = _normalize_task_metadata(metadata)
+    if not _carries_audit_task_contract(body, normalized_metadata):
+        raise ValueError("body or metadata must carry audit_task_contract.v1")
+
+    existing = conn.execute(
+        "SELECT id FROM tasks WHERE correlation_key = ? AND status != 'archived' LIMIT 1",
+        (correlation_key,),
+    ).fetchone()
+    if existing:
+        raise ValueError(
+            "exactly-one-task guard rejected duplicate correlation_key; "
+            f"existing_task_id={existing['id']}"
+        )
+
+    now = int(time.time())
+    task_id = _new_task_id()
+    with write_txn(conn):
+        # Re-check inside the write transaction so duplicate retries fail before
+        # the second task is inserted, even if another creator won the race.
+        existing = conn.execute(
+            "SELECT id FROM tasks WHERE correlation_key = ? AND status != 'archived' LIMIT 1",
+            (correlation_key,),
+        ).fetchone()
+        if existing:
+            raise ValueError(
+                "exactly-one-task guard rejected duplicate correlation_key; "
+                f"existing_task_id={existing['id']}"
+            )
+        conn.execute(
+            """
+            INSERT INTO tasks (
+                id, title, body, assignee, status, priority,
+                created_by, created_at, workspace_kind, tenant, session_id,
+                task_metadata, no_dispatch, correlation_key, dispatcher_pickup_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'scratch', ?, ?, ?, 1, ?, 0)
+            """,
+            (
+                task_id,
+                title.strip(),
+                body,
+                assignee,
+                initial_status,
+                int(priority),
+                created_by,
+                now,
+                tenant,
+                session_id,
+                json.dumps(normalized_metadata, sort_keys=True),
+                correlation_key,
+            ),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "created_non_dispatched",
+            {
+                "assignee": assignee,
+                "status": initial_status,
+                "no_dispatch": True,
+                "correlation_key": correlation_key,
+            },
+        )
+    return read_after_create_non_dispatched_task(
+        conn,
+        task_id,
+        expected_assignee=assignee,
+        expected_status=initial_status,
+        expected_metadata=normalized_metadata,
+    )
+
+
+def read_after_create_non_dispatched_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_assignee: Optional[str] = None,
+    expected_status: Optional[str] = None,
+    expected_metadata: Optional[dict] = None,
+) -> dict:
+    task = get_task(conn, task_id)
+    if task is None:
+        raise ValueError("read-after-create could not find task_id")
+    if not task.no_dispatch:
+        raise ValueError("read-after-create no_dispatch mismatch")
+    if task.current_run_id is not None or task.worker_pid is not None or task.claim_lock is not None:
+        raise ValueError("no_dispatch invariant failed: worker execution or claim observed")
+    if task.dispatcher_pickup_count != 0:
+        raise ValueError("no_dispatch invariant failed: dispatcher pickup observed")
+    if expected_assignee is not None and task.assignee != expected_assignee:
+        raise ValueError("read-after-create assignee mismatch")
+    if expected_status is not None and task.status != expected_status:
+        raise ValueError("read-after-create status mismatch")
+    if expected_metadata is not None and task.task_metadata != expected_metadata:
+        raise ValueError("read-after-create metadata mismatch")
+    return {
+        "task_id": task.id,
+        "assignee": task.assignee,
+        "status": task.status,
+        "metadata": task.task_metadata,
+        "no_dispatch": task.no_dispatch,
+        "correlation_key": task.correlation_key,
+        "read_after_create_verified": True,
+        "worker_execution_started": False,
+        "dispatcher_pickup_count": task.dispatcher_pickup_count,
+    }
 
 
 def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> list[str]:
@@ -3440,6 +3664,7 @@ def claim_task(
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
+               AND COALESCE(no_dispatch, 0) = 0
             """,
             (lock, expires, now, task_id),
         )

--- a/tests/hermes_cli/test_non_dispatched_kanban_capability.py
+++ b/tests/hermes_cli/test_non_dispatched_kanban_capability.py
@@ -1,0 +1,124 @@
+"""Native non-dispatched Kanban task capability tests."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def request_kwargs(status="todo", correlation_key="batch9-contract"):
+    return {
+        "title": "non-dispatched audit pickup",
+        "body": "Audit pickup task carrying audit_task_contract.v1.",
+        "assignee": "bafuxunan",
+        "initial_status": status,
+        "no_dispatch": True,
+        "correlation_key": correlation_key,
+        "metadata": {
+            "audit_task_contract": {
+                "schema_version": "audit_task_contract.v1",
+                "verdict_source": "structured_completion_metadata",
+                "github_comment_verdict_allowed": False,
+            },
+            "source_issue": "#595",
+        },
+        "created_by": "test",
+    }
+
+
+@pytest.mark.parametrize("status", ["todo", "ready"])
+def test_create_non_dispatched_todo_ready_read_after_create(kanban_home, status):
+    with kb.connect() as conn:
+        proof = kb.create_non_dispatched_task(
+            conn, **request_kwargs(status=status, correlation_key=f"key-{status}")
+        )
+        assert proof["status"] == status
+        assert proof["assignee"] == "bafuxunan"
+        assert proof["metadata"]["audit_task_contract"]["schema_version"] == "audit_task_contract.v1"
+        assert proof["no_dispatch"] is True
+        assert proof["read_after_create_verified"] is True
+        assert proof["worker_execution_started"] is False
+        assert proof["dispatcher_pickup_count"] == 0
+
+        task = kb.get_task(conn, proof["task_id"])
+        assert task is not None
+        assert task.no_dispatch is True
+        assert task.correlation_key == f"key-{status}"
+        assert task.task_metadata == proof["metadata"]
+
+
+def test_no_dispatch_ready_cannot_be_claimed_by_dispatcher(kanban_home):
+    with kb.connect() as conn:
+        proof = kb.create_non_dispatched_task(conn, **request_kwargs(status="ready"))
+        assert kb.claim_task(conn, proof["task_id"]) is None
+        after = kb.read_after_create_non_dispatched_task(conn, proof["task_id"])
+        assert after["status"] == "ready"
+        assert after["dispatcher_pickup_count"] == 0
+
+
+def test_correlation_key_duplicate_rejected_before_second_create(kanban_home):
+    with kb.connect() as conn:
+        first = kb.create_non_dispatched_task(conn, **request_kwargs(correlation_key="dup"))
+        with pytest.raises(ValueError, match="duplicate correlation_key"):
+            kb.create_non_dispatched_task(conn, **request_kwargs(status="ready", correlation_key="dup"))
+        rows = conn.execute("SELECT id FROM tasks WHERE correlation_key = 'dup'").fetchall()
+        assert [r["id"] for r in rows] == [first["task_id"]]
+
+
+@pytest.mark.parametrize(
+    ("status", "message"),
+    [("running", "running cannot be used or interpreted as ready"), ("blocked", "blocked cannot be used or interpreted as todo")],
+)
+def test_status_substitution_rejected_fail_closed(kanban_home, status, message):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match=message):
+            kb.create_non_dispatched_task(conn, **request_kwargs(status=status))
+
+
+@pytest.mark.parametrize("value", [False, None])
+def test_missing_or_false_no_dispatch_rejected(kanban_home, value):
+    kwargs = request_kwargs()
+    kwargs["no_dispatch"] = value
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="no_dispatch must be true"):
+            kb.create_non_dispatched_task(conn, **kwargs)
+
+
+def test_missing_correlation_key_rejected(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="correlation_key is required"):
+            kb.create_non_dispatched_task(conn, **request_kwargs(correlation_key=""))
+
+
+@pytest.mark.parametrize("source", ["github_comment_regex", "github_comment", "regex", "timeout"])
+def test_github_comment_regex_timeout_cannot_produce_verdict(kanban_home, source):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="GitHub comment / regex / timeout cannot produce audit verdict"):
+            kb.create_non_dispatched_task(conn, **request_kwargs(), audit_verdict_source=source)
+
+
+@pytest.mark.parametrize("kwargs", [{"created_via": "direct_db_write"}, {"direct_db_write": True}])
+def test_direct_db_write_cannot_satisfy_native_contract(kanban_home, kwargs):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="direct Kanban DB write"):
+            kb.create_non_dispatched_task(conn, **request_kwargs(), **kwargs)
+
+
+def test_dispatch_leakage_fails_closed(kanban_home):
+    with kb.connect() as conn:
+        proof = kb.create_non_dispatched_task(conn, **request_kwargs())
+        conn.execute("UPDATE tasks SET dispatcher_pickup_count = 1 WHERE id = ?", (proof["task_id"],))
+        with pytest.raises(ValueError, match="dispatcher pickup observed"):
+            kb.read_after_create_non_dispatched_task(conn, proof["task_id"])

--- a/tests/tools/test_kanban_create_non_dispatched.py
+++ b/tests/tools/test_kanban_create_non_dispatched.py
@@ -1,0 +1,82 @@
+"""Tool-surface tests for native non-dispatched Kanban creation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def worker_env(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    tid = None
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="worker-test", assignee="test-worker")
+        kb.claim_task(conn, tid)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    return tid
+
+
+def payload(status="todo", correlation_key="tool-key", no_dispatch=True):
+    return {
+        "title": "native non-dispatched task",
+        "assignee": "bafuxunan",
+        "body": "Carries audit_task_contract.v1 for structured verdict metadata.",
+        "initial_status": status,
+        "no_dispatch": no_dispatch,
+        "correlation_key": correlation_key,
+        "metadata": {
+            "audit_task_contract": {
+                "schema_version": "audit_task_contract.v1",
+                "verdict_source": "structured_completion_metadata",
+            }
+        },
+    }
+
+
+def test_tool_create_non_dispatched_todo_returns_read_after_create_proof(worker_env):
+    from tools import kanban_tools as kt
+
+    out = json.loads(kt._handle_create(payload(status="todo")))
+    assert out["ok"] is True
+    assert out["status"] == "todo"
+    assert out["proof"]["no_dispatch"] is True
+    assert out["proof"]["read_after_create_verified"] is True
+    assert out["proof"]["worker_execution_started"] is False
+    assert out["proof"]["dispatcher_pickup_count"] == 0
+
+
+def test_tool_create_non_dispatched_ready_cannot_be_claimed(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    out = json.loads(kt._handle_create(payload(status="ready", correlation_key="ready-key")))
+    assert out["ok"] is True
+    with kb.connect() as conn:
+        assert kb.claim_task(conn, out["task_id"]) is None
+
+
+def test_tool_todo_ready_requires_no_dispatch(worker_env):
+    from tools import kanban_tools as kt
+
+    out = json.loads(kt._handle_create(payload(status="todo", no_dispatch=False)))
+    assert out.get("ok") is not True
+    assert "requires no_dispatch=true" in out["error"] or "no_dispatch must be true" in out["error"]
+
+
+def test_tool_schema_exposes_non_dispatched_contract_fields():
+    from tools.kanban_tools import KANBAN_CREATE_SCHEMA
+
+    props = KANBAN_CREATE_SCHEMA["parameters"]["properties"]
+    assert props["initial_status"]["enum"] == ["running", "blocked", "todo", "ready"]
+    for key in ["no_dispatch", "correlation_key", "metadata", "capability"]:
+        assert key in props

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -791,8 +791,19 @@ def _handle_create(args: dict, **kw) -> str:
     if bool_error:
         return tool_error(bool_error)
     idempotency_key = args.get("idempotency_key")
+    correlation_key = args.get("correlation_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
+    no_dispatch, no_dispatch_bool_error = _parse_bool_arg(args, "no_dispatch")
+    if no_dispatch_bool_error:
+        return tool_error(no_dispatch_bool_error)
+    direct_db_write, direct_db_write_bool_error = _parse_bool_arg(args, "direct_db_write")
+    if direct_db_write_bool_error:
+        return tool_error(direct_db_write_bool_error)
+    capability = args.get("capability")
+    metadata = args.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        return tool_error(f"metadata must be an object, got {type(metadata).__name__}")
     skills = args.get("skills")
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
@@ -828,6 +839,35 @@ def _handle_create(args: dict, **kw) -> str:
                         # whole subtree shares one repo + branch convention.
                         if project_id is None and _self_task.project_id:
                             project_id = _self_task.project_id
+            if no_dispatch or capability == getattr(kb, "NON_DISPATCHED_CAPABILITY_NAME", ""):
+                proof = kb.create_non_dispatched_task(
+                    conn,
+                    title=str(title).strip(),
+                    body=body,
+                    assignee=str(assignee),
+                    initial_status=str(initial_status),
+                    no_dispatch=bool(no_dispatch),
+                    correlation_key=str(correlation_key or ""),
+                    metadata=metadata,
+                    created_by=os.environ.get("HERMES_PROFILE") or "worker",
+                    tenant=tenant,
+                    priority=int(priority) if priority is not None else 0,
+                    audit_verdict_source=args.get("audit_verdict_source"),
+                    created_via=args.get("created_via"),
+                    direct_db_write=direct_db_write,
+                    session_id=session_id,
+                )
+                return _ok(
+                    task_id=proof["task_id"],
+                    status=proof["status"],
+                    proof=proof,
+                    subscribed=False,
+                )
+            if str(initial_status) in {"todo", "ready"}:
+                return tool_error(
+                    "initial_status todo/ready requires no_dispatch=true for "
+                    "hermes_kanban_create_non_dispatched_task"
+                )
             new_tid = kb.create_task(
                 conn,
                 title=str(title).strip(),
@@ -1414,13 +1454,52 @@ KANBAN_CREATE_SCHEMA = {
             },
             "initial_status": {
                 "type": "string",
-                "enum": ["running", "blocked"],
+                "enum": ["running", "blocked", "todo", "ready"],
                 "description": (
-                    "Initial card status. Use 'blocked' for tasks that "
-                    "require immediate human ops (R3 gate) to skip the "
-                    "brief running-to-blocked transition. Defaults to "
-                    "'running', which preserves the usual dispatch path."
+                    "Initial card status. 'running' and 'blocked' preserve "
+                    "the usual dispatch path. 'todo' and 'ready' are accepted "
+                    "only with no_dispatch=true for the native "
+                    "hermes_kanban_create_non_dispatched_task capability."
                 ),
+            },
+            "no_dispatch": {
+                "type": "boolean",
+                "description": (
+                    "When true, create a native non-dispatched task in todo "
+                    "or ready without starting worker execution. Required for "
+                    "hermes_kanban_create_non_dispatched_task."
+                ),
+            },
+            "correlation_key": {
+                "type": "string",
+                "description": (
+                    "Exactly-one guard key for no_dispatch task creation. "
+                    "Duplicate non-archived correlation keys are rejected "
+                    "before a second task is created."
+                ),
+            },
+            "metadata": {
+                "type": "object",
+                "description": (
+                    "Structured task metadata for no_dispatch creation; must "
+                    "carry audit_task_contract.v1 unless the body carries it."
+                ),
+            },
+            "capability": {
+                "type": "string",
+                "description": "Optional capability name, e.g. hermes_kanban_create_non_dispatched_task.",
+            },
+            "audit_verdict_source": {
+                "type": "string",
+                "description": "Rejected if set to github_comment/regex/timeout for the non-dispatched capability.",
+            },
+            "created_via": {
+                "type": "string",
+                "description": "Rejected for direct DB write markers in the non-dispatched capability.",
+            },
+            "direct_db_write": {
+                "type": "boolean",
+                "description": "Rejected when true for the non-dispatched capability.",
             },
             "skills": {
                 "type": "array",


### PR DESCRIPTION
## Summary

AION-controlled implementation PR for the native non-dispatched Kanban task capability proven locally in AION governance PR #598 / issue #595.

This PR wires the contract into the Hermes native Kanban surface while preserving existing `running` / `blocked` behavior:

- `kanban_create` accepts `initial_status: todo` or `ready` only when `no_dispatch: true` is present.
- Adds native read-after-create proof for `task_id`, `assignee`, `status`, `metadata`, and `no_dispatch`.
- Adds native exactly-one `correlation_key` guard that rejects duplicates before a second create.
- Adds dispatch suppression so `no_dispatch=1` ready tasks are not claimed into `running`.
- Adds fail-closed tests for unsafe substitutions, missing/false `no_dispatch`, GitHub comment/regex/timeout verdict sources, direct DB write markers, and dispatch leakage.

## Scope boundary

This PR does not create live Kanban tasks, does not call live `kanban_create`, does not write any production/current runtime DB, does not start dispatcher/controller/cron, does not deploy, and does not enter Batch 9 retry.

## Validation

```text
python -m pytest tests/hermes_cli/test_non_dispatched_kanban_capability.py tests/tools/test_kanban_create_non_dispatched.py -q
20 passed in 1.27s

python -m pytest tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_non_dispatched_kanban_capability.py tests/tools/test_kanban_create_non_dispatched.py -q
333 passed in 27.65s
```

## AION references

Refs: AION governance #595, #594, #591, PR #598.

## Caveats

Merge/deploy/Batch 9 retry/live Kanban task creation remain separate AION authorization gates.
