### PR TITLE
Convert image tool results to Converse image blocks for Bedrock

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -643,11 +643,21 @@ def convert_messages_to_converse(
         if role == "tool":
             # Tool result messages → merge into the preceding user turn
             tool_call_id = msg.get("tool_call_id", "")
-            result_content = content if isinstance(content, str) else json.dumps(content)
+            if isinstance(content, list):
+                # Multimodal tool results (computer-use screenshots, image
+                # tools, vision results) carry image parts. Converse
+                # toolResult.content accepts image blocks, so convert them the
+                # same way as user/assistant content. Flattening to a single
+                # text block via json.dumps instead hides the image from the
+                # model and inlines the raw base64 as text, bloating the
+                # request toward the size limit.
+                tr_content = _convert_content_to_converse(content)
+            else:
+                tr_content = [{"text": _safe_text(content if isinstance(content, str) else json.dumps(content))}]
             tool_result_block = {
                 "toolResult": {
                     "toolUseId": tool_call_id,
-                    "content": [{"text": _safe_text(result_content)}],
+                    "content": tr_content,
                 }
             }
             # In Converse, tool results go in a "user" role message

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -536,6 +536,22 @@ def _safe_text(text) -> str:
     return text if text.strip() else _EMPTY_TEXT_PLACEHOLDER
 
 
+def _is_openai_content_part(part) -> bool:
+    """Whether *part* is an OpenAI-style content part rather than plain data.
+
+    ``_convert_content_to_converse`` only understands ``text`` and
+    ``image_url`` parts and silently skips anything else. A list that is
+    ordinary tool output rather than message content (``[{"file": "a.py"},
+    {"file": "b.py"}]``, ``[1, 2, 3]``) therefore converts to nothing, and the
+    tool's entire result is replaced by the ``(empty)`` placeholder. Lists
+    that are not content parts have to stay on the ``json.dumps`` path that
+    preserves them.
+    """
+    if isinstance(part, str):
+        return True
+    return isinstance(part, dict) and part.get("type") in {"text", "image_url"}
+
+
 def _convert_content_to_converse(content) -> List[Dict]:
     """Convert OpenAI message content (string or list) to Converse content blocks.
 
@@ -643,14 +659,41 @@ def convert_messages_to_converse(
         if role == "tool":
             # Tool result messages → merge into the preceding user turn
             tool_call_id = msg.get("tool_call_id", "")
-            if isinstance(content, list):
-                # Multimodal tool results (computer-use screenshots, image
-                # tools, vision results) carry image parts. Converse
-                # toolResult.content accepts image blocks, so convert them the
-                # same way as user/assistant content. Flattening to a single
-                # text block via json.dumps instead hides the image from the
-                # model and inlines the raw base64 as text, bloating the
-                # request toward the size limit.
+            # Multimodal tool results (computer-use screenshots, image tools,
+            # vision results) carry image parts. Converse toolResult.content
+            # accepts image blocks, so convert them the same way as
+            # user/assistant content. Flattening to a single text block via
+            # json.dumps instead hides the image from the model and inlines the
+            # raw base64 as text, bloating the request toward the size limit.
+            #
+            # Both shapes have to be handled, dict first, exactly as
+            # anthropic_adapter._collect_multimodal_blocks already does:
+            # vision_analyze's native fast path returns the envelope dict
+            # {"_multimodal": True, "content": [...], "text_summary": ...}
+            # rather than a bare list, and it is the most common producer of
+            # image-bearing tool results. Matching only on list would leave it
+            # falling through to json.dumps with the base64 still inline.
+            if isinstance(content, dict) and content.get("_multimodal"):
+                tr_content = _convert_content_to_converse(
+                    content.get("content") or [])
+                # Fall back to the envelope's own plain-text summary when the
+                # parts convert to nothing usable, rather than sending a bare
+                # placeholder. Note _convert_content_to_converse never returns
+                # an empty list: it substitutes the non-whitespace placeholder
+                # Converse demands, so "nothing was converted" has to be
+                # recognised by that value and not by emptiness.
+                if (tr_content == [{"text": _EMPTY_TEXT_PLACEHOLDER}]
+                        and content.get("text_summary")):
+                    tr_content = [
+                        {"text": _safe_text(str(content["text_summary"]))}]
+            # Only a list that really is message content parts goes through the
+            # converter. A list-shaped tool result that is plain data (a JSON
+            # array of records, of numbers, of anything without a recognised
+            # part "type") has no parts to convert, so it would come back as
+            # the bare "(empty)" placeholder with the tool's output destroyed.
+            # anthropic_adapter guards its own list arm for the same reason.
+            elif (isinstance(content, list) and content
+                    and all(_is_openai_content_part(p) for p in content)):
                 tr_content = _convert_content_to_converse(content)
             else:
                 tr_content = [{"text": _safe_text(content if isinstance(content, str) else json.dumps(content))}]

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -326,6 +326,54 @@ class TestConvertMessagesToConverse:
         assert len(blocks) == 1 and "text" in blocks[0], blocks
         assert "\"ok\"" in blocks[0]["text"]
 
+    def test_list_shaped_json_tool_result_keeps_its_output(self):
+        """A list-shaped tool result that is plain data, not content parts,
+        must keep its output.
+
+        _convert_content_to_converse only recognises text/image_url parts and
+        skips everything else, so sending every list through it turns an
+        ordinary JSON array result into the bare "(empty)" placeholder and the
+        model never learns what the tool returned.
+        """
+        from agent.bedrock_adapter import convert_messages_to_converse
+        for result in ([{"file": "a.py"}, {"file": "b.py"}],
+                       [1, 2, 3],
+                       [1, "two", 3.0],
+                       [{"type": "file", "path": "a.py"}],
+                       []):
+            messages = [
+                {"role": "user", "content": "list them"},
+                {"role": "assistant", "content": None, "tool_calls": [{
+                    "id": "tu1", "type": "function",
+                    "function": {"name": "list_files", "arguments": "{}"},
+                }]},
+                {"role": "tool", "tool_call_id": "tu1", "content": result},
+            ]
+            _, msgs = convert_messages_to_converse(messages)
+            tr = [b for m in msgs for b in m["content"] if "toolResult" in b][0]
+            blocks = tr["toolResult"]["content"]
+            assert blocks == [{"text": json.dumps(result)}], (result, blocks)
+
+    def test_text_only_content_parts_still_become_separate_blocks(self):
+        """The guard above must not push a genuine content-part list back onto
+        the json.dumps path: text parts still convert to text blocks."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "read it"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "tu1", "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }]},
+            {"role": "tool", "tool_call_id": "tu1", "content": [
+                {"type": "text", "text": "line A"},
+                {"type": "text", "text": "line B"},
+            ]},
+        ]
+        _, msgs = convert_messages_to_converse(messages)
+        tr = [b for m in msgs for b in m["content"] if "toolResult" in b][0]
+        assert tr["toolResult"]["content"] == [
+            {"text": "line A"}, {"text": "line B"}]
+
 
 class TestNormalizeConverseResponse:
     """Test Bedrock Converse response → OpenAI format conversion."""

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -221,6 +221,112 @@ class TestConvertMessagesToConverse:
 # Response normalization: Converse → OpenAI
 # ---------------------------------------------------------------------------
 
