### PR TITLE
Bound Codex image SSE parsing

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -75,6 +75,9 @@ _SIZES = {
 # done by ``API_MODEL``.
 _CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+_SSE_MAX_LINE_BYTES = 64 * 1024 * 1024
+_SSE_MAX_EVENT_BYTES = 96 * 1024 * 1024
+_SSE_MAX_STREAM_BYTES = 192 * 1024 * 1024
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "
     "using the image_generation tool when provided."
@@ -195,6 +198,45 @@ def _extract_image_b64(value: Any) -> Optional[str]:
     return found
 
 
+def _iter_sse_lines(response: Any):
+    """Yield SSE lines from bytes while enforcing parser-local size caps."""
+    pending = bytearray()
+    total_bytes = 0
+
+    for chunk in response.iter_bytes():
+        if isinstance(chunk, str):
+            chunk = chunk.encode("utf-8", errors="replace")
+        if not chunk:
+            continue
+        total_bytes += len(chunk)
+        if total_bytes > _SSE_MAX_STREAM_BYTES:
+            raise RuntimeError("Codex image SSE stream exceeded size limit")
+
+        pending.extend(chunk)
+        while True:
+            newline = pending.find(b"\n")
+            if newline < 0:
+                break
+            line = bytes(pending[:newline])
+            del pending[: newline + 1]
+            if line.endswith(b"\r"):
+                line = line[:-1]
+            if len(line) > _SSE_MAX_LINE_BYTES:
+                raise RuntimeError("Codex image SSE line exceeded size limit")
+            yield line.decode("utf-8", errors="replace")
+
+        if len(pending) > _SSE_MAX_LINE_BYTES:
+            raise RuntimeError("Codex image SSE line exceeded size limit")
+
+    if pending:
+        line = bytes(pending)
+        if line.endswith(b"\r"):
+            line = line[:-1]
+        if len(line) > _SSE_MAX_LINE_BYTES:
+            raise RuntimeError("Codex image SSE line exceeded size limit")
+        yield line.decode("utf-8", errors="replace")
+
+
 def _iter_sse_json(response: Any):
     """Yield JSON payloads from an SSE response without OpenAI SDK parsing.
 
@@ -204,16 +246,19 @@ def _iter_sse_json(response: Any):
     """
     event_name: Optional[str] = None
     data_lines: List[str] = []
+    event_bytes = 0
 
     def flush():
-        nonlocal event_name, data_lines
+        nonlocal event_name, data_lines, event_bytes
         if not data_lines:
             event_name = None
+            event_bytes = 0
             return None
         raw = "\n".join(data_lines).strip()
         event = event_name
         event_name = None
         data_lines = []
+        event_bytes = 0
         if not raw or raw == "[DONE]":
             return None
         payload = json.loads(raw)
@@ -221,15 +266,15 @@ def _iter_sse_json(response: Any):
             payload["type"] = event
         return payload
 
-    for line in response.iter_lines():
-        if isinstance(line, bytes):
-            line = line.decode("utf-8", errors="replace")
-        line = str(line)
+    for line in _iter_sse_lines(response):
         if line == "":
             payload = flush()
             if payload is not None:
                 yield payload
             continue
+        event_bytes += len(line.encode("utf-8", errors="replace")) + 1
+        if event_bytes > _SSE_MAX_EVENT_BYTES:
+            raise RuntimeError("Codex image SSE event exceeded size limit")
         if line.startswith(":"):
             continue
         if line.startswith("event:"):

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -119,6 +119,9 @@ _SIZES = {
 # done by ``API_MODEL``.
 _CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+_SSE_MAX_LINE_BYTES = 64 * 1024 * 1024
+_SSE_MAX_EVENT_BYTES = 96 * 1024 * 1024
+_SSE_MAX_STREAM_BYTES = 192 * 1024 * 1024
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation and image editing "
     "requests by using the image_generation tool when provided."
@@ -356,6 +359,45 @@ def _extract_image_b64(value: Any) -> Optional[str]:
     return found
 
 
+def _iter_sse_lines(response: Any):
+    """Yield SSE lines from bytes while enforcing parser-local size caps."""
+    pending = bytearray()
+    total_bytes = 0
+
+    for chunk in response.iter_bytes():
+        if isinstance(chunk, str):
+            chunk = chunk.encode("utf-8", errors="replace")
+        if not chunk:
+            continue
+        total_bytes += len(chunk)
+        if total_bytes > _SSE_MAX_STREAM_BYTES:
+            raise RuntimeError("Codex image SSE stream exceeded size limit")
+
+        pending.extend(chunk)
+        while True:
+            newline = pending.find(b"\n")
+            if newline < 0:
+                break
+            line = bytes(pending[:newline])
+            del pending[: newline + 1]
+            if line.endswith(b"\r"):
+                line = line[:-1]
+            if len(line) > _SSE_MAX_LINE_BYTES:
+                raise RuntimeError("Codex image SSE line exceeded size limit")
+            yield line.decode("utf-8", errors="replace")
+
+        if len(pending) > _SSE_MAX_LINE_BYTES:
+            raise RuntimeError("Codex image SSE line exceeded size limit")
+
+    if pending:
+        line = bytes(pending)
+        if line.endswith(b"\r"):
+            line = line[:-1]
+        if len(line) > _SSE_MAX_LINE_BYTES:
+            raise RuntimeError("Codex image SSE line exceeded size limit")
+        yield line.decode("utf-8", errors="replace")
+
+
 def _iter_sse_json(response: Any):
     """Yield JSON payloads from an SSE response without OpenAI SDK parsing.
 
@@ -365,16 +407,19 @@ def _iter_sse_json(response: Any):
     """
     event_name: Optional[str] = None
     data_lines: List[str] = []
+    event_bytes = 0
 
     def flush():
-        nonlocal event_name, data_lines
+        nonlocal event_name, data_lines, event_bytes
         if not data_lines:
             event_name = None
+            event_bytes = 0
             return None
         raw = "\n".join(data_lines).strip()
         event = event_name
         event_name = None
         data_lines = []
+        event_bytes = 0
         if not raw or raw == "[DONE]":
             return None
         payload = json.loads(raw)
@@ -382,15 +427,15 @@ def _iter_sse_json(response: Any):
             payload["type"] = event
         return payload
 
-    for line in response.iter_lines():
-        if isinstance(line, bytes):
-            line = line.decode("utf-8", errors="replace")
-        line = str(line)
+    for line in _iter_sse_lines(response):
         if line == "":
             payload = flush()
             if payload is not None:
                 yield payload
             continue
+        event_bytes += len(line.encode("utf-8", errors="replace")) + 1
+        if event_bytes > _SSE_MAX_EVENT_BYTES:
+            raise RuntimeError("Codex image SSE event exceeded size limit")
         if line.startswith(":"):
             continue
         if line.startswith("event:"):

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -375,18 +375,19 @@ def _iter_sse_lines(response: Any):
 
         pending.extend(chunk)
         while True:
-            newline = pending.find(b"\n")
-            if newline < 0:
+            cr = pending.find(b"\r")
+            lf = pending.find(b"\n")
+            newline = min((pos for pos in (cr, lf) if pos >= 0), default=-1)
+            if newline < 0 or (newline == cr == len(pending) - 1):
                 break
+            separator_bytes = 2 if pending[newline : newline + 2] == b"\r\n" else 1
             line = bytes(pending[:newline])
-            del pending[: newline + 1]
-            if line.endswith(b"\r"):
-                line = line[:-1]
+            del pending[: newline + separator_bytes]
             if len(line) > _SSE_MAX_LINE_BYTES:
                 raise RuntimeError("Codex image SSE line exceeded size limit")
             yield line.decode("utf-8", errors="replace")
 
-        if len(pending) > _SSE_MAX_LINE_BYTES:
+        if len(pending) - int(pending.endswith(b"\r")) > _SSE_MAX_LINE_BYTES:
             raise RuntimeError("Codex image SSE line exceeded size limit")
 
     if pending:

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -170,11 +170,11 @@ class TestGenerate:
 
     def test_sse_parser_handles_event_and_data_lines(self):
         class _Response:
-            def iter_lines(self):
+            def iter_bytes(self):
                 return iter([
-                    "event: response.output_item.done",
-                    'data: {"item": {"type": "image_generation_call", "result": "abc"}}',
-                    "",
+                    b"event: response.output_item.done\n",
+                    b'data: {"item": {"type": "image_generation_call", "result": "abc"}}\n',
+                    b"\n",
                 ])
 
         events = list(codex_plugin._iter_sse_json(_Response()))
@@ -182,6 +182,51 @@ class TestGenerate:
             "type": "response.output_item.done",
             "item": {"type": "image_generation_call", "result": "abc"},
         }]
