### PR TITLE
fix(browser): bound provider session JSON reads

### DIFF
--- a/plugins/browser/_response.py
+++ b/plugins/browser/_response.py
@@ -1,0 +1,75 @@
+"""Bounded response readers for browser provider control-plane JSON."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import requests
+
+MAX_BROWSER_PROVIDER_JSON_BYTES = 16 * 1024 * 1024
+MAX_BROWSER_PROVIDER_ERROR_BYTES = 64 * 1024
+
+
+def _declared_content_length(response: requests.Response) -> int | None:
+    raw = response.headers.get("Content-Length") or response.headers.get("content-length")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def read_browser_provider_response_bytes(
+    response: requests.Response,
+    *,
+    label: str,
+    max_bytes: int = MAX_BROWSER_PROVIDER_JSON_BYTES,
+) -> bytes:
+    """Read a streamed ``requests`` response with an explicit byte cap."""
+
+    declared = _declared_content_length(response)
+    if declared is not None and declared > max_bytes:
+        response.close()
+        raise RuntimeError(f"{label}: response exceeds {max_bytes} bytes")
+
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > max_bytes:
+            response.close()
+            raise RuntimeError(f"{label}: response exceeds {max_bytes} bytes")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def read_browser_provider_json(
+    response: requests.Response,
+    *,
+    label: str,
+    max_bytes: int = MAX_BROWSER_PROVIDER_JSON_BYTES,
+) -> Any:
+    raw = read_browser_provider_response_bytes(
+        response,
+        label=label,
+        max_bytes=max_bytes,
+    )
+    return json.loads(raw.decode("utf-8"))
+
+
+def read_browser_provider_text(
+    response: requests.Response,
+    *,
+    label: str,
+    max_bytes: int = MAX_BROWSER_PROVIDER_ERROR_BYTES,
+) -> str:
+    raw = read_browser_provider_response_bytes(
+        response,
+        label=label,
+        max_bytes=max_bytes,
+    )
+    return raw.decode("utf-8", errors="replace")

--- a/plugins/browser/_response.py
+++ b/plugins/browser/_response.py
@@ -1,0 +1,85 @@
+"""Bounded response readers for browser provider control-plane JSON."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import requests
+
+MAX_BROWSER_PROVIDER_JSON_BYTES = 16 * 1024 * 1024
+MAX_BROWSER_PROVIDER_ERROR_BYTES = 64 * 1024
+
+
+class BrowserProviderResponseTooLarge(RuntimeError):
+    """Raised when a browser-provider control response exceeds its byte cap."""
+
+
+def _declared_content_length(response: requests.Response) -> int | None:
+    raw = response.headers.get("Content-Length") or response.headers.get(
+        "content-length"
+    )
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def read_browser_provider_response_bytes(
+    response: requests.Response,
+    *,
+    label: str,
+    max_bytes: int = MAX_BROWSER_PROVIDER_JSON_BYTES,
+) -> bytes:
+    """Read a streamed ``requests`` response with an explicit byte cap."""
+
+    declared = _declared_content_length(response)
+    if declared is not None and declared > max_bytes:
+        response.close()
+        raise BrowserProviderResponseTooLarge(
+            f"{label}: response exceeds {max_bytes} bytes"
+        )
+
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > max_bytes:
+            response.close()
+            raise BrowserProviderResponseTooLarge(
+                f"{label}: response exceeds {max_bytes} bytes"
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def read_browser_provider_json(
+    response: requests.Response,
+    *,
+    label: str,
+    max_bytes: int = MAX_BROWSER_PROVIDER_JSON_BYTES,
+) -> Any:
+    raw = read_browser_provider_response_bytes(
+        response,
+        label=label,
+        max_bytes=max_bytes,
+    )
+    return json.loads(raw.decode("utf-8"))
+
+
+def read_browser_provider_text(
+    response: requests.Response,
+    *,
+    label: str,
+    max_bytes: int = MAX_BROWSER_PROVIDER_ERROR_BYTES,
+) -> str:
+    raw = read_browser_provider_response_bytes(
+        response,
+        label=label,
+        max_bytes=max_bytes,
+    )
+    return raw.decode("utf-8", errors="replace")

--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -28,6 +28,7 @@ Auth env vars (one of)::
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import threading
@@ -37,6 +38,10 @@ from typing import Any, Dict, Optional
 import requests
 
 from agent.browser_provider import BrowserProvider
+from plugins.browser._response import (
+    read_browser_provider_json,
+    read_browser_provider_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +73,7 @@ def _clear_pending_create_key(task_id: str) -> None:
         _pending_create_keys.pop(task_id, None)
 
 
-def _should_preserve_pending_create_key(response: requests.Response) -> bool:
+def _should_preserve_pending_create_key(status_code: int, payload: object) -> bool:
     """Decide whether to keep the idempotency key after a failed create.
 
     Preserve the key when the failure looks retryable (5xx) OR when the
@@ -79,15 +84,10 @@ def _should_preserve_pending_create_key(response: requests.Response) -> bool:
     Drop the key on any other 4xx (auth failure, bad request, etc.) — those
     won't succeed by being retried.
     """
-    if response.status_code >= 500:
+    if status_code >= 500:
         return True
 
-    if response.status_code != 409:
-        return False
-
-    try:
-        payload = response.json()
-    except Exception:
+    if status_code != 409:
         return False
 
     if not isinstance(payload, dict):
@@ -211,6 +211,7 @@ class BrowserUseBrowserProvider(BrowserProvider):
                 headers=headers,
                 json=payload,
                 timeout=30,
+                stream=True,
             )
         except requests.RequestException as exc:
             # Managed mode: propagate raw so callers can retry with the
@@ -222,21 +223,42 @@ class BrowserUseBrowserProvider(BrowserProvider):
                 f"Browser Use API connection failed: {exc}"
             ) from exc
 
