### PR TITLE
fix(desktop): stop tool-result summary from counting empty fields as "N more fields"

### DIFF
--- a/apps/desktop/src/lib/tool-result-summary.test.ts
+++ b/apps/desktop/src/lib/tool-result-summary.test.ts
@@ -64,6 +64,32 @@ describe('formatToolResultSummary', () => {
     expect(summary).toContain('- Title: Build report')
     expect(summary).toContain('- Completed: true')
   })
+
+  it('does not count empty fields as hidden "more fields"', () => {
+    // `tags: []` and `note: ''` render nothing (formatFieldValue returns
+    // empty for empty arrays / empty strings), so they are not fields the
+    // user is "missing" — only the cap-truncated remainder should be
+    // reported. Before the fix this emitted "- … 2 more fields".
+    const summary = formatToolResultSummary({ name: 'x', tags: [], note: '' })
+
+    expect(summary).toBe('- Name: x')
+    expect(summary).not.toContain('more fields')
+  })
+
+  it('still reports genuinely cap-truncated fields as "N more fields"', () => {
+    // 10 content-bearing keys with an 8-field cap → 2 truly hidden fields.
+    // This guards against over-correcting the empty-field fix into dropping
+    // the real cap-overflow tail.
+    const record: Record<string, string> = {}
+
+    for (let i = 1; i <= 10; i += 1) {
+      record[`field${i}`] = `value${i}`
+    }
+
+    const summary = formatToolResultSummary(record)
+
+    expect(summary).toContain('… 2 more fields')
+  })
 })
 
 describe('extractToolErrorMessage', () => {
@@ -102,31 +128,5 @@ describe('extractToolErrorMessage', () => {
     })
 
     expect(error).toBe('')
-  })
-
-  it('does not count empty fields as hidden "more fields"', () => {
-    // `tags: []` and `note: ''` render nothing (formatFieldValue returns
-    // empty for empty arrays / empty strings), so they are not fields the
-    // user is "missing" — only the cap-truncated remainder should be
-    // reported. Before the fix this emitted "- … 2 more fields".
-    const summary = formatToolResultSummary({ name: 'x', tags: [], note: '' })
-
-    expect(summary).toBe('- Name: x')
-    expect(summary).not.toContain('more fields')
-  })
-
-  it('still reports genuinely cap-truncated fields as "N more fields"', () => {
-    // 10 content-bearing keys with an 8-field cap → 2 truly hidden fields.
-    // This guards against over-correcting the empty-field fix into dropping
-    // the real cap-overflow tail.
-    const record: Record<string, string> = {}
-
-    for (let i = 1; i <= 10; i += 1) {
-      record[`field${i}`] = `value${i}`
-    }
-
-    const summary = formatToolResultSummary(record)
-
-    expect(summary).toContain('… 2 more fields')
   })
 })

--- a/apps/desktop/src/lib/tool-result-summary.test.ts
+++ b/apps/desktop/src/lib/tool-result-summary.test.ts
@@ -103,4 +103,30 @@ describe('extractToolErrorMessage', () => {
 
     expect(error).toBe('')
   })
+
+  it('does not count empty fields as hidden "more fields"', () => {
+    // `tags: []` and `note: ''` render nothing (formatFieldValue returns
+    // empty for empty arrays / empty strings), so they are not fields the
+    // user is "missing" — only the cap-truncated remainder should be
+    // reported. Before the fix this emitted "- … 2 more fields".
+    const summary = formatToolResultSummary({ name: 'x', tags: [], note: '' })
+
+    expect(summary).toBe('- Name: x')
+    expect(summary).not.toContain('more fields')
+  })
+
+  it('still reports genuinely cap-truncated fields as "N more fields"', () => {
+    // 10 content-bearing keys with an 8-field cap → 2 truly hidden fields.
+    // This guards against over-correcting the empty-field fix into dropping
+    // the real cap-overflow tail.
+    const record: Record<string, string> = {}
+
+    for (let i = 1; i <= 10; i += 1) {
+      record[`field${i}`] = `value${i}`
+    }
+
+    const summary = formatToolResultSummary(record)
+
+    expect(summary).toContain('… 2 more fields')
+  })
 })

