### PR TITLE
Draft: preserve local Hermes Agent hotfixes after updater resets

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12031,6 +12031,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     record_final_assistant(self.agent, response)
                 except Exception:
                     logging.debug("kanban worker final assistant journal failed", exc_info=True)
+                try:
+                    _kanban_activity = getattr(self, "_kanban_activity_journal", None)
+                    if _kanban_activity is not None:
+                        _kanban_activity.flush_assistant_text()
+                        _kanban_activity.assistant_text(response)
+                except Exception:
+                    logging.debug("kanban worker activity final assistant journal failed", exc_info=True)
 
             # Auto-generate session title after first exchange (non-blocking)
             if response and result and not result.get("failed") and not result.get("partial"):

--- a/cli.py
+++ b/cli.py
@@ -12024,6 +12024,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             # Get the final response
             response = result.get("final_response", "") if result else ""
+            if response:
+                try:
+                    from hermes_cli.kanban_worker_journal import record_final_assistant
+
+                    record_final_assistant(self.agent, response)
+                except Exception:
+                    logging.debug("kanban worker final assistant journal failed", exc_info=True)
 
             # Auto-generate session title after first exchange (non-blocking)
             if response and result and not result.get("failed") and not result.get("partial"):
@@ -15592,6 +15599,13 @@ def main(
                         ):
                             cli.session_id = cli.agent.session_id
                         response = result.get("final_response", "") if isinstance(result, dict) else str(result)
+                        if response:
+                            try:
+                                from hermes_cli.kanban_worker_journal import record_final_assistant
+
+                                record_final_assistant(cli.agent, response)
+                            except Exception:
+                                logger.debug("kanban worker final assistant journal failed", exc_info=True)
                         # Surface backend errors that produced no visible output
                         # (e.g. invalid model slug → provider 4xx). Mirrors the
                         # interactive CLI path. Write to stderr so piped stdout

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -14,6 +14,7 @@ Exposes an HTTP server with endpoints:
 - GET  /api/sessions/{session_id}/messages — read session message history
 - POST /api/sessions/{session_id}/fork — branch a session using SessionDB lineage
 - POST /api/sessions/{session_id}/chat[/stream] — chat with a persisted session
+- POST /api/sessions/{session_id}/steer — inject non-interrupting guidance into an active session
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
@@ -794,6 +795,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # Active run agent/task references for stop support
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
+        # Active agents keyed by session identity (X-Hermes-Session-Key or session_id).
+        # The OpenAI-compatible streaming path needs this for /api/sessions/{id}/steer:
+        # clients address the short-lived WebUI session id while the running AIAgent
+        # lives inside a background executor thread.
+        self._active_session_agents: Dict[str, Any] = {}
         # Pollable run status for dashboards and external control-plane UIs.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
         # Active approval session key for each run_id.  The approval core
@@ -1047,6 +1053,28 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return raw, None
 
+    @staticmethod
+    def _client_platform_from_request(
+        request: Any,
+        gateway_session_key: Optional[str] = None,
+    ) -> str:
+        """Return the presentation platform for an API-server request.
+
+        The API server remains the transport for auth, toolset resolution and
+        session persistence.  Hermes WebUI still needs the WebUI prompt hint so
+        final answers use rich Markdown instead of the conservative plain-text
+        API hint.  ``X-Hermes-Client`` is deliberately non-sensitive and does
+        not grant session/memory access; ``X-Hermes-Session-Key`` keeps its
+        existing API-key requirement.
+        """
+        raw_client = request.headers.get("X-Hermes-Client", "") if request is not None else ""
+        client = str(raw_client or "").strip().lower().replace("_", "-")
+        if client in {"webui", "hermes-webui"}:
+            return "webui"
+        if isinstance(gateway_session_key, str) and gateway_session_key.lower().startswith("webui:"):
+            return "webui"
+        return "api_server"
+
     # ------------------------------------------------------------------
     # Session DB helper
     # ------------------------------------------------------------------
@@ -1078,6 +1106,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
+        client_platform: str = "api_server",
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1108,7 +1137,10 @@ class APIServerAdapter(BasePlatformAdapter):
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
 
+        client_platform = client_platform if client_platform in {"api_server", "webui"} else "api_server"
         user_config = _load_gateway_config()
+        # Tool capability remains governed by the API-server transport config.
+        # ``client_platform`` only selects presentation prompt hints.
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
         max_iterations = _current_max_iterations()
@@ -1126,7 +1158,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ephemeral_system_prompt=ephemeral_system_prompt or None,
             enabled_toolsets=enabled_toolsets,
             session_id=session_id,
-            platform="api_server",
+            platform=client_platform,
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
@@ -1254,6 +1286,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_resources": True,
                 "session_chat": True,
                 "session_chat_streaming": True,
+                "session_steer": True,
                 "session_fork": True,
                 "admin_config_rw": False,
                 "jobs_admin": False,
@@ -1287,6 +1320,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
+                "session_steer": {"method": "POST", "path": "/api/sessions/{session_id}/steer"},
             },
         })
 
@@ -1629,6 +1663,71 @@ class APIServerAdapter(BasePlatformAdapter):
         fork = db.get_session(fork_id) or {"id": fork_id, "parent_session_id": source_id}
         return web.json_response({"object": "hermes.session", "session": self._session_response(fork)}, status=201)
 
+    async def _handle_session_steer(self, request: "web.Request") -> "web.Response":
+        """POST /api/sessions/{session_id}/steer — inject guidance into an active run.
+
+        WebUI's gateway-backed chat uses /v1/chat/completions with
+        X-Hermes-Session-Id and X-Hermes-Session-Key: webui:{session_id}.  The
+        non-interrupting /steer control must reach that in-flight AIAgent rather
+        than queue or cancel the browser turn.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        gateway_session_key, key_err = self._parse_session_key_header(request)
+        if key_err is not None:
+            return key_err
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+        session_id = str(request.match_info["session_id"] or "").strip()
+        text = str((body or {}).get("text") or (body or {}).get("message") or "").strip()
+        if not session_id:
+            return web.json_response(_openai_error("Missing session_id", code="missing_session_id"), status=400)
+        if not text:
+            return web.json_response(_openai_error("Missing steer text", code="missing_text"), status=400)
+
+        candidate_keys = []
+        if gateway_session_key:
+            candidate_keys.append(gateway_session_key)
+        candidate_keys.extend([f"webui:{session_id}", session_id])
+        agent = None
+        matched_key = None
+        for key in candidate_keys:
+            if not key:
+                continue
+            agent = self._active_session_agents.get(key)
+            if agent is not None:
+                matched_key = key
+                break
+        if agent is None:
+            return web.json_response({
+                "accepted": False,
+                "fallback": "not_running",
+                "session_id": session_id,
+            })
+        if not hasattr(agent, "steer"):
+            return web.json_response({
+                "accepted": False,
+                "fallback": "agent_lacks_steer",
+                "session_id": session_id,
+            })
+        try:
+            accepted = bool(agent.steer(text))
+        except Exception as exc:
+            logger.warning("API server steer failed for session %s (%s): %s", session_id, matched_key, exc)
+            return web.json_response({
+                "accepted": False,
+                "fallback": "steer_error",
+                "session_id": session_id,
+                "error": str(exc)[:500],
+            })
+        return web.json_response({
+            "accepted": accepted,
+            "fallback": None if accepted else "steer_rejected",
+            "session_id": session_id,
+        })
+
     async def _handle_session_chat(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/chat — one synchronous agent turn."""
         auth_err = self._check_auth(request)
@@ -1637,6 +1736,7 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        client_platform = self._client_platform_from_request(request, gateway_session_key)
         session_id = request.match_info["session_id"]
         _, err = self._get_existing_session_or_404(session_id)
         if err:
@@ -1657,6 +1757,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ephemeral_system_prompt=system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
+            client_platform=client_platform,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = result.get("final_response", "") if isinstance(result, dict) else ""
@@ -1681,6 +1782,7 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        client_platform = self._client_platform_from_request(request, gateway_session_key)
         session_id = request.match_info["session_id"]
         _, err = self._get_existing_session_or_404(session_id)
         if err:
@@ -1748,6 +1850,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
+                    client_platform=client_platform,
                 )
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
@@ -1883,6 +1986,7 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        client_platform = self._client_platform_from_request(request, gateway_session_key)
 
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
@@ -2029,6 +2133,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                client_platform=client_platform,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2048,6 +2153,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                client_platform=client_platform,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -2958,6 +3064,7 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        client_platform = self._client_platform_from_request(request, gateway_session_key)
 
         # Parse request body
         try:
@@ -3111,6 +3218,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                client_platform=client_platform,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -3144,6 +3252,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                client_platform=client_platform,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -3736,16 +3845,19 @@ class APIServerAdapter(BasePlatformAdapter):
         chat_id: str = "",
         session_key: str = "",
         session_id: str = "",
+        client_platform: str = "api_server",
     ) -> list:
         """Bind session contextvars for an API-server agent run.
 
         This is the SINGLE structural chokepoint every API-server agent-entry
-        path must use to seed session context — it hardwires
-        ``platform="api_server"`` and ``async_delivery=False`` so a new route
-        physically cannot reintroduce the silent-no-op bug (#10760) by
-        forgetting to mark the channel as non-delivering. There is no
-        ``async_delivery`` parameter to get wrong; the stateless HTTP path can
-        never wake the agent after the turn ends, on ANY route.
+        path must use to seed session context.  It hardwires the transport
+        context to ``platform="api_server"`` and ``async_delivery=False`` so a
+        new route physically cannot reintroduce the silent-no-op bug (#10760)
+        by forgetting to mark the channel as non-delivering.  ``client_platform``
+        is accepted for call-site symmetry with agent creation, but it must not
+        change delivery/session context: Hermes WebUI presentation hints are
+        selected via ``AIAgent.platform`` while stateless HTTP still cannot wake
+        the agent after the turn ends, on ANY route.
 
         Returns reset tokens; pass them to ``clear_session_vars`` in a
         ``finally`` block (the binding is request-scoped and must not outlive
@@ -3774,6 +3886,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        client_platform: str = "api_server",
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -3786,6 +3899,7 @@ class APIServerAdapter(BasePlatformAdapter):
         callers (e.g. the SSE writer) to call ``agent.interrupt()`` from
         another thread to stop in-progress LLM calls.
         """
+        client_platform = client_platform if client_platform in {"api_server", "webui"} else "api_server"
         loop = asyncio.get_running_loop()
 
         def _run():
@@ -3795,6 +3909,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 chat_id=session_id or "",
                 session_key=gateway_session_key or session_id or "",
                 session_id=session_id or "",
+                client_platform=client_platform,
             )
             try:
                 agent = self._create_agent(
@@ -3805,9 +3920,17 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_start_callback=tool_start_callback,
                     tool_complete_callback=tool_complete_callback,
                     gateway_session_key=gateway_session_key,
+                    client_platform=client_platform,
                 )
                 if agent_ref is not None:
                     agent_ref[0] = agent
+                active_keys = []
+                if gateway_session_key:
+                    active_keys.append(gateway_session_key)
+                if session_id:
+                    active_keys.append(session_id)
+                for key in dict.fromkeys(active_keys):
+                    self._active_session_agents[key] = agent
                 effective_task_id = session_id or str(uuid.uuid4())
                 result = agent.run_conversation(
                     user_message=user_message,
@@ -3827,6 +3950,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     result["session_id"] = _eff_sid
                 return result, usage
             finally:
+                try:
+                    agent_obj = locals().get("agent")
+                    for key in dict.fromkeys([gateway_session_key, session_id]):
+                        if key and self._active_session_agents.get(key) is agent_obj:
+                            self._active_session_agents.pop(key, None)
+                except Exception:
+                    pass
                 clear_session_vars(tokens)
 
         self._inflight_agent_runs += 1
@@ -3913,6 +4043,7 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        client_platform = self._client_platform_from_request(request, gateway_session_key)
 
         # Enforce concurrency limit (shared across all agent-serving
         # endpoints; configurable via gateway.api_server.max_concurrent_runs).
@@ -4024,6 +4155,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
                     gateway_session_key=gateway_session_key,
+                    client_platform=client_platform,
                 )
                 self._active_run_agents[run_id] = agent
 
