### PR TITLE
docs: fix cron invariant — 600s inactivity timeout, not 3-minute hard interrupt

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -734,7 +734,8 @@ the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
   job), `context_from` (chain job A's output into job B), `workdir`
   (run in a specific dir with its `AGENTS.md` / `CLAUDE.md` loaded),
   multi-platform delivery.
-- **Invariants:** 3-minute hard interrupt per run, `.tick.lock` file
+- **Invariants:** 600s inactivity timeout per run (actively-working jobs can
+  run for hours; override via `HERMES_CRON_TIMEOUT`, 0 = unlimited), `.tick.lock` file
   prevents duplicate ticks across processes, cron sessions pass
   `skip_memory=True` by default, and cron deliveries are framed with a
   header/footer instead of being mirrored into the target gateway


### PR DESCRIPTION
## What does this PR do?

Fixes the bundled `hermes-agent` skill's cron invariant description. The skill stated a **"3-minute hard interrupt per run"** but the scheduler actually uses a **600s (10-minute) inactivity timeout**. Actively-working jobs can run for hours. Also documents the `HERMES_CRON_TIMEOUT` env var override.

## Related Issue

Fixes #55038

## Type of Change

- [x] 📝 Documentation (non-code changes)

## Changes Made

- `skills/autonomous-ai-agents/hermes-agent/SKILL.md`: Update cron invariant from "3-minute hard interrupt per run" to "600s inactivity timeout per run (actively-working jobs can run for hours; override via `HERMES_CRON_TIMEOUT`, 0 = unlimited)"

## How to Test

1. Read the skill file and verify the updated text
2. Verify against `cron/scheduler.py` source code:
   ```python
   # Run the agent with an *inactivity*-based timeout: the job can run
   # for hours if it's actively calling tools / receiving stream tokens,
   # but a hung API call or stuck tool with no activity for the configured
   # duration is caught and killed. Default 600s (10 min inactivity);
   # override via HERMES_CRON_TIMEOUT env var. 0 = unlimited.
   ```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've verified the fix against `cron/scheduler.py` source code

### Documentation & Housekeeping
- [x] I've updated relevant documentation (SKILL.md)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A