-        if not response.ok:
-            if managed_mode and not _should_preserve_pending_create_key(response):
-                _clear_pending_create_key(task_id)
-            raise RuntimeError(
-                f"Failed to create Browser Use session: "
-                f"{response.status_code} {response.text}"
-            )
+        try:
+            if not response.ok:
+                try:
+                    error_text = read_browser_provider_text(
+                        response,
+                        label="Browser Use session create error",
+                    )
+                except RuntimeError as exc:
+                    error_text = str(exc)
+                try:
+                    error_payload: object = json.loads(error_text)
+                except Exception:
+                    error_payload = None
+                if managed_mode and not _should_preserve_pending_create_key(
+                    response.status_code,
+                    error_payload,
+                ):
+                    _clear_pending_create_key(task_id)
+                raise RuntimeError(
+                    f"Failed to create Browser Use session: "
+                    f"{response.status_code} {error_text}"
+                )
 
-        session_data = response.json()
-        if managed_mode:
-            _clear_pending_create_key(task_id)
+            external_call_id = (
+                response.headers.get("x-external-call-id") if managed_mode else None
+            )
+            session_data = read_browser_provider_json(
+                response,
+                label="Browser Use session create",
+            )
+            if managed_mode:
+                _clear_pending_create_key(task_id)
+        finally:
+            response.close()
+
         session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
-        external_call_id = (
-            response.headers.get("x-external-call-id") if managed_mode else None
-        )
 
         logger.info("Created Browser Use session %s", session_name)
 

--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -28,6 +28,7 @@ Auth env vars (one of)::
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import threading
@@ -38,6 +39,11 @@ import requests
 
 from agent.browser_provider import BrowserProvider
 from agent.secret_scope import get_secret
