### PR TITLE
fix: strip internal tool-trace banner lines from chat gateway delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -69,6 +69,14 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
+# Internal tool-trace banner lines that should be stripped from chat delivery.
+# Matches lines like: ⚠️ 🛠️ `search repos (agent)` failed
+# These are diagnostic scaffolding, not user-facing content.
+_TOOL_TRACE_BANNER_RE = re.compile(
+    r"^[ \t]*(?:⚠️?\s*)?(?:🛠️?\s*)?`[^`]+`\s+failed\s*$",
+    re.MULTILINE,
+)
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
     r"auxiliary\s+.+\s+failed"
@@ -426,6 +434,8 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
+    # Strip internal tool-trace banner lines (e.g. ⚠️ 🛠️ `tool (agent)` failed)
+    redacted = _TOOL_TRACE_BANNER_RE.sub("", redacted).strip()
     return redacted
 
 

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -232,3 +232,20 @@ def test_chat_gateways_redact_all_issue_23810_credential_shapes(platform, shape_
     # Prose around the secret is preserved — redaction is surgical.
     assert "here is the token you asked me to echo" in sanitized
     assert sanitized.endswith("done.")
+
+
+def test_tool_trace_banner_stripped_from_chat():
+    """Internal tool-trace lines like ⚠️ 🛠️ `tool (agent)` failed must be
+    stripped from chat delivery. Regression test for #54957.
+    """
+    raw = "Done.\n⚠️ 🛠️ `search repos (agent)` failed"
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+    assert sanitized == "Done."
+    assert "failed" not in sanitized
+
+
+def test_tool_trace_banner_kept_on_raw_surface():
+    """Programmatic surfaces (local, api_server) should keep raw trace text."""
+    raw = "Done.\n⚠️ 🛠️ `search repos (agent)` failed"
+    result = _sanitize_gateway_final_response("local", raw)
+    assert "failed" in result


### PR DESCRIPTION
## What does this PR do?

Chat gateway final replies could contain internal tool-trace scaffold lines like `⚠️ 🛠️ \`search repos (agent)\` failed` that are diagnostic noise, not user-facing content. Add a regex pattern to strip these lines from chat surfaces while keeping them on programmatic/raw surfaces (`local`, `api_server`, `webhook`).

## Related Issue

Fixes #54957

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Add `_TOOL_TRACE_BANNER_RE` regex pattern that matches lines like `` ⚠️ 🛠️ `tool (agent)` failed ``. Apply it in `_sanitize_gateway_final_response()` after secret redaction and provider error classification.
- `tests/gateway/test_telegram_noise_filter.py`: Add 2 regression tests:
  - `test_tool_trace_banner_stripped_from_chat` — banner stripped on Telegram
  - `test_tool_trace_banner_kept_on_raw_surface` — banner kept on `local`

## How to Test

1. Run `uv run --extra dev python -m pytest tests/gateway/test_telegram_noise_filter.py::test_tool_trace_banner_stripped_from_chat tests/gateway/test_telegram_noise_filter.py::test_tool_trace_banner_kept_on_raw_surface -q` — both pass
2. Reproduce the original bug:
   ```python
   from gateway.config import Platform
   from gateway.run import _sanitize_gateway_final_response
   raw = "Done.\n⚠️ 🛠️ \`search repos (agent)\` failed"
   assert _sanitize_gateway_final_response(Platform.TELEGRAM, raw) == "Done."
   ```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `uv run --extra dev python -m pytest tests/gateway/test_telegram_noise_filter.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] I've considered cross-platform impact — regex is platform-agnostic
- [x] I've updated tool descriptions/schemas — or N/A