### PR TITLE
fix(azure): bound detection response reads

### DIFF
--- a/hermes_cli/azure_detect.py
+++ b/hermes_cli/azure_detect.py
@@ -61,6 +61,9 @@ _AZURE_OPENAI_PROBE_API_VERSIONS = (
 # ``agent/anthropic_adapter.py`` when building the Anthropic client.
 _AZURE_ANTHROPIC_API_VERSION = "2025-04-15"
 
+_AZURE_DETECT_JSON_BODY_LIMIT_BYTES = 1 * 1024 * 1024
+_AZURE_DETECT_ERROR_BODY_LIMIT_BYTES = 8 * 1024
+
 
 @dataclass
 class DetectionResult:
@@ -145,6 +148,19 @@ def _apply_auth_headers(req: urllib_request.Request,
         req.add_header("Authorization", f"Bearer {token}")
 
 
+def _read_response_body_limited(resp: Any, max_bytes: int) -> bytes:
+    """Read at most ``max_bytes`` from a urllib response-like object."""
+    if max_bytes <= 0:
+        return b""
+    try:
+        body = resp.read(max_bytes + 1)
+    except TypeError:
+        body = resp.read()
+    if not isinstance(body, (bytes, bytearray)):
+        body = bytes(body or b"")
+    return bytes(body[:max_bytes])
+
+
 def _http_get_json(url: str,
                    api_key: Any,
                    timeout: float = 6.0,
@@ -159,7 +175,10 @@ def _http_get_json(url: str,
     req.add_header("User-Agent", "hermes-agent/azure-detect")
     try:
         with urllib_request.urlopen(req, timeout=timeout) as resp:
-            body = resp.read()
+            body = _read_response_body_limited(
+                resp,
+                _AZURE_DETECT_JSON_BODY_LIMIT_BYTES,
+            )
             try:
                 return resp.status, json.loads(body.decode("utf-8", errors="replace"))
             except Exception:
@@ -276,7 +295,10 @@ def _probe_anthropic_messages(base_url: str,
     except HTTPError as exc:
         # 4xx with an Anthropic-shaped error body = Anthropic endpoint.
         try:
-            body = exc.read().decode("utf-8", errors="replace")
+            body = _read_response_body_limited(
+                exc,
+                _AZURE_DETECT_ERROR_BODY_LIMIT_BYTES,
+            ).decode("utf-8", errors="replace")
             lowered = body.lower()
             if "anthropic" in lowered or '"type"' in lowered and '"error"' in lowered:
                 return True

--- a/tests/hermes_cli/test_azure_detect.py
+++ b/tests/hermes_cli/test_azure_detect.py
@@ -20,6 +20,7 @@ class _FakeHTTPResponse:
     def __init__(self, status: int, body: bytes):
         self.status = status
         self._body = body
+        self.read_sizes = []
 
     def __enter__(self):
         return self
@@ -27,8 +28,28 @@ class _FakeHTTPResponse:
     def __exit__(self, exc_type, exc, tb):
         return False
 
-    def read(self) -> bytes:
-        return self._body
+    def read(self, size=None) -> bytes:
+        self.read_sizes.append(size)
+        if size is None:
+            return self._body
+        return self._body[:size]
+
+
+class _FakeHTTPErrorBody:
+    """File-like body object used by urllib.error.HTTPError."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+        self.read_sizes = []
+
+    def read(self, size=None) -> bytes:
+        self.read_sizes.append(size)
+        if size is None:
+            return self._body
+        return self._body[:size]
+
+    def close(self) -> None:
+        pass
 
 
 def _openai_models_body(*ids: str) -> bytes:
@@ -203,6 +224,31 @@ def test_http_get_json_on_http_error_returns_code_none():
         status, body = azure_detect._http_get_json("https://x/", "k")
     assert status == 403
     assert body is None
+
+
+def test_http_get_json_limits_success_body_read():
+    """A hostile /models endpoint must not be read without a cap."""
+    limit = azure_detect._AZURE_DETECT_JSON_BODY_LIMIT_BYTES
+    resp = _FakeHTTPResponse(200, b'{"data":' + b'"x"' * limit)
+    with patch("hermes_cli.azure_detect.urllib_request.urlopen", return_value=resp):
+        status, body = azure_detect._http_get_json("https://x/models", "k")
+    assert status == 200
+    assert body is None
+    assert resp.read_sizes == [limit + 1]
+
+
+def test_probe_anthropic_messages_limits_http_error_body_read():
+    """Anthropic detection only needs a small diagnostic prefix."""
+    import urllib.error
+
+    limit = azure_detect._AZURE_DETECT_ERROR_BODY_LIMIT_BYTES
+    prefix = _anthropic_error_body("model not found")
+    fp = _FakeHTTPErrorBody(prefix + (b"x" * (limit * 4)))
+    err = urllib.error.HTTPError("https://x/v1/messages", 400, "Bad Request", {}, fp)
+    with patch("hermes_cli.azure_detect.urllib_request.urlopen", side_effect=err):
+        ok = azure_detect._probe_anthropic_messages("https://x", "k")
+    assert ok is True
+    assert fp.read_sizes == [limit + 1]
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- bound Azure/Foundry detection `/models` response reads to 1 MiB before JSON parsing
- bound Anthropic probe HTTPError body reads to 8 KiB before prefix inspection
- add regression coverage proving both paths call bounded `read(limit + 1)` instead of unbounded `read()`

Fixes #55205

## Why

`hermes_cli.azure_detect` probes a user-configured base URL during Azure/Foundry setup. A wrong endpoint, proxy, or hostile host can stream a large body with no `Content-Length`; the previous code buffered the entire body even though the detector only needs a model-list JSON payload or a small error prefix.

## Validation

- `C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests\hermes_cli\test_azure_detect.py -q --basetemp .tmp-pytest-azure-detect` -> 21 passed
- `C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check hermes_cli\azure_detect.py tests\hermes_cli\test_azure_detect.py` -> All checks passed
- `git diff --check` -> passed

Related OpenClaw pattern reviewed: openclaw/openclaw#97812.