### PR TITLE
fix(dashboard): skip auto-SSO redirect for password-only providers (#55130)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,11 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers have no OAuth redirect / start_login flow —
+    # auto-SSO to /auth/login would 500.  Fall through to /login (form).
+    if getattr(provider, "supports_password", False):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -593,3 +593,63 @@ def test_unverifiable_token_with_reachable_providers_redirects(_gated_state):
     r = client.get("/api/auth/me")
     assert r.status_code == 401
     assert "unreachable" not in r.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Auto-SSO skip for password-only providers (#55130)
+# ---------------------------------------------------------------------------
+
+
+def _make_basic_provider():
+    """Create a BasicAuthProvider for testing (password-only, no OAuth)."""
+    import plugins.dashboard_auth.basic as basic_plugin
+    h = basic_plugin.hash_password("hunter2")
+    return basic_plugin.BasicAuthProvider(
+        username="admin",
+        password_hash=h,
+        secret=b"test-secret-at-least-16-bytes-long",
+    )
+
+
+@pytest.fixture
+def basic_only_app():
+    """Configure web_server.app with only the basic (password-only) provider."""
+    clear_providers()
+    register_provider(_make_basic_provider())
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    client = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+    yield client
+    clear_providers()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+def test_auto_sso_skips_password_only_provider(basic_only_app):
+    """Auto-SSO must NOT redirect to /auth/login when the sole provider is
+    password-only (supports_password=True).  That route calls start_login()
+    which raises NotImplementedError for BasicAuthProvider, causing HTTP 500.
+
+    Instead, the request should fall through to the /login interstitial
+    which renders the password form.
+
+    Regression test for #55130.
+    """
+    r = basic_only_app.get("/", follow_redirects=False)
+    # Should redirect to /login (the password form), NOT to /auth/login
+    assert r.status_code == 302, (
+        f"Expected 302 redirect, got {r.status_code}"
+    )
+    location = r.headers.get("location", "")
+    assert "/auth/login" not in location, (
+        f"Auto-SSO redirected to {location} — password-only providers have "
+        f"no OAuth flow; should fall through to /login instead"
+    )
+    assert "/login" in location, (
+        f"Expected redirect to /login (password form), got {location}"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes HTTP 500 on every unauthenticated dashboard page load when the only registered auth provider is the built-in `basic` (username/password) provider.

The `_auto_sso_response()` shortcut in the auth middleware unconditionally redirects to `/auth/login?provider=<name>` when exactly one provider is registered. That route calls `provider.start_login()`, which `BasicAuthProvider` doesn't implement (it's password-only, not OAuth). The resulting `NotImplementedError` bubbles up as an unhandled 500.

The fix adds a `supports_password` guard: when the sole provider is password-based, auto-SSO is skipped and the request falls through to the `/login` interstitial (the password form), which already works correctly.

## Related Issue

Fixes #55130

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/middleware.py` — Add `getattr(provider, "supports_password", False)` check in `_auto_sso_response()` to skip auto-SSO for password-only providers (3 lines + comment)
- `tests/hermes_cli/test_dashboard_auth_middleware.py` — Add regression test `test_auto_sso_skips_password_only_provider` that registers a `BasicAuthProvider` as the sole provider and verifies `/` redirects to `/login` (password form) instead of `/auth/login` (OAuth initiation)

## How to Test

1. Set `HERMES_DASHBOARD_BASIC_AUTH_USERNAME` and `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD` environment variables
2. Launch `hermes dashboard --host 0.0.0.0` with no other auth providers configured
3. Navigate to `/` in a browser without a session cookie
4. **Before fix**: HTTP 500 (NotImplementedError from BasicAuthProvider.start_login)
5. **After fix**: Redirect to `/login` showing the username/password form; login works normally
6. Run `pytest tests/hermes_cli/test_dashboard_auth_middleware.py -v` — all 34 tests pass (including the new regression test)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
