### PR TITLE
fix(acp): stop draining queued prompts after cancel

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1641,20 +1641,21 @@ class HermesACPAgent(acp.Agent):
             state.is_running = False
             state.current_prompt_text = ""
 
-        while True:
-            with state.runtime_lock:
-                if not state.queued_prompts:
-                    break
-                next_prompt = state.queued_prompts.pop(0)
-            if conn:
-                await conn.session_update(
-                    session_id,
-                    acp.update_user_message_text(next_prompt),
+        if not cancelled:
+            while True:
+                with state.runtime_lock:
+                    if not state.queued_prompts:
+                        break
+                    next_prompt = state.queued_prompts.pop(0)
+                if conn:
+                    await conn.session_update(
+                        session_id,
+                        acp.update_user_message_text(next_prompt),
+                    )
+                await self.prompt(
+                    prompt=[TextContentBlock(type="text", text=next_prompt)],
+                    session_id=session_id,
                 )
-            await self.prompt(
-                prompt=[TextContentBlock(type="text", text=next_prompt)],
-                session_id=session_id,
-            )
 
         usage = None
         if any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2032,21 +2032,23 @@ class HermesACPAgent(acp.Agent):
             state.is_running = False
             state.current_prompt_text = ""
 
-        if not cancelled:
-            while True:
-                with state.runtime_lock:
-                    if not state.queued_prompts:
-                        break
-                    next_prompt = state.queued_prompts.pop(0)
-                if conn:
-                    await conn.session_update(
-                        session_id,
-                        acp.update_user_message_text(next_prompt),
-                    )
-                await self.prompt(
-                    prompt=[TextContentBlock(type="text", text=next_prompt)],
-                    session_id=session_id,
+        while True:
+            with state.runtime_lock:
+                if (
+                    state.cancel_event
+                    and state.cancel_event.is_set()
+                ) or not state.queued_prompts:
+                    break
+                next_prompt = state.queued_prompts.pop(0)
+            if conn:
+                await conn.session_update(
+                    session_id,
+                    acp.update_user_message_text(next_prompt),
                 )
+            await self.prompt(
+                prompt=[TextContentBlock(type="text", text=next_prompt)],
+                session_id=session_id,
+            )
 
         usage = None
         if any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2032,20 +2032,21 @@ class HermesACPAgent(acp.Agent):
             state.is_running = False
             state.current_prompt_text = ""
 
-        while True:
-            with state.runtime_lock:
-                if not state.queued_prompts:
-                    break
-                next_prompt = state.queued_prompts.pop(0)
-            if conn:
-                await conn.session_update(
-                    session_id,
-                    acp.update_user_message_text(next_prompt),
+        if not cancelled:
+            while True:
+                with state.runtime_lock:
+                    if not state.queued_prompts:
+                        break
+                    next_prompt = state.queued_prompts.pop(0)
+                if conn:
+                    await conn.session_update(
+                        session_id,
+                        acp.update_user_message_text(next_prompt),
+                    )
+                await self.prompt(
+                    prompt=[TextContentBlock(type="text", text=next_prompt)],
+                    session_id=session_id,
                 )
-            await self.prompt(
-                prompt=[TextContentBlock(type="text", text=next_prompt)],
-                session_id=session_id,
-            )
 
         usage = None
         if any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1439,6 +1439,28 @@ class TestPrompt:
 
         assert resp.stop_reason == "cancelled"
 
+    @pytest.mark.asyncio
+    async def test_prompt_cancelled_turn_does_not_drain_queued_prompts(self, agent):
+        """ACP cancel should not auto-run queued work after the current turn stops."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.queued_prompts.append("then run tests")
+        seen_messages = []
+
+        def mock_run(user_message, *args, **kwargs):
+            seen_messages.append(user_message)
+            state.cancel_event.set()
+            return {"final_response": "interrupted", "messages": []}
+
+        state.agent.run_conversation = mock_run
+
+        prompt = [TextContentBlock(type="text", text="start long task")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert resp.stop_reason == "cancelled"
+        assert seen_messages == ["start long task"]
+        assert state.queued_prompts == ["then run tests"]
+
 
 # ---------------------------------------------------------------------------
 # on_connect

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -461,6 +461,28 @@ class TestPrompt:
 
 
 
+    @pytest.mark.asyncio
+    async def test_prompt_cancelled_turn_does_not_drain_queued_prompts(self, agent):
+        """ACP cancel should not auto-run queued work after the current turn stops."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.queued_prompts.append("then run tests")
+        seen_messages = []
+
+        def mock_run(user_message, *args, **kwargs):
+            seen_messages.append(user_message)
+            state.cancel_event.set()
+            return {"final_response": "interrupted", "messages": []}
+
+        state.agent.run_conversation = mock_run
+
+        prompt = [TextContentBlock(type="text", text="start long task")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert resp.stop_reason == "cancelled"
+        assert seen_messages == ["start long task"]
+        assert state.queued_prompts == ["then run tests"]
+
 
 # ---------------------------------------------------------------------------
 # on_connect

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -483,6 +483,30 @@ class TestPrompt:
         assert seen_messages == ["start long task"]
         assert state.queued_prompts == ["then run tests"]
 
+    @pytest.mark.asyncio
+    async def test_cancel_during_first_drained_prompt_preserves_remaining_queue(self, agent):
+        """A recursive queued turn must stop its ancestor's drain loop on cancel."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.queued_prompts.extend(["first queued", "second queued"])
+        seen_messages = []
+
+        def mock_run(user_message, *args, **kwargs):
+            seen_messages.append(user_message)
+            if user_message == "first queued":
+                state.cancel_event.set()
+            return {"final_response": "done", "messages": []}
+
+        state.agent.run_conversation = mock_run
+
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="initial")],
+            session_id=new_resp.session_id,
+        )
+
+        assert seen_messages == ["initial", "first queued"]
+        assert state.queued_prompts == ["second queued"]
+
 
 # ---------------------------------------------------------------------------
 # on_connect


### PR DESCRIPTION
Closes #55183

## What Problem This Solves

ACP cancellation could stop the current turn but still immediately run queued prompts from the same session. After the cancelled turn returned, `prompt()` drained `state.queued_prompts`; the recursive prompt call then cleared `state.cancel_event`, so queued work started even though the user had just cancelled.

## Summary

- skip ACP queue draining when the just-finished turn was cancelled
- leave queued prompts intact instead of deleting user-entered follow-up text
- add a regression test proving a cancelled turn does not auto-run queued work

AI-assisted: found while comparing OpenClaw ACP cancellation hardening fixes against Hermes' ACP adapter lifecycle.

## Evidence

- `uv run --extra acp --extra dev python -m pytest tests\acp\test_server.py -k cancel -q` (6 passed)
- `uv run --extra acp --extra dev python -m pytest tests\acp\test_server.py -q` (81 passed)
- `uv run --extra dev ruff check acp_adapter\server.py tests\acp\test_server.py`
- `git diff --check`
- `python scripts\check-windows-footguns.py --diff origin/main`