### PR TITLE
feat(gateway): stream reasoning.delta over Runs API SSE

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1077,6 +1077,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        reasoning_callback=None,
         gateway_session_key: Optional[str] = None,
     ) -> Any:
         """
@@ -1131,6 +1132,7 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
+            reasoning_callback=reasoning_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
@@ -3996,6 +3998,23 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
+        # Wire reasoning_callback so token-by-token thinking deltas stream
+        # live (parity with native TUI/OpenClaw). Without this the only
+        # reasoning signal is the whole-block ``reasoning.available`` fallback,
+        # which can't drive a live token-streamed thinking view.
+        def _reasoning_cb(delta: Optional[str]) -> None:
+            if not delta:
+                return
+            try:
+                loop.call_soon_threadsafe(q.put_nowait, {
+                    "event": "reasoning.delta",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "delta": delta,
+                })
+            except Exception:
+                pass
+
         self._set_run_status(
             run_id,
             "queued",
@@ -4012,6 +4031,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id,
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
+                    reasoning_callback=_reasoning_cb,
                     gateway_session_key=gateway_session_key,
                 )
                 self._active_run_agents[run_id] = agent


### PR DESCRIPTION
## What

The Runs API gateway (`gateway/platforms/api_server.py`) never wired `reasoning_callback`, so token-by-token thinking ("reasoning") deltas were not emitted over the SSE stream. SSE clients could only observe the whole-block `reasoning.available` fallback, which can't drive a live token-streamed thinking view.

## Why

`reasoning_callback` is already a first-class param threaded through `run_agent.py`, `agent_init.py`, and `agent/chat_completion_helpers.py`, and it's already consumed by the CLI (`cli.py`), the TUI gateway (`tui_gateway/server.py`), and the ACP adapter (`acp_adapter/server.py`). The Runs API was the one transport that never got wired, so it lagged the others on live reasoning parity.

## Change

- Thread `reasoning_callback` through `_run_agent_streaming`.
- Add a `_reasoning_cb` that pushes a `reasoning.delta` SSE event (mirroring the existing `message.delta` emitter).

No behavior change when no client consumes the event; purely additive parity with the other transports.

## Test

Verified locally: with the callback wired, `reasoning.delta` events stream over the Runs API SSE; without it, only `reasoning.available` fires. Idempotent re-apply confirmed against a clean checkout.