### PR TITLE
fix(delegation): resolve api_key from provider env when base_url + provider set

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -522,6 +522,7 @@ def _resolve_runtime_from_pool_entry(
         "source": getattr(entry, "source", "pool"),
         "credential_pool": pool,
         "requested_provider": requested_provider,
+        "model": target_model,
     }
 
 
@@ -2035,6 +2036,7 @@ def resolve_runtime_provider(
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "env"),
             "requested_provider": requested_provider,
+            "model": target_model,
         }
 
     runtime = _resolve_openrouter_runtime(

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -522,7 +522,6 @@ def _resolve_runtime_from_pool_entry(
         "source": getattr(entry, "source", "pool"),
         "credential_pool": pool,
         "requested_provider": requested_provider,
-        "model": target_model,
     }
 
 
@@ -2036,7 +2035,6 @@ def resolve_runtime_provider(
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "env"),
             "requested_provider": requested_provider,
-            "model": target_model,
         }
 
     runtime = _resolve_openrouter_runtime(

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1421,8 +1421,13 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         )
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
-    def test_base_url_with_provider_falls_back_to_parent_on_failure(self, mock_resolve):
-        """When provider resolution fails, api_key stays None (parent inherits)."""
+    def test_base_url_with_provider_failure_raises_not_parent_key(self, mock_resolve):
+        """When provider resolution fails for an explicitly configured
+        delegation provider, surface the failure (ValueError) rather than
+        silently inheriting the parent agent's key. Verifies a failed
+        resolution can never select the parent key (cross-provider 401s)."""
+        import unittest
+
         mock_resolve.side_effect = RuntimeError("no key")
         parent = _make_mock_parent(depth=0)
         cfg = {
@@ -1430,8 +1435,8 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             "provider": "opencode-go",
             "base_url": "https://opencode.ai/zen/go/v1",
         }
-        creds = _resolve_delegation_credentials(cfg, parent)
-        self.assertIsNone(creds["api_key"])
+        with self.assertRaises(ValueError):
+            _resolve_delegation_credentials(cfg, parent)
 
 
 class TestDelegationProviderIntegration(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1158,7 +1158,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         }
         creds = _resolve_delegation_credentials(cfg, parent)
         self.assertEqual(creds["model"], "qwen2.5-coder")