+from plugins.browser._response import (
+    BrowserProviderResponseTooLarge,
+    read_browser_provider_json,
+    read_browser_provider_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +75,12 @@ def _clear_pending_create_key(task_id: str) -> None:
         _pending_create_keys.pop(task_id, None)
 
 
-def _should_preserve_pending_create_key(response: requests.Response) -> bool:
+def _should_preserve_pending_create_key(
+    status_code: int,
+    payload: object,
+    *,
+    body_was_capped: bool = False,
+) -> bool:
     """Decide whether to keep the idempotency key after a failed create.
 
     Preserve the key when the failure looks retryable (5xx) OR when the
@@ -80,16 +91,14 @@ def _should_preserve_pending_create_key(response: requests.Response) -> bool:
     Drop the key on any other 4xx (auth failure, bad request, etc.) — those
     won't succeed by being retried.
     """
-    if response.status_code >= 500:
+    if status_code >= 500:
         return True
 
-    if response.status_code != 409:
+    if status_code != 409:
         return False
 
-    try:
-        payload = response.json()
-    except Exception:
-        return False
+    if body_was_capped:
+        return True
 
     if not isinstance(payload, dict):
         return False
@@ -212,6 +221,7 @@ class BrowserUseBrowserProvider(BrowserProvider):
                 headers=headers,
                 json=payload,
                 timeout=30,
+                stream=True,
             )
         except requests.RequestException as exc:
             # Managed mode: propagate raw so callers can retry with the
@@ -223,21 +233,45 @@ class BrowserUseBrowserProvider(BrowserProvider):
                 f"Browser Use API connection failed: {exc}"
             ) from exc
 
-        if not response.ok:
-            if managed_mode and not _should_preserve_pending_create_key(response):
-                _clear_pending_create_key(task_id)
-            raise RuntimeError(
-                f"Failed to create Browser Use session: "
-                f"{response.status_code} {response.text}"
-            )
+        try:
+            if not response.ok:
+                body_was_capped = False
+                try:
+                    error_text = read_browser_provider_text(
+                        response,
+                        label="Browser Use session create error",
+                    )
+                except BrowserProviderResponseTooLarge as exc:
+                    error_text = str(exc)
+                    body_was_capped = True
+                try:
+                    error_payload: object = json.loads(error_text)
+                except Exception:
+                    error_payload = None
+                if managed_mode and not _should_preserve_pending_create_key(
+                    response.status_code,
+                    error_payload,
+                    body_was_capped=body_was_capped,
+                ):
+                    _clear_pending_create_key(task_id)
+                raise RuntimeError(
+                    f"Failed to create Browser Use session: "
+                    f"{response.status_code} {error_text}"
+                )
 
-        session_data = response.json()
-        if managed_mode:
-            _clear_pending_create_key(task_id)
+            external_call_id = (
+                response.headers.get("x-external-call-id") if managed_mode else None
+            )
+            session_data = read_browser_provider_json(
+                response,
+                label="Browser Use session create",
+            )
+            if managed_mode:
+                _clear_pending_create_key(task_id)
+        finally:
+            response.close()
+
         session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
-        external_call_id = (
-            response.headers.get("x-external-call-id") if managed_mode else None
-        )
 
         logger.info("Created Browser Use session %s", session_name)
 

--- a/plugins/browser/browserbase/provider.py
+++ b/plugins/browser/browserbase/provider.py
@@ -39,6 +39,10 @@ from typing import Any, Dict, Optional
 import requests
 
 from agent.browser_provider import BrowserProvider
+from plugins.browser._response import (
+    read_browser_provider_json,
+    read_browser_provider_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +149,7 @@ class BrowserbaseBrowserProvider(BrowserProvider):
                 headers=headers,
                 json=session_config,
                 timeout=30,
+                stream=True,
             )
 
             proxies_fallback = False
@@ -159,11 +164,13 @@ class BrowserbaseBrowserProvider(BrowserProvider):
                         "Sessions may timeout during long operations."
                     )
                     session_config.pop("keepAlive", None)
+                    response.close()
                     response = requests.post(
                         f"{config['base_url']}/v1/sessions",
                         headers=headers,
                         json=session_config,
                         timeout=30,
+                        stream=True,
                     )
 
                 if response.status_code == 402 and enable_proxies:
@@ -173,24 +180,40 @@ class BrowserbaseBrowserProvider(BrowserProvider):
                         "Bot detection may be less effective."
                     )
                     session_config.pop("proxies", None)
+                    response.close()
                     response = requests.post(
                         f"{config['base_url']}/v1/sessions",
                         headers=headers,
                         json=session_config,
                         timeout=30,
+                        stream=True,
                     )
         except requests.RequestException as exc:
             raise RuntimeError(
                 f"Browserbase API connection failed: {exc}"
             ) from exc
 
