### PR TITLE
fix(gateway): await async post-delivery callbacks in goal judge status notices

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3705,15 +3705,14 @@ class BasePlatformAdapter(ABC):
                 _prev = existing_cb
                 _new = callback
 
-                def _chained() -> None:
-                    try:
-                        _prev()
-                    except Exception:
-                        logger.debug("Post-delivery callback failed", exc_info=True)
-                    try:
-                        _new()
-                    except Exception:
-                        logger.debug("Post-delivery callback failed", exc_info=True)
+                async def _chained() -> None:
+                    for _cb in (_prev, _new):
+                        try:
+                            _result = _cb()
+                            if inspect.isawaitable(_result):
+                                await _result
+                        except Exception:
+                            logger.debug("Post-delivery callback failed", exc_info=True)
 
                 callback = _chained
 


### PR DESCRIPTION
The goal judge defers its status notice via . When a session already had a registered callback, the chained wrapper called both callbacks as plain functions. For async callbacks (such as  in ) this produced  and the status message was lost.

Make the chained wrapper async and await any awaitable callback result.