### PR TITLE
fix(dashboard): inject placeholder session token in gated mode so reveal works

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12803,6 +12803,7 @@ def mount_spa(application: FastAPI):
         if gated:
             bootstrap_script = (
                 f"<script>"
+                f'window.__HERMES_SESSION_TOKEN__="gated";'
                 f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
                 f'window.__HERMES_BASE_PATH__="{prefix}";'
                 f"window.__HERMES_AUTH_REQUIRED__={gated_js};"


### PR DESCRIPTION
## Problem

In gated (basic_auth/OAuth) mode, clicking the **reveal button** (eye icon) on the Keys page shows a toast `"Failed to reveal <KEY_NAME>"` but **no HTTP request is ever sent** — the frontend throws before the fetch.

## Root Cause

The SPA bootstrap intentionally omits `window.__HERMES_SESSION_TOKEN__` in gated mode — the SPA authenticates via cookie instead. However, the frontend `revealEnvVar` function bypasses the standard API wrapper `q()` and calls `hf()` directly to get the token:

```javascript
revealEnvVar: async (key) => {
    let token = await hf();  // ← throws! window.__HERMES_SESSION_TOKEN__ is undefined
    return q("/api/env/reveal", { headers: { [SESSION_TOKEN_HEADER]: token }, ... });
}
```

`hf()` throws `Error("Session token not available")` because the variable is undefined in gated mode. The fetch never fires.

Meanwhile, the standard wrapper `q()` already handles both modes correctly:
```javascript
let token = window.__HERMES_SESSION_TOKEN__;
if (token) headers.set(SESSION_TOKEN_HEADER, token);  // skipped if undefined
```

The backend also handles gated mode correctly — `_require_token()` defers to cookie auth per #42139.

## Fix

Inject a placeholder `window.__HERMES_SESSION_TOKEN__="gated"` in gated mode. The value is never checked by the backend in gated mode (the cookie is authoritative), but it prevents `hf()` from throwing so the fetch can proceed.

This is a **one-line fix** that unblocks the reveal button, session export, and any other frontend code path that reads the token directly.

## Alternatives Considered

The proper fix is updating `revealEnvVar` (and other `hf()` callers) to use the `q()` wrapper. But that requires a frontend rebuild, and the built SPA in `web_dist/` is a minified bundle that can't be easily patched. This server-side fix works with the existing built frontend.

Fixes #55210