### PR TITLE
fix: remove invalid Ruff noqa directive in run_agent.py

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -105,7 +105,7 @@ def _session_source_for_agent(platform: Optional[str]) -> str:
 
 # OpenAI lazy proxy + safe stdio + proxy URL helpers — see agent/process_bootstrap.py.
 # `OpenAI` is re-exported here so `patch("run_agent.OpenAI", ...)` in tests works.
-# The other `# noqa: F401` re-exports below cover names accessed via
+# The other F401 suppressions on re-exports below cover names accessed via
 # `mock.patch("run_agent.<X>")`, `from run_agent import <X>` in production
 # siblings, or the `_ra().<X>` indirection in agent/system_prompt.py — none
 # of which ruff's in-module usage scan can see.


### PR DESCRIPTION
## What does this PR do?

Fixes an invalid Ruff `# noqa: F401` directive embedded in a comment at `run_agent.py:107`. Ruff flagged it on every run:

```
warning: Invalid `# noqa` directive on run_agent.py:107: expected code to consist of uppercase letters followed by digits only (e.g. `F401`)
```

The comment was reworded to avoid triggering the linter while preserving the explanatory intent. No behavioral change.

## Related Issue

Minor hygiene — no open issue, but removes lint noise that could mask real warnings.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: Replace literal `` `# noqa: F401` `` in comment text with `F401 suppressions` to avoid Ruff misinterpreting it as a directive.

## How to Test

1. Run `uv run --extra dev ruff check run_agent.py` — should pass without warning.
2. Run `uv run --extra dev ruff check .` — should pass.
3. No behavioral change — comment-only edit.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `ruff check run_agent.py` and it passes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A