### PR TITLE
docs: document uv run --extra dev for pytest on fresh checkouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1294,6 +1294,12 @@ scripts/run_tests.sh                                  # full suite, CI-parity
 scripts/run_tests.sh tests/gateway/                   # one directory
 scripts/run_tests.sh tests/agent/test_foo.py -k test_x  # one test (file + -k; the runner is file-granular)
 scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
+
+For a fresh uv-managed checkout where dev dependencies are not yet installed,
+you can also run pytest directly through uv:
+
+```bash
+uv run --extra dev python -m pytest tests/ -q
 ```
 
 **Flake policy:** the runner auto-retries a failing test FILE once in a fresh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,9 +205,10 @@ ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
 # via run_tests_parallel.py, worker count auto-scaled); see AGENTS.md
 scripts/run_tests.sh
 
-# Alternative (activate the venv first). The wrapper is still recommended
-# for parity with GitHub Actions before you open a PR:
-pytest tests/ -v
+# Alternative for IDEs or shells where the wrapper is unavailable. The
+# wrapper is still recommended for parity with GitHub Actions before you
+# open a PR. Use `--extra dev` so a fresh uv-managed checkout has pytest:
+uv run --extra dev python -m pytest tests/ -v
 ```
 
 ---

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -137,6 +137,16 @@ ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
 scripts/run_tests.sh
 ```
 
+If the wrapper is unavailable in a local dev shell or IDE, run pytest through
+uv with the dev extra so a fresh checkout has the test dependencies installed:
+
+```bash
+uv run --extra dev python -m pytest tests/ -q
+```
+
+The wrapper remains the preferred final check before opening a PR because it
+matches CI's hermetic environment.
+
 ## Code Style
 
 - **PEP 8** with practical exceptions (no strict line length enforcement)


### PR DESCRIPTION
## What does this PR do?

Documents the `uv run --extra dev python -m pytest` command as an alternative for running tests on fresh `uv`-managed checkouts where dev dependencies are not installed. On such checkouts, running `pytest` directly fails with `No module named pytest` because `pytest` is in the `dev` extra.

## Related Issue

No open issue — DX improvement discovered during Windows development.

## Type of Change

- [x] 📝 Documentation (non-code changes)

## Changes Made

- `CONTRIBUTING.md`: Update "Run tests" section to show `uv run --extra dev` alternative alongside `scripts/run_tests.sh`
- `AGENTS.md`: Add note about `uv run --extra dev` in "Running without the wrapper" section
- `website/docs/developer-guide/contributing.md`: Add fallback command after "Run Tests" section

## How to Test

1. Clone the repo fresh: `git clone https://github.com/NousResearch/hermes-agent.git && cd hermes-agent`
2. Install with uv: `uv sync --extra all --extra dev`
3. Verify the documented command works: `uv run --extra dev python -m pytest tests/test_project_metadata.py -q`
4. Confirm `scripts/run_tests.sh` is still documented as the preferred method

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation (CONTRIBUTING.md, AGENTS.md, docs site)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (docs only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A