### PR TITLE
fix(gateway): restrict write approval toggles to admins

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -83,6 +83,30 @@ def _model_switch_skew_guard() -> Optional[str]:
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
+    @staticmethod
+    def _is_write_approval_toggle(args: list[str]) -> bool:
+        return bool(args) and args[0].lower() in {"approval", "mode"} and len(args) > 1
+
+    def _write_approval_toggle_denial(
+        self,
+        event: MessageEvent,
+        command: str,
+        args: list[str],
+    ) -> Optional[str]:
+        """Block non-admin gateway users from changing global approval config."""
+        if not self._is_write_approval_toggle(args):
+            return None
+
+        from gateway.slash_access import policy_for_source
+
+        policy = policy_for_source(self.config, event.source)
+        if policy.is_admin(getattr(event.source, "user_id", None)):
+            return None
+        return (
+            f"Permission denied: /{command} approval is admin-only here. "
+            f"You can still use other /{command} review subcommands allowed for your account."
+        )
+
     def _typed_command_prefix_for(self, platform) -> str:
         """Return the prefix users can always type to reach Hermes commands.
 
@@ -2449,6 +2473,10 @@ class GatewaySlashCommandsMixin:
         session_key = self._session_key_for_source(event.source)
         config_path = _hermes_home / "config.yaml"
 
+        denial = self._write_approval_toggle_denial(event, "memory", args)
+        if denial is not None:
+            return denial
+
         def _set_approval(enabled: bool):
             import yaml
             user_config = {}
@@ -2504,6 +2532,10 @@ class GatewaySlashCommandsMixin:
             return ("Skill write approval is off (skills.write_approval). "
                     "Enable it with /skills approval on, then review staged "
                     "writes here with /skills pending.")
+
+        denial = self._write_approval_toggle_denial(event, "skills", args)
+        if denial is not None:
+            return denial
 
         def _set_approval(enabled: bool):
             import yaml

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -103,6 +103,30 @@ class GatewaySlashCommandsMixin:
 
     async_session_store: AsyncSessionStore
 
+    @staticmethod
+    def _is_write_approval_toggle(args: list[str]) -> bool:
+        return bool(args) and args[0].lower() in {"approval", "mode"} and len(args) > 1
+
+    def _write_approval_toggle_denial(
+        self,
+        event: MessageEvent,
+        command: str,
+        args: list[str],
+    ) -> Optional[str]:
+        """Block non-admin gateway users from changing global approval config."""
+        if not self._is_write_approval_toggle(args):
+            return None
+
+        from gateway.slash_access import policy_for_source
+
+        policy = policy_for_source(self.config, event.source)
+        if policy.is_admin(getattr(event.source, "user_id", None)):
+            return None
+        return (
+            f"Permission denied: /{command} approval is admin-only here. "
+            f"You can still use other /{command} review subcommands allowed for your account."
+        )
+
     def _typed_command_prefix_for(self, platform) -> str:
         """Return the prefix users can always type to reach Hermes commands.
 
@@ -3598,6 +3622,10 @@ class GatewaySlashCommandsMixin:
         session_key = self._session_key_for_source(event.source)
         config_path = _hermes_home / "config.yaml"
 
+        denial = self._write_approval_toggle_denial(event, "memory", args)
+        if denial is not None:
+            return denial
+
         def _set_approval(enabled: bool):
             # Write-back round-trip: raw read is correct (merged defaults must
             # not be persisted back to the user's file).
@@ -3652,6 +3680,10 @@ class GatewaySlashCommandsMixin:
             return ("Skill write approval is off (skills.write_approval). "
                     "Enable it with /skills approval on, then review staged "
                     "writes here with /skills pending.")
