### PR TITLE
fix(auxiliary): prepend zai coding-plan vision endpoint before metered paas/v4 (fixes #55112)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4769,7 +4769,7 @@ def resolve_vision_provider_client(
     # while the OpenAI wire handles it correctly.
     if requested == "zai" and not resolved_base_url:
         zai_openai_urls = [
-            "https://api.z.ai/api/coding/paas/v4",   # coding-plan quota
+            "https://api.z.ai/api/coding/paas/v4",  # coding-plan quota
         "https://open.bigmodel.cn/api/paas/v4",  # metered fallthrough
             "https://api.z.ai/api/paas/v4",
         ]

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4769,7 +4769,8 @@ def resolve_vision_provider_client(
     # while the OpenAI wire handles it correctly.
     if requested == "zai" and not resolved_base_url:
         zai_openai_urls = [
-            "https://open.bigmodel.cn/api/paas/v4",
+            "https://api.z.ai/api/coding/paas/v4",   # coding-plan quota
+        "https://open.bigmodel.cn/api/paas/v4",  # metered fallthrough
             "https://api.z.ai/api/paas/v4",
         ]
         for _zai_url in zai_openai_urls:


### PR DESCRIPTION
Closes #55112

Prepend the coding-plan quota endpoint as the first URL tried for ZAI vision requests, so subscription users hit the quota-billed endpoint before falling through to the metered pay-as-you-go endpoints.