### PR TITLE
fix(discord): harden council and bot routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -77,6 +77,8 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|configured\s+compression\s+model\s+.+\s+failed"
     r"|no\s+auxiliary\s+llm\s+provider\s+configured"
     r"|auto-lowered\s+compression\s+threshold"
+    r"|codex\s+gpt-5\.5\s+caps\s+context"
+    r"|auto-compaction\s+was\s+raised"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
     r"|session\s+compressed\s+\d+\s+times"
@@ -16098,7 +16100,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return
             _fut = safe_schedule_threadsafe(
-                _send_or_update_status_coro(_status_adapter, _status_chat_id, event_type, prepared_message, _status_thread_metadata),
+                _send_or_update_status_coro(
+                    _status_adapter,
+                    _status_chat_id,
+                    event_type,
+                    prepared_message,
+                    _non_conversational_metadata(
+                        _status_thread_metadata,
+                        platform=source.platform,
+                    ),
+                ),
                 _loop_for_step,
                 logger=logger,
                 log_message=f"status_callback ({event_type}) scheduling error",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4449,6 +4449,28 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_allowed_channels(self) -> set[str]:
+        """Return Discord channel IDs where this profile may respond.
+
+        This is the worker blast-radius boundary: when configured, *all*
+        server-channel messages outside the whitelist are ignored, including
+        explicit @mentions. Thread messages match either the thread ID or the
+        parent channel ID so a worker can be restricted to an approved
+        workbench channel while still responding inside workbench threads.
+
+        Empty means unrestricted for backwards compatibility; worker profiles
+        that should be restricted must configure a non-empty whitelist.
+        """
+        raw = self.config.extra.get("allowed_channels")
+        if raw is None:
+            raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
     def _message_mentions_own_role(self, message: Any) -> list[Any]:
         """Return role mentions that belong to this bot's guild member.
 
@@ -6027,13 +6049,14 @@ class DiscordAdapter(BasePlatformAdapter):
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
 
-            # Check allowed channels - if set, only respond in these channels
-            allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
-            if allowed_channels_raw:
-                allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
-                if "*" not in allowed_channels and not (channel_ids & allowed_channels):
-                    logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
-                    return
+            # Check allowed channels - if set, only respond in these channels.
+            # This gate intentionally runs before mention handling: a direct
+            # @mention outside an approved worker context should not pierce a
+            # worker profile's channel whitelist.
+            allowed_channels = self._discord_allowed_channels()
+            if allowed_channels and "*" not in allowed_channels and not (channel_ids & allowed_channels):
+                logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
+                return
 
             # Check ignored channels - never respond even when mentioned
             ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4770,6 +4770,35 @@ class DiscordAdapter(BasePlatformAdapter):
         transcript, _responders = await self._collect_council_transcript_and_responders(thread, limit, [])
         return transcript
 
+    async def _wait_for_council_replies_or_timeout(
+        self,
+        thread: Any,
+        workers: list[dict[str, str]],
+        wait_seconds: float,
+    ) -> tuple[str, list[str], str]:
+        """Collect until every invited worker replies once, or timeout expires."""
+        worker_ids = [str(worker.get("id") or "") for worker in workers if str(worker.get("id") or "")]
+        expected = set(worker_ids)
+        deadline = asyncio.get_running_loop().time() + max(0.0, wait_seconds)
+        transcript = "(No worker replies captured.)"
+        actual_responder_ids: list[str] = []
+        close_reason = "timeout"
+        while True:
+            transcript, actual_responder_ids = await self._collect_council_transcript_and_responders(
+                thread,
+                self._discord_council_history_limit(),
+                workers,
+            )
+            if expected and expected.issubset(set(actual_responder_ids)):
+                close_reason = "all_replied"
+                break
+            remaining = deadline - asyncio.get_running_loop().time()
+            if wait_seconds <= 0 or remaining <= 0:
+                close_reason = "timeout"
+                break
+            await asyncio.sleep(min(2.0, remaining))
+        return transcript, actual_responder_ids, close_reason
+
     async def _run_council_synthesis_after_wait(
         self,
         *,
@@ -4782,17 +4811,19 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> None:
         thread_id = str(getattr(huddle_thread, "id", ""))
         try:
-            if wait_seconds > 0:
-                await asyncio.sleep(wait_seconds)
-            transcript, actual_responder_ids = await self._collect_council_transcript_and_responders(
+            transcript, actual_responder_ids, close_reason = await self._wait_for_council_replies_or_timeout(
                 huddle_thread,
-                self._discord_council_history_limit(),
                 workers,
+                wait_seconds,
             )
             worker_ids = [str(worker.get("id") or "") for worker in workers if str(worker.get("id") or "")]
             missing_worker_ids = [wid for wid in worker_ids if wid not in set(actual_responder_ids)]
+            if close_reason == "all_replied":
+                close_detail = "All invited workers replied."
+            else:
+                close_detail = "Timeout reached before every invited worker replied."
             close_text = (
-                f"Huddle closed. Route: `{route_id}`. I have enough for this round. "
+                f"Huddle closed. Route: `{route_id}`. {close_detail} "
                 "Workers, stop here unless this thread is reopened or you are tagged directly."
             )
             with suppress(Exception):
@@ -4826,6 +4857,7 @@ class DiscordAdapter(BasePlatformAdapter):
             self._council_route_records.upsert(
                 route_id,
                 status="closed",
+                close_reason=close_reason,
                 actual_responder_ids=actual_responder_ids,
                 missing_worker_ids=missing_worker_ids,
                 closed_at=datetime.now(timezone.utc).isoformat(),
@@ -4838,6 +4870,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     f"Huddle: {huddle_ref}\n\n"
                     "Huddle transcript:\n"
                     f"{transcript}\n\n"
+                    f"Council contribution status: close_reason={close_reason}; "
+                    f"actual_responder_ids={actual_responder_ids}; "
+                    f"missing_worker_ids={missing_worker_ids}.\n\n"
                     "Now answer the original user with one concise final answer. "
                     "Do not continue the huddle unless the user explicitly asks. "
                     "Mention that the huddle is closed if relevant."

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1130,15 +1130,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
                 _role_authorized = False
                 _self_role_mentions = adapter_self._message_mentions_own_role(message)
+                _explicit_self_mention = adapter_self._message_explicitly_mentions_self(message, _self_role_mentions)
                 if getattr(message.author, "bot", False):
                     allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or (
-                            self._client.user not in message.mentions
-                            and not _self_role_mentions
-                        ):
+                        if not _explicit_self_mention:
                             return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
@@ -4496,6 +4494,25 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception:
             return []
 
+    def _message_explicitly_mentions_self(self, message: Any, bot_role_mentions: Optional[list[Any]] = None) -> bool:
+        """Return True only for textual @mentions / own-role mentions.
+
+        Discord replies may include the replied-to user in ``message.mentions``
+        even when the message body has no ``<@id>`` text. In council huddles,
+        Pixoid progress/final messages can reply to a worker's one-round answer;
+        those implicit reply mentions must not wake the worker again.
+        """
+        user = getattr(self._client, "user", None) if self._client else None
+        user_id = str(getattr(user, "id", "") or "")
+        if not user_id:
+            return False
+        content = str(getattr(message, "content", "") or "")
+        if f"<@{user_id}>" in content or f"<@!{user_id}>" in content:
+            return True
+        if bot_role_mentions is None:
+            bot_role_mentions = self._message_mentions_own_role(message)
+        return bool(bot_role_mentions)
+
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
 
@@ -4519,6 +4536,46 @@ class DiscordAdapter(BasePlatformAdapter):
         """Return phrases that intentionally wake every participating crew bot."""
         raw = os.getenv("DISCORD_CREW_ALIASES", "")
         return {alias.strip().lower() for alias in raw.split(",") if alias.strip()}
+
+    def _discord_council_role_ids(self) -> set[str]:
+        """Return role IDs that explicitly trigger council-mode huddles.
+
+        A bot can have multiple Discord roles (for example @Pixoid and @Crew).
+        Mentioning any owned role should still wake the bot when mention-gating
+        is enabled, but council mode must only start for the shared council role,
+        not every role mention that happens to belong to the bot.
+        """
+        cfg = self._discord_council_config()
+        raw = cfg.get("role_ids") or cfg.get("roles") or cfg.get("role_id") or os.getenv("DISCORD_COUNCIL_ROLE_IDS", "")
+        if isinstance(raw, (list, tuple, set)):
+            return {str(item).strip().lstrip("<@&").rstrip(">") for item in raw if str(item).strip()}
+        return {part.strip().lstrip("<@&").rstrip(">") for part in str(raw or "").split(",") if part.strip()}
+
+    def _discord_council_role_names(self) -> set[str]:
+        """Return role names that explicitly trigger council-mode huddles."""
+        cfg = self._discord_council_config()
+        raw = cfg.get("role_names") or cfg.get("role_name") or os.getenv("DISCORD_COUNCIL_ROLE_NAMES", "")
+        if isinstance(raw, (list, tuple, set)):
+            names = {str(item).strip().lower() for item in raw if str(item).strip()}
+        else:
+            names = {part.strip().lower() for part in str(raw or "").split(",") if part.strip()}
+        if names:
+            return names
+        # Backwards-compatible default for the common setup while avoiding the
+        # previous over-broad behavior where *any* owned role opened a huddle.
+        return {"crew", "council"}
+
+    def _filter_council_role_mentions(self, bot_role_mentions: list[Any]) -> list[Any]:
+        """Return the subset of owned role mentions that should start council mode."""
+        role_ids = self._discord_council_role_ids()
+        role_names = self._discord_council_role_names()
+        result: list[Any] = []
+        for role in bot_role_mentions or []:
+            rid = str(getattr(role, "id", "") or "")
+            name = str(getattr(role, "name", "") or "").strip().lower()
+            if (role_ids and rid in role_ids) or (not role_ids and name in role_names):
+                result.append(role)
+        return result
 
     def _matches_crew_call_alias(self, content: str) -> bool:
         """Return True when a message explicitly calls the configured crew."""
@@ -4929,7 +4986,8 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> bool:
         if not self._discord_council_enabled():
             return False
-        if not (bot_role_mentions or crew_call_prefix):
+        council_role_mentions = self._filter_council_role_mentions(bot_role_mentions)
+        if not (council_role_mentions or crew_call_prefix):
             return False
         if self._discord_council_no_tools_requested(normalized_content):
             with suppress(Exception):
@@ -4965,7 +5023,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         route_id = self._council_route_id_for_message(message)
         request_text = normalized_content
-        for role in bot_role_mentions:
+        for role in council_role_mentions:
             request_text = request_text.replace(f"<@&{getattr(role, 'id')}>", "").strip()
         thread_name = self._derive_council_thread_name(request_text)
         huddle = await self._resolve_council_huddle_thread(message, thread_name)
@@ -6020,13 +6078,20 @@ class DiscordAdapter(BasePlatformAdapter):
                 raw_content = "\n".join(snapshot_text_parts)
                 normalized_content = raw_content
         bot_role_mentions = self._message_mentions_own_role(message)
+        explicit_self_mention = self._message_explicitly_mentions_self(message, bot_role_mentions)
         crew_call_prefix = self._matches_crew_call_alias(normalized_content)
 
         if self._client.user and self._client.user in message.mentions:
-            mention_prefix = True
-            normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
-            normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
-            message.content = normalized_content
+            if getattr(message.author, "bot", False) and not explicit_self_mention:
+                # Bot-authored Discord replies can implicitly mention the
+                # replied-to worker without a textual <@id>. Do not treat that
+                # reply ping as a direct worker summon in council huddles.
+                pass
+            else:
+                mention_prefix = True
+                normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
+                normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
+                message.content = normalized_content
         elif bot_role_mentions:
             mention_prefix = True
             for role in bot_role_mentions:
@@ -6039,11 +6104,12 @@ class DiscordAdapter(BasePlatformAdapter):
             is_thread
             and thread_id in self._council_huddle_threads
             and not mention_prefix
-            and (not self._client.user or self._client.user not in message.mentions)
         ):
             # Council huddles are deliberately bounded. Once Pixoid has opened
-            # or closed one, worker replies and casual acks in that thread must
-            # not wake the coordinator ambiently via thread participation.
+            # or closed one, worker replies, casual acks, and implicit Discord
+            # reply pings in that thread must not wake any bot ambiently. Only
+            # an explicit textual @mention / own-role mention / crew alias sets
+            # mention_prefix and can reopen work.
             return
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
@@ -6094,7 +6160,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
             if require_mention and not is_free_channel and not in_bot_thread:
-                if self._client.user not in message.mentions and not mention_prefix:
+                if not mention_prefix:
                     return
 
             if await self._maybe_start_council_huddle(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1132,7 +1132,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 _self_role_mentions = adapter_self._message_mentions_own_role(message)
                 _explicit_self_mention = adapter_self._message_explicitly_mentions_self(message, _self_role_mentions)
                 if getattr(message.author, "bot", False):
-                    allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+                    allow_bots = adapter_self._discord_allow_bots_for_message(message)
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
@@ -4512,6 +4512,24 @@ class DiscordAdapter(BasePlatformAdapter):
         if bot_role_mentions is None:
             bot_role_mentions = self._message_mentions_own_role(message)
         return bool(bot_role_mentions)
+
+    def _discord_allow_bots_for_message(self, message: Any) -> str:
+        """Return the bot-message policy for this Discord message.
+
+        ``DISCORD_ALLOW_BOTS`` remains the general/thread policy.  Shared
+        top-level channels can be stricter via ``DISCORD_CHANNEL_ALLOW_BOTS`` so
+        bot/status chatter in a channel cannot wake Pixoid unless explicitly
+        enabled.  Threads keep the older policy because thread handoffs are the
+        intended place for bot-to-bot collaboration.
+        """
+        default_policy = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip() or "none"
+        channel = getattr(message, "channel", None)
+        is_dm = isinstance(channel, discord.DMChannel)
+        is_thread = isinstance(channel, discord.Thread)
+        if is_dm or is_thread:
+            return default_policy
+        channel_policy = os.getenv("DISCORD_CHANNEL_ALLOW_BOTS", "").lower().strip()
+        return channel_policy or default_policy
 
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
@@ -8006,6 +8024,12 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     allow_bots = discord_cfg.get("allow_bots")
     if allow_bots is not None and not os.getenv("DISCORD_ALLOW_BOTS"):
         os.environ["DISCORD_ALLOW_BOTS"] = str(allow_bots).lower()
+    # channel_allow_bots can make top-level shared channels stricter than
+    # threads.  Use "none" to prevent bot/status chatter in channels from
+    # waking the bot while keeping ``allow_bots: mentions`` for thread handoffs.
+    channel_allow_bots = discord_cfg.get("channel_allow_bots")
+    if channel_allow_bots is not None and not os.getenv("DISCORD_CHANNEL_ALLOW_BOTS"):
+        os.environ["DISCORD_CHANNEL_ALLOW_BOTS"] = str(channel_allow_bots).lower()
     crew_aliases = discord_cfg.get("crew_aliases")
     if crew_aliases is not None and not os.getenv("DISCORD_CREW_ALIASES"):
         if isinstance(crew_aliases, list):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7873,8 +7873,9 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
 
     Env vars take precedence over YAML — every assignment is guarded by
     ``not os.getenv(...)`` so explicit env vars survive a config.yaml
-    update.  Returns ``None`` because no extras are seeded into
-    ``PlatformConfig.extra`` directly (everything flows through env).
+    update.  Most settings flow through env for backwards compatibility, but
+    structured settings such as ``discord.council_mode`` are returned into
+    ``PlatformConfig.extra`` because the adapter consumes them as nested data.
     """
     if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
         os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
@@ -7977,7 +7978,12 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     lft = discord_cfg.get("liveness_failure_threshold")
     if lft is not None and not os.getenv("HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD"):
         os.environ["HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD"] = str(lft)
-    return None  # all settings flow through env; nothing to merge into extras
+
+    seeded_extra = {}
+    council_mode = discord_cfg.get("council_mode") or discord_cfg.get("council")
+    if isinstance(council_mode, dict):
+        seeded_extra["council_mode"] = council_mode
+    return seeded_extra or None
 
 
 def _is_connected(config) -> bool:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -816,6 +816,10 @@ class DiscordAdapter(BasePlatformAdapter):
         # history backfill to skip the full scan on hot paths.  Falls back to
         # scanning channel.history() on cache miss (cold start / restart).
         self._last_self_message_id: Dict[str, str] = {}
+        # Council-mode huddles opened by the coordinator. While a huddle is
+        # open/closed, the coordinator must not ambiently respond to worker
+        # chatter in that thread; only explicit direct mentions should wake it.
+        self._council_huddle_threads: Dict[str, str] = {}
         # Persistent set of bot-authored lifecycle/status message IDs that
         # should not act as conversational history boundaries after restart.
         self._nonconversational_messages = _DiscordNonConversationalMessageTracker()
@@ -1045,12 +1049,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 # permitted by DISCORD_ALLOW_BOTS are not rejected for
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
                 _role_authorized = False
+                _self_role_mentions = adapter_self._message_mentions_own_role(message)
                 if getattr(message.author, "bot", False):
                     allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                        if not self._client.user or (
+                            self._client.user not in message.mentions
+                            and not _self_role_mentions
+                        ):
                             return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
@@ -1082,7 +1090,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not isinstance(message.channel, discord.DMChannel) and message.mentions:
                     _self_mentioned = (
                         self._client.user is not None
-                        and self._client.user in message.mentions
+                        and (
+                            self._client.user in message.mentions
+                            or bool(_self_role_mentions)
+                        )
                     )
                     _other_bots_mentioned = any(
                         m.bot and m != self._client.user
@@ -4358,6 +4369,31 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _message_mentions_own_role(self, message: Any) -> list[Any]:
+        """Return role mentions that belong to this bot's guild member.
+
+        Discord role mentions are separate from ``message.mentions``. For a
+        shared role like @Crew, every participating bot should treat that role
+        mention as an explicit call even when the message also mentions a human.
+        """
+        if not self._client.user or not getattr(message, "guild", None) or not getattr(message, "role_mentions", None):
+            return []
+        try:
+            guild_me = getattr(message.guild, "me", None)
+            if guild_me is None and hasattr(message.guild, "get_member"):
+                guild_me = message.guild.get_member(getattr(self._client.user, "id", None))
+            own_role_ids = {
+                int(getattr(role, "id"))
+                for role in getattr(guild_me, "roles", []) or []
+                if getattr(role, "id", None) is not None
+            }
+            return [
+                role for role in (getattr(message, "role_mentions", []) or [])
+                if int(getattr(role, "id", 0)) in own_role_ids
+            ]
+        except Exception:
+            return []
+
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
 
@@ -4376,6 +4412,428 @@ class DiscordAdapter(BasePlatformAdapter):
                 return configured.lower() not in {"false", "0", "no", "off"}
             return bool(configured)
         return os.getenv("DISCORD_THREAD_REQUIRE_MENTION", "false").lower() in {"true", "1", "yes", "on"}
+
+    def _discord_crew_call_aliases(self) -> set[str]:
+        """Return phrases that intentionally wake every participating crew bot."""
+        raw = os.getenv("DISCORD_CREW_ALIASES", "")
+        return {alias.strip().lower() for alias in raw.split(",") if alias.strip()}
+
+    def _matches_crew_call_alias(self, content: str) -> bool:
+        """Return True when a message explicitly calls the configured crew."""
+        aliases = self._discord_crew_call_aliases()
+        if not aliases:
+            return False
+        normalized = re.sub(r"\s+", " ", (content or "").strip().lower())
+        if not normalized:
+            return False
+        for alias in aliases:
+            if alias.endswith(":"):
+                if normalized.startswith(alias):
+                    return True
+                continue
+            escaped = re.escape(alias)
+            if re.search(rf"(?:^|\b){escaped}(?:\b|\s*[:!,.-])", normalized):
+                return True
+        return False
+
+    @staticmethod
+    def _discord_council_no_tools_requested(content: str) -> bool:
+        """Return True when the user explicitly forbids tool/huddle work.
+
+        Council mode creates/uses Discord huddle threads and wakes worker bots.
+        If a smoke test says "don't run tools" or "no tools", acknowledge the
+        boundary instead of silently falling through to a bare LLM answer or
+        opening a huddle anyway.
+        """
+        text = re.sub(r"\s+", " ", (content or "").strip().lower())
+        if not text:
+            return False
+        return bool(
+            re.search(
+                r"\b(?:do\s+not|don't|dont)\s+(?:run|use)\s+(?:any\s+)?tools?\b"
+                r"|\bno\s+tools?\b"
+                r"|\bwithout\s+tools?\b",
+                text,
+            )
+        )
+
+    @staticmethod
+    def _coerce_discord_bool(value: Any, default: bool = False) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return bool(value)
+        return str(value).strip().lower() in {"true", "1", "yes", "on"}
+
+    def _discord_council_config(self) -> dict:
+        """Return coordinator council-mode config.
+
+        ``discord.council_mode`` keeps @Crew as a coordinator trigger: Pixoid
+        opens a bounded workbench huddle, explicitly invites worker bots, waits
+        one short round, closes the huddle, then synthesizes back in the origin
+        chat. Worker profiles should keep ``thread_require_mention: true`` so
+        the close marker and acknowledgements do not wake them again.
+        """
+        raw = self.config.extra.get("council_mode")
+        if raw is None:
+            raw = self.config.extra.get("council")
+        return raw if isinstance(raw, dict) else {}
+
+    def _discord_council_enabled(self) -> bool:
+        cfg = self._discord_council_config()
+        raw = cfg.get("enabled")
+        if raw is None:
+            raw = os.getenv("DISCORD_COUNCIL_MODE_ENABLED")
+        return self._coerce_discord_bool(raw, default=False)
+
+    def _discord_council_wait_seconds(self) -> float:
+        cfg = self._discord_council_config()
+        raw = cfg.get("wait_seconds", os.getenv("DISCORD_COUNCIL_WAIT_SECONDS", 75))
+        try:
+            return max(0.0, float(raw))
+        except (TypeError, ValueError):
+            return 75.0
+
+    def _discord_council_history_limit(self) -> int:
+        cfg = self._discord_council_config()
+        raw = cfg.get("history_limit", os.getenv("DISCORD_COUNCIL_HISTORY_LIMIT", 80))
+        try:
+            return max(5, min(200, int(raw)))
+        except (TypeError, ValueError):
+            return 80
+
+    def _discord_council_workbench_channel_id(self) -> Optional[str]:
+        cfg = self._discord_council_config()
+        raw = cfg.get("workbench_channel_id") or cfg.get("channel_id") or os.getenv("DISCORD_COUNCIL_WORKBENCH_CHANNEL_ID")
+        raw_s = str(raw).strip() if raw is not None else ""
+        return raw_s or None
+
+    def _discord_council_workers(self) -> list[dict[str, str]]:
+        cfg = self._discord_council_config()
+        workers = cfg.get("workers")
+        if isinstance(workers, str) and workers.strip():
+            try:
+                workers = json.loads(workers)
+            except Exception:
+                workers = [part.strip() for part in workers.split(",") if part.strip()]
+        if workers is None:
+            raw = os.getenv("DISCORD_COUNCIL_WORKERS", "").strip()
+            if raw:
+                try:
+                    workers = json.loads(raw)
+                except Exception:
+                    workers = [part.strip() for part in raw.split(",") if part.strip()]
+        if workers is None:
+            workers = []
+        result: list[dict[str, str]] = []
+        for item in workers:
+            if isinstance(item, dict):
+                name = str(item.get("name") or item.get("label") or item.get("id") or "worker").strip()
+                user_id = str(item.get("id") or item.get("user_id") or "").strip()
+                role = str(item.get("role") or item.get("assignment") or "").strip()
+            else:
+                name = str(item).strip()
+                user_id = ""
+                role = ""
+            if user_id.startswith("<@") and user_id.endswith(">"):
+                user_id = user_id.lstrip("<@!").rstrip(">")
+            if not user_id:
+                continue
+            result.append({"name": name or user_id, "id": user_id, "role": role})
+        return result
+
+    def _derive_council_thread_name(self, request_text: str) -> str:
+        cfg = self._discord_council_config()
+        prefix = str(cfg.get("thread_prefix") or "crew-huddle").strip() or "crew-huddle"
+        cleaned = re.sub(r"<@!?\d+>|<@&\d+>", "", request_text or "")
+        cleaned = re.sub(r"\s+", " ", cleaned).strip(" -:,.\n\t")
+        if not cleaned:
+            cleaned = "untitled"
+        if len(cleaned) > 48:
+            cleaned = cleaned[:45].rstrip() + "..."
+        name = f"{prefix}: {cleaned}"
+        return name[:90]
+
+    def _format_council_brief(self, request_text: str, workers: list[dict[str, str]], origin_channel_id: str) -> str:
+        lines = [
+            "Council brief — bounded huddle.",
+            "",
+            f"User request: {request_text.strip() or '(no text)'}",
+            f"Origin channel/thread: <#{origin_channel_id}>",
+            "",
+            "Worker rules:",
+            "- Reply once, briefly, only for your assigned perspective.",
+            "- Do not run tools unless the brief explicitly asks you to.",
+            "- Do not reply to acknowledgements, thanks, lol/ok, or the close marker.",
+            "- When the coordinator posts `Huddle closed`, stop unless this huddle is reopened or you are tagged directly.",
+            "",
+            "Assignments:",
+        ]
+        default_roles = {
+            "boba": "reality check / outside-in risks",
+            "quill": "source-of-truth, docs, vault implications",
+            "tinker": "implementation feasibility and breakage risks",
+        }
+        mention_line = []
+        for worker in workers:
+            name = worker["name"]
+            wid = worker["id"]
+            role = worker.get("role") or default_roles.get(name.lower(), "specialist input")
+            mention = f"<@{wid}>"
+            mention_line.append(mention)
+            lines.append(f"- {mention} ({name}): {role}")
+        lines.extend([
+            "",
+            "Council members: " + " ".join(mention_line),
+            "",
+            "Pixoid will collect one round, close this huddle, then return one final answer to the user.",
+        ])
+        return "\n".join(lines)
+
+    async def _resolve_council_huddle_thread(self, message: Any, thread_name: str) -> Optional[Any]:
+        workbench_id = self._discord_council_workbench_channel_id()
+        current = getattr(message, "channel", None)
+        parent_id = str(getattr(current, "parent_id", "") or "")
+
+        # If the user is already in the configured workbench thread, use it as
+        # the huddle so @Crew can invite the workers into the current thread.
+        if isinstance(current, discord.Thread) and workbench_id and parent_id == workbench_id:
+            return current
+
+        parent = None
+        if workbench_id and self._client:
+            parent = self._client.get_channel(int(workbench_id))
+            if parent is None:
+                parent = await self._client.fetch_channel(int(workbench_id))
+        if parent is None:
+            parent = getattr(current, "parent", None) if isinstance(current, discord.Thread) else current
+        if parent is None:
+            return None
+
+        try:
+            return await parent.create_thread(
+                name=thread_name,
+                auto_archive_duration=1440,
+                reason="Hermes council-mode huddle",
+            )
+        except Exception:
+            try:
+                seed = await parent.send(f"🧵 Council huddle: **{thread_name}**")
+                return await seed.create_thread(
+                    name=thread_name,
+                    auto_archive_duration=1440,
+                    reason="Hermes council-mode huddle fallback",
+                )
+            except Exception:
+                logger.warning("[%s] Failed to create council huddle thread", self.name, exc_info=True)
+                return None
+
+    async def _add_council_workers_to_thread(self, thread: Any, workers: list[dict[str, str]]) -> list[str]:
+        failures: list[str] = []
+        add_user = getattr(thread, "add_user", None)
+        if not callable(add_user):
+            return failures
+        for worker in workers:
+            wid = worker.get("id") or ""
+            try:
+                user_obj = None
+                if self._client and hasattr(self._client, "get_user"):
+                    user_obj = self._client.get_user(int(wid))
+                if user_obj is None and self._client and hasattr(self._client, "fetch_user"):
+                    with suppress(Exception):
+                        user_obj = await self._client.fetch_user(int(wid))
+                if user_obj is None:
+                    user_obj = discord.Object(id=int(wid))
+                await add_user(user_obj)
+            except Exception as exc:
+                failures.append(f"{worker.get('name') or wid}: {exc}")
+        return failures
+
+    async def _collect_council_transcript(self, thread: Any, limit: int) -> str:
+        history = getattr(thread, "history", None)
+        if not callable(history):
+            return "(No readable huddle transcript; thread history unavailable.)"
+        lines: list[str] = []
+        try:
+            async for msg in history(limit=limit, oldest_first=True):
+                content = getattr(msg, "clean_content", None) or getattr(msg, "content", "") or ""
+                if not content:
+                    continue
+                author = getattr(msg, "author", None)
+                name = getattr(author, "display_name", None) or getattr(author, "name", None) or "unknown"
+                if getattr(author, "bot", False):
+                    name = f"{name} [bot]"
+                lines.append(f"[{name}] {content}")
+        except Exception as exc:
+            return f"(Failed to read huddle transcript: {exc})"
+        return "\n".join(lines) if lines else "(No worker replies captured.)"
+
+    async def _run_council_synthesis_after_wait(
+        self,
+        *,
+        origin_message: Any,
+        huddle_thread: Any,
+        request_text: str,
+        wait_seconds: float,
+    ) -> None:
+        thread_id = str(getattr(huddle_thread, "id", ""))
+        try:
+            if wait_seconds > 0:
+                await asyncio.sleep(wait_seconds)
+            transcript = await self._collect_council_transcript(
+                huddle_thread,
+                self._discord_council_history_limit(),
+            )
+            close_text = (
+                "Huddle closed. I have enough for this round. "
+                "Workers, stop here unless this thread is reopened or you are tagged directly."
+            )
+            with suppress(Exception):
+                await huddle_thread.send(close_text)
+            if thread_id:
+                self._council_huddle_threads[thread_id] = "closed"
+
+            origin_channel = getattr(origin_message, "channel", None)
+            origin_is_thread = isinstance(origin_channel, discord.Thread)
+            origin_parent_id = self._get_parent_channel_id(origin_channel) if origin_is_thread else None
+            chat_type = "thread" if origin_is_thread else "group"
+            chat_name = self._format_thread_chat_name(origin_channel) if origin_is_thread else getattr(origin_channel, "name", str(getattr(origin_channel, "id", "")))
+            if not origin_is_thread and getattr(origin_channel, "guild", None):
+                chat_name = f"{origin_channel.guild.name} / #{chat_name}"
+            guild = getattr(origin_message, "guild", None)
+            source = self.build_source(
+                chat_id=str(getattr(origin_channel, "id", "")),
+                chat_name=chat_name,
+                chat_type=chat_type,
+                user_id=str(getattr(getattr(origin_message, "author", None), "id", "council")),
+                user_name=getattr(getattr(origin_message, "author", None), "display_name", "Council"),
+                thread_id=str(getattr(origin_channel, "id", "")) if origin_is_thread else None,
+                chat_topic=self._get_effective_topic(origin_channel, is_thread=origin_is_thread),
+                is_bot=False,
+                guild_id=str(getattr(guild, "id", "")) if guild else None,
+                parent_chat_id=origin_parent_id,
+                message_id=str(getattr(origin_message, "id", "")),
+                role_authorized=True,
+            )
+            huddle_ref = f"<#{thread_id}>" if thread_id else "the council huddle"
+            event = MessageEvent(
+                text=(
+                    "[COUNCIL MODE SYNTHESIS]\n"
+                    f"Original user request: {request_text.strip() or '(no text)'}\n"
+                    f"Huddle: {huddle_ref}\n\n"
+                    "Huddle transcript:\n"
+                    f"{transcript}\n\n"
+                    "Now answer the original user with one concise final answer. "
+                    "Do not continue the huddle unless the user explicitly asks. "
+                    "Mention that the huddle is closed if relevant."
+                ),
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=origin_message,
+                message_id=str(getattr(origin_message, "id", "")),
+                timestamp=getattr(origin_message, "created_at", None),
+                internal=True,
+            )
+            await self.handle_message(event)
+        except Exception:
+            logger.warning("[%s] Council synthesis task failed", self.name, exc_info=True)
+        finally:
+            if thread_id:
+                self._council_huddle_threads[thread_id] = "closed"
+
+    async def _maybe_start_council_huddle(
+        self,
+        message: Any,
+        *,
+        normalized_content: str,
+        bot_role_mentions: list[Any],
+        crew_call_prefix: bool,
+    ) -> bool:
+        if not self._discord_council_enabled():
+            return False
+        if not (bot_role_mentions or crew_call_prefix):
+            return False
+        if self._discord_council_no_tools_requested(normalized_content):
+            with suppress(Exception):
+                await message.channel.send(
+                    "Yes — I hear you. @Crew is coordinator-led by default. "
+                    "Because you asked me not to run tools, I won't open a huddle "
+                    "or summon Boba/Quill/Tinker. When tools are allowed, @Crew "
+                    "opens a bounded #agent-workbench huddle and I bring back one "
+                    "final answer. You can also directly mention @Boba, @Quill, "
+                    "or @Tinker when you want one specialist."
+                )
+            return True
+        workers = self._discord_council_workers()
+        if not workers:
+            with suppress(Exception):
+                await message.channel.send(
+                    "Yes — I hear you. @Crew is coordinator-led by default, but I "
+                    "couldn't start a crew huddle because no council workers are "
+                    "configured for this gateway. Direct specialist summons remain "
+                    "available via @Boba, @Quill, and @Tinker when those bots are "
+                    "configured to listen here."
+                )
+            return True
+        if isinstance(getattr(message, "channel", None), discord.DMChannel):
+            with suppress(Exception):
+                await message.channel.send(
+                    "Yes — I hear you. @Crew is coordinator-led by default, but I "
+                    "can't open a Discord crew huddle inside a DM. Use @Crew in a "
+                    "server channel/thread, or directly mention @Boba, @Quill, or "
+                    "@Tinker where those specialists are configured."
+                )
+            return True
+
+        request_text = normalized_content
+        for role in bot_role_mentions:
+            request_text = request_text.replace(f"<@&{getattr(role, 'id')}>", "").strip()
+        thread_name = self._derive_council_thread_name(request_text)
+        huddle = await self._resolve_council_huddle_thread(message, thread_name)
+        if huddle is None:
+            with suppress(Exception):
+                await message.channel.send(
+                    "Yes — I hear you. @Crew is coordinator-led by default, but I "
+                    "couldn't open the crew huddle in Discord. Direct specialist "
+                    "summons remain available via @Boba, @Quill, and @Tinker; "
+                    "otherwise I can answer as Pixoid here."
+                )
+            return True
+
+        thread_id = str(getattr(huddle, "id", ""))
+        if thread_id:
+            self._council_huddle_threads[thread_id] = "open"
+        add_failures = await self._add_council_workers_to_thread(huddle, workers)
+        brief = self._format_council_brief(
+            request_text,
+            workers,
+            str(getattr(getattr(message, "channel", None), "id", "")),
+        )
+        if add_failures:
+            brief += "\n\nWorker thread-add warnings (continuing with direct mentions):\n" + "\n".join(f"- {item}" for item in add_failures)
+        await huddle.send(brief)
+
+        ack = (
+            "Yes — I hear you. @Crew is coordinator-led by default, so I'm "
+            f"opening a bounded crew huddle in <#{thread_id}>. "
+            "I’ll collect one round, close it, then bring back one answer. "
+            "You can also directly mention @Boba, @Quill, or @Tinker when "
+            "you want one specialist."
+        )
+        with suppress(Exception):
+            await message.channel.send(ack)
+
+        asyncio.create_task(
+            self._run_council_synthesis_after_wait(
+                origin_message=message,
+                huddle_thread=huddle,
+                request_text=request_text,
+                wait_seconds=self._discord_council_wait_seconds(),
+            )
+        )
+        return True
 
     def _discord_history_backfill(self) -> bool:
         """Return whether history backfill is enabled for shared sessions."""
@@ -4722,6 +5180,29 @@ class DiscordAdapter(BasePlatformAdapter):
             thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
             return thread
         except Exception as direct_error:
+            # Multi-agent Discord setups can race here: Boba/Quill/Tinker may
+            # all receive the same multi-mention and try to create the starter
+            # thread. Discord permits only one thread per starter message, so
+            # later bots can see "already has a thread" failures. Reuse the
+            # existing thread instead of falling back to a seed message, which
+            # would create one private thread per bot and split the council.
+            existing_thread = getattr(message, "thread", None)
+            if existing_thread is not None:
+                return existing_thread
+            fetch_message = getattr(getattr(message, "channel", None), "fetch_message", None)
+            if callable(fetch_message):
+                try:
+                    refreshed = await fetch_message(message.id)
+                    existing_thread = getattr(refreshed, "thread", None)
+                    if existing_thread is not None:
+                        return existing_thread
+                except Exception:
+                    logger.debug(
+                        "[%s] Failed to fetch existing Discord starter thread after create_thread error",
+                        self.name,
+                        exc_info=True,
+                    )
+
             display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
             reason = f"Auto-threaded from mention by {display_name}"
             try:
@@ -5341,11 +5822,32 @@ class DiscordAdapter(BasePlatformAdapter):
             if snapshot_text_parts and not raw_content:
                 raw_content = "\n".join(snapshot_text_parts)
                 normalized_content = raw_content
+        bot_role_mentions = self._message_mentions_own_role(message)
+        crew_call_prefix = self._matches_crew_call_alias(normalized_content)
+
         if self._client.user and self._client.user in message.mentions:
             mention_prefix = True
             normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
             normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
             message.content = normalized_content
+        elif bot_role_mentions:
+            mention_prefix = True
+            for role in bot_role_mentions:
+                normalized_content = normalized_content.replace(f"<@&{getattr(role, 'id')}>", "").strip()
+            message.content = normalized_content
+        elif crew_call_prefix:
+            mention_prefix = True
+
+        if (
+            is_thread
+            and thread_id in self._council_huddle_threads
+            and not mention_prefix
+            and (not self._client.user or self._client.user not in message.mentions)
+        ):
+            # Council huddles are deliberately bounded. Once Pixoid has opened
+            # or closed one, worker replies and casual acks in that thread must
+            # not wake the coordinator ambiently via thread participation.
+            return
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
             if parent_channel_id:
@@ -5396,6 +5898,14 @@ class DiscordAdapter(BasePlatformAdapter):
             if require_mention and not is_free_channel and not in_bot_thread:
                 if self._client.user not in message.mentions and not mention_prefix:
                     return
+
+            if await self._maybe_start_council_huddle(
+                message,
+                normalized_content=normalized_content,
+                bot_role_mentions=bot_role_mentions,
+                crew_call_prefix=crew_call_prefix,
+            ):
+                return
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
@@ -7156,7 +7666,8 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     ``DISCORD_AUTO_THREAD``, ``DISCORD_REACTIONS``,
     ``DISCORD_IGNORED_CHANNELS``, ``DISCORD_ALLOWED_CHANNELS``,
     ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_HISTORY_BACKFILL``,
-    ``DISCORD_HISTORY_BACKFILL_LIMIT``, ``DISCORD_ALLOW_MENTION_*``,
+    ``DISCORD_HISTORY_BACKFILL_LIMIT``, ``DISCORD_ALLOW_BOTS``,
+    ``DISCORD_CREW_ALIASES``, ``DISCORD_ALLOW_MENTION_*``,
     ``DISCORD_REPLY_TO_MODE``, ``DISCORD_THREAD_REQUIRE_MENTION``).
     Rather than rewrite ~50 call sites inside the adapter to read from
     ``PlatformConfig.extra`` instead, this hook keeps the existing
@@ -7223,6 +7734,18 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     hbl = discord_cfg.get("history_backfill_limit")
     if hbl is not None and not os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT"):
         os.environ["DISCORD_HISTORY_BACKFILL_LIMIT"] = str(hbl)
+    # allow_bots controls whether other bot/webhook messages are accepted and
+    # included in history context. "mentions" is the safe multi-agent default:
+    # other bots can be seen in context, but only trigger this bot when they
+    # explicitly @mention it.
+    allow_bots = discord_cfg.get("allow_bots")
+    if allow_bots is not None and not os.getenv("DISCORD_ALLOW_BOTS"):
+        os.environ["DISCORD_ALLOW_BOTS"] = str(allow_bots).lower()
+    crew_aliases = discord_cfg.get("crew_aliases")
+    if crew_aliases is not None and not os.getenv("DISCORD_CREW_ALIASES"):
+        if isinstance(crew_aliases, list):
+            crew_aliases = ",".join(str(v) for v in crew_aliases)
+        os.environ["DISCORD_CREW_ALIASES"] = str(crew_aliases).lower()
     # allow_mentions: granular control over what the bot can ping.
     # Safe defaults (no @everyone/roles) are applied in the adapter;
     # these YAML keys only override when set and let users opt back
@@ -7294,10 +7817,10 @@ def register(ctx) -> None:
         # YAML→env config bridge — owns the translation of ``config.yaml``
         # ``discord:`` keys (require_mention, free_response_channels,
         # auto_thread, reactions, ignored_channels, allowed_channels,
-        # no_thread_channels, allow_mentions.*, reply_to_mode,
-        # thread_require_mention) into ``DISCORD_*`` env vars that the
-        # adapter reads via ``os.getenv()``.  Replaces the hardcoded block
-        # that used to live in ``gateway/config.py``.  Hook contract: #24836.
+        # no_thread_channels, history_backfill, allow_bots, crew_aliases,
+        # allow_mentions.*, reply_to_mode, thread_require_mention) into
+        # ``DISCORD_*`` env vars that the adapter reads via ``os.getenv()``.
+        # block that used to live in ``gateway/config.py``. Hook contract: #24836.
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration
         allowed_users_env="DISCORD_ALLOWED_USERS",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4673,8 +4673,9 @@ class DiscordAdapter(BasePlatformAdapter):
             "Worker rules:",
             "- Reply once, briefly, only for your assigned perspective.",
             "- Do not run tools unless the brief explicitly asks you to.",
-            "- Do not reply to acknowledgements, thanks, lol/ok, or the close marker.",
-            "- When the coordinator posts `Huddle closed`, stop unless this huddle is reopened or you are tagged directly.",
+            "- After you have given your assigned one-round reply, your only valid follow-up action is silence unless directly tagged by name after the close marker.",
+            "- Do not post acknowledgements such as 'standing by', 'no further input', 'already answered', 'ok', or similar.",
+            "- After `Huddle closed`, stop completely unless this huddle is explicitly reopened or you are directly tagged.",
             "",
             "Assignments:",
         ]

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -22,6 +22,7 @@ import threading
 import time
 from collections import defaultdict
 from contextlib import suppress