+
+        denial = self._write_approval_toggle_denial(event, "skills", args)
+        if denial is not None:
+            return denial
 
         def _set_approval(enabled: bool):
             # Write-back round-trip: raw read is correct (merged defaults must

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import yaml
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
@@ -110,6 +111,24 @@ def _make_runner(*, platform_extra: dict | None = None,
     return runner
 
 
+def _isolate_hermes_home(monkeypatch, tmp_path, config: dict):
+    import gateway.run as gateway_run
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(config),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    return hermes_home
+
+
+def _read_test_config(hermes_home):
+    return yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8")) or {}
+
+
 # ---------------------------------------------------------------------------
 # /whoami response shape — proves the handler is reachable AND uses the
 # resolver. We use /whoami because it's deterministic and short-circuits
@@ -146,6 +165,110 @@ async def test_whoami_non_admin_lists_runnable_commands():
     assert "/whoami" in result    # always-allowed floor
     assert "/status" in result
     assert "/model" in result
+
+
+# ---------------------------------------------------------------------------
+# Listed write-review commands must not let non-admins mutate global gates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_admin_memory_approval_toggle_denied_when_command_allowlisted(
+    monkeypatch,
+    tmp_path,
+):
+    hermes_home = _isolate_hermes_home(
+        monkeypatch,
+        tmp_path,
+        {"memory": {"write_approval": True}},
+    )
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["memory"],
+        }
+    )
+    runner._evict_cached_agent = MagicMock()
+
+    result = await runner._handle_message(
+        _make_event("/memory approval off", _make_source(user_id="999"))
+    )
+
+    assert "admin-only" in result
+    assert _read_test_config(hermes_home)["memory"]["write_approval"] is True
+    runner._evict_cached_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_admin_memory_approval_toggle_still_updates_config(monkeypatch, tmp_path):
+    hermes_home = _isolate_hermes_home(
+        monkeypatch,
+        tmp_path,
+        {"memory": {"write_approval": True}},
+    )
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["memory"],
+        }
+    )
+    runner._evict_cached_agent = MagicMock()
+
+    result = await runner._handle_message(
+        _make_event("/memory approval off", _make_source(user_id="111"))
+    )
+
+    assert "memory.write_approval set to 'off'" in result
+    assert _read_test_config(hermes_home)["memory"]["write_approval"] is False
+    runner._evict_cached_agent.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_legacy_memory_approval_toggle_works_without_admin_list(
+    monkeypatch,
+    tmp_path,
+):
+    hermes_home = _isolate_hermes_home(
+        monkeypatch,
+        tmp_path,
+        {"memory": {"write_approval": True}},
+    )
+    runner = _make_runner(platform_extra={})
+    runner._evict_cached_agent = MagicMock()
+
+    result = await runner._handle_message(
+        _make_event("/memory approval off", _make_source(user_id="999"))
+    )
+
+    assert "memory.write_approval set to 'off'" in result
+    assert _read_test_config(hermes_home)["memory"]["write_approval"] is False
+
+
+@pytest.mark.asyncio
+async def test_non_admin_skills_approval_toggle_denied_when_command_allowlisted(
+    monkeypatch,
+    tmp_path,
+):
+    hermes_home = _isolate_hermes_home(
+        monkeypatch,
+        tmp_path,
+        {"skills": {"write_approval": True}},
+    )
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["skills"],
+        }
+    )
+    runner._evict_cached_agent = MagicMock()
+
+    result = await runner._handle_message(
+        _make_event("/skills approval off", _make_source(user_id="999"))
+    )
+
+    assert "admin-only" in result
+    assert _read_test_config(hermes_home)["skills"]["write_approval"] is True
+    runner._evict_cached_agent.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import yaml
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
@@ -110,6 +111,24 @@ def _make_runner(*, platform_extra: dict | None = None,
     return runner
 
 
+def _isolate_hermes_home(monkeypatch, tmp_path, config: dict):
+    import gateway.run as gateway_run
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(config),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    return hermes_home
+
+
+def _read_test_config(hermes_home):
+    return yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8")) or {}
+
+
 # ---------------------------------------------------------------------------
 # /whoami response shape — proves the handler is reachable AND uses the
 # resolver. We use /whoami because it's deterministic and short-circuits
@@ -131,6 +150,114 @@ async def test_whoami_non_admin_lists_runnable_commands():
     assert "/whoami" in result    # always-allowed floor
     assert "/status" in result
     assert "/model" in result
+
+
+# ---------------------------------------------------------------------------
+# Listed write-review commands must not let non-admins mutate global gates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("subcommand", ["approval", "mode"])
+async def test_non_admin_memory_approval_toggle_denied_when_command_allowlisted(
+    monkeypatch,
+    tmp_path,
+    subcommand,
+):
+    hermes_home = _isolate_hermes_home(
+        monkeypatch,
+        tmp_path,
+        {"memory": {"write_approval": True}},
+    )
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["memory"],
+        }
+    )
+    runner._evict_cached_agent = MagicMock()
+
+    result = await runner._handle_message(
+        _make_event(f"/memory {subcommand} off", _make_source(user_id="999"))
+    )
+
+    assert "admin-only" in result
+    assert _read_test_config(hermes_home)["memory"]["write_approval"] is True
+    runner._evict_cached_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_admin_memory_approval_toggle_still_updates_config(monkeypatch, tmp_path):
+    hermes_home = _isolate_hermes_home(
+        monkeypatch,
+        tmp_path,
+        {"memory": {"write_approval": True}},
+    )
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["memory"],
+        }
+    )
+    runner._evict_cached_agent = MagicMock()
+
+    result = await runner._handle_message(
+        _make_event("/memory approval off", _make_source(user_id="111"))
+    )
+
+    assert "memory.write_approval set to 'off'" in result
+    assert _read_test_config(hermes_home)["memory"]["write_approval"] is False
+    runner._evict_cached_agent.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_legacy_memory_approval_toggle_works_without_admin_list(
+    monkeypatch,
+    tmp_path,
+):
+    hermes_home = _isolate_hermes_home(
+        monkeypatch,
+        tmp_path,
+        {"memory": {"write_approval": True}},
+    )
+    runner = _make_runner(platform_extra={})
+    runner._evict_cached_agent = MagicMock()
+
+    result = await runner._handle_message(
+        _make_event("/memory approval off", _make_source(user_id="999"))
+    )
+
+    assert "memory.write_approval set to 'off'" in result
+    assert _read_test_config(hermes_home)["memory"]["write_approval"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("subcommand", ["approval", "mode"])
+async def test_non_admin_skills_approval_toggle_denied_when_command_allowlisted(
+    monkeypatch,
+    tmp_path,
+    subcommand,
+):
+    hermes_home = _isolate_hermes_home(
+        monkeypatch,
+        tmp_path,
+        {"skills": {"write_approval": True}},
+    )
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["skills"],
+        }
+    )
+    runner._evict_cached_agent = MagicMock()
+
+    result = await runner._handle_message(
+        _make_event(f"/skills {subcommand} off", _make_source(user_id="999"))
+    )
+
+    assert "admin-only" in result
+    assert _read_test_config(hermes_home)["skills"]["write_approval"] is True
+    runner._evict_cached_agent.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #55147.

Gateway `/memory` and `/skills` can be allowlisted for non-admin slash users so they can review pending writes, but `approval on|off` mutates global `memory.write_approval` / `skills.write_approval` in `config.yaml`.

This patch adds a shared gateway-side subcommand guard:

- `/memory approval` and `/skills approval` with no value still show current state
- `/memory approval on|off` and `/skills approval on|off` require slash admin status when slash access gating is enabled
- legacy installs without `allow_admin_from` keep the previous unrestricted behavior
- CLI behavior is unchanged because local CLI use is already operator-side

## Testing

- `python -m pytest tests\gateway\test_slash_access_dispatch.py -q -k "approval_toggle or whoami_non_admin_lists_runnable_commands"` (`5 passed`)
- `python -m pytest tests\gateway\test_slash_access_dispatch.py -q -k "not quick_command"` (`22 passed, 3 deselected`; the deselected quick-command tests use POSIX `printf`, which is an existing Windows-only test portability issue)
- `python -m pytest tests\gateway\test_slash_access.py -q` (`21 passed`)
- `ruff check gateway\slash_commands.py tests\gateway\test_slash_access_dispatch.py`
- `git diff --check`