--- a/apps/desktop/src/lib/tool-result-summary.ts
+++ b/apps/desktop/src/lib/tool-result-summary.ts
@@ -259,8 +259,11 @@ function formatRecordSummary(record: Json, depth: number): string {
   const candidates = orderedKeys(keys).filter(k => !skipField(k, record[k]))
   const max = 8
   const lines: string[] = []
+  let consumed = 0
 
   for (const k of candidates) {
+    consumed += 1
+
     const v = formatFieldValue(record[k], depth + 1)
 
     if (!v) {
@@ -278,8 +281,13 @@ function formatRecordSummary(record: Json, depth: number): string {
     return ''
   }
 
-  if (candidates.length > lines.length) {
-    const remaining = candidates.length - lines.length
+  // Only candidates we never examined (because the `max` cap broke the loop
+  // early) are genuinely hidden. Candidates whose value rendered empty were
+  // consumed and intentionally produced nothing — counting them here would
+  // inflate the tail with fields that don't exist.
+  const remaining = candidates.length - consumed
+
+  if (remaining > 0) {
     lines.push(`- … ${remaining} more ${remaining === 1 ? 'field' : 'fields'}`)
   }
 


### PR DESCRIPTION
## What does this PR do?

`apps/desktop/src/lib/tool-result-summary.ts` renders a tool result's record as a few `- Key: value` lines, then appends a `- … N more fields` tail when some fields aren't shown. The tail count was computed as:

```ts
if (candidates.length > lines.length) {
  const remaining = candidates.length - lines.length
  lines.push(`- … ${remaining} more ${remaining === 1 ? 'field' : 'fields'}`)
}
```

`candidates.length - lines.length` conflates two unrelated shortfalls:

- **(a)** a candidate whose value rendered empty — `formatFieldValue` returns `''` for an empty array, empty string, or null, so the loop hits `if (!v) continue` and adds no line. These produced nothing *on purpose*.
- **(b)** the `max = 8` cap broke the loop early, leaving real candidates unexamined.

Only **(b)** is genuinely "more fields the user isn't seeing." Empty-valued candidates inflated the tail with fields that don't exist. For example:

```ts
formatToolResultSummary({ name: 'x', tags: [], note: '' })
// before: "- Name: x\n- … 2 more fields"   ← tags/note are empty, not hidden
// after:  "- Name: x"
```

The sibling `formatArraySummary` already does this correctly — it gates on true overflow (`value.length > max`) and counts `value.length - max`. This change brings the record path in line: track how many candidates were `consumed` by the loop and report only `candidates.length - consumed` (the ones the cap stopped us from examining).

## Related Issue

N/A — author-found logic defect in the desktop tool-result summary.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/tool-result-summary.ts`: in `formatRecordSummary`, track a `consumed` counter (incremented once per candidate the loop visits) and compute the tail as `candidates.length - consumed` instead of `candidates.length - lines.length`. Empty-valued fields → all consumed → no tail; true cap overflow → reports the correct hidden count.
- `apps/desktop/src/lib/tool-result-summary.test.ts`: two regression tests (empty-field case + cap-overflow guard).

## How to Test

1. `formatToolResultSummary({ name: 'x', tags: [], note: '' })` — before: `"- Name: x\n- … 2 more fields"`; after: `"- Name: x"`.
2. A record with 10 content-bearing keys (8-field cap) still emits `"… 2 more fields"` — the genuine cap-overflow path is preserved.
3. `npm run test:ui` (in `apps/desktop/`) — `tool-result-summary.test.ts` passes (9 tests).

The empty-field test fails before the production change (`expected '- Name: x\n- … 2 more fields' to be '- Name: x'`) and passes after; the cap-overflow guard passes both before and after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched test file (`tool-result-summary.test.ts`) and all tests pass; I ran `tsc -p .` and `eslint` on the touched files (clean)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin), Node + vitest

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure string/logic change, platform-independent.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A