+from datetime import datetime, timezone
 from typing import Callable, Dict, List, Optional, Any, Tuple
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,7 @@ _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
 _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.json"
+_DISCORD_COUNCIL_ROUTES_STATE_FILENAME = "discord_council_routes.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
 # Discord enforces a hard cap of 100 global application (slash) commands per
@@ -231,6 +233,78 @@ class _DiscordNonConversationalMessageTracker:
 
     def __contains__(self, message_id: str) -> bool:
         return str(message_id or "") in self._ids
+
+
+class _DiscordCouncilRouteRecordTracker:
+    """Persistent bounded council route records for restart reconstruction."""
+
+    _MAX_TRACKED = 500
+
+    def __init__(self, max_tracked: int = _MAX_TRACKED):
+        self._max_tracked = max_tracked
+        self._routes: dict[str, dict[str, Any]] = self._load()
+
+    def _state_path(self) -> _Path:
+        from hermes_constants import get_hermes_home
+
+        return (
+            get_hermes_home()
+            / _DISCORD_COMMAND_SYNC_STATE_SUBDIR
+            / _DISCORD_COUNCIL_ROUTES_STATE_FILENAME
+        )
+
+    def _load(self) -> dict[str, dict[str, Any]]:
+        path = self._state_path()
+        if not path.exists():
+            return {}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("routes"), dict):
+                data = data["routes"]
+            if isinstance(data, dict):
+                return {
+                    str(route_id): record
+                    for route_id, record in data.items()
+                    if str(route_id).strip() and isinstance(record, dict)
+                }
+        except Exception:
+            logger.debug("[%s] Failed to load Discord council route records", "Discord", exc_info=True)
+        return {}
+
+    def _save(self) -> None:
+        items = list(self._routes.items())
+        if len(items) > self._max_tracked:
+            self._routes = dict(items[-self._max_tracked:])
+        try:
+            atomic_json_write(self._state_path(), {"routes": self._routes}, indent=None)
+        except Exception:
+            logger.debug("[%s] Failed to save Discord council route records", "Discord", exc_info=True)
+
+    def upsert(self, route_id: str, **fields: Any) -> dict[str, Any]:
+        route_id = str(route_id or "").strip()
+        if not route_id:
+            return {}
+        record = dict(self._routes.get(route_id) or {})
+        record["route_id"] = route_id
+        for key, value in fields.items():
+            record[key] = value
+        self._routes[route_id] = record
+        self._save()
+        return record
+
+    def get(self, route_id: str) -> Optional[dict[str, Any]]:
+        record = self._routes.get(str(route_id or ""))
+        return dict(record) if isinstance(record, dict) else None
+
+    def records(self) -> list[dict[str, Any]]:
+        return [dict(record) for record in self._routes.values()]
+
+    def by_huddle_thread_id(self, thread_id: str) -> Optional[dict[str, Any]]:
+        thread_id = str(thread_id or "")
+        for record in reversed(list(self._routes.values())):
+            if str(record.get("huddle_thread_id") or "") == thread_id:
+                return dict(record)
+        return None
 
 
 def _metadata_marks_nonconversational(metadata: Optional[Dict[str, Any]]) -> bool:
