### PR TITLE
fix(memory): configure supermemory conversation ingest retries

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import threading
+import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -29,6 +30,13 @@ _DEFAULT_CAPTURE_MODE = "all"
 _DEFAULT_SEARCH_MODE = "hybrid"
 _VALID_SEARCH_MODES = ("hybrid", "memories", "documents")
 _DEFAULT_API_TIMEOUT = 5.0
+_DEFAULT_CONVERSATION_INGEST_TIMEOUT = _DEFAULT_API_TIMEOUT + 3.0
+_DEFAULT_CONVERSATION_INGEST_RETRIES = 0
+_MIN_CONVERSATION_INGEST_TIMEOUT = 1.0
+_MAX_CONVERSATION_INGEST_TIMEOUT = 300.0
+_MIN_CONVERSATION_INGEST_RETRIES = 0
+_MAX_CONVERSATION_INGEST_RETRIES = 5
+_RETRYABLE_CONVERSATION_HTTP_CODES = {408, 409, 425, 429, 500, 502, 503, 504}
 _MIN_CAPTURE_LENGTH = 10
 _MAX_ENTITY_CONTEXT_LENGTH = 1500
 _CONVERSATIONS_URL = "https://api.supermemory.ai/v4/conversations"
@@ -65,6 +73,8 @@ def _default_config() -> dict:
         "search_mode": _DEFAULT_SEARCH_MODE,
         "entity_context": _DEFAULT_ENTITY_CONTEXT,
         "api_timeout": _DEFAULT_API_TIMEOUT,
+        "conversation_ingest_timeout": _DEFAULT_CONVERSATION_INGEST_TIMEOUT,
+        "conversation_ingest_retries": _DEFAULT_CONVERSATION_INGEST_RETRIES,
         "enable_custom_container_tags": False,
         "custom_containers": [],
         "custom_container_instructions": "",
@@ -107,6 +117,21 @@ def _load_supermemory_config(hermes_home: str) -> dict:
         except Exception:
             logger.debug("Failed to parse %s", config_path, exc_info=True)
 
+    yaml_config_path = Path(hermes_home) / "config.yaml"
+    if yaml_config_path.exists():
+        try:
+            import yaml
+            raw_yaml = yaml.safe_load(yaml_config_path.read_text(encoding="utf-8")) or {}
+            if isinstance(raw_yaml, dict):
+                memory_cfg = raw_yaml.get("memory") or {}
+                supermemory_cfg = memory_cfg.get("supermemory") if isinstance(memory_cfg, dict) else None
+                if isinstance(supermemory_cfg, dict):
+                    for key in ("conversation_ingest_timeout", "conversation_ingest_retries"):
+                        if supermemory_cfg.get(key) is not None:
+                            config[key] = supermemory_cfg[key]
+        except Exception:
+            logger.debug("Failed to parse %s", yaml_config_path, exc_info=True)
+
     # Keep raw container_tag — template variables like {identity} are resolved
     # in initialize(), and _sanitize_tag runs AFTER resolution.
     raw_tag = str(config.get("container_tag", _DEFAULT_CONTAINER_TAG)).strip()
@@ -129,6 +154,26 @@ def _load_supermemory_config(hermes_home: str) -> dict:
         config["api_timeout"] = max(0.5, min(15.0, float(config.get("api_timeout", _DEFAULT_API_TIMEOUT))))
     except Exception:
         config["api_timeout"] = _DEFAULT_API_TIMEOUT
