### PR TITLE
Merge consecutive same-role contents for native Gemini (fix parallel tool calls)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -337,6 +337,22 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
         if parts:
             contents.append({"role": gemini_role, "parts": parts})
 
+    # Gemini's generateContent requires strict user/model alternation;
+    # consecutive same-role contents are rejected with HTTP 400 "Please ensure
+    # that multiturn requests alternate between user and model". The loop above
+    # emits one content per source message, so parallel tool calls (N tool
+    # results become N user functionResponse contents), back-to-back user turns,
+    # or merged assistant turns would each violate that. Merge adjacent
+    # same-role contents by concatenating their parts. For parallel calls this
+    # also produces the grouped multi-functionResponse turn Gemini expects.
+    merged_contents: List[Dict[str, Any]] = []
+    for content in contents:
+        if merged_contents and merged_contents[-1]["role"] == content["role"]:
+            merged_contents[-1]["parts"].extend(content["parts"])
+        else:
+            merged_contents.append(content)
+    contents = merged_contents
+
     system_instruction = None
     joined_system = "\n".join(part for part in system_text_parts if part).strip()
     if joined_system:

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -85,6 +85,59 @@ def test_build_native_request_uses_original_function_name_for_tool_result():
     assert tool_response["name"] == "get_weather"
 
 
+def test_parallel_tool_results_merge_into_one_user_content():
+    """Gemini requires strict user/model alternation; two consecutive `user`
+    contents are rejected with HTTP 400. Parallel tool calls produce two tool
+    results in a row, so their functionResponses must be grouped into a single
+    user content instead of two consecutive ones."""
+    from agent.gemini_native_adapter import _build_gemini_contents
+
+    messages = [
+        {"role": "user", "content": "Read a.txt and b.txt"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "type": "function",
+                 "function": {"name": "read_file", "arguments": '{"path": "a.txt"}'}},
+                {"id": "call_2", "type": "function",
+                 "function": {"name": "read_file", "arguments": '{"path": "b.txt"}'}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "AAA"},
+        {"role": "tool", "tool_call_id": "call_2", "content": "BBB"},
+    ]
+
+    contents, _ = _build_gemini_contents(messages)
+    roles = [c["role"] for c in contents]
+
+    # No two adjacent contents may share a role.
+    assert all(roles[i] != roles[i - 1] for i in range(1, len(roles))), roles
+    assert roles == ["user", "model", "user"]
+
+    # Both parallel functionResponses land in the single trailing user content.
+    response_parts = [
+        p for p in contents[2]["parts"] if "functionResponse" in p
+    ]
+    outputs = [p["functionResponse"]["response"]["output"] for p in response_parts]
+    assert outputs == ["AAA", "BBB"]
+
+
+def test_consecutive_user_messages_merge_for_gemini_alternation():
+    """Back-to-back user messages must also be merged, not sent as two
+    consecutive user contents."""
+    from agent.gemini_native_adapter import _build_gemini_contents
+
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "ok"},
+    ]
+    contents, _ = _build_gemini_contents(messages)
+    roles = [c["role"] for c in contents]
+    assert roles == ["user", "model"], roles
+
+
 def test_build_native_request_strips_json_schema_only_fields_from_tool_parameters():
     from agent.gemini_native_adapter import build_gemini_request
 


### PR DESCRIPTION
Fixes #55125

`_build_gemini_contents` emitted one `contents` entry per source message and never merged adjacent same-role entries. Gemini's `generateContent` requires strict user/model alternation and rejects consecutive same-role turns with HTTP 400 (`Please ensure that multiturn requests alternate between user and model`).

Each tool result becomes its own `{"role": "user", "parts": [functionResponse]}` entry, so a parallel tool call (two or more tool calls in one model turn) produces two consecutive `user` contents and the request fails. Because the shape is part of the stored history, every subsequent turn rebuilds it and fails again. The Anthropic and Bedrock converters already merge consecutive tool results; the native Gemini path did not.

### Change

- After the per-message loop, fold adjacent same-role `contents` into one by concatenating their `parts`. For a parallel call this produces the grouped multi-`functionResponse` user turn Gemini expects; it also covers back-to-back user turns and merged assistant turns.

### Tests

- `test_parallel_tool_results_merge_into_one_user_content`: two parallel tool results land in a single trailing `user` content and the role sequence alternates (`user, model, user`).
- `test_consecutive_user_messages_merge_for_gemini_alternation`: back-to-back user messages collapse to one `user` content.

Both fail on the current code (consecutive `user` contents) and pass with this change.

```
$ python -m pytest tests/agent/test_gemini_native_adapter.py -q
22 passed
```