+    def test_multimodal_tool_result_keeps_image_block(self):
+        """A tool result carrying an image (computer-use screenshot, image
+        tool, vision result) must convert to a Converse image block, not a
+        json.dumps text dump that hides the image from the model and inlines
+        the base64 as text."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        png = (
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1"
+            "HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )
+        messages = [
+            {"role": "user", "content": "screenshot it"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "tu1", "type": "function",
+                "function": {"name": "screenshot", "arguments": "{}"},
+            }]},
+            {"role": "tool", "tool_call_id": "tu1", "content": [
+                {"type": "text", "text": "Here:"},
+                {"type": "image_url", "image_url": {"url": png}},
+            ]},
+        ]
+        _, msgs = convert_messages_to_converse(messages)
+        tr = [b for m in msgs for b in m["content"] if "toolResult" in b][0]
+        blocks = tr["toolResult"]["content"]
+        assert any("image" in b for b in blocks), blocks
+        # The base64 payload must not be leaked into a text block.
+        assert not any("iVBORw0KGgo" in b.get("text", "") for b in blocks)
+
+    def test_multimodal_envelope_dict_keeps_image_block(self):
+        """The same, for the envelope dict rather than a bare list.
+
+        vision_analyze's native fast path returns
+        ``{"_multimodal": True, "content": [...], "text_summary": ...}``
+        (tools/vision_tools.py), which is the most common producer of an
+        image-bearing tool result. Matching only ``isinstance(content, list)``
+        sent it down the json.dumps branch with the base64 still inline.
+        """
+        from agent.bedrock_adapter import convert_messages_to_converse
+        png = (
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1"
+            "HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )
+        messages = [
+            {"role": "user", "content": "what is in this image?"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "tu1", "type": "function",
+                "function": {"name": "vision_analyze", "arguments": "{}"},
+            }]},
+            {"role": "tool", "tool_call_id": "tu1", "content": {
+                "_multimodal": True,
+                "content": [
+                    {"type": "text", "text": "Image loaded into your context"},
+                    {"type": "image_url", "image_url": {"url": png}},
+                ],
+                "text_summary": "Image attached natively for the main model.",
+                "meta": {"size_bytes": 899000},
+            }},
+        ]
+        _, msgs = convert_messages_to_converse(messages)
+        tr = [b for m in msgs for b in m["content"] if "toolResult" in b][0]
+        blocks = tr["toolResult"]["content"]
+        assert any("image" in b for b in blocks), blocks
+        assert not any("iVBORw0KGgo" in b.get("text", "") for b in blocks)
+
+    def test_multimodal_envelope_falls_back_to_its_text_summary(self):
+        """An envelope whose parts convert to nothing uses text_summary,
+        not a json.dumps of the envelope itself."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "look"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "tu1", "type": "function",
+                "function": {"name": "vision_analyze", "arguments": "{}"},
+            }]},
+            {"role": "tool", "tool_call_id": "tu1", "content": {
+                "_multimodal": True,
+                "content": [],
+                "text_summary": "Image attached natively for the main model.",
+            }},
+        ]
+        _, msgs = convert_messages_to_converse(messages)
+        tr = [b for m in msgs for b in m["content"] if "toolResult" in b][0]
+        blocks = tr["toolResult"]["content"]
+        assert blocks == [
+            {"text": "Image attached natively for the main model."}], blocks
+
+    def test_plain_dict_tool_result_is_unchanged(self):
+        """Only the _multimodal envelope takes the new path. An ordinary dict
+        result still serialises to one text block exactly as before."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "read it"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "tu1", "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }]},
+            {"role": "tool", "tool_call_id": "tu1",
+             "content": {"ok": True, "lines": 3}},
+        ]
+        _, msgs = convert_messages_to_converse(messages)
+        tr = [b for m in msgs for b in m["content"] if "toolResult" in b][0]
+        blocks = tr["toolResult"]["content"]
+        assert len(blocks) == 1 and "text" in blocks[0], blocks
+        assert "\"ok\"" in blocks[0]["text"]
+
+
 class TestNormalizeConverseResponse:
     """Test Bedrock Converse response → OpenAI format conversion."""
 


### PR DESCRIPTION
Fixes #55134

`convert_messages_to_converse` flattened list-shaped tool result content with `json.dumps`:

```python
result_content = content if isinstance(content, str) else json.dumps(content)
tool_result_block = {"toolResult": {"toolUseId": ..., "content": [{"text": result_content}]}}
```

So a tool returning an image (computer-use screenshots, image tools, vision results) arrived as a `text` block with the base64 inlined. The model never saw the image as an image, and the inlined base64 (often 1-2 MB per screenshot) inflated token usage and pushed multi-screenshot sessions toward the request size limit. Bedrock Converse `toolResult.content` accepts image blocks, and `_convert_content_to_converse` already produces them for user and assistant content; the tool branch just did not use it.

### Change

- Route list-shaped tool result content through `_convert_content_to_converse` (the existing image-aware path). String tool results are unchanged.

### Test

`test_multimodal_tool_result_keeps_image_block` asserts that an image tool result produces a Converse `image` block and does not leak the base64 into a text block. It fails on the current code and passes with this change.

```
$ python -m pytest tests/agent/test_bedrock_adapter.py -q
133 passed
```