@@ -820,6 +894,12 @@ class DiscordAdapter(BasePlatformAdapter):
         # open/closed, the coordinator must not ambiently respond to worker
         # chatter in that thread; only explicit direct mentions should wake it.
         self._council_huddle_threads: Dict[str, str] = {}
+        self._council_route_records = _DiscordCouncilRouteRecordTracker()
+        for _record in self._council_route_records.records():
+            _huddle_id = str(_record.get("huddle_thread_id") or "")
+            _status = str(_record.get("status") or "")
+            if _huddle_id and _status in {"open", "closed"}:
+                self._council_huddle_threads[_huddle_id] = _status
         # Persistent set of bot-authored lifecycle/status message IDs that
         # should not act as conversational history boundaries after restart.
         self._nonconversational_messages = _DiscordNonConversationalMessageTracker()
@@ -4556,9 +4636,14 @@ class DiscordAdapter(BasePlatformAdapter):
         name = f"{prefix}: {cleaned}"
         return name[:90]
 
-    def _format_council_brief(self, request_text: str, workers: list[dict[str, str]], origin_channel_id: str) -> str:
+    @staticmethod
+    def _council_route_id_for_message(message: Any) -> str:
+        mid = str(getattr(message, "id", "") or "unknown")
+        return f"discord-council-{mid}"
+
+    def _format_council_brief(self, request_text: str, workers: list[dict[str, str]], origin_channel_id: str, route_id: str = "") -> str:
         lines = [
-            "Council brief — bounded huddle.",
+            f"Council brief — bounded huddle. Route: `{route_id}`" if route_id else "Council brief — bounded huddle.",
             "",
             f"User request: {request_text.strip() or '(no text)'}",
             f"Origin channel/thread: <#{origin_channel_id}>",
@@ -4651,10 +4736,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 failures.append(f"{worker.get('name') or wid}: {exc}")
         return failures
 
-    async def _collect_council_transcript(self, thread: Any, limit: int) -> str:
+    async def _collect_council_transcript_and_responders(
+        self,
+        thread: Any,
+        limit: int,
+        workers: list[dict[str, str]],
+    ) -> tuple[str, list[str]]:
         history = getattr(thread, "history", None)
         if not callable(history):
-            return "(No readable huddle transcript; thread history unavailable.)"
+            return "(No readable huddle transcript; thread history unavailable.)", []
+        worker_ids = {str(worker.get("id") or "") for worker in workers}
+        responder_ids: set[str] = set()
         lines: list[str] = []
         try:
             async for msg in history(limit=limit, oldest_first=True):
@@ -4662,13 +4754,21 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not content:
                     continue
                 author = getattr(msg, "author", None)
+                author_id = str(getattr(author, "id", "") or "")
+                if author_id in worker_ids:
+                    responder_ids.add(author_id)
                 name = getattr(author, "display_name", None) or getattr(author, "name", None) or "unknown"
                 if getattr(author, "bot", False):
                     name = f"{name} [bot]"
                 lines.append(f"[{name}] {content}")
         except Exception as exc:
-            return f"(Failed to read huddle transcript: {exc})"
-        return "\n".join(lines) if lines else "(No worker replies captured.)"
+            return f"(Failed to read huddle transcript: {exc})", sorted(responder_ids)
+        transcript = "\n".join(lines) if lines else "(No worker replies captured.)"
+        return transcript, sorted(responder_ids)
+
+    async def _collect_council_transcript(self, thread: Any, limit: int) -> str:
+        transcript, _responders = await self._collect_council_transcript_and_responders(thread, limit, [])
+        return transcript
 
     async def _run_council_synthesis_after_wait(
         self,
@@ -4677,17 +4777,22 @@ class DiscordAdapter(BasePlatformAdapter):
         huddle_thread: Any,
         request_text: str,
         wait_seconds: float,
+        route_id: str,
+        workers: list[dict[str, str]],
     ) -> None:
         thread_id = str(getattr(huddle_thread, "id", ""))
         try:
             if wait_seconds > 0:
                 await asyncio.sleep(wait_seconds)
-            transcript = await self._collect_council_transcript(
+            transcript, actual_responder_ids = await self._collect_council_transcript_and_responders(
                 huddle_thread,
                 self._discord_council_history_limit(),
+                workers,
             )
+            worker_ids = [str(worker.get("id") or "") for worker in workers if str(worker.get("id") or "")]
+            missing_worker_ids = [wid for wid in worker_ids if wid not in set(actual_responder_ids)]
             close_text = (
-                "Huddle closed. I have enough for this round. "
+                f"Huddle closed. Route: `{route_id}`. I have enough for this round. "
                 "Workers, stop here unless this thread is reopened or you are tagged directly."
             )
             with suppress(Exception):
@@ -4718,6 +4823,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 role_authorized=True,
             )
             huddle_ref = f"<#{thread_id}>" if thread_id else "the council huddle"
+            self._council_route_records.upsert(
+                route_id,
+                status="closed",
+                actual_responder_ids=actual_responder_ids,
+                missing_worker_ids=missing_worker_ids,
+                closed_at=datetime.now(timezone.utc).isoformat(),
+                final_delivery_target=str(getattr(origin_channel, "id", "")),
+            )
             event = MessageEvent(
                 text=(
                     "[COUNCIL MODE SYNTHESIS]\n"
@@ -4738,6 +4851,11 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             await self.handle_message(event)
         except Exception:
+            self._council_route_records.upsert(
+                route_id,
+                status="failed",
+                closed_at=datetime.now(timezone.utc).isoformat(),
+            )
             logger.warning("[%s] Council synthesis task failed", self.name, exc_info=True)
         finally:
             if thread_id:
@@ -4787,6 +4905,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
             return True
 
+        route_id = self._council_route_id_for_message(message)
         request_text = normalized_content
         for role in bot_role_mentions:
             request_text = request_text.replace(f"<@&{getattr(role, 'id')}>", "").strip()
@@ -4806,10 +4925,28 @@ class DiscordAdapter(BasePlatformAdapter):
         if thread_id:
             self._council_huddle_threads[thread_id] = "open"
         add_failures = await self._add_council_workers_to_thread(huddle, workers)
+        origin_channel = getattr(message, "channel", None)
+        origin_channel_id = str(getattr(origin_channel, "id", ""))
+        origin_thread_id = origin_channel_id if isinstance(origin_channel, discord.Thread) else None
+        self._council_route_records.upsert(
+            route_id,
+            status="open",
+            origin_channel_id=origin_channel_id,
+            origin_thread_id=origin_thread_id,
+            origin_message_id=str(getattr(message, "id", "")),
+            huddle_thread_id=thread_id,
+            worker_ids=[str(worker.get("id") or "") for worker in workers if str(worker.get("id") or "")],
+            actual_responder_ids=[],
+            missing_worker_ids=[str(worker.get("id") or "") for worker in workers if str(worker.get("id") or "")],
+            opened_at=datetime.now(timezone.utc).isoformat(),
+            closed_at=None,
+            final_delivery_target=origin_channel_id,
+        )
         brief = self._format_council_brief(
             request_text,
             workers,
-            str(getattr(getattr(message, "channel", None), "id", "")),
+            origin_channel_id,
+            route_id,
         )
         if add_failures:
             brief += "\n\nWorker thread-add warnings (continuing with direct mentions):\n" + "\n".join(f"- {item}" for item in add_failures)
@@ -4831,6 +4968,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 huddle_thread=huddle,
                 request_text=request_text,
                 wait_seconds=self._discord_council_wait_seconds(),
+                route_id=route_id,
+                workers=workers,
             )
         )
         return True

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -40,9 +40,11 @@ def _make_message(*, author=None, content="hello", mentions=None, is_dm=False):
 class TestDiscordBotFilter(unittest.TestCase):
     """Test the DISCORD_ALLOW_BOTS filtering logic."""
 
-    def _run_filter(self, message, allow_bots="none", client_user=None):
-        """Simulate the on_message filter logic and return whether message was accepted."""
-        # Replicate the exact filter logic from discord.py on_message
+    def _run_filter(self, message, allow_bots="none", client_user=None, self_role_mentions=None):
+        """Simulate the on_message bot filter and return whether message was accepted."""
+        # Replicate the Discord adapter's bot-message filter: other bots are
+        # accepted only when bot messages are allowed, and in `mentions` mode
+        # only when they mention this bot directly or via one of its roles.
         if message.author == client_user:
             return False  # own messages always ignored
 
@@ -51,10 +53,14 @@ class TestDiscordBotFilter(unittest.TestCase):
             if allow == "none":
                 return False
             elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
+                role_mentions_self = bool(self_role_mentions)
+                if not client_user or (
+                    client_user not in message.mentions
+                    and not role_mentions_self
+                ):
                     return False
             # "all" falls through
-        
+
         return True  # message accepted
 
     def test_own_messages_always_ignored(self):
@@ -96,6 +102,18 @@ class TestDiscordBotFilter(unittest.TestCase):
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[our_user])
         self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+
