### PR TITLE
feat(desktop): add Copy File Content right-click menu item

### DIFF
--- a/apps/desktop/src/app/right-sidebar/file-actions.tsx
+++ b/apps/desktop/src/app/right-sidebar/file-actions.tsx
@@ -18,6 +18,7 @@ import {
   beginInlineRename,
   cancelInlineRename,
   closeFileActionDialog,
+  copyFileContent,
   copyFilePath,
   executeFileDelete,
   executeFileRename,
@@ -79,6 +80,9 @@ export function FileEntryContextMenu({ children, isDirectory, name, path, relati
           <ContextMenuItem onSelect={() => void copyFilePath(toRelativePath(path, relativeTo))}>
             {m.copyRelativePath}
           </ContextMenuItem>
+        )}
+        {!isDirectory && (
+          <ContextMenuItem onSelect={() => void copyFileContent(path)}>{m.copyContent}</ContextMenuItem>
         )}
         {localFs && (
           <>

--- a/apps/desktop/src/app/right-sidebar/file-actions.tsx
+++ b/apps/desktop/src/app/right-sidebar/file-actions.tsx
@@ -18,6 +18,7 @@ import {
   beginInlineRename,
   cancelInlineRename,
   closeFileActionDialog,
+  copyFileContent,
   copyFilePath,
   downloadRemoteFile,
   executeFileDelete,
@@ -84,6 +85,7 @@ export function FileEntryContextMenu({ children, isDirectory, name, path, relati
             {m.copyRelativePath}
           </ContextMenuItem>
         )}
+        {!isDirectory && <ContextMenuItem onSelect={() => void copyFileContent(path)}>{m.copyContent}</ContextMenuItem>}
         {remoteDownload && (
           <>
             <ContextMenuSeparator />

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -19,7 +19,7 @@ import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { displayPath } from '@/lib/display-path'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
-import { $renamingPath, copyFilePath, revealFile, toRelativePath } from '@/store/file-actions'
+import { $renamingPath, copyFileContent, copyFilePath, revealFile, toRelativePath } from '@/store/file-actions'
 import { $sidebarWorkspaceNodeOpen, revealFileInTree, toggleWorkspaceNodeCollapsed } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
@@ -441,6 +441,7 @@ function ReviewFileContextMenu({
             {m.copyRelativePath}
           </ContextMenuItem>
         )}
+        <ContextMenuItem onSelect={() => void copyFileContent(dragPath)}>{m.copyContent}</ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
   )

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -22,6 +22,7 @@ import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
 import {
   $renamingPath,
+  copyFileContent,
   copyFilePath,
   downloadRemoteFile,
   revealFile,
@@ -521,6 +522,7 @@ function ReviewFileContextMenu({
             {m.copyRelativePath}
           </ContextMenuItem>
         )}
+        <ContextMenuItem onSelect={() => void copyFileContent(dragPath)}>{m.copyContent}</ContextMenuItem>
         {shouldOfferRemoteFileDownload(false) && (
           <>
             <ContextMenuSeparator />

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -46,13 +46,15 @@ export const ar = defineLocale({
     revealInSidebar: 'إظهار في شجرة الملفات',
     copyPath: 'نسخ المسار',
     copyRelativePath: 'نسخ المسار النسبي',
+    copyContent: 'نسخ محتوى الملف',
     rename: 'إعادة تسمية...',
     delete: 'حذف',
     renameTitle: 'إعادة تسمية',
     renameLabel: 'الاسم الجديد',
     deleteTitle: name => `حذف ${name}؟`,
     deleteBody: 'سيتم نقله إلى سلة المهملات — يمكنك استعادته من هناك.',
-    pathCopied: 'تم نسخ المسار'
+    pathCopied: 'تم نسخ المسار',
+    contentCopied: 'تم نسخ محتوى الملف'
   },
   boot: {
     ready: 'Hermes Desktop جاهز',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -68,6 +68,7 @@ export const ar = defineLocale({
     revealInSidebar: 'إظهار في شجرة الملفات',
     copyPath: 'نسخ المسار',
     copyRelativePath: 'نسخ المسار النسبي',
+    copyContent: 'نسخ محتوى الملف',
     download: 'تنزيل',
     downloadSaved: 'تم الحفظ',
     downloadFailed: 'فشل التنزيل',
@@ -77,7 +78,8 @@ export const ar = defineLocale({
     renameLabel: 'الاسم الجديد',
     deleteTitle: name => `حذف ${name}؟`,
     deleteBody: 'سيتم نقله إلى سلة المهملات — يمكنك استعادته من هناك.',
-    pathCopied: 'تم نسخ المسار'
+    pathCopied: 'تم نسخ المسار',
+    contentCopied: 'تم نسخ محتوى الملف'
   },
   boot: {
     ready: 'Hermes Desktop جاهز',

--- a/apps/desktop/src/i18n/copy-content.test.ts
+++ b/apps/desktop/src/i18n/copy-content.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// @tabler/icons-react is a native dep that may be absent in partial installs.
+// Stub it so the transitive import chain (en.ts → settings/constants → icons)
+// doesn't block i18n unit tests. Each named export becomes a no-op component.
+vi.mock('@tabler/icons-react', () => ({
+  IconActivity: () => null,
+  IconAlertCircle: () => null,
+}))
+
+import { TRANSLATIONS } from './catalog'
+import { setRuntimeI18nLocale, translateNow } from './runtime'
+
+/**
+ * Tests for the "Copy File Content" context-menu action added to the file
+ * browser and git-review file trees. Verifies the i18n keys exist in every
+ * locale and resolve at runtime.
+ */
+describe('fileMenu.copyContent i18n', () => {
+  const locales = ['en', 'zh', 'zh-hant', 'ja', 'ar'] as const
+
+  it('has copyContent and contentCopied keys in every locale', () => {
+    for (const locale of locales) {
+      const fm = TRANSLATIONS[locale].fileMenu
+      expect(fm.copyContent, `${locale}.fileMenu.copyContent`).toBeTypeOf('string')
+      expect(fm.copyContent.length, `${locale}.fileMenu.copyContent non-empty`).toBeGreaterThan(0)
+      expect(fm.contentCopied, `${locale}.fileMenu.contentCopied`).toBeTypeOf('string')
+      expect(fm.contentCopied.length, `${locale}.fileMenu.contentCopied non-empty`).toBeGreaterThan(0)
+    }
+  })
+
+  it('translateNow resolves fileMenu.copyContent at runtime for every locale', () => {
+    for (const locale of locales) {
+      setRuntimeI18nLocale(locale)
+      const value = translateNow('fileMenu.copyContent')
+      expect(value, `${locale} fileMenu.copyContent`).not.toBe('fileMenu.copyContent')
+      expect(value.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('translateNow resolves fileMenu.contentCopied at runtime for every locale', () => {
+    for (const locale of locales) {
+      setRuntimeI18nLocale(locale)
+      const value = translateNow('fileMenu.contentCopied')
+      expect(value, `${locale} fileMenu.contentCopied`).not.toBe('fileMenu.contentCopied')
+      expect(value.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('falls back to English when a locale is missing the key', () => {
+    // Simulate a missing key by deleting it from ja, then restoring.
+    const jaFm = TRANSLATIONS.ja.fileMenu as { copyContent?: string }
+    const original = jaFm.copyContent
+    try {
+      jaFm.copyContent = undefined
+      setRuntimeI18nLocale('ja')
+      // Should fall back to the English string, not the raw key.
+      expect(translateNow('fileMenu.copyContent')).toBe('Copy File Content')
+    } finally {
+      jaFm.copyContent = original
+    }
+  })
+})

--- a/apps/desktop/src/i18n/copy-content.test.ts
+++ b/apps/desktop/src/i18n/copy-content.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// @tabler/icons-react is a native dep that may be absent in partial installs.
+// Stub it so the transitive import chain (en.ts → settings/constants → icons)
+// doesn't block i18n unit tests. Each named export becomes a no-op component.
+vi.mock('@tabler/icons-react', () => ({
+  IconActivity: () => null,
+  IconAlertCircle: () => null
+}))
+
+import { TRANSLATIONS } from './catalog'
+import { setRuntimeI18nLocale, translateNow } from './runtime'
+
+/**
+ * Tests for the "Copy File Content" context-menu action added to the file
+ * browser and git-review file trees. Verifies the i18n keys exist in every
+ * locale and resolve at runtime.
+ */
+describe('fileMenu.copyContent i18n', () => {
+  const locales = ['en', 'zh', 'zh-hant', 'ja', 'ar', 'ru'] as const
+
+  it('has copyContent and contentCopied keys in every locale', () => {
+    for (const locale of locales) {
+      const fm = TRANSLATIONS[locale].fileMenu
+      expect(fm.copyContent, `${locale}.fileMenu.copyContent`).toBeTypeOf('string')
+      expect(fm.copyContent.length, `${locale}.fileMenu.copyContent non-empty`).toBeGreaterThan(0)
+      expect(fm.contentCopied, `${locale}.fileMenu.contentCopied`).toBeTypeOf('string')
+      expect(fm.contentCopied.length, `${locale}.fileMenu.contentCopied non-empty`).toBeGreaterThan(0)
+    }
+  })
+
+  it('translateNow resolves fileMenu.copyContent at runtime for every locale', () => {
+    for (const locale of locales) {
+      setRuntimeI18nLocale(locale)
+      const value = translateNow('fileMenu.copyContent')
+      expect(value, `${locale} fileMenu.copyContent`).not.toBe('fileMenu.copyContent')
+      expect(value.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('translateNow resolves fileMenu.contentCopied at runtime for every locale', () => {
+    for (const locale of locales) {
+      setRuntimeI18nLocale(locale)
+      const value = translateNow('fileMenu.contentCopied')
+      expect(value, `${locale} fileMenu.contentCopied`).not.toBe('fileMenu.contentCopied')
+      expect(value.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('falls back to English when a locale is missing the key', () => {
+    // Simulate a missing key by deleting it from ja, then restoring.
+    const jaFm = TRANSLATIONS.ja.fileMenu as { copyContent?: string }
+    const original = jaFm.copyContent
+
+    try {
+      jaFm.copyContent = undefined
+      setRuntimeI18nLocale('ja')
+      // Should fall back to the English string, not the raw key.
+      expect(translateNow('fileMenu.copyContent')).toBe('Copy file content')
+    } finally {
+      jaFm.copyContent = original
+    }
+  })
+})

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -52,13 +52,15 @@ export const en: Translations = {
     revealInSidebar: 'Reveal in filetree',
     copyPath: 'Copy Path',
     copyRelativePath: 'Copy Relative Path',
+    copyContent: 'Copy File Content',
     rename: 'Rename…',
     delete: 'Delete',
     renameTitle: 'Rename',
     renameLabel: 'New name',
     deleteTitle: name => `Delete ${name}?`,
     deleteBody: 'It will be moved to the Trash — you can restore it from there.',
-    pathCopied: 'Path copied'
+    pathCopied: 'Path copied',
+    contentCopied: 'File content copied'
   },
 
   boot: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -52,6 +52,7 @@ export const en: Translations = {
     revealInSidebar: 'Reveal in filetree',
     copyPath: 'Copy path',
     copyRelativePath: 'Copy relative path',
+    copyContent: 'Copy file content',
     download: 'Download',
     downloadSaved: 'Saved',
     downloadFailed: 'Download failed',
@@ -61,7 +62,8 @@ export const en: Translations = {
     renameLabel: 'New name',
     deleteTitle: name => `Delete ${name}?`,
     deleteBody: 'It will be moved to the Trash — you can restore it from there.',
-    pathCopied: 'Path copied'
+    pathCopied: 'Path copied',
+    contentCopied: 'File content copied'
   },
 
   boot: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -52,13 +52,15 @@ export const ja = defineLocale({
     revealInSidebar: 'ファイルツリーで表示',
     copyPath: 'パスをコピー',
     copyRelativePath: '相対パスをコピー',
+    copyContent: 'ファイルの内容をコピー',
     rename: '名前を変更…',
     delete: '削除',
     renameTitle: '名前を変更',
     renameLabel: '新しい名前',
     deleteTitle: name => `${name} を削除しますか？`,
     deleteBody: 'ゴミ箱に移動します。そこから復元できます。',
-    pathCopied: 'パスをコピーしました'
+    pathCopied: 'パスをコピーしました',
+    contentCopied: 'ファイルの内容をコピーしました'
   },
 
   boot: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -52,6 +52,7 @@ export const ja = defineLocale({
     revealInSidebar: 'ファイルツリーで表示',
     copyPath: 'パスをコピー',
     copyRelativePath: '相対パスをコピー',
+    copyContent: 'ファイルの内容をコピー',
     download: 'ダウンロード',
     downloadSaved: '保存しました',
     downloadFailed: 'ダウンロードに失敗しました',
@@ -61,7 +62,8 @@ export const ja = defineLocale({
     renameLabel: '新しい名前',
     deleteTitle: name => `${name} を削除しますか？`,
     deleteBody: 'ゴミ箱に移動します。そこから復元できます。',
-    pathCopied: 'パスをコピーしました'
+    pathCopied: 'パスをコピーしました',
+    contentCopied: 'ファイルの内容をコピーしました'
   },
 
   boot: {

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -72,6 +72,7 @@ export const ru = defineLocale({
     revealInSidebar: 'Показать в дереве файлов',
     copyPath: 'Копировать путь',
     copyRelativePath: 'Копировать относительный путь',
+    copyContent: 'Копировать содержимое файла',
     download: 'Скачать',
     downloadSaved: 'Сохранено',
     downloadFailed: 'Не удалось скачать',
@@ -81,7 +82,8 @@ export const ru = defineLocale({
     renameLabel: 'Новое имя',
     deleteTitle: name => `Удалить ${name}?`,
     deleteBody: 'Элемент будет перемещён в корзину — его можно восстановить оттуда.',
-    pathCopied: 'Путь скопирован'
+    pathCopied: 'Путь скопирован',
+    contentCopied: 'Содержимое файла скопировано'
   },
   boot: {
     ready: 'Hermes Desktop готов',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -98,6 +98,7 @@ export interface Translations {
     revealInSidebar: string
     copyPath: string
     copyRelativePath: string
+    copyContent: string
     rename: string
     delete: string
     renameTitle: string
@@ -105,6 +106,7 @@ export interface Translations {
     deleteTitle: (name: string) => string
     deleteBody: string
     pathCopied: string
+    contentCopied: string
   }
 
   boot: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -100,6 +100,7 @@ export interface Translations {
     revealInSidebar: string
     copyPath: string
     copyRelativePath: string
+    copyContent: string
     download: string
     downloadSaved: string
     downloadFailed: string
@@ -110,6 +111,7 @@ export interface Translations {
     deleteTitle: (name: string) => string
     deleteBody: string
     pathCopied: string
+    contentCopied: string
   }
 
   boot: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -52,13 +52,15 @@ export const zhHant = defineLocale({
     revealInSidebar: '在檔案樹中顯示',
     copyPath: '複製路徑',
     copyRelativePath: '複製相對路徑',
+    copyContent: '複製檔案內容',
     rename: '重新命名…',
     delete: '刪除',
     renameTitle: '重新命名',
     renameLabel: '新名稱',
     deleteTitle: name => `刪除 ${name}？`,
     deleteBody: '將移至垃圾桶，你可以從那裡還原。',
-    pathCopied: '已複製路徑'
+    pathCopied: '已複製路徑',
+    contentCopied: '已複製檔案內容'
   },
 
   boot: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -52,6 +52,7 @@ export const zhHant = defineLocale({
     revealInSidebar: '在檔案樹中顯示',
     copyPath: '複製路徑',
     copyRelativePath: '複製相對路徑',
+    copyContent: '複製檔案內容',
     download: '下載',
     downloadSaved: '已儲存',
     downloadFailed: '下載失敗',
@@ -61,7 +62,8 @@ export const zhHant = defineLocale({
     renameLabel: '新名稱',
     deleteTitle: name => `刪除 ${name}？`,
     deleteBody: '將移至垃圾桶，你可以從那裡還原。',
-    pathCopied: '已複製路徑'
+    pathCopied: '已複製路徑',
+    contentCopied: '已複製檔案內容'
   },
 
   boot: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -52,13 +52,15 @@ export const zh: Translations = {
     revealInSidebar: '在文件树中显示',
     copyPath: '复制路径',
     copyRelativePath: '复制相对路径',
+    copyContent: '复制文件内容',
     rename: '重命名…',
     delete: '删除',
     renameTitle: '重命名',
     renameLabel: '新名称',
     deleteTitle: name => `删除 ${name}？`,
     deleteBody: '将移至废纸篓，你可以从那里恢复。',
-    pathCopied: '已复制路径'
+    pathCopied: '已复制路径',
+    contentCopied: '已复制文件内容'
   },
 
   boot: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -52,6 +52,7 @@ export const zh: Translations = {
     revealInSidebar: '在文件树中显示',
     copyPath: '复制路径',
     copyRelativePath: '复制相对路径',
+    copyContent: '复制文件内容',
     download: '下载',
     downloadSaved: '已保存',
     downloadFailed: '下载失败',
@@ -61,7 +62,8 @@ export const zh: Translations = {
     renameLabel: '新名称',
     deleteTitle: name => `删除 ${name}？`,
     deleteBody: '将移至废纸篓，你可以从那里恢复。',
-    pathCopied: '已复制路径'
+    pathCopied: '已复制路径',
+    contentCopied: '已复制文件内容'
   },
 
   boot: {

--- a/apps/desktop/src/store/file-actions.ts
+++ b/apps/desktop/src/store/file-actions.ts
@@ -1,7 +1,7 @@
 import { atom } from 'nanostores'
 
 import { translateNow } from '@/i18n'
-import { copyTextToClipboard, renameDesktopPath, revealDesktopPath, trashDesktopPath } from '@/lib/desktop-fs'
+import { copyTextToClipboard, readDesktopFileText, renameDesktopPath, revealDesktopPath, trashDesktopPath } from '@/lib/desktop-fs'
 import { notify, notifyError } from '@/store/notifications'
 import { notifyWorkspaceChanged } from '@/store/workspace-events'
 
@@ -60,6 +60,32 @@ export async function copyFilePath(path: string): Promise<void> {
   try {
     await copyTextToClipboard(path)
     notify({ durationMs: 1500, kind: 'info', message: translateNow('fileMenu.pathCopied') })
+  } catch (error) {
+    notifyError(error, translateNow('common.copyFailed'))
+  }
+}
+
+/** Read a file's text content and copy it to the system clipboard. */
+export async function copyFileContent(path: string): Promise<void> {
+  try {
+    const result = await readDesktopFileText(path)
+
+    if (result.binary) {
+      notifyError(new Error('Binary file'), translateNow('common.copyFailed'))
+
+      return
+    }
+
+    const text = result.text
+
+    if (!text) {
+      notifyError(new Error('File has no readable text content'), translateNow('common.copyFailed'))
+
+      return
+    }
+
+    await copyTextToClipboard(text)
+    notify({ durationMs: 1500, kind: 'info', message: translateNow('fileMenu.contentCopied') })
   } catch (error) {
     notifyError(error, translateNow('common.copyFailed'))
   }

--- a/apps/desktop/src/store/file-actions.ts
+++ b/apps/desktop/src/store/file-actions.ts
@@ -4,6 +4,7 @@ import { translateNow } from '@/i18n'
 import {
   copyTextToClipboard,
   isDesktopFsRemoteMode,
+  readDesktopFileText,
   renameDesktopPath,
   revealDesktopPath,
   trashDesktopPath
@@ -13,11 +14,11 @@ import { notify, notifyError } from '@/store/notifications'
 import { notifyWorkspaceChanged } from '@/store/workspace-events'
 
 // Shared file-row actions for BOTH trees (the file browser + the review/git
-// tree): reveal, copy path, download (remote), rename, delete. Rename/delete
-// route through a single dialog set (driven by this atom, rendered once by
-// `FileActionDialogs`) instead of one dialog per row. After a successful
-// mutation we bump the workspace tick so every git-/fs-mirroring surface
-// refreshes.
+// tree): reveal, copy path, copy content, download (remote), rename, delete.
+// Rename/delete route through a single dialog set (driven by this atom,
+// rendered once by `FileActionDialogs`) instead of one dialog per row. After a
+// successful mutation we bump the workspace tick so every git-/fs-mirroring
+// surface refreshes.
 
 export interface FileActionTarget {
   isDirectory: boolean
@@ -68,6 +69,32 @@ export async function copyFilePath(path: string): Promise<void> {
   try {
     await copyTextToClipboard(path)
     notify({ durationMs: 1500, kind: 'info', message: translateNow('fileMenu.pathCopied') })
+  } catch (error) {
+    notifyError(error, translateNow('common.copyFailed'))
+  }
+}
+
+/** Read a file's text content and copy it to the system clipboard. */
+export async function copyFileContent(path: string): Promise<void> {
+  try {
+    const result = await readDesktopFileText(path)
+
+    if (result.binary) {
+      notifyError(new Error('Binary file'), translateNow('common.copyFailed'))
+
+      return
+    }
+
+    const text = result.text
+
+    if (!text) {
+      notifyError(new Error('File has no readable text content'), translateNow('common.copyFailed'))
+
+      return
+    }
+
+    await copyTextToClipboard(text)
+    notify({ durationMs: 1500, kind: 'info', message: translateNow('fileMenu.contentCopied') })
   } catch (error) {
     notifyError(error, translateNow('common.copyFailed'))
   }

--- a/contributors/emails/nyhhome@gmail.com
+++ b/contributors/emails/nyhhome@gmail.com
@@ -1,0 +1,2 @@
+nyhhome
+# PR #55236 rebase


### PR DESCRIPTION
## What does this PR do?

Adds a **"Copy file content"** item to the desktop file-tree right-click menus. Clicking it reads the file's text and writes it to the system clipboard — a faster path than open-then-select-all-then-copy for the common "grab a file's contents" action. Binary files and files with no readable text are guarded with an error toast instead of copying garbage.

The action is wired into **both** file trees that share the file-row action menu: the main file browser (`right-sidebar/file-actions.tsx`) and the review/git tree (`right-sidebar/review/file-tree.tsx`). It is hidden for directories in the main browser. Implemented on top of the existing `readDesktopFileText` / `copyTextToClipboard` desktop-fs helpers, mirroring the existing `copyFilePath` action's structure and error handling. Because `readDesktopFileText` is mode-aware, the item works against a remote backend too (it reads through the same gateway path the file preview uses), so it is not gated behind `localFs` like Reveal/Rename/Delete.

## Related Issue

N/A — small self-contained UX addition.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/store/file-actions.ts` — new `copyFileContent(path)`: reads via `readDesktopFileText`, guards `result.binary` and empty text, copies, notifies `fileMenu.contentCopied`; on error notifies `common.copyFailed`.
- `apps/desktop/src/app/right-sidebar/file-actions.tsx` — adds the menu item after "Copy relative path" (hidden for directories), before the remote Download entry.
- `apps/desktop/src/app/right-sidebar/review/file-tree.tsx` — adds the same item to the review/git tree menu.
- `apps/desktop/src/i18n/types.ts` — adds `fileMenu.copyContent` / `fileMenu.contentCopied` to the i18n type.
- `apps/desktop/src/i18n/{en,zh,zh-hant,ja,ar,ru}.ts` — translations for the two new keys in every locale.
- `apps/desktop/src/i18n/copy-content.test.ts` — new test: key presence across all six locales, runtime translation, and English fallback (4 tests).
- `contributors/emails/nyhhome@gmail.com` — contributor attribution mapping, per the `Check contributors` gate's mapping requirement.

## How to Test

1. Build & launch the desktop app (`cd apps/desktop && npm run pack`, then open `release/<platform>/Hermes.app`).
2. Right-click any file in the file tree (or the review/git tree) → click **Copy file content**.
3. Paste elsewhere → the file's text is on the clipboard; a "File content copied" toast appears.
4. Right-click a binary file (e.g. an image) → an error toast appears, nothing is copied. Directories don't show the item in the main file browser.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(desktop): …`, `chore: …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] Desktop checks pass on the rebased branch (main @ `79445a496`, 2026-09-05, Linux arm64 / Node 22): `npm run typecheck` (renderer + electron + e2e tsconfigs) clean; `npm run lint` 0 errors; `npm run test:ui` (the full `ui` vitest project) → 723/723 test files green, incl. `copy-content.test.ts` 4/4; changed files pass `prettier --check` / `eslint` with 0 warnings.
- [x] I've added tests for my change (`copy-content.test.ts`, 4 tests)
- [x] I've tested on my platform: macOS 26.5, Apple Silicon (arm64) — built, launched, action verified end-to-end on the original (June) base. The rebase changed only merge context, one label's casing and the `ru` strings (see note below); it has **not** been re-launched in Electron since.

### Documentation & Housekeeping

- [x] No docs change needed — N/A
- [x] No config keys added/changed — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform: pure renderer-side TS using existing cross-platform desktop-fs helpers; no platform-specific code — clipboard/file-read go through the existing abstractions used by `copyFilePath`.

## Rebase note (2026-09-05)

The branch was ~11.9k commits behind `main` and no longer merged cleanly (that is why the last CI run dispatched 0 jobs). Rebased onto `main` @ `79445a496`; what changed relative to the previously pushed revision:

- **Conflicts** — all nine were the same shape: `main` added the remote-file **Download** item (6a843f95c) at exactly the spot this PR inserts *Copy file content*, in both trees and in every locale/type file. Resolved by keeping both: the new item sits after *Copy relative path* and before the Download separator.
- **Label casing** — `main` moved the file menu to sentence case (*Copy path*, *Copy relative path*), so the label is now **"Copy file content"** instead of "Copy File Content"; the toast text was already sentence case. The test's English-fallback assertion follows.
- **Russian locale** — `ru.ts` landed on `main` after this PR was opened (a922dad9d); both keys are added there and `ru` is included in the test's locale list.
- The comment in `store/file-actions.ts` listing the shared row actions now includes *copy content*.
- No functional change to the feature itself.

On the `sweeper:risk-security-boundary` label: this adds no new filesystem or IPC surface. It reads through the existing mode-aware `readDesktopFileText` bridge — the same helper `preview-file.tsx`, `local-preview.ts` and the inline preview directive already use — and writes through `copyTextToClipboard`, exactly like the existing *Copy path* action.

*Disclosure: the original implementation and this rebase (conflict resolution, `ru` strings, this description) were done with AI assistance at the account owner's direction; AI co-authorship is recorded in the commit trailers.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ah1vb8AgEppJp3XmTqJopZ
