### PR TITLE
fix(google-chat): bound attachment downloads

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -138,6 +138,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
+    validate_inbound_media_size,
 )
 
 
@@ -186,6 +187,7 @@ _RETRY_BASE_DELAY = 1.0
 _RETRY_MAX_DELAY = 8.0
 _RETRY_JITTER = 0.3
 _RETRYABLE_HTTP_STATUSES = frozenset({429, 500, 502, 503, 504})
+_ATTACHMENT_DOWNLOAD_CHUNK_BYTES = 1024 * 1024
 
 
 def _is_retryable_error(exc: BaseException) -> bool:
@@ -297,6 +299,48 @@ def _redact_sensitive(text: str) -> str:
         text,
     )
     return text
+
+
+def _validate_attachment_size(size: int, *, mime: str = "") -> None:
+    media_type = "Google Chat attachment"
+    if mime:
+        media_type = f"{media_type} ({mime})"
+    validate_inbound_media_size(size, media_type=media_type)
+
+
+def _read_streaming_attachment_response(resp: Any, *, mime: str = "") -> bytes:
+    headers = getattr(resp, "headers", {}) or {}
+    content_length = None
+    try:
+        content_length = headers.get("content-length") or headers.get("Content-Length")
+    except Exception:
+        content_length = None
+    if content_length:
+        try:
+            _validate_attachment_size(int(content_length), mime=mime)
+        except ValueError:
+            raise
+        except Exception:
+            logger.debug(
+                "[GoogleChat] ignoring invalid attachment Content-Length: %r",
+                content_length,
+            )
+
+    iter_content = getattr(resp, "iter_content", None)
+    if callable(iter_content):
+        chunks: list[bytes] = []
+        total = 0
+        for chunk in iter_content(chunk_size=_ATTACHMENT_DOWNLOAD_CHUNK_BYTES):
+            if not chunk:
+                continue
+            total += len(chunk)
+            _validate_attachment_size(total, mime=mime)
+            chunks.append(chunk)
+        return b"".join(chunks)
+
+    data = getattr(resp, "content", b"") or b""
+    _validate_attachment_size(len(data), mime=mime)
+    return data
 
 
 def _mime_for_message_type(mime: str) -> MessageType:
@@ -1703,15 +1747,20 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 import io
 
                 buf = io.BytesIO()
-                downloader = MediaIoBaseDownload(buf, req)
+                downloader = MediaIoBaseDownload(
+                    buf,
+                    req,
+                    chunksize=_ATTACHMENT_DOWNLOAD_CHUNK_BYTES,
+                )
                 done = False
                 while not done:
                     _status, done = downloader.next_chunk()
+                    _validate_attachment_size(buf.tell(), mime=mime)
                 return buf.getvalue()
 
             try:
                 data = await asyncio.to_thread(_fetch_media)