+    def test_allow_bots_mentions_accepts_with_self_role_mention(self):
+        """With allow_bots=mentions, a bot message mentioning our role is accepted."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        role = MagicMock()
+        role.id = 1234
+        msg = _make_message(author=bot, mentions=[])
+        self.assertTrue(
+            self._run_filter(msg, "mentions", our_user, self_role_mentions=[role])
+        )
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -96,6 +96,14 @@ class TestDiscordBotFilter(unittest.TestCase):
         msg = _make_message(author=bot, mentions=[])
         self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
+    def test_allow_bots_mentions_rejects_bot_message_to_other_agent(self):
+        """Worker bot chatter mentioning another agent must not wake this bot."""
+        our_user = _make_author(is_self=True)
+        other_agent = _make_author(bot=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, mentions=[other_agent])
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
+
     def test_allow_bots_mentions_accepts_with_mention(self):
         """With allow_bots=mentions, bot messages with @mention are accepted."""
         our_user = _make_author(is_self=True)

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
+import asyncio
 import sys
 
 import pytest
@@ -59,8 +60,19 @@ class FakeTextChannel:
     def __init__(self, channel_id: int = 1, name: str = "general", guild_name: str = "Hermes Server"):
         self.id = channel_id
         self.name = name
-        self.guild = SimpleNamespace(name=guild_name)
+        self.guild = SimpleNamespace(id=12345, name=guild_name)
         self.topic = None
+        self.sent_messages = []
+        self.created_threads = []
+
+    async def send(self, content, **kwargs):
+        self.sent_messages.append(content)
+        return SimpleNamespace(id=9000 + len(self.sent_messages), content=content, create_thread=AsyncMock())
+
+    async def create_thread(self, name: str, **kwargs):
+        thread = FakeThread(channel_id=8000 + len(self.created_threads), name=name, parent=self)
+        self.created_threads.append(thread)
+        return thread
 
 
 class FakeThread:
@@ -69,8 +81,32 @@ class FakeThread:
         self.name = name
         self.parent = parent
         self.parent_id = getattr(parent, "id", None)
-        self.guild = getattr(parent, "guild", None) or SimpleNamespace(name=guild_name)
+        self.guild = getattr(parent, "guild", None) or SimpleNamespace(id=12345, name=guild_name)
         self.topic = None
+        self.sent_messages = []
+        self.added_users = []
+        self._history_messages = []
+
+    async def send(self, content, **kwargs):
+        self.sent_messages.append(content)
+        author = SimpleNamespace(display_name="Pixoid", name="Pixoid", bot=True)
+        msg = SimpleNamespace(id=9100 + len(self.sent_messages), content=content, clean_content=content, author=author)
+        self._history_messages.append(msg)
+        return msg
+
+    async def add_user(self, user):
+        self.added_users.append(user)
+
+    def history(self, *, limit=100, oldest_first=False):
+        messages = list(self._history_messages)[:limit]
+        if not oldest_first:
+            messages.reverse()
+
+        async def _iter():
+            for msg in messages:
+                yield msg
+
+        return _iter()
 
 
 @pytest.fixture
@@ -80,23 +116,27 @@ def adapter(monkeypatch):
 
     config = PlatformConfig(enabled=True, token="fake-token")
     adapter = DiscordAdapter(config)
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
     adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
     adapter._text_batch_delay_seconds = 0  # disable batching for tests
     adapter.handle_message = AsyncMock()
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None):
+def make_message(*, channel, content: str, mentions=None, role_mentions=None):
     author = SimpleNamespace(id=42, display_name="TestUser", name="TestUser")
     return SimpleNamespace(
         id=123,
         content=content,
         mentions=list(mentions or []),
+        role_mentions=list(role_mentions or []),
         attachments=[],
         reference=None,
         created_at=datetime.now(timezone.utc),
         channel=channel,
         author=author,
+        guild=getattr(channel, "guild", None),
     )
 
 
@@ -127,6 +167,251 @@ async def test_ignored_channel_blocks_even_with_mention(adapter, monkeypatch):
         channel=FakeTextChannel(channel_id=500),
         content=f"<@{bot_user.id}> hello",
         mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_managed_bot_role_mention_counts_as_bot_mention(adapter, monkeypatch):
+    """Selecting a bot's managed @role should route like a direct bot mention."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_role = SimpleNamespace(id=1234, managed=True)
+    other_role = SimpleNamespace(id=5678, managed=True)
+    channel = FakeTextChannel(channel_id=700)
+    channel.guild.me = SimpleNamespace(roles=[bot_role])
+    message = make_message(
+        channel=channel,
+        content=f"<@&{bot_role.id}> hello",
+        role_mentions=[bot_role],
+        mentions=[],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "hello"
+
+    adapter.handle_message.reset_mock()
+    message = make_message(
+        channel=channel,
+        content=f"<@&{other_role.id}> hello",
+        role_mentions=[other_role],
+        mentions=[],
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shared_role_mention_with_human_mention_counts_as_bot_call(adapter, monkeypatch):
+    """@Crew plus @Human should still call every bot that has the Crew role."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    crew_role = SimpleNamespace(id=2468, managed=False)
+    human = SimpleNamespace(id=42, bot=False)
+    channel = FakeTextChannel(channel_id=700)
+    channel.guild.me = SimpleNamespace(roles=[crew_role])
+    message = make_message(
+        channel=channel,
+        content=f"<@&{crew_role.id}> say hi to <@{human.id}>",
+        role_mentions=[crew_role],
+        mentions=[human],
+    )
+
+    assert adapter._message_mentions_own_role(message) == [crew_role]
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == f"say hi to <@{human.id}>"
+
+
+@pytest.mark.asyncio
+async def test_configured_crew_alias_counts_as_bot_call(adapter, monkeypatch):
+    """Configured crew phrases wake each participating bot without a direct tag."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_CREW_ALIASES", "crew:,get the crew,calling the crew")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=700),
+        content="crew: discuss this together",
+        mentions=[],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "crew: discuss this together"
+
+
+@pytest.mark.asyncio
+async def test_council_mode_opens_huddle_invites_workers_closes_and_synthesizes(adapter, monkeypatch):
+    """Coordinator council mode turns a crew call into a bounded huddle, not a dogpile."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_CREW_ALIASES", "crew:")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["council_mode"] = {
+        "enabled": True,
+        "wait_seconds": 0,
+        "workers": [
+            {"name": "Boba", "id": "111", "role": "reality check"},
+            {"name": "Quill", "id": "222", "role": "docs"},
+            {"name": "Tinker", "id": "333", "role": "implementation"},
+        ],
+    }
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=999),
+        get_user=lambda user_id: SimpleNamespace(id=user_id),
+    )
+
+    channel = FakeTextChannel(channel_id=700)
+    message = make_message(channel=channel, content="crew: decide the multiplayer flow", mentions=[])
+    await adapter._handle_message(message)
+
+    assert len(channel.created_threads) == 1
+    huddle = channel.created_threads[0]
+    assert huddle.id in {8000, "8000"} or str(huddle.id) == "8000"
+    assert len(huddle.added_users) == 3
+    assert "<@111>" in huddle.sent_messages[0]
+    assert not huddle.sent_messages[0].startswith("Huddle closed")
+    assert "@Crew is coordinator-led" in channel.sent_messages[0]
+    assert "bounded crew huddle" in channel.sent_messages[0]
+    assert "@Boba" in channel.sent_messages[0]
+
+    for _ in range(10):
+        if adapter.handle_message.await_count:
+            break
+        await asyncio.sleep(0)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.internal is True
+    assert event.text.startswith("[COUNCIL MODE SYNTHESIS]")
+    assert "Huddle transcript" in event.text
+    assert "Huddle closed" in huddle.sent_messages[-1]
+    assert adapter._council_huddle_threads[str(huddle.id)] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_council_mode_no_tools_smoke_test_explains_no_huddle(adapter, monkeypatch):
+    """@Crew + no-tools should be legible and should not wake workers."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_CREW_ALIASES", "crew:")
+    adapter.config.extra["council_mode"] = {
+        "enabled": True,
+        "wait_seconds": 0,
+        "workers": [{"name": "Boba", "id": "111"}],
+    }
+
+    channel = FakeTextChannel(channel_id=700)
+    message = make_message(
+        channel=channel,
+        content="crew: can we test the multiplayer experience? just reply yes; dont run any tools yet",
+        mentions=[],
+    )
+    await adapter._handle_message(message)
+
+    assert channel.created_threads == []
+    adapter.handle_message.assert_not_awaited()
+    assert len(channel.sent_messages) == 1
+    assert "Yes — I hear you" in channel.sent_messages[0]
+    assert "asked me not to run tools" in channel.sent_messages[0]
+    assert "won't open a huddle" in channel.sent_messages[0]
+    assert "@Boba" in channel.sent_messages[0]
+
+
+@pytest.mark.asyncio
+async def test_council_mode_missing_workers_reports_route_gap_not_bare_answer(adapter, monkeypatch):
+    """Enabled @Crew route with no workers should not collapse to the LLM."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_CREW_ALIASES", "crew:")
+    adapter.config.extra["council_mode"] = {"enabled": True, "wait_seconds": 0, "workers": []}
+
+    channel = FakeTextChannel(channel_id=700)
+    message = make_message(
+        channel=channel,
+        content="crew: can we test the multiplayer experience? just reply yes if you hear it from me",
+        mentions=[],
+    )
+    await adapter._handle_message(message)
+
+    assert channel.created_threads == []
+    adapter.handle_message.assert_not_awaited()
+    assert len(channel.sent_messages) == 1
+    assert "@Crew is coordinator-led" in channel.sent_messages[0]
+    assert "couldn't start a crew huddle" in channel.sent_messages[0]
+    assert "no council workers are configured" in channel.sent_messages[0]
+
+
+@pytest.mark.asyncio
+async def test_council_huddle_suppresses_ambient_worker_chatter(adapter, monkeypatch):
+    """Open/closed huddle threads do not wake Pixoid on unmentioned worker messages."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    parent = FakeTextChannel(channel_id=700)
+    thread = FakeThread(channel_id=8000, name="crew-huddle", parent=parent)
+    adapter._council_huddle_threads[str(thread.id)] = "open"
+    worker_author = SimpleNamespace(id=111, display_name="Boba", name="Boba", bot=True)
+    message = make_message(channel=thread, content="Boba view: risk here", mentions=[])
+    message.author = worker_author
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_council_mode_reuses_current_workbench_thread(adapter, monkeypatch):
+    """@Crew inside an agent-workbench thread invites workers into that thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_CREW_ALIASES", "crew:")
+    adapter.config.extra["council_mode"] = {
+        "enabled": True,
+        "wait_seconds": 0,
+        "workbench_channel_id": "700",
+        "workers": [{"name": "Tinker", "id": "333"}],
+    }
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=999),
+        get_channel=lambda channel_id: None,
+        fetch_channel=AsyncMock(),
+        get_user=lambda user_id: SimpleNamespace(id=user_id),
+    )
+    parent = FakeTextChannel(channel_id=700, name="agent-workbench")
+    thread = FakeThread(channel_id=8000, name="existing", parent=parent)
+    message = make_message(channel=thread, content="crew: discuss in here", mentions=[])
+
+    await adapter._handle_message(message)
+
+    assert parent.created_threads == []
+    assert len(thread.added_users) == 1
+    assert "<@333>" in thread.sent_messages[0]
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_crew_word_does_not_wake_bot(adapter, monkeypatch):
+    """The word crew is not ambient wakeup unless an explicit alias is configured."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=700),
+        content="the crew should discuss things",
+        mentions=[],
     )
     await adapter._handle_message(message)
 
