### PR TITLE
fix(image-gen): bound provider JSON responses

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -54,6 +54,8 @@ logger = logging.getLogger(__name__)
 
 VALID_ASPECT_RATIOS: Tuple[str, ...] = ("landscape", "square", "portrait")
 DEFAULT_ASPECT_RATIO = "landscape"
+IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES = 40 * 1024 * 1024
+_IMAGE_GEN_RESPONSE_CHUNK_BYTES = 64 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -241,6 +243,7 @@ def save_b64_image(
     *,
     prefix: str = "image",
     extension: str = "png",
+    max_bytes: int = 25 * 1024 * 1024,
 ) -> Path:
     """Decode base64 image data and write it under ``$HERMES_HOME/cache/images/``.
 
@@ -249,6 +252,11 @@ def save_b64_image(
     Filename format: ``<prefix>_<YYYYMMDD_HHMMSS>_<short-uuid>.<ext>``.
     """
     raw = base64.b64decode(b64_data)
+    if len(raw) > max_bytes:
+        raise ValueError(
+            f"Inline image exceeds {max_bytes} bytes "
+            f"({max_bytes // (1024 * 1024)}MB cap); refusing to cache."
+        )
     ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     short = uuid.uuid4().hex[:8]
     path = _images_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
@@ -267,6 +275,74 @@ _URL_IMAGE_CONTENT_TYPES = {
     "image/webp": "webp",
     "image/gif": "gif",
 }
