### PR TITLE
test: add behavioral contracts for toolset safety boundaries

### DIFF
--- a/tests/tools/test_toolset_contracts.py
+++ b/tests/tools/test_toolset_contracts.py
@@ -1,0 +1,64 @@
+"""Behavioral contracts for built-in toolset safety boundaries.
+
+These tests intentionally guard high-level invariants rather than exact full
+snapshots. Toolsets can grow, but unsafe surfaces must not accidentally gain
+local file/system execution or desktop-only project controls.
+"""
+
+from __future__ import annotations
+
+import model_tools  # noqa: F401  # import triggers built-in tool self-registration
+from tools.registry import registry
+from toolsets import TOOLSETS, _HERMES_CORE_TOOLS, resolve_toolset
+
+LOCAL_SYSTEM_TOOLS = {
+    "terminal", "process", "read_terminal", "close_terminal",
+    "read_file", "write_file", "patch", "search_files",
+    "execute_code", "delegate_task", "cronjob",
+    "computer_use",
+}
+
+DESKTOP_PROJECT_TOOLS = {"project_list", "project_create", "project_switch"}
+
+
+def test_webhook_toolset_stays_local_system_safe():
+    """Webhook prompts may include untrusted third-party text.
+
+    They must not get local file, shell, code-execution, delegation, cron, or
+    desktop-project tools by accident.
+    """
+    tools = set(resolve_toolset("hermes-webhook", include_registry=False))
+    assert tools
+    assert tools.isdisjoint(LOCAL_SYSTEM_TOOLS)
+    assert tools.isdisjoint(DESKTOP_PROJECT_TOOLS)
+
+
+def test_safe_toolset_stays_without_local_system_access():
+    """The named safe posture may include web/media helpers but no local system tools."""
+    tools = set(resolve_toolset("safe", include_registry=False))
+    assert tools
+    assert tools.isdisjoint(LOCAL_SYSTEM_TOOLS)
+    assert tools.isdisjoint(DESKTOP_PROJECT_TOOLS)
+
+
+def test_desktop_project_tools_are_not_in_default_core_bundle():
+    """Project tools only make sense when a GUI can follow workspace changes."""
+    assert set(_HERMES_CORE_TOOLS).isdisjoint(DESKTOP_PROJECT_TOOLS)
+    for platform in ("hermes-cli", "hermes-cron", "hermes-telegram", "hermes-discord"):
+        assert set(resolve_toolset(platform, include_registry=False)).isdisjoint(DESKTOP_PROJECT_TOOLS)
+
+
+def test_static_toolsets_reference_registered_builtin_tools():
+    """Every built-in static tool reference should resolve to a registered tool."""
+    registered = set(registry.get_all_tool_names())
+    referenced = set()
+    for name in TOOLSETS:
+        referenced.update(resolve_toolset(name))
+    assert referenced - registered == set()
+
+
+def test_all_resolved_toolsets_are_deduplicated_and_sorted():
+    """Resolution order should be stable for prompt/tool-schema cacheability."""
+    for name in TOOLSETS:
+        resolved = resolve_toolset(name)
+        assert resolved == sorted(set(resolved)), name


### PR DESCRIPTION
## What does this PR do?

Adds 5 behavioral contract tests that guard the "narrow waist" design invariants for toolsets. These tests prevent accidental expansion of unsafe surfaces — ensuring webhook/safe toolsets don't gain system tools, project tools stay out of default bundles, and all static tool references resolve to registered tools.

## Related Issue

Supports #55139 and #54963 (Shrink the Core: Migrate Non-Essential Tools to Plugins/MCP Servers) by protecting against accidental core expansion.

## Type of Change

- [x] ✅ Tests (adding missing tests or correcting existing tests)

## Changes Made

- `tests/tools/test_toolset_contracts.py`: 5 new tests:
  1. `test_webhook_toolset_stays_local_system_safe` — webhook must not include terminal/file/process/code/delegation/cron/project tools
  2. `test_safe_toolset_stays_without_local_system_access` — safe posture must not include local system tools
  3. `test_desktop_project_tools_are_not_in_default_core_bundle` — project tools must not leak into core or platform toolsets
  4. `test_static_toolsets_reference_registered_builtin_tools` — every static tool reference must resolve to a registered tool
  5. `test_all_resolved_toolsets_are_deduplicated_and_sorted` — resolution order must be stable for cacheability

## How to Test

Run `uv run --extra dev python -m pytest tests/tools/test_toolset_contracts.py -q` — all 5 tests should pass.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `uv run --extra dev python -m pytest tests/tools/test_toolset_contracts.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A