@@ -281,6 +566,31 @@ async def test_no_thread_with_auto_thread_disabled_is_noop(adapter, monkeypatch)
     adapter.handle_message.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_auto_create_thread_reuses_existing_starter_thread(adapter):
+    """Multi-bot races should reuse the starter's thread, not spawn fallback threads."""
+    existing_thread = FakeThread(channel_id=999, name="crew-council")
+    refreshed_message = SimpleNamespace(thread=existing_thread)
+    channel = SimpleNamespace(
+        fetch_message=AsyncMock(return_value=refreshed_message),
+        send=AsyncMock(),
+    )
+    message = SimpleNamespace(
+        id=123,
+        content="<@999> <@888> discuss this together",
+        author=SimpleNamespace(display_name="Pixiedust"),
+        channel=channel,
+        thread=None,
+        create_thread=AsyncMock(side_effect=RuntimeError("message already has a thread")),
+    )
+
+    thread = await adapter._auto_create_thread(message)
+
+    assert thread is existing_thread
+    channel.fetch_message.assert_awaited_once_with(123)
+    channel.send.assert_not_awaited()
+
+
 # ── config.py bridging ───────────────────────────────────────────────
 
 
@@ -322,6 +632,44 @@ def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("DISCORD_NO_THREAD_CHANNELS") == "333"
+
+
+def test_config_bridges_allow_bots(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.allow_bots to DISCORD_ALLOW_BOTS."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "allow_bots": "mentions",
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_ALLOW_BOTS") == "mentions"
+
+
+def test_config_bridges_crew_aliases(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.crew_aliases to DISCORD_CREW_ALIASES."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "crew_aliases": ["crew:", "get the crew"],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_CREW_ALIASES", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_CREW_ALIASES") == "crew:,get the crew"
 
 
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -546,6 +546,49 @@ async def test_unconfigured_crew_word_does_not_wake_bot(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_allowed_channels_blocks_direct_mention_outside_worker_context(adapter, monkeypatch):
+    """Worker whitelists block explicit @mentions outside approved contexts."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "700")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=900, name="random"),
+        content=f"<@{bot_user.id}> Boba can you check this?",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_allowed_channels_permits_direct_mention_in_approved_thread(adapter, monkeypatch):
+    """A worker restricted to the workbench parent can still be summoned in its threads."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["allowed_channels"] = ["700"]
+
+    bot_user = adapter._client.user
+    parent = FakeTextChannel(channel_id=700, name="agent-workbench")
+    thread = FakeThread(channel_id=8000, name="crew-huddle", parent=parent)
+    message = make_message(
+        channel=thread,
+        content=f"<@{bot_user.id}> Quill please add source-truth notes",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_non_ignored_channel_processes_normally(adapter, monkeypatch):
     """Channels not in the ignored list process normally."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
@@ -1039,6 +1082,25 @@ def test_config_bridges_allow_bots(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("DISCORD_ALLOW_BOTS") == "mentions"
+
+
+def test_config_bridges_allowed_channels(monkeypatch, tmp_path):
+    """gateway/config.py bridges worker channel whitelists to DISCORD_ALLOWED_CHANNELS."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "allowed_channels": ["700", "800"],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_ALLOWED_CHANNELS") == "700,800"
 
 
 def test_config_bridges_crew_aliases(monkeypatch, tmp_path):

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -1122,6 +1122,33 @@ def test_config_bridges_crew_aliases(monkeypatch, tmp_path):
     assert os.getenv("DISCORD_CREW_ALIASES") == "crew:,get the crew"
 
 
+def test_config_seeds_council_mode_extra(monkeypatch, tmp_path):
+    """Nested discord.council_mode must reach DiscordAdapter via PlatformConfig.extra."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "enabled": True,
+            "council_mode": {
+                "enabled": True,
+                "workbench_channel_id": "700",
+                "wait_seconds": 0,
+                "workers": [{"name": "Boba", "id": "111"}],
+            },
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "token")
+
+    from gateway.config import Platform, load_gateway_config
+    config = load_gateway_config()
+
+    council_mode = config.platforms[Platform.DISCORD].extra["council_mode"]
+    assert council_mode["enabled"] is True
+    assert council_mode["workbench_channel_id"] == "700"
+    assert council_mode["workers"] == [{"name": "Boba", "id": "111"}]
+
+
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     """Env vars should take precedence over config.yaml values."""
     import yaml

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -327,6 +327,8 @@ async def test_council_mode_opens_huddle_invites_workers_closes_and_synthesizes(
     assert huddle.id in {8000, "8000"} or str(huddle.id) == "8000"
     assert len(huddle.added_users) == 3
     assert "<@111>" in huddle.sent_messages[0]
+    assert "no further input" in huddle.sent_messages[0]
+    assert "After `Huddle closed`, stop completely" in huddle.sent_messages[0]
     assert not huddle.sent_messages[0].startswith("Huddle closed")
     assert "@Crew is coordinator-led" in channel.sent_messages[0]
     assert "bounded crew huddle" in channel.sent_messages[0]

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -538,6 +538,33 @@ async def test_council_mode_missing_workers_reports_route_gap_not_bare_answer(ad
 
 
 @pytest.mark.asyncio
+async def test_channel_allow_bots_none_only_blocks_top_level_channels(adapter, monkeypatch):
+    """Safer shared-channel config blocks bot chatter in channels but preserves thread handoffs."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("DISCORD_CHANNEL_ALLOW_BOTS", "none")
+
+    bot_user = SimpleNamespace(id=999)
+    adapter._client = SimpleNamespace(user=bot_user)
+    bot_author = SimpleNamespace(id=111, display_name="Boba", name="Boba", bot=True)
+
+    channel_msg = make_message(
+        channel=FakeTextChannel(channel_id=700),
+        content=f"<@{bot_user.id}> channel status ping",
+        mentions=[bot_user],
+    )
+    channel_msg.author = bot_author
+    assert adapter._discord_allow_bots_for_message(channel_msg) == "none"
+
+    thread_msg = make_message(
+        channel=FakeThread(channel_id=8000, parent=FakeTextChannel(channel_id=700)),
+        content=f"<@{bot_user.id}> thread handoff ping",
+        mentions=[bot_user],
+    )
+    thread_msg.author = bot_author
+    assert adapter._discord_allow_bots_for_message(thread_msg) == "mentions"
+
+
+@pytest.mark.asyncio
 async def test_council_huddle_suppresses_ambient_worker_chatter(adapter, monkeypatch):
     """Open/closed huddle threads do not wake Pixoid on unmentioned worker messages."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
@@ -1228,6 +1255,28 @@ def test_config_bridges_allow_bots(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("DISCORD_ALLOW_BOTS") == "mentions"
+
+
+def test_config_bridges_channel_allow_bots(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.channel_allow_bots to DISCORD_CHANNEL_ALLOW_BOTS."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "allow_bots": "mentions",
+            "channel_allow_bots": "none",
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "")
+    monkeypatch.setenv("DISCORD_CHANNEL_ALLOW_BOTS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_ALLOW_BOTS") == "mentions"
+    assert os.getenv("DISCORD_CHANNEL_ALLOW_BOTS") == "none"
 
 
 def test_config_bridges_allowed_channels(monkeypatch, tmp_path):

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -614,6 +614,119 @@ async def test_dms_unaffected_by_ignored_channels(adapter, monkeypatch):
 
 
 
+
+
+def _append_worker_reply(thread, *, worker_id: int, name: str, content: str):
+    author = SimpleNamespace(id=worker_id, display_name=name, name=name, bot=True)
+    msg = SimpleNamespace(
+        id=9200 + len(thread._history_messages),
+        content=content,
+        clean_content=content,
+        author=author,
+    )
+    thread._history_messages.append(msg)
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_council_closes_as_soon_as_all_workers_replied(adapter):
+    """All-replied path closes without waiting for the full timeout."""
+    origin = FakeTextChannel(channel_id=700)
+    huddle = FakeThread(channel_id=8000, name="crew-huddle", parent=origin)
+    workers = [{"name": "Boba", "id": "111"}, {"name": "Quill", "id": "222"}]
+    _append_worker_reply(huddle, worker_id=111, name="Boba", content="Boba: yes")
+    _append_worker_reply(huddle, worker_id=222, name="Quill", content="Quill: yes")
+
+    await adapter._run_council_synthesis_after_wait(
+        origin_message=make_message(channel=origin, content="crew: test", mentions=[]),
+        huddle_thread=huddle,
+        request_text="crew: test",
+        wait_seconds=999,
+        route_id="discord-council-all-replied",
+        workers=workers,
+    )
+
+    assert "All invited workers replied" in huddle.sent_messages[-1]
+    record = adapter._council_route_records.get("discord-council-all-replied")
+    assert record["close_reason"] == "all_replied"
+    assert record["actual_responder_ids"] == ["111", "222"]
+    assert record["missing_worker_ids"] == []
+    event = adapter.handle_message.await_args.args[0]
+    assert "close_reason=all_replied" in event.text
+    assert "missing_worker_ids=[]" in event.text
+
+
+@pytest.mark.asyncio
+async def test_council_timeout_records_partial_missing_workers(adapter):
+    """Timeout path records contributors and missing workers explicitly."""
+    origin = FakeTextChannel(channel_id=700)
+    huddle = FakeThread(channel_id=8000, name="crew-huddle", parent=origin)
+    workers = [{"name": "Boba", "id": "111"}, {"name": "Quill", "id": "222"}]
+    _append_worker_reply(huddle, worker_id=111, name="Boba", content="Boba: yes")
+
+    await adapter._run_council_synthesis_after_wait(
+        origin_message=make_message(channel=origin, content="crew: test", mentions=[]),
+        huddle_thread=huddle,
+        request_text="crew: test",
+        wait_seconds=0,
+        route_id="discord-council-partial-timeout",
+        workers=workers,
+    )
+
+    assert "Timeout reached" in huddle.sent_messages[-1]
+    record = adapter._council_route_records.get("discord-council-partial-timeout")
+    assert record["close_reason"] == "timeout"
+    assert record["actual_responder_ids"] == ["111"]
+    assert record["missing_worker_ids"] == ["222"]
+
+
+@pytest.mark.asyncio
+async def test_council_timeout_records_no_replies(adapter):
+    """No-reply timeout keeps every invited worker in missing_worker_ids."""
+    origin = FakeTextChannel(channel_id=700)
+    huddle = FakeThread(channel_id=8000, name="crew-huddle", parent=origin)
+    workers = [{"name": "Boba", "id": "111"}, {"name": "Quill", "id": "222"}]
+
+    await adapter._run_council_synthesis_after_wait(
+        origin_message=make_message(channel=origin, content="crew: test", mentions=[]),
+        huddle_thread=huddle,
+        request_text="crew: test",
+        wait_seconds=0,
+        route_id="discord-council-no-reply-timeout",
+        workers=workers,
+    )
+
+    record = adapter._council_route_records.get("discord-council-no-reply-timeout")
+    assert record["close_reason"] == "timeout"
+    assert record["actual_responder_ids"] == []
+    assert record["missing_worker_ids"] == ["111", "222"]
+
+
+@pytest.mark.asyncio
+async def test_late_worker_reply_after_close_does_not_reopen_huddle(adapter, monkeypatch):
+    """Late worker messages after close stay silent and do not alter route state."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    parent = FakeTextChannel(channel_id=700)
+    huddle = FakeThread(channel_id=8000, name="crew-huddle", parent=parent)
+    adapter._council_huddle_threads[str(huddle.id)] = "closed"
+    adapter._council_route_records.upsert(
+        "discord-council-late",
+        status="closed",
+        huddle_thread_id=str(huddle.id),
+        worker_ids=["111"],
+        actual_responder_ids=[],
+        missing_worker_ids=["111"],
+    )
+    worker_author = SimpleNamespace(id=111, display_name="Boba", name="Boba", bot=True)
+    message = make_message(channel=huddle, content="late worker reply", mentions=[])
+    message.author = worker_author
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+    assert adapter._council_huddle_threads[str(huddle.id)] == "closed"
+    assert adapter._council_route_records.get("discord-council-late")["status"] == "closed"
+
 # ── council replay regressions ────────────────────────────────────────
 
 

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -256,6 +256,45 @@ async def test_configured_crew_alias_counts_as_bot_call(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_direct_specialist_mention_still_wakes_when_crew_alias_disabled(adapter, monkeypatch):
+    """Restricted workers stay directly summonable by explicit @mention."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=700),
+        content=f"<@{bot_user.id}> Boba, quick reality check",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "Boba, quick reality check"
+
+
+@pytest.mark.asyncio
+async def test_worker_profile_ignores_broad_crew_alias_when_not_configured(adapter, monkeypatch):
+    """Worker profiles with no crew aliases do not join @Crew/crew: dogpiles."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=700),
+        content="crew: discuss this together",
+        mentions=[],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_council_mode_opens_huddle_invites_workers_closes_and_synthesizes(adapter, monkeypatch):
     """Coordinator council mode turns a crew call into a bounded huddle, not a dogpile."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
@@ -370,6 +409,27 @@ async def test_council_huddle_suppresses_ambient_worker_chatter(adapter, monkeyp
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_thread_require_mention_worker_ignores_close_markers_and_acks(adapter, monkeypatch):
+    """Worker-style profiles stay quiet on huddle close markers and casual acks."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    parent = FakeTextChannel(channel_id=700)
+    thread = FakeThread(channel_id=8000, name="crew-huddle", parent=parent)
+    adapter._threads.mark(str(thread.id))
+
+    for content in (
+        "Huddle closed. Workers, stop here unless tagged directly.",
+        "ok thanks",
+    ):
+        adapter.handle_message.reset_mock()
+        message = make_message(channel=thread, content=content, mentions=[])
+        await adapter._handle_message(message)
+        adapter.handle_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -110,9 +110,12 @@ class FakeThread:
 
 
 @pytest.fixture
-def adapter(monkeypatch):
+def adapter(monkeypatch, tmp_path):
     monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
     monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     config = PlatformConfig(enabled=True, token="fake-token")
     adapter = DiscordAdapter(config)
@@ -124,10 +127,10 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None, role_mentions=None):
+def make_message(*, channel, content: str, mentions=None, role_mentions=None, message_id: int = 123):
     author = SimpleNamespace(id=42, display_name="TestUser", name="TestUser")
     return SimpleNamespace(
-        id=123,
+        id=message_id,
         content=content,
         mentions=list(mentions or []),
         role_mentions=list(role_mentions or []),
@@ -340,7 +343,71 @@ async def test_council_mode_opens_huddle_invites_workers_closes_and_synthesizes(
     assert event.text.startswith("[COUNCIL MODE SYNTHESIS]")
     assert "Huddle transcript" in event.text
     assert "Huddle closed" in huddle.sent_messages[-1]
+    assert "Route: `discord-council-123`" in huddle.sent_messages[0]
+    assert "Route: `discord-council-123`" in huddle.sent_messages[-1]
     assert adapter._council_huddle_threads[str(huddle.id)] == "closed"
+    record = adapter._council_route_records.get("discord-council-123")
+    assert record["status"] == "closed"
+    assert record["origin_channel_id"] == "700"
+    assert record["huddle_thread_id"] == str(huddle.id)
+    assert record["worker_ids"] == ["111", "222", "333"]
+    assert record["actual_responder_ids"] == []
+    assert record["missing_worker_ids"] == ["111", "222", "333"]
+    assert record["final_delivery_target"] == "700"
+
+
+@pytest.mark.asyncio
+async def test_council_route_records_do_not_collide_between_huddles(adapter, monkeypatch):
+    """Separate @Crew requests get distinct route records and huddle IDs."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_CREW_ALIASES", "crew:")
+    adapter.config.extra["council_mode"] = {
+        "enabled": True,
+        "wait_seconds": 0,
+        "workers": [{"name": "Boba", "id": "111"}],
+    }
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=999),
+        get_user=lambda user_id: SimpleNamespace(id=user_id),
+    )
+    channel = FakeTextChannel(channel_id=700)
+
+    await adapter._handle_message(
+        make_message(channel=channel, content="crew: first huddle", mentions=[], message_id=123)
+    )
+    await adapter._handle_message(
+        make_message(channel=channel, content="crew: second huddle", mentions=[], message_id=124)
+    )
+    for _ in range(20):
+        if adapter.handle_message.await_count >= 2:
+            break
+        await asyncio.sleep(0)
+
+    first = adapter._council_route_records.get("discord-council-123")
+    second = adapter._council_route_records.get("discord-council-124")
+    assert first["route_id"] != second["route_id"]
+    assert first["huddle_thread_id"] != second["huddle_thread_id"]
+    assert first["status"] == "closed"
+    assert second["status"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_council_route_records_restore_huddle_status_from_disk(adapter):
+    """Restart reconstruction restores open/closed huddle suppression state."""
+    adapter._council_route_records.upsert(
+        "discord-council-restore",
+        status="open",
+        huddle_thread_id="9001",
+        origin_channel_id="700",
+        worker_ids=["111"],
+        actual_responder_ids=[],
+        missing_worker_ids=["111"],
+    )
+
+    restored = DiscordAdapter(PlatformConfig(enabled=True, token="fake-token"))
+
+    assert restored._council_huddle_threads["9001"] == "open"
+    assert restored._council_route_records.get("discord-council-restore")["worker_ids"] == ["111"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -545,6 +545,154 @@ async def test_dms_unaffected_by_ignored_channels(adapter, monkeypatch):
     adapter.handle_message.assert_awaited_once()
 
 
+
+
+# ── council replay regressions ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_replay_existing_workbench_thread_membership_trap_reuses_thread(adapter, monkeypatch):
+    """Replay: @Crew inside #agent-workbench should reuse the current thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_CREW_ALIASES", "crew:")
+    adapter.config.extra["council_mode"] = {
+        "enabled": True,
+        "wait_seconds": 0,
+        "workbench_channel_id": "700",
+        "workers": [{"name": "Tinker", "id": "333"}],
+    }
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=999),
+        get_channel=lambda channel_id: None,
+        fetch_channel=AsyncMock(),
+        get_user=lambda user_id: SimpleNamespace(id=user_id),
+    )
+    parent = FakeTextChannel(channel_id=700, name="agent-workbench")
+    existing = FakeThread(channel_id=8000, name="existing-huddle", parent=parent)
+
+    await adapter._handle_message(
+        make_message(channel=existing, content="crew: test multiplayer here", mentions=[])
+    )
+
+    assert parent.created_threads == []
+    assert len(existing.added_users) == 1
+    assert "<@333>" in existing.sent_messages[0]
+    assert "bounded crew huddle" in existing.sent_messages[1]
+
+
+@pytest.mark.asyncio
+async def test_replay_crew_role_mention_opens_pixoid_council_route(adapter, monkeypatch):
+    """Replay: @Crew role mention should become Pixoid-led council, not bare yes."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
+    crew_role = SimpleNamespace(id=2468, managed=False)
+    channel = FakeTextChannel(channel_id=700)
+    channel.guild.me = SimpleNamespace(roles=[crew_role])
+    adapter.config.extra["council_mode"] = {
+        "enabled": True,
+        "wait_seconds": 0,
+        "workers": [{"name": "Boba", "id": "111"}],
+    }
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=999),
+        get_user=lambda user_id: SimpleNamespace(id=user_id),
+    )
+
+    await adapter._handle_message(
+        make_message(
+            channel=channel,
+            content=f"<@&{crew_role.id}> can we test the multiplayer experience? just reply yes",
+            role_mentions=[crew_role],
+            mentions=[],
+        )
+    )
+
+    assert len(channel.created_threads) == 1
+    assert "@Crew is coordinator-led" in channel.sent_messages[0]
+    assert "bounded crew huddle" in channel.sent_messages[0]
+
+    for _ in range(10):
+        if adapter.handle_message.await_count:
+            break
+        await asyncio.sleep(0)
+
+    adapter.handle_message.assert_awaited_once()
+    assert adapter.handle_message.await_args.args[0].internal is True
+
+
+@pytest.mark.asyncio
+async def test_replay_crew_no_tools_skips_huddle_with_explanation(adapter, monkeypatch):
+    """Replay: user's original no-tools smoke test should not create a huddle."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_CREW_ALIASES", "crew:")
+    adapter.config.extra["council_mode"] = {
+        "enabled": True,
+        "wait_seconds": 0,
+        "workers": [{"name": "Boba", "id": "111"}],
+    }
+    channel = FakeTextChannel(channel_id=700)
+
+    await adapter._handle_message(
+        make_message(
+            channel=channel,
+            content="crew: can we test the multiplayer experience here? just reply yes if you hear it from me...dont run any tools yet",
+            mentions=[],
+        )
+    )
+
+    assert channel.created_threads == []
+    assert "asked me not to run tools" in channel.sent_messages[0]
+    assert "@Boba" in channel.sent_messages[0]
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_replay_crew_without_no_tools_reports_unavailable_instead_of_bare_yes(adapter, monkeypatch):
+    """Replay: tools-allowed smoke test must open council or explain why not."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_CREW_ALIASES", "crew:")
+    adapter.config.extra["council_mode"] = {"enabled": True, "workers": []}
+    channel = FakeTextChannel(channel_id=700)
+
+    await adapter._handle_message(
+        make_message(
+            channel=channel,
+            content="crew: can we test out the multiplayer experience here? just reply yes if you hear it from me...",
+            mentions=[],
+        )
+    )
+
+    assert channel.created_threads == []
+    assert "no council workers are configured" in channel.sent_messages[0]
+    assert "@Crew is coordinator-led" in channel.sent_messages[0]
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_replay_worker_close_marker_ack_lol_thanks_stay_silent(adapter, monkeypatch):
+    """Replay: workers do not loop on close markers or casual acknowledgements."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
+    thread = FakeThread(channel_id=8000, name="crew-huddle", parent=FakeTextChannel(channel_id=700))
+    adapter._threads.mark(str(thread.id))
+    adapter._council_huddle_threads[str(thread.id)] = "closed"
+
+    for content in (
+        "Huddle closed. I have enough for this round.",
+        "ok",
+        "lol thanks",
+    ):
+        adapter.handle_message.reset_mock()
+        await adapter._handle_message(make_message(channel=thread, content=content, mentions=[]))
+        adapter.handle_message.assert_not_awaited()
+
+
+def test_replay_duplicate_discord_event_id_is_idempotent(adapter):
+    """Replay: duplicate Discord message IDs are suppressed by the dedup cache."""
+    assert adapter._dedup.is_duplicate("1521209357902024715") is False
+    assert adapter._dedup.is_duplicate("1521209357902024715") is True
+
 # ── no_thread_channels ───────────────────────────────────────────────
 
 

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -359,6 +359,80 @@ async def test_council_mode_opens_huddle_invites_workers_closes_and_synthesizes(
 
 
 @pytest.mark.asyncio
+async def test_council_mode_role_trigger_only_for_council_role(adapter, monkeypatch):
+    """Mentioning @Pixoid should not open an @Crew huddle just because Pixoid owns that role."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["council_mode"] = {
+        "enabled": True,
+        "wait_seconds": 0,
+        "workers": [{"name": "Boba", "id": "111", "role": "reality check"}],
+    }
+
+    pixoid_role = SimpleNamespace(id=2468, name="Pixoid", managed=False)
+    channel = FakeTextChannel(channel_id=700)
+    channel.guild.me = SimpleNamespace(roles=[pixoid_role])
+    message = make_message(
+        channel=channel,
+        content=f"<@&{pixoid_role.id}> can you check what processes are running?",
+        role_mentions=[pixoid_role],
+        mentions=[],
+    )
+
+    await adapter._handle_message(message)
+
+    assert channel.created_threads == []
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "can you check what processes are running?"
+
+
+@pytest.mark.asyncio
+async def test_council_mode_role_trigger_accepts_crew_role_name(adapter, monkeypatch):
+    """A real @Crew role mention still opens the bounded council huddle."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["council_mode"] = {
+        "enabled": True,
+        "wait_seconds": 0,
+        "workers": [{"name": "Boba", "id": "111", "role": "reality check"}],
+    }
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=999),
+        get_user=lambda user_id: SimpleNamespace(id=user_id),
+    )
+
+    crew_role = SimpleNamespace(id=2468, name="Crew", managed=False)
+    channel = FakeTextChannel(channel_id=700)
+    channel.guild.me = SimpleNamespace(roles=[crew_role])
+    message = make_message(
+        channel=channel,
+        content=f"<@&{crew_role.id}> decide the multiplayer flow",
+        role_mentions=[crew_role],
+        mentions=[],
+    )
+
+    await adapter._handle_message(message)
+
+    assert len(channel.created_threads) == 1
+    huddle = channel.created_threads[0]
+    assert "<@111>" in huddle.sent_messages[0]
+    assert "decide the multiplayer flow" in huddle.sent_messages[0]
+    assert "@Crew is coordinator-led" in channel.sent_messages[0]
+
+    for _ in range(10):
+        if adapter.handle_message.await_count:
+            break
+        await asyncio.sleep(0)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_council_route_records_do_not_collide_between_huddles(adapter, monkeypatch):
     """Separate @Crew requests get distinct route records and huddle IDs."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
@@ -481,6 +555,27 @@ async def test_council_huddle_suppresses_ambient_worker_chatter(adapter, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_council_huddle_suppresses_bot_reply_ping_after_close(adapter, monkeypatch):
+    """Closed huddles drop implicit reply pings before model invocation."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    parent = FakeTextChannel(channel_id=700)
+    thread = FakeThread(channel_id=8000, name="crew-huddle", parent=parent)
+    adapter._council_huddle_threads[str(thread.id)] = "closed"
+    worker_author = SimpleNamespace(id=111, display_name="Boba", name="Boba", bot=True)
+    message = make_message(
+        channel=thread,
+        content="Silence.",
+        mentions=[adapter._client.user],  # implicit Discord reply ping, not textual <@id>
+    )
+    message.author = worker_author
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_thread_require_mention_worker_ignores_close_markers_and_acks(adapter, monkeypatch):
     """Worker-style profiles stay quiet on huddle close markers and casual acks."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
@@ -499,6 +594,55 @@ async def test_thread_require_mention_worker_ignores_close_markers_and_acks(adap
         message = make_message(channel=thread, content=content, mentions=[])
         await adapter._handle_message(message)
         adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_thread_require_mention_worker_ignores_bot_reply_ping_without_textual_tag(adapter, monkeypatch):
+    """Discord reply pings from Pixoid do not count as direct worker summons."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    parent = FakeTextChannel(channel_id=700)
+    thread = FakeThread(channel_id=8000, name="crew-huddle", parent=parent)
+    adapter._threads.mark(str(thread.id))
+
+    bot_user = adapter._client.user
+    pixoid_author = SimpleNamespace(id=1510114832991522906, display_name="Pixoid", name="Pixoid", bot=True)
+    message = make_message(
+        channel=thread,
+        content="Verified: huddle closed; no further worker action needed.",
+        mentions=[bot_user],  # implicit Discord reply mention, not textual <@id>
+    )
+    message.author = pixoid_author
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_thread_require_mention_worker_accepts_bot_textual_tag(adapter, monkeypatch):
+    """Explicit bot-authored <@id> text still counts as a direct worker summon."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    parent = FakeTextChannel(channel_id=700)
+    thread = FakeThread(channel_id=8000, name="crew-huddle", parent=parent)
+
+    bot_user = adapter._client.user
+    pixoid_author = SimpleNamespace(id=1510114832991522906, display_name="Pixoid", name="Pixoid", bot=True)
+    message = make_message(
+        channel=thread,
+        content=f"<@{bot_user.id}> direct follow-up requested",
+        mentions=[bot_user],
+    )
+    message.author = pixoid_author
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -810,7 +954,7 @@ async def test_replay_crew_role_mention_opens_pixoid_council_route(adapter, monk
     """Replay: @Crew role mention should become Pixoid-led council, not bare yes."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_CREW_ALIASES", raising=False)
