### PR TITLE
fix(account-usage): stream bounded usage responses

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import math
 from dataclasses import dataclass
@@ -16,6 +17,46 @@ if TYPE_CHECKING:
     from typing import TypeGuard
 
 logger = logging.getLogger(__name__)
+_ACCOUNT_USAGE_JSON_BODY_LIMIT_BYTES = 1 * 1024 * 1024
+
+
+def _close_response(response: Any) -> None:
+    close = getattr(response, "close", None)
+    if callable(close):
+        close()
+
+
+def _read_json_response_limited(
+    response: Any,
+    *,
+    limit_bytes: int = _ACCOUNT_USAGE_JSON_BODY_LIMIT_BYTES,
+) -> dict[str, Any]:
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_bytes():
+        if isinstance(chunk, str):
+            chunk = chunk.encode("utf-8", "replace")
+        total += len(chunk)
+        if total > limit_bytes:
+            _close_response(response)
+            raise ValueError(f"account usage JSON response exceeds {limit_bytes} bytes")
+        chunks.append(chunk)
+    if not chunks:
+        return {}
+    encoding = getattr(response, "encoding", None) or "utf-8"
+    payload = json.loads(b"".join(chunks).decode(encoding, "replace"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def _get_json_limited(
+    client: httpx.Client,
+    url: str,
+    *,
+    headers: dict[str, str],
+) -> dict[str, Any]:
+    with client.stream("GET", url, headers=headers) as response:
+        response.raise_for_status()
+        return _read_json_response_limited(response)
 
 
 def _utc_now() -> datetime:
@@ -449,9 +490,11 @@ def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
     if account_id:
         headers["ChatGPT-Account-Id"] = account_id
     with httpx.Client(timeout=15.0) as client:
-        response = client.get(_resolve_codex_usage_url(creds.get("base_url", "")), headers=headers)
-        response.raise_for_status()
-    payload = response.json() or {}
+        payload = _get_json_limited(
+            client,
+            _resolve_codex_usage_url(creds.get("base_url", "")),
+            headers=headers,
+        )
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
     for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
@@ -503,9 +546,11 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         "User-Agent": "claude-code/2.1.0",
     }
     with httpx.Client(timeout=15.0) as client:
-        response = client.get("https://api.anthropic.com/api/oauth/usage", headers=headers)
-        response.raise_for_status()
-    payload = response.json() or {}
+        payload = _get_json_limited(
+            client,
+            "https://api.anthropic.com/api/oauth/usage",
+            headers=headers,
+        )
     windows: list[AccountUsageWindow] = []
     mapping = (
         ("five_hour", "Current session"),
@@ -562,13 +607,9 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
         "Accept": "application/json",
     }
     with httpx.Client(timeout=10.0) as client:
-        credits_resp = client.get(credits_url, headers=headers)
-        credits_resp.raise_for_status()
-        credits = (credits_resp.json() or {}).get("data") or {}
+        credits = _get_json_limited(client, credits_url, headers=headers).get("data") or {}
         try:
-            key_resp = client.get(key_url, headers=headers)
-            key_resp.raise_for_status()
-            key_data = (key_resp.json() or {}).get("data") or {}
+            key_data = _get_json_limited(client, key_url, headers=headers).get("data") or {}
         except Exception:
             key_data = {}
     total_credits = float(credits.get("total_credits") or 0.0)

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,6 +1,8 @@
+import json
 from datetime import datetime, timezone
 
 from agent.account_usage import (
+    _ACCOUNT_USAGE_JSON_BODY_LIMIT_BYTES,
     AccountUsageSnapshot,
     AccountUsageWindow,
     fetch_account_usage,
@@ -9,21 +11,46 @@ from agent.account_usage import (
 
 
 class _Response:
-    def __init__(self, payload, status_code=200):
+    def __init__(self, payload, status_code=200, raw_body=None, chunk_size=None):
         self._payload = payload
         self.status_code = status_code
+        self._raw_body = raw_body
+        self._chunk_size = chunk_size
+        self.encoding = "utf-8"
+        self.closed = False
+        self.json_called = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
 
     def raise_for_status(self):
         if self.status_code >= 400:
             raise RuntimeError(f"HTTP {self.status_code}")
 
+    def iter_bytes(self):
+        body = self._raw_body
+        if body is None:
+            body = json.dumps(self._payload).encode("utf-8")
+        chunk_size = self._chunk_size or len(body) or 1
+        for start in range(0, len(body), chunk_size):
+            yield body[start : start + chunk_size]
+
     def json(self):
+        self.json_called = True
         return self._payload
+
+    def close(self):
+        self.closed = True
 
 
 class _Client:
-    def __init__(self, payload):
+    def __init__(self, payload, response=None):
         self._payload = payload
+        self._response = response
+        self.responses = []
 
     def __enter__(self):
         return self
@@ -32,7 +59,13 @@ class _Client:
         return False
 
     def get(self, url, headers=None):
-        return _Response(self._payload)
+        response = self._response or _Response(self._payload)
+        self.responses.append(response)
+        return response
+
+    def stream(self, method, url, headers=None):
+        assert method == "GET"
+        return self.get(url, headers=headers)
 
 
 class _RoutingClient:
@@ -47,6 +80,10 @@ class _RoutingClient:
 
     def get(self, url, headers=None):
         return _Response(self._payloads[url])
+
+    def stream(self, method, url, headers=None):
+        assert method == "GET"
+        return self.get(url, headers=headers)
 
 
 def test_fetch_account_usage_codex(monkeypatch):
@@ -93,6 +130,37 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+
+
+def test_fetch_account_usage_codex_limits_streamed_usage_body(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "access-token",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._read_codex_tokens",
+        lambda: {"tokens": {"account_id": "acct_123"}},
+    )
+    body = b'{"rate_limit":"' + b"A" * (_ACCOUNT_USAGE_JSON_BODY_LIMIT_BYTES + 1) + b'"}'
+    response = _Response(
+        {},
+        raw_body=body,
+        chunk_size=_ACCOUNT_USAGE_JSON_BODY_LIMIT_BYTES + 1,
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client({}, response=response),
+    )
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is None
+    assert response.closed is True
+    assert response.json_called is False
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():


### PR DESCRIPTION
## Summary

- stream account usage JSON responses instead of using eager `httpx.Client.get()`
- cap usage JSON bodies at 1 MiB before parsing
- apply the bounded reader to Codex/WHAM usage, Anthropic OAuth usage, and OpenRouter credits/key usage fetches
- keep existing fail-open behavior: oversized or invalid usage responses still return `None` / omit optional key details instead of breaking the caller

Fixes #55211

## Validation

- `python -m pytest tests\test_account_usage.py -q --basetemp .tmp-pytest-account-usage` — 5 passed
- `python -m ruff check agent\account_usage.py tests\test_account_usage.py` — passed
- `git diff --check` — passed

## Notes

This was found while checking recent OpenClaw provider-usage response-body cap fixes for analogous Hermes surfaces. Hermes uses httpx here, so the fix streams via `client.stream(...)`; only replacing `response.json()` would not bound the real download path because `httpx.Client.get()` eagerly reads the response body.

AI-assisted: implementation, tests, and validation summary were prepared with Codex.