### PR TITLE
fix(dashboard): suppress credential source on pool delete to prevent resurrection

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9514,6 +9514,16 @@ async def remove_credential_pool_entry(provider: str, index: int):
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if removed is None:
         raise HTTPException(status_code=404, detail="No pool entry at that index")
+    # Suppress the source so _seed_from_env/_seed_from_singletons do not
+    # resurrect the entry on the next load_pool() call. The CLI auth remove
+    # command does this (auth_commands.py:475) but the dashboard endpoint
+    # was missing it — entries came back after refresh.
+    if removed.source:
+        try:
+            from hermes_cli.auth import suppress_credential_source
+            suppress_credential_source(provider, removed.source)
+        except Exception:
+            _log.warning("Could not suppress source %s for %s", removed.source, provider)
     return {"ok": True, "provider": provider, "count": len(pool.entries())}
 
 


### PR DESCRIPTION
## Problem

Deleting a credential from the credential pool via the dashboard (System Settings → Credentials → Remove) shows a success toast "Credential removed", but the entry **reappears on page refresh**.

## Root Cause

The dashboard DELETE endpoint calls `pool.remove_index(index)`, which correctly removes the entry from `auth.json`. However, the next `load_pool()` call re-creates it via `_seed_from_env()` because the environment variable is still present in `.env`.

The CLI command `hermes auth remove` handles this correctly by calling `suppress_credential_source(provider, removed.source)` (`auth_commands.py:475`), which marks the source as suppressed so seeding functions skip it.

The dashboard endpoint was **missing this call**.

## Fix

Add `suppress_credential_source()` after successful removal in the DELETE handler, matching the CLI behavior.

## Testing

- Before fix: delete credential → refresh → entry reappears
- After fix: delete credential → refresh → entry stays gone

Fixes #55217