### PR TITLE
fix: preserve default and const values in schema sanitizer

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -700,3 +700,29 @@ def test_strip_slash_enum_ignores_non_string_enum_values():
     props = tools[0]["function"]["parameters"]["properties"]
     assert props["level"]["enum"] == [1, 2, 3]
     assert props["flag"]["enum"] == [True, False]
+
+
+def test_default_and_const_values_preserved():
+    """Array/object default and const values must not be rewritten as schemas.
+
+    Regression test for #55077: _sanitize_node() was recursing into
+    'default' and 'const' values as if they were nested schemas, replacing
+    string elements with {"type": "object", "properties": {}}.
+    """
+    tools = [_tool("demo", {
+        "type": "object",
+        "properties": {
+            "perms": {"type": "array", "items": {"type": "string"},
+                      "default": ["read", "write"]},
+            "cfg":   {"type": "object", "default": {"nested": ["a", "b"]}},
+            "tier":  {"type": "string", "const": "gold"},
+        },
+        "required": ["perms"],
+    })]
+
+    sanitize_tool_schemas(tools)
+    props = tools[0]["function"]["parameters"]["properties"]
+
+    assert props["perms"]["default"] == ["read", "write"]
+    assert props["cfg"]["default"] == {"nested": ["a", "b"]}
+    assert props["tier"]["const"] == "gold"

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -305,11 +305,13 @@ def _sanitize_node(node: Any, path: str) -> Any:
                 _sanitize_node(item, f"{path}.{key}[{i}]")
                 for i, item in enumerate(value)
             ]
-        elif key in {"required", "enum", "examples"}:
+        elif key in {"required", "enum", "examples", "default", "const"}:
             # Schema "sibling" keywords whose values are NOT schemas:
             #  - ``required``: list of property-name strings
             #  - ``enum``: list of literal values (any JSON type)
             #  - ``examples``: list of example values (any JSON type)
+            #  - ``default``: a single literal instance value (any JSON type)
+            #  - ``const``: a single literal instance value (any JSON type)
             # Recursing into these with _sanitize_node() would mis-interpret
             # literal strings like "path" as bare-string schemas and replace
             # them with {"type": "object"} dicts. Pass through unchanged.


### PR DESCRIPTION
## What does this PR do?

Fixes `tools/schema_sanitizer.py` so that `default` and `const` keyword values are passed through unchanged instead of being recursively walked as nested schemas. Previously, string elements inside array/object defaults were replaced with `{"type": "object", "properties": {}}`.

## Related Issue

Fixes #55077

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/schema_sanitizer.py`: Add `"default"` and `"const"` to the allow-list at line 308 alongside `"required"`, `"enum"`, and `"examples"`. These keywords hold literal instance values (any JSON type), not nested schemas.
- `tests/tools/test_schema_sanitizer.py`: Add `test_default_and_const_values_preserved` regression test covering array defaults, object defaults, and string const.

## How to Test

1. Run `uv run --extra dev python -m pytest tests/tools/test_schema_sanitizer.py::test_default_and_const_values_preserved -q` — should pass
2. Reproduce the original bug:
   ```python
   from tools.schema_sanitizer import sanitize_tool_schemas
   tool = {"type": "function", "function": {"name": "demo", "parameters": {
       "type": "object", "properties": {
           "perms": {"type": "array", "items": {"type": "string"}, "default": ["read", "write"]},
       }, "required": ["perms"],
   }}}
   props = sanitize_tool_schemas([tool])[0]["function"]["parameters"]["properties"]
   assert props["perms"]["default"] == ["read", "write"]  # was [{"type": "object", ...}]
   ```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `uv run --extra dev python -m pytest tests/tools/test_schema_sanitizer.py -q` and all tests pass
- [x] I've added tests for my changes (regression test for #55077)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (fixes existing behavior)