+    try:
+        config["conversation_ingest_timeout"] = max(
+            _MIN_CONVERSATION_INGEST_TIMEOUT,
+            min(
+                _MAX_CONVERSATION_INGEST_TIMEOUT,
+                float(config.get("conversation_ingest_timeout", _DEFAULT_CONVERSATION_INGEST_TIMEOUT)),
+            ),
+        )
+    except Exception:
+        config["conversation_ingest_timeout"] = _DEFAULT_CONVERSATION_INGEST_TIMEOUT
+    try:
+        config["conversation_ingest_retries"] = max(
+            _MIN_CONVERSATION_INGEST_RETRIES,
+            min(
+                _MAX_CONVERSATION_INGEST_RETRIES,
+                int(config.get("conversation_ingest_retries", _DEFAULT_CONVERSATION_INGEST_RETRIES)),
+            ),
+        )
+    except Exception:
+        config["conversation_ingest_retries"] = _DEFAULT_CONVERSATION_INGEST_RETRIES
 
     # Multi-container support
     config["enable_custom_container_tags"] = _as_bool(config.get("enable_custom_container_tags"), False)
@@ -263,7 +308,15 @@ def _is_trivial_message(text: str) -> bool:
 
 
 class _SupermemoryClient:
-    def __init__(self, api_key: str, timeout: float, container_tag: str, search_mode: str = "hybrid"):
+    def __init__(
+        self,
+        api_key: str,
+        timeout: float,
+        container_tag: str,
+        search_mode: str = "hybrid",
+        conversation_ingest_timeout: float = _DEFAULT_CONVERSATION_INGEST_TIMEOUT,
+        conversation_ingest_retries: int = _DEFAULT_CONVERSATION_INGEST_RETRIES,
+    ):
         # Lazy-install the supermemory SDK on demand. ensure() honors
         # security.allow_lazy_installs (default true) and, on a sealed Docker
         # venv, redirects the install to the durable target. On failure we
@@ -283,6 +336,14 @@ class _SupermemoryClient:
         self._container_tag = container_tag
         self._search_mode = search_mode if search_mode in _VALID_SEARCH_MODES else _DEFAULT_SEARCH_MODE
         self._timeout = timeout
+        self._conversation_ingest_timeout = max(
+            _MIN_CONVERSATION_INGEST_TIMEOUT,
+            min(_MAX_CONVERSATION_INGEST_TIMEOUT, float(conversation_ingest_timeout)),
+        )
+        self._conversation_ingest_retries = max(
+            _MIN_CONVERSATION_INGEST_RETRIES,
+            min(_MAX_CONVERSATION_INGEST_RETRIES, int(conversation_ingest_retries)),
+        )
         self._client = Supermemory(
             api_key=api_key,
             timeout=timeout,
@@ -387,18 +448,30 @@ class _SupermemoryClient:
         if metadata:
             payload["metadata"] = self._merge_metadata(metadata)
 
-        req = urllib.request.Request(
-            _CONVERSATIONS_URL,
-            data=json.dumps(payload).encode("utf-8"),
-            headers={
-                "Authorization": f"Bearer {self._api_key}",
-                "Content-Type": "application/json",
-                "x-sm-source": "hermes",
-            },
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=self._timeout + 3):
-            return
+        data = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "x-sm-source": "hermes",
+        }
+        attempts = self._conversation_ingest_retries + 1
+        for attempt in range(attempts):
+            req = urllib.request.Request(
+                _CONVERSATIONS_URL,
+                data=data,
+                headers=headers,
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=self._conversation_ingest_timeout):
+                    return
+            except urllib.error.HTTPError as exc:
+                if exc.code not in _RETRYABLE_CONVERSATION_HTTP_CODES or attempt >= attempts - 1:
+                    raise
+            except (TimeoutError, urllib.error.URLError):
+                if attempt >= attempts - 1:
+                    raise
+            time.sleep(min(5.0, 0.5 * (2 ** attempt)))
 
 
 def _resolve_container_tag_for_setup(hermes_home: str, *, identity: str = "default") -> str:
