### PR TITLE
fix: sanitize 'unexpected status 401 Unauthorized' in gateway chat output

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -135,7 +135,7 @@ _GATEWAY_PROVIDER_POLICY_RE = re.compile(
 )
 
 _GATEWAY_AUTH_ERROR_RE = re.compile(
-    r"(provider\s+authentication\s+failed|incorrect\s+api\s+key|invalid\s+api\s+key|\b401\b)",
+    r"(provider\s+authentication\s+failed|incorrect\s+api\s+key|invalid\s+api\s+key|unexpected\s+status\s+401\b|\b401\b)",
     re.IGNORECASE,
 )
 
@@ -380,6 +380,7 @@ _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
     r"|http\s*\d{3}\b"
     r"|incorrect\s+api\s+key"
     r"|invalid\s+api\s+key"
+    r"|unexpected\s+status\s+\d{3}\b"
     r")",
     re.IGNORECASE,
 )

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -175,6 +175,22 @@ def test_telegram_final_response_sanitizes_raw_provider_errors():
     assert "req_abc" not in sanitized
 
 
+def test_telegram_final_response_sanitizes_unexpected_status_401():
+    """'unexpected status 401 Unauthorized' envelopes must be sanitized.
+
+    Regression test for #55071: the gateway sanitizer previously leaked
+    raw auth envelopes like 'unexpected status 401 Unauthorized: Missing
+    bearer or basic authentication in header' to chat surfaces.
+    """
+    raw = "unexpected status 401 Unauthorized: Missing bearer or basic authentication in header"
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "401" not in sanitized or "credentials" in sanitized.lower()
+    assert "unexpected status" not in sanitized
+    assert "Missing bearer" not in sanitized
+
+
 def test_telegram_final_response_redacts_auth_secrets():
     """Authentication errors should be useful without leaking key material."""
     raw = (


### PR DESCRIPTION
## What does this PR do?

Fixes the gateway chat sanitizer so that "unexpected status 401 Unauthorized" provider error envelopes are properly sanitized before delivery to human-facing chat surfaces (Telegram, Discord, Slack, etc). Previously, these envelopes leaked verbatim because the provider-error shape regex didn't match the "unexpected status" prefix.

## Related Issue

Fixes #55071

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Add `unexpected\s+status\s+\d{3}` to both `_GATEWAY_AUTH_ERROR_RE` and `_GATEWAY_PROVIDER_ERROR_SHAPE_RE` so these envelopes are classified as provider errors and replaced with safe credential guidance.
- `tests/gateway/test_telegram_noise_filter.py`: Add regression test `test_telegram_final_response_sanitizes_unexpected_status_401` covering the exact scenario from #55071.

## How to Test

1. Run `uv run --extra dev python -m pytest tests/gateway/test_telegram_noise_filter.py -q` — all tests should pass including the new regression test
2. Reproduce the original bug:
   ```python
   from gateway.run import _sanitize_gateway_final_response
   from gateway.config import Platform
   raw = "unexpected status 401 Unauthorized: Missing bearer or basic authentication in header"
   result = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
   # Should NOT contain "unexpected status", "401", or "Missing bearer"
   # Should contain credential guidance
   ```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `uv run --extra dev python -m pytest tests/gateway/test_telegram_noise_filter.py -q` and all tests pass
- [x] I've added tests for my changes (regression test for #55071)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — regex is platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A