+
+    def test_sse_parser_handles_multiline_data_across_chunks(self):
+        class _Response:
+            def iter_bytes(self):
+                return iter([
+                    b"event: response.output_item.done\n",
+                    b'data: {"item":\n',
+                    b'data: {"type": "image_generation_call", "result": "abc"}}\n\n',
+                ])
+
+        events = list(codex_plugin._iter_sse_json(_Response()))
+        assert events == [{
+            "type": "response.output_item.done",
+            "item": {"type": "image_generation_call", "result": "abc"},
+        }]
+
+    def test_sse_parser_rejects_oversized_line(self, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_SSE_MAX_LINE_BYTES", 8)
+
+        class _Response:
+            def iter_bytes(self):
+                return iter([b"data: " + (b"x" * 9)])
+
+        with pytest.raises(RuntimeError, match="SSE line exceeded"):
+            list(codex_plugin._iter_sse_json(_Response()))
+
+    def test_sse_parser_rejects_oversized_event(self, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_SSE_MAX_EVENT_BYTES", 10)
+
+        class _Response:
+            def iter_bytes(self):
+                return iter([b"data: 12345\n\n"])
+
+        with pytest.raises(RuntimeError, match="SSE event exceeded"):
+            list(codex_plugin._iter_sse_json(_Response()))
+
+    def test_sse_parser_rejects_oversized_stream(self, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_SSE_MAX_STREAM_BYTES", 10)
+
+        class _Response:
+            def iter_bytes(self):
+                return iter([b":1234567890\n"])
+
+        with pytest.raises(RuntimeError, match="SSE stream exceeded"):
+            list(codex_plugin._iter_sse_json(_Response()))
 
     def test_final_response_sweep_recovers_image(self):
         """Completed response output is found by recursive payload scanning."""

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -186,11 +186,11 @@ class TestGenerate:
 
     def test_sse_parser_handles_event_and_data_lines(self):
         class _Response:
-            def iter_lines(self):
+            def iter_bytes(self):
                 return iter([
-                    "event: response.output_item.done",
-                    'data: {"item": {"type": "image_generation_call", "result": "abc"}}',
-                    "",
+                    b"event: response.output_item.done\n",
+                    b'data: {"item": {"type": "image_generation_call", "result": "abc"}}\n',
+                    b"\n",
                 ])
 
         events = list(codex_plugin._iter_sse_json(_Response()))
@@ -198,6 +198,51 @@ class TestGenerate:
             "type": "response.output_item.done",
             "item": {"type": "image_generation_call", "result": "abc"},
         }]
+
+    def test_sse_parser_handles_multiline_data_across_chunks(self):
+        class _Response:
+            def iter_bytes(self):
+                return iter([
+                    b"event: response.output_item.done\n",
+                    b'data: {"item":\n',
+                    b'data: {"type": "image_generation_call", "result": "abc"}}\n\n',
+                ])
+
+        events = list(codex_plugin._iter_sse_json(_Response()))
+        assert events == [{
+            "type": "response.output_item.done",
+            "item": {"type": "image_generation_call", "result": "abc"},
+        }]
+
+    def test_sse_parser_rejects_oversized_line(self, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_SSE_MAX_LINE_BYTES", 8)
+
+        class _Response:
+            def iter_bytes(self):
+                return iter([b"data: " + (b"x" * 9)])
+
+        with pytest.raises(RuntimeError, match="SSE line exceeded"):
+            list(codex_plugin._iter_sse_json(_Response()))
+
+    def test_sse_parser_rejects_oversized_event(self, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_SSE_MAX_EVENT_BYTES", 10)
+
+        class _Response:
+            def iter_bytes(self):
+                return iter([b"data: 12345\n\n"])
+
+        with pytest.raises(RuntimeError, match="SSE event exceeded"):
+            list(codex_plugin._iter_sse_json(_Response()))
+
+    def test_sse_parser_rejects_oversized_stream(self, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_SSE_MAX_STREAM_BYTES", 10)
+
+        class _Response:
+            def iter_bytes(self):
+                return iter([b":1234567890\n"])
+
+        with pytest.raises(RuntimeError, match="SSE stream exceeded"):
+            list(codex_plugin._iter_sse_json(_Response()))
 
     def test_final_response_sweep_recovers_image(self):
         """Completed response output is found by recursive payload scanning."""

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -188,9 +188,8 @@ class TestGenerate:
         class _Response:
             def iter_bytes(self):
                 return iter([
-                    b"event: response.output_item.done\n",
-                    b'data: {"item": {"type": "image_generation_call", "result": "abc"}}\n',
-                    b"\n",
+                    b"event: response.output_item.done\r",
+                    b'data: {"item": {"type": "image_generation_call", "result": "abc"}}\r\r',
                 ])
 
         events = list(codex_plugin._iter_sse_json(_Response()))
@@ -203,9 +202,10 @@ class TestGenerate:
         class _Response:
             def iter_bytes(self):
                 return iter([
-                    b"event: response.output_item.done\n",
-                    b'data: {"item":\n',
-                    b'data: {"type": "image_generation_call", "result": "abc"}}\n\n',
+                    b"event: response.output_item.done\r",
+                    b'\ndata: {"item":\r',
+                    b'\ndata: {"type": "image_generation_call", "result": "abc"}}\r',
+                    b"\n\r\n",
                 ])
 
         events = list(codex_plugin._iter_sse_json(_Response()))


### PR DESCRIPTION
## Summary
- replace the `openai-codex` image SSE parser's raw `iter_lines()` loop with a byte-based line iterator over `iter_bytes()`
- cap single SSE lines, accumulated SSE events, and total streamed bytes with generous image-safe limits
- add regression coverage for normal events, multi-line `data:` events, and line/event/stream cap failures

Fixes #55248.

## Notes
This is intentionally separate from #54841/#54842, which cover non-2xx error body previews. This PR covers the successful 2xx `text/event-stream` parsing path.

## Validation
- `PYTHONPATH=$PWD C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests\plugins\image_gen\test_openai_codex_provider.py -q --basetemp .pytest-tmp-codex-image-sse` → 22 passed
- `PYTHONPATH=$PWD C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check plugins\image_gen\openai-codex\__init__.py tests\plugins\image_gen\test_openai_codex_provider.py` → passed
- `git diff --check origin/main...HEAD` → passed