### PR TITLE
fix(desktop): extend prompt.submit timeout

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@/hermes', () => ({
 // the stored sessions table and 404s on a runtime id. session.title accepts
 // the runtime id directly.
 const RUNTIME_SESSION_ID = 'rt-abc123'
+const PROMPT_SUBMIT_TIMEOUT_MS = 30 * 60_000
 
 function sessionInfo(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -63,7 +64,7 @@ function Harness({
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
   refreshSessions: () => Promise<void>
-  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
   seedMessages?: unknown[]
   storedSessionId?: null | string
@@ -219,11 +220,11 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
   })
 
   it('submits /goal send directives returned directly by slash.exec instead of rendering no output', async () => {
-    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const calls: { method: string; params?: Record<string, unknown>; timeoutMs?: number }[] = []
     const states: Record<string, unknown>[] = []
 
-    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
-      calls.push({ method, params })
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>, timeoutMs?: number) => {
+      calls.push({ method, params, timeoutMs })
 
       if (method === 'slash.exec') {
         return {
@@ -257,6 +258,7 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
       session_id: RUNTIME_SESSION_ID,
       text: 'write the implementation plan'
     })
+    expect(calls[1]?.timeoutMs).toBe(PROMPT_SUBMIT_TIMEOUT_MS)
 
     const renderedText = states
       .flatMap(state => {
@@ -365,10 +367,38 @@ describe('usePromptActions submit / queue drain semantics', () => {
     // every delta of this brand-new turn.
     expect(seeds.length).toBeGreaterThan(0)
     expect(seeds.every(s => s.interrupted === false)).toBe(true)
-    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
-      session_id: RUNTIME_SESSION_ID,
-      text: 'hello after a stop'
-    })
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'hello after a stop'
+      },
+      PROMPT_SUBMIT_TIMEOUT_MS
+    )
+  })
+
+  it('uses a long prompt.submit timeout because turn completion arrives over the stream', async () => {
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('run a deep reasoning turn')
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'run a deep reasoning turn'
+      },
+      PROMPT_SUBMIT_TIMEOUT_MS
+    )
   })
 
   it('a fromQueue drain sends even when busyRef is still true on the settle edge', async () => {
@@ -390,10 +420,14 @@ describe('usePromptActions submit / queue drain semantics', () => {
     const accepted = await handle!.submitText('queued message', { fromQueue: true })
 
     expect(accepted).toBe(true)
-    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
-      session_id: RUNTIME_SESSION_ID,
-      text: 'queued message'
-    })
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'queued message'
+      },
+      PROMPT_SUBMIT_TIMEOUT_MS
+    )
   })
 
   it('a rejected fromQueue drain returns false (entry stays queued) and a later retry sends it', async () => {
@@ -430,10 +464,14 @@ describe('usePromptActions submit / queue drain semantics', () => {
 
     const second = await handle!.submitText('please send me', { fromQueue: true })
     expect(second).toBe(true)
-    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
-      session_id: RUNTIME_SESSION_ID,
-      text: 'please send me'
-    })
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'please send me'
+      },
+      PROMPT_SUBMIT_TIMEOUT_MS
+    )
   })
 
   it('rides out a transient "session busy" so the user never sees it (retries, no error bubble)', async () => {
@@ -593,11 +631,15 @@ describe('usePromptActions restoreToMessage', () => {
 
     // Ordinal 0 = "truncate before the first visible user message": the gateway
     // drops that turn and everything after, then runs the same text again.
-    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
-      session_id: RUNTIME_SESSION_ID,
-      text: 'first prompt',
-      truncate_before_user_ordinal: 0
-    })
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'first prompt',
+        truncate_before_user_ordinal: 0
+      },
+      PROMPT_SUBMIT_TIMEOUT_MS
+    )
     expect((lastState.messages as { id: string }[]).map(m => m.id)).toEqual(['u1'])
     expect(lastState.busy).toBe(true)
   })
