### PR TITLE
fix: honor explicit context_length config override for small-context models

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1670,8 +1670,10 @@ def init_agent(
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).
+    # Skip this check when the user explicitly set context_length in config —
+    # they know their model's true window and chose to override.
     _ctx = getattr(agent.context_compressor, "context_length", 0)
-    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
+    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH and _config_context_length is None:
         raise ValueError(
             f"Model {agent.model} has a context window of {_ctx:,} tokens, "
             f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "

--- a/tests/run_agent/test_invalid_context_length_warning.py
+++ b/tests/run_agent/test_invalid_context_length_warning.py
@@ -112,3 +112,20 @@ def test_custom_providers_valid_context_length():
         )
     for c in mock_logger.warning.call_args_list:
         assert "Invalid" not in str(c)
+
+
+def test_explicit_context_length_override_skips_minimum_check():
+    """When user explicitly sets context_length < 64K, the minimum check
+    should be skipped. Regression test for #8430.
+    """
+    # Build agent with explicit context_length below MINIMUM_CONTEXT_LENGTH
+    agent = _build_agent({
+        "default": "qwen3-235b",
+        "provider": "custom",
+        "base_url": "http://localhost:4000/v1",
+        "context_length": 32768,
+    })
+    # Should have stored the explicit value
+    assert agent._config_context_length == 32768
+    # The agent should build successfully without raising ValueError
+    # about "context window below minimum"

--- a/tests/run_agent/test_invalid_context_length_warning.py
+++ b/tests/run_agent/test_invalid_context_length_warning.py
@@ -1,9 +1,11 @@
 """Tests that invalid context_length values in config produce visible warnings."""
 
+import pytest
 from unittest.mock import patch
 
 
-def _build_agent(model_cfg, custom_providers=None, model="anthropic/claude-opus-4.6"):
+def _build_agent(model_cfg, custom_providers=None, model="anthropic/claude-opus-4.6",
+                 mock_context_length=128_000):
     """Build an AIAgent with the given model config."""
     cfg = {"model": model_cfg}
     if custom_providers is not None:
@@ -13,7 +15,7 @@ def _build_agent(model_cfg, custom_providers=None, model="anthropic/claude-opus-
 
     with (
         patch("hermes_cli.config.load_config", return_value=cfg),
-        patch("agent.model_metadata.get_model_context_length", return_value=128_000),
+        patch("agent.model_metadata.get_model_context_length", return_value=mock_context_length),
         patch("run_agent.get_tool_definitions", return_value=[]),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
@@ -38,7 +40,6 @@ def test_valid_integer_context_length_no_warning():
                               "base_url": "http://localhost:4000/v1",
                               "context_length": 256000})
     assert agent._config_context_length == 256000
-    # No warning about invalid context_length
     for c in mock_logger.warning.call_args_list:
         assert "Invalid" not in str(c)
 
@@ -50,7 +51,6 @@ def test_string_k_suffix_context_length_warns():
                               "base_url": "http://localhost:4000/v1",
                               "context_length": "256K"})
     assert agent._config_context_length is None
-    # Should have warned
     warning_calls = [c for c in mock_logger.warning.call_args_list
                      if "Invalid" in str(c) and "256K" in str(c)]
     assert len(warning_calls) == 1
@@ -118,14 +118,34 @@ def test_explicit_context_length_override_skips_minimum_check():
     """When user explicitly sets context_length < 64K, the minimum check
     should be skipped. Regression test for #8430.
     """
-    # Build agent with explicit context_length below MINIMUM_CONTEXT_LENGTH
-    agent = _build_agent({
-        "default": "qwen3-235b",
-        "provider": "custom",
-        "base_url": "http://localhost:4000/v1",
-        "context_length": 32768,
-    })
+    # Mock model metadata to return a small context (below 64K minimum)
+    # but user explicitly overrides via config — should NOT raise ValueError
+    agent = _build_agent(
+        {
+            "default": "qwen3-235b",
+            "provider": "custom",
+            "base_url": "http://localhost:4000/v1",
+            "context_length": 32768,
+        },
+        mock_context_length=32768,  # Simulate model with small context
+    )
     # Should have stored the explicit value
     assert agent._config_context_length == 32768
-    # The agent should build successfully without raising ValueError
-    # about "context window below minimum"
+    # Agent built successfully — no ValueError raised
+    # (without the fix, this would raise ValueError about context below minimum)
+
+
+def test_no_explicit_context_length_raises_on_small_model():
+    """When user does NOT set context_length and model context is below 64K,
+    ValueError should be raised. This is the negative case.
+    """
+    with pytest.raises(ValueError, match="context window.*below the minimum"):
+        _build_agent(
+            {
+                "default": "small-model",
+                "provider": "custom",
+                "base_url": "http://localhost:4000/v1",
+                # No context_length override — should trigger the check
+            },
+            mock_context_length=32_000,  # Model with small context
+        )


### PR DESCRIPTION
## What does this PR do?

When a user explicitly sets `model.context_length` in config.yaml, the minimum context length check (64K tokens) is now skipped. Previously, the check at `agent/agent_init.py:1674` raised a `ValueError` even when the user had explicitly overridden the context length — the error message itself said "set model.context_length in config.yaml to override" but the override was not actually honored.

## Related Issue

Fixes #8430

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py`: Add `and _config_context_length is None` to the minimum context length check, so the check is skipped when the user explicitly set the value in config

## How to Test

1. Configure a model with a small context window and explicit override:
   ```yaml
   model:
     default: some-small-model
     context_length: 32768
   ```
2. Start Hermes — should NOT raise "context window below minimum" error
3. Remove `context_length` from config — should raise the error as before

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `ruff check agent/agent_init.py` and it passes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python logic, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A