### PR TITLE
fix(scripts): don't crash the Windows footgun checker on paths outside the repo root

### DIFF
--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -39,6 +39,15 @@ from typing import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+
+def _repo_rel(path: Path) -> str | None:
+    """Repo-relative POSIX path, or None if `path` is outside REPO_ROOT."""
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return None
+
+
 SUPPRESS_MARKER = re.compile(r"#\s*windows-footgun\s*:\s*ok\b", re.IGNORECASE)
 
 # Line-level guard hints. If a line contains any of these tokens, we assume
@@ -337,9 +346,13 @@ def should_scan_file(path: Path) -> bool:
     for suffix in EXCLUDED_SUFFIXES:
         if str(path).endswith(suffix):
             return False
-    # Skip self and docs that intentionally mention the patterns
-    rel = path.relative_to(REPO_ROOT).as_posix()
-    if rel in EXCLUDED_FILES:
+    # Skip self and docs that intentionally mention the patterns. Paths
+    # outside REPO_ROOT (e.g. explicit-path mode on a sibling file or a
+    # relocated worktree) can never be in EXCLUDED_FILES, which only holds
+    # repo-relative paths — so treat "outside the repo" as "not excluded"
+    # rather than crashing on relative_to()'s ValueError.
+    rel = _repo_rel(path)
+    if rel is not None and rel in EXCLUDED_FILES:
         return False
     # Only scan text files (rough heuristic — .py, .md, .sh, .ps1, .yaml, etc.)
     if path.suffix in {".py", ".pyw", ".pyi"}:
@@ -600,7 +613,7 @@ def main(argv: list[str]) -> int:
         files_scanned += 1
         matches = scan_file(path, FOOTGUNS)
         for lineno, line, fg in matches:
-            rel = path.relative_to(REPO_ROOT).as_posix()
+            rel = _repo_rel(path) or str(path)
             print(f"{rel}:{lineno}: [{fg.name}]")
             print(f"    {line.strip()}")
             print(f"    — {fg.message}")

--- a/tests/scripts/test_check_windows_footguns.py
+++ b/tests/scripts/test_check_windows_footguns.py
@@ -1,0 +1,74 @@
+"""Regression tests for scripts/check-windows-footguns.py path handling.
+
+The checker documents an explicit-path mode
+(``python scripts/check-windows-footguns.py path/to/file.py``). ``main()``
+resolves those arguments to absolute paths and feeds them through
+``iter_files`` -> ``should_scan_file``. Both ``should_scan_file`` and the
+``main`` output loop called ``path.relative_to(REPO_ROOT).as_posix()``
+unconditionally — but ``Path.relative_to`` raises ``ValueError`` for any path
+that does not live under ``REPO_ROOT`` (a sibling file, a symlinked/relocated
+worktree, an agent worktree under a different prefix). That crashed the whole
+checker with a traceback, silently defeating the pre-PR footgun gate it exists
+to enforce. ``EXCLUDED_FILES`` only ever holds repo-relative paths, so for a
+file outside the repo the correct answer is simply "not excluded" — never a
+crash.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check-windows-footguns.py"
+_MODULE_NAME = "check_windows_footguns_test_module"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the module-level @dataclass can resolve
+    # ``cls.__module__`` via ``sys.modules`` during decoration.
+    sys.modules[_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+footguns = _load_script_module()
+
+
+def test_should_scan_file_outside_repo_does_not_crash():
+    """A path outside REPO_ROOT must not raise and must be in scope.
+
+    Before the fix this raised ``ValueError`` from
+    ``path.relative_to(REPO_ROOT)``.
+    """
+    outside = Path("/tmp/outside-repo-check/foo.py")
+    # Does not raise, and a .py file outside the repo is still scannable
+    # (it can never match EXCLUDED_FILES, which is repo-relative only).
+    assert footguns.should_scan_file(outside) is True
+
+
+def test_main_scans_explicit_path_outside_repo(tmp_path, capsys):
+    """End-to-end: explicit-path mode on a file outside the repo reports the
+    footgun and exits 1 instead of crashing with an uncaught ValueError.
+    """
+    # tmp_path is a pytest temp dir outside the repo checkout. Write a file
+    # containing a real footgun the checker matches: ``os.killpg`` (no
+    # post_filter, so the bare reference is always flagged).
+    outside_file = tmp_path / "uses_killpg.py"
+    outside_file.write_text(
+        "import os\n\n\ndef stop(pgid):\n    os.killpg(pgid, 9)\n",
+        encoding="utf-8",
+    )
+
+    rc = footguns.main([str(outside_file)])
+
+    out = capsys.readouterr().out
+    assert rc == 1, "explicit-path scan of a footgun file should exit 1"
+    # The finding line falls back to the absolute path when the file is
+    # outside the repo (no relative_to crash).
+    assert str(outside_file) in out
+    assert "os.killpg" in out


### PR DESCRIPTION
## What does this PR do?

`scripts/check-windows-footguns.py` documents an explicit-path mode:

```
python scripts/check-windows-footguns.py path/to/file.py path/to/dir/
```

`main()` resolves those arguments to absolute paths (`roots = [p.resolve() for p in args.paths]`) and feeds them through `iter_files` → `should_scan_file`. Two sites then called `path.relative_to(REPO_ROOT).as_posix()` **unconditionally**:

- `should_scan_file()` — to test the path against `EXCLUDED_FILES`.
- the `main()` output loop — to print the finding location.

`Path.relative_to()` raises `ValueError` for any path that does not live under `REPO_ROOT`. So pointing the checker at a file that resolves *outside* the checkout — a sibling file, a symlinked/relocated worktree, or an agent worktree under a different prefix — crashed the whole script with a traceback, silently defeating the pre-PR footgun gate it exists to enforce:

```
ValueError: '/tmp/uses_killpg.py' is not in the subpath of
'/path/to/hermes-agent' OR one path is relative and the other is absolute.
```

`EXCLUDED_FILES` only ever holds repo-relative paths (`scripts/check-windows-footguns.py`, `CONTRIBUTING.md`), so for an outside-repo file the correct answer is simply "not excluded" — never a crash. This PR adds a tiny `_repo_rel()` helper that returns `None` on `ValueError`; `should_scan_file` treats `None` as not-excluded, and the output loop falls back to the absolute path.

## Related Issue

N/A — author-found defect in the footgun checker itself.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/check-windows-footguns.py`: add `_repo_rel(path) -> str | None` helper next to `REPO_ROOT`; guard the `should_scan_file()` exclusion check (`rel is not None and rel in EXCLUDED_FILES`) and the `main()` print loop (`_repo_rel(path) or str(path)`).
- `tests/scripts/test_check_windows_footguns.py`: new regression tests.

## How to Test

1. `should_scan_file(Path("/tmp/outside-repo/foo.py"))` — before: raises `ValueError`; after: returns `True` (a `.py` outside the repo can never be in `EXCLUDED_FILES`, so it stays in scope).
2. End-to-end: write a `.py` file **outside** the repo containing a real footgun (e.g. `os.killpg(pgid, 9)`), then `main([str(that_file)])` — before: uncaught `ValueError` traceback; after: prints the finding with the absolute path and returns exit code `1`.
3. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/scripts/ -v` — 7 passed.

Both new tests fail before the production change (the exact `ValueError`) and pass after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/scripts/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the helper is pure-`pathlib`, behavior-identical on all platforms; the bug it fixes affects every OS.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A