### PR TITLE
Sanitize lone surrogates in markdown_to_signal before UTF-16 offset math

### DIFF
--- a/gateway/platforms/signal_format.py
+++ b/gateway/platforms/signal_format.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 import re
 
+# Lone surrogate code points are invalid in UTF-8/UTF-16 and cannot be encoded.
+_LONE_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
 
 def markdown_to_signal(text: str) -> tuple[str, list[str]]:
     """Convert markdown to plain text + Signal textStyles list.
@@ -40,6 +43,13 @@ def markdown_to_signal(text: str) -> tuple[str, list[str]]:
                 continue
             parts[idx] = re.sub(r"(?m)^([ \t]{0,3})[-*+]\s+", r"\1• ", part)
         return "".join(parts)
+
+    # Replace lone surrogates (e.g. a truncated emoji half some local-model
+    # backends emit) with U+FFFD before any UTF-16 offset math runs. Without
+    # this, ``_utf16_len`` raises UnicodeEncodeError on the first formatted
+    # span and the whole Signal send aborts, so the reply never reaches the
+    # user. Mirrors the _sanitize_surrogates pass applied to stored history.
+    text = _LONE_SURROGATE_RE.sub("�", text)
 
     text = re.sub(r"\n{3,}", "\n\n", text)
     text = text.strip()

--- a/tests/gateway/test_signal_format.py
+++ b/tests/gateway/test_signal_format.py
@@ -256,3 +256,20 @@ class TestSignalStreamingPatch:
         from gateway.platforms.signal import SignalAdapter
         assert SignalAdapter.SUPPORTS_MESSAGE_EDITING is False
 
+
+
+def test_lone_surrogate_in_formatted_text_does_not_crash():
+    """A lone surrogate (e.g. a truncated emoji half some local-model backends
+    emit) must not crash the UTF-16 bodyRange math. Before the fix, any
+    formatted span alongside a lone surrogate raised UnicodeEncodeError and
+    aborted the whole Signal send, so the reply never reached the user."""
+    text = "**bold \ud800 text** and `code \udc00 here`"
+    plain, styles = markdown_to_signal(text)
+    # No lone surrogate survives into the delivered text.
+    assert "\ud800" not in plain and "\udc00" not in plain
+    # Formatting is still applied (the bold and monospace spans).
+    style_kinds = {s.split(":")[-1] for s in styles}
+    assert "BOLD" in style_kinds
+    assert "MONOSPACE" in style_kinds
+
+


### PR DESCRIPTION
Fixes #55143

`markdown_to_signal` measures bodyRange offsets in UTF-16 code units:

```python
def _utf16_len(s: str) -> int:
    return len(s.encode("utf-16-le")) // 2
```

A lone surrogate code point cannot be UTF-16 encoded, so this raises `UnicodeEncodeError`. `_utf16_len` runs once per formatted span, so any reply containing a lone surrogate plus a markdown span (bold, heading, inline code, italic) aborts the whole `SignalAdapter.send()` and the reply never reaches the user.

Lone surrogates reach the formatter because the delivered text is the raw assistant content (`final_response = assistant_message.content`); the existing `_sanitize_surrogates` pass only cleans the stored history copy, and the gateway delivery sanitizer does not strip surrogates.

### Change

- Replace lone surrogates with U+FFFD at the top of `markdown_to_signal`, before any UTF-16 offset math, mirroring `_sanitize_surrogates`. A lone surrogate has no valid Signal representation, so the substitution keeps the message deliverable and leaves normal formatting untouched.

### Test

`test_lone_surrogate_in_formatted_text_does_not_crash` formats a reply containing a lone surrogate plus bold and monospace spans, and asserts it does not raise, no surrogate survives into the delivered text, and the formatting spans are still present. It raises `UnicodeEncodeError` on the current code and passes with this change.

```
$ python -m pytest tests/gateway/test_signal_format.py -q
55 passed
```