-            except HttpError as exc:
+            except (HttpError, ValueError) as exc:
                 logger.warning(
                     "[GoogleChat] media.download_media failed: %s",
                     _redact_sensitive(str(exc)),
@@ -1730,9 +1779,14 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 import google.auth.transport.requests as gar
 
                 authed_session = gar.AuthorizedSession(self._credentials)
-                resp = authed_session.get(download_uri, timeout=30)
-                resp.raise_for_status()
-                return resp.content
+                resp = authed_session.get(download_uri, timeout=30, stream=True)
+                try:
+                    resp.raise_for_status()
+                    return _read_streaming_attachment_response(resp, mime=mime)
+                finally:
+                    close = getattr(resp, "close", None)
+                    if callable(close):
+                        close()
 
             try:
                 data = await asyncio.to_thread(_fetch_uri)

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2162,6 +2162,117 @@ class TestAttachmentSSRFGuard:
         assert mime == "application/pdf"
 
     @pytest.mark.asyncio
+    async def test_bot_media_download_rejects_oversized_chunks(self, adapter, monkeypatch):
+        """media.download_media should validate each downloaded chunk before cache."""
+        attachment = {
+            "source": "DRIVE_FILE",
+            "contentType": "application/pdf",
+            "name": "spaces/S/messages/M/attachments/A",
+            "attachmentDataRef": {
+                "resourceName": "spaces/S/messages/M/attachments/A",
+            },
+        }
+        adapter._chat_api.media.return_value.download_media.return_value = object()
+        seen = {}
+
+        def _fake_validate(size, *, media_type="media", max_bytes=None):
+            seen.setdefault("sizes", []).append(size)
+            if size > 8:
+                raise ValueError("too large")
+
+        class _FakeDownloader:
+            def __init__(self, buf, _req, chunksize=None):
+                seen["chunksize"] = chunksize
+                self._buf = buf
+
+            def next_chunk(self):
+                self._buf.write(b"A" * 9)
+                return None, True
+
+        google_http = sys.modules["googleapiclient.http"]
+        monkeypatch.setattr(google_http, "MediaIoBaseDownload", _FakeDownloader, raising=False)
+        monkeypatch.setattr(_gc_mod, "validate_inbound_media_size", _fake_validate)
+
+        path, mime = await adapter._download_attachment(attachment)
+
+        assert path is None
+        assert mime == "application/pdf"
+        assert seen["chunksize"] == _gc_mod._ATTACHMENT_DOWNLOAD_CHUNK_BYTES
+        assert seen["sizes"] == [9]
+
+    @pytest.mark.asyncio
+    async def test_download_uri_uses_streaming_size_guard(self, adapter, monkeypatch):
+        """downloadUri fallback must stream and close instead of reading .content."""
+        attachment = {
+            "contentType": "image/png",
+            "downloadUri": "https://chat.googleapis.com/media/x",
+        }
+        seen = {}
+
+        def _fake_validate(size, *, media_type="media", max_bytes=None):
+            seen.setdefault("sizes", []).append(size)
+            if size > 8:
+                raise ValueError("too large")
+
+        class _FakeResponse:
+            headers = {}
+
+            def __init__(self):
+                self.closed = False
+                self.content_accessed = False
+
+            @property
+            def content(self):
+                self.content_accessed = True
+                raise AssertionError("downloadUri fallback should stream")
+
+            def raise_for_status(self):
+                return None
+
+            def iter_content(self, chunk_size=1):
+                seen["chunk_size"] = chunk_size
+                yield b"A" * 9
+
+            def close(self):
+                self.closed = True
+
+        response = _FakeResponse()
+
+        class _FakeAuthorizedSession:
+            def __init__(self, _credentials):
+                pass
+
+            def get(self, url, **kwargs):
+                seen["url"] = url
+                seen["kwargs"] = kwargs
+                return response
+
+        google_root = types.ModuleType("google")
+        google_auth = types.ModuleType("google.auth")
+        google_auth_transport = types.ModuleType("google.auth.transport")
+        google_auth_requests = types.ModuleType("google.auth.transport.requests")
+        google_auth_requests.AuthorizedSession = _FakeAuthorizedSession
+        google_root.auth = google_auth
+        google_auth.transport = google_auth_transport
+        google_auth_transport.requests = google_auth_requests
+        monkeypatch.setitem(sys.modules, "google", google_root)
+        monkeypatch.setitem(sys.modules, "google.auth", google_auth)
+        monkeypatch.setitem(sys.modules, "google.auth.transport", google_auth_transport)
+        monkeypatch.setitem(sys.modules, "google.auth.transport.requests", google_auth_requests)
+        monkeypatch.setattr(_gc_mod, "validate_inbound_media_size", _fake_validate)
+
+        path, mime = await adapter._download_attachment(attachment)
+
+        assert path is None
+        assert mime == "image/png"
+        assert seen["url"] == "https://chat.googleapis.com/media/x"
+        assert seen["kwargs"]["stream"] is True
+        assert seen["chunk_size"] == _gc_mod._ATTACHMENT_DOWNLOAD_CHUNK_BYTES
+        assert seen["sizes"] == [9]
+        assert response.closed is True
+        assert response.content_accessed is False
+
+    @pytest.mark.asyncio
     async def test_rejects_non_google_host(self, adapter):
         attachment = {
             "contentType": "image/png",


### PR DESCRIPTION
## Summary

- enforce Hermes' existing inbound media size cap while Google Chat attachments are downloading
- set `MediaIoBaseDownload` to 1 MiB chunks and validate after each chunk
- switch the `downloadUri` fallback to `stream=True` and validate `iter_content(...)` chunks before buffering
- treat size-cap failures like attachment download failures, so oversized attachments are skipped instead of crashing the message path

Fixes #55215

## Validation

- `python -m pytest tests\gateway\test_google_chat.py::TestAttachmentSSRFGuard -q --basetemp .tmp-pytest-google-chat-attachments` — 6 passed
- `python -m pytest tests\gateway\test_google_chat.py -q --basetemp .tmp-pytest-google-chat` — 162 passed, 2 existing coroutine warnings
- `python -m ruff check plugins\platforms\google_chat\adapter.py tests\gateway\test_google_chat.py` — passed
- `git diff --check` — passed

## Notes

This was found while checking recent OpenClaw Google Drive / response-body cap fixes for analogous Hermes surfaces. Hermes does not have the exact OpenClaw Google Meet Drive export path, but its Google Chat attachment downloader had the same practical boundary issue: size validation happened after the body was already buffered.

AI-assisted: implementation, tests, and validation summary were prepared with Codex.