-        if not response.ok:
-            raise RuntimeError(
-                f"Failed to create Browserbase session: "
-                f"{response.status_code} {response.text}"
-            )
+        try:
+            if not response.ok:
+                try:
+                    error_text = read_browser_provider_text(
+                        response,
+                        label="Browserbase session create error",
+                    )
+                except RuntimeError as exc:
+                    error_text = str(exc)
+                raise RuntimeError(
+                    f"Failed to create Browserbase session: "
+                    f"{response.status_code} {error_text}"
+                )
 
-        session_data = response.json()
+            session_data = read_browser_provider_json(
+                response,
+                label="Browserbase session create",
+            )
+        finally:
+            response.close()
+
         session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
 
         if enable_proxies and not proxies_fallback:

--- a/plugins/browser/browserbase/provider.py
+++ b/plugins/browser/browserbase/provider.py
@@ -40,6 +40,10 @@ import requests
 
 from agent.browser_provider import BrowserProvider
 from agent.secret_scope import get_secret
+from plugins.browser._response import (
+    read_browser_provider_json,
+    read_browser_provider_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +150,7 @@ class BrowserbaseBrowserProvider(BrowserProvider):
                 headers=headers,
                 json=session_config,
                 timeout=30,
+                stream=True,
             )
 
             proxies_fallback = False
@@ -160,11 +165,13 @@ class BrowserbaseBrowserProvider(BrowserProvider):
                         "Sessions may timeout during long operations."
                     )
                     session_config.pop("keepAlive", None)
+                    response.close()
                     response = requests.post(
                         f"{config['base_url']}/v1/sessions",
                         headers=headers,
                         json=session_config,
                         timeout=30,
+                        stream=True,
                     )
 
                 if response.status_code == 402 and enable_proxies:
@@ -174,24 +181,40 @@ class BrowserbaseBrowserProvider(BrowserProvider):
                         "Bot detection may be less effective."
                     )
                     session_config.pop("proxies", None)
+                    response.close()
                     response = requests.post(
                         f"{config['base_url']}/v1/sessions",
                         headers=headers,
                         json=session_config,
                         timeout=30,
+                        stream=True,
                     )
         except requests.RequestException as exc:
             raise RuntimeError(
                 f"Browserbase API connection failed: {exc}"
             ) from exc
 
-        if not response.ok:
-            raise RuntimeError(
-                f"Failed to create Browserbase session: "
-                f"{response.status_code} {response.text}"
-            )
+        try:
+            if not response.ok:
+                try:
+                    error_text = read_browser_provider_text(
+                        response,
+                        label="Browserbase session create error",
+                    )
+                except RuntimeError as exc:
+                    error_text = str(exc)
+                raise RuntimeError(
+                    f"Failed to create Browserbase session: "
+                    f"{response.status_code} {error_text}"
+                )
 
-        session_data = response.json()
+            session_data = read_browser_provider_json(
+                response,
+                label="Browserbase session create",
+            )
+        finally:
+            response.close()
+
         session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
 
         if enable_proxies and not proxies_fallback:

--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -34,6 +34,10 @@ from typing import Any, Dict
 import requests
 
 from agent.browser_provider import BrowserProvider
+from plugins.browser._response import (
+    read_browser_provider_json,
+    read_browser_provider_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -91,19 +95,34 @@ class FirecrawlBrowserProvider(BrowserProvider):
                 headers=self._headers(),
                 json=body,
                 timeout=30,
+                stream=True,
             )
         except requests.RequestException as exc:
             raise RuntimeError(
                 f"Firecrawl API connection failed: {exc}"
             ) from exc
 
-        if not response.ok:
-            raise RuntimeError(
-                f"Failed to create Firecrawl browser session: "
-                f"{response.status_code} {response.text}"
-            )
+        try:
+            if not response.ok:
+                try:
+                    error_text = read_browser_provider_text(
+                        response,
+                        label="Firecrawl browser session create error",
+                    )
+                except RuntimeError as exc:
+                    error_text = str(exc)
+                raise RuntimeError(
+                    f"Failed to create Firecrawl browser session: "
+                    f"{response.status_code} {error_text}"
+                )
 
