### PR TITLE
fix(mcp): add skip_preflight config option for servers serving HTML on GET

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2312,7 +2312,7 @@ class MCPServerTask:
             # re-probing is a redundant round-trip. Also skip for OAuth servers:
             # without a cached token the endpoint returns HTML or 401, which
             # would incorrectly block the OAuth flow before it can run.
-            if config.get("transport") != "sse" and not self._ready.is_set() and self._auth_type != "oauth":
+            if config.get("transport") != "sse" and not config.get("skip_preflight") and not self._ready.is_set() and self._auth_type != "oauth":
                 try:
                     _probe_headers = dict(config.get("headers") or {})
                     await self._preflight_content_type(


### PR DESCRIPTION
## Problem

Some MCP servers (e.g. Spring Boot apps with a React SPA frontend) serve their frontend on any unmatched GET route. The actual MCP endpoint works perfectly via POST (JSON-RPC), but a GET to `/mcp` falls through to the SPA controller and returns `text/html`.

Hermes's preflight content-type probe (`_preflight_content_type`) sees HTML instead of `application/json` or `text/event-stream` and refuses to connect with `NonMcpEndpointError` — even though the server is a perfectly valid MCP endpoint.

## Reproduction

```yaml
mcp_servers:
  stirling-pdf:
    url: http://localhost:8090/mcp
    headers:
      X-API-KEY: <key>
```

`hermes mcp test stirling-pdf` → `NonMcpEndpointError: returned Content-Type 'text/html', not an MCP response`.

Yet `curl -X POST http://localhost:8090/mcp` with a JSON-RPC payload works perfectly.

## Fix

Add a per-server `skip_preflight: true` config option that bypasses the content-type probe, letting the SDK connect directly:

```yaml
mcp_servers:
  stirling-pdf:
    url: http://localhost:8090/mcp
    headers:
      X-API-KEY: <key>
    skip_preflight: true
```

One-line change — adds `not config.get("skip_preflight")` to the existing preflight condition, alongside the existing `sse` transport, `_ready.is_set()`, and `_auth_type != "oauth"` skips.

## Why a config option (not auto-detection)

The preflight probe exists for good reason — it catches genuinely misconfigured URLs. Auto-skipping on any HTML response would defeat its purpose (e.g. issue #52460 where OAuth redirects land on marketing pages). A per-server opt-in is the right granularity: users who know their server is valid can bypass the probe, while everyone else keeps the safety check.

## Related

- #52460 — OAuth servers fail preflight when GET redirects (different root cause: redirect-following)
- #51600 — Skip probe when OAuth just configured in `mcp add` (different lifecycle point)
- #40366 — Skip probe on reconnect (already merged — the `_ready.is_set()` check this builds on)