### PR TITLE
perf(web/context): concurrent @-reference expansion + web_extract truncate-store robustness

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -152,13 +152,24 @@ async def preprocess_context_references_async(
     blocks: list[str] = []
     injected_tokens = 0
 
-    for ref in refs:
-        warning, block = await _expand_reference(
-            ref,
-            cwd_path,
-            url_fetcher=url_fetcher,
-            allowed_root=allowed_root_path,
+    # Expand all references concurrently. Each _expand_reference is independent
+    # (no shared state during expansion) — a message with several @url: refs
+    # would otherwise pay one full web_extract round-trip per ref in series.
+    # gather preserves positional order, so we reassemble warnings/blocks in the
+    # original ref order exactly as the prior serial loop did; the token-budget
+    # check below is unchanged (it runs once, after all refs are expanded).
+    expanded = await asyncio.gather(
+        *(
+            _expand_reference(
+                ref,
+                cwd_path,
+                url_fetcher=url_fetcher,
+                allowed_root=allowed_root_path,
+            )
+            for ref in refs
         )
+    )
+    for warning, block in expanded:
         if warning:
             warnings.append(warning)
         if block:

--- a/tests/agent/test_context_refs_concurrent.py
+++ b/tests/agent/test_context_refs_concurrent.py
@@ -1,0 +1,53 @@
+"""Tests for concurrent @-reference expansion in context_references.
+
+RED before the refactor: test_refs_expand_concurrently asserts that N URL refs
+(each a ~0.2s fetch) complete in roughly one fetch-time, not N×. On the serial
+`for ref in refs: await` loop this FAILS (takes ~N×0.2s); after switching to
+asyncio.gather it passes. The output-contract test guards that concurrency does
+NOT change ordering, warnings, blocks, or token accounting.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from agent.context_references import preprocess_context_references_async
+
+
+async def _slow_fetcher(url: str) -> str:
+    # Simulate a per-URL network fetch (web_extract round trip).
+    await asyncio.sleep(0.2)
+    return f"CONTENT[{url}]"
+
+
+@pytest.mark.asyncio
+async def test_refs_expand_concurrently(tmp_path):
+    # Three independent URL refs in one message.
+    msg = "see @url:https://a.example/x @url:https://b.example/y @url:https://c.example/z please"
+    t0 = time.perf_counter()
+    res = await preprocess_context_references_async(
+        msg, cwd=tmp_path, context_length=100_000, url_fetcher=_slow_fetcher,
+    )
+    elapsed = time.perf_counter() - t0
+    # Serial would be ~0.6s (3×0.2). Concurrent ~0.2s. Assert well under 2× one fetch.
+    assert elapsed < 0.4, f"expected concurrent (~0.2s), got {elapsed:.2f}s (serial?)"
+    # All three blocks present, in order.
+    assert res.expanded
+    body = res.message
+    assert body.index("a.example") < body.index("b.example") < body.index("c.example"), \
+        "reference blocks must stay in original order"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_preserves_output_contract(tmp_path):
+    """Concurrency must not change which blocks/warnings appear or their order."""
+    msg = "@url:https://one.example/p @url:https://two.example/q"
+    res = await preprocess_context_references_async(
+        msg, cwd=tmp_path, context_length=100_000, url_fetcher=_slow_fetcher,
+    )
+    assert "CONTENT[https://one.example/p]" in res.message
+    assert "CONTENT[https://two.example/q]" in res.message
+    assert res.message.index("one.example") < res.message.index("two.example")
+    assert res.injected_tokens > 0

--- a/tests/tools/test_web_extract_robustness.py
+++ b/tests/tools/test_web_extract_robustness.py
@@ -1,0 +1,54 @@
+"""Tests for web_extract truncate-store robustness (findings from #54843 review).
+
+Covers two robustness gaps left unaddressed when #54843 merged:
+  1. _store_full_text bounded by MAX_STORED_TEXT_CHARS (no unbounded disk write).
+  2. _truncate_with_footer emits a CONCRETE read_file offset for the omitted
+     middle (was a literal `offset=<line>` placeholder the model had to guess).
+"""
+from __future__ import annotations
+
+import re
+
+import tools.web_tools as wt
+
+
+def test_store_full_text_is_bounded(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Force the cache dir under the temp home.
+    from hermes_constants import get_hermes_dir  # noqa: F401
+    huge = "x\n" * (wt.MAX_STORED_TEXT_CHARS)  # > MAX_STORED_TEXT_CHARS chars
+    assert len(huge) > wt.MAX_STORED_TEXT_CHARS
+    path = wt._store_full_text("https://example.com/big", huge)
+    assert path is not None
+    stored = open(path, encoding="utf-8").read()
+    # Stored copy capped (+ short marker), not the full unbounded blob.
+    assert len(stored) <= wt.MAX_STORED_TEXT_CHARS + 200
+    assert "stored copy truncated" in stored
+
+
+def test_truncate_footer_gives_concrete_offset(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Build content well over the limit with many lines so head has a known count.
+    content = "\n".join(f"line {i}" for i in range(5000))
+    model_text, truncated = wt._truncate_with_footer(
+        content, "https://example.com/page", char_limit=4000
+    )
+    assert truncated
+    # Footer must contain a real integer offset, NOT the <line> placeholder.
+    assert "offset=<line>" not in model_text
+    m = re.search(r"offset=(\d+) limit=\d+", model_text)
+    assert m, f"no concrete offset in footer: {model_text[-400:]}"
+    offset = int(m.group(1))
+    # Offset should point past the head we showed (head is ~75% of 4000 chars).
+    assert offset > 1
+
+
+def test_small_page_not_truncated_no_footer(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    content = "short page\nwith a few lines\n"
+    model_text, truncated = wt._truncate_with_footer(
+        content, "https://example.com/s", char_limit=15000
+    )
+    assert not truncated
+    assert model_text == content
+    assert "[TRUNCATED]" not in model_text

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -307,6 +307,15 @@ def _web_requires_env() -> list[str]:
 # Override via web.extract_char_limit in config.yaml.
 DEFAULT_EXTRACT_CHAR_LIMIT = 15000
 
+# Hard ceiling on the full-text file written to cache/web. The truncate-store
+# path otherwise calls path.write_text(content) with no upper bound, so a
+# multi-MB page (some backends return very large markdown) writes unbounded
+# bytes to disk on every extract. Cap the stored copy; the model only ever
+# sees char_limit anyway, and a 2MB page is already far more than any single
+# read_file paging session needs. Mirrors the pre-truncate-store era's 2MB
+# refusal ceiling, but stores (capped) instead of refusing.
+MAX_STORED_TEXT_CHARS = 2_000_000
+
 _debug = DebugSession("web_tools", env_var="WEB_TOOLS_DEBUG")
 
 
@@ -374,6 +383,15 @@ def _store_full_text(url: str, content: str) -> Optional[str]:
         slug = re.sub(r"[^A-Za-z0-9._-]", "-", host)[:60].strip("-") or "page"
         digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:10]
         path = cache_dir / f"{slug}-{digest}.md"
+        # Bound the stored copy so a pathologically large page can't write
+        # unbounded bytes to disk. If capped, append a marker so a reader of
+        # the file knows it isn't the literal complete page.
+        if len(content) > MAX_STORED_TEXT_CHARS:
+            content = (
+                content[:MAX_STORED_TEXT_CHARS]
+                + f"\n\n[... stored copy truncated at {MAX_STORED_TEXT_CHARS:,} chars "
+                f"of {len(content):,}; re-extract a more specific URL for the rest ...]"
+            )
         path.write_text(content, encoding="utf-8")
         return str(path)
     except Exception as exc:  # noqa: BLE001
@@ -422,10 +440,16 @@ def _truncate_with_footer(
         f"of {total:,} total clean characters.",
     ]
     if stored_path:
+        # The omitted middle begins right after the head we're showing. Give
+        # the model a concrete starting line (head line count + 1) so its first
+        # read_file lands in the gap instead of guessing <line>. read_file is
+        # 1-indexed; +1 moves past the last head line we already showed.
+        middle_start_line = head.count("\n") + 2
         footer_lines.append(f"Full text saved to: {stored_path}")
         footer_lines.append(
             f'To read the omitted middle: read_file path="{stored_path}" '
-            f"offset=<line> limit=<n>  (the file is the complete page)."
+            f"offset={middle_start_line} limit=200  (the file is the complete page; "
+            f"raise/lower offset to page through it)."
         )
     else:
         footer_lines.append(


### PR DESCRIPTION
## Summary

Two independent, provider-agnostic web/context optimizations + robustness fixes,
both verified with tests. They sit at the **core agent layer** (not in any
provider plugin), so they help every web backend (exa/tavily/firecrawl/parallel)
equally.

---

### Part 1 — Concurrent `@`-reference expansion  (`agent/context_references.py`)

A message with multiple `@`-references (especially several `@url:` refs, each a
full `web_extract` round-trip) expanded them in a **serial `for ref in refs: await`**
loop — N independent fetches paid back-to-back.

Switched to `asyncio.gather` over the independent `_expand_reference` calls,
reassembling warnings/blocks in **original positional order** so output is
byte-identical to the serial path. The token-budget check is unchanged (it runs
once, after all refs expand).

- Generic + provider-agnostic (above the provider dispatch layer).
- RED/GREEN: 3 `@url:` refs @ 0.2s each = **0.60s serial → ~0.20s concurrent**.

### Part 2 — `web_extract` truncate-store robustness  (`tools/web_tools.py`)

Two gaps in the truncate-store path (from #54843):

1. **Unbounded stored file.** `_store_full_text` wrote the full clean page to
   `cache/web` via `path.write_text(content)` with no upper bound — a multi-MB
   page meant unbounded per-extract disk writes. Now capped at
   `MAX_STORED_TEXT_CHARS` (2MB, the pre-truncate-store refusal ceiling), with a
   marker appended when capped. The model only ever sees `char_limit` regardless.

2. **Dead `offset=<line>` placeholder.** The truncation footer told the model
   `read_file path="…" offset=<line>` — a literal placeholder it had to guess.
   Now computes the **real starting line** of the omitted middle (head line count
   + 1) so the first `read_file` lands in the gap.

---

## Why one PR

Both are small, core-layer web/context perf+robustness changes discovered in the
same pass; kept together for review convenience. They touch disjoint files
(`context_references.py` vs `web_tools.py`) and can be reverted independently by
commit.

## Verification

- `tests/agent/test_context_refs_concurrent.py` (new) + `test_context_references.py`
- `tests/tools/test_web_extract_robustness.py` (new) + `test_web_tools_truncate.py` + `test_web_tools.py`
- **32 passed**, no regressions. Diff: +149/−7 across 4 files (2 source, 2 new test files).