-        data = response.json()
+            data = read_browser_provider_json(
+                response,
+                label="Firecrawl browser session create",
+            )
+        finally:
+            response.close()
+
         session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
 
         logger.info("Created Firecrawl browser session %s", session_name)

--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -35,6 +35,10 @@ import requests
 
 from agent.browser_provider import BrowserProvider
 from agent.secret_scope import get_secret
+from plugins.browser._response import (
+    read_browser_provider_json,
+    read_browser_provider_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,19 +96,34 @@ class FirecrawlBrowserProvider(BrowserProvider):
                 headers=self._headers(),
                 json=body,
                 timeout=30,
+                stream=True,
             )
         except requests.RequestException as exc:
             raise RuntimeError(
                 f"Firecrawl API connection failed: {exc}"
             ) from exc
 
-        if not response.ok:
-            raise RuntimeError(
-                f"Failed to create Firecrawl browser session: "
-                f"{response.status_code} {response.text}"
-            )
+        try:
+            if not response.ok:
+                try:
+                    error_text = read_browser_provider_text(
+                        response,
+                        label="Firecrawl browser session create error",
+                    )
+                except RuntimeError as exc:
+                    error_text = str(exc)
+                raise RuntimeError(
+                    f"Failed to create Firecrawl browser session: "
+                    f"{response.status_code} {error_text}"
+                )
 
-        data = response.json()
+            data = read_browser_provider_json(
+                response,
+                label="Firecrawl browser session create",
+            )
+        finally:
+            response.close()
+
         session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
 
         logger.info("Created Firecrawl browser session %s", session_name)

