### PR TITLE
fix(model): probe no-key custom provider catalogs

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2176,6 +2176,7 @@ def list_authenticated_providers(
                     "api_url": api_url,
                     "api_key": api_key,
                     "models": [],
+                    "has_explicit_models": False,
                     "discover_models": discover,
                     "extra_headers": entry_extra_headers,
                 }
@@ -2201,6 +2202,7 @@ def list_authenticated_providers(
             for model_id in _declared_model_ids(entry.get("models", {})):
                 if model_id not in groups[group_key]["models"]:
                     groups[group_key]["models"].append(model_id)
+                    groups[group_key]["has_explicit_models"] = True
 
         _section4_emitted_slugs: set = set()
         _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()
@@ -2262,11 +2264,13 @@ def list_authenticated_providers(
             #   the (possibly partial) ``models:`` subset configured for
             #   context-length overrides with the full live catalog.
             #   This is the Bifrost / aggregator-gateway case.
-            # - Without an api_key but with an explicit ``models:`` list
-            #   (or top-level ``model:``), the user is narrowing a public
-            #   endpoint to a specific subset (e.g. ollama.com /v1/models
-            #   returns 35 models but the user only wants 4). Preserve the
-            #   explicit list and skip live discovery.
+            # - Without an api_key but with an explicit ``models:`` list,
+            #   the user is narrowing a public endpoint to a specific subset
+            #   (e.g. ollama.com /v1/models returns 35 models but the user
+            #   only wants 4). Preserve the explicit list and skip live
+            #   discovery. The singular ``model:`` field is only the current
+            #   active selection and must not suppress discovery on local
+            #   no-key endpoints.
             # - Without an api_key AND no explicit models, fall through to
             #   live discovery so bare-endpoint custom providers (local
             #   llama.cpp / Ollama servers) still appear populated.
@@ -2278,7 +2282,7 @@ def list_authenticated_providers(
             should_probe = (
                 probe_custom_providers
                 and bool(api_url)
-                and (bool(api_key) or not grp["models"])
+                and (bool(api_key) or not grp.get("has_explicit_models"))
                 and grp.get("discover_models", True)
             )
             if should_probe:

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -5,9 +5,16 @@ shared slash-command pipeline (`/model` in CLI/gateway/Telegram) historically
 only looked at `providers:`.
 """
 
+import pytest
+
 import hermes_cli.providers as providers_mod
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli.providers import resolve_provider_full
+
+
+@pytest.fixture(autouse=True)
+def _no_live_custom_provider_model_fetch(monkeypatch):
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *args, **kwargs: [])
 
 
 _MOCK_VALIDATION = {
@@ -261,6 +268,42 @@ def test_list_deduplicates_same_model_in_group(monkeypatch):
     assert len(my_rows) == 1
     assert my_rows[0]["models"] == ["llama3", "mistral"]
     assert my_rows[0]["total_models"] == 2
+
+
+def test_custom_provider_no_key_singular_model_still_probes_live_models(monkeypatch):
+    """A singular ``model:`` is the active selection, not an explicit catalog.
+
+    No-key local endpoints such as Ollama and llama.cpp should still be probed
+    so /model matches the terminal ``hermes model`` flow.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
+        return ["llama3", "mistral", "qwen3-coder"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local Ollama",
+                "base_url": "http://localhost:11434/v1",
+                "model": "llama3",
+            }
+        ],
+        max_models=50,
+    )
+
+    assert calls == [("", "http://localhost:11434/v1", {"headers": None})]
+    row = next(p for p in providers if p["name"] == "Local Ollama")
+    assert row["models"] == ["llama3", "mistral", "qwen3-coder"]
+    assert row["total_models"] == 3
 
 
 def test_list_enumerates_dict_format_models_alongside_default(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes `custom_providers:` model picker discovery for no-key local/OpenAI-compatible endpoints.

The Section 4 picker grouping already documents that singular `model:` is only the active model, while `models:` is the explicit configured catalog. The probe gate still used the combined `grp['models']` list, so a no-key local provider with only `model:` skipped `/v1/models` discovery and `/model` showed only one active model.

This tracks whether a grouped custom provider actually has an explicit `models:` catalog and only suppresses no-key live discovery for that explicit list. Singular `model:` no longer blocks live discovery.

Fixes #40542.

## Related Issue

Fixes #40542

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/model_switch.py`
  - Adds a `has_explicit_models` flag to Section 4 custom-provider groups.
  - Sets the flag only for explicit `models:` dict/list entries, not singular `model:`.
  - Uses that flag for the no-key live discovery gate.
- `tests/hermes_cli/test_model_switch_custom_providers.py`
  - Keeps the file offline by default with a `fetch_api_models` stub.
  - Adds regression coverage proving no-key `custom_providers` with only singular `model:` still probe `/v1/models` and use the live catalog.

## How to Test

Run:

```bash
python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py -q
python -m pytest tests/hermes_cli/test_user_providers_model_switch.py -q
ruff check hermes_cli/model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py
git diff --check
python scripts/check-windows-footguns.py --diff origin/main
```

## Validation

- `tests/hermes_cli/test_model_switch_custom_providers.py` — 29 passed
- `tests/hermes_cli/test_user_providers_model_switch.py` — 35 passed
- `ruff check hermes_cli/model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py` — pass
- `git diff --check` — pass
- `python scripts/check-windows-footguns.py --diff origin/main` — pass

Autoreview note: no repository-local autoreview helper was present in this checkout.