### PR TITLE
fix: sanitize lone surrogates in Signal message formatting

### DIFF
--- a/gateway/platforms/signal_format.py
+++ b/gateway/platforms/signal_format.py
@@ -22,6 +22,11 @@ def markdown_to_signal(text: str) -> tuple[str, list[str]]:
     Supported styles: BOLD, ITALIC, STRIKETHROUGH, MONOSPACE.
     """
 
+    # Sanitize lone surrogates (U+D800–U+DFFF) that can appear in LLM output.
+    # These cause UnicodeEncodeError in .encode("utf-16-le") below.
+    # Replace with U+FFFD (Unicode replacement character).
+    text = text.encode("utf-8", errors="surrogatepass").decode("utf-8", errors="replace")
+
     def _utf16_len(s: str) -> int:
         """Length of *s* in UTF-16 code units."""
         return len(s.encode("utf-16-le")) // 2

--- a/tests/gateway/test_signal_format.py
+++ b/tests/gateway/test_signal_format.py
@@ -476,3 +476,28 @@ class TestSignalStreamingPatch:
             content="Hello",
         )
         assert result.message_id is None
+
+
+def test_lone_surrogate_does_not_crash():
+    """Lone surrogates in LLM output must not crash Signal formatting.
+
+    Regression test for #55143: _utf16_len() calls .encode("utf-16-le")
+    which raises UnicodeEncodeError on lone surrogates (U+D800–U+DFFF).
+    """
+    from gateway.platforms.signal_format import markdown_to_signal
+
+    # A string containing a lone surrogate (U+DC00)
+    text_with_surrogate = "Hello \udc00 world"
+    # Should not raise UnicodeEncodeError
+    body, styles = markdown_to_signal(text_with_surrogate)
+    assert "Hello" in body
+    assert "world" in body
+
+
+def test_normal_text_unchanged():
+    """Normal text should pass through without modification."""
+    from gateway.platforms.signal_format import markdown_to_signal
+
+    body, styles = markdown_to_signal("Hello **bold** world")
+    assert "Hello" in body
+    assert "bold" in body


### PR DESCRIPTION
## What does this PR do?

Adds surrogate sanitization at the top of `markdown_to_signal()` in `gateway/platforms/signal_format.py`. Lone surrogates (U+D800–U+DFFF) in LLM output caused `UnicodeEncodeError` in `_utf16_len()` which calls `.encode("utf-16-le")`, crashing Signal message delivery.

## Related Issue

Fixes #55143

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/signal_format.py`: Add surrogate sanitization at the top of `markdown_to_signal()` using the standard `encode("utf-8", errors="surrogatepass").decode("utf-8", errors="replace")` roundtrip
- `tests/gateway/test_signal_format.py`: Add `test_lone_surrogate_does_not_crash` and `test_normal_text_unchanged` regression tests

## How to Test

1. Run `uv run --extra dev python -m pytest tests/gateway/test_signal_format.py -q` — all tests should pass
2. Reproduce the original bug:
   ```python
   from gateway.platforms.signal_format import markdown_to_signal
   text = "Hello \udc00 world"  # lone surrogate
   body, styles = markdown_to_signal(text)  # was: UnicodeEncodeError
   ```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `uv run --extra dev python -m pytest tests/gateway/test_signal_format.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A