--- a/tests/plugins/browser/test_browser_provider_plugins.py
+++ b/tests/plugins/browser/test_browser_provider_plugins.py
@@ -23,6 +23,8 @@ PR #25182.
 """
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 
@@ -53,6 +55,40 @@ def _ensure_plugins_loaded() -> None:
     from hermes_cli.plugins import _ensure_plugins_discovered
 
     _ensure_plugins_discovered()
+
+
+class _FakeStreamResponse:
+    def __init__(
+        self,
+        body: bytes = b"{}",
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        chunks: list[bytes] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._chunks = chunks if chunks is not None else [body]
+        self.closed = False
+        self.iter_content_calls: list[int] = []
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 400
+
+    @property
+    def text(self) -> str:
+        raise AssertionError("unbounded response.text should not be used")
+
+    def json(self) -> dict[str, Any]:
+        raise AssertionError("unbounded response.json() should not be used")
+
+    def iter_content(self, chunk_size: int):
+        self.iter_content_calls.append(chunk_size)
+        yield from self._chunks
+
+    def close(self) -> None:
+        self.closed = True
 
 
 # ---------------------------------------------------------------------------
@@ -377,3 +413,124 @@ class TestPickerIntegration:
 
         for row in _plugin_browser_providers():
             assert row.get("browser_plugin_name") == row.get("browser_provider")
+
+
+# ---------------------------------------------------------------------------
+# Bounded session-create response reads
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedSessionCreateResponses:
+    def test_json_reader_rejects_oversized_content_length(self) -> None:
+        from plugins.browser._response import read_browser_provider_json
+
+        response = _FakeStreamResponse(
+            b'{"id":"session"}',
+            headers={"Content-Length": "11"},
+        )
+
+        with pytest.raises(RuntimeError, match="test reader: response exceeds 10 bytes"):
+            read_browser_provider_json(response, label="test reader", max_bytes=10)
+
+        assert response.closed is True
+        assert response.iter_content_calls == []
+
+    def test_json_reader_rejects_stream_overflow(self) -> None:
+        from plugins.browser._response import read_browser_provider_response_bytes
+
+        response = _FakeStreamResponse(chunks=[b"123456", b"789012"])
+
+        with pytest.raises(RuntimeError, match="test reader: response exceeds 10 bytes"):
+            read_browser_provider_response_bytes(
+                response,
+                label="test reader",
+                max_bytes=10,
+            )
+
+        assert response.closed is True
+        assert response.iter_content_calls == [64 * 1024]
+
+    def test_browser_use_create_session_streams_and_caps_json(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from plugins.browser.browser_use.provider import BrowserUseBrowserProvider
+
+        monkeypatch.setenv("BROWSER_USE_API_KEY", "key")
+        calls: list[dict[str, Any]] = []
+        response = _FakeStreamResponse(
+            b'{"id":"bu-1","cdpUrl":"ws://browser-use"}',
+        )
+
+        def fake_post(*_args: Any, **kwargs: Any) -> _FakeStreamResponse:
+            calls.append(kwargs)
+            return response
+
+        monkeypatch.setattr(
+            "plugins.browser.browser_use.provider.requests.post",
+            fake_post,
+        )
+
+        result = BrowserUseBrowserProvider().create_session("task")
+
+        assert calls[0]["stream"] is True
+        assert response.closed is True
+        assert result["bb_session_id"] == "bu-1"
+        assert result["cdp_url"] == "ws://browser-use"
+
+    def test_browserbase_create_session_streams_and_caps_json(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from plugins.browser.browserbase.provider import BrowserbaseBrowserProvider
+
+        monkeypatch.setenv("BROWSERBASE_API_KEY", "key")
+        monkeypatch.setenv("BROWSERBASE_PROJECT_ID", "project")
+        calls: list[dict[str, Any]] = []
+        response = _FakeStreamResponse(
+            b'{"id":"bb-1","connectUrl":"ws://browserbase"}',
+        )
+
+        def fake_post(*_args: Any, **kwargs: Any) -> _FakeStreamResponse:
+            calls.append(kwargs)
+            return response
+
+        monkeypatch.setattr(
+            "plugins.browser.browserbase.provider.requests.post",
+            fake_post,
+        )
+
+        result = BrowserbaseBrowserProvider().create_session("task")
+
+        assert calls[0]["stream"] is True
+        assert response.closed is True
+        assert result["bb_session_id"] == "bb-1"
+        assert result["cdp_url"] == "ws://browserbase"
+
+    def test_firecrawl_create_session_streams_and_caps_json(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from plugins.browser.firecrawl.provider import FirecrawlBrowserProvider
+
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "key")
+        calls: list[dict[str, Any]] = []
+        response = _FakeStreamResponse(
+            b'{"id":"fc-1","cdpUrl":"ws://firecrawl"}',
+        )
+
+        def fake_post(*_args: Any, **kwargs: Any) -> _FakeStreamResponse:
+            calls.append(kwargs)
+            return response
+
+        monkeypatch.setattr(
+            "plugins.browser.firecrawl.provider.requests.post",
+            fake_post,
+        )
+
+        result = FirecrawlBrowserProvider().create_session("task")
+
+        assert calls[0]["stream"] is True
+        assert response.closed is True
+        assert result["bb_session_id"] == "fc-1"
+        assert result["cdp_url"] == "ws://firecrawl"

--- a/tests/plugins/browser/test_browser_provider_plugins.py
+++ b/tests/plugins/browser/test_browser_provider_plugins.py
@@ -23,6 +23,8 @@ PR #25182.
 """
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 
@@ -53,6 +55,40 @@ def _ensure_plugins_loaded() -> None:
     from hermes_cli.plugins import _ensure_plugins_discovered
 
     _ensure_plugins_discovered()
