### PR TITLE
fix: add errno.EINVAL to TUI WebSocket peer-gone errnos on Windows

### DIFF
--- a/tests/tui_gateway/test_transport.py
+++ b/tests/tui_gateway/test_transport.py
@@ -1,0 +1,29 @@
+"""Tests for tui_gateway.transport — WebSocket transport error handling."""
+
+from __future__ import annotations
+
+import errno
+
+from tui_gateway.transport import _PEER_GONE_ERRNOS
+
+
+def test_einval_in_peer_gone_errnos():
+    """EINVAL (errno 22) must be treated as a clean disconnect on Windows.
+
+    On Windows, detached stdout raises OSError(22, 'Invalid argument')
+    instead of POSIX EPIPE. Without EINVAL in the set, this was re-raised
+    as a fatal error causing WebSocket 1011 crash loops.
+
+    Regression test for #55119.
+    """
+    assert errno.EINVAL in _PEER_GONE_ERRNOS
+
+
+def test_epipe_in_peer_gone_errnos():
+    """EPIPE must always be treated as a clean disconnect."""
+    assert errno.EPIPE in _PEER_GONE_ERRNOS
+
+
+def test_peer_gone_errnos_is_frozen():
+    """The set must be immutable to prevent accidental mutation."""
+    assert isinstance(_PEER_GONE_ERRNOS, frozenset)

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -38,6 +38,7 @@ _PEER_GONE_ERRNOS = frozenset({
     errno.ECONNRESET,   # peer reset the connection
     errno.EBADF,        # fd closed under us
     errno.ESHUTDOWN,    # transport endpoint shut down
+    errno.EINVAL,       # Windows: stdout detached → errno 22
     getattr(errno, "WSAECONNRESET", -1),  # win32 mapping (no-op on POSIX)
     getattr(errno, "WSAESHUTDOWN", -1),
 } - {-1})


### PR DESCRIPTION
## What does this PR do?

Adds `errno.EINVAL` (22) to `_PEER_GONE_ERRNOS` in `tui_gateway/transport.py`. On Windows, detached stdout raises `OSError(22, 'Invalid argument')` instead of POSIX `EPIPE`. Without `EINVAL` in the set, this was re-raised as a fatal error causing WebSocket 1011 crash loops with 28+ reconnections in 10 minutes.

## Related Issue

Fixes #55119

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/transport.py`: Add `errno.EINVAL` to `_PEER_GONE_ERRNOS` frozenset with comment explaining the Windows detached-stdout case
- `tests/tui_gateway/test_transport.py`: NEW — 3 tests covering EINVAL presence, EPIPE presence, and frozenset immutability

## How to Test

1. Run `uv run --extra dev python -m pytest tests/tui_gateway/test_transport.py -q` — all 3 tests should pass
2. On Windows: launch TUI gateway, detach stdout (e.g. close terminal) — should see clean disconnect instead of WebSocket 1011 crash loop
3. On POSIX: no behavioral change (EINVAL was already not raised for pipe scenarios)

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `uv run --extra dev python -m pytest tests/tui_gateway/test_transport.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — this is a Windows-specific fix
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A