@@ -656,11 +698,15 @@ describe('usePromptActions restoreToMessage', () => {
 
     expect(requestGateway).toHaveBeenCalledWith('session.interrupt', { session_id: RUNTIME_SESSION_ID })
     expect(submitAttempts).toBe(2)
-    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
-      session_id: RUNTIME_SESSION_ID,
-      text: 'first prompt',
-      truncate_before_user_ordinal: 0
-    })
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'first prompt',
+        truncate_before_user_ordinal: 0
+      },
+      PROMPT_SUBMIT_TIMEOUT_MS
+    )
   })
 
   it('rejects non-user targets and unknown ids without touching the gateway', async () => {
@@ -697,11 +743,15 @@ describe('usePromptActions restoreToMessage', () => {
       userOrdinal: 0
     })
 
-    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
-      session_id: RUNTIME_SESSION_ID,
-      text: 'first prompt',
-      truncate_before_user_ordinal: 0
-    })
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'first prompt',
+        truncate_before_user_ordinal: 0
+      },
+      PROMPT_SUBMIT_TIMEOUT_MS
+    )
     expect((lastState.messages as { id: string }[]).map(m => m.id)).toEqual(['u1'])
   })
 })
@@ -734,10 +784,10 @@ describe('usePromptActions file attachment sync', () => {
       value: { readFileDataUrl: vi.fn(async () => 'data:text/plain;base64,aGVsbG8=') }
     })
 
-    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const calls: { method: string; params?: Record<string, unknown>; timeoutMs?: number }[] = []
 