+
+
+class _FakeStreamResponse:
+    def __init__(
+        self,
+        body: bytes = b"{}",
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        chunks: list[bytes] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._chunks = chunks if chunks is not None else [body]
+        self.closed = False
+        self.iter_content_calls: list[int] = []
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 400
+
+    @property
+    def text(self) -> str:
+        raise AssertionError("unbounded response.text should not be used")
+
+    def json(self) -> dict[str, Any]:
+        raise AssertionError("unbounded response.json() should not be used")
+
+    def iter_content(self, chunk_size: int):
+        self.iter_content_calls.append(chunk_size)
+        yield from self._chunks
+
+    def close(self) -> None:
+        self.closed = True
 
 
 # ---------------------------------------------------------------------------
@@ -295,3 +331,164 @@ class TestPickerIntegration:
         assert names == ["browserbase", "firecrawl"]
 
 
+# ---------------------------------------------------------------------------
+# Bounded session-create response reads
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedSessionCreateResponses:
+    def test_json_reader_rejects_oversized_content_length(self) -> None:
+        from plugins.browser._response import read_browser_provider_json
+
+        response = _FakeStreamResponse(
+            b'{"id":"session"}',
+            headers={"Content-Length": "11"},
+        )
+
+        with pytest.raises(RuntimeError, match="test reader: response exceeds 10 bytes"):
+            read_browser_provider_json(response, label="test reader", max_bytes=10)
+
+        assert response.closed is True
+        assert response.iter_content_calls == []
+
+    def test_json_reader_rejects_stream_overflow(self) -> None:
+        from plugins.browser._response import read_browser_provider_response_bytes
+
+        response = _FakeStreamResponse(chunks=[b"123456", b"789012"])
+
+        with pytest.raises(RuntimeError, match="test reader: response exceeds 10 bytes"):
+            read_browser_provider_response_bytes(
+                response,
+                label="test reader",
+                max_bytes=10,
+            )
+
+        assert response.closed is True
+        assert response.iter_content_calls == [64 * 1024]
+
+    def test_browser_use_create_session_streams_and_caps_json(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from plugins.browser.browser_use.provider import BrowserUseBrowserProvider
+
+        monkeypatch.setenv("BROWSER_USE_API_KEY", "key")
+        calls: list[dict[str, Any]] = []
+        response = _FakeStreamResponse(
+            b'{"id":"bu-1","cdpUrl":"ws://browser-use"}',
+        )
+
+        def fake_post(*_args: Any, **kwargs: Any) -> _FakeStreamResponse:
+            calls.append(kwargs)
+            return response
+
+        monkeypatch.setattr(
+            "plugins.browser.browser_use.provider.requests.post",
+            fake_post,
+        )
+
+        result = BrowserUseBrowserProvider().create_session("task")
+
+        assert calls[0]["stream"] is True
+        assert response.closed is True
+        assert result["bb_session_id"] == "bu-1"
+        assert result["cdp_url"] == "ws://browser-use"
+
+    def test_browser_use_capped_managed_409_preserves_idempotency_key(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from plugins.browser._response import MAX_BROWSER_PROVIDER_ERROR_BYTES
+        from plugins.browser.browser_use import provider as browser_use
+
+        task_id = "managed-capped-409"
+        oversized_body = (
+            b'{"error":{"message":"already in progress","padding":"'
+            + b"x" * MAX_BROWSER_PROVIDER_ERROR_BYTES
+            + b'"}}'
+        )
+        response = _FakeStreamResponse(oversized_body, status_code=409)
+        idempotency_keys: list[str] = []
+
+        def fake_post(*_args: Any, **kwargs: Any) -> _FakeStreamResponse:
+            idempotency_keys.append(kwargs["headers"]["X-Idempotency-Key"])
+            return response
+
+        provider = browser_use.BrowserUseBrowserProvider()
+        monkeypatch.setattr(
+            provider,
+            "_get_config",
+            lambda: {
+                "api_key": "managed-key",
+                "base_url": "https://gateway.example",
+                "managed_mode": True,
+            },
+        )
+        monkeypatch.setattr(browser_use.requests, "post", fake_post)
+
+        try:
+            with pytest.raises(RuntimeError, match="Failed to create"):
+                provider.create_session(task_id)
+            assert (
+                browser_use._get_or_create_pending_create_key(task_id)
+                == idempotency_keys[0]
+            )
+        finally:
+            browser_use._clear_pending_create_key(task_id)
+
+    def test_browserbase_create_session_streams_and_caps_json(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from plugins.browser.browserbase.provider import BrowserbaseBrowserProvider
+
+        monkeypatch.setenv("BROWSERBASE_API_KEY", "key")
+        monkeypatch.setenv("BROWSERBASE_PROJECT_ID", "project")
+        calls: list[dict[str, Any]] = []
+        response = _FakeStreamResponse(
+            b'{"id":"bb-1","connectUrl":"ws://browserbase"}',
+        )
+
+        def fake_post(*_args: Any, **kwargs: Any) -> _FakeStreamResponse:
+            calls.append(kwargs)
+            return response
+
+        monkeypatch.setattr(
+            "plugins.browser.browserbase.provider.requests.post",
+            fake_post,
+        )
+
+        result = BrowserbaseBrowserProvider().create_session("task")
+
+        assert calls[0]["stream"] is True
+        assert response.closed is True
+        assert result["bb_session_id"] == "bb-1"
+        assert result["cdp_url"] == "ws://browserbase"
+
+    def test_firecrawl_create_session_streams_and_caps_json(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from plugins.browser.firecrawl.provider import FirecrawlBrowserProvider
+
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "key")
+        calls: list[dict[str, Any]] = []
+        response = _FakeStreamResponse(
+            b'{"id":"fc-1","cdpUrl":"ws://firecrawl"}',
+        )
+
+        def fake_post(*_args: Any, **kwargs: Any) -> _FakeStreamResponse:
+            calls.append(kwargs)
+            return response
+
+        monkeypatch.setattr(
+            "plugins.browser.firecrawl.provider.requests.post",
+            fake_post,
+        )
+
+        result = FirecrawlBrowserProvider().create_session("task")
+
+        assert calls[0]["stream"] is True
+        assert response.closed is True
+        assert result["bb_session_id"] == "fc-1"
+        assert result["cdp_url"] == "ws://firecrawl"

--- a/tests/tools/test_browser_use_session_expiry.py
+++ b/tests/tools/test_browser_use_session_expiry.py
@@ -19,11 +19,10 @@ def test_browser_use_preserves_provider_timeout(monkeypatch):
         ok=True,
         headers={},
     )
-    response.json.return_value = {
-        "id": "browser-session-1",
-        "cdpUrl": "ws://browser-use.example/devtools/browser/1",
-        "timeoutAt": "2030-01-01T00:05:00Z",
-    }
+    response.iter_content.return_value = [
+        b'{"id":"browser-session-1","cdpUrl":"ws://browser-use.example/'
+        b'devtools/browser/1","timeoutAt":"2030-01-01T00:05:00Z"}'
+    ]
 
     monkeypatch.setattr(
         provider,

--- a/tests/tools/test_managed_browserbase_and_modal.py
+++ b/tests/tools/test_managed_browserbase_and_modal.py
@@ -139,7 +139,7 @@ def _install_fake_tools_package():
     plugins_package.__path__ = []  # type: ignore[attr-defined]
     sys.modules["plugins"] = plugins_package
     plugins_browser_package = types.ModuleType("plugins.browser")
-    plugins_browser_package.__path__ = []  # type: ignore[attr-defined]
+    plugins_browser_package.__path__ = [str(PLUGINS_DIR / "browser")]  # type: ignore[attr-defined]
     sys.modules["plugins.browser"] = plugins_browser_package
 
     for _name, _classname in (


### PR DESCRIPTION
﻿## Summary

Fixes #55196.

Browser Use, Browserbase, and Firecrawl cloud browser providers parsed session-create control-plane responses with `response.json()` after normal `requests.post(...)` calls. With `requests`' default `stream=False`, an external or operator-configured endpoint can make Hermes buffer an unexpectedly large body before the provider extracts the tiny session id / CDP URL payload.

## Change

- Add `plugins.browser._response` with bounded readers for browser-provider control JSON and short error bodies.
- Request the three session-create responses with `stream=True`.
- Replace session-create `response.json()` and create-error `response.text` reads with capped stream readers.
- Preserve existing Browser Use managed-gateway idempotency behavior by parsing the bounded 409 payload before deciding whether to keep the pending idempotency key.
- Close streamed responses after success, failure, and Browserbase 402 fallback retries.

## Validation

- `C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests\plugins\browser\test_browser_provider_plugins.py -q --basetemp .tmp-pytest-browser-cap` -> `36 passed in 8.41s`
- `C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check plugins\browser\_response.py plugins\browser\browser_use\provider.py plugins\browser\browserbase\provider.py plugins\browser\firecrawl\provider.py tests\plugins\browser\test_browser_provider_plugins.py` -> `All checks passed!`
- `git diff --check` -> passed

## Notes

The regression tests use fake streamed responses whose `.json()` and `.text` methods raise if called. That locks the intended boundary: session-create payloads must be read through the bounded `iter_content()` path, and the provider calls must pass `stream=True`.
