### PR TITLE
refactor: extract color/theme utilities from cli.py to hermes_cli/cli_theme.py

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1808,273 +1808,27 @@ def _prune_orphaned_branches(repo_root: str) -> None:
 # - Dim: #B8860B (muted text)
 
 # ANSI building blocks for conversation display
-_ACCENT_ANSI_DEFAULT = "\033[1;38;2;255;215;0m"  # True-color #FFD700 bold — fallback
-_BOLD = "\033[1m"
-_RST = "\033[0m"
-_STREAM_PAD = "    "  # 4-space indent for streamed response text (matches Panel padding)
-
-
-def _hex_to_ansi(hex_color: str, *, bold: bool = False) -> str:
-    """Convert a hex color like '#268bd2' to a true-color ANSI escape.
-
-    Auto-remaps known dark-mode-tuned colors to readable light-mode
-    equivalents when running on a light terminal (see
-    _maybe_remap_for_light_mode + _LIGHT_MODE_REMAP).
-    """
-    hex_color = _maybe_remap_for_light_mode(hex_color)
-    try:
-        r = int(hex_color[1:3], 16)
-        g = int(hex_color[3:5], 16)
-        b = int(hex_color[5:7], 16)
-        prefix = "1;" if bold else ""
-        return f"\033[{prefix}38;2;{r};{g};{b}m"
-    except (ValueError, IndexError):
-        return _ACCENT_ANSI_DEFAULT if bold else "\033[38;2;184;134;11m"
-
-
-# ────────────────────────────────────────────────────────────────────────
-# Light/dark terminal mode detection.
-#
-# Mirrors ui-tui/src/theme.ts detectLightMode().  Used to decide whether
-# to remap "near-white" skin colors (e.g. #FFF8DC banner_text, #B8860B
-# banner_dim) to darker equivalents that are readable on a light
-# Terminal.app / iTerm2 background.
-#
-# Detection priority:
-#   1. HERMES_LIGHT / HERMES_TUI_LIGHT env (true/false) — explicit override
-#   2. HERMES_TUI_THEME=light|dark — explicit theme
-#   3. HERMES_TUI_BACKGROUND=#RRGGBB — explicit bg hint
-#   4. COLORFGBG env (set by xterm/Konsole/urxvt) — bg slot 7/15 = light
-#   5. OSC 11 query (\x1b]11;?\x1b\\) — ask the terminal directly
-#   6. Default: assume dark (matches the legacy Hermes assumption)
-#
-# Cached after first call so we don't query the terminal repeatedly.
-_LIGHT_MODE_CACHE: bool | None = None
-_TRUE_RE = re.compile(r"^(1|true|on|yes|y)$")
-_FALSE_RE = re.compile(r"^(0|false|off|no|n)$")
-_LIGHT_DEFAULT_TERM_PROGRAMS = frozenset()  # Apple_Terminal doesn't reliably indicate; require explicit
-
-
-def _luminance_from_hex(hex_str: str) -> float | None:
-    s = (hex_str or "").strip().lstrip("#")
-    if len(s) == 3:
-        s = "".join(c * 2 for c in s)
-    if len(s) != 6 or not all(c in "0123456789abcdefABCDEF" for c in s):
-        return None
-    try:
-        r, g, b = int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16)
-    except ValueError:
-        return None
-    # Rec.709 luma
-    return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0
-
-
-def _query_osc11_background() -> str | None:
-    """Ask the terminal for its background color via OSC 11.
-
-    Most modern terminals reply with \x1b]11;rgb:RRRR/GGGG/BBBB\x1b\\
-    within a few ms.  We wait up to 100ms total before giving up.
-    Returns "#RRGGBB" or None on timeout / non-tty.
-
-    Skipped over SSH: the round-trip routinely exceeds our 100ms budget, so a
-    late reply lands after prompt_toolkit has grabbed the tty — its payload
-    leaks in as typed text and the BEL terminator reads as Ctrl+G (open
-    editor), trapping the user in a stray editor. Remote sessions fall back to
-    COLORFGBG / env hints / the dark default instead.
-    """
-    if not sys.stdin.isatty() or not sys.stdout.isatty():
-        return None
-    if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
-        return None
-    try:
-        import termios
-        import tty
-        fd = sys.stdin.fileno()
-        old = termios.tcgetattr(fd)
-    except Exception:
-        return None
-    try:
-        try:
-            tty.setcbreak(fd)
-        except Exception:
-            return None
-        try:
-            sys.stdout.write("\x1b]11;?\x1b\\")
-            sys.stdout.flush()
-        except Exception:
-            return None
-        # Read up to ~50ms for the response
-        import select
-        deadline = time.monotonic() + 0.1
-        buf = b""
-        while time.monotonic() < deadline:
-            r, _, _ = select.select([fd], [], [], deadline - time.monotonic())
-            if not r:
-                continue
-            try:
-                chunk = os.read(fd, 64)
-            except OSError:
-                break
-            if not chunk:
-                break
-            buf += chunk
-            if b"\x1b\\" in buf or b"\x07" in buf:
-                break
-        # Parse: \x1b]11;rgb:RRRR/GGGG/BBBB\x1b\\
-        m = re.search(rb"rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)", buf)
-        if not m:
-            return None
-        # Each component is 1-4 hex digits — normalize to 8-bit
-        def norm(h: bytes) -> int:
-            v = int(h, 16)
-            # Scale to 0-255 based on hex length
-            bits = len(h) * 4
-            return (v * 255) // ((1 << bits) - 1) if bits else 0
-        r, g, b = norm(m.group(1)), norm(m.group(2)), norm(m.group(3))
-        return f"#{r:02X}{g:02X}{b:02X}"
-    finally:
-        # TCSAFLUSH discards any unread input as it restores the original
-        # attributes — scrubs a slow/partial OSC 11 reply out of the tty
-        # buffer before prompt_toolkit can read it as keystrokes.
-        try:
-            termios.tcsetattr(fd, termios.TCSAFLUSH, old)
-        except Exception:
-            pass
-
-
-def _detect_light_mode() -> bool:
-    global _LIGHT_MODE_CACHE
-    if _LIGHT_MODE_CACHE is not None:
-        return _LIGHT_MODE_CACHE
-    result = False
-    try:
-        # 1. Explicit env override
-        for var in ("HERMES_LIGHT", "HERMES_TUI_LIGHT"):
-            v = (os.environ.get(var) or "").strip().lower()
-            if _TRUE_RE.match(v):
-                result = True
-                _LIGHT_MODE_CACHE = result
-                return result
-            if _FALSE_RE.match(v):
-                _LIGHT_MODE_CACHE = result
-                return result
-        # 2. Theme hint
-        theme = (os.environ.get("HERMES_TUI_THEME") or "").strip().lower()
-        if theme == "light":
-            result = True
-            _LIGHT_MODE_CACHE = result
-            return result
-        if theme == "dark":
-            _LIGHT_MODE_CACHE = result
-            return result
-        # 3. Explicit bg hex
-        bg_hint = os.environ.get("HERMES_TUI_BACKGROUND") or ""
-        bg_lum = _luminance_from_hex(bg_hint)
-        if bg_lum is not None:
-            result = bg_lum >= 0.5
-            _LIGHT_MODE_CACHE = result
-            return result
-        # 4. COLORFGBG (xterm/Konsole/urxvt)
-        cfgbg = (os.environ.get("COLORFGBG") or "").strip()
-        if cfgbg:
-            last = cfgbg.split(";")[-1] if ";" in cfgbg else cfgbg
-            if last.isdigit():
-                bg = int(last)
-                if bg in {7, 15}:
-                    result = True
-                    _LIGHT_MODE_CACHE = result
-                    return result
-                if 0 <= bg < 16:
-                    _LIGHT_MODE_CACHE = result
-                    return result
-        # 5. OSC 11 query (best-effort, only when stdin/stdout are TTY)
-        bg_color = _query_osc11_background()
-        if bg_color:
-            lum = _luminance_from_hex(bg_color)
-            if lum is not None:
-                result = lum >= 0.5
-                _LIGHT_MODE_CACHE = result
-                return result
-        # 6. TERM_PROGRAM allow-list (currently empty)
-        tp = (os.environ.get("TERM_PROGRAM") or "").strip()
-        if tp in _LIGHT_DEFAULT_TERM_PROGRAMS:
-            result = True
-    except Exception:
-        result = False
-    _LIGHT_MODE_CACHE = result
-    return result
-
-
-# Light-mode equivalents of skin colors that are unreadable on cream
-# Terminal.app backgrounds.  Used by _SkinAwareAnsi to remap colors
-# at resolution time when light mode is detected.
-#
-# IMPORTANT: only remap colors that are used as STANDALONE foregrounds
-# on the terminal's background.  Don't remap colors that are paired
-# with a dark bg (e.g. status bar text on bg:#1a1a2e) — those would
-# become invisible the OTHER direction (dark gray on dark navy).
-_LIGHT_MODE_REMAP: dict[str, str] = {
-    # Original (dark-mode) -> Light-mode replacement (darker, readable)
-    "#FFF8DC": "#1A1A1A",   # cornsilk -> near-black
-    "#FFD700": "#9A6B00",   # gold -> dark goldenrod (readable on cream)
-    "#FFBF00": "#8A5A00",   # amber -> dark amber
-    "#B8860B": "#5C4500",   # dark goldenrod -> deeper brown (more contrast)
-    "#DAA520": "#6B4F00",   # goldenrod -> dark olive
-    "#F1E6CF": "#1A1A1A",   # cream -> near-black
-    "#c9d1d9": "#24292F",   # github-light fg
-    "#EAF7FF": "#0F1B26",   # ice
-    "#F5F5F5": "#1A1A1A",
-    "#FFF0D4": "#1A1A1A",
-    "#CD7F32": "#8A4F1A",   # bronze -> darker bronze
-    "#FFEFB5": "#3A2A00",
-    # NOTE: skipping #C0C0C0/#888888/#555555/#8B8682 — those are
-    # status-bar foregrounds paired with dark navy bg, where dark
-    # remap values would become invisible.
-}
-
-
-def _maybe_remap_for_light_mode(hex_color: str) -> str:
-    """If we're in light mode, remap a dark-mode-tuned color to a
-    higher-contrast equivalent.  No-op in dark mode."""
-    if not _detect_light_mode():
-        return hex_color
-    if not hex_color or not hex_color.startswith("#"):
-        return hex_color
-    # Case-insensitive lookup
-    upper = hex_color.upper()
-    if upper in _LIGHT_MODE_REMAP_UPPER:
-        return _LIGHT_MODE_REMAP_UPPER[upper]
-    return hex_color
-
-
-# Pre-uppercased lookup table for case-insensitive remapping
-_LIGHT_MODE_REMAP_UPPER = {k.upper(): v for k, v in _LIGHT_MODE_REMAP.items()}
-
-
-def _install_skin_light_mode_hook() -> None:
-    """Wrap SkinConfig.get_color at import time so EVERY skin color read goes
-    through the light-mode remap.  Idempotent."""
-    try:
-        from hermes_cli.skin_engine import SkinConfig  # type: ignore[import]
-    except Exception:
-        return
-    if getattr(SkinConfig, "_hermes_light_mode_hook_installed", False):
-        return
-    _orig_get_color = SkinConfig.get_color
-
-    def _wrapped_get_color(self, key, fallback=""):
-        value = _orig_get_color(self, key, fallback)
-        try:
-            return _maybe_remap_for_light_mode(value)
-        except Exception:
-            return value
-
-    SkinConfig.get_color = _wrapped_get_color  # type: ignore[method-assign]
-    SkinConfig._hermes_light_mode_hook_installed = True  # type: ignore[attr-defined]
-
+from hermes_cli.cli_theme import (
+    _ACCENT_ANSI_DEFAULT,
+    _BOLD,
+    _FALSE_RE,
+    _LIGHT_DEFAULT_TERM_PROGRAMS,
+    _LIGHT_MODE_CACHE,
+    _LIGHT_MODE_REMAP,
+    _LIGHT_MODE_REMAP_UPPER,
+    _RST,
+    _STREAM_PAD,
+    _TRUE_RE,
+    _SkinAwareAnsi,
+    _detect_light_mode,
+    _hex_to_ansi,
+    _install_skin_light_mode_hook,
+    _luminance_from_hex,
+    _maybe_remap_for_light_mode,
+    _query_osc11_background,
+)
 
 _install_skin_light_mode_hook()