@@ -4072,6 +4204,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         approval_token = set_current_session_key(approval_session_key)
                         session_tokens = self._bind_api_server_session(
                             session_key=approval_session_key,
+                            client_platform=client_platform,
                         )
                         register_gateway_notify(approval_session_key, _approval_notify)
                         r = agent.run_conversation(
@@ -4464,6 +4597,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/sessions/{session_id}/fork", self._handle_fork_session)
             self._app.router.add_post("/api/sessions/{session_id}/chat", self._handle_session_chat)
             self._app.router.add_post("/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream)
+            self._app.router.add_post("/api/sessions/{session_id}/steer", self._handle_session_steer)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)

--- a/gateway/progress_summary.py
+++ b/gateway/progress_summary.py
@@ -1,0 +1,391 @@
+"""Concise human-facing progress summaries for gateway chat surfaces.
+
+The raw tool-progress stream is useful in a terminal, but noisy on mobile chat
+clients: long shell commands become half-visible code blocks and repeated
+``process wait`` calls are poor signal.  ``ToolProgressSummary`` consumes the
+same display-only lifecycle events and renders one editable operational status
+bubble: current stage, safe action detail, counters, and delegated agent/profile
+status when it can be inferred.
+
+No tool output is included here.  The summary intentionally avoids raw shell
+commands and only extracts low-risk identifiers such as Hermes profile names,
+Kanban task IDs, file paths, and tool names.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, OrderedDict
+import re
+import shlex
+from typing import Any, Optional
+
+
+_SECRETISH_RE = re.compile(
+    r"(?i)(sk-[A-Za-z0-9_\-]{8,}|gh[pousr]_[A-Za-z0-9_]{8,}|xox[baprs]-[A-Za-z0-9\-]{8,}|bearer\s+[A-Za-z0-9._\-]{8,})"
+)
+_KANBAN_TASK_RE = re.compile(r"\b([A-Za-z][A-Za-z0-9]{0,8}_[A-Za-z0-9]{6,}|t_[A-Za-z0-9]{6,})\b")
+_PROCESS_WAIT_RE = re.compile(r"\bwait\s+(proc_[A-Za-z0-9]+)(?:\s+(\d+)s?)?", re.IGNORECASE)
+
+
+class ToolProgressSummary:
+    """Stateful renderer for ``display.tool_progress: summary``.
+
+    ``update()`` returns the full replacement text for the editable progress
+    bubble.  Callers should replace the previous progress bubble with this text
+    rather than append it as a new line.
+    """
+
+    def __init__(self) -> None:
+        self.started = 0
+        self.completed = 0
+        self.failed = 0
+        self.subagent_tool_count = 0
+        self.stage = "Préparation"
+        self.detail = "Démarrage du traitement"
+        self.tools: Counter[str] = Counter()
+        self.recent_tools: list[str] = []
+        self.profiles: "OrderedDict[str, dict[str, str]]" = OrderedDict()
+        self.subagents: "OrderedDict[str, dict[str, str]]" = OrderedDict()
+        self.moa_refs_done = 0
+        self.moa_refs_total: Optional[int] = None
+
+    def update(
+        self,
+        event_type: str,
+        tool_name: Optional[str] = None,
+        preview: Optional[str] = None,
+        args: Any = None,
+        **kwargs: Any,
+    ) -> Optional[str]:
+        """Ingest one gateway progress event and return a replacement summary."""
+
+        event = str(event_type or "")
+        if event == "tool.started":
+            self._tool_started(str(tool_name or "outil"), preview, args)
+            return self.render()
+        if event == "tool.completed":
+            self._tool_completed(str(tool_name or "outil"), kwargs)
+            return self.render()
+        if event.startswith("subagent") or event == "subagent_progress":
+            self._subagent_event(event, tool_name, preview, args, kwargs)
+            return self.render()
+        if event.startswith("moa."):
+            self._moa_event(event, tool_name, preview, kwargs)
+            return self.render()
+        return None
+
+    def _tool_started(self, name: str, preview: Optional[str], args: Any) -> None:
+        self.started += 1
+        self.tools[name] += 1
+        self._remember_tool(name)
+        self.stage, self.detail = self._describe_tool(name, preview, args)
+
+    def _tool_completed(self, name: str, kwargs: dict[str, Any]) -> None:
+        self.completed += 1
+        if bool(kwargs.get("is_error")):
+            self.failed += 1
+            self.stage = "Point de contrôle"
+            self.detail = f"{_safe_text(name)} a retourné une erreur"
+            return
+        duration = _format_duration(kwargs.get("duration"))
+        if duration:
+            self.detail = f"{_safe_text(name)} terminé en {duration}"
+        else:
+            self.detail = f"{_safe_text(name)} terminé"
+
+    def _subagent_event(
+        self,
+        event: str,
+        tool_name: Optional[str],
+        preview: Optional[str],
+        args: Any,
+        kwargs: dict[str, Any],
+    ) -> None:
+        raw_ident = (
+            kwargs.get("subagent_id")
+            or kwargs.get("child_session_id")
+        )
+        if raw_ident is None and "task_index" in kwargs:
+            raw_ident = kwargs.get("task_index")
+        ident = str(raw_ident if raw_ident is not None else f"agent-{len(self.subagents) + 1}")
+        rec = self.subagents.setdefault(
+            ident,
+            {
+                "label": self._subagent_label(kwargs),
+                "goal": _shorten(kwargs.get("goal") or preview or "", 70),
+                "status": "actif",
+                "last": "initialisation",
+            },
+        )
+        if kwargs.get("goal") and not rec.get("goal"):
+            rec["goal"] = _shorten(kwargs.get("goal"), 70)
+        if kwargs.get("model") and "model" not in rec:
+            rec["model"] = _shorten(kwargs.get("model"), 42)
+
+        if event in {"subagent.spawn_requested", "subagent.start"}:
+            rec["status"] = "actif"
+            rec["last"] = "démarrage"
+            self.stage = "Délégation"
+            self.detail = f"Agent {rec['label']} lancé"
+        elif event in {"subagent.complete", "subagent.completed"}:
+            rec["status"] = "terminé"
+            rec["last"] = "résultat reçu"
+            self.stage = "Délégation"
+            self.detail = f"Agent {rec['label']} terminé"
+        elif event in {"subagent.tool", "delegate.task_tool_started"}:
+            self.subagent_tool_count += 1
+            rec["status"] = "actif"
+            rec["last"] = _safe_text(tool_name or "outil")
+            self.stage = "Délégation"
+            self.detail = f"Agent {rec['label']} utilise {rec['last']}"
+        elif event in {"subagent.progress", "subagent_progress"}:
+            summary = _clean_preview(preview or tool_name or "")
+            if summary:
+                rec["last"] = _shorten(summary, 70)
+                self.stage = "Délégation"
+                self.detail = rec["last"]
+        elif event in {"subagent.text", "subagent.thinking"}:
+            # Do not mirror child free text into the compact operational bubble;
+            # interim assistant messages already carry deliberate user-facing text.
+            self.stage = "Délégation"
+            self.detail = f"Agent {rec['label']} rédige ou analyse"
+
+    def _subagent_label(self, kwargs: dict[str, Any]) -> str:
+        raw_index = kwargs.get("task_index")
+        if raw_index is not None:
+            try:
+                idx = int(raw_index) + 1
+                base = f"#{idx}"
+            except Exception:
+                base = f"#{len(self.subagents) + 1}"
+        else:
+            base = f"#{len(self.subagents) + 1}"
+        model = kwargs.get("model")
+        if model:
+            return f"{base} {_shorten(model, 28)}"
+        return base
+
+    def _moa_event(
+        self,
+        event: str,
+        tool_name: Optional[str],
+        preview: Optional[str],
+        kwargs: dict[str, Any],
+    ) -> None:
+        if event == "moa.reference":
+            self.moa_refs_done = max(self.moa_refs_done, _safe_int(kwargs.get("moa_index"), -1) + 1)
+            total = _safe_int(kwargs.get("moa_count"), 0)
+            if total > 0:
+                self.moa_refs_total = total
+            label = _shorten(tool_name or "référence", 40)
+            suffix = f" {self.moa_refs_done}/{self.moa_refs_total}" if self.moa_refs_total else ""
+            self.stage = "Consultation MoA"
+            self.detail = f"Réponse de référence{suffix}: {label}"
+        elif event == "moa.aggregating":
+            total = _safe_int(kwargs.get("moa_ref_count"), 0) or self.moa_refs_total
+            self.stage = "Synthèse MoA"
+            self.detail = f"Agrégation de {total} réponse(s)" if total else "Agrégation des réponses"
+
+    def _describe_tool(self, name: str, preview: Optional[str], args: Any) -> tuple[str, str]:
+        argd = args if isinstance(args, dict) else {}
+        if name in {"read_file", "browser_snapshot"}:
+            path = argd.get("path") or preview
+            return "Lecture contexte", f"Lecture {_shorten(path or 'du contexte', 90)}"
+        if name in {"search_files", "session_search"}:
+            query = argd.get("pattern") or argd.get("query") or preview
+            return "Recherche contexte", f"Recherche {_shorten(query or 'ciblée', 90)}"
+        if name in {"skill_view", "skills_list"}:
+            skill = argd.get("name") or preview
+            return "Procédure", f"Chargement compétence {_shorten(skill or '', 70)}".rstrip()
+        if name in {"todo"}:
+            items = argd.get("todos")
+            if isinstance(items, list):
+                return "Planification", f"Plan de travail mis à jour ({len(items)} tâche(s))"
+            return "Planification", "Lecture du plan de travail"
+        if name in {"terminal"}:
+            return self._describe_terminal(argd.get("command") or preview or "")
+        if name in {"execute_code"}:
+            return "Analyse script", "Exécution d’un script Python de contrôle"
+        if name in {"patch", "write_file"}:
+            path = argd.get("path") or preview
+            return "Modification fichiers", f"Mise à jour {_shorten(path or 'fichier', 90)}"
+        if name in {"delegate_task"}:
+            count = len(argd.get("tasks") or []) or 1
+            return "Délégation", f"Lancement de {count} agent(s) délégué(s)"
+        if name in {"cronjob"}:
+            action = argd.get("action") or preview
+            return "Planification", f"Cron: {_shorten(action or 'opération', 60)}"
+        if name.startswith("kanban"):
+            task = argd.get("task_id") or argd.get("id") or _extract_kanban_task(str(preview or ""))
+            return "Kanban", f"{name}" + (f" sur {task}" if task else "")
+        if name in {"process", "background_process"}:
+            return self._describe_process(preview or argd.get("action") or "")
+        if name.startswith("browser"):
+            return "Navigation web", _shorten(preview or name, 90)
+        if name.startswith("image") or name.startswith("vision"):
+            return "Analyse média", _shorten(preview or name, 90)
+        clean = _clean_preview(preview or "")
+        return "Travail en cours", f"{name}" + (f" — {_shorten(clean, 90)}" if clean else "")
+
+    def _describe_terminal(self, command: str) -> tuple[str, str]:
+        command = str(command or "")
+        profile, task_id = _extract_hermes_profile_and_task(command)
+        if profile:
+            info = self.profiles.setdefault(profile, {"status": "actif"})
+            if task_id:
+                info["task"] = task_id
+            detail = f"Profil {profile}"
+            if task_id:
+                detail += f" — tâche Kanban {task_id}"
+            return "Délégation profil", f"Lancement {detail}"
+        if _PROCESS_WAIT_RE.search(command):
+            return self._describe_process(command)
+        return "Commande système", _summarize_command_shape(command)
+
+    def _describe_process(self, text: str) -> tuple[str, str]:
+        match = _PROCESS_WAIT_RE.search(str(text or ""))
+        if match:
+            proc_id = match.group(1)
+            waited = match.group(2)
+            detail = f"Attente processus {proc_id}"
+            if waited:
+                detail += f" ({waited}s)"
+            return "Suivi processus", detail
+        clean = _clean_preview(text)
+        return "Suivi processus", _shorten(clean or "Contrôle d’un processus en arrière-plan", 90)
+
+    def _remember_tool(self, name: str) -> None:
+        self.recent_tools.append(name)
+        if len(self.recent_tools) > 5:
+            self.recent_tools = self.recent_tools[-5:]
+
+    def render(self) -> str:
+        lines = ["📊 Suivi du travail"]
+        lines.append(f"Étape: {self.stage}")
+        if self.detail:
+            lines.append(f"Action: {self.detail}")
+
+        counters = []
+        if self.started:
+            counters.append(f"outils {self.completed}/{self.started} terminés")
+        if self.failed:
+            counters.append(f"erreurs {self.failed}")
+        if self.subagent_tool_count:
+            counters.append(f"outils agents {self.subagent_tool_count}")
+        if counters:
+            lines.append("Compteurs: " + " · ".join(counters))
+
+        if self.profiles:
+            rendered = []
+            for profile, info in list(self.profiles.items())[-3:]:
+                task = info.get("task")
+                rendered.append(f"{profile}" + (f"({task})" if task else ""))
+            lines.append("Profils: " + ", ".join(rendered))
+
+        if self.subagents:
+            active = sum(1 for rec in self.subagents.values() if rec.get("status") != "terminé")
+            done = sum(1 for rec in self.subagents.values() if rec.get("status") == "terminé")
+            lines.append(f"Agents: {active} actif(s), {done} terminé(s)")
+            for rec in list(self.subagents.values())[-3:]:
+                tail = rec.get("last") or rec.get("goal") or rec.get("status") or ""
+                lines.append(f"- {rec.get('label', '#?')}: {_shorten(tail, 80)}")
+
+        if self.tools:
+            common = ", ".join(
+                f"{name}×{count}" for name, count in self.tools.most_common(4)
+            )
+            lines.append("Outils: " + common)
+
+        return "\n".join(lines)
+
+
+def _extract_hermes_profile_and_task(command: str) -> tuple[Optional[str], Optional[str]]:
+    profile: Optional[str] = None
+    try:
+        tokens = shlex.split(command)
+    except Exception:
+        tokens = command.split()
+    for index, token in enumerate(tokens):
+        if token in {"-p", "--profile"} and index + 1 < len(tokens):
+            profile = tokens[index + 1]
+            break
+        if token.startswith("--profile="):
+            profile = token.split("=", 1)[1]
+            break
+    if profile and not any(_is_hermes_token(token) for token in tokens):
+        profile = None
+    return profile, _extract_kanban_task(command)
+
+
+def _is_hermes_token(token: str) -> bool:
+    return token == "hermes" or token.endswith("/hermes")
+
+
+def _extract_kanban_task(text: str) -> Optional[str]:
+    match = _KANBAN_TASK_RE.search(str(text or ""))
+    return match.group(1) if match else None
+
+
+def _summarize_command_shape(command: str) -> str:
+    try:
+        tokens = shlex.split(command)
+    except Exception:
+        tokens = command.split()
+    if not tokens:
+        return "Commande en cours"
+    # Skip VAR=value environment prefixes to show the executable, not secrets or env noise.
+    command_token = next((tok for tok in tokens if "=" not in tok or tok.startswith(('/', './'))), tokens[0])
+    executable = command_token.rsplit("/", 1)[-1]
+    if executable in {"python", "python3"}:
+        return "Script Python en shell"
+    if executable in {"git", "gh"}:
+        return "Opération Git/GitHub"
+    if executable in {"yarn", "npm", "pnpm", "node"}:
+        return "Opération Node/Yarn"
+    if executable in {"pytest", "python -m pytest"}:
+        return "Tests automatisés"
+    return f"Commande {executable}"
+
+
+def _clean_preview(value: Any) -> str:
+    text = str(value or "").replace("\n", " ").strip()
+    text = _SECRETISH_RE.sub("[secret]", text)
+    return " ".join(text.split())
+
+
+def _safe_text(value: Any) -> str:
+    return _shorten(_clean_preview(value), 90)
+
+
+def _shorten(value: Any, limit: int = 80) -> str:
+    text = _clean_preview(value)
+    if len(text) <= limit:
+        return text
+    if limit <= 3:
+        return text[:limit]
+    return text[: limit - 3] + "..."
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _format_duration(value: Any) -> str:
+    try:
+        seconds = float(value)
+    except Exception:
+        return ""
+    if seconds <= 0:
+        return ""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{minutes:.1f} min"
+    return f"{minutes / 60:.1f} h"
+
+
+__all__ = ["ToolProgressSummary"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15452,6 +15452,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # fenced code block — consecutive terminal calls then drop the
         # repeated "💻 terminal" header and render back-to-back blocks.
         last_was_terminal_block = [False]
+        summary_progress = None
+        if str(progress_mode or "").lower() == "summary":
+            try:
+                from gateway.progress_summary import ToolProgressSummary
+                summary_progress = ToolProgressSummary()
+            except Exception as _summary_err:
+                logger.debug("tool-progress summary renderer unavailable: %s", _summary_err)
+                summary_progress = None
 
         # ── Discord voice "verbal ack before tool calls" ────────────────
         # When the bot is in a voice channel with the continuous mixer
@@ -15521,6 +15529,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not progress_queue or not _run_still_current():
                 return
 
+            # "_thinking" is assistant scratch text between tool calls.  It
+            # is never ordinary tool progress: only relay it when the platform
+            # explicitly opted into thinking_progress.  Handle both legacy
+            # callback shapes: ("_thinking", text) and
+            # ("reasoning.available", "_thinking", text, ...).
+            if event_type == "_thinking" or tool_name == "_thinking":
+                if not _thinking_enabled:
+                    return
+                thinking_text = preview if tool_name == "_thinking" else tool_name
+                msg = f"💬 {thinking_text}" if thinking_text else None
+                if msg:
+                    progress_queue.put(msg)
+                return
+
+            # Summary mode is the mobile/chat-oriented alternative to raw tool
+            # chrome. It replaces the progress bubble with one operational
+            # snapshot (stage, safe action detail, counters, agent/profile
+            # status) instead of appending every half-visible tool call.
+            if summary_progress is not None:
+                try:
+                    rendered_summary = summary_progress.update(
+                        event_type, tool_name, preview, args, **kwargs
+                    )
+                except Exception as _summary_err:
+                    logger.debug("tool-progress summary update failed: %s", _summary_err)
+                    rendered_summary = None
+                if rendered_summary:
+                    progress_queue.put(("__replace__", rendered_summary))
+                return
+
             # First-touch onboarding: the first time a tool takes longer than
             # _LONG_TOOL_THRESHOLD_S during a run that's streaming every tool
             # (progress_mode == "all"), append a one-time hint suggesting
@@ -15548,20 +15586,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
                 except Exception as _hint_err:
                     logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
-                return
-
-            # "_thinking" is assistant scratch text between tool calls.  It
-            # is never ordinary tool progress: only relay it when the platform
-            # explicitly opted into thinking_progress.  Handle both legacy
-            # callback shapes: ("_thinking", text) and
-            # ("reasoning.available", "_thinking", text, ...).
-            if event_type == "_thinking" or tool_name == "_thinking":
-                if not _thinking_enabled:
-                    return
-                thinking_text = preview if tool_name == "_thinking" else tool_name
-                msg = f"💬 {thinking_text}" if thinking_text else None
-                if msg:
-                    progress_queue.put(msg)
                 return
 
             # If tool_progress is off, only _thinking passes through (above).
@@ -15903,6 +15927,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if progress_lines:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
+                    elif isinstance(raw, tuple) and len(raw) == 2 and raw[0] == "__replace__":
+                        # Summary mode: replace the editable bubble content
+                        # with one fresh operational snapshot instead of
+                        # accumulating historical tool lines.
+                        msg = str(raw[1])
+                        progress_lines = [msg]
                     elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                         # Content bubble just landed on the platform — close off
                         # the current tool-progress bubble so the next tool
@@ -16025,6 +16055,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
                                     await _roll_progress_overflow_if_needed()
+                            elif isinstance(raw, tuple) and len(raw) == 2 and raw[0] == "__replace__":
+                                progress_lines = [str(raw[1])]
+                                await _roll_progress_overflow_if_needed()
                             elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                                 # Content-bubble marker during drain: close off
                                 # the current progress bubble and start a fresh

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -342,12 +342,14 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
 
     # Try to identify our unit name and ask systemctl for its config.
     unit_name: Optional[str] = None
+    cgroup_path: Optional[str] = None
     try:
         # /proc/self/cgroup gives us "0::/user.slice/.../hermes-gateway.service"
         with open("/proc/self/cgroup", encoding="utf-8") as fh:
             for line in fh:
                 # systemd cgroup line ends with the unit name
                 if ".service" in line:
+                    cgroup_path = line.strip().split(":", 2)[-1]
                     parts = line.strip().split("/")
                     for p in reversed(parts):
                         if p.endswith(".service"):
@@ -360,11 +362,20 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     if not unit_name:
         return None
 
-    # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
-    # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # Query systemctl for TimeoutStopUSec. Use --user OR system depending
+    # on which manager actually owns the unit.  The cgroup path tells us
+    # which manager launched this process; respecting it avoids false
+    # positives when an inactive user unit with the same name has a stale
+    # TimeoutStopSec but the running service is a system unit.
     timeout_us: Optional[int] = None
-    for flag in (["--user"], []):
+    if cgroup_path and "/system.slice/" in cgroup_path:
+        flag_order = ([], ["--user"])
+    elif cgroup_path and "/user.slice/" in cgroup_path:
+        flag_order = (["--user"], [])
+    else:
+        flag_order = (["--user"], [])
+
+    for flag in flag_order:
         try:
             result = subprocess.run(
                 ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2610,10 +2610,10 @@ class GatewaySlashCommandsMixin:
         """Handle /verbose command — cycle tool progress display mode.
 
         Gated by ``display.tool_progress_command`` in config.yaml (default off).
-        When enabled, cycles the tool progress mode through off → new → all →
-        verbose → off for the *current platform*.  The setting is saved to
-        ``display.platforms.<platform>.tool_progress`` so each channel can
-        have its own verbosity level independently.
+        When enabled, cycles the tool progress mode through off → summary →
+        new → all → verbose → off for the *current platform*.  The setting is
+        saved to ``display.platforms.<platform>.tool_progress`` so each channel
+        can have its own verbosity level independently.
         """
         from gateway.run import _hermes_home, _load_gateway_config, _platform_config_key
 
@@ -2634,9 +2634,10 @@ class GatewaySlashCommandsMixin:
             return t("gateway.verbose.not_enabled")
 
         # --- cycle mode (per-platform) ----------------------------------------
-        cycle = ["off", "new", "all", "verbose"]
+        cycle = ["off", "summary", "new", "all", "verbose"]
         descriptions = {
             "off": t("gateway.verbose.mode_off"),
+            "summary": t("gateway.verbose.mode_summary"),
             "new": t("gateway.verbose.mode_new"),
             "all": t("gateway.verbose.mode_all"),
             "verbose": t("gateway.verbose.mode_verbose"),

--- a/gateway/stream_dispatch.py
+++ b/gateway/stream_dispatch.py
@@ -33,6 +33,7 @@ from gateway.stream_events import (
     ToolCallChunk,
     ToolCallFinished,
 )
+from gateway.progress_summary import ToolProgressSummary
 
 logger = logging.getLogger("gateway.stream_events")
 
@@ -55,8 +56,8 @@ class GatewayEventDispatcher:
         progress queue (the same queue ``send_progress_messages`` drains).  May
         be None when tool progress is disabled for this channel.
     tool_mode:
-        Resolved tool-progress mode for this channel ("all" / "new" / "verbose"
-        / "off").
+        Resolved tool-progress mode for this channel ("all" / "new" /
+        "summary" / "verbose" / "off").
     preview_max_len:
         Resolved ``tool_preview_length`` (0 = no cap in verbose mode).
     on_long_tool / on_notice:
@@ -84,6 +85,7 @@ class GatewayEventDispatcher:
         self._on_notice = on_notice
         # "new" mode dedup — only report when the tool changes.
         self._last_tool: Optional[str] = None
+        self._summary = ToolProgressSummary() if self.tool_mode == "summary" else None
 
     def dispatch(self, event: StreamEvent) -> None:
         """Route a single event.  Never raises into the agent's worker thread."""
@@ -101,6 +103,13 @@ class GatewayEventDispatcher:
         if isinstance(event, ToolCallChunk):
             if self.tool_mode == "off" or self._enqueue_tool_line is None:
                 return
+            if self._summary is not None:
+                rendered = self._summary.update(
+                    "tool.started", event.tool_name, event.preview, event.args
+                )
+                if rendered:
+                    self._enqueue_tool_line(("__replace__", rendered))
+                return
             # "new" mode: only emit when the tool changes.
             if self.tool_mode == "new" and event.tool_name == self._last_tool:
                 return
@@ -114,8 +123,20 @@ class GatewayEventDispatcher:
             return
 
         if isinstance(event, ToolCallFinished):
-            # Default: no chrome on completion (matches today — the gateway only
-            # rendered "started" events).  Completion drives onboarding hints.
+            if self._summary is not None and self._enqueue_tool_line is not None:
+                rendered = self._summary.update(
+                    "tool.completed",
+                    event.tool_name,
+                    None,
+                    None,
+                    duration=event.duration,
+                    is_error=not event.ok,
+                )
+                if rendered:
+                    self._enqueue_tool_line(("__replace__", rendered))
+            # Default non-summary path: no chrome on completion (matches today —
+            # the gateway only rendered "started" events). Completion also
+            # drives onboarding hints through LongToolHint.
             return
 
         if isinstance(event, LongToolHint):

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -405,6 +405,17 @@ class CLIAgentSetupMixin:
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
             self.agent._print_fn = _cprint
+            # Kanban dispatcher workers are plain CLI agents launched with
+            # HERMES_KANBAN_TASK in their environment. Compose a best-effort
+            # journal onto the existing callbacks so dashboards can show
+            # observable progress (tools + visible assistant text) without
+            # exposing private reasoning and without affecting ordinary CLI runs.
+            try:
+                from hermes_cli.kanban_worker_journal import install_on_agent
+
+                install_on_agent(self.agent)
+            except Exception:
+                logger.debug("kanban worker journal install failed", exc_info=True)
             # Hydrate credits notices at session OPEN (parity with the TUI), so a
             # depletion / usage-band warning shows before the first message. The
             # notice_callback is bound above → _on_notice renders the line. Idempotent

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -22,6 +22,29 @@ from rich.markup import escape as _escape
 class CLIAgentSetupMixin:
     """Agent construction + session-resume display methods for ``HermesCLI``."""
 
+    @staticmethod
+    def _compose_kanban_worker_callback(primary, secondary):
+        """Compose an existing UI callback with a best-effort Kanban activity callback."""
+        if secondary is None:
+            return primary
+        if primary is None:
+            def only_secondary(*args, **kwargs):
+                try:
+                    secondary(*args, **kwargs)
+                except Exception:
+                    pass
+            return only_secondary
+
+        def composed(*args, **kwargs):
+            try:
+                primary(*args, **kwargs)
+            finally:
+                try:
+                    secondary(*args, **kwargs)
+                except Exception:
+                    pass
+        return composed
+
     def _ensure_runtime_credentials(self) -> bool:
         """
         Ensure runtime credentials are resolved before agent use.
@@ -340,6 +363,27 @@ class CLIAgentSetupMixin:
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
             effective_model = model_override or self.model
+            kanban_activity = None
+            try:
+                from hermes_cli.kanban_worker_activity import KanbanWorkerActivityJournal
+                kanban_activity = KanbanWorkerActivityJournal.from_environment()
+                self._kanban_activity_journal = kanban_activity
+            except Exception:
+                kanban_activity = None
+                self._kanban_activity_journal = None
+
+            tool_progress_callback = self._on_tool_progress
+            tool_start_callback = self._on_tool_start if self._inline_diffs_enabled else None
+            tool_complete_callback = self._on_tool_complete if self._inline_diffs_enabled else None
+            stream_delta_callback = self._stream_delta if self.streaming_enabled else None
+            interim_assistant_callback = None
+            if kanban_activity is not None:
+                tool_progress_callback = self._compose_kanban_worker_callback(tool_progress_callback, kanban_activity.tool_progress)
+                tool_start_callback = self._compose_kanban_worker_callback(tool_start_callback, kanban_activity.tool_start)
+                tool_complete_callback = self._compose_kanban_worker_callback(tool_complete_callback, kanban_activity.tool_complete)
+                stream_delta_callback = self._compose_kanban_worker_callback(stream_delta_callback, kanban_activity.stream_delta)
+                interim_assistant_callback = kanban_activity.assistant_text
+
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),
@@ -383,10 +427,11 @@ class CLIAgentSetupMixin:
                 pass_session_id=self.pass_session_id,
                 skip_context_files=self.ignore_rules,
                 skip_memory=self.ignore_rules,
-                tool_progress_callback=self._on_tool_progress,
-                tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
-                tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
-                stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
+                tool_progress_callback=tool_progress_callback,
+                tool_start_callback=tool_start_callback,
+                tool_complete_callback=tool_complete_callback,
+                stream_delta_callback=stream_delta_callback,
+                interim_assistant_callback=interim_assistant_callback,
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
                 notice_callback=self._on_notice,
                 notice_clear_callback=self._on_notice_clear,
@@ -416,6 +461,11 @@ class CLIAgentSetupMixin:
                 install_on_agent(self.agent)
             except Exception:
                 logger.debug("kanban worker journal install failed", exc_info=True)
+            if kanban_activity is not None:
+                try:
+                    kanban_activity.start_steer_polling(self.agent)
+                except Exception:
+                    logger.debug("kanban worker activity steer polling failed", exc_info=True)
             # Hydrate credits notices at session OPEN (parity with the TUI), so a
             # depletion / usage-band warning shows before the first message. The
             # notice_callback is bound above → _on_notice renders the line. Idempotent

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3994,7 +3994,9 @@ def complete_task(
     ``summary`` and ``metadata`` are stored on the closing run (if any)
     and surfaced to downstream children via :func:`build_worker_context`.
     When ``summary`` is omitted we fall back to ``result`` so single-run
-    callers do not have to pass both. ``metadata`` is a free-form dict
+    callers do not have to pass both. When ``result`` is omitted we mirror
+    ``summary`` into ``tasks.result`` so dashboard/task-detail views do not
+    show a completed card as visually empty. ``metadata`` is a free-form dict
     (e.g. ``{"changed_files": [...], "tests_run": [...]}``) — workers
     are encouraged to use it for structured handoff facts.
 
@@ -4014,6 +4016,10 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+    # Dashboard/task-detail views primarily read tasks.result, while worker
+    # completions are encouraged to pass summary. Mirror summary into result
+    # when result is omitted so completed cards are not visually empty.
+    stored_result = result if result is not None else summary
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
@@ -4058,7 +4064,7 @@ def complete_task(
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
                 """,
-                (result, now, task_id),
+                (stored_result, now, task_id),
             )
         else:
             cur = conn.execute(
@@ -4076,7 +4082,7 @@ def complete_task(
                    AND status IN ('running', 'ready', 'blocked')
                    AND current_run_id = ?
                 """,
-                (result, now, task_id, int(expected_run_id)),
+                (stored_result, now, task_id, int(expected_run_id)),
             )
         if cur.rowcount != 1:
             return False
@@ -4090,11 +4096,11 @@ def complete_task(
         # blocked → done with no run in flight), synthesize a
         # zero-duration run so the handoff fields are persisted in
         # attempt history instead of silently lost.
-        if run_id is None and (summary or metadata or result):
+        if run_id is None and (summary or metadata or stored_result):
             run_id = _synthesize_ended_run(
                 conn, task_id,
                 outcome="completed",
-                summary=summary if summary is not None else result,
+                summary=summary if summary is not None else stored_result,
                 metadata=metadata,
             )
         # Carry the handoff summary in the event payload so gateway
@@ -4104,7 +4110,7 @@ def complete_task(
         ev_summary = (summary if summary is not None else result) or ""
         ev_summary = ev_summary.strip().splitlines()[0][:400] if ev_summary else ""
         completed_payload: dict = {
-            "result_len": len(result) if result else 0,
+            "result_len": len(stored_result) if stored_result else 0,
             "summary": ev_summary or None,
         }
         if verified_cards:

--- a/hermes_cli/kanban_worker_activity.py
+++ b/hermes_cli/kanban_worker_activity.py
@@ -1,0 +1,326 @@
+"""Structured activity events for dispatcher-spawned Kanban workers.
+
+Kanban workers run as standalone ``hermes chat -q ...`` subprocesses. Their rich
+chat/tool stream is not automatically visible to the Kanban WebUI, so this module
+bridges existing agent callbacks into durable ``task_events`` rows.
+
+The bridge is intentionally best-effort: it must never break the agent turn when
+SQLite is locked, the board disappeared, or the process is not a Kanban worker.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from typing import Any, Optional
+
+SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer",
+    "cookie",
+    "credential",
+    "password",
+    "secret",
+    "token",
+)
+
+
+class KanbanWorkerActivityJournal:
+    """Persist observable worker progress as structured Kanban task events."""
+
+    EVENT_KINDS = frozenset(
+        {
+            "tool_start",
+            "tool_end",
+            "assistant_text",
+            "progress_note",
+            "heartbeat_note",
+            "steer_accepted",
+        }
+    )
+
+    def __init__(self, *, task_id: str, run_id: Optional[int] = None):
+        self.task_id = str(task_id or "").strip()
+        self.run_id = int(run_id) if run_id is not None else None
+        self._assistant_buffer: list[str] = []
+        self._last_stream_emit = 0.0
+        self._steer_cursor: Optional[int] = None
+        self._steer_stop: Optional[threading.Event] = None
+
+    @classmethod
+    def from_environment(cls) -> Optional["KanbanWorkerActivityJournal"]:
+        task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+        if not task_id:
+            return None
+        run_id = None
+        raw_run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+        if raw_run_id:
+            try:
+                run_id = int(raw_run_id)
+            except ValueError:
+                run_id = None
+        return cls(task_id=task_id, run_id=run_id)
+
+    def _record(self, kind: str, payload: Optional[dict[str, Any]] = None) -> None:
+        if not self.task_id or kind not in self.EVENT_KINDS:
+            return
+        safe_payload = self._sanitize_payload(payload or {})
+        safe_payload.setdefault("source", "worker_activity")
+        safe_payload.setdefault("recorded_at", int(time.time()))
+        try:
+            from hermes_cli import kanban_db as kb
+
+            conn = kb.connect()
+            try:
+                with kb.write_txn(conn):
+                    kb._append_event(
+                        conn,
+                        self.task_id,
+                        kind,
+                        safe_payload,
+                        run_id=self.run_id,
+                    )
+            finally:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+        except Exception:
+            # Progress visibility must never interrupt the worker itself.
+            return
+
+    def tool_start(self, tool_call_id: str, tool: str, args: Optional[dict[str, Any]] = None) -> None:
+        self._record(
+            "tool_start",
+            {
+                "tool_call_id": tool_call_id,
+                "tool": tool,
+                "args": args or {},
+            },
+        )
+
+    def tool_end(
+        self,
+        tool_call_id: str,
+        tool: str,
+        args: Optional[dict[str, Any]] = None,
+        result: Any = None,
+        *,
+        duration: Optional[float] = None,
+        is_error: Optional[bool] = None,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "tool_call_id": tool_call_id,
+            "tool": tool,
+            "args": args or {},
+            "result_preview": self._preview(result),
+        }
+        if duration is not None:
+            try:
+                payload["duration"] = round(float(duration), 3)
+            except (TypeError, ValueError):
+                pass
+        if is_error is not None:
+            payload["is_error"] = bool(is_error)
+        self._record("tool_end", payload)
+
+    def assistant_text(self, text: str) -> None:
+        text = str(text or "").strip()
+        if not text:
+            return
+        self._record("assistant_text", {"text": self._truncate(text, 4000)})
+
+    def progress_note(self, note: str, **extra: Any) -> None:
+        note = str(note or "").strip()
+        if not note:
+            return
+        payload = {"note": self._truncate(note, 1000)}
+        payload.update(extra)
+        self._record("progress_note", payload)
+
+    def heartbeat_note(self, note: str = "active", **extra: Any) -> None:
+        payload = {"note": self._truncate(str(note or "active"), 1000)}
+        payload.update(extra)
+        self._record("heartbeat_note", payload)
+
+    def tool_progress(self, event_type: str, name: str = "", preview: Any = None, args: Any = None, **kwargs: Any) -> None:
+        if event_type == "tool.started":
+            self.progress_note(
+                f"tool started: {name}",
+                tool=name,
+                preview=self._preview(preview),
+                args=args or {},
+            )
+        elif event_type == "tool.completed":
+            self.progress_note(
+                f"tool completed: {name}",
+                tool=name,
+                duration=kwargs.get("duration"),
+                is_error=kwargs.get("is_error"),
+                result_preview=self._preview(kwargs.get("result")),
+            )
+        elif event_type == "reasoning.available":
+            # Do not persist chain-of-thought/reasoning. A coarse note is enough
+            # to show the worker is active without exposing private reasoning.
+            self.progress_note("reasoning available")
+        else:
+            self.progress_note(str(event_type or "progress"), tool=name, preview=self._preview(preview))
+
+    def tool_complete(self, tool_call_id: str, tool: str, args: Optional[dict[str, Any]] = None, result: Any = None) -> None:
+        self.tool_end(tool_call_id, tool, args or {}, result)
+
+    def stream_delta(self, text: str) -> None:
+        text = str(text or "")
+        if not text:
+            return
+        self._assistant_buffer.append(text)
+        now = time.monotonic()
+        buffered = "".join(self._assistant_buffer)
+        if len(buffered) >= 500 or "\n" in text or now - self._last_stream_emit >= 5.0:
+            self._assistant_buffer.clear()
+            self._last_stream_emit = now
+            self.assistant_text(buffered)
+
+    def flush_assistant_text(self) -> None:
+        if not self._assistant_buffer:
+            return
+        buffered = "".join(self._assistant_buffer)
+        self._assistant_buffer.clear()
+        self.assistant_text(buffered)
+
+    def _latest_event_id(self) -> int:
+        try:
+            from hermes_cli import kanban_db as kb
+
+            conn = kb.connect()
+            try:
+                row = conn.execute("SELECT COALESCE(MAX(id), 0) AS latest FROM task_events").fetchone()
+                return int(row["latest"] or 0)
+            finally:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+        except Exception:
+            return 0
+
+    def consume_steer_once(self, agent: Any) -> int:
+        """Consume pending ``steer_note`` events and inject them via ``agent.steer``.
+
+        This is the Kanban equivalent of the chat `/steer` control: it does not
+        interrupt the running tool, but the next model iteration receives the
+        user note through Hermes Agent's existing pending-steer mechanism.
+        """
+        if not self.task_id or agent is None or not hasattr(agent, "steer"):
+            return 0
+        cursor = int(self._steer_cursor or 0)
+        rows = []
+        try:
+            from hermes_cli import kanban_db as kb
+
+            conn = kb.connect()
+            try:
+                rows = conn.execute(
+                    "SELECT id, run_id, payload FROM task_events "
+                    "WHERE task_id = ? AND kind = 'steer_note' AND id > ? "
+                    "ORDER BY id ASC LIMIT 20",
+                    (self.task_id, cursor),
+                ).fetchall()
+            finally:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+        except Exception:
+            return 0
+
+        accepted = 0
+        for row in rows:
+            try:
+                event_id = int(row["id"])
+                cursor = max(cursor, event_id)
+                row_run_id = row["run_id"]
+                if self.run_id is not None and row_run_id is not None and int(row_run_id) != self.run_id:
+                    continue
+                payload = json.loads(row["payload"]) if row["payload"] else {}
+                if not isinstance(payload, dict):
+                    continue
+                message = str(payload.get("message") or payload.get("text") or payload.get("note") or "").strip()
+                if not message:
+                    continue
+                if agent.steer(message):
+                    accepted += 1
+                    self._record(
+                        "steer_accepted",
+                        {
+                            "message": self._truncate(message, 1000),
+                            "steer_event_id": event_id,
+                        },
+                    )
+            except Exception:
+                continue
+        self._steer_cursor = cursor
+        return accepted
+
+    def start_steer_polling(self, agent: Any, *, interval: float = 2.0) -> Optional[threading.Event]:
+        """Start a daemon poller that injects WebUI steer notes into the worker."""
+        if not self.task_id or agent is None or not hasattr(agent, "steer"):
+            return None
+        if getattr(self, "_steer_stop", None) is not None:
+            return self._steer_stop
+        self._steer_cursor = self._latest_event_id()
+        stop = threading.Event()
+        self._steer_stop = stop
+
+        def _loop() -> None:
+            while not stop.is_set():
+                try:
+                    self.consume_steer_once(agent)
+                except Exception:
+                    pass
+                stop.wait(max(0.5, float(interval or 2.0)))
+
+        thread = threading.Thread(target=_loop, name="kanban-worker-steer", daemon=True)
+        thread.start()
+        return stop
+
+    @classmethod
+    def _sanitize_payload(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            out = {}
+            for key, item in value.items():
+                key_str = str(key)
+                if any(part in key_str.lower() for part in SENSITIVE_KEY_PARTS):
+                    out[key_str] = "[REDACTED]"
+                else:
+                    out[key_str] = cls._sanitize_payload(item)
+            return out
+        if isinstance(value, (list, tuple)):
+            return [cls._sanitize_payload(item) for item in value]
+        if isinstance(value, str):
+            return cls._truncate(value, 4000)
+        return value
+
+    @staticmethod
+    def _truncate(text: str, limit: int) -> str:
+        text = str(text)
+        if len(text) <= limit:
+            return text
+        return text[: max(0, limit - 1)] + "…"
+
+    @classmethod
+    def _preview(cls, value: Any, limit: int = 2000) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return cls._truncate(value.strip(), limit)
+        try:
+            import json
+
+            return cls._truncate(json.dumps(cls._sanitize_payload(value), ensure_ascii=False), limit)
+        except Exception:
+            return cls._truncate(str(value), limit)

--- a/hermes_cli/kanban_worker_journal.py
+++ b/hermes_cli/kanban_worker_journal.py
@@ -1,0 +1,242 @@
+"""Best-effort Kanban worker activity journaling.
+
+Dispatcher-spawned Kanban workers are ordinary CLI agents with
+``HERMES_KANBAN_TASK`` in their environment. This module bridges observable
+AIAgent callbacks into durable ``task_events`` rows so Kanban UIs can show a
+readable execution story (tool activity + visible worker text) without exposing
+private chain-of-thought.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+_LOG = logging.getLogger(__name__)
+
+_MAX_TEXT = 4000
+_MAX_RESULT = 2000
+_MAX_ARGS_JSON = 4000
+_TOOL_PROGRESS_LIFECYCLE_EVENTS = {"tool.started", "tool.completed"}
+_PRIVATE_PROGRESS_EVENTS = {"reasoning.available", "_thinking", "thinking"}
+
+
+def _truncate(value: str, limit: int) -> str:
+    text = str(value or "")
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)] + "…"
+
+
+def _redact_text(value: Any, *, limit: int = _MAX_TEXT) -> str:
+    try:
+        from agent.redact import redact_sensitive_text
+
+        return _truncate(redact_sensitive_text(str(value or ""), force=True), limit)
+    except Exception:
+        return _truncate(str(value or ""), limit)
+
+
+def _redact_jsonable(value: Any, *, limit: int = _MAX_ARGS_JSON) -> Any:
+    """Redact a JSON-like value while preserving shape when practical."""
+    try:
+        raw = json.dumps(value, ensure_ascii=False, default=str)
+    except Exception:
+        return _redact_text(value, limit=limit)
+    redacted = _redact_text(raw, limit=limit)
+    try:
+        return json.loads(redacted)
+    except Exception:
+        return redacted
+
+
+def _safe_call(cb: Optional[Callable], *args: Any, **kwargs: Any) -> None:
+    if cb is None:
+        return
+    try:
+        cb(*args, **kwargs)
+    except Exception:
+        _LOG.debug("kanban worker composed callback failed", exc_info=True)
+
+
+@dataclass
+class KanbanWorkerJournal:
+    """Write observable worker callback events into the Kanban task journal."""
+
+    task_id: str
+    run_id: Optional[int] = None
+    _seen_assistant_texts: set[str] = field(default_factory=set)
+
+    @classmethod
+    def from_env(cls) -> Optional["KanbanWorkerJournal"]:
+        task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+        if not task_id:
+            return None
+        run_raw = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+        try:
+            run_id = int(run_raw) if run_raw else None
+        except ValueError:
+            run_id = None
+        return cls(task_id=task_id, run_id=run_id)
+
+    def _record(self, kind: str, payload: Optional[dict[str, Any]]) -> None:
+        try:
+            from hermes_cli import kanban_db as kb
+
+            conn = kb.connect()
+            try:
+                with kb.write_txn(conn):
+                    kb._append_event(  # existing internal primitive; best-effort bridge
+                        conn,
+                        self.task_id,
+                        kind,
+                        payload or None,
+                        run_id=self.run_id,
+                    )
+            finally:
+                conn.close()
+        except Exception:
+            # Observability must never break the worker loop.
+            _LOG.debug("failed to persist kanban worker journal event", exc_info=True)
+
+    def tool_start(self, tool_call_id: str, name: str, args: Any) -> None:
+        payload = {
+            "tool_call_id": _redact_text(tool_call_id, limit=200),
+            "tool": _redact_text(name, limit=200),
+            "args": _redact_jsonable(args or {}, limit=_MAX_ARGS_JSON),
+            "source": "tool_start_callback",
+        }
+        self._record("tool_start", payload)
+
+    def tool_complete(self, tool_call_id: str, name: str, args: Any, result: Any) -> None:
+        payload = {
+            "tool_call_id": _redact_text(tool_call_id, limit=200),
+            "tool": _redact_text(name, limit=200),
+            "args": _redact_jsonable(args or {}, limit=_MAX_ARGS_JSON),
+            "result_preview": _redact_text(result, limit=_MAX_RESULT),
+            "source": "tool_complete_callback",
+        }
+        self._record("tool_end", payload)
+
+    def tool_progress(
+        self,
+        event_type: str,
+        name: str | None = None,
+        preview: str | None = None,
+        args: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        event = str(event_type or "").strip()
+        if event in _TOOL_PROGRESS_LIFECYCLE_EVENTS or event in _PRIVATE_PROGRESS_EVENTS:
+            return
+        note = preview or kwargs.get("message") or kwargs.get("text") or event
+        note = _redact_text(note, limit=1000).strip()
+        if not note:
+            return
+        payload: dict[str, Any] = {"note": note, "source": "tool_progress"}
+        if name:
+            payload["name"] = _redact_text(name, limit=200)
+        if event and event not in {"status", "progress"}:
+            payload["event_type"] = _redact_text(event, limit=200)
+        self._record("progress_note", payload)
+
+    def assistant_text(self, text: str, *, source: str) -> None:
+        visible = _redact_text(text, limit=_MAX_TEXT).strip()
+        if not visible:
+            return
+        seen_key = " ".join(visible.split())
+        if seen_key in self._seen_assistant_texts:
+            return
+        self._seen_assistant_texts.add(seen_key)
+        self._record(
+            "assistant_text",
+            {"text": visible, "source": source},
+        )
+
+    def interim_assistant(self, text: str, **kwargs: Any) -> None:
+        self.assistant_text(text, source="interim_assistant")
+
+
+def install_on_agent(agent: Any) -> Optional[KanbanWorkerJournal]:
+    """Compose Kanban journaling callbacks onto an AIAgent instance.
+
+    Returns the journal when installed, ``None`` outside dispatcher-spawned
+    workers. Existing callbacks are preserved and invoked first.
+    """
+    journal = KanbanWorkerJournal.from_env()
+    if journal is None or agent is None:
+        return None
+    if getattr(agent, "_kanban_worker_journal_installed", False):
+        return getattr(agent, "_kanban_worker_journal", journal)
+
+    old_start = getattr(agent, "tool_start_callback", None)
+    old_complete = getattr(agent, "tool_complete_callback", None)
+    old_progress = getattr(agent, "tool_progress_callback", None)
+    old_interim = getattr(agent, "interim_assistant_callback", None)
+    old_stream = getattr(agent, "stream_delta_callback", None)
+    stream_buf: list[str] = []
+
+    def flush_stream_assistant_text() -> None:
+        if not stream_buf:
+            return
+        text = "".join(stream_buf)
+        stream_buf.clear()
+        journal.assistant_text(text, source="stream_delta")
+
+    def tool_start(tool_call_id: str, name: str, args: Any) -> None:
+        _safe_call(old_start, tool_call_id, name, args)
+        journal.tool_start(tool_call_id, name, args)
+
+    def tool_complete(tool_call_id: str, name: str, args: Any, result: Any) -> None:
+        _safe_call(old_complete, tool_call_id, name, args, result)
+        journal.tool_complete(tool_call_id, name, args, result)
+
+    def tool_progress(
+        event_type: str,
+        name: str | None = None,
+        preview: str | None = None,
+        args: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        _safe_call(old_progress, event_type, name, preview, args, **kwargs)
+        journal.tool_progress(event_type, name=name, preview=preview, args=args, **kwargs)
+
+    def interim_assistant(text: str, **kwargs: Any) -> None:
+        _safe_call(old_interim, text, **kwargs)
+        journal.interim_assistant(text, **kwargs)
+
+    def stream_delta(delta: Any) -> None:
+        _safe_call(old_stream, delta)
+        if isinstance(delta, str) and delta:
+            stream_buf.append(delta)
+        elif delta is None:
+            flush_stream_assistant_text()
+
+    agent.tool_start_callback = tool_start
+    agent.tool_complete_callback = tool_complete
+    agent.tool_progress_callback = tool_progress
+    agent.interim_assistant_callback = interim_assistant
+    if old_stream is not None:
+        agent.stream_delta_callback = stream_delta
+    agent._kanban_worker_journal_flush = flush_stream_assistant_text
+    agent._kanban_worker_journal = journal
+    agent._kanban_worker_journal_installed = True
+    return journal
+
+
+def record_final_assistant(agent: Any, text: str) -> None:
+    """Flush buffered stream text and persist a final visible response if needed."""
+    if agent is None:
+        return
+    flush = getattr(agent, "_kanban_worker_journal_flush", None)
+    if callable(flush):
+        try:
+            flush()
+        except Exception:
+            _LOG.debug("kanban worker stream flush failed", exc_info=True)
+    journal = getattr(agent, "_kanban_worker_journal", None)
+    if isinstance(journal, KanbanWorkerJournal):
+        journal.assistant_text(text, source="final_response")

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "Die `/verbose`-opdrag is nie vir boodskapplatforms geaktiveer nie.\n\nAktiveer dit in `config.yaml`:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Gereedskap-vordering: **AF** — geen gereedskap-aktiwiteit word vertoon nie."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Gereedskap-vordering: **NUUT** — vertoon wanneer gereedskap verander (voorskoulengte: `display.tool_preview_length`, verstek 40)."
     mode_all:              "⚙️ Gereedskap-vordering: **ALMAL** — elke gereedskaps-oproep vertoon (voorskoulengte: `display.tool_preview_length`, verstek 40)."
     mode_verbose:          "⚙️ Gereedskap-vordering: **OMSLAGTIG** — elke gereedskaps-oproep met volle argumente."

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "Der Befehl `/verbose` ist für Messaging-Plattformen nicht aktiviert.\n\nIn `config.yaml` aktivieren:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Tool-Fortschritt: **OFF** — keine Tool-Aktivität angezeigt."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Tool-Fortschritt: **NEW** — angezeigt bei Tool-Wechsel (Vorschaulänge: `display.tool_preview_length`, Standard 40)."
     mode_all:              "⚙️ Tool-Fortschritt: **ALL** — jeder Tool-Aufruf wird angezeigt (Vorschaulänge: `display.tool_preview_length`, Standard 40)."
     mode_verbose:          "⚙️ Tool-Fortschritt: **VERBOSE** — jeder Tool-Aufruf mit vollständigen Argumenten."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -356,6 +356,7 @@ gateway:
   verbose:
     not_enabled:           "The `/verbose` command is not enabled for messaging platforms.\n\nEnable it in `config.yaml`:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Tool progress: **OFF** — no tool activity shown."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Tool progress: **NEW** — shown when tool changes (preview length: `display.tool_preview_length`, default 40)."
     mode_all:              "⚙️ Tool progress: **ALL** — every tool call shown (preview length: `display.tool_preview_length`, default 40)."
     mode_verbose:          "⚙️ Tool progress: **VERBOSE** — every tool call with full arguments."

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -341,6 +341,7 @@ gateway:
   verbose:
     not_enabled:           "El comando `/verbose` no está habilitado para plataformas de mensajería.\n\nHabilítalo en `config.yaml`:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Progreso de herramientas: **OFF** — no se muestra actividad de herramientas."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Progreso de herramientas: **NEW** — se muestra al cambiar de herramienta (longitud de vista previa: `display.tool_preview_length`, por defecto 40)."
     mode_all:              "⚙️ Progreso de herramientas: **ALL** — se muestra cada llamada a herramienta (longitud de vista previa: `display.tool_preview_length`, por defecto 40)."
     mode_verbose:          "⚙️ Progreso de herramientas: **VERBOSE** — cada llamada a herramienta con sus argumentos completos."

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "La commande `/verbose` n'est pas activée pour les plateformes de messagerie.\n\nActivez-la dans `config.yaml` :\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Progression des outils : **OFF** — aucune activité d'outil affichée."
+    mode_summary:          "📊 Progression des outils : **SUMMARY** — une seule bulle opérationnelle concise avec étape, compteurs et agents/profils détectés."
     mode_new:              "⚙️ Progression des outils : **NEW** — affichée lors d'un changement d'outil (longueur d'aperçu : `display.tool_preview_length`, par défaut 40)."
     mode_all:              "⚙️ Progression des outils : **ALL** — chaque appel d'outil est affiché (longueur d'aperçu : `display.tool_preview_length`, par défaut 40)."
     mode_verbose:          "⚙️ Progression des outils : **VERBOSE** — chaque appel d'outil avec ses arguments complets."

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -348,6 +348,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "Níl an t-ordú `/verbose` cumasaithe d'ardáin teachtaireachtaí.\n\nCumasaigh in `config.yaml`:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Dul chun cinn uirlise: **AS** — gan aon ghníomhaíocht uirlise á thaispeáint."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Dul chun cinn uirlise: **NUA** — taispeánta nuair a athraíonn an uirlis (fad réamhamhairc: `display.tool_preview_length`, réamhshocrú 40)."
     mode_all:              "⚙️ Dul chun cinn uirlise: **GACH CEANN** — taispeántar gach glao uirlise (fad réamhamhairc: `display.tool_preview_length`, réamhshocrú 40)."
     mode_verbose:          "⚙️ Dul chun cinn uirlise: **BÉALSCAOILTE** — gach glao uirlise le hargóintí iomlána."

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "A `/verbose` parancs nincs engedélyezve az üzenetküldő platformokon.\n\nEngedélyezd a `config.yaml` fájlban:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Eszközfolyamat: **OFF** — nem jelenik meg eszközaktivitás."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Eszközfolyamat: **NEW** — eszközváltáskor jelenik meg (előnézet hossza: `display.tool_preview_length`, alapértelmezetten 40)."
     mode_all:              "⚙️ Eszközfolyamat: **ALL** — minden eszközhívás megjelenik (előnézet hossza: `display.tool_preview_length`, alapértelmezetten 40)."
     mode_verbose:          "⚙️ Eszközfolyamat: **VERBOSE** — minden eszközhívás teljes argumentumokkal."

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "Il comando `/verbose` non è abilitato per le piattaforme di messaggistica.\n\nAbilitalo in `config.yaml`:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Progresso strumenti: **OFF** — nessuna attività degli strumenti mostrata."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Progresso strumenti: **NEW** — mostrato quando lo strumento cambia (lunghezza anteprima: `display.tool_preview_length`, predefinito 40)."
     mode_all:              "⚙️ Progresso strumenti: **ALL** — ogni chiamata a uno strumento viene mostrata (lunghezza anteprima: `display.tool_preview_length`, predefinito 40)."
     mode_verbose:          "⚙️ Progresso strumenti: **VERBOSE** — ogni chiamata a uno strumento con argomenti completi."

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "`/verbose` コマンドはメッセージングプラットフォームで有効になっていません。\n\n`config.yaml` で有効にしてください:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ ツール進捗: **OFF** — ツールの動作は表示されません。"
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ ツール進捗: **NEW** — ツールが変わったときに表示 (プレビュー長: `display.tool_preview_length`、デフォルト 40)。"
     mode_all:              "⚙️ ツール進捗: **ALL** — すべてのツール呼び出しを表示 (プレビュー長: `display.tool_preview_length`、デフォルト 40)。"
     mode_verbose:          "⚙️ ツール進捗: **VERBOSE** — すべてのツール呼び出しを完全な引数とともに表示。"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "`/verbose` 명령은 메시징 플랫폼에서 활성화되어 있지 않습니다.\n\n`config.yaml`에서 활성화하세요:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ 도구 진행 상황: **OFF** — 도구 활동이 표시되지 않습니다."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ 도구 진행 상황: **NEW** — 도구가 변경될 때 표시됩니다 (미리보기 길이: `display.tool_preview_length`, 기본 40)."
     mode_all:              "⚙️ 도구 진행 상황: **ALL** — 모든 도구 호출이 표시됩니다 (미리보기 길이: `display.tool_preview_length`, 기본 40)."
     mode_verbose:          "⚙️ 도구 진행 상황: **VERBOSE** — 모든 도구 호출이 전체 인수와 함께 표시됩니다."

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "O comando `/verbose` não está ativado para plataformas de mensagens.\n\nAtiva-o em `config.yaml`:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Progresso de ferramentas: **OFF** — não é mostrada qualquer atividade de ferramentas."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Progresso de ferramentas: **NEW** — mostrado quando a ferramenta muda (comprimento da pré-visualização: `display.tool_preview_length`, predefinição 40)."
     mode_all:              "⚙️ Progresso de ferramentas: **ALL** — cada chamada de ferramenta é mostrada (comprimento da pré-visualização: `display.tool_preview_length`, predefinição 40)."
     mode_verbose:          "⚙️ Progresso de ferramentas: **VERBOSE** — cada chamada de ferramenta com os argumentos completos."

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "Команда `/verbose` не включена для платформ обмена сообщениями.\n\nВключите в `config.yaml`:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Прогресс инструментов: **OFF** — активность инструментов не показывается."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Прогресс инструментов: **NEW** — показывается при смене инструмента (длина предпросмотра: `display.tool_preview_length`, по умолчанию 40)."
     mode_all:              "⚙️ Прогресс инструментов: **ALL** — показывается каждый вызов инструмента (длина предпросмотра: `display.tool_preview_length`, по умолчанию 40)."
     mode_verbose:          "⚙️ Прогресс инструментов: **VERBOSE** — каждый вызов инструмента с полными аргументами."

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "`/verbose` komutu mesajlaşma platformlarında etkin değil.\n\n`config.yaml` içinde etkinleştirin:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Araç ilerlemesi: **OFF** — araç etkinliği gösterilmez."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Araç ilerlemesi: **NEW** — araç değiştiğinde gösterilir (önizleme uzunluğu: `display.tool_preview_length`, varsayılan 40)."
     mode_all:              "⚙️ Araç ilerlemesi: **ALL** — her araç çağrısı gösterilir (önizleme uzunluğu: `display.tool_preview_length`, varsayılan 40)."
     mode_verbose:          "⚙️ Araç ilerlemesi: **VERBOSE** — her araç çağrısı tüm argümanlarıyla gösterilir."

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "Команду `/verbose` не ввімкнено для платформ обміну повідомленнями.\n\nУвімкніть у `config.yaml`:\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ Прогрес інструментів: **OFF** — активність інструментів не показується."
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ Прогрес інструментів: **NEW** — показується при зміні інструмента (довжина попереднього перегляду: `display.tool_preview_length`, за замовчуванням 40)."
     mode_all:              "⚙️ Прогрес інструментів: **ALL** — показується кожен виклик інструмента (довжина попереднього перегляду: `display.tool_preview_length`, за замовчуванням 40)."
     mode_verbose:          "⚙️ Прогрес інструментів: **VERBOSE** — кожен виклик інструмента з повними аргументами."

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "`/verbose` 指令未在訊息平台上啟用。\n\n請在 `config.yaml` 中啟用：\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ 工具進度：**OFF** — 不顯示任何工具活動。"
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ 工具進度：**NEW** — 工具變更時顯示（預覽長度：`display.tool_preview_length`，預設 40）。"
     mode_all:              "⚙️ 工具進度：**ALL** — 顯示每次工具呼叫（預覽長度：`display.tool_preview_length`，預設 40）。"
     mode_verbose:          "⚙️ 工具進度：**VERBOSE** — 顯示每次工具呼叫及完整參數。"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -344,6 +344,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   verbose:
     not_enabled:           "`/verbose` 命令未在消息平台启用。\n\n请在 `config.yaml` 中启用：\n```yaml\ndisplay:\n  tool_progress_command: true\n```"
     mode_off:              "⚙️ 工具进度：**OFF** — 不显示任何工具活动。"
+    mode_summary:          "📊 Tool progress: **SUMMARY** — one concise operational status bubble with stage, counters, and agents/profiles when detected."
     mode_new:              "⚙️ 工具进度：**NEW** — 工具变化时显示（预览长度：`display.tool_preview_length`，默认 40）。"
     mode_all:              "⚙️ 工具进度：**ALL** — 显示每次工具调用（预览长度：`display.tool_preview_length`，默认 40）。"
     mode_verbose:          "⚙️ 工具进度：**VERBOSE** — 显示每次工具调用及完整参数。"

--- a/tests/gateway/test_api_server_webui_client_platform.py
+++ b/tests/gateway/test_api_server_webui_client_platform.py
@@ -1,0 +1,179 @@
+"""API server client-platform selection for Hermes WebUI callers."""
+
+import asyncio
+import json
+
+from gateway.platforms.api_server import APIServerAdapter
+
+
+class _Request:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+class _JsonRequest(_Request):
+    def __init__(self, headers, body, session_id="sess-1"):
+        super().__init__(headers)
+        self._body = body
+        self.match_info = {"session_id": session_id}
+
+    async def json(self):
+        return self._body
+
+
+def test_client_platform_header_selects_webui_without_session_key():
+    request = _Request({"X-Hermes-Client": "webui"})
+
+    assert APIServerAdapter._client_platform_from_request(request) == "webui"
+
+
+def test_client_platform_falls_back_to_api_server_for_generic_clients():
+    request = _Request({"X-Hermes-Client": "curl"})
+
+    assert APIServerAdapter._client_platform_from_request(request) == "api_server"
+
+
+def test_webui_session_key_still_selects_webui_when_present():
+    request = _Request({})
+
+    assert APIServerAdapter._client_platform_from_request(request, "webui:session-123") == "webui"
+
+
+def test_bind_api_server_session_keeps_async_delivery_off_for_webui(monkeypatch):
+    from gateway import session_context
+
+    captured = {}
+
+    def fake_set_session_vars(**kwargs):
+        captured.update(kwargs)
+        return ["token"]
+
+    monkeypatch.setattr(session_context, "set_session_vars", fake_set_session_vars)
+
+    tokens = APIServerAdapter._bind_api_server_session(
+        chat_id="sess-1",
+        session_key="webui:sess-1",
+        session_id="sess-1",
+        client_platform="webui",
+    )
+
+    assert tokens == ["token"]
+    assert captured["platform"] == "api_server"
+    assert captured["async_delivery"] is False
+
+
+def test_run_agent_uses_webui_presentation_but_api_server_session_context(monkeypatch):
+    from gateway.session_context import get_session_env
+
+    captured = {}
+
+    class FakeAgent:
+        session_id = "sess-1"
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            captured["context_platform"] = get_session_env("HERMES_SESSION_PLATFORM")
+            captured["context_session_key"] = get_session_env("HERMES_SESSION_KEY")
+            return {"final_response": "ok", "messages": []}
+
+    def fake_create_agent(**kwargs):
+        captured["client_platform"] = kwargs.get("client_platform")
+        return FakeAgent()
+
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._inflight_agent_runs = 0
+    adapter._active_session_agents = {}
+    monkeypatch.setattr(adapter, "_create_agent", fake_create_agent)
+
+    result, usage = asyncio.run(
+        adapter._run_agent(
+            "hi",
+            [],
+            session_id="sess-1",
+            gateway_session_key="webui:sess-1",
+            client_platform="webui",
+        )
+    )
+
+    assert result["final_response"] == "ok"
+    assert usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    assert captured["client_platform"] == "webui"
+    assert captured["context_platform"] == "api_server"
+    assert captured["context_session_key"] == "webui:sess-1"
+    assert adapter._active_session_agents == {}
+
+
+def test_session_steer_routes_to_active_webui_session_key():
+    calls = []
+
+    class FakeAgent:
+        def steer(self, text):
+            calls.append(text)
+            return True
+
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._api_key = "sk-secret"
+    adapter._active_session_agents = {"webui:sess-1": FakeAgent()}
+    request = _JsonRequest(
+        {
+            "Authorization": "Bearer sk-secret",
+            "X-Hermes-Session-Key": "webui:sess-1",
+        },
+        {"text": "keep going"},
+    )
+
+    response = asyncio.run(adapter._handle_session_steer(request))
+    payload = json.loads(response.text)
+
+    assert payload == {"accepted": True, "fallback": None, "session_id": "sess-1"}
+    assert calls == ["keep going"]
+
+
+def test_session_steer_reports_not_running_without_queue_or_interrupt():
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._api_key = "sk-secret"
+    adapter._active_session_agents = {}
+    request = _JsonRequest(
+        {
+            "Authorization": "Bearer sk-secret",
+            "X-Hermes-Session-Key": "webui:sess-1",
+        },
+        {"text": "keep going"},
+    )
+
+    response = asyncio.run(adapter._handle_session_steer(request))
+    payload = json.loads(response.text)
+
+    assert payload == {"accepted": False, "fallback": "not_running", "session_id": "sess-1"}
+
+
+def test_create_agent_uses_webui_platform_but_api_server_toolsets(monkeypatch):
+    import gateway.run as gateway_run
+    from hermes_cli import tools_config
+    import run_agent
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(run_agent, "AIAgent", FakeAgent)
+    monkeypatch.setattr(gateway_run, "_current_max_iterations", lambda: 3)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: "test-model")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"platform_toolsets": {"api_server": ["web"]}})
+    monkeypatch.setattr(gateway_run.GatewayRunner, "_load_reasoning_config", staticmethod(lambda: None))
+    monkeypatch.setattr(gateway_run.GatewayRunner, "_load_fallback_model", staticmethod(lambda: None))
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda cfg, platform: {f"toolset:{platform}"})
+
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._session_db = None
+
+    agent = adapter._create_agent(session_id="sess-1", client_platform="webui")
+
+    assert isinstance(agent, FakeAgent)
+    assert captured["platform"] == "webui"
+    assert captured["enabled_toolsets"] == ["toolset:api_server"]

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -22,6 +22,12 @@ class TestResolveDisplaySetting:
         }
         assert resolve_display_setting(config, "telegram", "tool_progress") == "verbose"
 
+    def test_summary_tool_progress_mode_is_preserved(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"platforms": {"telegram": {"tool_progress": "summary"}}}}
+        assert resolve_display_setting(config, "telegram", "tool_progress") == "summary"
+
     def test_global_setting_when_no_platform_override(self):
         """Falls back to display.<key> when no platform override exists."""
         from gateway.display_config import resolve_display_setting

--- a/tests/gateway/test_progress_summary.py
+++ b/tests/gateway/test_progress_summary.py
@@ -1,0 +1,108 @@
+from gateway.progress_summary import ToolProgressSummary
+
+
+def test_summary_hides_raw_hermes_command_but_shows_profile_and_kanban_task():
+    summary = ToolProgressSummary()
+
+    text = summary.update(
+        "tool.started",
+        "terminal",
+        args={
+            "command": (
+                "HERMES_KANBAN_BOARD=mes hermes -p mes-release-run "
+                "--accept-hooks --skills kanban-agent-workflows "
+                "--workdir /a0/usr/projects/MES chat -q \"work kanban task t_62b0683f\""
+            )
+        },
+    )
+
+    assert text is not None
+    assert "Profil mes-release-run" in text
+    assert "t_62b0683f" in text
+    assert "HERMES_KANBAN_BOARD" not in text
+    assert "--accept-hooks" not in text
+    assert "chat -q" not in text
+    assert "outils 0/1 terminés" in text
+
+
+def test_summary_updates_tool_completion_counters_and_errors():
+    summary = ToolProgressSummary()
+
+    summary.update("tool.started", "read_file", args={"path": "AGENTS.md"})
+    text = summary.update("tool.completed", "read_file", duration=1.25, is_error=False)
+
+    assert text is not None
+    assert "read_file terminé en 1.2s" in text
+    assert "outils 1/1 terminés" in text
+
+    summary.update("tool.started", "patch", args={"path": "gateway/run.py"})
+    text = summary.update("tool.completed", "patch", duration=0.5, is_error=True)
+
+    assert text is not None
+    assert "erreurs 1" in text
+    assert "outils 2/2 terminés" in text
+
+
+def test_summary_renders_process_wait_as_process_tracking():
+    summary = ToolProgressSummary()
+
+    text = summary.update("tool.started", "process", preview="wait proc_a2671d234bd 240s")
+
+    assert text is not None
+    assert "Étape: Suivi processus" in text
+    assert "Attente processus proc_a2671d234bd (240s)" in text
+
+
+def test_summary_tracks_subagents_without_mirroring_child_text():
+    summary = ToolProgressSummary()
+
+    text = summary.update(
+        "subagent.spawn_requested",
+        preview="Audit du module Telegram",
+        task_index=0,
+        model="openai/gpt-test",
+        goal="Audit du module Telegram et proposition de correctif",
+    )
+    assert text is not None
+    assert "Agents: 1 actif(s), 0 terminé(s)" in text
+    assert "#1 openai/gpt-test" in text
+
+    text = summary.update(
+        "subagent.tool",
+        "search_files",
+        preview="telegram",
+        task_index=0,
+        model="openai/gpt-test",
+    )
+    assert text is not None
+    assert "outils agents 1" in text
+    assert "search_files" in text
+
+    text = summary.update(
+        "subagent.complete",
+        preview="Correctif prêt",
+        task_index=0,
+        model="openai/gpt-test",
+    )
+    assert text is not None
+    assert "Agents: 0 actif(s), 1 terminé(s)" in text
+
+
+def test_summary_tracks_moa_reference_and_aggregation():
+    summary = ToolProgressSummary()
+
+    text = summary.update(
+        "moa.reference",
+        "ref-model-a",
+        "réponse longue non recopiée ici",
+        moa_index=0,
+        moa_count=2,
+    )
+    assert text is not None
+    assert "Étape: Consultation MoA" in text
+    assert "1/2" in text
+
+    text = summary.update("moa.aggregating", "aggregator", moa_ref_count=2)
+    assert text is not None
+    assert "Étape: Synthèse MoA" in text
+    assert "Agrégation de 2 réponse(s)" in text

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import io
 import os
 import signal
 import sys
@@ -248,3 +249,48 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    def test_system_slice_prefers_system_manager_over_stale_user_unit(self, monkeypatch):
+        """A system service must not read a same-named stale user unit.
+
+        Root can have both a system gateway unit and an inactive user unit with
+        the same name. If the system unit has TimeoutStopSec=210 but the user
+        manager reports the default 90s, consulting --user first produces a
+        false "stale systemd unit" warning at gateway startup.
+        """
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+
+        def fake_open(path, *args, **kwargs):
+            assert path == "/proc/self/cgroup"
+            return io.StringIO(
+                "0::/system.slice/hermes-gateway-mes-kanban-orchestrator.service\n"
+            )
+
+        class Result:
+            returncode = 0
+
+            def __init__(self, stdout):
+                self.stdout = stdout
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "--user" in cmd:
+                return Result("TimeoutStopUSec=1min 30s\n")
+            return Result("TimeoutStopUSec=3min 30s\n")
+
+        monkeypatch.setattr("builtins.open", fake_open)
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert calls
+        assert "--user" not in calls[0]
+        assert result == {
+            "unit": "hermes-gateway-mes-kanban-orchestrator.service",
+            "timeout_stop_sec": 210.0,
+            "drain_timeout": 180.0,
+            "expected_min": 210.0,
+            "mismatch": False,
+        }

--- a/tests/gateway/test_stream_events.py
+++ b/tests/gateway/test_stream_events.py
@@ -151,6 +151,25 @@ def test_tool_finished_emits_no_chrome():
     assert lines == []
 
 
+def test_summary_mode_enqueues_replacement_snapshots():
+    lines = []
+    d = GatewayEventDispatcher(
+        _base_adapter(), _FakeSink(),
+        enqueue_tool_line=lines.append, tool_mode="summary",
+    )
+    d.dispatch(ToolCallChunk(
+        tool_name="terminal",
+        args={"command": "hermes -p mes-release-run chat -q 'work kanban task t_62b0683f'"},
+    ))
+    d.dispatch(ToolCallFinished(tool_name="terminal", duration=2.0, ok=True))
+
+    assert len(lines) == 2
+    assert all(isinstance(line, tuple) and line[0] == "__replace__" for line in lines)
+    assert "Profil mes-release-run" in lines[0][1]
+    assert "t_62b0683f" in lines[0][1]
+    assert "outils 1/1 terminés" in lines[-1][1]
+
+
 # ── Control events → gateway-owned hooks ─────────────────────────────────────
 
 def test_long_tool_hint_routes_to_hook():

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1468,6 +1468,24 @@ def test_run_summary_falls_back_to_result(kanban_home):
         conn.close()
 
 
+def test_task_result_falls_back_to_summary_for_visibility(kanban_home):
+    """Workers are encouraged to complete with summary; mirror it into
+    task.result so dashboard/card detail views do not look empty."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, tid)
+        ok = kb.complete_task(conn, tid, summary="visible handoff")
+        assert ok is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "done"
+        assert task.result == "visible handoff"
+        r = kb.latest_run(conn, tid)
+        assert r.summary == "visible handoff"
+    finally:
+        conn.close()
+
+
 def test_multiple_attempts_preserved_as_runs(kanban_home):
     """Crash / retry / complete flow produces one run per attempt, all
     visible in list_runs in chronological order."""
@@ -2124,7 +2142,9 @@ def test_complete_never_claimed_task_synthesizes_run(kanban_home):
         # Zero-duration synthetic run.
         assert r.started_at == r.ended_at
         # Task pointer still NULL (we never claimed, never opened a run).
-        assert kb.get_task(conn, tid).current_run_id is None
+        task = kb.get_task(conn, tid)
+        assert task.current_run_id is None
+        assert task.result == "did it manually"
 
         # Event carries the synthetic run_id.
         evts = [e for e in kb.list_events(conn, tid) if e.kind == "completed"]

--- a/tests/hermes_cli/test_kanban_worker_activity_events.py
+++ b/tests/hermes_cli/test_kanban_worker_activity_events.py
@@ -1,0 +1,116 @@
+"""Kanban worker activity event tests.
+
+Workers run outside the live WebUI chat stream, so their observable progress must
+be persisted as structured Kanban events that every UI can render.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def isolated_kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _load_activity_journal_class():
+    try:
+        module = importlib.import_module("hermes_cli.kanban_worker_activity")
+    except ModuleNotFoundError as exc:
+        raise AssertionError("missing hermes_cli.kanban_worker_activity module") from exc
+    assert hasattr(module, "KanbanWorkerActivityJournal")
+    return module.KanbanWorkerActivityJournal
+
+
+def test_worker_activity_journal_persists_structured_events(isolated_kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="visible worker", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer="test-worker")
+        assert claimed is not None
+        journal_cls = _load_activity_journal_class()
+        journal = journal_cls(task_id=task_id, run_id=claimed.current_run_id)
+
+        journal.tool_start("call-1", "terminal", {"command": "pytest -q"})
+        journal.tool_end("call-1", "terminal", {"command": "pytest -q"}, "1 passed", duration=1.25, is_error=False)
+        journal.assistant_text("Je lance les tests ciblés.")
+        journal.progress_note("Lecture du journal worker")
+        journal.heartbeat_note("toujours en cours")
+
+        events = [e for e in kb.list_events(conn, task_id) if e.kind in journal.EVENT_KINDS]
+        assert [e.kind for e in events] == [
+            "tool_start",
+            "tool_end",
+            "assistant_text",
+            "progress_note",
+            "heartbeat_note",
+        ]
+        assert all(e.run_id == claimed.current_run_id for e in events)
+        assert events[0].payload["tool"] == "terminal"
+        assert events[0].payload["tool_call_id"] == "call-1"
+        assert events[1].payload["duration"] == 1.25
+        assert events[1].payload["is_error"] is False
+        assert events[2].payload["text"] == "Je lance les tests ciblés."
+        assert events[-1].payload["note"] == "toujours en cours"
+    finally:
+        conn.close()
+
+
+def test_worker_activity_journal_consumes_steer_events(isolated_kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="steerable worker", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer="test-worker")
+        assert claimed is not None
+        journal_cls = _load_activity_journal_class()
+        journal = journal_cls(task_id=task_id, run_id=claimed.current_run_id)
+        journal._steer_cursor = 0
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                task_id,
+                "steer_note",
+                {"message": "Arrête la piste A, teste plutôt B", "source": "webui"},
+                run_id=claimed.current_run_id,
+            )
+
+        class FakeAgent:
+            def __init__(self):
+                self.steers = []
+            def steer(self, text):
+                self.steers.append(text)
+                return True
+
+        agent = FakeAgent()
+        assert journal.consume_steer_once(agent) == 1
+        assert agent.steers == ["Arrête la piste A, teste plutôt B"]
+        events = [e for e in kb.list_events(conn, task_id) if e.kind == "steer_accepted"]
+        assert len(events) == 1
+        assert events[0].payload["message"] == "Arrête la piste A, teste plutôt B"
+    finally:
+        conn.close()
+
+
+def test_cli_agent_setup_wires_kanban_worker_activity_callbacks():
+    """HermesCLI must compose normal display callbacks with Kanban journal callbacks."""
+    mixin = Path("hermes_cli/cli_agent_setup_mixin.py").read_text(encoding="utf-8")
+    assert "KanbanWorkerActivityJournal.from_environment" in mixin
+    assert "_compose_kanban_worker_callback" in mixin
+    assert "kanban_activity.tool_progress" in mixin
+    assert "kanban_activity.tool_start" in mixin
+    assert "kanban_activity.tool_complete" in mixin
+    assert "kanban_activity.stream_delta" in mixin
+    assert "interim_assistant_callback=interim_assistant_callback" in mixin
+    assert "kanban_activity.assistant_text" in mixin
+    assert "kanban_activity.start_steer_polling(self.agent)" in mixin

--- a/tests/hermes_cli/test_kanban_worker_journal.py
+++ b/tests/hermes_cli/test_kanban_worker_journal.py
@@ -1,0 +1,229 @@
+"""Tests for automatic Kanban worker activity journaling.
+
+Dispatcher-spawned workers run as detached CLI processes. They should persist
+observable callbacks into task_events so Kanban UIs can show an Agent0-style
+execution story without exposing private chain-of-thought.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _running_task():
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="journal me", assignee="worker")
+        # create_task defaults to running for programmatic callers; dispatcher
+        # workers need a current run, so start from ready and claim it.
+        conn.execute("UPDATE tasks SET status='ready', current_run_id=NULL WHERE id=?", (tid,))
+        conn.commit()
+        task = kb.claim_task(conn, tid, claimer="test-lock")
+        run = kb.latest_run(conn, tid)
+        assert task is not None
+        assert run is not None
+        return tid, run.id
+    finally:
+        conn.close()
+
+
+def _events_for(task_id: str):
+    conn = kb.connect()
+    try:
+        return kb.list_events(conn, task_id)
+    finally:
+        conn.close()
+
+
+def test_worker_journal_persists_observable_callbacks_from_env(kanban_home, monkeypatch):
+    task_id, run_id = _running_task()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    from hermes_cli.kanban_worker_journal import KanbanWorkerJournal
+
+    journal = KanbanWorkerJournal.from_env()
+    assert journal is not None
+
+    journal.tool_start("tc-1", "terminal", {"command": "echo hello", "api_key": "sk-secret"})
+    journal.tool_complete("tc-1", "terminal", {"command": "echo hello"}, "hello\n")
+    journal.tool_progress("status", name="terminal", preview="running tests")
+    journal.interim_assistant("Tests OK, build en cours")
+
+    events = [e for e in _events_for(task_id) if e.kind in {"tool_start", "tool_end", "progress_note", "assistant_text"}]
+    assert [e.kind for e in events] == ["tool_start", "tool_end", "progress_note", "assistant_text"]
+    assert all(e.run_id == run_id for e in events)
+
+    assert events[0].payload["tool"] == "terminal"
+    assert events[0].payload["tool_call_id"] == "tc-1"
+    assert events[0].payload["args"]["command"] == "echo hello"
+    assert "sk-secret" not in str(events[0].payload)
+
+    assert events[1].payload["tool"] == "terminal"
+    assert "hello" in events[1].payload["result_preview"]
+
+    assert events[2].payload == {"note": "running tests", "source": "tool_progress", "name": "terminal"}
+    assert events[3].payload == {"text": "Tests OK, build en cours", "source": "interim_assistant"}
+
+
+def test_worker_journal_is_noop_without_kanban_task(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+
+    from hermes_cli.kanban_worker_journal import KanbanWorkerJournal
+
+    assert KanbanWorkerJournal.from_env() is None
+
+
+def test_worker_journal_swallow_errors_so_callbacks_cannot_break_worker(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_missing")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "not-an-int")
+    monkeypatch.setenv("HERMES_KANBAN_DB", "/dev/null/kanban.db")
+
+    from hermes_cli.kanban_worker_journal import KanbanWorkerJournal
+
+    journal = KanbanWorkerJournal.from_env()
+    assert journal is not None
+
+    # Missing/corrupt board context must not raise into the agent callback path.
+    journal.tool_start("tc", "terminal", {"command": "pwd"})
+    journal.tool_complete("tc", "terminal", {}, "ok")
+    journal.tool_progress("status", preview="still working")
+    journal.interim_assistant("visible worker text")
+
+
+def test_install_on_agent_composes_existing_callbacks(kanban_home, monkeypatch):
+    task_id, run_id = _running_task()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    from hermes_cli.kanban_worker_journal import install_on_agent
+
+    calls = []
+
+    class Agent:
+        def tool_start_callback(self, tool_call_id, name, args):
+            calls.append(("start", tool_call_id, name, args))
+
+        def tool_complete_callback(self, tool_call_id, name, args, result):
+            calls.append(("complete", tool_call_id, name, args, result))
+
+        def tool_progress_callback(self, event_type, name=None, preview=None, args=None, **kwargs):
+            calls.append(("progress", event_type, name, preview, args, kwargs))
+
+        def interim_assistant_callback(self, text, **kwargs):
+            calls.append(("assistant", text, kwargs))
+
+        def stream_delta_callback(self, delta):
+            calls.append(("stream", delta))
+
+    agent = Agent()
+    install_on_agent(agent)
+
+    agent.tool_start_callback("tc-2", "read_file", {"path": "AGENTS.md"})
+    agent.tool_complete_callback("tc-2", "read_file", {"path": "AGENTS.md"}, "content")
+    agent.tool_progress_callback("status", name="read_file", preview="reading")
+    agent.interim_assistant_callback("J’ai lu le contexte", already_streamed=False)
+    agent.stream_delta_callback("Réponse ")
+    agent.stream_delta_callback("streamée")
+    agent.stream_delta_callback(None)
+
+    assert calls == [
+        ("start", "tc-2", "read_file", {"path": "AGENTS.md"}),
+        ("complete", "tc-2", "read_file", {"path": "AGENTS.md"}, "content"),
+        ("progress", "status", "read_file", "reading", None, {}),
+        ("assistant", "J’ai lu le contexte", {"already_streamed": False}),
+        ("stream", "Réponse "),
+        ("stream", "streamée"),
+        ("stream", None),
+    ]
+
+    events = _events_for(task_id)
+    kinds = [e.kind for e in events]
+    assert "tool_start" in kinds
+    assert "tool_end" in kinds
+    assert "progress_note" in kinds
+    assert "assistant_text" in kinds
+    assistant_payloads = [e.payload for e in events if e.kind == "assistant_text"]
+    assert {p["source"] for p in assistant_payloads} == {"interim_assistant", "stream_delta"}
+
+
+def test_record_final_assistant_flushes_stream_and_deduplicates(kanban_home, monkeypatch):
+    task_id, run_id = _running_task()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    from hermes_cli.kanban_worker_journal import install_on_agent, record_final_assistant
+
+    class Agent:
+        def stream_delta_callback(self, delta):
+            pass
+
+    agent = Agent()
+    install_on_agent(agent)
+
+    agent.stream_delta_callback("Même réponse")
+    record_final_assistant(agent, "Même réponse")
+    record_final_assistant(agent, "Même réponse")
+
+    assistant_events = [e for e in _events_for(task_id) if e.kind == "assistant_text"]
+    assert len(assistant_events) == 1
+    assert assistant_events[0].payload == {"text": "Même réponse", "source": "stream_delta"}
+
+
+def test_cli_init_agent_installs_worker_journal(kanban_home, monkeypatch):
+    task_id, run_id = _running_task()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    import cli as cli_mod
+    from hermes_cli import mcp_startup
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.tool_progress_callback = kwargs.get("tool_progress_callback")
+            self.tool_start_callback = kwargs.get("tool_start_callback")
+            self.tool_complete_callback = kwargs.get("tool_complete_callback")
+            self.stream_delta_callback = kwargs.get("stream_delta_callback")
+            self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
+
+    monkeypatch.setattr(cli_mod, "AIAgent", FakeAgent)
+    monkeypatch.setattr(mcp_startup, "wait_for_mcp_discovery", lambda timeout=0.75: None)
+
+    shell = cli_mod.HermesCLI(compact=True, max_turns=1)
+    shell._session_db = object()
+    shell._resumed = False
+    shell.conversation_history = []
+    shell._install_tool_callbacks = lambda: None
+    shell._ensure_tirith_security = lambda: None
+    shell._ensure_runtime_credentials = lambda: True
+
+    assert shell._init_agent() is True
+    assert getattr(shell.agent, "_kanban_worker_journal_installed") is True
+
+    shell.agent.tool_progress_callback("status", name="init", preview="journal installed")
+    shell.agent.interim_assistant_callback("Initialisation worker visible")
+
+    payloads = [(e.kind, e.payload) for e in _events_for(task_id)]
+    assert (
+        "progress_note",
+        {"note": "journal installed", "source": "tool_progress", "name": "init"},
+    ) in payloads
+    assert (
+        "assistant_text",
+        {"text": "Initialisation worker visible", "source": "interim_assistant"},
+    ) in payloads


### PR DESCRIPTION
Draft stack from Anthony/Pichot local Hermes maintenance.

Contains protected hotfixes currently carried locally:
- WebUI/API-server session steer route
- Kanban progress journal summaries
- systemd timeout scope detection
- Kanban worker activity events and steer polling
- mirror Kanban completion summary into task result for dashboard visibility

Local validation on Anthony host:
- protected reapply simulation from current origin/main: clean
- py_compile: clean
- targeted pytest: 223 passed

This is opened as draft because the stack may need splitting before upstream merge.