@@ -432,6 +505,8 @@ def _probe_supermemory_connection(api_key: str, hermes_home: str, *, identity: s
             timeout=config["api_timeout"],
             container_tag=status["container_tag"],
             search_mode=config["search_mode"],
+            conversation_ingest_timeout=config["conversation_ingest_timeout"],
+            conversation_ingest_retries=config["conversation_ingest_retries"],
         )
         profile = client.get_profile()
         facts = [
@@ -531,6 +606,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._search_mode = _DEFAULT_SEARCH_MODE
         self._entity_context = _DEFAULT_ENTITY_CONTEXT
         self._api_timeout = _DEFAULT_API_TIMEOUT
+        self._conversation_ingest_timeout = _DEFAULT_CONVERSATION_INGEST_TIMEOUT
+        self._conversation_ingest_retries = _DEFAULT_CONVERSATION_INGEST_RETRIES
         self._hermes_home = ""
         self._write_enabled = True
         self._active = False
@@ -645,6 +722,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._search_mode = self._config["search_mode"]
         self._entity_context = self._config["entity_context"]
         self._api_timeout = self._config["api_timeout"]
+        self._conversation_ingest_timeout = self._config["conversation_ingest_timeout"]
+        self._conversation_ingest_retries = self._config["conversation_ingest_retries"]
         self._enable_custom_containers = self._config["enable_custom_container_tags"]
         self._custom_containers = self._config["custom_containers"]
         self._custom_container_instructions = self._config["custom_container_instructions"]
@@ -663,6 +742,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
                     timeout=self._api_timeout,
                     container_tag=self._container_tag,
                     search_mode=self._search_mode,
+                    conversation_ingest_timeout=self._conversation_ingest_timeout,
+                    conversation_ingest_retries=self._conversation_ingest_retries,
                 )
             except Exception:
                 logger.warning("Supermemory initialization failed", exc_info=True)

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -2,11 +2,14 @@ import json
 import os
 import stat
 import threading