-
 
 # Prime the light-mode detection cache early (at module load) when
 # we're running interactively so OSC 11 happens before pt grabs the
@@ -2084,43 +1838,6 @@ try:
         _detect_light_mode()
 except Exception:
     pass
-
-
-
-class _SkinAwareAnsi:
-    """Lazy ANSI escape that resolves from the skin engine on first use.
-
-    Acts as a string in f-strings and concatenation.  Call ``.reset()`` to
-    force re-resolution after a ``/skin`` switch.
-    """
-
-    def __init__(self, skin_key: str, fallback_hex: str = "#FFD700", *, bold: bool = False):
-        self._skin_key = skin_key
-        self._fallback_hex = fallback_hex
-        self._bold = bold
-        self._cached: str | None = None
-
-    def __str__(self) -> str:
-        if self._cached is None:
-            try:
-                from hermes_cli.skin_engine import get_active_skin
-                self._cached = _hex_to_ansi(
-                    get_active_skin().get_color(self._skin_key, self._fallback_hex),
-                    bold=self._bold,
-                )
-            except Exception:
-                self._cached = _hex_to_ansi(self._fallback_hex, bold=self._bold)
-        return self._cached
-
-    def __add__(self, other: str) -> str:
-        return str(self) + other
-
-    def __radd__(self, other: str) -> str:
-        return other + str(self)
-
-    def reset(self) -> None:
-        """Clear cache so the next access re-reads the skin."""
-        self._cached = None
 
 
 _ACCENT = _SkinAwareAnsi("response_border", "#FFD700", bold=True)

