### PR TITLE
fix(qqbot): bound onboarding portal responses

### DIFF
--- a/gateway/platforms/qqbot/onboard.py
+++ b/gateway/platforms/qqbot/onboard.py
@@ -34,6 +34,9 @@ from .utils import get_api_headers
 
 logger = logging.getLogger(__name__)
 
+_ONBOARD_RESPONSE_BODY_LIMIT_BYTES = 1 * 1024 * 1024
+_ONBOARD_RESPONSE_CHUNK_BYTES = 64 * 1024
+
 
 # ---------------------------------------------------------------------------
 # Bind status
@@ -76,6 +79,66 @@ def _render_qr(url: str) -> bool:
         return False
 
 
+def _read_onboard_response_with_limit(
+    response,
+    *,
+    body_limit: Optional[int] = None,
+):
+    """Return a fully-read response without buffering unbounded portal bodies."""
+    import httpx
+
+    limit = (
+        _ONBOARD_RESPONSE_BODY_LIMIT_BYTES
+        if body_limit is None
+        else body_limit
+    )
+    declared = response.headers.get("content-length")
+    if declared:
+        try:
+            declared_size = int(declared)
+        except ValueError:
+            pass
+        else:
+            if declared_size > limit:
+                response.close()
+                raise RuntimeError(
+                    f"QQBot onboard response exceeds {limit} bytes"
+                )
+
+    chunks: list[bytes] = []
+    total = 0
+    try:
+        for chunk in response.iter_bytes(chunk_size=_ONBOARD_RESPONSE_CHUNK_BYTES):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > limit:
+                raise RuntimeError(
+                    f"QQBot onboard response exceeds {limit} bytes"
+                )
+            chunks.append(chunk)
+    except Exception:
+        response.close()
+        raise
+
+    return httpx.Response(
+        status_code=response.status_code,
+        headers=response.headers,
+        content=b"".join(chunks),
+        request=response.request,
+    )
+
+
+def _post_onboard_json(client, url: str, payload: dict):
+    with client.stream(
+        "POST",
+        url,
+        json=payload,
+        headers=get_api_headers(),
+    ) as response:
+        return _read_onboard_response_with_limit(response)
+
+
 # ---------------------------------------------------------------------------
 # Synchronous HTTP helpers (mirrors Feishu _post_registration pattern)
 # ---------------------------------------------------------------------------
@@ -93,7 +156,7 @@ def _create_bind_task(timeout: float = ONBOARD_API_TIMEOUT) -> Tuple[str, str]:
     key = generate_bind_key()
 
     with httpx.Client(timeout=timeout, follow_redirects=True) as client:
-        resp = client.post(url, json={"key": key}, headers=get_api_headers())
+        resp = _post_onboard_json(client, url, {"key": key})
         resp.raise_for_status()
         data = resp.json()
 
@@ -125,7 +188,7 @@ def _poll_bind_result(
     url = f"https://{PORTAL_HOST}{ONBOARD_POLL_PATH}"
 
     with httpx.Client(timeout=timeout, follow_redirects=True) as client:
-        resp = client.post(url, json={"task_id": task_id}, headers=get_api_headers())
+        resp = _post_onboard_json(client, url, {"task_id": task_id})
         resp.raise_for_status()
         data = resp.json()
 

--- a/tests/gateway/test_qqbot_onboard_response_limit.py
+++ b/tests/gateway/test_qqbot_onboard_response_limit.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+import httpx
+
+from gateway.platforms.qqbot import onboard
+
+
+class _ChunkStream(httpx.SyncByteStream):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    def __iter__(self):
+        yield from self._chunks
+
+
+def _stream_response(
+    chunks: list[bytes],
+    *,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers=headers or {},
+        stream=_ChunkStream(chunks),
+        request=httpx.Request("POST", "https://q.qq.com/onboard"),
+    )
+
+
+def test_onboard_response_rejects_oversized_content_length():
+    response = _stream_response([], headers={"content-length": "11"})
+
+    with pytest.raises(RuntimeError, match="exceeds 10 bytes"):
+        onboard._read_onboard_response_with_limit(response, body_limit=10)
+
+
+def test_onboard_response_rejects_streamed_body_over_limit():
+    response = _stream_response([b"a" * 6, b"b" * 6])
+
+    with pytest.raises(RuntimeError, match="exceeds 10 bytes"):
+        onboard._read_onboard_response_with_limit(response, body_limit=10)
+
+
+def test_onboard_response_preserves_json_body():
+    response = _stream_response([b'{"retcode":0,', b'"data":{"task_id":"t"}}'])
+
+    bounded = onboard._read_onboard_response_with_limit(response, body_limit=100)
+
+    assert bounded.json() == {"retcode": 0, "data": {"task_id": "t"}}
+
+
+def test_post_onboard_json_uses_streamed_response():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/api"
+        return httpx.Response(
+            200,
+            json={"retcode": 0, "data": {"task_id": "task-1"}},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        response = onboard._post_onboard_json(
+            client,
+            "https://q.qq.com/api",
+            {"key": "k"},
+        )
+
+    assert response.json()["data"]["task_id"] == "task-1"


### PR DESCRIPTION
﻿Fixes #55131

## Summary

- add a bounded streaming response reader for QQBot QR onboarding portal calls
- use it for both `create_bind_task` and `poll_bind_result`
- preserve the existing `raise_for_status()` and JSON parsing behavior after the body is safely read

## Why

The QR onboarding flow previously used `httpx.Client.post(...)` and then `resp.json()`. That buffers the full portal response before Hermes checks status or parses JSON, so an oversized portal/proxy response could pressure memory during onboarding.

The new helper rejects oversized `Content-Length` early and enforces the same 1 MiB cap while iterating response chunks.

## Validation

- `python -m pytest tests/gateway/test_qqbot_onboard_response_limit.py -q` -> `4 passed`
- `python -m ruff check gateway/platforms/qqbot/onboard.py tests/gateway/test_qqbot_onboard_response_limit.py`
- `git diff --check`
