### PR TITLE
fix: preserve property names named 'definitions' in MCP schema normalization

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4136,3 +4136,47 @@ class TestMcpParallelToolCalls:
             register_mcp_servers(config_off)
         with _lock:
             assert sanitize_mcp_name_component("toggle_srv") not in _parallel_safe_servers
+
+
+def test_property_named_definitions_not_renamed():
+    """A tool parameter literally named 'definitions' must not be renamed to '$defs'.
+
+    Regression test for #55081: _rewrite_local_refs was renaming every
+    'definitions' key to '$defs', even inside properties maps where the
+    key is a user-defined property name, not the schema keyword.
+    """
+    from tools.mcp_tool import _normalize_mcp_input_schema
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "term": {"type": "string"},
+            "definitions": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["term", "definitions"],
+    }
+
+    out = _normalize_mcp_input_schema(schema)
+
+    assert "definitions" in out["properties"], f"Property renamed: {list(out['properties'].keys())}"
+    assert "$defs" not in out["properties"], f"Spurious $defs in properties"
+    assert "definitions" in out["required"], f"Required pruned: {out['required']}"
+
+
+def test_schema_level_definitions_still_renamed():
+    """The schema keyword 'definitions' at the top level should still be
+    renamed to '$defs' and refs rewritten.
+    """
+    from tools.mcp_tool import _normalize_mcp_input_schema
+
+    schema = {
+        "type": "object",
+        "definitions": {"MyType": {"type": "string"}},
+        "properties": {"ref_field": {"$ref": "#/definitions/MyType"}},
+    }
+
+    out = _normalize_mcp_input_schema(schema)
+
+    assert "$defs" in out, f"Top-level definitions not renamed: {list(out.keys())}"
+    assert "definitions" not in out
+    assert out["properties"]["ref_field"]["$ref"] == "#/$defs/MyType"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3730,18 +3730,30 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
     if not schema:
         return {"type": "object", "properties": {}}
 
-    def _rewrite_local_refs(node):
+    def _rewrite_local_refs(node, *, in_name_map=False):
         if isinstance(node, dict):
             normalized = {}
             for key, value in node.items():
-                out_key = "$defs" if key == "definitions" else key
-                normalized[out_key] = _rewrite_local_refs(value)
+                # Inside name-to-schema maps (properties, patternProperties),
+                # keys are user-defined names, not schema keywords — don't
+                # rename them. At the top level and inside $defs/definitions
+                # blocks, "definitions" is the schema keyword and should be
+                # renamed to "$defs".
+                if in_name_map:
+                    out_key = key
+                else:
+                    out_key = "$defs" if key == "definitions" else key
+                # Recurse into name-to-schema maps with in_name_map=True
+                child_in_name_map = key in {"properties", "patternProperties"}
+                normalized[out_key] = _rewrite_local_refs(
+                    value, in_name_map=child_in_name_map
+                )
             ref = normalized.get("$ref")
             if isinstance(ref, str) and ref.startswith("#/definitions/"):
                 normalized["$ref"] = "#/$defs/" + ref[len("#/definitions/"):]
             return normalized
         if isinstance(node, list):
-            return [_rewrite_local_refs(item) for item in node]
+            return [_rewrite_local_refs(item, in_name_map=in_name_map) for item in node]
         return node
 
     def _strip_nullable_union(node):


### PR DESCRIPTION
## What does this PR do?

`_rewrite_local_refs()` in `tools/mcp_tool.py` was renaming every dict key `"definitions"` to `"$defs"`, even inside `properties`/`patternProperties` maps where the key is a user-defined property name, not the JSON Schema keyword. This silently renamed tool parameters and broke `required` arrays.

Fix: pass `in_name_map` context through the recursion. Inside `properties`/`patternProperties`, keys are left untouched. At the top level and inside `definitions` blocks, the rename still applies.

## Related Issue

Fixes #55081

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: Make `_rewrite_local_refs` aware of name-to-schema maps (`properties`, `patternProperties`). When inside such maps, don't rename keys — they are property names, not schema keywords.
- `tests/tools/test_mcp_tool.py`: Add 2 regression tests:
  - `test_property_named_definitions_not_renamed` — property name preserved
  - `test_schema_level_definitions_still_renamed` — schema keyword still migrated

## How to Test

1. Run `uv run --extra dev python -m pytest tests/tools/test_mcp_tool.py::test_property_named_definitions_not_renamed tests/tools/test_mcp_tool.py::test_schema_level_definitions_still_renamed -q` — both pass
2. Reproduce the original bug:
   ```python
   from tools.mcp_tool import _normalize_mcp_input_schema
   schema = {"type": "object", "properties": {"definitions": {"type": "array"}}, "required": ["definitions"]}
   out = _normalize_mcp_input_schema(schema)
   assert "definitions" in out["properties"]  # was renamed to "$defs"
   ```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `uv run --extra dev python -m pytest tests/tools/test_mcp_tool.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] I've considered cross-platform impact — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas — or N/A