### PR TITLE
fix(tools): keep terminal toolset available when optional helpers fail

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -139,6 +139,57 @@ class TestToolsetAvailability:
         )
         assert reg.is_toolset_available("locked") is False
 
+    def test_mixed_toolset_available_when_any_tool_available(self):
+        """Optional helper tools must not make a mixed toolset look broken."""
+        reg = ToolRegistry()
+        reg.register(
+            name="desktop_only_helper",
+            toolset="terminal",
+            schema=_make_schema("desktop_only_helper"),
+            handler=_dummy_handler,
+            check_fn=lambda: False,
+        )
+        reg.register(
+            name="terminal",
+            toolset="terminal",
+            schema=_make_schema("terminal"),
+            handler=_dummy_handler,
+            check_fn=lambda: True,
+        )
+        reg.register(
+            name="process",
+            toolset="terminal",
+            schema=_make_schema("process"),
+            handler=_dummy_handler,
+        )
+
+        assert reg.is_toolset_available("terminal") is True
+        assert reg.check_toolset_requirements()["terminal"] is True
+        assert reg.get_available_toolsets()["terminal"]["available"] is True
+        available, unavailable = reg.check_tool_availability()
+        assert "terminal" in available
+        assert not any(item["name"] == "terminal" for item in unavailable)
+
+    def test_mixed_toolset_unavailable_when_all_tools_unavailable(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="a",
+            toolset="locked",
+            schema=_make_schema("a"),
+            handler=_dummy_handler,
+            check_fn=lambda: False,
+        )
+        reg.register(
+            name="b",
+            toolset="locked",
+            schema=_make_schema("b"),
+            handler=_dummy_handler,
+            check_fn=lambda: False,
+        )
+
+        assert reg.is_toolset_available("locked") is False
+        assert reg.check_toolset_requirements()["locked"] is False
+
     def test_check_toolset_requirements(self):
         reg = ToolRegistry()
         reg.register(

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -236,7 +236,14 @@ class ToolRegistry:
         return self._snapshot_state()[1]
 
     def _evaluate_toolset_check(self, toolset: str, check: Callable | None) -> bool:
-        """Run a toolset check, treating missing or failing checks as unavailable/available."""
+        """Run a legacy toolset-level check.
+
+        Newer availability surfaces should prefer
+        :meth:`_evaluate_toolset_entries`, because a toolset may mix generally
+        available tools with optional helpers that have their own stricter
+        checks.  This helper remains for backward-compatible metadata that
+        still stores one representative check per toolset.
+        """
         if not check:
             return True
         try:
@@ -244,6 +251,31 @@ class ToolRegistry:
         except Exception:
             logger.debug("Toolset %s check raised; marking unavailable", toolset)
             return False
+
+    def _evaluate_entry_check(self, entry: ToolEntry) -> bool:
+        """Return whether a single tool entry is currently available."""
+        if not entry.check_fn:
+            return True
+        try:
+            return bool(entry.check_fn())
+        except Exception:
+            logger.debug("Tool %s check raised; marking unavailable", entry.name)
+            return False
+
+    def _evaluate_toolset_entries(self, toolset: str, entries: List[ToolEntry]) -> bool:
+        """Return whether any tool in *toolset* is available.
+
+        Toolset-level health is shown in coarse surfaces such as ``doctor`` and
+        startup banners.  A mixed toolset should stay available when its core
+        tools are usable even if optional helpers are not.  For example, the
+        ``terminal`` toolset contains normal ``terminal``/``process`` tools and
+        desktop-only ``read_terminal``/``close_terminal`` helpers; missing the
+        desktop helpers must not make the whole terminal toolset look broken.
+        """
+        toolset_entries = [entry for entry in entries if entry.toolset == toolset]
+        if not toolset_entries:
+            return False
+        return any(self._evaluate_entry_check(entry) for entry in toolset_entries)
 
     def get_entry(self, name: str) -> Optional[ToolEntry]:
         """Return a registered tool entry by name, or None."""
@@ -518,30 +550,27 @@ class ToolRegistry:
         Returns False (rather than crashing) when the check function raises
         an unexpected exception (e.g. network error, missing import, bad config).
         """
-        with self._lock:
-            check = self._toolset_checks.get(toolset)
-        return self._evaluate_toolset_check(toolset, check)
+        entries = self._snapshot_entries()
+        return self._evaluate_toolset_entries(toolset, entries)
 
     def check_toolset_requirements(self) -> Dict[str, bool]:
         """Return ``{toolset: available_bool}`` for every toolset."""
-        entries, toolset_checks = self._snapshot_state()
+        entries = self._snapshot_entries()
         toolsets = sorted({entry.toolset for entry in entries})
         return {
-            toolset: self._evaluate_toolset_check(toolset, toolset_checks.get(toolset))
+            toolset: self._evaluate_toolset_entries(toolset, entries)
             for toolset in toolsets
         }
 
     def get_available_toolsets(self) -> Dict[str, dict]:
         """Return toolset metadata for UI display."""
         toolsets: Dict[str, dict] = {}
-        entries, toolset_checks = self._snapshot_state()
+        entries = self._snapshot_entries()
         for entry in entries:
             ts = entry.toolset
             if ts not in toolsets:
                 toolsets[ts] = {
-                    "available": self._evaluate_toolset_check(
-                        ts, toolset_checks.get(ts)
-                    ),
+                    "available": self._evaluate_toolset_entries(ts, entries),
                     "tools": [],
                     "description": "",
                     "requirements": [],
@@ -579,13 +608,13 @@ class ToolRegistry:
         available = []
         unavailable = []
         seen = set()
-        entries, toolset_checks = self._snapshot_state()
+        entries = self._snapshot_entries()
         for entry in entries:
             ts = entry.toolset
             if ts in seen:
                 continue
             seen.add(ts)
-            if self._evaluate_toolset_check(ts, toolset_checks.get(ts)):
+            if self._evaluate_toolset_entries(ts, entries):
                 available.append(ts)
             else:
                 unavailable.append({


### PR DESCRIPTION
## Summary

Fixes #54820.

Hermes doctor could report the terminal toolset as unavailable even when the core terminal / process tools were usable.

The issue was caused by coarse toolset availability relying on a single representative check function per toolset. In the terminal toolset, optional desktop-only helpers such as read_terminal and close_terminal can fail their checks outside desktop/PTY contexts, which made the whole toolset look unavailable.

This PR updates coarse toolset availability so a toolset remains available when at least one registered tool in that toolset is currently available. Individual tool definitions are still filtered by their own check function, so unavailable optional helpers remain unavailable.

## Tests

    uv run python -m pytest \
      tests/test_model_tools.py \
      tests/tools/test_registry.py \
      tests/tools/test_process_registry.py \
      -q -o 'addopts='

Result:

    162 passed

Manual smoke check:

    HERMES_HOME="$(mktemp -d)" uv run python -m hermes_cli.main doctor | grep -i terminal

Result includes:

    ✓ terminal