### PR TITLE
fix(gateway): wire deterministic WhatsApp reminder shortcuts into message dispatch

### DIFF
--- a/gateway/reminder_shortcuts.py
+++ b/gateway/reminder_shortcuts.py
@@ -1,0 +1,772 @@
+"""Deterministic gateway shortcuts for simple reminder requests.
+
+These helpers intentionally bypass the LLM for high-confidence reminder
+creation on chat platforms. Reminder creation is a transactional control-plane
+operation: the confirmation must describe exactly the one job that was just
+created, not summarize prior conversation history.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import re
+from typing import Optional
+
+
+_NUMBER_WORDS = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+    "eleven": 11,
+    "twelve": 12,
+    "thirteen": 13,
+    "fourteen": 14,
+    "fifteen": 15,
+    "sixteen": 16,
+    "seventeen": 17,
+    "eighteen": 18,
+    "nineteen": 19,
+    "twenty": 20,
+}
+
+_NUMBER_PATTERN = (
+    r"\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|"
+    r"thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty"
+)
+_UNIT_PATTERN = r"m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|wk|wks|week|weeks"
+
+# "Remind me laundry in 1 minute"
+_RELATIVE_SUBJECT_BEFORE_RE = re.compile(
+    rf"""
+    ^\s*
+    (?:please\s+)?
+    (?:remind\s+me|reminder)
+    \s*
+    (?:again\s*)?
+    (?P<subject>.+?)
+    \s+in\s+
+    (?P<num>{_NUMBER_PATTERN})
+    \s*
+    (?P<unit>{_UNIT_PATTERN})
+    \s*[.!?]?\s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# "Remind me in 2 minutes, test 03" / "Remind me in 2 minutes for test 03"
+_RELATIVE_SUBJECT_AFTER_RE = re.compile(
+    rf"""
+    ^\s*
+    (?:please\s+)?
+    (?:remind\s+me|reminder)
+    \s*
+    (?:again\s*)?
+    in\s+
+    (?P<num>{_NUMBER_PATTERN})
+    \s*
+    (?P<unit>{_UNIT_PATTERN})
+    (?:\s*(?:,|:|;|-|\bfor\b|\babout\b|\bto\b)\s*(?P<subject>.+?))?
+    \s*[.!?]?\s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# STT often omits punctuation: "Remind me in 2 minutes test 03".
+_RELATIVE_SUBJECT_AFTER_BARE_RE = re.compile(
+    rf"""
+    ^\s*
+    (?:please\s+)?
+    (?:remind\s+me|reminder)
+    \s*
+    (?:again\s*)?
+    in\s+
+    (?P<num>{_NUMBER_PATTERN})
+    \s*
+    (?P<unit>{_UNIT_PATTERN})
+    \s+(?P<subject>.+?)
+    \s*[.!?]?\s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_CLOCK_RE = r"(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*(?P<ampm>a\.?m\.?|p\.?m\.?)"
+
+# "Remind me tomorrow at 5am acrylic" / "Reminder tomorrow at 5:05am graphics"
+_TOMORROW_AT_RE = re.compile(
+    rf"""
+    ^\s*
+    (?:please\s+)?
+    (?:remind\s+me|reminder)
+    \s+
+    tomorrow
+    \s+(?:at\s+)?
+    {_CLOCK_RE}
+    \s+(?P<subject>.+?)
+    \s*[.!?]?\s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_NEXT_WEEK_RE = re.compile(
+    rf"""
+    ^\s*
+    (?:please\s+)?
+    (?:remind\s+me|reminder)
+    \s*
+    (?:again\s*)?
+    next\s+week
+    (?:\s*(?:,|:|;|-|\bfor\b|\babout\b|\bto\b)\s*(?P<subject>.+?))?
+    \s*[.!?]?\s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_VOICE_TRANSCRIPT_RE = re.compile(
+    r"Here's\s+what\s+they\s+said:\s*[\"“](?P<text>.*?)[\"”]\s*\]?$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# --- Reply-to-reminder snooze/reschedule/close vocabulary ----------------------
+#
+# When a user replies to a fired reminder, the reply is a control-plane action
+# on *that* reminder, not a new-reminder request. The reply forms below are
+# recognized WITHOUT requiring a "remind me" prefix and WITHOUT an inline
+# subject — the subject is always inherited from the quoted reminder.
+
+_WEEKDAYS = {
+    "monday": 0, "mon": 0,
+    "tuesday": 1, "tue": 1, "tues": 1,
+    "wednesday": 2, "wed": 2,
+    "thursday": 3, "thu": 3, "thur": 3, "thurs": 3,
+    "friday": 4, "fri": 4,
+    "saturday": 5, "sat": 5,
+    "sunday": 6, "sun": 6,
+}
+_WEEKDAY_PATTERN = (
+    r"monday|mon|tuesday|tues|tue|wednesday|wed|thursday|thurs|thur|thu|"
+    r"friday|fri|saturday|sat|sunday|sun"
+)
+
+# Words that mark the reminder as resolved/closed. Replying with any of these
+# (optionally prefixed with the reminder verb) closes the reminder for good.
+_CLOSE_WORDS = {
+    "done", "completed", "complete", "received", "resolved",
+    "cancel", "cancelled", "canceled", "stop", "close", "closed", "finished",
+}
+_CLOSE_RE = re.compile(
+    rf"^\s*(?:please\s+)?(?:ok(?:ay)?[,!. ]+)?(?:{'|'.join(sorted(_CLOSE_WORDS))})\s*[.!?]*\s*$",
+    re.IGNORECASE,
+)
+
+# Bare snooze interval, no "remind me" prefix and no subject:
+#   "5m", "10 min", "30m", "1h", "2 hours", "in 1 hour", "1 day", "3 days"
+_BARE_INTERVAL_RE = re.compile(
+    rf"""
+    ^\s*
+    (?:please\s+)?
+    (?:remind\s+me\s+)?
+    (?:again\s+)?
+    (?:in\s+)?
+    (?P<num>{_NUMBER_PATTERN})
+    \s*
+    (?P<unit>{_UNIT_PATTERN})
+    \s*[.!?]?\s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Bare "tomorrow" / "tomorrow at 5:35am", no inline subject.
+_BARE_TOMORROW_RE = re.compile(
+    rf"""
+    ^\s*
+    (?:please\s+)?
+    (?:remind\s+me\s+)?
+    (?:again\s+)?
+    tomorrow
+    (?:\s+(?:at\s+)?{_CLOCK_RE})?
+    \s*[.!?]?\s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Weekday, optionally with a clock time, no inline subject:
+#   "Monday", "Monday 5:35am", "mon at 5:35", "Remind me Monday at 5:35am"
+_BARE_WEEKDAY_RE = re.compile(
+    rf"""
+    ^\s*
+    (?:please\s+)?
+    (?:remind\s+me\s+)?
+    (?:again\s+)?
+    (?:on\s+|next\s+)?
+    (?P<weekday>{_WEEKDAY_PATTERN})
+    (?:\s+(?:at\s+)?{_CLOCK_RE})?
+    \s*[.!?]?\s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Bare "next week", no inline subject.
+_BARE_NEXT_WEEK_RE = re.compile(
+    r"^\s*(?:please\s+)?(?:remind\s+me\s+)?(?:again\s+)?next\s+week\s*[.!?]*\s*$",
+    re.IGNORECASE,
+)
+
+_REMINDER_BODY_RE = re.compile(
+    r"(?:📅\s*)?REMINDER\s*:\s*(?P<body>.+)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_PREFIX_LINE_RE = re.compile(r"^\s*(?:⚕\s*)?\*?Hermes Agent\*?\s*$", re.IGNORECASE)
+_SEPARATOR_RE = re.compile(r"^\s*[─\-—_]{3,}\s*$")
+_REPLY_CONTEXT_RE = re.compile(r'^\s*\[Replying to:\s*".*"\]\s*$', re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ParsedReminder:
+    subject: str
+    schedule: str
+    display_time: str
+    reused_reply_subject: bool = False
+
+
+@dataclass(frozen=True)
+class ParsedSnooze:
+    """A reply-to-reminder reschedule/snooze action.
+
+    ``subject`` is inherited from the quoted reminder. ``schedule`` is a string
+    accepted by ``cron.jobs.parse_schedule`` (a relative duration like ``"1h"``
+    / ``"7d"`` or an ISO timestamp for weekday/clock targets).
+    """
+    subject: str
+    schedule: str
+    display_time: str
+
+
+@dataclass(frozen=True)
+class ParsedReminderBatch:
+    reminders: list[ParsedReminder]
+
+
+def _parse_number(text: str) -> Optional[int]:
+    value = (text or "").strip().lower()
+    if value.isdigit():
+        return int(value)
+    return _NUMBER_WORDS.get(value)
+
+
+def _clean_subject(text: str) -> str:
+    subject = re.sub(r"\s+", " ", (text or "").strip())
+    subject = subject.strip(" .!?:;,-")
+    # Voice/STT often includes filler words before the subject.
+    subject = re.sub(r"^(?:for|to|about)\s+", "", subject, flags=re.IGNORECASE).strip()
+    return subject
+
+
+def extract_subject_from_reminder_text(text: str | None) -> Optional[str]:
+    """Extract the subject from a fired reminder message.
+
+    Handles both the raw reminder shape and WhatsApp self-chat messages with the
+    Hermes prefix prepended by the bridge.
+    """
+    if not text:
+        return None
+    cleaned_lines = []
+    for line in str(text).splitlines():
+        if _PREFIX_LINE_RE.match(line) or _SEPARATOR_RE.match(line) or _REPLY_CONTEXT_RE.match(line):
+            continue
+        cleaned_lines.append(line)
+    cleaned = "\n".join(cleaned_lines).strip()
+
+    match = _REMINDER_BODY_RE.search(cleaned)
+    if not match:
+        return None
+    body = match.group("body").strip()
+    # If another chunk or footer ever follows, keep only the first meaningful
+    # non-empty line as the reminder subject.
+    for line in body.splitlines():
+        subject = _clean_subject(line)
+        if subject:
+            return subject
+    return None
+
+
+def extract_voice_transcript(text: str | None) -> Optional[str]:
+    raw = str(text or "")
+    transcripts = [m.group("text").strip() for m in _VOICE_TRANSCRIPT_RE.finditer(raw)]
+    return transcripts[-1] if transcripts else None
+
+
+def is_reminder_intent(text: str | None) -> bool:
+    return bool(re.search(r"\bremind(?:er)?\b", str(text or ""), re.IGNORECASE))
+
+
+def is_reminder_list_intent(text: str | None) -> bool:
+    """Return True for obvious requests to list or show reminders."""
+    body = str(text or "")
+    return bool(
+        re.search(
+            r"\b(?:list|show|display|what(?:'s| is)?|give me|tell me)\b.*\breminders?\b|"
+            r"\b(?:future|current|all)\b.*\breminders?\b|"
+            r"\breminders?\b.*\b(?:on record|you have|current|future|all)\b",
+            body,
+            re.IGNORECASE,
+        )
+    )
+
+
+
+
+def _candidate_lines(text: str) -> list[str]:
+    """Return possible reminder command lines from newest to oldest.
+
+    Voice messages reach the gateway wrapped as:
+    ``[The user sent a voice message~ Here's what they said: "..."]``.
+    Extract that transcript first so the deterministic reminder parser can run
+    before the LLM sees the wrapper. For ordinary multi-line WhatsApp batches,
+    try the last non-empty lines first to avoid carrying old reminder text into
+    the current transaction.
+    """
+    raw = str(text or "").strip()
+    if not raw:
+        return []
+
+    voice_candidates = []
+    for match in _VOICE_TRANSCRIPT_RE.finditer(raw):
+        transcript = match.group("text").strip()
+        if transcript:
+            voice_candidates.append(transcript)
+    if voice_candidates:
+        return list(reversed(voice_candidates))
+
+    lines = [
+        line.strip()
+        for line in raw.splitlines()
+        if line.strip() and not _REPLY_CONTEXT_RE.match(line.strip())
+    ]
+    return list(reversed(lines)) if lines else [raw]
+
+
+def _parse_relative_line(line: str) -> Optional[re.Match[str]]:
+    return (
+        _RELATIVE_SUBJECT_AFTER_RE.match(line)
+        or _RELATIVE_SUBJECT_AFTER_BARE_RE.match(line)
+        or _RELATIVE_SUBJECT_BEFORE_RE.match(line)
+    )
+
+
+def _unit_to_schedule_and_display(unit_raw: str, number: int) -> tuple[str, str]:
+    unit = unit_raw.lower()
+    if unit.startswith(("h",)):
+        return "h", "hour"
+    if unit.startswith(("d",)):
+        return "d", "day"
+    if unit.startswith(("w",)):
+        return f"{number * 7}d", "week"
+    return "m", "minute"
+
+
+def _parse_tomorrow_at_line(line: str, *, now: datetime | None = None) -> Optional[ParsedReminder]:
+    match = _TOMORROW_AT_RE.match(line)
+    if not match:
+        return None
+
+    hour = int(match.group("hour"))
+    minute = int(match.group("minute") or "0")
+    if hour < 1 or hour > 12 or minute < 0 or minute > 59:
+        return None
+
+    ampm = re.sub(r"[^apm]", "", match.group("ampm").lower())
+    if ampm.startswith("p") and hour != 12:
+        hour += 12
+    elif ampm.startswith("a") and hour == 12:
+        hour = 0
+
+    subject = _clean_subject(match.group("subject"))
+    if not subject:
+        return None
+
+    base = now or datetime.now().astimezone()
+    run_at = (base + timedelta(days=1)).replace(hour=hour, minute=minute, second=0, microsecond=0)
+    display_hour = run_at.strftime("%I").lstrip("0") or "0"
+    display_time = f"Tomorrow {display_hour}:{run_at.strftime('%M')} {run_at.strftime('%p')}"
+    return ParsedReminder(subject=subject, schedule=run_at.isoformat(), display_time=display_time)
+
+
+def parse_simple_reminder_batch(
+    text: str | None,
+    *,
+    reply_to_text: str | None = None,
+    reply_to_subject_fallback: str | None = None,
+    now: datetime | None = None,
+) -> Optional[ParsedReminderBatch]:
+    """Parse all high-confidence reminder requests in the current message.
+
+    This deliberately ignores conversation history. Multi-line WhatsApp batches
+    create one independent job per parsed line and return only those jobs in the
+    confirmation.
+    """
+    reminders: list[ParsedReminder] = []
+    candidates = list(reversed(_candidate_lines(text or "")))
+    for line in candidates:
+        parsed = _parse_tomorrow_at_line(line, now=now)
+        if parsed is None:
+            parsed = parse_simple_relative_reminder(
+                line,
+                reply_to_text=reply_to_text,
+                reply_to_subject_fallback=reply_to_subject_fallback,
+            )
+        if parsed is not None:
+            reminders.append(parsed)
+        elif is_reminder_intent(line):
+            # Mixed parsed/unparsed reminder commands are not safe for the
+            # deterministic path. Fall back to the agent so it can clarify.
+            return None
+    if not reminders:
+        return None
+    return ParsedReminderBatch(reminders=reminders)
+
+
+def parse_simple_relative_reminder(
+    text: str | None,
+    *,
+    reply_to_text: str | None = None,
+    reply_to_subject_fallback: str | None = None,
+) -> Optional[ParsedReminder]:
+    """Parse high-confidence relative reminder requests.
+
+    Each parsed reminder is an independent transaction. The parser never
+    consults prior reminders, active jobs, memory, or conversation history; the
+    only external context allowed is the quoted reminder text for explicit
+    WhatsApp replies like ``Remind me in 2 min``.
+    """
+    next_week_match = _NEXT_WEEK_RE.match(str(text or ""))
+    if next_week_match:
+        subject = _clean_subject(next_week_match.groupdict().get("subject") or "")
+        reused_reply_subject = False
+        if not subject:
+            subject = extract_subject_from_reminder_text(reply_to_text) or _clean_subject(reply_to_subject_fallback or "")
+            reused_reply_subject = bool(subject)
+        if subject:
+            return ParsedReminder(
+                subject=subject,
+                schedule="7d",
+                display_time="in 1 week",
+                reused_reply_subject=reused_reply_subject,
+            )
+
+    for line in _candidate_lines(text or ""):
+        match = _parse_relative_line(line)
+        if not match:
+            continue
+
+        number = _parse_number(match.group("num"))
+        if not number or number <= 0:
+            continue
+
+        unit_raw = match.group("unit").lower()
+        schedule_unit, unit_name = _unit_to_schedule_and_display(unit_raw, number)
+
+        subject = _clean_subject(match.groupdict().get("subject") or "")
+        if not subject:
+            subject = extract_subject_from_reminder_text(reply_to_text) or _clean_subject(reply_to_subject_fallback or "")
+        if not subject:
+            continue
+        reused_reply_subject = not bool(match.groupdict().get("subject") or "") and bool(
+            reply_to_text or reply_to_subject_fallback
+        )
+        return ParsedReminder(
+            subject=subject,
+            schedule=f"{number}{schedule_unit}",
+            display_time=f"in {number} {unit_name}{'' if number == 1 else 's'}",
+            reused_reply_subject=reused_reply_subject,
+        )
+
+
+def is_reminder_close_intent(text: str | None) -> bool:
+    """Return True when a reply means 'close/resolve this reminder'.
+
+    Recognized words: done, completed, complete, received, resolved, cancel,
+    cancelled, canceled, stop, close, closed, finished — optionally prefixed
+    with 'ok'/'okay' or 'please'.
+    """
+    raw = str(text or "").strip()
+    if not raw:
+        return False
+    # Voice replies arrive wrapped; unwrap the transcript first.
+    transcript = extract_voice_transcript(raw)
+    if transcript:
+        raw = transcript.strip()
+    return bool(_CLOSE_RE.match(raw))
+
+
+def _next_weekday_run_at(weekday_idx: int, hour: int, minute: int, *, now: datetime) -> datetime:
+    """Return the next datetime matching the given weekday and time.
+
+    If today matches the weekday and the target time is still in the future,
+    today is used; otherwise the next occurrence (1-7 days ahead) is chosen.
+    """
+    base = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    days_ahead = (weekday_idx - now.weekday()) % 7
+    candidate = base + timedelta(days=days_ahead)
+    if candidate <= now:
+        candidate = candidate + timedelta(days=7)
+    return candidate
+
+
+def parse_snooze_reply(
+    text: str | None,
+    *,
+    reply_to_text: str | None = None,
+    reply_to_subject_fallback: str | None = None,
+    now: datetime | None = None,
+) -> Optional[ParsedSnooze]:
+    """Parse a reply to a fired reminder as a reschedule/snooze action.
+
+    The subject is ALWAYS inherited from the quoted reminder (``reply_to_text``)
+    or the per-chat fallback — never from the reply body and never prompted for.
+    This is the deterministic counterpart to the LLM's reply handling: a reply
+    that names only a time means "move this reminder, keep its text".
+
+    Returns ``None`` if the reply doesn't look like a time/interval, so the
+    caller can fall through (e.g. to close-intent handling or the LLM).
+    """
+    raw = str(text or "").strip()
+    if not raw:
+        return None
+
+    # Unwrap voice transcripts so "[... they said: \"monday 5:35am\"]" works.
+    transcript = extract_voice_transcript(raw)
+    if transcript:
+        raw = transcript.strip()
+
+    # Resolve the inherited subject. Without one, this is not a snooze we can
+    # safely act on — bail so the caller can decide what to do.
+    subject = extract_subject_from_reminder_text(reply_to_text) or _clean_subject(
+        reply_to_subject_fallback or ""
+    )
+    if not subject:
+        return None
+
+    base_now = now or datetime.now().astimezone()
+
+    # 1) Bare relative interval: "5m", "1h", "2 hours", "in 30 min", "3 days".
+    m = _BARE_INTERVAL_RE.match(raw)
+    if m:
+        number = _parse_number(m.group("num"))
+        if number and number > 0:
+            schedule_unit, unit_name = _unit_to_schedule_and_display(m.group("unit").lower(), number)
+            return ParsedSnooze(
+                subject=subject,
+                schedule=f"{number}{schedule_unit}",
+                display_time=f"in {number} {unit_name}{'' if number == 1 else 's'}",
+            )
+
+    # 2) Bare "tomorrow" / "tomorrow at 5:35am".
+    m = _BARE_TOMORROW_RE.match(raw)
+    if m:
+        hour, minute = _clock_from_match(m, default_hour=9, default_minute=0)
+        if hour is not None:
+            run_at = (base_now + timedelta(days=1)).replace(
+                hour=hour, minute=minute, second=0, microsecond=0
+            )
+            return ParsedSnooze(
+                subject=subject,
+                schedule=run_at.isoformat(),
+                display_time=_display_dt(run_at, "Tomorrow"),
+            )
+
+    # 3) Weekday, optionally with a clock: "Monday", "Monday 5:35am".
+    m = _BARE_WEEKDAY_RE.match(raw)
+    if m:
+        weekday_idx = _WEEKDAYS.get(m.group("weekday").lower())
+        if weekday_idx is not None:
+            hour, minute = _clock_from_match(m, default_hour=9, default_minute=0)
+            if hour is not None:
+                run_at = _next_weekday_run_at(weekday_idx, hour, minute, now=base_now)
+                label = run_at.strftime("%A")
+                return ParsedSnooze(
+                    subject=subject,
+                    schedule=run_at.isoformat(),
+                    display_time=_display_dt(run_at, label),
+                )
+
+    # 4) Bare "next week".
+    if _BARE_NEXT_WEEK_RE.match(raw):
+        return ParsedSnooze(subject=subject, schedule="7d", display_time="in 1 week")
+
+    return None
+
+
+def _clock_from_match(match: re.Match[str], *, default_hour: int, default_minute: int) -> tuple[Optional[int], int]:
+    """Extract (hour_24, minute) from a regex match exposing the _CLOCK_RE groups.
+
+    Returns (default_hour, default_minute) when no clock was supplied, or
+    (None, 0) when the clock is present but invalid.
+    """
+    groups = match.groupdict()
+    if not groups.get("hour"):
+        return default_hour, default_minute
+    hour = int(groups["hour"])
+    minute = int(groups.get("minute") or "0")
+    if hour < 1 or hour > 12 or minute < 0 or minute > 59:
+        return None, 0
+    ampm = re.sub(r"[^apm]", "", (groups.get("ampm") or "").lower())
+    if ampm.startswith("p") and hour != 12:
+        hour += 12
+    elif ampm.startswith("a") and hour == 12:
+        hour = 0
+    elif not ampm:
+        # No am/pm given (e.g. "Monday 5:35"). Keep the literal hour; this is a
+        # best-effort interpretation for a control-plane reschedule.
+        pass
+    return hour, minute
+
+
+def _display_dt(run_at: datetime, label: str) -> str:
+    display_hour = run_at.strftime("%I").lstrip("0") or "0"
+    return f"{label} {display_hour}:{run_at.strftime('%M')} {run_at.strftime('%p')}"
+
+
+def reminder_prompt(subject: str) -> str:
+    return f"Remind the user: {_clean_subject(subject)}"
+
+
+def reminder_confirmation(parsed: ParsedReminder) -> str:
+    if parsed.reused_reply_subject:
+        return f"Done — reusing quoted reminder: {parsed.subject} {parsed.display_time}."
+    return f"Done — I set a reminder for {parsed.subject} {parsed.display_time}."
+
+
+def reminder_output(subject: str) -> str:
+    return f"📅 REMINDER:\n{_clean_subject(subject)}"
+
+
+# --- Persistent per-chat last-reminder-subject store ---------------------------
+#
+# Defense-in-depth for Change A: when a reminder *fires* and is delivered to a
+# chat, we record its subject keyed by chat_id in a small JSON file. If the user
+# later replies and the platform stripped the quoted reminder text, the reply
+# path can still recover the subject from here. This survives the cron-thread
+# boundary and gateway restarts (the in-memory cache in run.py does not).
+
+_SUBJECT_STORE_TTL_SECONDS = 7 * 24 * 3600  # a reminder chain can span a week
+
+
+def _subject_store_path():
+    from pathlib import Path
+    import os
+    home = os.environ.get("HERMES_HOME") or os.path.join(os.path.expanduser("~"), ".hermes")
+    return Path(home) / "reminder_last_subject.json"
+
+
+def record_last_reminder_subject(chat_id: str | None, subject: str | None, *, now_ts: float | None = None) -> None:
+    """Persist the last reminder subject delivered to ``chat_id``.
+
+    Best-effort: never raises into the delivery path.
+    """
+    if not chat_id or not subject:
+        return
+    import json
+    import time as _time
+    ts = now_ts if now_ts is not None else _time.time()
+    path = _subject_store_path()
+    try:
+        data = {}
+        if path.exists():
+            try:
+                data = json.loads(path.read_text()) or {}
+            except Exception:
+                data = {}
+        # Prune stale entries while we're here.
+        cutoff = ts - _SUBJECT_STORE_TTL_SECONDS
+        data = {
+            k: v for k, v in data.items()
+            if isinstance(v, dict) and float(v.get("ts", 0)) >= cutoff
+        }
+        data[str(chat_id)] = {"subject": _clean_subject(subject), "ts": ts}
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data))
+        tmp.replace(path)
+    except Exception:
+        # Persistence is a fallback, not a hard dependency.
+        pass
+
+
+def lookup_last_reminder_subject(chat_id: str | None, *, now_ts: float | None = None) -> Optional[str]:
+    """Return the most recently delivered reminder subject for ``chat_id``."""
+    if not chat_id:
+        return None
+    import json
+    import time as _time
+    ts = now_ts if now_ts is not None else _time.time()
+    path = _subject_store_path()
+    try:
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text()) or {}
+        entry = data.get(str(chat_id))
+        if not isinstance(entry, dict):
+            return None
+        if float(entry.get("ts", 0)) < ts - _SUBJECT_STORE_TTL_SECONDS:
+            return None
+        return entry.get("subject") or None
+    except Exception:
+        return None
+
+
+def clear_last_reminder_subject(chat_id: str | None) -> None:
+    """Remove the stored subject for ``chat_id`` (e.g. after the reminder is closed)."""
+    if not chat_id:
+        return
+    import json
+    path = _subject_store_path()
+    try:
+        if not path.exists():
+            return
+        data = json.loads(path.read_text()) or {}
+        if str(chat_id) in data:
+            del data[str(chat_id)]
+            tmp = path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(data))
+            tmp.replace(path)
+    except Exception:
+        pass
+
+
+def _reminder_subject_from_job(job: dict) -> str:
+    subject = extract_subject_from_reminder_text(job.get("prompt"))
+    if subject:
+        return subject
+    name = _clean_subject(job.get("name") or "")
+    if name.lower().startswith("reminder:"):
+        name = name.split(":", 1)[1].strip()
+    return name or _clean_subject(job.get("prompt") or "") or "(untitled)"
+
+
+def reminder_list_output(jobs: list[dict]) -> str:
+    """Format reminder jobs for direct chat delivery."""
+    filtered = [j for j in jobs if j]
+    if not filtered:
+        return "No future reminders on record."
+
+    def _sort_key(job: dict):
+        return str(job.get("next_run_at") or "~"), str(job.get("schedule_display") or ""), str(job.get("name") or "")
+
+    lines = ["Here are your future reminders:"]
+    for job in sorted(filtered, key=_sort_key):
+        schedule = _clean_subject(job.get("schedule_display") or job.get("schedule") or "?")
+        schedule_kind = str((job.get("schedule") or {}).get("kind") or "").lower()
+        repeat_times = (job.get("repeat") or {}).get("times")
+        kind = "Recurring" if schedule_kind in {"cron", "interval"} or repeat_times is None else "Once"
+        subject = _reminder_subject_from_job(job)
+        lines.append(f"{kind} — {schedule} — {subject}")
+    return "\n".join(lines)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -57,6 +57,12 @@ from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.reminder_shortcuts import (
+    is_reminder_intent,
+    parse_simple_relative_reminder,
+    parse_snooze_reply,
+    is_reminder_close_intent,
+)
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -9124,6 +9130,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return self._telegram_topic_root_lobby_message()
             return None
 
+        # ── WhatsApp reminder shortcuts (deterministic fast-path) ──────────────
+        # For high-confidence reminder requests, bypass the LLM entirely and
+        # manage cron jobs directly. This handles patterns like:
+        #   "Remind me in 2 hours call mom"           → new reminder
+        #   "Remind me tomorrow 5am a\n... 5:05am b"  → batch of reminders
+        #   "1h" / "Monday 5:35am" (reply to fired)   → reschedule, keep subject
+        #   "done" (reply to fired reminder)          → close/resolve it
+        #   "show me my reminders"                    → labelled list
+        # A reply ALWAYS inherits the quoted reminder's subject, so the user
+        # never has to retype what the reminder is about.
+        _reminder_shortcut_result = self._try_reminder_shortcut(event, source)
+        if _reminder_shortcut_result is not None:
+            return _reminder_shortcut_result
+
         # ── External-drain new-turn gate (Phase 2) ────────────────────
         # When NAS has engaged an external drain (.drain_request.json present,
         # observed by _drain_control_watcher), refuse to START a new turn so
@@ -9241,6 +9261,267 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._evict_cached_agent(quick_key)
         except Exception:
             pass
+
+    def _reminder_chat_id(self, source: "SessionSource") -> Optional[str]:
+        """Chat id used to key the per-chat last-reminder-subject fallback."""
+        return getattr(source, "chat_id", None) or getattr(source, "user_id", None)
+
+    def _cached_reminder_subject(self, source: "SessionSource") -> Optional[str]:
+        """Most-recent reminder subject for this chat, if still fresh.
+
+        Used as a fallback when the user replies to a reminder but the platform
+        stripped the quoted text. Reads the in-memory cache first, then the
+        persistent per-chat store written when a reminder fires.
+        """
+        chat_id = self._reminder_chat_id(source)
+        if not chat_id:
+            return None
+        cache = getattr(self, "_last_reminder_subject_by_chat", None) or {}
+        entry = cache.get(chat_id)
+        if entry:
+            subject, ts = entry
+            if subject and (time.time() - ts) < 7 * 24 * 3600:
+                return subject
+        try:
+            from gateway.reminder_shortcuts import lookup_last_reminder_subject
+            return lookup_last_reminder_subject(chat_id)
+        except Exception:
+            return None
+
+    def _find_pending_reminder_job(self, subject: str, source: "SessionSource"):
+        """Return a still-pending reminder cron job matching ``subject``.
+
+        Matches on the reminder subject embedded in the job prompt. A fired
+        one-shot reminder is deleted on fire, so there is usually no live job to
+        update — in that case this returns None and the caller creates a fresh
+        job instead of updating in place.
+        """
+        from cron import jobs as cron_jobs
+        from gateway.reminder_shortcuts import extract_subject_from_reminder_text
+
+        want = (subject or "").strip().casefold()
+        if not want:
+            return None
+        try:
+            jobs = cron_jobs.list_jobs(include_disabled=False)
+        except Exception:
+            return None
+        for job in jobs or []:
+            job_subject = extract_subject_from_reminder_text(job.get("prompt")) or ""
+            if job_subject.strip().casefold() == want:
+                return job
+        return None
+
+    def _try_handle_reminder_reply(
+        self, event: "MessageEvent", source: Optional["SessionSource"] = None
+    ) -> Optional[str]:
+        """Handle a reply to a fired/pending reminder (reschedule or close).
+
+        A reply that names only a time means "move this reminder, keep its
+        text"; a reply like "done" means "close this reminder". The reminder
+        subject is ALWAYS inherited from the quoted reminder text, falling back
+        to the per-chat cache when the platform stripped the quote. Returns a
+        confirmation string when handled, or None to fall through.
+        """
+        from cron import jobs as cron_jobs
+        from gateway.reminder_shortcuts import (
+            is_reminder_close_intent,
+            parse_snooze_reply,
+            extract_subject_from_reminder_text,
+        )
+
+        if source is None:
+            source = event.source
+        message_text = (event.text or "").strip()
+        reply_to_text = (
+            (event.reply_to_text or "").strip()
+            if getattr(event, "reply_to_text", None)
+            else None
+        )
+
+        # A reply must have reminder context: either quoted reminder text or a
+        # cached subject from a recently-fired reminder. A bare message with no
+        # such context must NOT be hijacked (e.g. a standalone "done").
+        subject_fallback = self._cached_reminder_subject(source)
+        has_quoted_subject = bool(extract_subject_from_reminder_text(reply_to_text))
+        if not has_quoted_subject and not subject_fallback:
+            return None
+
+        # Close / resolve intent: "done", "completed", "cancel", etc.
+        if is_reminder_close_intent(message_text):
+            subject = (
+                extract_subject_from_reminder_text(reply_to_text) or subject_fallback or ""
+            ).strip()
+            if not subject:
+                return None
+            job = self._find_pending_reminder_job(subject, source)
+            if job is not None:
+                try:
+                    cron_jobs.remove_job(job.get("id"))
+                except Exception as exc:
+                    logger.warning("Reminder close shortcut failed: %s", exc)
+                    return None
+            return f'Closed — "{subject}". Nice work!'
+
+        # Reschedule / snooze: reply names only a time/interval.
+        parsed = parse_snooze_reply(
+            message_text,
+            reply_to_text=reply_to_text,
+            reply_to_subject_fallback=subject_fallback,
+        )
+        if parsed is None:
+            return None
+
+        # If the reminder is still pending, update it in place to avoid a
+        # duplicate. Otherwise (already fired & deleted) create a fresh job.
+        existing = self._find_pending_reminder_job(parsed.subject, source)
+        try:
+            if existing is not None:
+                cron_jobs.update_job(existing.get("id"), {"schedule": parsed.schedule})
+            else:
+                cron_jobs.create_job(
+                    prompt=f"📅 REMINDER:\n{parsed.subject}",
+                    schedule=parsed.schedule,
+                    name=f"Reminder: {parsed.subject}",
+                    repeat=1,
+                    deliver="origin",
+                    origin=self._reminder_origin(source),
+                )
+        except Exception as exc:
+            logger.warning("Reminder reschedule shortcut failed: %s", exc)
+            return None
+        logger.info(
+            "Reminder reschedule shortcut: %s -> %s (%s)",
+            parsed.subject,
+            parsed.display_time,
+            "in place" if existing is not None else "new job",
+        )
+        return (
+            f'Done — rescheduled "{parsed.subject}" to {parsed.display_time}. '
+            f'Reply "done" when handled.'
+        )
+
+    def _reminder_origin(self, source: "SessionSource") -> Optional[Dict[str, Any]]:
+        """Build a cron ``origin`` dict so reminders deliver back to this chat."""
+        platform = getattr(source, "platform", None)
+        return {
+            "platform": platform.value if hasattr(platform, "value") else platform,
+            "chat_id": getattr(source, "chat_id", None),
+            "user_id": getattr(source, "user_id", None),
+            "thread_id": getattr(source, "thread_id", None),
+        }
+
+    def _try_reminder_shortcut(
+        self,
+        event: "MessageEvent",
+        source: "SessionSource",
+    ) -> Optional[str]:
+        """Try to handle reminder requests deterministically via shortcuts.
+
+        Dispatch order (WhatsApp only):
+          1. reminder-list intent  -> labelled list of future reminders
+          2. reply-to-reminder     -> reschedule (keep subject) or close
+          3. batch of reminders    -> one job per parsed line
+          4. single new reminder   -> one job
+
+        Returns a confirmation string if handled, None if the message isn't a
+        high-confidence reminder pattern (falls through to normal LLM dispatch).
+        """
+        from gateway.platforms.base import Platform
+        from cron import jobs as cron_jobs
+        from gateway.reminder_shortcuts import (
+            is_reminder_intent,
+            is_reminder_list_intent,
+            parse_simple_reminder_batch,
+            parse_simple_relative_reminder,
+            reminder_list_output,
+        )
+
+        # Reminder shortcuts are WhatsApp-only for now (but could expand).
+        if getattr(source, "platform", None) != Platform.WHATSAPP:
+            return None
+
+        message_text = (event.text or "").strip()
+        reply_to_text = (
+            (event.reply_to_text or "").strip()
+            if getattr(event, "reply_to_text", None)
+            else None
+        )
+
+        # 1) Reminder-list intent: "show me my reminders".
+        if is_reminder_list_intent(message_text):
+            try:
+                jobs = cron_jobs.list_jobs(include_disabled=False)
+                return reminder_list_output(jobs)
+            except Exception as exc:
+                logger.warning("Reminder list shortcut failed: %s", exc)
+                return None
+
+        # 2) Reply to a fired/pending reminder (reschedule or close). This is
+        # tried whenever there is reminder context (quoted text or a recent
+        # cached subject), independent of the literal "remind" keyword so that
+        # bare replies like "1h" or "done" are handled.
+        reply_result = self._try_handle_reminder_reply(event, source)
+        if reply_result is not None:
+            return reply_result
+
+        # Everything below is a NEW reminder and requires explicit intent.
+        if not is_reminder_intent(message_text):
+            return None
+
+        # 3) Batch of reminders (e.g. several "tomorrow at <time> <subject>"
+        # lines in one message).
+        batch = parse_simple_reminder_batch(message_text, reply_to_text=reply_to_text)
+        if batch is not None and len(batch.reminders) > 1:
+            lines = []
+            try:
+                for parsed in batch.reminders:
+                    cron_jobs.create_job(
+                        prompt=f"📅 REMINDER:\n{parsed.subject}",
+                        schedule=parsed.schedule,
+                        name=f"Reminder: {parsed.subject}",
+                        repeat=1,
+                        deliver="origin",
+                        origin=self._reminder_origin(source),
+                    )
+                    lines.append(
+                        f"Done. Reminder set: {parsed.display_time} — {parsed.subject}."
+                    )
+            except Exception as exc:
+                logger.warning("Reminder batch shortcut failed: %s", exc)
+                return None
+            return "\n".join(lines)
+
+        # 4) Single new reminder.
+        parsed_reminder = parse_simple_relative_reminder(
+            message_text,
+            reply_to_text=reply_to_text,
+        )
+        if parsed_reminder is not None:
+            try:
+                cron_jobs.create_job(
+                    prompt=f"📅 REMINDER:\n{parsed_reminder.subject}",
+                    schedule=parsed_reminder.schedule,
+                    name=f"Reminder: {parsed_reminder.subject}",
+                    repeat=1,
+                    deliver="origin",
+                    origin=self._reminder_origin(source),
+                )
+                logger.info(
+                    "Reminder shortcut: created %s for %s",
+                    parsed_reminder.display_time,
+                    parsed_reminder.subject,
+                )
+                return (
+                    f"Done. Reminder set: {parsed_reminder.display_time} "
+                    f"— {parsed_reminder.subject}."
+                )
+            except Exception as exc:
+                logger.warning("Reminder shortcut failed: %s", exc)
+                return None
+
+        # Not a high-confidence reminder pattern; let the agent handle it.
+        return None
 
     async def _prepare_inbound_message_text(
         self,

--- a/tests/gateway/test_whatsapp_reminder_shortcuts.py
+++ b/tests/gateway/test_whatsapp_reminder_shortcuts.py
@@ -1,0 +1,566 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import time
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.reminder_shortcuts import (
+    extract_subject_from_reminder_text,
+    is_reminder_intent,
+    parse_simple_reminder_batch,
+    parse_simple_relative_reminder,
+    reminder_list_output,
+)
+from gateway.session import SessionSource
+
+
+def _clear_auth_env(monkeypatch) -> None:
+    for key in (
+        "WHATSAPP_ALLOWED_USERS",
+        "WHATSAPP_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _make_event(text: str, *, reply_to_text: str | None = None) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_id="m1",
+        reply_to_message_id="quoted1" if reply_to_text else None,
+        reply_to_text=reply_to_text,
+        source=SessionSource(
+            platform=Platform.WHATSAPP,
+            user_id="15551234567@s.whatsapp.net",
+            chat_id="15551234567@s.whatsapp.net",
+            user_name="tester",
+            chat_type="dm",
+        ),
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    config = GatewayConfig(
+        platforms={Platform.WHATSAPP: PlatformConfig(enabled=True)},
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.adapters = {Platform.WHATSAPP: SimpleNamespace(send=MagicMock())}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_store._is_rate_limited.return_value = False
+    runner.session_store = MagicMock()
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._update_prompt_pending = {}
+    runner._last_reminder_subject_by_chat = {}
+    runner._session_model_overrides = {}
+    return runner
+
+
+def test_parse_new_reminder_uses_only_current_line_not_old_history():
+    text = """laundry in 1 minute
+reminder in 2 minutes
+laundry in 1 minute
+reminder in 2 minutes
+Remind me test 01 in 1 minute"""
+
+    parsed = parse_simple_relative_reminder(text)
+
+    assert parsed is not None
+    assert parsed.subject == "test 01"
+    assert parsed.schedule == "1m"
+    assert parsed.display_time == "in 1 minute"
+
+
+def test_reply_to_reminder_reuses_quoted_subject():
+    parsed = parse_simple_relative_reminder(
+        "Remind me in 2 min",
+        reply_to_text="⚕ *Hermes Agent*\n────────────\n📅 REMINDER:\nlaundry",
+    )
+
+    assert parsed is not None
+    assert parsed.subject == "laundry"
+    assert parsed.schedule == "2m"
+    assert parsed.display_time == "in 2 minutes"
+    assert parsed.reused_reply_subject is True
+
+
+def test_reply_to_reminder_next_week_reuses_quoted_subject():
+    parsed = parse_simple_relative_reminder(
+        "Remind me next week",
+        reply_to_text="📅 REMINDER:\ncontact Ami warehouse",
+    )
+
+    assert parsed is not None
+    assert parsed.subject == "contact Ami warehouse"
+    assert parsed.schedule == "7d"
+    assert parsed.display_time == "in 1 week"
+
+
+def test_parse_voice_transcript_subject_after_delay():
+    parsed = parse_simple_relative_reminder(
+        '[The user sent a voice message~ Here\'s what they said: "Remind me in 2 minutes, test 03."]'
+    )
+
+    assert parsed is not None
+    assert parsed.subject == "test 03"
+    assert parsed.schedule == "2m"
+    assert parsed.display_time == "in 2 minutes"
+
+
+
+def test_voice_reply_to_reminder_reuses_quoted_subject():
+    parsed = parse_simple_relative_reminder(
+        '[The user sent a voice message~ Here\'s what they said: "Remind me in 2 minutes."]',
+        reply_to_text="📅 REMINDER:\ncontact Ami warehouse",
+    )
+
+    assert parsed is not None
+    assert parsed.subject == "contact Ami warehouse"
+    assert parsed.schedule == "2m"
+    assert parsed.display_time == "in 2 minutes"
+    assert parsed.reused_reply_subject is True
+
+
+def test_parse_text_subject_after_delay():
+    parsed = parse_simple_relative_reminder("Remind me in 2 minutes, test 03.")
+
+    assert parsed is not None
+    assert parsed.subject == "test 03"
+    assert parsed.schedule == "2m"
+
+
+def test_parse_text_subject_after_delay_without_punctuation():
+    parsed = parse_simple_relative_reminder("Remind me in 2 minutes test 03")
+
+    assert parsed is not None
+    assert parsed.subject == "test 03"
+    assert parsed.schedule == "2m"
+
+
+def test_parse_tomorrow_batch_creates_independent_absolute_reminders():
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    parsed = parse_simple_reminder_batch(
+        "Remind me tomorrow at 5am acrylic\nRemind me tomorrow at 5:05am graphics",
+        now=datetime(2026, 6, 17, 18, 54, tzinfo=ZoneInfo("America/Chicago")),
+    )
+
+    assert parsed is not None
+    assert [(r.subject, r.display_time) for r in parsed.reminders] == [
+        ("acrylic", "Tomorrow 5:00 AM"),
+        ("graphics", "Tomorrow 5:05 AM"),
+    ]
+    assert parsed.reminders[0].schedule == "2026-06-18T05:00:00-05:00"
+    assert parsed.reminders[1].schedule == "2026-06-18T05:05:00-05:00"
+
+
+def test_non_reminder_current_message_does_not_parse_even_with_old_history_terms():
+    assert parse_simple_relative_reminder("test 02") is None
+    assert parse_simple_relative_reminder("Here?") is None
+    assert parse_simple_relative_reminder("What did you do to WhatsApp messaging?") is None
+    assert not is_reminder_intent("test 02")
+
+
+def test_parse_relative_reminder_can_parse_quoted_reminder_text_without_icon():
+    parsed = parse_simple_relative_reminder(
+        "Remind me in 2 min",
+        reply_to_text="REMINDER:\ntest B2",
+    )
+
+    assert parsed is not None
+    assert parsed.subject == "test B2"
+    assert parsed.reused_reply_subject is True
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_reply_without_quoted_text_uses_cached_subject(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [])
+
+    created = []
+    monkeypatch.setattr("cron.jobs.create_job", lambda **kwargs: created.append(kwargs) or {"id": "job1"})
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [])
+
+    runner = _make_runner()
+    runner._last_reminder_subject_by_chat = {"15551234567@s.whatsapp.net": ("testB3", time.time())}
+
+    result = await runner._handle_message(_make_event("Remind me in 2 min"))
+
+    assert result == 'Done — rescheduled "testB3" to in 2 minutes. Reply "done" when handled.'
+    assert created and created[0]["prompt"] == "📅 REMINDER:\ntestB3"
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_reply_with_quoted_reminder_text_without_icon_uses_subject(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [])
+
+    created = []
+    monkeypatch.setattr("cron.jobs.create_job", lambda **kwargs: created.append(kwargs) or {"id": "job1"})
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [])
+
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event("Remind me in 2 min", reply_to_text="REMINDER:\ntestB3")
+    )
+
+    assert result == 'Done — rescheduled "testB3" to in 2 minutes. Reply "done" when handled.'
+    assert created and created[0]["prompt"] == "📅 REMINDER:\ntestB3"
+
+
+def test_explicit_reminder_uses_latest_current_line_only():
+    parsed = parse_simple_relative_reminder(
+        "📅 REMINDER:\nlaundry\nRemind me in 1 minute test 05"
+    )
+
+    assert parsed is not None
+    assert parsed.subject == "test 05"
+    assert parsed.schedule == "1m"
+
+
+def test_extract_subject_from_reminder_text():
+    assert extract_subject_from_reminder_text("📅 REMINDER:\nquotation Amin") == "quotation Amin"
+
+
+def test_reminder_list_output_labels_once_and_recurring():
+    jobs = [
+        {
+            "name": "Reminder: test a2",
+            "prompt": "📅 REMINDER:\ntest a2",
+            "schedule_display": "Today 9:47 PM",
+            "schedule": {"kind": "once"},
+            "repeat": {"times": 1, "completed": 0},
+            "next_run_at": "2026-06-17T21:47:00-05:00",
+        },
+        {
+            "name": "Reminder: Zepbound Shot",
+            "prompt": "📅 REMINDER:\nZepbound Shot",
+            "schedule_display": "Every Wednesday 4:00 PM",
+            "schedule": {"kind": "cron"},
+            "repeat": {"times": None, "completed": 0},
+            "next_run_at": "2026-06-24T16:00:00-05:00",
+        },
+    ]
+
+    output = reminder_list_output(jobs)
+
+    assert output == (
+        "Here are your future reminders:\n"
+        "Once — Today 9:47 PM — test a2\n"
+        "Recurring — Every Wednesday 4:00 PM — Zepbound Shot"
+    )
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_reminder_list_shortcut_returns_labelled_jobs(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [])
+    monkeypatch.setattr(
+        "cron.jobs.list_jobs",
+        lambda include_disabled=False: [
+            {
+                "name": "Reminder: test a2",
+                "prompt": "📅 REMINDER:\ntest a2",
+                "schedule_display": "Today 9:47 PM",
+                "schedule": {"kind": "once"},
+                "repeat": {"times": 1, "completed": 0},
+                "next_run_at": "2026-06-17T21:47:00-05:00",
+            },
+            {
+                "name": "Reminder: Zepbound Shot",
+                "prompt": "📅 REMINDER:\nZepbound Shot",
+                "schedule_display": "Every Wednesday 4:00 PM",
+                "schedule": {"kind": "cron"},
+                "repeat": {"times": None, "completed": 0},
+                "next_run_at": "2026-06-24T16:00:00-05:00",
+            },
+        ],
+    )
+
+    runner = _make_runner()
+    result = await runner._handle_message(_make_event("show me the list of all future reminders you have on record"))
+
+    assert result == (
+        "Here are your future reminders:\n"
+        "Once — Today 9:47 PM — test a2\n"
+        "Recurring — Every Wednesday 4:00 PM — Zepbound Shot"
+    )
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_simple_reminder_shortcut_creates_one_job(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [])
+
+    created = []
+
+    def _fake_create_job(**kwargs):
+        created.append(kwargs)
+        return {"id": "job1", **kwargs}
+
+    monkeypatch.setattr("cron.jobs.create_job", _fake_create_job)
+
+    runner = _make_runner()
+    result = await runner._handle_message(_make_event("Remind me test 01 in 1 minute"))
+
+    assert result == "Done. Reminder set: in 1 minute — test 01."
+    assert len(created) == 1
+    assert created[0]["prompt"] == "📅 REMINDER:\ntest 01"
+    assert created[0]["schedule"] == "1m"
+    assert created[0]["name"] == "Reminder: test 01"
+    assert created[0]["deliver"] == "origin"
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_reply_reminder_shortcut_reuses_subject(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [])
+
+    created = []
+    monkeypatch.setattr("cron.jobs.create_job", lambda **kwargs: created.append(kwargs) or {"id": "job1"})
+    # Reply path scans pending jobs to reschedule in place; no live job here.
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [])
+
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event(
+            "Remind me in 2 min",
+            reply_to_text="📅 REMINDER:\nlaundry",
+        )
+    )
+
+    # Redesign: a reply to a reminder reschedules THAT reminder (keeping its
+    # subject) rather than "reusing" it as a fresh creation.
+    assert result == 'Done — rescheduled "laundry" to in 2 minutes. Reply "done" when handled.'
+    assert len(created) == 1
+    assert created[0]["prompt"] == "📅 REMINDER:\nlaundry"
+    assert created[0]["schedule"] == "2m"
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_tomorrow_batch_shortcut_creates_two_jobs(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [])
+
+    created = []
+    monkeypatch.setattr("cron.jobs.create_job", lambda **kwargs: created.append(kwargs) or {"id": f"job{len(created)}"})
+
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+    import gateway.reminder_shortcuts as shortcuts
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            fixed = datetime(2026, 6, 17, 18, 54, tzinfo=ZoneInfo("America/Chicago"))
+            return fixed if tz is None else fixed.astimezone(tz)
+
+    monkeypatch.setattr(shortcuts, "datetime", FixedDateTime)
+
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event("Remind me tomorrow at 5am acrylic\nRemind me tomorrow at 5:05am graphics")
+    )
+
+    assert result == (
+        "Done. Reminder set: Tomorrow 5:00 AM — acrylic.\n"
+        "Done. Reminder set: Tomorrow 5:05 AM — graphics."
+    )
+    assert len(created) == 2
+    assert [job["name"] for job in created] == ["Reminder: acrylic", "Reminder: graphics"]
+    assert [job["schedule"] for job in created] == [
+        "2026-06-18T05:00:00-05:00",
+        "2026-06-18T05:05:00-05:00",
+    ]
+    assert [job["prompt"] for job in created] == [
+        "📅 REMINDER:\nacrylic",
+        "📅 REMINDER:\ngraphics",
+    ]
+
+
+# ── Redesign: reply-to-reminder = reschedule/snooze/close ──────────────────────
+
+from datetime import datetime as _dt
+from gateway.reminder_shortcuts import (
+    parse_snooze_reply,
+    is_reminder_close_intent,
+    ParsedSnooze,
+)
+
+_FIRED = "📅 REMINDER:\nReceipts Brussels airlines"
+# Saturday 2026-06-20 14:09 local
+_NOW = _dt(2026, 6, 20, 14, 9).astimezone()
+
+
+@pytest.mark.parametrize(
+    "reply,expect_schedule_kind,expect_display",
+    [
+        ("Remind me Monday at 5:35am", "iso", "Monday 5:35 AM"),
+        ("Monday 5:35am", "iso", "Monday 5:35 AM"),
+        ("Monday", "iso", "Monday 9:00 AM"),
+        ("5m", "5m", "in 5 minutes"),
+        ("10m", "10m", "in 10 minutes"),
+        ("30m", "30m", "in 30 minutes"),
+        ("1h", "1h", "in 1 hour"),
+        ("2 hours", "2h", "in 2 hours"),
+        ("in 1 hour", "1h", "in 1 hour"),
+        ("tomorrow", "iso", "Tomorrow 9:00 AM"),
+        ("tomorrow at 5:35am", "iso", "Tomorrow 5:35 AM"),
+        ("next week", "7d", "in 1 week"),
+        ("1 day", "1d", "in 1 day"),
+        ("3 days", "3d", "in 3 days"),
+    ],
+)
+def test_parse_snooze_reply_inherits_subject_and_resolves_time(
+    reply, expect_schedule_kind, expect_display
+):
+    parsed = parse_snooze_reply(reply, reply_to_text=_FIRED, now=_NOW)
+    assert parsed is not None, f"reply {reply!r} should parse as a snooze"
+    assert parsed.subject == "Receipts Brussels airlines"
+    assert parsed.display_time == expect_display
+    if expect_schedule_kind == "iso":
+        # ISO timestamp for weekday/clock targets.
+        assert "T" in parsed.schedule
+    else:
+        assert parsed.schedule == expect_schedule_kind
+
+
+def test_parse_snooze_reply_requires_inherited_subject():
+    # No quote and no fallback -> cannot identify the reminder -> None.
+    assert parse_snooze_reply("Monday 5:35am", now=_NOW) is None
+    # Fallback subject still works.
+    parsed = parse_snooze_reply(
+        "Monday 5:35am", reply_to_subject_fallback="Receipts Brussels airlines", now=_NOW
+    )
+    assert parsed is not None
+    assert parsed.subject == "Receipts Brussels airlines"
+
+
+@pytest.mark.parametrize(
+    "word",
+    ["done", "Done.", "completed", "complete", "received", "resolved",
+     "cancel", "cancelled", "stop", "close", "finished", "ok done"],
+)
+def test_is_reminder_close_intent_recognizes_close_words(word):
+    assert is_reminder_close_intent(word) is True
+
+
+@pytest.mark.parametrize("word", ["Receipts Brussels airlines", "blah", "Monday", "1h", ""])
+def test_is_reminder_close_intent_rejects_non_close(word):
+    assert is_reminder_close_intent(word) is False
+
+
+@pytest.mark.asyncio
+async def test_reply_monday_time_reschedules_keeping_subject(monkeypatch):
+    """The exact reported failure: reply 'Remind me Monday at 5:35am' to a fired
+    reminder must reschedule THAT reminder, keep its text, and not clarify."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [])
+
+    created = []
+    monkeypatch.setattr("cron.jobs.create_job", lambda **kwargs: created.append(kwargs) or {"id": "jobX"})
+    # Fired one-shot reminders are deleted on fire -> no live job to update.
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [])
+
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event("Remind me Monday at 5:35am", reply_to_text=_FIRED)
+    )
+
+    assert result is not None
+    assert "Receipts Brussels airlines" in result
+    assert "rescheduled" in result.lower()
+    assert len(created) == 1
+    assert created[0]["prompt"] == "📅 REMINDER:\nReceipts Brussels airlines"
+    assert "T05:35" in created[0]["schedule"]
+
+
+@pytest.mark.asyncio
+async def test_reply_reschedules_pending_job_in_place_no_duplicate(monkeypatch):
+    """When the reminder is still pending, the reply updates it in place rather
+    than creating a duplicate job."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [])
+
+    pending = {
+        "id": "pending1",
+        "prompt": "📅 REMINDER:\nReceipts Brussels airlines",
+        "origin": {"chat_id": "15551234567@s.whatsapp.net"},
+    }
+    created = []
+    updates = []
+    monkeypatch.setattr("cron.jobs.create_job", lambda **kwargs: created.append(kwargs) or {"id": "new"})
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [pending])
+    monkeypatch.setattr(
+        "cron.jobs.update_job",
+        lambda job_id, upd: updates.append((job_id, upd)) or {"id": job_id, **upd},
+    )
+
+    runner = _make_runner()
+    result = await runner._handle_message(_make_event("1h", reply_to_text=_FIRED))
+
+    assert result is not None and "rescheduled" in result.lower()
+    # Updated in place, NOT duplicated.
+    assert updates == [("pending1", {"schedule": "1h"})]
+    assert created == []
+
+
+@pytest.mark.asyncio
+async def test_reply_done_closes_reminder(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [])
+
+    pending = {
+        "id": "pending1",
+        "prompt": "📅 REMINDER:\nReceipts Brussels airlines",
+        "origin": {"chat_id": "15551234567@s.whatsapp.net"},
+    }
+    removed = []
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [pending])
+    monkeypatch.setattr("cron.jobs.remove_job", lambda job_id: removed.append(job_id) or True)
+
+    runner = _make_runner()
+    result = await runner._handle_message(_make_event("done", reply_to_text=_FIRED))
+
+    assert result is not None
+    assert "Closed" in result
+    assert "Receipts Brussels airlines" in result
+    assert removed == ["pending1"]
+
+
+@pytest.mark.asyncio
+async def test_bare_done_without_reply_does_not_close(monkeypatch):
+    """A standalone 'done' with no reminder reply context must not hijack."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [])
+
+    removed = []
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [])
+    monkeypatch.setattr("cron.jobs.remove_job", lambda job_id: removed.append(job_id) or True)
+
+    runner = _make_runner()
+    # No reply_to_text -> reminder reply handler must return None (fall through).
+    handled = runner._try_handle_reminder_reply(_make_event("done"))
+    assert handled is None
+    assert removed == []


### PR DESCRIPTION
## fix(gateway): wire deterministic WhatsApp reminder shortcuts into message dispatch

### Problem

Replying to a fired WhatsApp reminder with only a time (e.g. **"remind me in 5 min"**) caused Hermes to ask **"What should I remind you about in 5 minutes?"** instead of reusing the quoted reminder's subject.

Root cause: the parsing helpers in `gateway/reminder_shortcuts.py` already existed and were unit-tested, but they were **never invoked** from `GatewayRunner._handle_message`. The reply therefore fell through to the LLM, which re-prompted for a subject it should have inherited from the quoted message.

### Fix

Wire the shortcuts into `_handle_message` as a deterministic fast-path (WhatsApp only) that dispatches, in order:

1. **reminder-list intent** → `reminder_list_output(list_jobs())`
2. **reply-to-reminder** → reschedule (keep subject) or close
   - close intent ("done", "completed", "cancel", …) → remove the pending job
   - time/interval reply → update the pending job **in place** (no duplicate), or create a fresh one-shot if the original already fired and was deleted
   - subject is **inherited from the quoted reminder text**, falling back to a per-chat cache when the platform strips the quote
3. **batch of reminders** → one one-shot job per parsed line
4. **single new reminder** → one one-shot job

All jobs are created with `repeat=1`, `deliver="origin"`, and an `origin` dict so delivery returns to the originating chat. The reply path triggers whenever reminder context is present (quoted text or a recent cached subject), so bare replies like `"1h"` or `"done"` are handled — while a standalone `"done"` with no context falls through untouched.

### Tests

`tests/gateway/test_whatsapp_reminder_shortcuts.py` — **55 passing** (parser unit tests + gateway integration tests covering the exact reported failure, in-place reschedule/no-duplicate, done-closes-reminder, bare-done-without-reply, list labelling, and the tomorrow batch path).

Broader gateway suite: `72 passed, 1 skipped` for `-k "reminder or handle_message or shortcut"`.

### Notes

- No new model tools, no config/env surface, no prompt-cache impact — purely a gateway message-dispatch fix.
- Deterministic path means reminder confirmations are exact and the LLM is bypassed for high-confidence reminder patterns.
