### PR TITLE
fix: remove stale session entry from sessions.json on idle-TTL eviction

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14915,6 +14915,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Agent cache idle-TTL evict: session=%s (idle=%.0fs)",
                 key, now - getattr(agent, "_last_activity_ts", now),
             )
+            # Remove from sessions.json so the stale entry doesn't route
+            # messages into an ended session until gateway restart.
+            try:
+                self.session_store.remove(key)
+            except Exception:
+                logger.debug("Failed to remove stale session entry for %s", key, exc_info=True)
             threading.Thread(
                 target=self._release_evicted_agent_soft,
                 args=(agent,),

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1615,6 +1615,22 @@ class SessionStore:
 
         return new_entry
 
+    def remove(self, session_key: str) -> bool:
+        """Remove a session key from the routing index.
+
+        Called after idle-TTL eviction to prevent sessions.json from holding
+        stale entries that route messages into ended sessions.
+
+        Returns True if the key was present and removed, False otherwise.
+        """
+        with self._lock:
+            self._ensure_loaded_locked()
+            if session_key not in self._entries:
+                return False
+            del self._entries[session_key]
+            self._save()
+            return True
+
     def list_sessions(self, active_minutes: Optional[int] = None) -> List[SessionEntry]:
         """List all sessions, optionally filtered by activity."""
         with self._lock:

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -179,3 +179,37 @@ class TestEnsureLoadedCallsPrune:
         store._ensure_loaded()
 
         assert "active_key" in store._entries
+
+
+def test_session_store_remove():
+    """SessionStore.remove() should remove a key from the routing index.
+
+    Regression test for #54878: after idle-TTL eviction, sessions.json
+    held stale entries that routed messages into ended sessions.
+    """
+    import tempfile
+    from pathlib import Path
+    from gateway.session import SessionStore, SessionSource
+    from gateway.config import GatewayConfig, Platform
+
+    with tempfile.TemporaryDirectory() as tmp:
+        sessions_dir = Path(tmp) / "sessions"
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir, config)
+
+        # Create a session entry via get_or_create
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            user_id="user1",
+        )
+        entry = store.get_or_create_session(source)
+        assert entry is not None
+
+        # Remove the key
+        removed = store.remove(entry.session_key)
+        assert removed is True
+
+        # Removing again should return False
+        removed2 = store.remove(entry.session_key)
+        assert removed2 is False


### PR DESCRIPTION
## What does this PR do?

When `_sweep_idle_cached_agents()` evicts an agent after the idle TTL (3600s), the session is ended in `state.db` but `sessions.json` was NOT updated. The stale `session_key → session_id` entry remained, routing all subsequent messages on that key into a closed session — silently dropping them until gateway restart (when `_prune_stale_sessions_locked()` fires).

Adds `SessionStore.remove()` method and calls it during idle eviction so `sessions.json` is cleaned up immediately.

## Related Issue

Fixes #54878

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py`: Add `SessionStore.remove(session_key)` method that removes an entry from `_entries` and calls `_save()`, following the existing thread-safety pattern (lock + `_ensure_loaded_locked`)
- `gateway/run.py`: In `_sweep_idle_cached_agents()`, call `self.session_store.remove(key)` after popping the agent from cache, wrapped in try/except to avoid blocking eviction on a save failure

## How to Test

1. Configure a gateway with a short idle TTL (or wait for the default 3600s)
2. Send a message, wait for idle eviction
3. Send another message on the same session key — should create a fresh session instead of being silently dropped

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `ruff check gateway/session.py gateway/run.py` and both pass
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — uses pathlib and threading, cross-platform safe
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A