+import email.message
+import urllib.error
 
 import pytest
 
 from plugins.memory.supermemory import (
     SupermemoryMemoryProvider,
+    _SupermemoryClient,
     _clean_text_for_capture,
     _format_connection_summary,
     _format_prefetch_context,
@@ -17,11 +20,21 @@ from plugins.memory.supermemory import (
 
 
 class FakeClient:
-    def __init__(self, api_key: str, timeout: float, container_tag: str, search_mode: str = "hybrid"):
+    def __init__(
+        self,
+        api_key: str,
+        timeout: float,
+        container_tag: str,
+        search_mode: str = "hybrid",
+        conversation_ingest_timeout: float | None = None,
+        conversation_ingest_retries: int = 0,
+    ):
         self.api_key = api_key
         self.timeout = timeout
         self.container_tag = container_tag
         self.search_mode = search_mode
+        self.conversation_ingest_timeout = conversation_ingest_timeout
+        self.conversation_ingest_retries = conversation_ingest_retries
         self.add_calls = []
         self.search_results = []
         self.profile_response = {"static": [], "dynamic": [], "search_results": []}
@@ -371,6 +384,134 @@ def test_invalid_search_mode_falls_back_to_default(monkeypatch, tmp_path):
     p = SupermemoryMemoryProvider()
     p.initialize("s1", hermes_home=str(tmp_path), platform="cli")
     assert p._search_mode == "hybrid"
+
+
+# -- Conversation ingest timeout/retry tests ---------------------------------
+
+
+def test_conversation_ingest_config_defaults_preserve_existing_timeout(tmp_path):
+    cfg = _load_supermemory_config(str(tmp_path))
+    assert cfg["conversation_ingest_timeout"] == 8.0
+    assert cfg["conversation_ingest_retries"] == 0
+
+
+def test_conversation_ingest_config_yaml_override_and_clamp(tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        "memory:\n"
+        "  supermemory:\n"
+        "    conversation_ingest_timeout: 600\n"
+        "    conversation_ingest_retries: 99\n",
+        encoding="utf-8",
+    )
+    cfg = _load_supermemory_config(str(tmp_path))
+    assert cfg["conversation_ingest_timeout"] == 300.0
+    assert cfg["conversation_ingest_retries"] == 5
+
+
+def test_conversation_ingest_config_passed_to_client(monkeypatch, tmp_path):
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "test-key")
+    monkeypatch.setattr("plugins.memory.supermemory._SupermemoryClient", FakeClient)
+    (tmp_path / "config.yaml").write_text(
+        "memory:\n"
+        "  supermemory:\n"
+        "    conversation_ingest_timeout: 60\n"
+        "    conversation_ingest_retries: 2\n",
+        encoding="utf-8",
+    )
+    p = SupermemoryMemoryProvider()
+    p.initialize("s1", hermes_home=str(tmp_path), platform="cli")
+    assert p._conversation_ingest_timeout == 60.0
+    assert p._conversation_ingest_retries == 2
+    assert p._client.conversation_ingest_timeout == 60.0
+    assert p._client.conversation_ingest_retries == 2
+
+
+def test_ingest_conversation_uses_dedicated_timeout(monkeypatch):
+    seen = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_urlopen(req, timeout):
+        seen.append(timeout)
+        return Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    client = _SupermemoryClient.__new__(_SupermemoryClient)
+    client._api_key = "test-key"
+    client._container_tag = "hermes"
+    client._conversation_ingest_timeout = 60.0
+    client._conversation_ingest_retries = 0
+    client.ingest_conversation("s1", [{"role": "user", "content": "hello"}])
+    assert seen == [60.0]
+
+
+def test_ingest_conversation_retries_transient_failure(monkeypatch):
+    attempts = []
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_urlopen(req, timeout):
+        attempts.append(timeout)
+        if len(attempts) == 1:
+            raise TimeoutError("slow")
+        return Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    client = _SupermemoryClient.__new__(_SupermemoryClient)
+    client._api_key = "test-key"
+    client._container_tag = "hermes"
+    client._conversation_ingest_timeout = 30.0
+    client._conversation_ingest_retries = 2
+    client.ingest_conversation("s1", [{"role": "user", "content": "hello"}])
+    assert attempts == [30.0, 30.0]
+
+
+def test_ingest_conversation_does_not_retry_http_400(monkeypatch):
+    attempts = []
+
+    def fake_urlopen(req, timeout):
+        attempts.append(timeout)
+        raise urllib.error.HTTPError(req.full_url, 400, "bad request", hdrs=email.message.Message(), fp=None)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    client = _SupermemoryClient.__new__(_SupermemoryClient)
+    client._api_key = "test-key"
+    client._container_tag = "hermes"
+    client._conversation_ingest_timeout = 30.0
+    client._conversation_ingest_retries = 2
+    with pytest.raises(urllib.error.HTTPError):
+        client.ingest_conversation("s1", [{"role": "user", "content": "hello"}])
+    assert attempts == [30.0]
+
+
+def test_ingest_conversation_exhausts_retryable_http_503(monkeypatch):
+    attempts = []
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    def fake_urlopen(req, timeout):
+        attempts.append(timeout)
+        raise urllib.error.HTTPError(req.full_url, 503, "unavailable", hdrs=email.message.Message(), fp=None)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    client = _SupermemoryClient.__new__(_SupermemoryClient)
+    client._api_key = "test-key"
+    client._container_tag = "hermes"
+    client._conversation_ingest_timeout = 30.0
+    client._conversation_ingest_retries = 2
+    with pytest.raises(urllib.error.HTTPError):
+        client.ingest_conversation("s1", [{"role": "user", "content": "hello"}])
+    assert attempts == [30.0, 30.0, 30.0]
 
 
 # -- Multi-container tests ----------------------------------------------------


### PR DESCRIPTION
## Summary
- add config-driven timeout/retry settings for Supermemory full-session conversation ingest
- keep default behavior compatible: 8s timeout and 0 retries unless configured
- retry only transient failures with bounded exponential backoff while leaving regular SDK operations unchanged

## Configuration
```yaml
memory:
  supermemory:
    conversation_ingest_timeout: 60
    conversation_ingest_retries: 2
```

## Tests
- `python -m pytest tests/plugins/memory/test_supermemory_provider.py tests/agent/test_memory_async_sync.py -q -o addopts=`
- `python -m py_compile plugins/memory/supermemory/__init__.py tests/plugins/memory/test_supermemory_provider.py`
- `git diff --check`
