### PR TITLE
fix: include current_entries in memory replace zero-match response

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -786,3 +786,28 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+def test_replace_zero_match_includes_current_entries():
+    """When replace() finds no match, the response must include current_entries.
+
+    Regression test for #42405: the zero-match branch returned only an error
+    string with no corrective feedback, causing the agent to retry blindly
+    until the turn budget was exhausted (silent hang).
+    """
+    from tools.memory_tool import MemoryStore
+
+    store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+
+    # Add an entry first
+    store.add("user", "User prefers concise responses")
+
+    # Try to replace with a non-matching substring
+    result = store.replace("user", "User likes brief answers", "User prefers short replies")
+
+    assert result["success"] is False
+    assert "No entry matched" in result["error"]
+    # The key fix: current_entries must be present so the agent can self-correct
+    assert "current_entries" in result
+    assert len(result["current_entries"]) > 0
+    assert "usage" in result

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -372,7 +372,12 @@ class MemoryStore:
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
 
             if not matches:
-                return {"success": False, "error": f"No entry matched '{old_text}'."}
+                return {
+                    "success": False,
+                    "error": f"No entry matched '{old_text}'.",
+                    "current_entries": entries,
+                    "usage": f"{self._char_count(target):,}/{self._char_limit(target):,}",
+                }
 
             if len(matches) > 1:
                 # If all matches are identical (exact duplicates), operate on the first one


### PR DESCRIPTION
## What does this PR do?

When `memory replace()` found no matching entry, the error response contained only the error string with no corrective feedback. The agent had no way to see what entries actually existed, so it retried blindly until the turn budget was exhausted — producing no user-facing response (silent hang).

Now the zero-match branch returns `current_entries` and `usage`, matching the pattern already used by `add()` at capacity. This gives the agent the information it needs to self-correct with a better match.

## Related Issue

Fixes #42405

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py`: In `replace()` zero-match branch, add `current_entries` and `usage` to the error response (matching the pattern used by `add()` at capacity)
- `tests/tools/test_memory_tool.py`: Add `test_replace_zero_match_includes_current_entries` regression test

## How to Test

1. Run `uv run --extra dev python -m pytest tests/tools/test_memory_tool.py::test_replace_zero_match_includes_current_entries -q` — should pass
2. Reproduce the original bug:
   ```python
   from tools.memory_tool import MemoryStore
   store = MemoryStore(memory_char_limit=500, user_char_limit=300)
   store.add("user", "User prefers concise responses")
   result = store.replace("user", "User likes brief answers", "User prefers short replies")
   # Before: {"success": false, "error": "No entry matched ..."}
   # After:  {"success": false, "error": "No entry matched ...", "current_entries": [...], "usage": "..."}
   ```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `uv run --extra dev python -m pytest tests/tools/test_memory_tool.py -q` and all tests pass
- [x] I've added tests for my changes (regression test for #42405)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A