### PR TITLE
test: add dynamic schema override immutability contract

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -544,3 +544,35 @@ class TestThreadSafety:
         toolsets = result_holder["value"]
         assert "gated" in toolsets
         assert toolsets["gated"]["available"] is True
+
+
+class TestDynamicSchemaOverrides:
+    """Verify that dynamic schema overrides don't mutate the base schema."""
+
+    def test_dynamic_override_does_not_mutate_base_schema(self):
+        reg = ToolRegistry()
+        base_schema = _make_schema("dyn_tool")
+        base_schema["description"] = "original"
+        override_counter = {"calls": 0}
+
+        def dynamic_overrides():
+            override_counter["calls"] += 1
+            return {"description": "overridden"}
+
+        reg.register(name="dyn_tool", toolset="s", schema=base_schema,
+                     handler=_dummy_handler, dynamic_schema_overrides=dynamic_overrides)
+
+        defs1 = reg.get_definitions({"dyn_tool"})
+        assert defs1[0]["function"]["description"] == "overridden"
+        assert base_schema["description"] == "original"
+        defs2 = reg.get_definitions({"dyn_tool"})
+        assert defs2[0]["function"]["description"] == "overridden"
+        assert override_counter["calls"] == 2
+
+    def test_no_dynamic_override_preserves_base_schema(self):
+        reg = ToolRegistry()
+        base_schema = _make_schema("static_tool")
+        base_schema["description"] = "static desc"
+        reg.register(name="static_tool", toolset="s", schema=base_schema, handler=_dummy_handler)
+        defs = reg.get_definitions({"static_tool"})
+        assert defs[0]["function"]["description"] == "static desc"


### PR DESCRIPTION
## What does this PR do?

Adds 2 tests verifying that `dynamic_schema_overrides` (used by `delegate_task` to reflect runtime config like `max_concurrent_children` and `max_spawn_depth`) don't mutate the base schema dict. This protects prompt/tool-schema cacheability across long-lived sessions.

## Related Issue

Supports #55140 and #54964 (Enforce E2E Testing over Isolated Unit Mocks in Core Agent Tests) by adding behavioral contract tests for the registry.

## Type of Change

- [x] ✅ Tests (adding missing tests or correcting existing tests)

## Changes Made

- `tests/tools/test_registry.py`: 2 new tests in `TestDynamicSchemaOverrides`:
  1. `test_dynamic_override_does_not_mutate_base_schema` — when a dynamic override changes `description`, the original base schema dict must remain unchanged; override must be called on every `get_definitions` call
  2. `test_no_dynamic_override_preserves_base_schema` — tools without dynamic overrides must keep their base schema intact

## How to Test

Run `uv run --extra dev python -m pytest tests/tools/test_registry.py::TestDynamicSchemaOverrides -q` — both tests should pass.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `uv run --extra dev python -m pytest tests/tools/test_registry.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A