### PR TITLE
fix: bust gateway agent cache on tool config changes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14961,6 +14961,16 @@ class GatewayRunner:
         ("compression", "protect_last_n"),
         ("agent", "disabled_toolsets"),
     )
+    _CACHE_BUSTING_TOP_LEVEL_CONFIG_KEYS: tuple = (
+        # Tool schemas are frozen into cached AIAgent instances.  Edits made
+        # via `hermes tools` or direct config.yaml changes must rebuild the
+        # gateway agent on the next message; otherwise a user can disable a
+        # huge MCP/toolset surface but keep sending turns through the stale,
+        # oversized cached agent until the gateway is restarted.
+        "toolsets",
+        "platform_toolsets",
+        "mcp_servers",
+    )
 
     @classmethod
     def _extract_cache_busting_config(cls, user_config: dict | None) -> dict:
@@ -14984,6 +14994,8 @@ class GatewayRunner:
                 out[f"{section}.{key}"] = section_val.get(key)
             else:
                 out[f"{section}.{key}"] = None
+        for key in cls._CACHE_BUSTING_TOP_LEVEL_CONFIG_KEYS:
+            out[key] = cfg.get(key)
         try:
             from tools.registry import registry
 
@@ -15010,8 +15022,9 @@ class GatewayRunner:
         ``cache_keys`` is an optional flat dict of additional config values
         that should invalidate the cache when they change.  Callers pass
         the output of ``_extract_cache_busting_config(user_config)`` so
-        edits to model.context_length / compression.* in config.yaml are
-        picked up on the next gateway message without a manual restart.
+        edits to model.context_length, compression.*, toolsets,
+        platform_toolsets, or mcp_servers in config.yaml are picked up on
+        the next gateway message without a manual restart.
         """
         import hashlib, json as _j
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -240,6 +240,21 @@ class TestExtractCacheBustingConfig:
         assert out["compression.target_ratio"] == 0.3
         assert out["compression.protect_last_n"] == 25
 
+    def test_reads_tool_surface_config(self):
+        """Tool surface config edits must bust stale cached agents."""
+        from gateway.run import GatewayRunner
+
+        out = GatewayRunner._extract_cache_busting_config(
+            {
+                "toolsets": ["hermes-cli"],
+                "platform_toolsets": {"telegram": ["web", "file"]},
+                "mcp_servers": {"posthog": {"enabled": False}},
+            }
+        )
+        assert out["toolsets"] == ["hermes-cli"]
+        assert out["platform_toolsets"] == {"telegram": ["web", "file"]}
+        assert out["mcp_servers"] == {"posthog": {"enabled": False}}
+
     def test_missing_keys_yield_none(self):
         """Absent config keys must produce None values (still contribute to signature)."""
         from gateway.run import GatewayRunner
@@ -249,6 +264,9 @@ class TestExtractCacheBustingConfig:
         for section, key in GatewayRunner._CACHE_BUSTING_CONFIG_KEYS:
             assert f"{section}.{key}" in out
             assert out[f"{section}.{key}"] is None
+        for key in GatewayRunner._CACHE_BUSTING_TOP_LEVEL_CONFIG_KEYS:
+            assert key in out
+            assert out[key] is None
 
     def test_non_dict_section_treated_as_missing(self):
         from gateway.run import GatewayRunner
@@ -267,6 +285,8 @@ class TestExtractCacheBustingConfig:
         out = GatewayRunner._extract_cache_busting_config(None)
         for section, key in GatewayRunner._CACHE_BUSTING_CONFIG_KEYS:
             assert out[f"{section}.{key}"] is None
+        for key in GatewayRunner._CACHE_BUSTING_TOP_LEVEL_CONFIG_KEYS:
+            assert out[key] is None
         assert "tools.registry_generation" in out
 
     def test_extract_includes_live_tool_registry_generation(self, monkeypatch):
@@ -306,6 +326,30 @@ class TestExtractCacheBustingConfig:
             "Editing compression.threshold in config.yaml must bust the "
             "gateway's cached agent so the new threshold takes effect."
         )
+
+    def test_tool_surface_config_change_busts_cache(self):
+        """Changing configured tools must evict stale, oversized cached agents."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        cfg_before = {
+            "platform_toolsets": {"telegram": ["web", "file", "posthog"]},
+            "mcp_servers": {"posthog": {"enabled": True}},
+        }
+        cfg_after = {
+            "platform_toolsets": {"telegram": ["web", "file"]},
+            "mcp_servers": {"posthog": {"enabled": False}},
+        }
+
+        sig_before = GatewayRunner._agent_config_signature(
+            "m", runtime, ["file", "posthog", "web"], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_before),
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m", runtime, ["file", "web"], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_after),
+        )
+        assert sig_before != sig_after
 
 
 class TestAgentCacheLifecycle:


### PR DESCRIPTION
## Summary
- include top-level tool surface config in gateway cached-agent signatures
- bust stale cached agents when toolsets, platform_toolsets, or mcp_servers change
- add regression coverage for extraction and signature changes

## Tests
- python -m pytest tests/gateway/test_agent_cache.py -q

Note: updated local venv typing_extensions from 4.12.2 to 4.15.0 because openai 2.24.0 imports typing_extensions.Sentinel; the initial run failed before this environment fix.