### PR TITLE
fix(slack): ignore stale thread sessions

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3806,7 +3806,15 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
             session_store._ensure_loaded()
-            return session_key in session_store._entries
+            entry = session_store._entries.get(session_key)
+            if entry is None:
+                return False
+
+            should_reset = getattr(type(session_store), "_should_reset", None)
+            if callable(should_reset) and should_reset(session_store, entry, source):
+                return False
+
+            return True
         except Exception:
             return False
 

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -663,6 +663,31 @@ class TestSessionKeyFix:
         )
         assert result is False
 
+    def test_stale_session_returns_false(self):
+        adapter = _make_adapter()
+
+        class Store:
+            config = MagicMock()
+            config.group_sessions_per_user = False
+            config.thread_sessions_per_user = False
+            _entries = {
+                "agent:main:slack:group:C1:1000.0": MagicMock()
+            }
+
+            def _ensure_loaded(self):
+                return None
+
+            def _should_reset(self, entry, source):
+                return "idle"
+
+        adapter._session_store = Store()
+
+        result = adapter._has_active_session_for_thread(
+            channel_id="C1", thread_ts="1000.0", user_id="U123"
+        )
+
+        assert result is False
+
 
 # ===========================================================================
 # Thread engagement — bot-started threads & mentioned threads


### PR DESCRIPTION
## Summary

Fixes #55239.

Slack thread auto-engagement now treats an existing session key as active only if the session store would keep that entry fresh under the current reset policy. If `_should_reset()` says the entry is stale, `_has_active_session_for_thread()` returns false so the first reply after reset can fetch Slack thread context before the fresh session turn starts.

## Validation

- `python -m pytest tests\gateway\test_slack_approval_buttons.py -q --basetemp .pytest-tmp-slack-reset` — 27 passed
- `python -m pytest tests\gateway\test_slack.py -q --basetemp .pytest-tmp-slack-main` — 209 passed
- `python -m ruff check plugins\platforms\slack\adapter.py tests\gateway\test_slack_approval_buttons.py` — passed
- `git diff --check origin/main...HEAD` — passed

Pytest emitted existing AsyncMock runtime warnings in Slack tests; no failures.

## AI Assistance

Implemented with Codex assistance. I reviewed the diff and ran the focused validation above.