### PR TITLE
fix(dashboard): skip auto-SSO for password-only auth providers (500 on basic-auth-only dashboard)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,12 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers (e.g. the bundled basic-auth) have no OAuth
+    # redirect / start_login flow — auto-SSO to /auth/login would raise
+    # NotImplementedError and 500. Fall through to the /login interstitial,
+    # which renders the credential form and POSTs to /auth/password-login.
+    if getattr(provider, "supports_password", False):
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
### What & why
With a non-loopback dashboard bind (`hermes dashboard --host 0.0.0.0`) and the bundled **basic** (username/password) provider as the *only* registered auth provider, every unauthenticated HTML navigation returns **HTTP 500** — the dashboard is unreachable.

`_auto_sso_response()` (`hermes_cli/dashboard_auth/middleware.py`) is an OAuth-only shortcut: when exactly one interactive provider is registered it 302-redirects to `/auth/login?provider=<name>` to skip the `/login` chooser. `/auth/login` unconditionally calls `provider.start_login()`, but the `basic` provider is password-only and raises:

```
NotImplementedError: BasicAuthProvider is password-only; there is no OAuth redirect flow. The login page POSTs to /auth/password-login instead.
```

→ unhandled → 500. The `/login` page and `/auth/password-login` flow are correct; auto-SSO just routes *past* them into a flow the provider doesn't implement.

### The fix
Skip the auto-SSO shortcut when the sole provider supports password login, so the gate falls through to the `/login` interstitial that renders the credential form:

```python
provider = providers[0]
if getattr(provider, "supports_password", False):
    return None
```

### How to test
1. Set `HERMES_DASHBOARD_BASIC_AUTH_USERNAME` / `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD`
2. `hermes dashboard --host 0.0.0.0`
3. Load `/` with no session cookie

- **Before:** HTTP 500 (`NotImplementedError`)
- **After:** 302 → `/login` renders the password form; submitting valid credentials mints the session cookies and lands on `/`.

Verified on a live Linux deployment (Debian 13, v0.17.0) fronted by a TLS reverse proxy: unauth → `/login`, correct creds → 200, wrong creds → 401.

### Platforms tested
- Linux (Debian 13)

### Related
Fixes #55130
