### PR TITLE
fix: track session_id in agent cache to prevent spurious cross-process invalidation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14680,7 +14680,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and cached[0] is not _AGENT_PENDING_SENTINEL
             ):
                 if cached[2] != _live:
-                    _cache[session_key] = (cached[0], cached[1], _live)
+                    # Preserve session_id in the 4th slot if present
+                    new_tuple = (cached[0], cached[1], _live)
+                    if len(cached) > 3:
+                        new_tuple = (cached[0], cached[1], _live, cached[3])
+                    _cache[session_key] = new_tuple
 
     def _evict_cached_agent(self, session_key: str) -> None:
         """Remove a cached agent for a session (called on /new, /model, etc).
@@ -16359,11 +16363,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if cached and cached[1] == _sig:
                         # cached[2] is the message_count at cache time;
                         # stale when a second process appended rows.
+                        # cached[3] (if present) is the session_id at cache time;
+                        # skip the cross-process check when the session_id
+                        # differs — the message_count values belong to
+                        # different DB rows and comparison is meaningless.
                         _cached_mc = cached[2] if len(cached) > 2 else None
+                        _cached_sid = cached[3] if len(cached) > 3 else None
                         if (
                             _cached_mc is not None
                             and _current_msg_count is not None
                             and _current_msg_count != _cached_mc
+                            and (_cached_sid is None or _cached_sid == session_id)
                         ):
                             # Cross-process write detected — discard stale
                             # agent so it rebuilds from fresh DB transcript.
@@ -16462,7 +16472,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
-                        _cache[session_key] = (agent, _sig, _current_msg_count)
+                        _cache[session_key] = (agent, _sig, _current_msg_count, session_id)
                         self._enforce_agent_cache_cap()
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
 


### PR DESCRIPTION
## What does this PR do?

The agent cache uses `session_key` as the cache key, which groups all sessions for a user (e.g. `agent:main:telegram:dm:USER_ID`). When a user switches between different `session_id`s under the same key (via `/new`, auto-reset, or different conversation threads), the cross-process coherence guard compared `message_count`s from DIFFERENT DB rows, causing spurious invalidation and agent rebuilds that destroyed prompt caching.

Fix: include `session_id` as the 4th element of the cache tuple, and skip the cross-process comparison when the cached `session_id` differs from the current one. The comparison is only meaningful when tracking the SAME session's transcript.

## Related Issue

Fixes #54947

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`:
  - Store `session_id` as 4th element of cache tuple: `(agent, sig, message_count, session_id)`
  - In cross-process guard: extract `_cached_sid` and add condition `(_cached_sid is None or _cached_sid == session_id)` — skip invalidation when session_id differs
  - In `_refresh_agent_cache_message_count`: preserve `session_id` in 4th slot when re-baselining message_count
  - Backward-compatible: `len(cached) > 3` checks handle existing 3-tuple entries gracefully

## How to Test

1. Configure Telegram gateway with a user who has multiple conversation threads
2. Send messages on thread A, then thread B, then back to thread A
3. Before fix: agent rebuilds on every thread switch (check logs for "Agent cache invalidated")
4. After fix: agent reuse across thread switches (no spurious invalidation)

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `ruff check gateway/run.py` and it passes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python logic, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A