+
+
+class ImageGenResponseTooLarge(ValueError):
+    """Raised when a provider JSON response exceeds the image-gen body cap."""
+
+
+def read_response_body_with_limit(
+    response: Any,
+    *,
+    max_bytes: Optional[int] = None,
+) -> Any:
+    """Read a streamed ``requests`` response without buffering unbounded bodies.
+
+    Image-generation APIs may return inline base64 image data, so the cap is
+    intentionally larger than ordinary provider JSON limits while still
+    preventing an unbounded provider or proxy response from exhausting memory.
+    Non-``requests.Response`` test doubles are returned unchanged.
+    """
+    import requests
+
+    limit = IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES if max_bytes is None else max_bytes
+    if not isinstance(response, requests.Response):
+        return response
+
+    content = getattr(response, "_content", None)
+    if isinstance(content, (bytes, bytearray)):
+        if len(content) > limit:
+            response.close()
+            raise ImageGenResponseTooLarge(
+                f"response body exceeds {limit} bytes"
+            )
+        response._content_consumed = True
+        return response
+
+    declared = response.headers.get("Content-Length")
+    if declared:
+        try:
+            declared_size = int(declared)
+        except ValueError:
+            pass
+        else:
+            if declared_size > limit:
+                response.close()
+                raise ImageGenResponseTooLarge(
+                    f"response body exceeds {limit} bytes"
+                )
+
+    chunks: List[bytes] = []
+    total = 0
+    try:
+        for chunk in response.iter_content(
+            chunk_size=_IMAGE_GEN_RESPONSE_CHUNK_BYTES
+        ):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > limit:
+                raise ImageGenResponseTooLarge(
+                    f"response body exceeds {limit} bytes"
+                )
+            chunks.append(chunk)
+    except Exception:
+        response.close()
+        raise
+
+    response._content = b"".join(chunks)
+    response._content_consumed = True
+    return response
 
 
 def save_url_image(

--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -54,6 +54,8 @@ logger = logging.getLogger(__name__)
 
 VALID_ASPECT_RATIOS: Tuple[str, ...] = ("landscape", "square", "portrait")
 DEFAULT_ASPECT_RATIO = "landscape"
+IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES = 40 * 1024 * 1024
+_IMAGE_GEN_RESPONSE_CHUNK_BYTES = 64 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +249,7 @@ def save_b64_image(
     *,
     prefix: str = "image",
     extension: str = "png",
+    max_bytes: int = 25 * 1024 * 1024,
 ) -> Path:
     """Decode base64 image data and write it under ``$HERMES_HOME/cache/images/``.
 
@@ -255,6 +258,11 @@ def save_b64_image(
     Filename format: ``<prefix>_<YYYYMMDD_HHMMSS>_<short-uuid>.<ext>``.
     """
     raw = base64.b64decode(b64_data)
+    if len(raw) > max_bytes:
+        raise ValueError(
+            f"Inline image exceeds {max_bytes} bytes "
+            f"({max_bytes // (1024 * 1024)}MB cap); refusing to cache."
+        )
     ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     short = uuid.uuid4().hex[:8]
     path = _images_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
@@ -273,6 +281,74 @@ _URL_IMAGE_CONTENT_TYPES = {
     "image/webp": "webp",
     "image/gif": "gif",
 }
+
+
+class ImageGenResponseTooLarge(ValueError):
+    """Raised when a provider JSON response exceeds the image-gen body cap."""
+
+
+def read_response_body_with_limit(
+    response: Any,
+    *,
+    max_bytes: Optional[int] = None,
+) -> Any:
+    """Read a streamed ``requests`` response without buffering unbounded bodies.
+
+    Image-generation APIs may return inline base64 image data, so the cap is
+    intentionally larger than ordinary provider JSON limits while still
+    preventing an unbounded provider or proxy response from exhausting memory.
+    Non-``requests.Response`` test doubles are returned unchanged.
+    """
+    import requests
+
+    limit = IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES if max_bytes is None else max_bytes
+    if not isinstance(response, requests.Response):
+        return response
+
+    content = getattr(response, "_content", None)
+    if isinstance(content, (bytes, bytearray)):
+        if len(content) > limit:
+            response.close()
+            raise ImageGenResponseTooLarge(
+                f"response body exceeds {limit} bytes"
+            )
+        response._content_consumed = True
+        return response
+
+    declared = response.headers.get("Content-Length")
+    if declared:
+        try:
+            declared_size = int(declared)
+        except ValueError:
+            pass
+        else:
+            if declared_size > limit:
+                response.close()
+                raise ImageGenResponseTooLarge(
+                    f"response body exceeds {limit} bytes"
+                )
+
+    chunks: List[bytes] = []
+    total = 0
+    try:
+        for chunk in response.iter_content(
+            chunk_size=_IMAGE_GEN_RESPONSE_CHUNK_BYTES
+        ):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > limit:
+                raise ImageGenResponseTooLarge(
+                    f"response body exceeds {limit} bytes"
+                )
+            chunks.append(chunk)
+    except Exception:
+        response.close()
+        raise
+
+    response._content = b"".join(chunks)
+    response._content_consumed = True
+    return response
 
 
 def save_url_image(

--- a/plugins/image_gen/krea/__init__.py
+++ b/plugins/image_gen/krea/__init__.py
@@ -33,8 +33,10 @@ import requests
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
+    ImageGenResponseTooLarge,
     error_response,
     normalize_reference_images,
+    read_response_body_with_limit,
     resolve_aspect_ratio,
     save_url_image,
     success_response,
@@ -446,8 +448,19 @@ class KreaImageGenProvider(ImageGenProvider):
                 headers=headers,
                 json=payload,
                 timeout=30,
+                stream=True,
             )
+            read_response_body_with_limit(response)
             response.raise_for_status()
+        except ImageGenResponseTooLarge as exc:
+            return error_response(
+                error=f"Krea submit response too large: {exc}",
+                error_type="invalid_response",
+                provider="krea",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
         except requests.HTTPError as exc:
             resp = exc.response
             status = resp.status_code if resp is not None else 0
@@ -554,8 +567,23 @@ class KreaImageGenProvider(ImageGenProvider):
             interval = min(interval * _POLL_BACKOFF, _POLL_MAX_INTERVAL)
 
             try:
-                poll_resp = requests.get(job_url, headers=poll_headers, timeout=30)
+                poll_resp = requests.get(
+                    job_url,
+                    headers=poll_headers,
+                    timeout=30,
+                    stream=True,
+                )
+                read_response_body_with_limit(poll_resp)
                 poll_resp.raise_for_status()
+            except ImageGenResponseTooLarge as exc:
+                return error_response(
+                    error=f"Krea poll response too large for job {job_id}: {exc}",
+                    error_type="invalid_response",
+                    provider="krea",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
             except requests.HTTPError as exc:
                 resp = exc.response
                 status = resp.status_code if resp is not None else 0

--- a/plugins/image_gen/krea/__init__.py
+++ b/plugins/image_gen/krea/__init__.py
@@ -34,8 +34,10 @@ from agent.secret_scope import get_secret
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
+    ImageGenResponseTooLarge,
     error_response,
     normalize_reference_images,
+    read_response_body_with_limit,
     resolve_aspect_ratio,
     save_url_image,
     success_response,
@@ -575,8 +577,19 @@ class KreaImageGenProvider(ImageGenProvider):
                 headers=headers,
                 json=payload,
                 timeout=30,
+                stream=True,
             )
+            read_response_body_with_limit(response)
             response.raise_for_status()
+        except ImageGenResponseTooLarge as exc:
+            return error_response(
+                error=f"Krea submit response too large: {exc}",
+                error_type="invalid_response",
+                provider="krea",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
         except requests.HTTPError as exc:
             resp = exc.response
             status = resp.status_code if resp is not None else 0
@@ -683,8 +696,23 @@ class KreaImageGenProvider(ImageGenProvider):
             interval = min(interval * _POLL_BACKOFF, _POLL_MAX_INTERVAL)
 
             try:
-                poll_resp = requests.get(job_url, headers=poll_headers, timeout=30)
+                poll_resp = requests.get(
+                    job_url,
+                    headers=poll_headers,
+                    timeout=30,
+                    stream=True,
+                )
+                read_response_body_with_limit(poll_resp)
                 poll_resp.raise_for_status()
+            except ImageGenResponseTooLarge as exc:
+                return error_response(
+                    error=f"Krea poll response too large for job {job_id}: {exc}",
+                    error_type="invalid_response",
+                    provider="krea",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
             except requests.HTTPError as exc:
                 resp = exc.response
                 status = resp.status_code if resp is not None else 0

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -31,7 +31,9 @@ from typing import Any, Dict, List, Optional
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
+    ImageGenResponseTooLarge,
     error_response,
+    read_response_body_with_limit,
     resolve_aspect_ratio,
     save_b64_image,
     save_url_image,
@@ -340,8 +342,19 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
                     headers=headers,
                     json=payload,
                     timeout=_REQUEST_TIMEOUT,
+                    stream=True,
                 )
+                read_response_body_with_limit(response)
                 response.raise_for_status()
+            except ImageGenResponseTooLarge as exc:
+                return error_response(
+                    error=f"{self._display} image generation response too large: {exc}",
+                    error_type="invalid_response",
+                    provider=self._name,
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
             except requests.HTTPError as exc:
                 resp = exc.response
                 status = resp.status_code if resp is not None else 0

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -31,7 +31,9 @@ from typing import Any, Dict, List, Optional
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
+    ImageGenResponseTooLarge,
     error_response,
+    read_response_body_with_limit,
     resolve_aspect_ratio,
     save_b64_image,
     save_url_image,
@@ -355,8 +357,19 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
                     headers=headers,
                     json=payload,
                     timeout=_REQUEST_TIMEOUT,
+                    stream=True,
                 )
+                read_response_body_with_limit(response)
                 response.raise_for_status()
+            except ImageGenResponseTooLarge as exc:
+                return error_response(
+                    error=f"{self._display} image generation response too large: {exc}",
+                    error_type="invalid_response",
+                    provider=self._name,
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
             except requests.HTTPError as exc:
                 resp = exc.response
                 status = resp.status_code if resp is not None else 0

--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -26,8 +26,10 @@ import requests
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
+    ImageGenResponseTooLarge,
     error_response,
     normalize_reference_images,
+    read_response_body_with_limit,
     resolve_aspect_ratio,
     save_b64_image,
     save_url_image,
@@ -282,8 +284,19 @@ class XAIImageGenProvider(ImageGenProvider):
                 headers=headers,
                 json=payload,
                 timeout=120,
+                stream=True,
             )
+            read_response_body_with_limit(response)
             response.raise_for_status()
+        except ImageGenResponseTooLarge as exc:
+            return error_response(
+                error=f"xAI image generation response too large: {exc}",
+                error_type="invalid_response",
+                provider=provider_name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
         except requests.HTTPError as exc:
             response = exc.response
             status = response.status_code if response is not None else 0

--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -27,8 +27,10 @@ import requests
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
+    ImageGenResponseTooLarge,
     error_response,
     normalize_reference_images,
+    read_response_body_with_limit,
     resolve_aspect_ratio,
     save_b64_image,
     save_url_image,
@@ -338,8 +340,19 @@ class XAIImageGenProvider(ImageGenProvider):
                 headers=headers,
                 json=payload,
                 timeout=120,
+                stream=True,
             )
+            read_response_body_with_limit(response)
             response.raise_for_status()
+        except ImageGenResponseTooLarge as exc:
+            return error_response(
+                error=f"xAI image generation response too large: {exc}",
+                error_type="invalid_response",
+                provider=provider_name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
         except requests.HTTPError as exc:
             response = exc.response
             status = response.status_code if response is not None else 0

--- a/tests/plugins/image_gen/test_response_limits.py
+++ b/tests/plugins/image_gen/test_response_limits.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+
+class _RawStream:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    def stream(self, chunk_size: int, decode_content: bool = False):
+        _ = chunk_size, decode_content
+        yield from self._chunks
+
+    def close(self) -> None:
+        return None
+
+
+def _stream_response(
+    chunks: list[bytes],
+    *,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response.headers.update(headers or {})
+    response.url = "https://provider.test/response"
+    response.raw = _RawStream(chunks)  # type: ignore[assignment]
+    response.request = requests.Request("POST", response.url).prepare()
+    return response
+
+
+def test_limited_reader_rejects_oversized_content_length():
+    from agent.image_gen_provider import (
+        ImageGenResponseTooLarge,
+        read_response_body_with_limit,
+    )
+
+    response = _stream_response([], headers={"Content-Length": "11"})
+
+    with pytest.raises(ImageGenResponseTooLarge, match="exceeds 10 bytes"):
+        read_response_body_with_limit(response, max_bytes=10)
+
+
+def test_limited_reader_rejects_streamed_body_over_limit():
+    from agent.image_gen_provider import (
+        ImageGenResponseTooLarge,
+        read_response_body_with_limit,
+    )
+
+    response = _stream_response([b"a" * 6, b"b" * 6])
+
+    with pytest.raises(ImageGenResponseTooLarge, match="exceeds 10 bytes"):
+        read_response_body_with_limit(response, max_bytes=10)
+
+
+def test_limited_reader_preserves_response_json():
+    from agent.image_gen_provider import read_response_body_with_limit
+
+    response = _stream_response([b'{"ok": ', b"true}"])
+
+    read_response_body_with_limit(response, max_bytes=20)
+
+    assert response.json() == {"ok": True}
+
+
+def test_save_b64_image_rejects_oversized_decoded_image():
+    from agent.image_gen_provider import save_b64_image
+
+    payload = base64.b64encode(b"x" * 11).decode("ascii")
+
+    with pytest.raises(ValueError, match="exceeds 10 bytes"):
+        save_b64_image(payload, max_bytes=10)
+
+
+def test_xai_generation_rejects_oversized_response(monkeypatch):
+    import agent.image_gen_provider as image_gen_provider
+    from plugins.image_gen.xai import XAIImageGenProvider
+
+    monkeypatch.setenv("XAI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        image_gen_provider, "IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES", 10
+    )
+
+    response = _stream_response([b"x" * 8, b"y" * 8])
+
+    with patch("plugins.image_gen.xai.requests.post", return_value=response):
+        result = XAIImageGenProvider().generate(prompt="test")
+
+    assert result["success"] is False
+    assert result["error_type"] == "invalid_response"
+    assert "response too large" in result["error"]
+
+
+def test_openrouter_generation_rejects_oversized_response(monkeypatch):
+    import agent.image_gen_provider as image_gen_provider
+    from plugins.image_gen.openrouter import OpenRouterCompatImageProvider
+
+    monkeypatch.setattr(
+        image_gen_provider, "IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES", 10
+    )
+    provider = OpenRouterCompatImageProvider(
+        provider_name="openrouter",
+        display_name="OpenRouter",
+        runtime_name="openrouter",
+        config_key="openrouter",
+        model_env_var="OPENROUTER_IMAGE_MODEL",
+        setup_schema={"name": "OpenRouter (image)", "badge": "paid", "env_vars": []},
+    )
+    runtime = {
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "sk-or-test",
+        "source": "env",
+    }
+    response = _stream_response([b"x" * 8, b"y" * 8])
+
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value=runtime,
+    ), patch("requests.post", return_value=response):
+        result = provider.generate(prompt="test")
+
+    assert result["success"] is False
+    assert result["error_type"] == "invalid_response"
+    assert "response too large" in result["error"]
+
+
+def test_krea_poll_rejects_oversized_response(monkeypatch):
+    import agent.image_gen_provider as image_gen_provider
+    from plugins.image_gen.krea import KreaImageGenProvider
+
+    monkeypatch.setenv("KREA_API_KEY", "test-key")
+    monkeypatch.setattr(
+        image_gen_provider, "IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES", 10
+    )
+
+    submit = MagicMock()
+    submit.status_code = 200
+    submit.raise_for_status = MagicMock()
+    submit.json.return_value = {"job_id": "job-1"}
+    poll = _stream_response([b"x" * 8, b"y" * 8])
+
+    with patch("plugins.image_gen.krea.requests.post", return_value=submit), patch(
+        "plugins.image_gen.krea.requests.get",
+        return_value=poll,
+    ), patch("plugins.image_gen.krea.time.sleep"):
+        result = KreaImageGenProvider().generate(prompt="test")
+
+    assert result["success"] is False
+    assert result["error_type"] == "invalid_response"
+    assert "poll response too large" in result["error"]

--- a/tests/plugins/image_gen/test_response_limits.py
+++ b/tests/plugins/image_gen/test_response_limits.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+
+class _RawStream:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    def stream(self, chunk_size: int, decode_content: bool = False):
+        _ = chunk_size, decode_content
+        yield from self._chunks
+
+    def close(self) -> None:
+        return None
+
+
+def _stream_response(
+    chunks: list[bytes],
+    *,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response.headers.update(headers or {})
+    response.url = "https://provider.test/response"
+    response.raw = _RawStream(chunks)  # type: ignore[assignment]
+    response.request = requests.Request("POST", response.url).prepare()
+    return response
+
+
+def test_limited_reader_rejects_oversized_content_length():
+    from agent.image_gen_provider import (
+        ImageGenResponseTooLarge,
+        read_response_body_with_limit,
+    )
+
+    response = _stream_response([], headers={"Content-Length": "11"})
+
+    with pytest.raises(ImageGenResponseTooLarge, match="exceeds 10 bytes"):
+        read_response_body_with_limit(response, max_bytes=10)
+
+
+def test_limited_reader_rejects_streamed_body_over_limit():
+    from agent.image_gen_provider import (
+        ImageGenResponseTooLarge,
+        read_response_body_with_limit,
+    )
+
+    response = _stream_response([b"a" * 6, b"b" * 6])
+
+    with pytest.raises(ImageGenResponseTooLarge, match="exceeds 10 bytes"):
+        read_response_body_with_limit(response, max_bytes=10)
+
+
+def test_limited_reader_preserves_response_json():
+    from agent.image_gen_provider import read_response_body_with_limit
+
+    response = _stream_response([b'{"ok": ', b"true}"])
+
+    read_response_body_with_limit(response, max_bytes=20)
+
+    assert response.json() == {"ok": True}
+
+
+def test_save_b64_image_rejects_oversized_decoded_image():
+    from agent.image_gen_provider import save_b64_image
+
+    payload = base64.b64encode(b"x" * 11).decode("ascii")
+
+    with pytest.raises(ValueError, match="exceeds 10 bytes"):
+        save_b64_image(payload, max_bytes=10)
+
+
+def test_xai_generation_rejects_oversized_response(monkeypatch):
+    import agent.image_gen_provider as image_gen_provider
+    from plugins.image_gen.xai import XAIImageGenProvider
+
+    monkeypatch.setenv("XAI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        image_gen_provider, "IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES", 10
+    )
+
+    response = _stream_response([b"x" * 8, b"y" * 8])
+
+    with patch("plugins.image_gen.xai.requests.post", return_value=response):
+        result = XAIImageGenProvider().generate(prompt="test")
+
+    assert result["success"] is False
+    assert result["error_type"] == "invalid_response"
+    assert "response too large" in result["error"]
+
+
+def test_openrouter_generation_rejects_oversized_response(monkeypatch):
+    import agent.image_gen_provider as image_gen_provider
+    from plugins.image_gen.openrouter import OpenRouterCompatImageProvider
+
+    monkeypatch.setattr(
+        image_gen_provider, "IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES", 10
+    )
+    provider = OpenRouterCompatImageProvider(
+        provider_name="openrouter",
+        display_name="OpenRouter",
+        runtime_name="openrouter",
+        config_key="openrouter",
+        model_env_var="OPENROUTER_IMAGE_MODEL",
+        setup_schema={"name": "OpenRouter (image)", "badge": "paid", "env_vars": []},
+    )
+    runtime = {
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "sk-or-test",
+        "source": "env",
+    }
+    response = _stream_response([b"x" * 8, b"y" * 8])
+
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value=runtime,
+    ), patch("requests.post", return_value=response):
+        result = provider.generate(prompt="test")
+
+    assert result["success"] is False
+    assert result["error_type"] == "invalid_response"
+    assert "response too large" in result["error"]
+
+
+def test_krea_poll_rejects_oversized_response(monkeypatch):
+    import agent.image_gen_provider as image_gen_provider
+    from plugins.image_gen.krea import KreaImageGenProvider
+
+    monkeypatch.setenv("KREA_API_KEY", "test-key")
+    monkeypatch.setattr(
+        image_gen_provider, "IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES", 10
+    )
+
+    submit = MagicMock()
+    submit.status_code = 200
+    submit.raise_for_status = MagicMock()
+    submit.json.return_value = {"job_id": "job-1"}
+    poll = _stream_response([b"x" * 8, b"y" * 8])
+
+    with patch("plugins.image_gen.krea.requests.post", return_value=submit), patch(
+        "plugins.image_gen.krea.requests.get",
+        return_value=poll,
+    ), patch("plugins.image_gen.krea.time.sleep"):
+        result = KreaImageGenProvider().generate(prompt="test")
+
+    assert result["success"] is False
+    assert result["error_type"] == "invalid_response"
+    assert "poll response too large" in result["error"]
+
+
+def test_krea_submit_rejects_oversized_response(monkeypatch):
+    import agent.image_gen_provider as image_gen_provider
+    from plugins.image_gen.krea import KreaImageGenProvider
+
+    monkeypatch.setenv("KREA_API_KEY", "test-key")
+    monkeypatch.setattr(
+        image_gen_provider, "IMAGE_GEN_RESPONSE_BODY_LIMIT_BYTES", 10
+    )
+    submit = _stream_response([b"x" * 8, b"y" * 8])
+
+    with patch("plugins.image_gen.krea.requests.post", return_value=submit), patch(
+        "plugins.image_gen.krea.requests.get"
+    ) as poll:
+        result = KreaImageGenProvider().generate(prompt="test")
+
+    assert result["success"] is False
+    assert result["error_type"] == "invalid_response"
+    assert "submit response too large" in result["error"]
+    poll.assert_not_called()


### PR DESCRIPTION
﻿Fixes #55128

## Summary

- add a shared bounded reader for streamed `requests.Response` bodies in image generation providers
- use it for xAI generation/edit responses, OpenRouter/Nous image chat responses, and Krea submit/poll responses
- return controlled `invalid_response` tool errors when provider JSON exceeds the cap
- align inline base64 image caching with the existing 25 MiB URL-image cache limit

## Why

The affected providers previously called `requests.post(...)` / `requests.get(...)` and only then parsed `.json()` or truncated `.text[:300]`. Requests buffers the response body before those calls, so a broken provider endpoint, proxy, or managed gateway could return an oversized JSON/error body and pressure Hermes memory before the provider rejected it.

The helper reads with `stream=True`, rejects oversized `Content-Length`, and enforces the same cap while iterating chunks. The response cap is 40 MiB because image-generation JSON can legitimately contain inline base64 image data; decoded inline images are then capped at the same 25 MiB limit already used for downloaded image URLs.

## Validation

- `python -m pytest tests/plugins/image_gen/test_response_limits.py -q` -> `7 passed`
- `python -m ruff check agent/image_gen_provider.py plugins/image_gen/xai/__init__.py plugins/image_gen/openrouter/__init__.py plugins/image_gen/krea/__init__.py tests/plugins/image_gen/test_response_limits.py`
- `git diff --check`

I also ran the broader provider suite on Windows:

- `python -m pytest tests/plugins/image_gen/test_response_limits.py tests/plugins/image_gen/test_xai_provider.py tests/plugins/image_gen/test_openrouter_compat_provider.py tests/plugins/image_gen/test_krea_provider.py -q`
- result before the inline-image follow-up: 99 passed, 5 failed

The 5 failures are existing Windows path-shape assertions where tests mock `Path("/tmp/...")` and then expect the string to start with `/tmp`; on Windows that string becomes `\\tmp\\...`. The failures are not from the response-bound changes.
