### PR TITLE
feat(security): add opt-in local PII redaction

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -102,6 +102,7 @@ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
+from agent.pii_redaction import maybe_redact_api_kwargs
 from agent.process_bootstrap import build_keepalive_http_client
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -3051,6 +3052,7 @@ def _retry_same_provider_sync(
     )
     if _is_anthropic_compat_endpoint(resolved_provider, retry_base):
         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
+    retry_kwargs = _maybe_redact_aux_kwargs(retry_kwargs, retry_base or resolved_base_url)
     return _validate_llm_response(
         retry_client.chat.completions.create(**retry_kwargs), task,
     )
@@ -3064,6 +3066,7 @@ async def _retry_same_provider_async(
     resolved_base_url: Optional[str],
     resolved_api_key: Optional[str],
     resolved_api_mode: Optional[str],
+    main_runtime: Optional[Dict[str, Any]],
     final_model: Optional[str],
     messages: list,
     temperature: Optional[float],
@@ -3088,6 +3091,7 @@ async def _retry_same_provider_async(
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            main_runtime=main_runtime,
         )
     if retry_client is None:
         raise RuntimeError(
@@ -3108,6 +3112,7 @@ async def _retry_same_provider_async(
     )
     if _is_anthropic_compat_endpoint(resolved_provider, retry_base):
         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
+    retry_kwargs = _maybe_redact_aux_kwargs(retry_kwargs, retry_base or resolved_base_url)
     return _validate_llm_response(
         await retry_client.chat.completions.create(**retry_kwargs), task,
     )
@@ -5541,6 +5546,11 @@ def _build_call_kwargs(
     return kwargs
 
 
+def _maybe_redact_aux_kwargs(kwargs: dict, base_url: Optional[str]) -> dict:
+    redacted, _stats = maybe_redact_api_kwargs(kwargs, base_url=base_url)
+    return redacted
+
+
 def _validate_llm_response(response: Any, task: str = None) -> Any:
     """Validate that an LLM response has the expected .choices[0].message shape.
 
@@ -5766,6 +5776,7 @@ def call_llm(
     _client_base = str(getattr(client, "base_url", "") or "")
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+    kwargs = _maybe_redact_aux_kwargs(kwargs, _client_base or resolved_base_url)
 
     # Handle unsupported temperature, max_tokens vs max_completion_tokens retry,
     # then payment fallback.
@@ -6115,12 +6126,16 @@ def call_llm(
                         resolved_provider, task, reason=reason)
 
             if fb_client is not None:
+                fb_base = str(getattr(fb_client, "base_url", "") or "")
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
-                    base_url=str(getattr(fb_client, "base_url", "") or ""))
+                    base_url=fb_base)
+                if _is_anthropic_compat_endpoint(fb_label, fb_base):
+                    fb_kwargs["messages"] = _convert_openai_images_to_anthropic(fb_kwargs["messages"])
+                fb_kwargs = _maybe_redact_aux_kwargs(fb_kwargs, fb_base)
                 return _validate_llm_response(
                     fb_client.chat.completions.create(**fb_kwargs), task)
             # All fallback layers exhausted — emit a single user-visible
@@ -6299,6 +6314,7 @@ async def async_call_llm(
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+    kwargs = _maybe_redact_aux_kwargs(kwargs, _client_base or resolved_base_url)
 
     try:
         # Retry ONCE on the same provider for a transient transport blip
@@ -6467,6 +6483,7 @@ async def async_call_llm(
                     resolved_base_url=resolved_base_url,
                     resolved_api_key=resolved_api_key,
                     resolved_api_mode=resolved_api_mode,
+                    main_runtime=main_runtime,
                     final_model=final_model,
                     messages=messages,
                     temperature=temperature,
@@ -6504,6 +6521,7 @@ async def async_call_llm(
                         resolved_base_url=resolved_base_url,
                         resolved_api_key=resolved_api_key,
                         resolved_api_mode=resolved_api_mode,
+                        main_runtime=main_runtime,
                         final_model=final_model,
                         messages=messages,
                         temperature=temperature,
@@ -6590,18 +6608,23 @@ async def async_call_llm(
                         resolved_provider, task, reason=reason)
 
             if fb_client is not None:
+                fb_base = str(getattr(fb_client, "base_url", "") or "")
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
-                    base_url=str(getattr(fb_client, "base_url", "") or ""))
+                    base_url=fb_base)
                 # Convert sync fallback client to async
                 async_fb, async_fb_model = _to_async_client(
                     fb_client, fb_model or "", is_vision=(task == "vision")
                 )
                 if async_fb_model and async_fb_model != fb_kwargs.get("model"):
                     fb_kwargs["model"] = async_fb_model
+                async_fb_base = str(getattr(async_fb, "base_url", "") or fb_base)
+                if _is_anthropic_compat_endpoint(fb_label, async_fb_base):
+                    fb_kwargs["messages"] = _convert_openai_images_to_anthropic(fb_kwargs["messages"])
+                fb_kwargs = _maybe_redact_aux_kwargs(fb_kwargs, async_fb_base)
                 return _validate_llm_response(
                     await async_fb.chat.completions.create(**fb_kwargs), task)
             # All fallback layers exhausted — warn before re-raising. (#26882)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -34,6 +34,7 @@ from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
 )
+from agent.pii_redaction import maybe_redact_api_kwargs
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
@@ -591,6 +592,14 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
 
+    def _finalize(api_kwargs: dict) -> dict:
+        redacted, stats = maybe_redact_api_kwargs(
+            api_kwargs,
+            base_url=getattr(agent, "base_url", None),
+        )
+        agent._last_pii_redaction_stats = stats
+        return redacted
+
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
         anthropic_messages = agent._prepare_anthropic_messages_for_api(api_messages)
@@ -599,7 +608,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
         if ephemeral_out is not None:
             agent._ephemeral_max_output_tokens = None  # consume immediately
-        return _transport.build_kwargs(
+        return _finalize(_transport.build_kwargs(
             model=agent.model,
             messages=anthropic_messages,
             tools=tools_for_api,
@@ -611,7 +620,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             base_url=getattr(agent, "_anthropic_base_url", None),
             fast_mode=(agent.request_overrides or {}).get("speed") == "fast",
             drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
-        )
+        ))
 
     # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
     # The adapter handles message/tool conversion and boto3 calls directly.
@@ -619,14 +628,14 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         _bt = agent._get_transport()
         region = getattr(agent, "_bedrock_region", None) or "us-east-1"
         guardrail = getattr(agent, "_bedrock_guardrail_config", None)
-        return _bt.build_kwargs(
+        return _finalize(_bt.build_kwargs(
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
             max_tokens=agent.max_tokens or 4096,
             region=region,
             guardrail_config=guardrail,
-        )
+        ))
 
     if agent.api_mode == "codex_responses":
         _ct = agent._get_transport()
@@ -676,7 +685,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
                     getattr(agent, "log_prefix", ""), exc,
                 )
 
-        return _ct.build_kwargs(
+        return _finalize(_ct.build_kwargs(
             model=agent.model,
             messages=_msgs_for_codex,
             tools=tools_for_api,
@@ -692,7 +701,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             replay_encrypted_reasoning=bool(
                 getattr(agent, "_codex_reasoning_replay_enabled", True)
             ),
-        )
+        ))
 
     # ── chat_completions (default) ─────────────────────────────────────
     _ct = agent._get_transport()
@@ -777,7 +786,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         # registered providers with profiles were bypassing the strip.
         api_messages = agent._prepare_messages_for_non_vision_model(api_messages)
 
-        return _ct.build_kwargs(
+        return _finalize(_ct.build_kwargs(
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
@@ -797,7 +806,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
-        )
+        ))
 
     # ── Legacy flag path ────────────────────────────────────────────
     # Reached only when get_provider_profile() returns None — i.e. a
@@ -809,7 +818,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
 
-    return _ct.build_kwargs(
+    return _finalize(_ct.build_kwargs(
         model=agent.model,
         messages=_msgs_for_chat,
         tools=tools_for_api,
@@ -844,7 +853,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
-    )
+    ))
 
 
 
@@ -1570,10 +1579,18 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                                max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
                                is_oauth=agent._is_anthropic_oauth,
                                preserve_dots=agent._anthropic_preserve_dots())
+                _ant_kw, agent._last_pii_redaction_stats = maybe_redact_api_kwargs(
+                    _ant_kw,
+                    base_url=getattr(agent, "base_url", None),
+                )
                 summary_response = agent._anthropic_messages_create(_ant_kw)
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_summary_result.content or "").strip()
             else:
+                summary_kwargs, agent._last_pii_redaction_stats = maybe_redact_api_kwargs(
+                    summary_kwargs,
+                    base_url=getattr(agent, "base_url", None),
+                )
                 summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)
                 _summary_result = agent._get_transport().normalize_response(summary_response)
                 final_response = (_summary_result.content or "").strip()
@@ -1600,6 +1617,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                                 is_oauth=agent._is_anthropic_oauth,
                                 max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
                                 preserve_dots=agent._anthropic_preserve_dots())
+                _ant_kw2, agent._last_pii_redaction_stats = maybe_redact_api_kwargs(
+                    _ant_kw2,
+                    base_url=getattr(agent, "base_url", None),
+                )
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_retry_result.content or "").strip()
@@ -1617,6 +1638,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body
 
+                summary_kwargs, agent._last_pii_redaction_stats = maybe_redact_api_kwargs(
+                    summary_kwargs,
+                    base_url=getattr(agent, "base_url", None),
+                )
                 summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary_retry").chat.completions.create(**summary_kwargs)
                 _retry_result = agent._get_transport().normalize_response(summary_response)
                 final_response = (_retry_result.content or "").strip()

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -287,9 +287,19 @@ def run_codex_app_server_turn(
     # NOTE: the user message is ALREADY appended to messages by the
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
+    outbound_user_message = user_message
+    try:
+        from agent.pii_redaction import redact_text_for_llm
+
+        outbound_user_message, agent._last_pii_redaction_stats = redact_text_for_llm(
+            user_message,
+            base_url=getattr(agent, "base_url", None),
+        )
+    except Exception:
+        raise
 
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        turn = agent._codex_session.run_turn(user_input=outbound_user_message)
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn

--- a/agent/pii_redaction.py
+++ b/agent/pii_redaction.py
@@ -1,0 +1,388 @@
+"""Opt-in local PII redaction for outbound hosted-LLM payloads.
+
+This module is the last Python-side boundary before Hermes sends structured
+request data to model providers.  When enabled, it redacts text fields in API
+payloads with a local backend before hosted-provider dispatch, while preserving
+local inference by default through ``hosted_only``.  The feature reduces
+accidental exposure of common PII, but it is not a hard security boundary:
+opaque binary/media fields, identifiers, and provider metadata are deliberately
+left untouched so requests remain valid.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.model_metadata import is_local_endpoint
+
+
+logger = logging.getLogger(__name__)
+
+SKIP_DISABLED = "disabled"
+SKIP_LOCAL_ENDPOINT = "local_endpoint"
+
+_SKIP_STRING_KEYS = {
+    "audio_url",
+    "base_url",
+    "b64_json",
+    "cache_control",
+    "cache_key",
+    "call_id",
+    "encrypted_content",
+    "encoding",
+    "endpoint",
+    "extra_headers",
+    "data",
+    "file_data",
+    "file_id",
+    "filename",
+    "function_call_id",
+    "id",
+    "image_url",
+    "include",
+    "item_id",
+    "metadata",
+    "mime_type",
+    "model",
+    "name",
+    "output_index",
+    "previous_response_id",
+    "provider",
+    "prompt_cache_key",
+    "reasoning",
+    "reasoning_effort",
+    "response_id",
+    "role",
+    "service_tier",
+    "status",
+    "store",
+    "temperature",
+    "tool_call_id",
+    "type",
+    "url",
+}
+
+
+def load_pii_redaction_config(config: Optional[dict] = None) -> dict:
+    if config is None:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    raw = (config or {}).get("security", {}).get("pii_redaction", {}) or {}
+    rampart = raw.get("rampart", {}) or {}
+    return {
+        "enabled": bool(raw.get("enabled", False)),
+        "provider": str(raw.get("provider", "rampart") or "rampart"),
+        "hosted_only": bool(raw.get("hosted_only", True)),
+        "fail_closed": bool(raw.get("fail_closed", True)),
+        "timeout_seconds": float(raw.get("timeout_seconds", 10) or 10),
+        "rampart": {
+            "command": str(rampart.get("command", "") or ""),
+            "model": str(rampart.get("model", "nationaldesignstudio/rampart") or "nationaldesignstudio/rampart"),
+            "heuristics_only": bool(rampart.get("heuristics_only", False)),
+        },
+    }
+
+
+def should_redact_for_llm(
+    base_url: Optional[str],
+    *,
+    config: Optional[dict] = None,
+    pii_config: Optional[dict] = None,
+) -> bool:
+    cfg = pii_config or load_pii_redaction_config(config)
+    if not cfg.get("enabled"):
+        return False
+    if cfg.get("hosted_only", True) and base_url and is_local_endpoint(base_url):
+        return False
+    return True
+
+
+def _skip_reason(base_url: Optional[str], cfg: dict) -> Optional[str]:
+    if not cfg.get("enabled"):
+        return SKIP_DISABLED
+    if cfg.get("hosted_only", True) and base_url and is_local_endpoint(base_url):
+        return SKIP_LOCAL_ENDPOINT
+    return None
+
+
+def redact_messages_for_llm(
+    messages: Any,
+    *,
+    base_url: Optional[str] = None,
+    config: Optional[dict] = None,
+    pii_config: Optional[dict] = None,
+) -> Tuple[Any, Dict[str, Any]]:
+    cfg = pii_config or load_pii_redaction_config(config)
+    reason = _skip_reason(base_url, cfg)
+    if reason:
+        stats = _stats(redacted=False, skipped=True, skipped_reason=reason)
+        _log_stats(stats)
+        return messages, stats
+    redacted, stats = _redact_payload(messages, cfg)
+    _log_stats(stats)
+    return redacted, stats
+
+
+def redact_text_for_llm(
+    text: str,
+    *,
+    base_url: Optional[str] = None,
+    config: Optional[dict] = None,
+    pii_config: Optional[dict] = None,
+) -> Tuple[str, Dict[str, Any]]:
+    cfg = pii_config or load_pii_redaction_config(config)
+    reason = _skip_reason(base_url, cfg)
+    if reason:
+        stats = _stats(redacted=False, skipped=True, skipped_reason=reason)
+        _log_stats(stats)
+        return text, stats
+    redacted, stats = _redact_payload(str(text), cfg)
+    _log_stats(stats)
+    return redacted, stats
+
+
+def maybe_redact_api_kwargs(
+    api_kwargs: dict,
+    *,
+    base_url: Optional[str] = None,
+    config: Optional[dict] = None,
+    pii_config: Optional[dict] = None,
+) -> Tuple[dict, Dict[str, Any]]:
+    cfg = pii_config or load_pii_redaction_config(config)
+    reason = _skip_reason(base_url, cfg)
+    if reason:
+        stats = _stats(redacted=False, skipped=True, skipped_reason=reason)
+        _log_stats(stats)
+        return api_kwargs, stats
+    redacted, stats = _redact_payload(api_kwargs, cfg)
+    _log_stats(stats)
+    return redacted, stats
+
+
+def _stats(**overrides: Any) -> Dict[str, Any]:
+    stats = {
+        "enabled": False,
+        "redacted": False,
+        "skipped": False,
+        "skipped_reason": None,
+        "backend": None,
+        "replacement_count": 0,
+        "texts_scanned": 0,
+        "texts_changed": 0,
+        "chars_in": 0,
+        "chars_out": 0,
+        "failure": None,
+    }
+    stats.update(overrides)
+    return stats
+
+
+def _log_stats(stats: Dict[str, Any]) -> None:
+    if stats.get("skipped"):
+        logger.info(
+            "PII redaction skipped: reason=%s backend=%s",
+            stats.get("skipped_reason"),
+            stats.get("backend"),
+        )
+        return
+    logger.info(
+        "PII redaction completed: backend=%s scanned=%s changed=%s replacements=%s failure=%s",
+        stats.get("backend"),
+        stats.get("texts_scanned"),
+        stats.get("texts_changed"),
+        stats.get("replacement_count"),
+        stats.get("failure"),
+    )
+
+
+def _redact_payload(payload: Any, cfg: dict) -> Tuple[Any, Dict[str, Any]]:
+    if isinstance(payload, str):
+        return _redact_plain_text(payload, cfg)
+    copied = copy.deepcopy(payload)
+    slots: List[Tuple[Any, Any]] = []
+    texts: List[str] = []
+    _collect_text_slots(copied, slots, texts)
+    stats = _stats(
+        enabled=True,
+        redacted=True,
+        backend=cfg.get("provider", "rampart"),
+        texts_scanned=len(texts),
+        chars_in=sum(len(t) for t in texts),
+    )
+    if not texts:
+        stats["chars_out"] = 0
+        return copied, stats
+
+    try:
+        redacted_texts = _redact_texts(texts, cfg)
+    except Exception as exc:
+        stats["failure"] = type(exc).__name__
+        if cfg.get("fail_closed", True):
+            raise RuntimeError(
+                "PII redaction failed before provider dispatch; refusing to send unredacted payload"
+            ) from exc
+        return payload, stats
+
+    if len(redacted_texts) != len(texts):
+        stats["failure"] = "InvalidRedactionCount"
+        if cfg.get("fail_closed", True):
+            raise RuntimeError(
+                "PII redaction failed before provider dispatch; backend returned an invalid response"
+            )
+        return payload, stats
+
+    changed = 0
+    for (container, key), value in zip(slots, redacted_texts):
+        if value != container[key]:
+            changed += 1
+        container[key] = value
+    stats["texts_changed"] = changed
+    stats["replacement_count"] = changed
+    stats["chars_out"] = sum(len(t) for t in redacted_texts)
+    return copied, stats
+
+
+def _redact_plain_text(text: str, cfg: dict) -> Tuple[str, Dict[str, Any]]:
+    stats = _stats(
+        enabled=True,
+        redacted=True,
+        backend=cfg.get("provider", "rampart"),
+        texts_scanned=1 if text else 0,
+        chars_in=len(text),
+    )
+    if not text:
+        return text, stats
+    try:
+        redacted_texts = _redact_texts([text], cfg)
+    except Exception as exc:
+        stats["failure"] = type(exc).__name__
+        if cfg.get("fail_closed", True):
+            raise RuntimeError(
+                "PII redaction failed before provider dispatch; refusing to send unredacted payload"
+            ) from exc
+        return text, stats
+    if len(redacted_texts) != 1:
+        stats["failure"] = "InvalidRedactionCount"
+        if cfg.get("fail_closed", True):
+            raise RuntimeError(
+                "PII redaction failed before provider dispatch; backend returned an invalid response"
+            )
+        return text, stats
+    redacted = redacted_texts[0]
+    stats["texts_changed"] = 1 if redacted != text else 0
+    stats["replacement_count"] = stats["texts_changed"]
+    stats["chars_out"] = len(redacted)
+    return redacted, stats
+
+
+def _collect_text_slots(node: Any, slots: List[Tuple[Any, Any]], texts: List[str], parent_key: str = "") -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            key_s = str(key)
+            if key_s == "tools" or key_s.lower() in _SKIP_STRING_KEYS:
+                continue
+            if isinstance(value, str):
+                if _is_text_string(key_s, value):
+                    slots.append((node, key))
+                    texts.append(value)
+            else:
+                _collect_text_slots(value, slots, texts, key_s)
+        return
+    if isinstance(node, list):
+        for index, value in enumerate(node):
+            if isinstance(value, str):
+                if _is_text_string(parent_key, value):
+                    slots.append((node, index))
+                    texts.append(value)
+            else:
+                _collect_text_slots(value, slots, texts, parent_key)
+
+
+def _is_text_string(key: str, value: str) -> bool:
+    if not value:
+        return False
+    key_l = key.lower()
+    if key_l in _SKIP_STRING_KEYS:
+        return False
+    value_l = value[:128].lower()
+    if value_l.startswith(("data:", "http://", "https://", "file://")):
+        return False
+    return True
+
+
+def _worker_env() -> dict:
+    allowed = {}
+    for key in (
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "SYSTEMROOT",
+        "WINDIR",
+    ):
+        value = os.environ.get(key)
+        if value:
+            allowed[key] = value
+    return allowed
+
+
+def _redact_texts(texts: List[str], cfg: dict) -> List[str]:
+    provider = str(cfg.get("provider", "rampart") or "rampart").lower()
+    if provider != "rampart":
+        raise RuntimeError("unsupported PII redaction provider")
+    return _redact_with_rampart(texts, cfg)
+
+
+def _redact_with_rampart(texts: List[str], cfg: dict) -> List[str]:
+    rampart = cfg.get("rampart", {}) or {}
+    command = str(rampart.get("command", "") or "").strip()
+    if command:
+        cmd = shlex.split(command)
+    else:
+        worker = Path(__file__).with_name("rampart_pii_worker.mjs")
+        cmd = ["node", str(worker)]
+    payload = {
+        "texts": texts,
+        "model": rampart.get("model") or "nationaldesignstudio/rampart",
+        "heuristicsOnly": bool(rampart.get("heuristics_only", False)),
+    }
+    try:
+        completed = subprocess.run(
+            cmd,
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            timeout=float(cfg.get("timeout_seconds", 10) or 10),
+            check=False,
+            env=_worker_env(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("PII redaction worker timed out") from exc
+    except OSError as exc:
+        raise RuntimeError("PII redaction worker unavailable") from exc
+    if completed.returncode != 0:
+        raise RuntimeError("PII redaction worker failed")
+    try:
+        data = json.loads(completed.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("PII redaction worker returned invalid JSON") from exc
+    redacted = (
+        data.get("texts")
+        or data.get("redactedTexts")
+        or data.get("redacted_texts")
+        or data.get("results")
+    )
+    if not isinstance(redacted, list) or not all(isinstance(item, str) for item in redacted):
+        raise RuntimeError("PII redaction worker returned invalid payload")
+    return redacted

--- a/agent/rampart_pii_worker.mjs
+++ b/agent/rampart_pii_worker.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+// Rampart is published as a JavaScript package, so Hermes keeps the optional
+// redaction backend in a Node worker instead of adding a Python ML stack to the
+// base install. `hermes redact setup` installs the pinned npm packages into the
+// active Hermes home, then Python invokes this worker as an isolated subprocess.
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function loadRampart() {
+  const names = ["@nationaldesignstudio/rampart", "rampart"];
+  let lastError;
+  for (const name of names) {
+    try {
+      return await import(name);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError || new Error("Rampart package not found");
+}
+
+async function loadTransformers() {
+  try {
+    return await import("@huggingface/transformers");
+  } catch (error) {
+    throw new Error(
+      "@huggingface/transformers is required for Rampart model-backed redaction in Node"
+    );
+  }
+}
+
+function extractProtectedText(result) {
+  if (typeof result === "string") return result;
+  if (!result || typeof result !== "object") return null;
+  return result.text || result.protectedText || result.protected_text || result.output || null;
+}
+
+async function protectWithRampartHeuristics(texts) {
+  const mod = await loadRampart();
+  const createGuard = mod.createGuard || mod.default?.createGuard;
+  if (typeof createGuard !== "function") {
+    throw new Error("Rampart package does not expose createGuard()");
+  }
+  const guard = await createGuard({ heuristicsOnly: true });
+  if (!guard || typeof guard.protect !== "function") {
+    throw new Error("Rampart guard does not expose protect()");
+  }
+
+  const protectedTexts = [];
+  for (const text of texts) {
+    const result = await guard.protect(String(text));
+    const protectedText = extractProtectedText(result);
+    if (typeof protectedText !== "string") {
+      throw new Error("Rampart protect() returned an unsupported payload");
+    }
+    protectedTexts.push(protectedText);
+  }
+  return protectedTexts;
+}
+
+async function createRampartGuardWithNodeModel(options) {
+  const mod = await loadRampart();
+  if (typeof mod.createGuard !== "function" || typeof mod.detectNer !== "function") {
+    throw new Error("Rampart package does not expose the required guard and NER APIs");
+  }
+  const { pipeline, env } = await loadTransformers();
+  if (env) {
+    env.allowLocalModels = false;
+    env.allowRemoteModels = true;
+  }
+  const classifier = await pipeline("token-classification", options.model, {
+    dtype: "q4",
+    device: "cpu",
+  });
+  const adapter = (text, detectOptions) => classifier(text, detectOptions);
+  if (classifier.tokenizer && typeof classifier.tokenizer.encode === "function") {
+    adapter.countTokens = (text) =>
+      classifier.tokenizer.encode(text, { add_special_tokens: false }).length;
+  }
+
+  return mod.createGuard({ ner: (text) => mod.detectNer(text, adapter) });
+}
+
+async function protectWithGuard(texts, guard) {
+  const redactedTexts = [];
+  for (const text of texts) {
+    const result = await guard.protect(String(text));
+    const protectedText = extractProtectedText(result);
+    if (typeof protectedText !== "string") {
+      throw new Error("Rampart protect() returned an unsupported payload");
+    }
+    redactedTexts.push(protectedText);
+  }
+  return redactedTexts;
+}
+
+async function main() {
+  const input = JSON.parse(await readStdin());
+  const texts = Array.isArray(input.texts) ? input.texts : [];
+  const options = {
+    model: input.model || "nationaldesignstudio/rampart",
+    heuristicsOnly: Boolean(input.heuristicsOnly),
+  };
+  const protectedTexts = options.heuristicsOnly
+    ? await protectWithRampartHeuristics(texts)
+    : await protectWithGuard(texts, await createRampartGuardWithNodeModel(options));
+
+  process.stdout.write(JSON.stringify({ texts: protectedTexts }));
+}
+
+main().catch((error) => {
+  const name = error && error.name ? error.name : "Error";
+  const message = error && error.message ? `: ${error.message}` : "";
+  process.stderr.write(`PII redaction worker failed: ${name}${message}\n`);
+  process.exit(1);
+});

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -337,6 +337,22 @@ terminal:
 #   tirith_path: "tirith"       # Path to tirith binary (supports ~ expansion)
 #   tirith_timeout: 5           # Scan timeout in seconds
 #   tirith_fail_open: true      # Allow commands if tirith unavailable
+#
+# Optional local PII redaction before hosted LLM calls. Disabled by default.
+# Run `hermes redact setup --enable` to install the pinned Rampart backend into
+# this Hermes profile, then adjust settings with `hermes redact config`.
+#
+# security:
+#   pii_redaction:
+#     enabled: false
+#     provider: "rampart"
+#     hosted_only: true         # Skip local endpoints such as Ollama/vLLM
+#     fail_closed: true         # Block hosted calls if redaction fails
+#     timeout_seconds: 10
+#     rampart:
+#       command: ""             # Written by `hermes redact setup`
+#       model: "nationaldesignstudio/rampart"
+#       heuristics_only: false
 
 # =============================================================================
 # Browser Tool Configuration

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2422,6 +2422,18 @@ DEFAULT_CONFIG = {
             "domains": [],
             "shared_files": [],
         },
+        "pii_redaction": {
+            "enabled": False,
+            "provider": "rampart",
+            "hosted_only": True,
+            "fail_closed": True,
+            "timeout_seconds": 10,
+            "rampart": {
+                "command": "",
+                "model": "nationaldesignstudio/rampart",
+                "heuristics_only": False,
+            },
+        },
         # Acknowledged supply-chain security advisories. Each entry is the
         # ID of an advisory the user has read and acted on (uninstalled the
         # compromised package, rotated credentials). Acked advisories no

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11928,7 +11928,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "model", "pairing", "pets", "plugins", "portal", "postinstall", "profile",
         "project", "proxy",
         "prompt-size",
-        "send", "sessions", "setup",
+        "redact", "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "whatsapp-cloud", "chat", "secrets", "security",
         # Help-ish invocations — plugin commands not being listed in
@@ -12500,6 +12500,13 @@ def main():
         help="Remove all fallback entries",
     )
     fallback_parser.set_defaults(func=cmd_fallback)
+
+    # =========================================================================
+    # redact command — local PII redaction
+    # =========================================================================
+    from hermes_cli.redact_cmd import register_redact_parser
+
+    register_redact_parser(subparsers)
 
     # =========================================================================
     # secrets command — external secret managers (currently: Bitwarden)

--- a/hermes_cli/redact_cmd.py
+++ b/hermes_cli/redact_cmd.py
@@ -1,0 +1,431 @@
+"""Top-level CLI for local PII redaction.
+
+The runtime redaction implementation lives in ``agent.pii_redaction``.  This
+module intentionally imports it lazily so the CLI can land before the core
+worker's module is present, and so normal ``hermes`` startup does not pay for
+the redaction backend.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CONFIG_SECTION = "pii_redaction"
+SECURITY_SECTION = "security"
+# These are optional runtime npm packages installed by `hermes redact setup`
+# into the active Hermes home, not Python install-time dependencies.
+RAMPART_PACKAGE_SPEC = "@nationaldesignstudio/rampart@0.1.1"
+TRANSFORMERS_PACKAGE_SPEC = "@huggingface/transformers@3.7.5"
+
+
+def register_redact_parser(subparsers) -> argparse.ArgumentParser:
+    parser = subparsers.add_parser(
+        "redact",
+        help="Configure and run local PII redaction",
+        description="Configure and run local PII redaction before model calls.",
+    )
+    redact_subparsers = parser.add_subparsers(dest="redact_command")
+
+    config = redact_subparsers.add_parser(
+        "config",
+        help="Show or update local PII redaction configuration",
+    )
+    enabled = config.add_mutually_exclusive_group()
+    enabled.add_argument("--enable", action="store_true", help="Enable local PII redaction")
+    enabled.add_argument("--disable", action="store_true", help="Disable local PII redaction")
+    endpoint_scope = config.add_mutually_exclusive_group()
+    endpoint_scope.add_argument(
+        "--hosted-only",
+        action="store_true",
+        help="Only redact requests sent to hosted model endpoints",
+    )
+    endpoint_scope.add_argument(
+        "--all-endpoints",
+        action="store_true",
+        help="Redact requests for hosted and local endpoints",
+    )
+    failure_mode = config.add_mutually_exclusive_group()
+    failure_mode.add_argument(
+        "--fail-closed",
+        action="store_true",
+        help="Block model calls when redaction fails",
+    )
+    failure_mode.add_argument(
+        "--fail-open",
+        action="store_true",
+        help="Allow model calls when redaction fails",
+    )
+    heuristics = config.add_mutually_exclusive_group()
+    heuristics.add_argument(
+        "--heuristics-only",
+        action="store_true",
+        help="Use built-in heuristic redaction instead of Rampart",
+    )
+    heuristics.add_argument(
+        "--no-heuristics-only",
+        action="store_true",
+        help="Use the configured backend instead of heuristics-only mode",
+    )
+    config.add_argument("--model", metavar="<id-or-path>", help="Rampart model id or local path")
+
+    setup = redact_subparsers.add_parser(
+        "setup",
+        help="Prepare the local Rampart backend under the active Hermes home",
+    )
+    setup.add_argument(
+        "--enable",
+        action="store_true",
+        help="Enable local PII redaction after Rampart setup succeeds",
+    )
+
+    run = redact_subparsers.add_parser(
+        "run",
+        help="Redact one text input using the configured backend",
+    )
+    run.add_argument("--text", help="Text to redact. Reads stdin when omitted.")
+    run.add_argument("--json", action="store_true", help="Emit JSON with text and stats")
+
+    parser.set_defaults(func=cmd_redact)
+    return parser
+
+
+def cmd_redact(args) -> int:
+    command = getattr(args, "redact_command", None)
+    if command == "config" or command is None:
+        return _cmd_config(args)
+    if command == "setup":
+        return _cmd_setup(args)
+    if command == "run":
+        return _cmd_run(args)
+    print(f"hermes redact: unknown subcommand: {command}", file=sys.stderr)
+    return 2
+
+
+def _cmd_config(args) -> int:
+    from hermes_cli.config import load_config, save_config
+
+    config = load_config()
+    section = _ensure_section(config)
+    changed = False
+
+    if getattr(args, "enable", False):
+        section["enabled"] = True
+        changed = True
+    if getattr(args, "disable", False):
+        section["enabled"] = False
+        changed = True
+    if getattr(args, "hosted_only", False):
+        section["hosted_only"] = True
+        changed = True
+    if getattr(args, "all_endpoints", False):
+        section["hosted_only"] = False
+        changed = True
+    if getattr(args, "fail_closed", False):
+        section["fail_closed"] = True
+        changed = True
+    if getattr(args, "fail_open", False):
+        section["fail_closed"] = False
+        changed = True
+    if getattr(args, "heuristics_only", False):
+        _ensure_rampart(section)["heuristics_only"] = True
+        section["provider"] = "rampart"
+        changed = True
+    if getattr(args, "no_heuristics_only", False):
+        _ensure_rampart(section)["heuristics_only"] = False
+        section["provider"] = "rampart"
+        changed = True
+    if getattr(args, "model", None):
+        _ensure_rampart(section)["model"] = args.model
+        changed = True
+
+    if changed:
+        save_config(config)
+        config = load_config()
+
+    _print_status(config, saved=changed)
+    return 0
+
+
+def _cmd_setup(args) -> int:
+    from hermes_cli.config import get_hermes_home, load_config, save_config
+
+    node = shutil.which("node")
+    npm = shutil.which("npm")
+    if not node:
+        print("hermes redact setup: node is not on PATH.", file=sys.stderr)
+        return 1
+    if not npm:
+        print("hermes redact setup: npm is not on PATH.", file=sys.stderr)
+        return 1
+
+    hermes_home = get_hermes_home()
+    support_dir = _support_dir(hermes_home)
+    support_dir.mkdir(parents=True, exist_ok=True)
+    worker_path = _prepare_profile_worker(support_dir)
+
+    print(f"Node: {node}")
+    print(f"npm:  {npm}")
+    print(f"Rampart support directory: {support_dir}")
+    print(f"Installing {RAMPART_PACKAGE_SPEC} and {TRANSFORMERS_PACKAGE_SPEC} ...")
+
+    try:
+        subprocess.run(
+            [npm, "install", RAMPART_PACKAGE_SPEC, TRANSFORMERS_PACKAGE_SPEC],
+            cwd=str(support_dir),
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"hermes redact setup: npm install failed with exit code {exc.returncode}.", file=sys.stderr)
+        return exc.returncode or 1
+    except OSError as exc:
+        print(f"hermes redact setup: failed to run npm: {exc}", file=sys.stderr)
+        return 1
+
+    config = load_config()
+    section = _ensure_section(config)
+    section["provider"] = "rampart"
+    rampart = _ensure_rampart(section)
+    rampart["command"] = shlex.join([node, str(worker_path)])
+    rampart["package"] = RAMPART_PACKAGE_SPEC
+    rampart["transformers_package"] = TRANSFORMERS_PACKAGE_SPEC
+    rampart["install_dir"] = str(support_dir)
+    if getattr(args, "enable", False):
+        section["enabled"] = True
+    save_config(config)
+
+    print("Rampart setup complete.")
+    if getattr(args, "enable", False):
+        print("Local PII redaction enabled.")
+    else:
+        print("Enable with: hermes redact config --enable")
+    return 0
+
+
+def _cmd_run(args) -> int:
+    text = getattr(args, "text", None)
+    if text is None:
+        if sys.stdin.isatty():
+            print("hermes redact run: provide --text or pipe input on stdin.", file=sys.stderr)
+            return 2
+        text = sys.stdin.read()
+
+    try:
+        redacted, stats = _redact_text(text)
+    except RuntimeError as exc:
+        print(f"hermes redact run: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"hermes redact run: redaction failed: {exc}", file=sys.stderr)
+        return 1
+
+    if stats.get("skipped"):
+        reason = stats.get("skipped_reason") or "unknown"
+        print(f"hermes redact run: redaction skipped ({reason}).", file=sys.stderr)
+    if getattr(args, "json", False):
+        print(json.dumps({"text": redacted, "stats": stats}, indent=2, sort_keys=True))
+    else:
+        print(redacted, end="" if redacted.endswith("\n") else "\n")
+    return 0
+
+
+def _ensure_section(config: dict[str, Any]) -> dict[str, Any]:
+    security = config.get(SECURITY_SECTION)
+    if not isinstance(security, dict):
+        security = {}
+        config[SECURITY_SECTION] = security
+    section = security.get(CONFIG_SECTION)
+    if not isinstance(section, dict):
+        section = {}
+        security[CONFIG_SECTION] = section
+    return section
+
+
+def _read_section(config: dict[str, Any]) -> dict[str, Any]:
+    security = config.get(SECURITY_SECTION)
+    if isinstance(security, dict):
+        section = security.get(CONFIG_SECTION)
+        if isinstance(section, dict):
+            return dict(section)
+    return {}
+
+
+def _ensure_rampart(section: dict[str, Any]) -> dict[str, Any]:
+    rampart = section.get("rampart")
+    if not isinstance(rampart, dict):
+        rampart = {}
+        section["rampart"] = rampart
+    return rampart
+
+
+def _support_dir(hermes_home: Path) -> Path:
+    return hermes_home / "support" / "pii-redaction" / "rampart"
+
+
+def _prepare_profile_worker(support_dir: Path) -> Path:
+    source = Path(__file__).resolve().parents[1] / "agent" / "rampart_pii_worker.mjs"
+    target = support_dir / "rampart_pii_worker.mjs"
+    shutil.copyfile(source, target)
+    return target
+
+
+def _load_runtime_module():
+    try:
+        from agent import pii_redaction  # type: ignore[attr-defined]
+    except Exception as exc:
+        raise RuntimeError(
+            "agent.pii_redaction is not available in this checkout yet. "
+            "Install or update the Hermes runtime redaction module, then retry."
+        ) from exc
+    return pii_redaction
+
+
+def _runtime_config(config: dict[str, Any] | None = None) -> Any:
+    module = _load_runtime_module()
+    loader = getattr(module, "load_pii_redaction_config", None)
+    if not callable(loader):
+        return (config or {}).get(CONFIG_SECTION, {})
+    return loader(config) if config is not None else loader()
+
+
+def _redact_text(text: str) -> tuple[str, dict[str, Any]]:
+    module = _load_runtime_module()
+    redactor = getattr(module, "redact_text_for_llm", None)
+    if not callable(redactor):
+        raise RuntimeError("agent.pii_redaction does not expose redact_text_for_llm.")
+
+    result = redactor(text, pii_config=_runtime_config())
+    return _normalize_redaction_result(result, fallback_text=text)
+
+
+def _normalize_redaction_result(result: Any, *, fallback_text: str) -> tuple[Any, dict[str, Any]]:
+    if isinstance(result, tuple) and result:
+        text = result[0]
+        stats = _stats_from_obj(result[1]) if len(result) > 1 else {}
+        return text, stats
+    if isinstance(result, dict):
+        text = result.get("text", result.get("redacted_text", fallback_text))
+        stats = _stats_from_obj(result.get("stats", result))
+        return text, stats
+    text = getattr(result, "text", getattr(result, "redacted_text", result))
+    stats = _stats_from_obj(getattr(result, "stats", result))
+    return text, stats
+
+
+def _stats_from_obj(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return {
+            str(k): v
+            for k, v in value.items()
+            if k not in {"text", "redacted_text", "messages", "redacted_messages"}
+        }
+    data: dict[str, Any] = {}
+    for key in ("replacements", "entities", "backend", "duration_ms", "failed", "error"):
+        if hasattr(value, key):
+            data[key] = getattr(value, key)
+    return data
+
+
+def _print_status(config: dict[str, Any], *, saved: bool) -> None:
+    raw = _read_section(config)
+    try:
+        effective = _config_to_dict(_runtime_config(config))
+    except RuntimeError:
+        effective = raw
+    except Exception as exc:
+        effective = raw
+        print(f"Runtime config unavailable: {exc}", file=sys.stderr)
+
+    status = {**raw, **effective}
+    ready = _setup_ready(status)
+
+    if saved:
+        print("Saved local PII redaction config.")
+    print(f"Enabled:        {_format_bool(status.get('enabled', False))}")
+    print(f"Backend:        {_default_backend(status)}")
+    print(f"Model:          {_rampart_value(status, 'model') or '(default)'}")
+    print(f"Hosted only:    {_format_bool(status.get('hosted_only', True))}")
+    print(f"Fail closed:    {_format_bool(status.get('fail_closed', True))}")
+    print(f"Heuristics only: {_format_bool(_rampart_value(status, 'heuristics_only', False))}")
+    print(f"Setup ready:    {_format_bool(ready)}")
+    if not ready:
+        print("Setup command:  hermes redact setup")
+
+
+def _setup_ready(status: dict[str, Any]) -> bool:
+    if "setup_ready" in status:
+        return bool(status["setup_ready"])
+    if status.get("provider") == "heuristics":
+        return True
+
+    def installed(base: Path) -> bool:
+        rampart_ok = (base / "node_modules" / "@nationaldesignstudio" / "rampart").exists()
+        if _rampart_value(status, "heuristics_only"):
+            return rampart_ok
+        transformers_ok = (base / "node_modules" / "@huggingface" / "transformers").exists()
+        return rampart_ok and transformers_ok
+
+    command = _rampart_value(status, "command")
+    if command:
+        try:
+            parts = shlex.split(str(command))
+        except ValueError:
+            parts = []
+        if len(parts) >= 2 and Path(parts[1]).exists():
+            worker = Path(parts[1])
+            return installed(worker.parent)
+    rampart_dir = _rampart_value(status, "install_dir")
+    if rampart_dir:
+        base = Path(str(rampart_dir))
+    else:
+        try:
+            from hermes_cli.config import get_hermes_home
+
+            base = _support_dir(get_hermes_home())
+        except Exception:
+            return False
+    return installed(base)
+
+
+def _config_to_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    data: dict[str, Any] = {}
+    for key in (
+        "enabled",
+        "provider",
+        "model",
+        "hosted_only",
+        "fail_closed",
+        "heuristics_only",
+        "rampart",
+        "setup_ready",
+    ):
+        if hasattr(value, key):
+            data[key] = getattr(value, key)
+    return data
+
+
+def _default_backend(status: dict[str, Any]) -> str:
+    provider = status.get("provider") or status.get("backend")
+    return str(provider or "rampart")
+
+
+def _rampart_value(status: dict[str, Any], key: str, default: Any = None) -> Any:
+    rampart = status.get("rampart")
+    if isinstance(rampart, dict) and key in rampart:
+        return rampart.get(key)
+    return status.get(key, default)
+
+
+def _format_bool(value: Any) -> str:
+    return "yes" if bool(value) else "no"

--- a/tests/agent/test_pii_redaction.py
+++ b/tests/agent/test_pii_redaction.py
@@ -1,0 +1,255 @@
+import copy
+from unittest.mock import patch
+
+import pytest
+
+import run_agent
+from run_agent import AIAgent
+from agent import pii_redaction
+from hermes_constants import get_hermes_home
+
+
+ENABLED_CFG = {
+    "enabled": True,
+    "provider": "rampart",
+    "hosted_only": True,
+    "fail_closed": True,
+    "timeout_seconds": 10,
+    "rampart": {
+        "command": "",
+        "model": "nationaldesignstudio/rampart",
+        "heuristics_only": False,
+    },
+}
+
+
+def _fake_redact(texts, _cfg):
+    return [
+        text.replace("alice@example.com", "[EMAIL]")
+        .replace("555-1212", "[PHONE]")
+        .replace("secret-token", "[TOKEN]")
+        for text in texts
+    ]
+
+
+def test_load_pii_redaction_config_defaults_from_partial_config():
+    cfg = pii_redaction.load_pii_redaction_config({"security": {"pii_redaction": {"enabled": True}}})
+
+    assert cfg == {
+        "enabled": True,
+        "provider": "rampart",
+        "hosted_only": True,
+        "fail_closed": True,
+        "timeout_seconds": 10.0,
+        "rampart": {
+            "command": "",
+            "model": "nationaldesignstudio/rampart",
+            "heuristics_only": False,
+        },
+    }
+
+
+def test_should_redact_skips_local_endpoints_when_hosted_only():
+    assert pii_redaction.should_redact_for_llm("https://api.openai.com/v1", pii_config=ENABLED_CFG)
+    assert not pii_redaction.should_redact_for_llm("http://localhost:11434/v1", pii_config=ENABLED_CFG)
+
+    cfg = {**ENABLED_CFG, "hosted_only": False}
+    assert pii_redaction.should_redact_for_llm("http://127.0.0.1:8000/v1", pii_config=cfg)
+
+
+def test_redact_text_for_llm_changes_text_and_reports_disabled_skip(monkeypatch):
+    monkeypatch.setattr(pii_redaction, "_redact_texts", _fake_redact)
+
+    redacted, stats = pii_redaction.redact_text_for_llm(
+        "Email alice@example.com before calling 555-1212.",
+        pii_config=ENABLED_CFG,
+    )
+    assert redacted == "Email [EMAIL] before calling [PHONE]."
+    assert stats["redacted"] is True
+    assert stats["texts_changed"] == 1
+    assert stats["replacement_count"] == 1
+
+    original, skipped = pii_redaction.redact_text_for_llm(
+        "Email alice@example.com",
+        pii_config={**ENABLED_CFG, "enabled": False},
+    )
+    assert original == "Email alice@example.com"
+    assert skipped["skipped"] is True
+    assert skipped["skipped_reason"] == "disabled"
+
+
+def test_redact_messages_deep_copies_and_does_not_mutate(monkeypatch):
+    monkeypatch.setattr(pii_redaction, "_redact_texts", _fake_redact)
+    messages = [{"role": "user", "content": "Contact alice@example.com"}]
+    before = copy.deepcopy(messages)
+
+    redacted, stats = pii_redaction.redact_messages_for_llm(messages, pii_config=ENABLED_CFG)
+
+    assert redacted is not messages
+    assert redacted[0] is not messages[0]
+    assert messages == before
+    assert redacted[0]["content"] == "Contact [EMAIL]"
+    assert stats["texts_scanned"] == 1
+
+
+def test_redact_payload_traverses_text_content_and_tool_call_arguments_only(monkeypatch):
+    seen = []
+
+    def fake(texts, cfg):
+        seen.extend(texts)
+        return _fake_redact(texts, cfg)
+
+    monkeypatch.setattr(pii_redaction, "_redact_texts", fake)
+    payload = {
+        "model": "gpt-alice@example.com",
+        "messages": [
+            {
+                "role": "user",
+                "name": "alice@example.com",
+                "content": "My email is alice@example.com",
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_alice@example.com",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_alice@example.com",
+                            "arguments": '{"email":"alice@example.com","phone":"555-1212"}',
+                        },
+                    }
+                ],
+            },
+        ],
+    }
+
+    redacted, stats = pii_redaction.maybe_redact_api_kwargs(payload, pii_config=ENABLED_CFG)
+
+    assert seen == [
+        "My email is alice@example.com",
+        '{"email":"alice@example.com","phone":"555-1212"}',
+    ]
+    assert redacted["model"] == "gpt-alice@example.com"
+    assert redacted["messages"][0]["name"] == "alice@example.com"
+    assert redacted["messages"][0]["content"] == "My email is [EMAIL]"
+    function = redacted["messages"][1]["tool_calls"][0]["function"]
+    assert function["name"] == "lookup_alice@example.com"
+    assert function["arguments"] == '{"email":"[EMAIL]","phone":"[PHONE]"}'
+    assert stats["texts_scanned"] == 2
+    assert stats["texts_changed"] == 2
+
+
+def test_encrypted_content_and_multimodal_image_file_parts_are_skipped(monkeypatch):
+    seen = []
+
+    def fake(texts, cfg):
+        seen.extend(texts)
+        return _fake_redact(texts, cfg)
+
+    monkeypatch.setattr(pii_redaction, "_redact_texts", fake)
+    messages = [
+        {
+            "role": "user",
+            "encrypted_content": "alice@example.com",
+            "content": [
+                {"type": "input_text", "text": "Visible alice@example.com"},
+                {"type": "input_image", "image_url": "https://example.test/alice@example.com.png"},
+                {"type": "input_file", "filename": "alice@example.com.pdf", "file_data": "alice@example.com"},
+                {"type": "image_url", "url": "data:image/png;base64,alice@example.com"},
+            ],
+        }
+    ]
+
+    redacted, stats = pii_redaction.redact_messages_for_llm(messages, pii_config=ENABLED_CFG)
+
+    assert seen == ["Visible alice@example.com"]
+    assert redacted[0]["encrypted_content"] == "alice@example.com"
+    assert redacted[0]["content"][0]["text"] == "Visible [EMAIL]"
+    assert redacted[0]["content"][1]["image_url"] == "https://example.test/alice@example.com.png"
+    assert redacted[0]["content"][2]["filename"] == "alice@example.com.pdf"
+    assert redacted[0]["content"][2]["file_data"] == "alice@example.com"
+    assert redacted[0]["content"][3]["url"] == "data:image/png;base64,alice@example.com"
+    assert stats["texts_scanned"] == 1
+
+
+def test_redaction_fail_closed_raises(monkeypatch):
+    def fail(_texts, _cfg):
+        raise RuntimeError("backend unavailable")
+
+    monkeypatch.setattr(pii_redaction, "_redact_texts", fail)
+
+    with pytest.raises(RuntimeError, match="refusing to send unredacted payload"):
+        pii_redaction.redact_messages_for_llm(
+            [{"role": "user", "content": "alice@example.com"}],
+            pii_config=ENABLED_CFG,
+        )
+
+
+def test_redaction_fail_open_returns_original_payload(monkeypatch):
+    def fail(_texts, _cfg):
+        raise RuntimeError("backend unavailable")
+
+    monkeypatch.setattr(pii_redaction, "_redact_texts", fail)
+    payload = [{"role": "user", "content": "alice@example.com"}]
+
+    redacted, stats = pii_redaction.redact_messages_for_llm(
+        payload,
+        pii_config={**ENABLED_CFG, "fail_closed": False},
+    )
+
+    assert redacted is payload
+    assert redacted[0]["content"] == "alice@example.com"
+    assert stats["failure"] == "RuntimeError"
+    assert stats["redacted"] is True
+
+
+def test_rampart_worker_uses_sanitized_environment(monkeypatch):
+    captured = {}
+
+    class Completed:
+        returncode = 0
+        stdout = '{"texts":["redacted"]}'
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return Completed()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+    monkeypatch.setenv("PATH", "/bin")
+    monkeypatch.setattr(pii_redaction.subprocess, "run", fake_run)
+
+    assert pii_redaction._redact_with_rampart(["raw"], ENABLED_CFG) == ["redacted"]
+    env = captured["env"]
+    assert env["PATH"] == "/bin"
+    assert "OPENAI_API_KEY" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_agent_build_api_kwargs_redacts_before_provider_dispatch(monkeypatch):
+    monkeypatch.setattr(pii_redaction, "_redact_texts", _fake_redact)
+    run_agent._hermes_home = get_hermes_home()
+    config = {"security": {"pii_redaction": ENABLED_CFG}}
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value=config),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            provider="custom",
+            model="gpt-test",
+            base_url="https://api.example.test/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        messages = [{"role": "user", "content": "Email alice@example.com"}]
+        kwargs = agent._build_api_kwargs(messages)
+
+    assert kwargs["messages"][0]["content"] == "Email [EMAIL]"
+    assert messages[0]["content"] == "Email alice@example.com"
+    assert agent._last_pii_redaction_stats["texts_changed"] == 1

--- a/tests/hermes_cli/test_redact_cmd.py
+++ b/tests/hermes_cli/test_redact_cmd.py
@@ -1,0 +1,230 @@
+import argparse
+import json
+
+from hermes_cli import redact_cmd
+
+
+def _args(**kwargs):
+    defaults = {
+        "redact_command": "config",
+        "enable": False,
+        "disable": False,
+        "hosted_only": False,
+        "all_endpoints": False,
+        "fail_closed": False,
+        "fail_open": False,
+        "heuristics_only": False,
+        "no_heuristics_only": False,
+        "model": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def test_register_redact_parser_wires_expected_flags():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    redact_cmd.register_redact_parser(subparsers)
+
+    args = parser.parse_args(
+        [
+            "redact",
+            "config",
+            "--enable",
+            "--all-endpoints",
+            "--fail-open",
+            "--heuristics-only",
+            "--model",
+            "local-model",
+        ]
+    )
+
+    assert args.command == "redact"
+    assert args.redact_command == "config"
+    assert args.enable is True
+    assert args.all_endpoints is True
+    assert args.fail_open is True
+    assert args.heuristics_only is True
+    assert args.model == "local-model"
+    assert args.func is redact_cmd.cmd_redact
+
+
+def test_cmd_redact_config_persists_nested_settings(monkeypatch, capsys):
+    saved = {}
+    current = {"security": {}}
+
+    def load_config():
+        return current
+
+    def save_config(config):
+        saved.clear()
+        saved.update(config)
+
+    monkeypatch.setattr("hermes_cli.config.load_config", load_config)
+    monkeypatch.setattr("hermes_cli.config.save_config", save_config)
+    monkeypatch.setattr(
+        redact_cmd,
+        "_runtime_config",
+        lambda config=None: {
+            "enabled": True,
+            "provider": "rampart",
+            "hosted_only": False,
+            "fail_closed": False,
+            "rampart": {"model": "local-rampart", "heuristics_only": True},
+            "setup_ready": True,
+        },
+    )
+
+    code = redact_cmd.cmd_redact(
+        _args(
+            enable=True,
+            all_endpoints=True,
+            fail_open=True,
+            heuristics_only=True,
+            model="local-rampart",
+        )
+    )
+
+    assert code == 0
+    section = saved["security"]["pii_redaction"]
+    assert section["enabled"] is True
+    assert section["hosted_only"] is False
+    assert section["fail_closed"] is False
+    assert section["provider"] == "rampart"
+    assert section["rampart"] == {"heuristics_only": True, "model": "local-rampart"}
+
+    out = capsys.readouterr().out
+    assert "Saved local PII redaction config." in out
+    assert "Enabled:        yes" in out
+    assert "Hosted only:    no" in out
+    assert "Fail closed:    no" in out
+    assert "Heuristics only: yes" in out
+
+
+def test_cmd_redact_config_show_does_not_save(monkeypatch, capsys):
+    save_calls = []
+    config = {
+        "security": {
+            "pii_redaction": {
+                "enabled": False,
+                "provider": "rampart",
+                "hosted_only": True,
+                "fail_closed": True,
+                "rampart": {"heuristics_only": False},
+            }
+        }
+    }
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: save_calls.append(cfg))
+    monkeypatch.setattr(redact_cmd, "_runtime_config", lambda config=None: config["security"]["pii_redaction"])
+
+    code = redact_cmd.cmd_redact(_args())
+
+    assert code == 0
+    assert save_calls == []
+    assert "Enabled:        no" in capsys.readouterr().out
+
+
+def test_setup_ready_requires_transformers_for_model_backed_rampart(tmp_path):
+    worker = tmp_path / "rampart_pii_worker.mjs"
+    worker.write_text("worker", encoding="utf-8")
+    rampart_dir = tmp_path / "node_modules" / "@nationaldesignstudio" / "rampart"
+    rampart_dir.mkdir(parents=True)
+
+    assert (
+        redact_cmd._setup_ready(
+            {
+                "provider": "rampart",
+                "rampart": {
+                    "command": f"node {worker}",
+                    "heuristics_only": False,
+                },
+            }
+        )
+        is False
+    )
+
+    transformers_dir = tmp_path / "node_modules" / "@huggingface" / "transformers"
+    transformers_dir.mkdir(parents=True)
+    assert (
+        redact_cmd._setup_ready(
+            {
+                "provider": "rampart",
+                "rampart": {
+                    "command": f"node {worker}",
+                    "heuristics_only": False,
+                },
+            }
+        )
+        is True
+    )
+
+
+def test_setup_ready_heuristics_only_still_requires_rampart_package(tmp_path):
+    worker = tmp_path / "rampart_pii_worker.mjs"
+    worker.write_text("worker", encoding="utf-8")
+    status = {
+        "provider": "rampart",
+        "rampart": {
+            "command": f"node {worker}",
+            "heuristics_only": True,
+        },
+    }
+
+    assert redact_cmd._setup_ready(status) is False
+
+    rampart_dir = tmp_path / "node_modules" / "@nationaldesignstudio" / "rampart"
+    rampart_dir.mkdir(parents=True)
+    assert redact_cmd._setup_ready(status) is True
+
+
+def test_cmd_redact_run_uses_runtime_redactor(monkeypatch, capsys):
+    calls = []
+
+    def fake_redact(text):
+        calls.append(text)
+        return "Email [EMAIL]\n", {"redacted": True, "texts_changed": 1}
+
+    monkeypatch.setattr(redact_cmd, "_redact_text", fake_redact)
+
+    code = redact_cmd.cmd_redact(argparse.Namespace(redact_command="run", text="Email alice@example.com", json=False))
+
+    assert code == 0
+    assert calls == ["Email alice@example.com"]
+    captured = capsys.readouterr()
+    assert captured.out == "Email [EMAIL]\n"
+    assert captured.err == ""
+
+
+def test_cmd_redact_run_json_reports_skipped(monkeypatch, capsys):
+    monkeypatch.setattr(
+        redact_cmd,
+        "_redact_text",
+        lambda text: (text, {"skipped": True, "skipped_reason": "disabled"}),
+    )
+
+    code = redact_cmd.cmd_redact(argparse.Namespace(redact_command="run", text="Email alice@example.com", json=True))
+
+    assert code == 0
+    captured = capsys.readouterr()
+    assert "redaction skipped (disabled)" in captured.err
+    payload = json.loads(captured.out)
+    assert payload == {
+        "text": "Email alice@example.com",
+        "stats": {"skipped": True, "skipped_reason": "disabled"},
+    }
+
+
+def test_cmd_redact_run_runtime_failure_returns_error(monkeypatch, capsys):
+    def fail(_text):
+        raise RuntimeError("backend unavailable")
+
+    monkeypatch.setattr(redact_cmd, "_redact_text", fail)
+
+    code = redact_cmd.cmd_redact(argparse.Namespace(redact_command="run", text="Email alice@example.com", json=False))
+
+    assert code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "hermes redact run: backend unavailable" in captured.err

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -53,6 +53,9 @@ def _make_codex_agent():
     """Construct an AIAgent in codex_app_server mode without contacting any
     real provider. We pass api_mode explicitly so the constructor takes the
     fast path for direct credentials."""
+    from hermes_constants import get_hermes_home
+
+    run_agent._hermes_home = get_hermes_home()
     return run_agent.AIAgent(
         api_key="stub",
         base_url="https://stub.invalid",
@@ -158,6 +161,43 @@ class TestRunConversationCodexPath:
 
         agent._memory_manager.sync_all.assert_called_once()
         assert agent._memory_manager.sync_all.call_args.kwargs["messages"] == result["messages"]
+
+    def test_codex_app_server_redacts_outbound_input_only(self, monkeypatch):
+        captured = {}
+
+        def fake_redact_text(text, **kwargs):
+            captured["redact_input"] = text
+            captured["redact_kwargs"] = kwargs
+            return text.replace("alice@example.com", "[EMAIL]"), {
+                "redacted": True,
+                "texts_changed": 1,
+            }
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            captured["codex_input"] = user_input
+            return TurnResult(
+                final_text=f"echo: {user_input}",
+                projected_messages=[{"role": "assistant", "content": f"echo: {user_input}"}],
+                tool_iterations=0,
+                interrupted=False,
+                error=None,
+                turn_id="turn-redacted",
+                thread_id="thread-redacted",
+            )
+
+        monkeypatch.setattr("agent.pii_redaction.redact_text_for_llm", fake_redact_text)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(CodexAppServerSession, "ensure_started", lambda self: "thread-redacted")
+
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("Email alice@example.com")
+
+        assert captured["redact_input"] == "Email alice@example.com"
+        assert captured["codex_input"] == "Email [EMAIL]"
+        assert result["messages"][0]["content"] == "Email alice@example.com"
+        assert result["final_response"] == "echo: Email [EMAIL]"
+        assert agent._last_pii_redaction_stats["texts_changed"] == 1
 
     def test_nudge_counters_tick(self, fake_session):
         """The skill nudge counter must accumulate tool_iterations across
@@ -588,4 +628,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1829,6 +1829,16 @@ Pre-execution security scanning and secret redaction:
 ```yaml
 security:
   redact_secrets: true           # Redact API key patterns in tool output and logs (on by default)
+  pii_redaction:                 # Optional local PII redaction before hosted LLM calls
+    enabled: false
+    provider: rampart
+    hosted_only: true
+    fail_closed: true
+    timeout_seconds: 10
+    rampart:
+      command: ""                # Written by `hermes redact setup`
+      model: nationaldesignstudio/rampart
+      heuristics_only: false
   tirith_enabled: true           # Enable Tirith security scanning for terminal commands
   tirith_path: "tirith"          # Path to tirith binary (default: "tirith" in $PATH)
   tirith_timeout: 5              # Seconds to wait for tirith scan before timing out
@@ -1840,10 +1850,60 @@ security:
 ```
 
 - `redact_secrets` — when `true`, automatically detects and redacts patterns that look like API keys, tokens, and passwords in tool output before it enters the conversation context and logs. **On by default**. Set to `false` explicitly only when you need raw credential-like strings for debugging or redactor development.
+- `pii_redaction` — optional local redaction for outbound LLM request payloads. It is **off by default** and intended for users who want to reduce accidental exposure of common PII before using hosted model providers.
 - `tirith_enabled` — when `true`, terminal commands are scanned by [Tirith](https://github.com/sheeki03/tirith) before execution to detect potentially dangerous operations.
 - `tirith_path` — path to the tirith binary. Set this if tirith is installed in a non-standard location.
 - `tirith_timeout` — maximum seconds to wait for a tirith scan. Commands proceed if the scan times out.
 - `tirith_fail_open` — when `true` (default), commands are allowed to execute if tirith is unavailable or fails. Set to `false` to block commands when tirith cannot verify them.
+
+### Local PII Redaction
+
+`security.pii_redaction` redacts text fields in model request payloads before Hermes sends them to an LLM provider. The default backend uses [Rampart](https://huggingface.co/nationaldesignstudio/rampart), installed locally and invoked as a subprocess.
+
+This feature is opt-in:
+
+```bash
+hermes redact setup --enable
+```
+
+`setup` requires `node` and `npm` on `PATH`. It installs exact-pinned npm packages under the active Hermes home (`support/pii-redaction/rampart`) rather than adding them to the base Python environment. The first model-backed run may fetch and cache the Rampart model from Hugging Face. For fully offline use after setup, make sure the model has already been cached locally, or use heuristics-only mode.
+
+Try the configured backend without sending anything to a provider:
+
+```bash
+hermes redact run --text "Call Alice at 415-555-1212"
+```
+
+Example output:
+
+```text
+Call [GIVEN_NAME_1] at [PHONE_1]
+```
+
+Common configuration commands:
+
+```bash
+hermes redact config --enable
+hermes redact config --disable
+hermes redact config --hosted-only       # default: skip local endpoints
+hermes redact config --all-endpoints     # also redact local inference requests
+hermes redact config --fail-closed       # default: block if redaction fails
+hermes redact config --fail-open         # allow unredacted send if redaction fails
+hermes redact config --heuristics-only   # no model load; less contextual coverage
+```
+
+Behavior summary:
+
+| Setting | Default | Behavior |
+|---------|---------|----------|
+| `enabled` | `false` | No PII redaction runs until explicitly enabled. |
+| `hosted_only` | `true` | Hosted provider calls are redacted; local endpoints such as Ollama or vLLM are skipped. |
+| `fail_closed` | `true` | If redaction fails, Hermes refuses to send the unredacted hosted request. |
+| `rampart.heuristics_only` | `false` | Uses Rampart's model-backed detector plus heuristics. Set to `true` to avoid model loading. |
+
+The redactor scans ordinary text fields in structured LLM requests, including messages and text inputs. It deliberately skips opaque or protocol-sensitive fields such as model names, provider metadata, tool call IDs, file IDs, URLs, base64 media payloads, encrypted content, and reasoning metadata so requests remain valid.
+
+Treat this as a privacy exposure-reduction layer, not a security boundary. PII detection is probabilistic and can miss uncommon formats or context-dependent identifiers. Keep using local inference for maximum privacy, and avoid sending highly sensitive material to hosted providers when policy or compliance requires stronger guarantees.
 
 ## Website Blocklist
 


### PR DESCRIPTION
## What changed

Adds an opt-in local PII redaction layer for outbound LLM request payloads before hosted-provider dispatch.

- Adds `agent.pii_redaction` to redact structured API kwargs/messages/text before hosted LLM calls.
- Wires redaction into chat completions, auxiliary client requests, and Codex app-server outbound input while preserving local in-memory conversation state.
- Adds `hermes redact` with `config`, `setup`, and `run` subcommands.
- Adds an isolated Rampart Node worker installed under the active Hermes home by `hermes redact setup`.
- Documents `security.pii_redaction` in the user guide and `cli-config.yaml.example`.

## Why

Hermes can load large amounts of local context into model requests. For hosted providers, users may want a local redaction pass that reduces accidental exposure of common PII before request payloads leave the machine. The feature is disabled by default and skips local endpoints by default.

## What Rampart is

Rampart is a newly released client-side PII redaction system from National Design Studio. The published model is a small ONNX token-classification artifact (`nationaldesignstudio/rampart`) that runs through `transformers.js`; the complete Rampart runtime combines that model with deterministic recognizers for structured identifiers and replaces detected values with stable typed placeholders such as `[PHONE_1]` or `[EMAIL_1]`.

This PR uses Rampart because it is designed for the exact use case Hermes needs here: redact user content locally before sending it to a hosted LLM provider. Hermes installs it as an optional per-profile Node backend instead of adding it to the base Python dependency set.

## Not already covered by existing features

This is distinct from the existing gateway-only `privacy.redact_pii`, which hashes or strips gateway session metadata such as platform user IDs and phone-like identifiers. It is also distinct from `security.redact_secrets`, which targets credential/token-like secrets in tool output, logs, and persistence paths. This PR adds an opt-in pre-dispatch redaction layer for ordinary text fields in hosted LLM request payloads.

## Security and privacy model

This is a privacy exposure-reduction layer, not a hard security boundary. It scans ordinary text fields in structured LLM payloads and intentionally skips opaque/protocol-sensitive fields such as model/provider metadata, tool call IDs, file IDs, URLs, base64 media payloads, encrypted content, and reasoning metadata so provider requests remain valid.

Default behavior:

| Case | Behavior |
|---|---|
| `enabled=false` | No PII redaction runs. |
| Hosted provider + `hosted_only=true` | Text payloads are redacted before dispatch. |
| Local endpoint + `hosted_only=true` | Redaction is skipped. |
| Redaction failure + `fail_closed=true` | Hermes refuses to send the unredacted hosted payload. |
| `rampart.heuristics_only=true` | Uses Rampart heuristics without model loading. |

## Dependency behavior

`hermes redact setup` requires `node` and `npm` on `PATH` and installs exact-pinned optional npm packages into the active Hermes profile under `support/pii-redaction/rampart`:

- `@nationaldesignstudio/rampart@0.1.1`
- `@huggingface/transformers@3.7.5`

These are optional runtime packages, not base Python install dependencies. The first model-backed run may fetch/cache the Rampart model from Hugging Face.

## How to try locally

From a checkout of this branch:

```bash
git checkout feat/local-pii-redaction
source ~/.hermes/hermes-agent/venv/bin/activate  # or your repo-local .venv/venv
python -m hermes_cli.main redact setup --enable
python -m hermes_cli.main redact run --text "Call 415-555-1212 or user@example.com. SSN 123-45-6789."
```

Expected output uses typed placeholders, for example:

```text
Call [PHONE_1] or [EMAIL_1]. SSN [SSN_1].
```

You can inspect or adjust settings with:

```bash
python -m hermes_cli.main redact config
python -m hermes_cli.main redact config --hosted-only --fail-closed
python -m hermes_cli.main redact config --heuristics-only
```

## Tests added

- Unit coverage for redaction config loading, hosted/local endpoint skip behavior, fail-closed behavior, structured payload traversal, opaque field preservation, subprocess backend invocation, and metadata-only logging in `tests/agent/test_pii_redaction.py`.
- CLI coverage for `hermes redact` parser wiring, config persistence, setup readiness checks, JSON output, skipped redaction reporting, and runtime failure handling in `tests/hermes_cli/test_redact_cmd.py`.
- Codex app-server integration coverage verifying outbound input is redacted while the local conversation history keeps the original user message in `tests/run_agent/test_codex_app_server_integration.py`.

## Validation

Tested locally on macOS.

- `python -m py_compile agent/pii_redaction.py agent/chat_completion_helpers.py agent/auxiliary_client.py agent/codex_runtime.py hermes_cli/redact_cmd.py hermes_cli/main.py`
- `node --check agent/rampart_pii_worker.mjs`
- `python -m ruff check agent/pii_redaction.py hermes_cli/redact_cmd.py agent/chat_completion_helpers.py agent/auxiliary_client.py agent/codex_runtime.py tests/agent/test_pii_redaction.py tests/hermes_cli/test_redact_cmd.py tests/run_agent/test_codex_app_server_integration.py`
- `python scripts/check-windows-footguns.py --all`
- `python -m pytest -o addopts="-m 'not integration'" tests/agent/test_pii_redaction.py tests/hermes_cli/test_redact_cmd.py tests/run_agent/test_codex_app_server_integration.py::TestRunConversationCodexPath::test_codex_app_server_redacts_outbound_input_only tests/run_agent/test_codex_app_server_integration.py::TestRunConversationCodexPath::test_projected_messages_are_synced_to_external_memory` (`20 passed`)
- Real isolated Rampart verification with a temporary `HERMES_HOME`: `hermes redact setup --enable` then `hermes redact run --json --text 'Call 415-555-1212 or user@example.com. SSN 123-45-6789.'`, producing placeholders for phone/email/SSN.