### PR TITLE
feat(optional-skills): add trial — gated judging that stops false-done

### DIFF
--- a/optional-skills/autonomous-ai-agents/trial/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/trial/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: trial
+description: "Gated judging that stops false-done: an agent may not ship until executable evidence survives an independent verdict. Use for high-stakes work where a green test is not enough proof."
+version: 0.3.0
+author: Da7_Tech
+license: MIT
+homepage: https://github.com/Da7-Tech/trial-skill
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    category: autonomous-ai-agents
+    tags: [verification, judging, false-done, quality-assurance, evidence, high-stakes]
+    related_skills: [subagent-driven-development, test-driven-development, systematic-debugging]
+---
+
+# Trial
+
+## Overview
+
+Trial runs a task through **gates**: nothing advances without a written artifact,
+and nothing ships until the work is verified with evidence. One rule governs it:
+
+> **No execution before the decision is sound. No delivery before an independent
+> verdict.** "Verified" means nothing without a written artifact showing the
+> method, the evidence, and the result.
+
+But rigor must be **fast**. The amount of ceremony — and whether to spawn
+subagents at all — scales to the task. Most tasks run the gates *inline* in
+minutes; only genuinely large or high-stakes work spawns the full parallel
+tribunal.
+
+Deep specs: `references/gates.md` (gates + lens matrix), `references/verdicts.md`
+(verdict rules), `references/console.md` (the live console). Artifact scaffolds
+in `templates/`.
+
+## How this differs from `subagent-driven-development`
+
+They are complementary, not competing:
+
+- **`subagent-driven-development`** is about *execution*: dispatch a fresh
+  subagent per task and review between tasks (2-stage review of the build).
+- **`trial`** is about *judging the finished claim*: it attacks the "done" itself
+  with executable evidence and an independent verdict. Its target is **false-done**
+  — work that passes the builder's own tests but is actually broken.
+
+Measured on 5 tasks with hidden SWE-bench-style oracles, a baseline that trusts
+the builder's "strong evidence" ships 4/5 false-done tasks; Trial ships 0/5 and
+blocks 0/5 correct ones (see the [benchmark](https://github.com/Da7-Tech/trial-skill/blob/main/benchmark/results/2026-06-29-judge-accuracy.md)).
+
+
+## Step 0 — Triage FIRST (this decides speed)
+
+Before doing anything, size the task. This is the most important decision.
+
+| Tier | What it is | Path | Subagents | Target time |
+|---|---|---|---|---|
+| **fast** (default) | a function, a script, a small fix, one component, a focused analysis/doc | gates run **inline**, verify by running | 0 (maybe 1) | minutes |
+| **standard** | a multi-file feature, a real module | light fan-out where it helps | ≤ 3 | tens of minutes |
+| **strict** | shipping a product, an important audit | full gated fan-out, 3 judges | ~6–9 | longer |
+| **maximum** | irreversible / high-risk / long-lived | full path, max reasoning | 9+ | longest |
+
+Default is **fast** unless the task is clearly bigger. Read the mode from the
+invocation (`/trial strict <task>`) if given; otherwise infer it. When unsure,
+pick the lighter tier — you can escalate mid-run if it proves harder.
+
+> **Speed is a feature.** Every delegated subagent costs real wall-clock —
+> minutes each on slower models (e.g. MiniMax-M3). A simple task that takes half
+> an hour, or stalls at "gate 3/8", is a **bug, not rigor**. Never run the full
+> fan-out on small work.
+
+## Autonomous run
+
+`/trial <prompt>` is one standing instruction (like goal mode): once started,
+run to completion without stopping to check in. Don't pause to summarize between
+gates or ask "shall I continue". The only stops: a 1–3 question clarification at
+framing if the task is genuinely underspecified, or a hard escalation (rework cap
+hit with a blocker needing a human) — set `verdict: escalated` and stop.
+
+## The Fast Path (default — most tasks)
+
+You (the orchestrator) run all eight gates **inline and quickly, with no
+delegation**. The gates still happen — they're just fast:
+
+1. **Frame** — short `mission-brief.md`: the real goal, testable acceptance
+   criteria, non-goals. (If underspecified, ask 1–3 short questions now.)
+2. **Research** — a quick inline scan: read the relevant files / recall the
+   standard. Not a delegated batch. One short note in the decision brief is enough.
+3. **Decide** — a 3-line `decision-brief.md`: approach + the acceptance bar +
+   anything the build must not do.
+4. **Council** — self-check the decision against the acceptance criteria inline.
+5. **Build** — do the work directly with `terminal`/`file`/`patch`. Delegate ONE
+   worker only if it genuinely needs an isolated context (rare for small tasks).
+6. **Judge** — **verify by RUNNING it**: execute the code, run the tests, hit the
+   edge cases yourself. Objective execution IS the independent check here — it's
+   evidence, not self-opinion.
+7. **Rework** — fix what the run exposed; re-run until green.
+8. **Deliver** — short `final-delivery.md` mapping each acceptance criterion to
+   the run evidence (command → result). Set `verdict: delivered`.
+
+Keep `status.json` + the console updated so the user watches it advance live —
+the gates just move fast. **Honesty:** the fast path trades a separate judge
+panel for objective execution; that's correct for low-stakes work. For
+high-stakes work, use the full path (real independent judges).
+
+## The Full Path (strict / maximum, or a genuinely complex task)
+
+Same eight gates, but with **parallel delegated** research, council, and judging —
+because the work is big enough that isolation + parallelism + independent judges
+earn their cost. The gate-by-gate detail and the triple-lens matrix are in
+`references/gates.md`; verdict rules in `references/verdicts.md`. In short:
+
+2. **Triple research** — one parallel `delegate_task` batch of independent lenses.
+4. **Council** — parallel batch of 3 judges on the decision brief.
+5. **Execution team** — builders sized to the task (architecture/backend/frontend/…).
+6. **Triple judging** — fresh judges, three different methods (requirement-match /
+   real execution / adversarial), each a written `judge-verdict.md` with evidence.
+7. **Targeted rework** — a blocking defect goes back to the responsible role only,
+   bounded by the mode's rework rounds; on deadlock, escalate.
+8. **Final review** — *you*, independently: re-run the tests, read the diff, check
+   every criterion. Never trust subagent summaries.
+
+`standard` is between the two: fan out only the part that genuinely benefits
+(e.g. one research lens or one builder), keep judges to 1–2.
+
+## Speed rules (apply on every path)
+
+- **Don't delegate what you can do inline faster.** Delegation buys parallelism
+  and context isolation on heavy work — it is pure latency cost on small work.
+- **Bound subagents.** Tight goals; cap the count (~3 unless the task truly needs
+  more). On slow models, prefer inline.
+- **Never let a gate stall.** If a subagent is slow or looping, cut it and do that
+  gate inline. Finishing is the job.
+
+## Setup (all paths)
+
+- `mkdir -p .hermes/trial/<timestamp>-<slug>` (relative to the workspace).
+- Start `status.json` from `templates/status.example.json` (set `task`, `mode`,
+  `lang`, `creator`, gates `pending`, `verdict: in-progress`) and `decision-log.md`.
+- Render + open the console once (below), then update it at every gate.
+
+## Language
+
+Trial is written in English but **operates in the user's language** (detect from
+how the user writes / `display.language`; default English). Every question,
+artifact, the ledger, and the final report follow the user's language. Set `lang`
+in `status.json` so the console matches (RTL for Arabic). Templates are English
+scaffolds — fill them in the user's language.
+
+## Live console (the visual the user watches)
+
+See `references/console.md`. At every gate transition: (1) update `status.json`
+(`current_gate`, each `gates[].state`, `judges[]`, `builders[]`, append a
+`ledger[]` line, `verdict`); (2) re-render:
+`python3 <skill_dir>/scripts/render_console.py --status <run>/status.json --out <run>/trial-console.html`;
+(3) on the FIRST render only, open it (`open <run>/trial-console.html` on macOS,
+`xdg-open` on Linux). It auto-reloads while `verdict` is `in-progress`.
+`<skill_dir>` is the absolute path injected with this skill.
+
+On the fast path the gates advance quickly — still update status.json so the
+console (and any in-app trace) shows live progress, but don't let console
+bookkeeping slow you down.
+
+## Delegation recipes (full path)
+
+`delegate_task` spawns a real subagent with an isolated context + terminal; the
+parent blocks until children return; concurrency caps at
+`delegation.max_concurrent_children` (default 3). Parallel batch:
+
+```
+delegate_task(tasks=[
+  {goal: "<lens 1 ...>", context: "<run dir + brief>", toolsets: ["search","web","file"]},
+  {goal: "<lens 2 ...>", context: "...", toolsets: ["search","web","file"]},
+])
+```
+
+Single worker: `delegate_task(goal="<slice>", context="<brief + run dir>", toolsets=["terminal","file"])`.
+Leaf limits: subagents cannot `delegate_task`, `clarify`, `memory`,
+`send_message`, or `execute_code` — put everything in `goal` + `context`, and
+have each write its artifact + return a short summary. Evidence in, evidence out:
+a judge's goal must demand method + exact evidence + verdict; reject "looks good".
+
+## Artifacts
+
+Under `.hermes/trial/<timestamp>-<slug>/`: `mission-brief.md`, `decision-brief.md`,
+`final-delivery.md`, `decision-log.md`, `status.json`, `trial-console.html`. The
+full path adds `research/`, `council/`, `build/`, `judging/`, `rework/`. The fast
+path writes the core set only. If `decision-log.md` has no line for a gate, that
+gate didn't happen.
+
+## Common Pitfalls
+
+1. **Over-ceremony on a simple task.** The #1 failure. A function does NOT need a
+   3-judge tribunal. Triage first; default to the fast path; finish in minutes.
+2. **Stalling.** A run stuck at gate N for many minutes is broken — cut the slow
+   subagent and do the gate inline.
+3. **Trusting summaries.** Verify by running; on the full path the orchestrator
+   re-runs tests at Gate 8.
+4. **Verdict with no evidence.** "Looks correct" is not a verdict.
+5. **Letting the builder judge itself** (full path) — judges are fresh subagents.
+6. **Unbounded rework** — cap rounds; on deadlock, escalate.
+7. **Wrong language / stale console** — render artifacts in the user's language;
+   set `lang`; keep `status.json` current.
+
+## Verification Checklist
+
+- [ ] Triaged first; effort + subagent count matched the task size (no fan-out on small work).
+- [ ] `mission-brief.md` has explicit, testable acceptance criteria.
+- [ ] The result was **verified by running it** (fast path) or by fresh judges with evidence (full path).
+- [ ] Every blocking defect fixed and re-verified; rework bounded.
+- [ ] `status.json` + console updated through to a final `verdict`.
+- [ ] `final-delivery.md` maps each acceptance criterion to its evidence.
+- [ ] All artifacts, ledger, and the report are in the user's language.
+- [ ] It finished in a time that fits the task — fast for small work.

--- a/optional-skills/autonomous-ai-agents/trial/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/trial/SKILL.md
@@ -64,9 +64,9 @@ invocation (`/trial strict <task>`) if given; otherwise infer it. When unsure,
 pick the lighter tier — you can escalate mid-run if it proves harder.
 
 > **Speed is a feature.** Every delegated subagent costs real wall-clock —
-> minutes each on slower models (e.g. MiniMax-M3). A simple task that takes half
-> an hour, or stalls at "gate 3/8", is a **bug, not rigor**. Never run the full
-> fan-out on small work.
+> minutes each on slower models. A simple task that takes half an hour, or
+> stalls at "gate 3/8", is a **bug, not rigor**. Never run the full fan-out on
+> small work.
 
 ## Autonomous run
 
@@ -98,9 +98,10 @@ delegation**. The gates still happen — they're just fast:
    the run evidence (command → result). Set `verdict: delivered`.
 
 Keep `status.json` + the console updated so the user watches it advance live —
-the gates just move fast. **Honesty:** the fast path trades a separate judge
-panel for objective execution; that's correct for low-stakes work. For
-high-stakes work, use the full path (real independent judges).
+the gates just move fast. **Honesty:** the fast path verifies by running the
+work directly instead of spawning fresh subagent judges; that's correct for
+low-stakes work. For high-stakes work, use the full path (fresh subagents with
+isolated context judge the claim independently).
 
 ## The Full Path (strict / maximum, or a genuinely complex task)
 

--- a/optional-skills/autonomous-ai-agents/trial/references/console.md
+++ b/optional-skills/autonomous-ai-agents/trial/references/console.md
@@ -1,0 +1,38 @@
+# Trial — Live Console (status.json + render)
+
+The orchestrator keeps a live visual the user can watch while the run proceeds.
+It is a single self-contained HTML file — no server, no build, works anywhere,
+and is shareable.
+
+## status.json
+
+Write/update `.hermes/trial/<run>/status.json` at every gate transition. Schema
+(a filled example is in `templates/status.example.json`):
+
+- `task` — short title of the work.
+- `mode` — light | standard | strict | maximum.
+- `lang` — BCP-47 of the user's language (e.g. `ar`, `en`). Drives RTL + chrome.
+- `creator` — the signature shown on the console (the user's name/handle).
+- `current_gate` — 1–8.
+- `round` — rework round counter (int).
+- `verdict` — `in-progress` | `delivered` | `escalated`.
+- `gates` — 8 entries: `{n, state: pending|active|done, artifact}`.
+- `judges` — `{name, lens, state: idle|think|pass|cond|fail, note}`.
+- `builders` — `{name, pct: 0–100, state: active|done|rework}`.
+- `ledger` — `{text, tag, tone: ok|info|warn|bad, time}` (newest last; one line
+  per gate event).
+
+Write all text fields (names, notes, ledger) in the USER'S language.
+
+## Render + open
+
+After each status.json update, render the console:
+
+```
+python3 <skill_dir>/scripts/render_console.py --status <run>/status.json --out <run>/trial-console.html
+```
+
+On the FIRST render, open it for the user once (macOS: `open <run>/trial-console.html`;
+Linux: `xdg-open <run>/trial-console.html`). The page reloads itself every few
+seconds while `verdict` is `in-progress`, so the user watches the tribunal live.
+Set `verdict` to `delivered` (or `escalated`) at the end so it stops refreshing.

--- a/optional-skills/autonomous-ai-agents/trial/references/gates.md
+++ b/optional-skills/autonomous-ai-agents/trial/references/gates.md
@@ -1,0 +1,102 @@
+# Trial — The Eight Gates (detail)
+
+Reference for the `trial` skill. The orchestrator reads this when it needs the
+full procedure for a gate. Keep every artifact in the run dir
+`.hermes/trial/<timestamp>-<slug>/`.
+
+## Gate 1 — Mission framing (orchestrator)
+
+Produce `mission-brief.md`. The hardest, most-skipped gate. Fill:
+- Mission: one paragraph — the real job to be done, not the feature list.
+- Non-goals: what this explicitly will NOT do.
+- Constraints: tech, time, budget, platform, compliance.
+- Acceptance criteria: testable bullets. "A trader can run 1,200 operations in a
+  day with no data error" beats "works well".
+- Rejection criteria: what makes the result unacceptable.
+- Must-not-assume: unknowns that, if wrongly assumed, sink the build.
+
+If any of these can't be filled, ask the user 1–3 short questions in their
+language. Do not proceed on guesses.
+
+## Gate 2 — Triple research (parallel batch)
+
+Three independent lenses, each a leaf subagent that writes a findings file and
+returns a 5-line summary. Pick the lens set by domain (matrix below). Generic
+software/product set:
+- `research/source.md` — external: market, competitors, prior art, best practice.
+- `research/internal.md` — internal: existing code, constraints, what's there.
+- `research/adversarial.md` — critical: what would make this plan fail? the
+  strongest case against it.
+
+Each findings file ends with: facts, risks, unknowns, one-line recommendation.
+
+## Gate 3 — Decision brief (orchestrator)
+
+Synthesize Gate 2 into `decision-brief.md`: proposed path, rejected
+alternatives + why, risks, and the acceptance criteria the build must hit
+(carried from the mission brief, sharpened by research). This is the contract the
+builders are bound to — they may not invent a new goal.
+
+## Gate 4 — Council approval (parallel batch)
+
+Three judges review the decision brief, each from one angle:
+- `council/strategy.md` — does this serve the real mission? right problem?
+- `council/feasibility.md` — buildable without fragility? hidden complexity?
+- `council/criteria.md` — are the acceptance criteria clear, complete, testable?
+
+Each returns accepted / accepted-with-conditions / rejected + reasons. Proceed
+only on accept; fold conditions into the build brief. On rejection, return to
+Gate 3 (or Gate 1 if the mission itself is wrong).
+
+## Gate 5 — Execution team (workers)
+
+Spawn builders sized to the task — not fixed roles. Common roles: architecture,
+backend, frontend, integration, docs, repair. Give each: the decision brief, its
+exact slice, the run dir, and the boundary of what it owns. Builders use
+`terminal`, `file`, `patch` (not `execute_code`). They write `build/<role>.md`
+(what changed, where, assumptions, open issues) and return a summary. Keep
+batches <= `delegation.max_concurrent_children`.
+
+## Gate 6 — Triple judging (parallel batch)
+
+Fresh judges — never a builder. Three DIFFERENT methods (not three reads):
+- `judging/requirements.md` — match output line-by-line to acceptance criteria.
+- `judging/execution.md` — actually run it: build, test, click the real path,
+  hit the edge case (the 1,200-operation day, not a toy).
+- `judging/adversarial.md` — try to break it: malformed input, concurrency, the
+  unhappy path, the security angle.
+
+Each writes a `judge-verdict.md`-shaped file with method, evidence, findings,
+blocking vs non-blocking, and a verdict. See `verdicts.md`.
+
+## Gate 7 — Targeted rework (loop, bounded)
+
+Collect blocking findings. Route each to the responsible role only, with a
+precise rework order in `rework/<n>-<role>.md`: the defect, the evidence, the fix
+expected, the acceptance bar. Re-spawn that builder; then re-run the relevant
+judge(s). Bound by the mode's rework rounds. On deadlock (judges keep
+disagreeing, or a fix breaks another part), stop and escalate to the user with
+the open verdicts — do not loop.
+
+## Gate 8 — Final review (orchestrator, independent)
+
+Do not trust summaries. Independently:
+- re-run the key tests yourself (`terminal`),
+- read the actual diff (`read_file` / `search_files`),
+- check every acceptance criterion in `mission-brief.md` against real evidence,
+- delete dead weight and contradictions.
+
+Write `final-delivery.md`: each acceptance criterion -> its evidence, known
+limits, and what was cut. Then report to the user in their language.
+
+## The triple-lens matrix (pick by domain)
+
+| Domain | Lens 1 | Lens 2 | Lens 3 |
+|---|---|---|---|
+| Research / plan | source (data) | logic (does it follow?) | adversarial (why wrong?) |
+| Software | static read | run + test | does it do what the user needs? |
+| Design | visual consistency | usability | does it sell / serve the goal? |
+| Writing | meaning correct | voice right | structure serves the argument |
+
+Three identical reviews catch the same bug three times. Three different lenses
+catch three classes of bug. Always vary the lens.

--- a/optional-skills/autonomous-ai-agents/trial/references/verdicts.md
+++ b/optional-skills/autonomous-ai-agents/trial/references/verdicts.md
@@ -1,0 +1,53 @@
+# Trial — Verdicts, Evidence, Termination
+
+Reference for the `trial` skill (Gates 4, 6, 7).
+
+## A verdict is evidence-bound
+
+Every judge returns the `judge-verdict.md` shape:
+- Lens / angle — which lens this is.
+- Method used — exactly how it was checked.
+- Evidence checked — commands run + output, files + lines read, criteria
+  compared. Concrete and reproducible.
+- Findings — what was found.
+- Blocking issues — defects that prevent acceptance.
+- Non-blocking issues — notes that don't block.
+- Required fixes — precise, per finding.
+- Verdict — one of: accepted / accepted-with-conditions / rejected.
+
+A verdict with no "evidence checked" section is invalid — treat it as
+"rejected, re-run". This single rule is what prevents the model from *performing*
+approval instead of *doing* it.
+
+## Blocking vs non-blocking
+
+- Blocking: violates an acceptance criterion, breaks a real user path, loses or
+  corrupts data, a security hole, a crash on normal input.
+- Non-blocking: style, minor polish, a nice-to-have, a future refactor.
+
+Only blocking issues trigger Gate-7 rework. Non-blocking issues are recorded in
+`final-delivery.md` as known limits.
+
+## Voting (multiple judges)
+
+- standard (2 judges): both must reach accepted / accepted-with-conditions. Any
+  reject -> rework.
+- strict / maximum (3 judges): majority (>= 2) accept to pass; but any blocking
+  finding from any judge must still be resolved or explicitly waived by the user.
+- Disagreement is data: if judges split on whether something blocks, treat it as
+  blocking until resolved.
+
+## Termination (no infinite loops)
+
+- Rework rounds are capped by mode (light 1, standard/strict 2, maximum 3).
+- A fix that introduces a new blocking defect counts toward the cap.
+- On reaching the cap with blocking issues still open, STOP and escalate to the
+  user: present the open verdicts, the attempted fixes, and a recommendation.
+  Never silently keep looping, and never silently ship with known blockers.
+
+## Maximum-reasoning judges
+
+For strict / maximum, judges reason adversarially and thoroughly. Ask the user
+to set `delegation.reasoning_effort: high` so subagents think hard, and phrase
+each judge's `goal` to "default to rejected when uncertain" — skepticism is the
+job, not politeness.

--- a/optional-skills/autonomous-ai-agents/trial/scripts/render_console.py
+++ b/optional-skills/autonomous-ai-agents/trial/scripts/render_console.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Render a self-contained Trial console from a run's status.json.
+
+Dependency-free (stdlib only). RTL-aware, bilingual chrome (ar/en, fallback en).
+The Trial orchestrator calls this after every gate transition; the page reloads
+itself every few seconds while the run is in progress, so the user watches the
+tribunal live.
+
+Usage:
+  python3 render_console.py --status <run>/status.json --out <run>/trial-console.html
+If --out is omitted, the HTML is written next to status.json.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+TEMPLATE = r"""<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Trial</title>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Readex+Pro:wght@300;400;600;700&family=Tajawal:wght@400;500;700&display=swap');
+*{box-sizing:border-box}
+html,body{margin:0;min-height:100vh;color:#f4f1e8;
+  font-family:'Readex Pro','Tajawal',-apple-system,BlinkMacSystemFont,'Segoe UI','Geeza Pro',Tahoma,sans-serif;
+  background:radial-gradient(120% 80% at 80% -10%,rgba(230,196,98,.10),transparent 60%),
+             radial-gradient(100% 90% at 10% 110%,rgba(120,90,255,.08),transparent 55%),#06080f;}
+#app{max-width:920px;margin:0 auto;padding:26px 22px 32px}
+.head{display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap}
+.brand{display:flex;align-items:center;gap:12px}
+.logo{width:40px;height:40px;color:#e6c462;filter:drop-shadow(0 0 10px rgba(230,196,98,.45))}
+.word{font-size:30px;font-weight:700;letter-spacing:7px;line-height:1;
+  background:linear-gradient(180deg,#fff3cf,#e6c462 55%,#b98f1e);-webkit-background-clip:text;background-clip:text;color:transparent}
+.sub{font-size:12px;color:#98a2b3;margin-top:3px}
+.tag{font-size:12px;color:#d9cfa3;max-width:330px;line-height:1.6;opacity:.9}
+.chips{display:flex;gap:8px;flex-wrap:wrap;margin:16px 0 18px}
+.chip{font-size:12px;color:#cdd5e0;background:rgba(255,255,255,.04);border:1px solid rgba(230,196,98,.16);padding:5px 11px;border-radius:999px}
+.chip b{color:#e6c462}
+.rail{display:flex;justify-content:space-between;position:relative;margin-bottom:20px}
+.rail::before{content:"";position:absolute;top:13px;left:3%;right:3%;height:2px;background:rgba(230,196,98,.16)}
+.step{position:relative;z-index:1;flex:1;text-align:center;font-size:11px;color:#98a2b3}
+.step .d{width:26px;height:26px;border-radius:50%;margin:0 auto 7px;display:flex;align-items:center;justify-content:center;
+  font-size:12px;background:#0e1426;border:2px solid rgba(255,255,255,.12);color:#98a2b3;transition:.4s}
+.step.active{color:#e6c462}
+.step.active .d{border-color:#e6c462;background:rgba(230,196,98,.14);color:#e6c462;box-shadow:0 0 0 4px rgba(230,196,98,.08)}
+.step.done{color:#bfe9d4}
+.step.done .d{border-color:#4ee0a3;color:#4ee0a3;background:#0f1c19}
+.grid{display:grid;grid-template-columns:1fr 252px;gap:16px}
+@media(max-width:640px){.grid{grid-template-columns:1fr}}
+.card{background:rgba(255,255,255,.04);border:1px solid rgba(230,196,98,.16);border-radius:16px;padding:16px}
+.phl{display:flex;justify-content:space-between;align-items:center;font-size:12px;color:#98a2b3;margin-bottom:14px}
+.phl b{color:#f4f1e8;font-size:14px}
+.rb{font-size:11px;color:#e6c462;background:rgba(230,196,98,.08);border:1px solid rgba(230,196,98,.16);padding:3px 9px;border-radius:999px}
+.judges{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:14px}
+.judge{background:#0c1325;border:1px solid rgba(255,255,255,.08);border-radius:14px;padding:12px 8px;text-align:center;transition:.4s}
+.judge .ic{width:26px;height:26px;margin:0 auto 6px;color:#8b95a7;transition:.4s}
+.judge .nm{font-size:12px;font-weight:600}
+.judge .st{font-size:11px;color:#98a2b3;margin-top:4px}
+.judge.think{border-color:#fbbf24}
+.judge.think .ic,.judge.think .st{color:#fbbf24}
+.judge.think .ic{animation:pulse 1s ease-in-out infinite}
+.judge.pass{border-color:#4ee0a3;background:#0c1c17}
+.judge.pass .ic,.judge.pass .st{color:#4ee0a3}
+.judge.cond{border-color:#fbbf24;background:#1a1608}
+.judge.cond .ic,.judge.cond .st{color:#fbbf24}
+.judge.fail{border-color:#fb7185;background:#1d0f14}
+.judge.fail .ic,.judge.fail .st{color:#fb7185}
+@keyframes pulse{0%,100%{opacity:.55;transform:scale(1)}50%{opacity:1;transform:scale(1.1)}}
+.builders{display:flex;flex-direction:column;gap:9px}
+.builder{display:grid;grid-template-columns:132px 1fr 42px;gap:10px;align-items:center;font-size:11.5px;color:#cfd6e2}
+.bar{height:8px;background:#0e1426;border:1px solid rgba(255,255,255,.06);border-radius:99px;overflow:hidden}
+.bar i{display:block;height:100%;border-radius:99px;background:linear-gradient(90deg,#caa12a,#e6c462);transition:width .6s ease}
+.builder.rework .bar i{background:linear-gradient(90deg,#b91c1c,#fb7185)}
+.pct{font-size:10px;color:#98a2b3;text-align:end;font-variant-numeric:tabular-nums}
+.ledger h4{margin:0 0 10px;font-size:12px;color:#e6c462;font-weight:600}
+.log{display:flex;flex-direction:column;gap:8px}
+.entry{display:flex;gap:8px;align-items:flex-start;font-size:11px}
+.dot{width:7px;height:7px;border-radius:50%;margin-top:5px;flex:none;background:#98a2b3}
+.entry.ok .dot{background:#4ee0a3}
+.entry.info .dot{background:#5bc8f7}
+.entry.warn .dot{background:#fbbf24}
+.entry.bad .dot{background:#fb7185}
+.etext{flex:1;color:#d7dde7;line-height:1.45}
+.etime{font-size:10px;color:#5b6577;font-variant-numeric:tabular-nums}
+.stamp{margin-top:16px;text-align:center}
+.seal{display:inline-flex;align-items:center;gap:8px;font-size:17px;font-weight:700;padding:12px 24px;border-radius:14px;
+  border:2px solid #4ee0a3;color:#4ee0a3;background:rgba(7,20,15,.6)}
+.seal.esc{border-color:#fbbf24;color:#fbbf24;background:rgba(26,22,8,.6)}
+.credit{text-align:center;margin-top:18px;font-size:11px;color:#5b6577}
+.credit b{color:#e6c462}
+</style>
+</head>
+<body>
+<div id="app"></div>
+<script>
+const S = __STATUS_JSON__;
+const LANG = (S.lang || 'en').toLowerCase();
+const RTL = ['ar','he','fa','ur','ps'].indexOf(LANG.split('-')[0]) >= 0;
+document.documentElement.dir = RTL ? 'rtl' : 'ltr';
+document.documentElement.lang = LANG;
+const GL = {
+  en:["Framing","Research","Decision","Council","Build","Judging","Review","Delivery"],
+  ar:["تأطير","بحث","قرار","مجلس","تنفيذ","تحكيم","مراجعة","تسليم"]
+};
+const C = {
+  en:{sub:"Tri-judge methodology",tag:"No execution before the decision is approved; no delivery before an independent verdict.",phase:"Current gate",round:"Round",ledger:"Ledger",empty:"No verdicts yet.",delivered:"Delivered — approved",escalated:"Escalated — needs you",running:"in session",gates:"gates",by:"by"},
+  ar:{sub:"منهجية الحكم الثلاثي",tag:"لا تنفيذ قبل اعتماد القرار، ولا تسليم قبل حكم مستقل.",phase:"المرحلة الحالية",round:"الجولة",ledger:"السِجلّ",empty:"لا أحكام بعد.",delivered:"تم التسليم — مُعتمد",escalated:"تصعيد — يحتاجك",running:"الجلسة منعقدة",gates:"بوابات",by:"من"}
+};
+const t = C[LANG] || C.en;
+const gl = GL[LANG] || GL.en;
+const num = RTL ? (s)=>(''+s).replace(/[0-9]/g, d=>'٠١٢٣٤٥٦٧٨٩'[d]) : (s)=>(''+s);
+function esc(s){return (s==null?'':''+s).replace(/[&<>"]/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));}
+const scales = '<svg class="logo" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3.2v17.6"/><path d="M7.5 20.8h9"/><path d="M5 7h14"/><path d="M5 7 3 11.6M5 7 7 11.6"/><path d="M2.4 11.6a2.6 2.6 0 0 0 5.2 0z"/><path d="M19 7 17 11.6M19 7 21 11.6"/><path d="M16.4 11.6a2.6 2.6 0 0 0 5.2 0z"/></svg>';
+const jicon = '<svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="3"/></svg>';
+
+const cur = S.current_gate || 0;
+const gates = (S.gates && S.gates.length) ? S.gates : [1,2,3,4,5,6,7,8].map(n=>({n:n}));
+function step(g){
+  const n = g.n;
+  const st = g.state || (n < cur ? 'done' : n === cur ? 'active' : 'pending');
+  const lab = gl[n-1] || ('#'+n);
+  return '<div class="step '+st+'"><div class="d">'+(st==='done'?'✓':num(n))+'</div>'+esc(lab)+'</div>';
+}
+const doneCount = gates.filter(g => g.state==='done' || g.n < cur).length;
+const head = '<div class="head"><div class="brand">'+scales+'<div><div class="word">Trial</div><div class="sub">'+esc(t.sub)+'</div></div></div><div class="tag">'+esc(S.tagline || t.tag)+'</div></div>';
+const chips = '<div class="chips"><span class="chip"><b>'+num(doneCount)+'</b>/<b>'+num(8)+'</b> '+esc(t.gates)+'</span><span class="chip">'+esc(S.mode||'standard')+'</span><span class="chip">'+esc(t.running)+'</span></div>';
+const rail = '<div class="rail">'+gates.map(step).join('')+'</div>';
+const curName = gl[(cur||1)-1] || '';
+const phl = '<div class="phl"><span>'+esc(t.phase)+': <b>'+esc(curName)+'</b></span><span class="rb">'+esc(t.round)+' '+num(S.round||1)+'</span></div>';
+const judges = (S.judges||[]).map(j => '<div class="judge '+esc(j.state||'idle')+'">'+jicon+'<div class="nm">'+esc(j.name||j.lens||'')+'</div><div class="st">'+esc(j.note||'')+'</div></div>').join('');
+const builders = (S.builders||[]).map(b => {
+  const pct = Math.max(0, Math.min(100, Math.round(b.pct||0)));
+  return '<div class="builder '+esc(b.state||'')+'"><span>'+esc(b.name||'')+'</span><span class="bar"><i style="width:'+pct+'%"></i></span><span class="pct">'+num(pct)+'%</span></div>';
+}).join('');
+let stamp = '';
+if (S.verdict === 'delivered') stamp = '<div class="stamp"><span class="seal">✦ '+esc(t.delivered)+'</span></div>';
+else if (S.verdict === 'escalated') stamp = '<div class="stamp"><span class="seal esc">▲ '+esc(t.escalated)+'</span></div>';
+const stage = '<div class="card">'+phl+(judges?'<div class="judges">'+judges+'</div>':'')+(builders?'<div class="builders">'+builders+'</div>':'')+stamp+'</div>';
+const led = (S.ledger||[]).map(e => '<div class="entry '+esc(e.tone||'info')+'"><span class="dot"></span><span class="etext">'+esc(e.text||'')+'</span><span class="etime">'+esc(e.time||'')+'</span></div>').join('') || '<div class="entry"><span class="etext" style="color:#98a2b3">'+esc(t.empty)+'</span></div>';
+const ledger = '<div class="card ledger"><h4>'+esc(t.ledger)+'</h4><div class="log">'+led+'</div></div>';
+const credit = '<div class="credit">'+esc(t.by)+' <b>'+esc(S.creator||'Da7_Tech')+'</b> · Trial · '+esc(S.task||'')+'</div>';
+document.getElementById('app').innerHTML = head + chips + rail + '<div class="grid">'+stage+ledger+'</div>' + credit;
+if (S.verdict !== 'delivered' && S.verdict !== 'escalated') { setTimeout(()=>location.reload(), 4000); }
+</script>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Render the Trial live console.")
+    ap.add_argument("--status", required=True, help="path to status.json")
+    ap.add_argument("--out", default=None, help="output html path (default: next to status.json)")
+    args = ap.parse_args()
+
+    status_path = Path(args.status).expanduser()
+    try:
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+        if not isinstance(status, dict):
+            raise ValueError("status.json must be a JSON object")
+    except Exception as exc:  # never crash the run over a malformed status file
+        status = {
+            "task": "(status.json unreadable: %s)" % exc,
+            "lang": "en", "mode": "standard", "current_gate": 0, "round": 1,
+            "verdict": "in-progress", "gates": [], "judges": [], "builders": [], "ledger": [],
+        }
+
+    out_path = Path(args.out).expanduser() if args.out else status_path.with_name("trial-console.html")
+    embedded = json.dumps(status, ensure_ascii=False).replace("</", "<\\/")
+    out_path.write_text(TEMPLATE.replace("__STATUS_JSON__", embedded), encoding="utf-8")
+    print(str(out_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/autonomous-ai-agents/trial/templates/decision-brief.md
+++ b/optional-skills/autonomous-ai-agents/trial/templates/decision-brief.md
@@ -1,0 +1,19 @@
+# Decision Brief — <task>
+
+## Recommended path
+<the chosen approach, concise>
+
+## Why this path
+<reasoning tied to the research and the mission>
+
+## Alternatives rejected
+- <option> — <why not>
+
+## Risks
+- <risk> — <mitigation>
+
+## Acceptance criteria the build must hit
+- [ ] <carried from the mission brief, sharpened by research>
+
+## Out of bounds for builders
+- <what the build team must NOT change or invent>

--- a/optional-skills/autonomous-ai-agents/trial/templates/decision-log.md
+++ b/optional-skills/autonomous-ai-agents/trial/templates/decision-log.md
@@ -1,0 +1,12 @@
+# Decision Log — <task>
+
+One line per gate transition: timestamp · gate · verdict · artifact.
+
+- <ts> · Gate 1 · mission framed · -> mission-brief.md
+- <ts> · Gate 2 · research complete (3 lenses) · -> research/
+- <ts> · Gate 3 · decision drafted · -> decision-brief.md
+- <ts> · Gate 4 · council: accepted · -> council/
+- <ts> · Gate 5 · build complete · -> build/
+- <ts> · Gate 6 · judging: <verdict> · -> judging/
+- <ts> · Gate 7 · rework <n> (<role>) · -> rework/
+- <ts> · Gate 8 · final review passed · -> final-delivery.md

--- a/optional-skills/autonomous-ai-agents/trial/templates/final-delivery.md
+++ b/optional-skills/autonomous-ai-agents/trial/templates/final-delivery.md
@@ -1,0 +1,19 @@
+# Final Delivery — <task>
+
+## Acceptance criteria -> evidence
+| Criterion | Evidence (test / file / check) | Status |
+|---|---|---|
+| <criterion> | <what proves it> | pass |
+
+## What was built
+<concise summary of the result>
+
+## Independent re-verification (orchestrator)
+- <test re-run by the orchestrator -> result>
+- <diff read -> confirmation>
+
+## Known limits (non-blocking)
+- <recorded non-blocking issues>
+
+## What was cut
+- <dead weight removed at final review>

--- a/optional-skills/autonomous-ai-agents/trial/templates/judge-verdict.md
+++ b/optional-skills/autonomous-ai-agents/trial/templates/judge-verdict.md
@@ -1,0 +1,27 @@
+# Judge Verdict — <gate> / <angle>
+
+## Lens
+<strategy | feasibility | criteria | requirements | execution | adversarial>
+
+## Method used
+<exactly how this was checked>
+
+## Evidence checked
+- <command run -> result>
+- <file:lines read -> finding>
+- <criterion compared -> pass/fail>
+
+## Findings
+<what was found>
+
+## Blocking issues
+- <defect that prevents acceptance, with the evidence>
+
+## Non-blocking issues
+- <note that does not block>
+
+## Required fixes
+- <precise fix per blocking finding>
+
+## Verdict
+<accepted | accepted-with-conditions | rejected>

--- a/optional-skills/autonomous-ai-agents/trial/templates/mission-brief.md
+++ b/optional-skills/autonomous-ai-agents/trial/templates/mission-brief.md
@@ -1,0 +1,19 @@
+# Mission Brief — <task>
+
+## Mission
+<the real goal, one paragraph>
+
+## Non-goals
+- <what this will NOT do>
+
+## Constraints
+- <tech / time / budget / platform / compliance>
+
+## Acceptance criteria (testable)
+- [ ] <criterion: concrete, measurable>
+
+## Rejection criteria
+- <what makes the result unacceptable>
+
+## Must not assume
+- <unknowns that would sink the build if assumed wrong>

--- a/optional-skills/autonomous-ai-agents/trial/templates/status.example.json
+++ b/optional-skills/autonomous-ai-agents/trial/templates/status.example.json
@@ -1,0 +1,35 @@
+{
+  "task": "Build a CSV-to-JSON CLI with tests",
+  "mode": "standard",
+  "lang": "ar",
+  "creator": "Da7_Tech",
+  "current_gate": 6,
+  "round": 1,
+  "verdict": "in-progress",
+  "gates": [
+    {"n": 1, "state": "done", "artifact": "mission-brief.md"},
+    {"n": 2, "state": "done", "artifact": "research/"},
+    {"n": 3, "state": "done", "artifact": "decision-brief.md"},
+    {"n": 4, "state": "done", "artifact": "council/"},
+    {"n": 5, "state": "done", "artifact": "build/"},
+    {"n": 6, "state": "active", "artifact": "judging/"},
+    {"n": 7, "state": "pending"},
+    {"n": 8, "state": "pending"}
+  ],
+  "judges": [
+    {"name": "قاضي المتطلبات", "lens": "requirements", "state": "pass", "note": "٣/٣ معايير"},
+    {"name": "قاضي التشغيل", "lens": "execution", "state": "think", "note": "يشغّل الاختبارات"},
+    {"name": "قاضي الخصومة", "lens": "adversarial", "state": "idle", "note": "بانتظار"}
+  ],
+  "builders": [
+    {"name": "وكيل البنية", "pct": 100, "state": "done"},
+    {"name": "وكيل المنطق", "pct": 100, "state": "done"},
+    {"name": "وكيل الاختبارات", "pct": 60, "state": "active"}
+  ],
+  "ledger": [
+    {"text": "بطاقة المهمة محدّدة", "tag": "محدّدة", "tone": "ok", "time": "00:04"},
+    {"text": "بحث ثلاثي مكتمل (٣ عدسات)", "tag": "بحث", "tone": "info", "time": "00:12"},
+    {"text": "المجلس: قبول مشروط", "tag": "مشروط", "tone": "warn", "time": "00:19"},
+    {"text": "فريق التنفيذ أنجز", "tag": "أُنجز", "tone": "ok", "time": "00:31"}
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an optional `autonomous-ai-agents` skill, **`trial`**, that attacks the "done" claim itself: an agent may not ship until executable evidence survives an independent verdict. Its target is **false-done** — work that passes the builder's own tests but is actually broken.

> **No execution before the decision is sound. No delivery before an independent verdict.**

Risk-scaled escalation keeps cheap work cheap: most tasks run inline in minutes; only high-stakes work spawns the full parallel tribunal with fresh, adversarial subagent judges.

## Model-agnostic by design

Trial is a **behavioral rule**, not a tool tied to any model. It works with whatever provider the user already runs — same as other skills (`subagent-driven-development`, `plan`). It needs no separate judge provider, no `.env`, no setup. The standalone repo (with per-agent wrappers for Claude / Cursor / Codex / Windsurf / Cline) lives at **https://github.com/Da7-Tech/trial-skill**; this PR contributes the Hermes packaging.

## What's in the skill

- **`SKILL.md`** — the eight-gate procedure, the fast/standard/strict/maximum triage table, and the speed rules that prevent over-ceremony on small tasks.
- **`references/gates.md`** — the triple-lens matrix and per-gate detail (frame → research → decide → council → build → judge → rework → deliver).
- **`references/verdicts.md`** — evidence-bound verdict rules, blocking vs non-blocking, bounded rework (no infinite loops).
- **`references/console.md`** + **`scripts/render_console.py`** — a self-contained, dependency-free, RTL-aware live console the user watches advance gate by gate.
- **`templates/`** — mission-brief, decision-brief, judge-verdict, final-delivery, decision-log, status.json scaffolds.

Pure skill content — no core changes, no new tool surface, no dependencies.

## How it differs from `subagent-driven-development` (complementary, not competing)

- **`subagent-driven-development`** is about *execution*: dispatch a fresh subagent per task and review between tasks (2-stage review of the build).
- **`trial`** is about *judging the finished claim*: it requires hash-bound executable evidence and an independent, adversarial verdict before any "done" ships. It catches the class of bug the builder's own green tests cannot.

I searched open and merged PRs first; the closest is #53854 (`cognitive-review-loop`), which is about reflective steps *during* work, not adversarial verdict on the completed claim — no overlap.

## Why it's low-risk

- **Optional skill, opt-in only.** Lives under `optional-skills/autonomous-ai-agents/`; not active by default. Installed with `hermes skills install official/autonomous-ai-agents/trial`.
- **No core touch.** No model-tool schema changes, no agent loop changes — respects the narrow-waist principle.
- **Dependency-free.** The console renderer is stdlib-only; everything else is Markdown + JSON.
- **The console is XSS-safe** (verified): the embedded status JSON escapes `</script>`, and every value passes through `esc()` before `innerHTML`.

## Measured result

On 5 small coding tasks (4 false-done traps + 1 clean), each ending in a "done" claim:

| arm | broken tasks shipped | correct tasks blocked |
|---|---|---|
| **baseline** (trusts "tests passed") | **4/5** ❌ | 0/5 |
| **trial** (requires bound evidence + independent verdict) | **0/5** ✅ | 0/5 |

The 4 traps each pass the builder's own tests but are actually broken (untested path, test weakened to pass, unbound claim, migration not verified). The hidden oracle — tests the agent never wrote or saw — is the ground truth.

> These numbers come from one experimental run on a single model. The skill itself is model-agnostic and ships with no benchmark; re-run on your own setup to see how the rule behaves for you.

## How to test

```bash
hermes skills install official/autonomous-ai-agents/trial
# then, on a real change you just finished:
#   /trial strict <restate the task + acceptance criteria>
# Trial frames, judges the claim against executable evidence, and either ships with a verdict or routes a precise rework order.
```

Authored by the contributor; Hermes remains owned and licensed by its original authors.