--- a/hermes_cli/cli_theme.py
+++ b/hermes_cli/cli_theme.py
@@ -1,0 +1,299 @@
+"""CLI color, ANSI escape, and light/dark terminal mode detection.
+
+Extracted from ``cli.py`` to keep that god-file smaller and make theme
+utilities independently testable.  ``cli.py`` imports everything from here
+so all existing call-sites keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+from typing import Dict
+
+# ── ANSI building blocks ─────────────────────────────────────────────
+_ACCENT_ANSI_DEFAULT = "\033[1;38;2;255;215;0m"  # True-color #FFD700 bold — fallback
+_BOLD = "\033[1m"
+_RST = "\033[0m"
+_STREAM_PAD = "    "  # 4-space indent for streamed response text (matches Panel padding)
+
+
+# ── Hex ↔ ANSI ───────────────────────────────────────────────────────
+
+def _hex_to_ansi(hex_color: str, *, bold: bool = False) -> str:
+    """Convert a hex color like '#268bd2' to a true-color ANSI escape.
+
+    Auto-remaps known dark-mode-tuned colors to readable light-mode
+    equivalents when running on a light terminal (see
+    _maybe_remap_for_light_mode + _LIGHT_MODE_REMAP).
+    """
+    hex_color = _maybe_remap_for_light_mode(hex_color)
+    try:
+        r = int(hex_color[1:3], 16)
+        g = int(hex_color[3:5], 16)
+        b = int(hex_color[5:7], 16)
+        prefix = "1;" if bold else ""
+        return f"\033[{prefix}38;2;{r};{g};{b}m"
+    except (ValueError, IndexError):
+        return _ACCENT_ANSI_DEFAULT if bold else "\033[38;2;184;134;11m"
+
+
+# ── Luminance ────────────────────────────────────────────────────────
+
+def _luminance_from_hex(hex_str: str) -> float | None:
+    s = (hex_str or "").strip().lstrip("#")
+    if len(s) == 3:
+        s = "".join(c * 2 for c in s)
+    if len(s) != 6 or not all(c in "0123456789abcdefABCDEF" for c in s):
+        return None
+    try:
+        r, g, b = int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16)
+    except ValueError:
+        return None
+    # Rec.709 luma
+    return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0
+
+
+# ── Light/dark terminal mode detection ───────────────────────────────
+#
+# Mirrors ui-tui/src/theme.ts detectLightMode().  Used to decide whether
+# to remap "near-white" skin colors (e.g. #FFF8DC banner_text, #B8860B
+# banner_dim) to darker equivalents that are readable on a light
+# Terminal.app / iTerm2 background.
+#
+# Detection priority:
+#   1. HERMES_LIGHT / HERMES_TUI_LIGHT env (true/false) — explicit override
+#   2. HERMES_TUI_THEME=light|dark — explicit theme
+#   3. HERMES_TUI_BACKGROUND=#RRGGBB — explicit bg hint
+#   4. COLORFGBG env (set by xterm/Konsole/urxvt) — bg slot 7/15 = light
+#   5. OSC 11 query (\x1b]11;?\x1b\\) — ask the terminal directly
+#   6. Default: assume dark (matches the legacy Hermes assumption)
+#
+# Cached after first call so we don't query the terminal repeatedly.
+_LIGHT_MODE_CACHE: bool | None = None
+_TRUE_RE = re.compile(r"^(1|true|on|yes|y)$")
+_FALSE_RE = re.compile(r"^(0|false|off|no|n)$")
+_LIGHT_DEFAULT_TERM_PROGRAMS = frozenset()  # Apple_Terminal doesn't reliably indicate; require explicit
+
+
+def _query_osc11_background() -> str | None:
+    """Ask the terminal for its background color via OSC 11.
+
+    Most modern terminals reply with \\x1b]11;rgb:RRRR/GGGG/BBBB\\x1b\\\\
+    within a few ms.  We wait up to 100ms total before giving up.
+    Returns "#RRGGBB" or None on timeout / non-tty.
+
+    Skipped over SSH: the round-trip routinely exceeds our 100ms budget, so a
+    late reply lands after prompt_toolkit has grabbed the tty — its payload
+    leaks in as typed text and the BEL terminator reads as Ctrl+G (open
+    editor), trapping the user in a stray editor. Remote sessions fall back to
+    COLORFGBG / env hints / the dark default instead.
+    """
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        return None
+    if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
+        return None
+    try:
+        import termios
+        import tty
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+    except Exception:
+        return None
+    try:
+        try:
+            tty.setcbreak(fd)
+        except Exception:
+            return None
+        try:
+            sys.stdout.write("\x1b]11;?\x1b\\")
+            sys.stdout.flush()
+        except Exception:
+            return None
+        # Read up to ~50ms for the response
+        import select
+        deadline = time.monotonic() + 0.1
+        buf = b""
+        while time.monotonic() < deadline:
+            r, _, _ = select.select([fd], [], [], deadline - time.monotonic())
+            if not r:
+                continue
+            try:
+                chunk = os.read(fd, 64)
+            except OSError:
+                break
+            if not chunk:
+                break
+            buf += chunk
+            if b"\x1b\\" in buf or b"\x07" in buf:
+                break
+        # Parse: \x1b]11;rgb:RRRR/GGGG/BBBB\x1b\\
+        m = re.search(rb"rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)", buf)
+        if not m:
+            return None
+        # Each component is 1-4 hex digits — normalize to 8-bit
+        def norm(h: bytes) -> int:
+            v = int(h, 16)
+            # Scale to 0-255 based on hex length
+            bits = len(h) * 4
+            return (v * 255) // ((1 << bits) - 1) if bits else 0
+        r, g, b = norm(m.group(1)), norm(m.group(2)), norm(m.group(3))
+        return f"#{r:02X}{g:02X}{b:02X}"
+    finally:
+        # TCSAFLUSH discards any unread input as it restores the original
+        # attributes — scrubs a slow/partial OSC 11 reply out of the tty
+        # buffer before prompt_toolkit can read it as keystrokes.
+        try:
+            termios.tcsetattr(fd, termios.TCSAFLUSH, old)
+        except Exception:
+            pass
+
+
+def _detect_light_mode() -> bool:
+    global _LIGHT_MODE_CACHE
+    if _LIGHT_MODE_CACHE is not None:
+        return _LIGHT_MODE_CACHE
+    result = False
+    try:
+        # 1. Explicit env override
+        for var in ("HERMES_LIGHT", "HERMES_TUI_LIGHT"):
+            v = (os.environ.get(var) or "").strip().lower()
+            if _TRUE_RE.match(v):
+                result = True
+                _LIGHT_MODE_CACHE = result
+                return result
+            if _FALSE_RE.match(v):
+                _LIGHT_MODE_CACHE = result
+                return result
+        # 2. Theme hint
+        theme = (os.environ.get("HERMES_TUI_THEME") or "").strip().lower()
+        if theme == "light":
+            result = True
+            _LIGHT_MODE_CACHE = result
+            return result
+        if theme == "dark":
+            _LIGHT_MODE_CACHE = result
+            return result
+        # 3. Explicit bg hex
+        bg_hint = os.environ.get("HERMES_TUI_BACKGROUND") or ""
+        bg_lum = _luminance_from_hex(bg_hint)
+        if bg_lum is not None:
+            result = bg_lum >= 0.5
+            _LIGHT_MODE_CACHE = result
+            return result
+        # 4. COLORFGBG (xterm/Konsole/urxvt)
+        cfgbg = (os.environ.get("COLORFGBG") or "").strip()
+        if cfgbg:
+            last = cfgbg.split(";")[-1] if ";" in cfgbg else cfgbg
+            if last.isdigit():
+                bg = int(last)
+                if bg in {7, 15}:
+                    result = True
+                    _LIGHT_MODE_CACHE = result
+                    return result
+                if 0 <= bg < 16:
+                    _LIGHT_MODE_CACHE = result
+                    return result
+        # 5. OSC 11 query (best-effort, only when stdin/stdout are TTY)
+        bg_color = _query_osc11_background()
+        if bg_color:
+            lum = _luminance_from_hex(bg_color)
+            if lum is not None:
+                result = lum >= 0.5
+                _LIGHT_MODE_CACHE = result
+                return result
+        # 6. TERM_PROGRAM allow-list (currently empty)
+        tp = (os.environ.get("TERM_PROGRAM") or "").strip()
+        if tp in _LIGHT_DEFAULT_TERM_PROGRAMS:
+            result = True
+    except Exception:
+        result = False
+    _LIGHT_MODE_CACHE = result
+    return result
+
+
+# ── Light-mode color remapping ───────────────────────────────────────
+#
+# Light-mode equivalents of skin colors that are unreadable on cream
+# Terminal.app backgrounds.  Used by _SkinAwareAnsi to remap colors
+# at resolution time when light mode is detected.
+#
+# IMPORTANT: only remap colors that are used as STANDALONE foregrounds
+# on the terminal's background.  Don't remap colors that are paired
+# with a dark bg (e.g. status bar text on bg:#1a1a2e) — those would
+# become invisible the OTHER direction (dark gray on dark navy).
+_LIGHT_MODE_REMAP: dict[str, str] = {
+    # Original (dark-mode) -> Light-mode replacement (darker, readable)
+    "#FFF8DC": "#1A1A1A",   # cornsilk -> near-black
+    "#FFD700": "#9A6B00",   # gold -> dark goldenrod (readable on cream)
+    "#FFBF00": "#8A5A00",   # amber -> dark amber
+    "#B8860B": "#5C4500",   # dark goldenrod -> deeper brown (more contrast)
+    "#DAA520": "#6B4F00",   # goldenrod -> dark olive
+    "#F1E6CF": "#1A1A1A",   # cream -> near-black
+    "#c9d1d9": "#24292F",   # github-light fg
+    "#EAF7FF": "#0F1B26",   # ice
+    "#F5F5F5": "#1A1A1A",
+    "#FFF0D4": "#1A1A1A",
+    "#CD7F32": "#8A4F1A",   # bronze -> darker bronze
+    "#FFEFB5": "#3A2A00",
+    # NOTE: skipping #C0C0C0/#888888/#555555/#8B8682 — those are
+    # status-bar foregrounds paired with dark navy bg, where dark
+    # remap values would become invisible.
+}
+
+# Pre-uppercased lookup table for case-insensitive remapping
+_LIGHT_MODE_REMAP_UPPER = {k.upper(): v for k, v in _LIGHT_MODE_REMAP.items()}
+
+
+def _maybe_remap_for_light_mode(hex_color: str) -> str:
+    """If we're in light mode, remap a dark-mode-tuned color to a
+    higher-contrast equivalent.  No-op in dark mode."""
+    if not _detect_light_mode():
+        return hex_color
+    if not hex_color or not hex_color.startswith("#"):
+        return hex_color
+    # Case-insensitive lookup
+    upper = hex_color.upper()
+    if upper in _LIGHT_MODE_REMAP_UPPER:
+        return _LIGHT_MODE_REMAP_UPPER[upper]
+    return hex_color
+
+
+# ── Skin-aware ANSI wrapper ──────────────────────────────────────────
+
+class _SkinAwareAnsi:
+    """Lazy ANSI escape that resolves from the skin engine on first use.
+
+    Acts as a string in f-strings and concatenation.  Call ``.reset()`` to
+    force re-resolution after a ``/skin`` switch.
+    """
+
+    def __init__(self, skin_key: str, fallback_hex: str = "#FFD700", *, bold: bool = False):
+        self._skin_key = skin_key
+        self._fallback_hex = fallback_hex
+        self._bold = bold
+        self._cached: str | None = None
+
+    def __str__(self) -> str:
+        if self._cached is None:
+            try:
+                from hermes_cli.skin_engine import get_active_skin
+                self._cached = _hex_to_ansi(
+                    get_active_skin().get_color(self._skin_key, self._fallback_hex),
+                    bold=self._bold,
+                )
+            except Exception:
+                self._cached = _hex_to_ansi(self._fallback_hex, bold=self._bold)
+        return self._cached
+
+    def __add__(self, other: str) -> str:
+        return str(self) + other
+
+    def __radd__(self, other: str) -> str:
+        return other + str(self)
+
+    def reset(self) -> None:
+        """Clear the cached ANSI escape so the next ``str()`` re-resolves."""
+        self._cached = None

--- a/tests/hermes_cli/test_cli_theme.py
+++ b/tests/hermes_cli/test_cli_theme.py
@@ -1,0 +1,137 @@
+"""Tests for hermes_cli.cli_theme — color, ANSI, and light-mode detection."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+
+def _load_cli_theme_module():
+    """Import hermes_cli/cli_theme.py without triggering cli.py side effects."""
+    import importlib.util
+    from pathlib import Path
+
+    spec = importlib.util.spec_from_file_location(
+        "cli_theme_under_test",
+        Path(__file__).resolve().parents[2] / "hermes_cli" / "cli_theme.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestHexToAnsi:
+    def test_basic_color(self):
+        m = _load_cli_theme_module()
+        result = m._hex_to_ansi("#FF0000")
+        assert "38;2;255;0;0" in result
+
+    def test_bold_prefix(self):
+        m = _load_cli_theme_module()
+        result = m._hex_to_ansi("#FF0000", bold=True)
+        assert result.startswith("\033[1;")
+
+    def test_invalid_hex_returns_default(self):
+        m = _load_cli_theme_module()
+        result = m._hex_to_ansi("invalid")
+        assert result  # should return a fallback, not crash
+
+
+class TestLuminanceFromHex:
+    def test_white(self):
+        m = _load_cli_theme_module()
+        assert m._luminance_from_hex("#FFFFFF") == pytest.approx(1.0, abs=0.01)
+
+    def test_black(self):
+        m = _load_cli_theme_module()
+        assert m._luminance_from_hex("#000000") == pytest.approx(0.0, abs=0.01)
+
+    def test_short_hex(self):
+        m = _load_cli_theme_module()
+        assert m._luminance_from_hex("#FFF") == pytest.approx(1.0, abs=0.01)
+
+    def test_invalid_returns_none(self):
+        m = _load_cli_theme_module()
+        assert m._luminance_from_hex("not-a-color") is None
+
+    def test_empty_returns_none(self):
+        m = _load_cli_theme_module()
+        assert m._luminance_from_hex("") is None
+
+
+class TestDetectLightMode:
+    def test_default_is_dark(self, monkeypatch):
+        m = _load_cli_theme_module()
+        m._LIGHT_MODE_CACHE = None
+        for var in ("HERMES_LIGHT", "HERMES_TUI_LIGHT", "HERMES_TUI_THEME", "HERMES_TUI_BACKGROUND", "COLORFGBG"):
+            monkeypatch.delenv(var, raising=False)
+        assert m._detect_light_mode() is False
+
+    def test_env_override_true(self, monkeypatch):
+        m = _load_cli_theme_module()
+        m._LIGHT_MODE_CACHE = None
+        monkeypatch.setenv("HERMES_LIGHT", "true")
+        assert m._detect_light_mode() is True
+
+    def test_env_override_false(self, monkeypatch):
+        m = _load_cli_theme_module()
+        m._LIGHT_MODE_CACHE = None
+        monkeypatch.setenv("HERMES_LIGHT", "false")
+        assert m._detect_light_mode() is False
+
+    def test_theme_light(self, monkeypatch):
+        m = _load_cli_theme_module()
+        m._LIGHT_MODE_CACHE = None
+        for var in ("HERMES_LIGHT", "HERMES_TUI_LIGHT"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("HERMES_TUI_THEME", "light")
+        assert m._detect_light_mode() is True
+
+    def test_colorfgbg_light(self, monkeypatch):
+        m = _load_cli_theme_module()
+        m._LIGHT_MODE_CACHE = None
+        for var in ("HERMES_LIGHT", "HERMES_TUI_LIGHT", "HERMES_TUI_THEME", "HERMES_TUI_BACKGROUND"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("COLORFGBG", "0;15")  # bg=15 = light
+        # Patch _query_osc11_background to avoid terminal I/O in tests
+        monkeypatch.setattr(m, "_query_osc11_background", lambda: None)
+        assert m._detect_light_mode() is True
+
+
+class TestMaybeRemapForLightMode:
+    def test_no_remap_in_dark_mode(self, monkeypatch):
+        m = _load_cli_theme_module()
+        m._LIGHT_MODE_CACHE = False
+        assert m._maybe_remap_for_light_mode("#FFF8DC") == "#FFF8DC"
+
+    def test_remap_in_light_mode(self, monkeypatch):
+        m = _load_cli_theme_module()
+        m._LIGHT_MODE_CACHE = True
+        assert m._maybe_remap_for_light_mode("#FFF8DC") == "#1A1A1A"
+
+    def test_remap_case_insensitive(self, monkeypatch):
+        m = _load_cli_theme_module()
+        m._LIGHT_MODE_CACHE = True
+        assert m._maybe_remap_for_light_mode("#fff8dc") == "#1A1A1A"
+
+    def test_unknown_color_unchanged(self, monkeypatch):
+        m = _load_cli_theme_module()
+        m._LIGHT_MODE_CACHE = True
+        assert m._maybe_remap_for_light_mode("#123456") == "#123456"
+
+
+class TestConstants:
+    def test_bold_is_ansi(self):
+        m = _load_cli_theme_module()
+        assert m._BOLD == "\033[1m"
+
+    def test_rst_is_ansi(self):
+        m = _load_cli_theme_module()
+        assert m._RST == "\033[0m"
+
+    def test_light_remap_table_is_non_empty(self):
+        m = _load_cli_theme_module()
+        assert len(m._LIGHT_MODE_REMAP) > 5


### PR DESCRIPTION
## What does this PR do?

Extracts ~300 lines of color, ANSI escape, and light/dark terminal mode detection code from `cli.py` (15,687 lines) into a focused `hermes_cli/cli_theme.py` module. This is the first step toward reducing the `cli.py` god-file, following the project guidance: *"Extracting a multi-thousand-line cluster out of cli.py into a focused mixin or module is wanted work."*

## Related Issue

Addresses #55136 and #54960 (Refactor cli.py God-File — UI & Commands Extraction).

## Type of Change

- [x] ♻️ Refactor (non-breaking change that restructures existing code)

## Changes Made

- `hermes_cli/cli_theme.py`: NEW — color/theme utilities extracted from `cli.py`:
  - `_hex_to_ansi`, `_luminance_from_hex`, `_query_osc11_background`
  - `_detect_light_mode`, `_maybe_remap_for_light_mode`, `_install_skin_light_mode_hook`
  - `_SkinAwareAnsi` class
  - Constants: `_BOLD`, `_RST`, `_ACCENT_ANSI_DEFAULT`, `_STREAM_PAD`
  - Light-mode remap table and lookup cache
- `cli.py`: Replace inline definitions with imports from `hermes_cli.cli_theme`. Side effects (`_install_skin_light_mode_hook`, light-mode cache prime) stay in `cli.py`.
- `tests/hermes_cli/test_cli_theme.py`: NEW — 20 tests covering hex-to-ANSI, luminance, light mode detection, color remapping, and constants.

## How to Test

1. Run `uv run --extra dev python -m pytest tests/hermes_cli/test_cli_theme.py -q` — all 20 tests should pass
2. Run `uv run --extra dev ruff check cli.py hermes_cli/cli_theme.py` — should pass
3. Run `hermes` and verify colors/theme still work correctly
4. Test light mode: `HERMES_LIGHT=true hermes chat -q "test"` — colors should be remapped

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `uv run --extra dev ruff check .` and it passes
- [x] I've run `uv run --extra dev python -m pytest tests/hermes_cli/test_cli_theme.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — `_query_osc11_background` is POSIX-only with safe fallback
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A