-    crew_role = SimpleNamespace(id=2468, managed=False)
+    crew_role = SimpleNamespace(id=2468, name="Crew", managed=False)
     channel = FakeTextChannel(channel_id=700)
     channel.guild.me = SimpleNamespace(roles=[crew_role])
     adapter.config.extra["council_mode"] = {

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -33,6 +33,7 @@ NOISY_STATUS_MESSAGES = [
     "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
     "⚠️  Session compressed 12 times — accuracy may degrade. Consider /new to start fresh.",
     "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
+    "ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised to 85% (from 75%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false",
     "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
     "⏳ Retrying in 4.2s (attempt 1/3)...",
 ]


### PR DESCRIPTION
## Summary
Discord routing now keeps shared channels quiet by default while preserving bounded thread handoffs. Crew/council triggers are explicit, reply metadata is not treated as a direct summon, and bot-authored chatter in top-level channels can be blocked separately from thread bot handoffs.

## What changed
- `@Crew`/crew aliases route through Pixoid as coordinator instead of waking every worker bot.
- Direct worker mentions remain specialist-only.
- Closed huddle chatter and Discord reply pings are suppressed before model invocation unless there is an explicit textual mention or approved route trigger.
- Added `discord.channel_allow_bots` / `DISCORD_CHANNEL_ALLOW_BOTS` so top-level channels can use `none` while threads keep `allow_bots: mentions`.

## Verification
- `env -u DISCORD_ALLOW_BOTS -u DISCORD_CHANNEL_ALLOW_BOTS python -m pytest tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_bot_filter.py -q -o 'addopts='` → 62 passed
- targeted council/channel policy regressions passed

## Deploy note
The local Pixoid gateway checkout has been restarted on this branch with `discord.channel_allow_bots: none` and `discord.allow_bots: mentions`.
