### PR TITLE
fix: classify upstream_error as server_error with fallback

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1201,6 +1201,13 @@ def _classify_by_error_code(
             should_fallback=False,
         )
 
+    if code_lower in {"upstream_error", "server_error", "internal_error"}:
+        return result_fn(
+            FailoverReason.server_error,
+            retryable=True,
+            should_fallback=True,
+        )
+
     return None
 
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1717,3 +1717,38 @@ class TestMultimodalToolContentUnsupported:
         e = MockAPIError("bad request: missing field 'model'", status_code=400)
         result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
         assert result.reason != FailoverReason.multimodal_tool_content_unsupported
+
+
+class TestUpstreamErrorClassification:
+    """Verify that upstream_error classifies as server_error with fallback."""
+
+    def test_upstream_error_classifies_as_server_error(self):
+        """Regression test for #55096."""
+        e = MockAPIError(
+            "Upstream request failed",
+            body={"error": {"message": "Upstream request failed", "type": "upstream_error"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.should_fallback is True
+        assert result.retryable is True
+
+    def test_server_error_code_classifies(self):
+        """server_error type should also classify as server_error."""
+        e = MockAPIError(
+            "Internal server error",
+            body={"error": {"message": "Internal server error", "type": "server_error"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.should_fallback is True
+
+    def test_internal_error_code_classifies(self):
+        """internal_error type should also classify as server_error."""
+        e = MockAPIError(
+            "Internal error",
+            body={"error": {"message": "Internal error", "type": "internal_error"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.should_fallback is True


### PR DESCRIPTION
## What does this PR do?

Adds `upstream_error`, `server_error`, and `internal_error` to the structured error code classification in `_classify_by_error_code()`. Previously, these codes fell through to `FailoverReason.unknown`, preventing proper fallback routing for transient upstream/provider failures.

## Related Issue

Fixes #55096

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: Add `{"upstream_error", "server_error", "internal_error"}` mapping to `FailoverReason.server_error` with `retryable=True` and `should_fallback=True`
- `tests/agent/test_error_classifier.py`: Add `TestUpstreamErrorClassification` with 3 tests covering all three error codes

## How to Test

1. Run `uv run --extra dev python -m pytest tests/agent/test_error_classifier.py::TestUpstreamErrorClassification -q` — all 3 tests should pass
2. Reproduce the original bug:
   ```python
   from agent.error_classifier import classify_api_error, FailoverReason
   e = Exception("Upstream request failed")
   e.body = {"error": {"message": "Upstream request failed", "type": "upstream_error"}}
   result = classify_api_error(e)
   assert result.reason == FailoverReason.server_error  # was: unknown
   assert result.should_fallback is True  # was: False
   ```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `uv run --extra dev python -m pytest tests/agent/test_error_classifier.py -q` and all tests pass
- [x] I've added tests for my changes (regression test for #55096)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A