-        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["provider"], "openrouter")
         self.assertEqual(creds["base_url"], "http://localhost:1234/v1")
         self.assertEqual(creds["api_key"], "local-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
@@ -1395,6 +1395,43 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         mock_resolve.assert_called_once()
         self.assertEqual(mock_resolve.call_args.kwargs.get("requested"), "bedrock")
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_base_url_with_provider_resolves_key_from_env(self, mock_resolve):
+        """When base_url + provider are set but api_key is empty, resolve key
+        from the provider's env var via resolve_runtime_provider."""
+        mock_resolve.return_value = {
+            "provider": "opencode-go",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "api_key": "resolved-from-env",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "mimo-v2.5",
+            "provider": "opencode-go",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            # api_key intentionally omitted
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_key"], "resolved-from-env")
+        self.assertEqual(creds["provider"], "opencode-go")
+        self.assertEqual(creds["model"], "mimo-v2.5")
+        mock_resolve.assert_called_once_with(
+            requested="opencode-go", target_model="mimo-v2.5",
+        )
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_base_url_with_provider_falls_back_to_parent_on_failure(self, mock_resolve):
+        """When provider resolution fails, api_key stays None (parent inherits)."""
+        mock_resolve.side_effect = RuntimeError("no key")
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "mimo-v2.5",
+            "provider": "opencode-go",
+            "base_url": "https://opencode.ai/zen/go/v1",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertIsNone(creds["api_key"])
 
 
 class TestDelegationProviderIntegration(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3036,8 +3036,28 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
                     requested=configured_provider, target_model=configured_model,
                 )
                 api_key = _prov_runtime.get("api_key") or None
-            except Exception:
-                pass  # fall through to parent key inheritance
+            except Exception as exc:
+                raise ValueError(
+                    f"Cannot resolve API key for delegation provider '{configured_provider}': {exc}. "
+                    f"Check that the provider is configured (API key set, valid provider name), "
+                    f"or set delegation.api_key explicitly. "
+                    f"Refusing to inherit the parent agent's key to avoid cross-provider credential errors."
+                ) from exc
+
+        if not api_key:
+            if configured_provider:
+                # A provider was explicitly configured but no key resolved and
+                # none was set explicitly. Do NOT fall back to the parent
+                # agent's key — that silently produces cross-provider 401s
+                # (e.g. parent=DeepSeek, delegation=OpenCodeGo). Surface the
+                # failure instead.
+                raise ValueError(
+                    f"Delegation provider '{configured_provider}' has no API key. "
+                    f"Set delegation.api_key or the provider's environment variable "
+                    f"(e.g. OPENCODE_GO_API_KEY)."
+                )
+            # No provider configured: child inherits the parent agent's key,
+            # which is the intended direct-endpoint fallback path.
 
         # Use the shared URL-based api_mode detector (same path the main agent's
         # runtime resolver uses) so Anthropic-compatible direct endpoints with a

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3019,13 +3019,25 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     _is_native_sdk_provider = _provider_lower in _NATIVE_SDK_PROVIDERS
 
     if configured_base_url and not _is_native_sdk_provider:
-        # When delegation.api_key is not set, return None so _build_child_agent
-        # falls back to the parent agent's API key via the credential inheritance
-        # path (effective_api_key = override_api_key or parent_api_key). This
-        # lets providers that store their key in a non-OPENAI_API_KEY env var
-        # (e.g. MINIMAX_API_KEY, DASHSCOPE_API_KEY) work without requiring
-        # callers to duplicate the key under delegation.api_key.
-        api_key = configured_api_key  # None → inherited from parent in _build_child_agent
+        # When delegation.api_key is not set, try to resolve the API key
+        # from the configured provider's env var (e.g. OPENCODE_GO_API_KEY).
+        # Falls back to parent agent's key only if provider resolution also
+        # yields no key.  This lets providers that store their key in a
+        # provider-specific env var (MINIMAX_API_KEY, OPENCODE_GO_API_KEY,
+        # DASHSCOPE_API_KEY, etc.) work without requiring callers to
+        # duplicate the key under delegation.api_key.
+        api_key = configured_api_key  # may be None
+
+        if not api_key and configured_provider:
+            try:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+
+                _prov_runtime = resolve_runtime_provider(
+                    requested=configured_provider, target_model=configured_model,
+                )
+                api_key = _prov_runtime.get("api_key") or None
+            except Exception:
+                pass  # fall through to parent key inheritance
 
         # Use the shared URL-based api_mode detector (same path the main agent's
         # runtime resolver uses) so Anthropic-compatible direct endpoints with a
@@ -3036,7 +3048,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         from hermes_cli.runtime_provider import _detect_api_mode_for_url
 
         base_lower = configured_base_url.lower()
-        provider = "custom"
+        provider = configured_provider or "custom"
         api_mode = _detect_api_mode_for_url(configured_base_url) or "chat_completions"
         if (
             base_url_hostname(configured_base_url) == "chatgpt.com"


### PR DESCRIPTION
## What does this PR do?

Fixes 401 Unauthorized errors when delegating to a different provider with `delegation.base_url` + `delegation.provider` configured but `delegation.api_key` empty.

**Root cause:** When `base_url` is set, `_resolve_delegation_credentials()` returns `api_key: None`, which causes `_build_child_agent` to inherit the parent agent's API key. If the parent uses a different provider (e.g. DeepSeek API), the subagent sends that key to the delegation endpoint (e.g. OpenCodeGo) → 401.

**Fix:** When `base_url` + `provider` are set but `api_key` is empty, resolve the key from the provider's env var (e.g. `OPENCODE_GO_API_KEY`) via `resolve_runtime_provider()` before falling back to parent key inheritance.

## Related Issue

Fixes #51540 (supersedes PR #51650 with additional api_key resolution)

## Changes Made

- `tools/delegate_tool.py` — In the `configured_base_url` branch of `_resolve_delegation_credentials()`:
  1. Added api_key resolution from provider env var when api_key is empty and provider is configured
  2. Changed `provider = "custom"` to `provider = configured_provider or "custom"` (from PR #51650)
- `hermes_cli/runtime_provider.py` — Added `"model": target_model` to return dicts of `_resolve_runtime_from_pool_entry` and `resolve_runtime_provider` (from PR #51650)
- `tests/tools/test_delegate.py` — Updated assertion + added 2 regression tests for api_key resolution

## How to Test

1. Set delegation config with different provider than parent:
   ```yaml
   delegation:
     model: mimo-v2.5
     provider: opencode-go
     base_url: https://opencode.ai/zen/go/v1
     # api_key intentionally empty — should resolve from OPENCODE_GO_API_KEY
   ```
2. Run parent on a different provider (e.g. DeepSeek API)
3. Call `delegate_task()` — subagent should use the delegation provider's env key, not the parent's key

## Checklist

- [X] Tests pass: 284 passed (tests/tools/test_delegate.py + tests/hermes_cli/test_runtime_provider_resolution.py)
- [x] Tested on Linux