### PR TITLE
fix: clarify pre-update backup disable hint

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8712,8 +8712,11 @@ def _run_pre_update_backup(args) -> None:
 
     print(f"  Saved:    {display_path} ({size_str}, {elapsed:.1f}s)")
     print(f"  Restore:  hermes import {out_path}")
-    print(f"  Disable:  omit --backup (backups are off by default)")
-    print(f"            set updates.pre_update_backup: false in config.yaml")
+    if enabled:
+        print("  Disable:  set updates.pre_update_backup: false in config.yaml")
+    else:
+        print("  Disable:  omit --backup")
+        print("            or set updates.pre_update_backup: false in config.yaml")
     print()
 
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2056,7 +2056,8 @@ class TestRunPreUpdateBackup:
         assert "Saved:" in out
         assert "Restore:" in out
         assert "hermes import" in out
-        assert "Disable:" in out
+        assert "Disable:  omit --backup" in out
+        assert "backups are off by default" not in out
         # Actual backup was created
         backups = list((hermes_home / "backups").glob("pre-update-*.zip"))
         assert len(backups) == 1
@@ -2103,6 +2104,9 @@ class TestRunPreUpdateBackup:
         out = capsys.readouterr().out
         assert "Creating pre-update backup" in out
         assert "Saved:" in out
+        assert "Disable:  set updates.pre_update_backup: false" in out
+        assert "omit --backup" not in out
+        assert "backups are off by default" not in out
         backups = list((hermes_home / "backups").glob("pre-update-*.zip"))
         assert len(backups) == 1
 


### PR DESCRIPTION
## Summary
- make the pre-update backup disable hint match whether backups are enabled by config or only forced with --backup
- remove the misleading 'backups are off by default' wording from the runtime message
- add regression assertions for both config-enabled and --backup-forced paths

## Test Plan
- PYTHONPATH=$PWD /opt/homebrew/Cellar/hermes-agent/2026.6.19/libexec/bin/python -m pytest tests/hermes_cli/test_backup.py -k 'RunPreUpdateBackup' -v --tb=short

Note: scripts/run_tests.sh could not run in this checkout because venv/bin/python has no pytest installed.