### PR TITLE
docs(cron): fix bundled skill doc to say 600s inactivity timeout not 3-minute hard interrupt (fixes #55038)

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -734,7 +734,7 @@ the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
   job), `context_from` (chain job A's output into job B), `workdir`
   (run in a specific dir with its `AGENTS.md` / `CLAUDE.md` loaded),
   multi-platform delivery.
-- **Invariants:** 600s inactivity-based timeout per run (override via HERMES_CRON_TIMEOUT), `.tick.lock` file
+- **Invariants:** 600s inactivity-based timeout per run (override via HERMES_CRON_TIMEOUT),  `.tick.lock` file
   prevents duplicate ticks across processes, cron sessions pass
   `skip_memory=True` by default, and cron deliveries are framed with a
   header/footer instead of being mirrored into the target gateway

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -734,7 +734,7 @@ the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
   job), `context_from` (chain job A's output into job B), `workdir`
   (run in a specific dir with its `AGENTS.md` / `CLAUDE.md` loaded),
   multi-platform delivery.
-- **Invariants:** 3-minute hard interrupt per run, `.tick.lock` file
+- **Invariants:** 600s inactivity-based timeout per run (override via HERMES_CRON_TIMEOUT), `.tick.lock` file
   prevents duplicate ticks across processes, cron sessions pass
   `skip_memory=True` by default, and cron deliveries are framed with a
   header/footer instead of being mirrored into the target gateway


### PR DESCRIPTION
Closes #55038

Correct the bundled hermes-agent skill's Cron Invariants bullet: the scheduler uses a 600s inactivity-based timeout (configurable via HERMES_CRON_TIMEOUT), not a hard 3-minute wall-clock cap.