-    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
-      calls.push({ method, params })
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>, timeoutMs?: number) => {
+      calls.push({ method, params, timeoutMs })
 
       if (method === 'file.attach') {
         return {
@@ -770,6 +820,7 @@ describe('usePromptActions file attachment sync', () => {
       session_id: RUNTIME_SESSION_ID,
       text: '@file:.hermes/desktop-attachments/report.txt\n\nconvert this to epub'
     })
+    expect(calls[1]?.timeoutMs).toBe(PROMPT_SUBMIT_TIMEOUT_MS)
   })
 
   it('passes a path-less @file: ref straight through (no path = nothing to upload)', async () => {
@@ -797,10 +848,10 @@ describe('usePromptActions file attachment sync', () => {
       refText: '@file:`/Users/mahmoud/Downloads/DEVIS_signed.pdf`'
     }
 
-    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const calls: { method: string; params?: Record<string, unknown>; timeoutMs?: number }[] = []
 
-    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
-      calls.push({ method, params })
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>, timeoutMs?: number) => {
+      calls.push({ method, params, timeoutMs })
 
       return {} as never
     })
@@ -817,15 +868,16 @@ describe('usePromptActions file attachment sync', () => {
     expect(calls.map(c => c.method)).toEqual(['prompt.submit'])
     expect(readFileDataUrl).not.toHaveBeenCalled()
     expect(calls[0]?.params?.text).toContain('@file:`/Users/mahmoud/Downloads/DEVIS_signed.pdf`')
+    expect(calls[0]?.timeoutMs).toBe(PROMPT_SUBMIT_TIMEOUT_MS)
   })
 
   it('passes the path directly via file.attach in local mode (no byte upload)', async () => {
     $connection.set({ mode: 'local' } as never)
 
-    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const calls: { method: string; params?: Record<string, unknown>; timeoutMs?: number }[] = []
 
-    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
-      calls.push({ method, params })
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>, timeoutMs?: number) => {
+      calls.push({ method, params, timeoutMs })
 
       if (method === 'file.attach') {
         return { attached: true, ref_text: '@file:data/report.txt', uploaded: false } as never
@@ -847,7 +899,8 @@ describe('usePromptActions file attachment sync', () => {
     expect(calls[0]?.params).not.toHaveProperty('data_url')
     expect(calls[1]).toEqual({
       method: 'prompt.submit',
-      params: { session_id: RUNTIME_SESSION_ID, text: '@file:data/report.txt\n\nsummarize' }
+      params: { session_id: RUNTIME_SESSION_ID, text: '@file:data/report.txt\n\nsummarize' },
+      timeoutMs: PROMPT_SUBMIT_TIMEOUT_MS
     })
   })
 })
@@ -929,11 +982,11 @@ describe('usePromptActions sleep/wake session recovery', () => {
     // first prompt.submit with the stale runtime id fails. The hook resumes the
     // durable stored id (which survives gateway restarts), gets a fresh live id,
     // and retries the send transparently.
-    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const calls: { method: string; params?: Record<string, unknown>; timeoutMs?: number }[] = []
     let submitAttempts = 0
 
-    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
-      calls.push({ method, params })
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>, timeoutMs?: number) => {
+      calls.push({ method, params, timeoutMs })
 
       if (method === 'prompt.submit') {
         submitAttempts += 1
@@ -969,6 +1022,8 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
     expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID })
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
+    expect(calls[0]?.timeoutMs).toBe(PROMPT_SUBMIT_TIMEOUT_MS)
+    expect(calls[2]?.timeoutMs).toBe(PROMPT_SUBMIT_TIMEOUT_MS)
   })
 
   it('resumes the stored session and retries once when session.interrupt reports "session not found"', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -130,6 +130,7 @@ function isSessionNotFoundError(error: unknown): boolean {
 // submit racing the settle edge (or a rewind interrupting mid-turn) just waits
 // a beat for the turn to wind down, then lands. Bounded so a genuinely stuck
 // turn still surfaces eventually.
+const PROMPT_SUBMIT_TIMEOUT_MS = 30 * 60_000
 const SESSION_BUSY_RETRY_TIMEOUT_MS = 6_000
 const SESSION_BUSY_RETRY_INTERVAL_MS = 150
 
@@ -324,7 +325,7 @@ interface PromptActionsOptions {
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
   handleSkinCommand: (arg: string) => string
   refreshSessions: () => Promise<void>
-  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   startFreshSessionDraft: () => void
@@ -774,7 +775,9 @@ export function usePromptActions({
         let submitErr: unknown = null
 
         try {
-          await withSessionBusyRetry(() => requestGateway('prompt.submit', { session_id: sessionId, text }))
+          await withSessionBusyRetry(() =>
+            requestGateway('prompt.submit', { session_id: sessionId, text }, PROMPT_SUBMIT_TIMEOUT_MS)
+          )
         } catch (firstErr) {
           if (isSessionNotFoundError(firstErr) && selectedStoredSessionIdRef.current) {
             // Re-register the session in the gateway and get a fresh live ID.
@@ -786,7 +789,9 @@ export function usePromptActions({
 
             if (recoveredId) {
               activeSessionIdRef.current = recoveredId
-              await withSessionBusyRetry(() => requestGateway('prompt.submit', { session_id: recoveredId, text }))
+              await withSessionBusyRetry(() =>
+                requestGateway('prompt.submit', { session_id: recoveredId, text }, PROMPT_SUBMIT_TIMEOUT_MS)
+              )
             } else {
               submitErr = firstErr
             }
@@ -1684,11 +1689,15 @@ export function usePromptActions({
       })
 
       try {
-        await requestGateway('prompt.submit', {
-          session_id: activeSessionId,
-          text: userText,
-          truncate_before_user_ordinal: truncateBeforeUserOrdinal
-        })
+        await requestGateway(
+          'prompt.submit',
+          {
+            session_id: activeSessionId,
+            text: userText,
+            truncate_before_user_ordinal: truncateBeforeUserOrdinal
+          },
+          PROMPT_SUBMIT_TIMEOUT_MS
+        )
       } catch (err) {
         updateSessionState(activeSessionId, state => ({
           ...state,
@@ -1721,11 +1730,15 @@ export function usePromptActions({
       }
 
       const submit = () =>
-        requestGateway('prompt.submit', {
-          session_id: sessionId,
-          text,
-          ...(truncateOrdinal !== undefined && { truncate_before_user_ordinal: truncateOrdinal })
-        })
+        requestGateway(
+          'prompt.submit',
+          {
+            session_id: sessionId,
+            text,
+            ...(truncateOrdinal !== undefined && { truncate_before_user_ordinal: truncateOrdinal })
+          },
+          PROMPT_SUBMIT_TIMEOUT_MS
+        )
 
       if (interruptFirst) {
         await interrupt()


### PR DESCRIPTION
## What does this PR do?

Extends the Desktop `prompt.submit` RPC timeout to 30 minutes so long-running turns do not show a false `request timed out: prompt.submit` toast while the answer is still streaming successfully.

`prompt.submit` is only the submit acknowledgement path; completion arrives through the gateway stream. The default 30s RPC timeout is too short for MoA, deep reasoning, or long tool-chain turns.

## Related Issue

Fixes #55024

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added a 30-minute `prompt.submit` timeout in `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`.
- Applied the timeout to normal submits, sleep/wake retry submits, regenerate, and rewind/restore submit paths.
- Extended `use-prompt-actions` tests to assert the long timeout is used for `prompt.submit`.

## How to Test

1. `npm ci`
2. `npm run --workspace apps/desktop test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx`
3. `npm run --workspace apps/desktop typecheck`
4. `npx eslint src/app/session/hooks/use-prompt-actions.ts src/app/session/hooks/use-prompt-actions.test.tsx` from `apps/desktop`
5. `git diff --check`

## Notes

The full Desktop lint script currently reports pre-existing unrelated lint failures outside this change; the two touched files pass ESLint directly.