### PR TITLE
Bound OpenAI Codex auth JSON responses

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -97,6 +97,7 @@ STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+CODEX_AUTH_JSON_BODY_MAX_BYTES = 1024 * 1024
 XAI_OAUTH_ISSUER = "https://auth.x.ai"
 XAI_OAUTH_DISCOVERY_URL = f"{XAI_OAUTH_ISSUER}/.well-known/openid-configuration"
 XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
@@ -164,6 +165,13 @@ class ProviderConfig:
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
+
+
+@dataclass
+class _CodexAuthJsonResponse:
+    status_code: int
+    headers: Dict[str, str]
+    payload: Optional[Dict[str, Any]] = None
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -781,6 +789,58 @@ def _parse_retry_after_seconds(headers: Any) -> Optional[int]:
     except (TypeError, ValueError):
         return None
     return seconds if seconds >= 0 else None
+
+
+def _read_codex_auth_json_response(response: httpx.Response, *, label: str, code: str) -> Dict[str, Any]:
+    chunks: List[bytes] = []
+    total = 0
+    for chunk in response.iter_bytes():
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > CODEX_AUTH_JSON_BODY_MAX_BYTES:
+            raise AuthError(
+                f"Codex {label} response exceeded {CODEX_AUTH_JSON_BODY_MAX_BYTES} bytes.",
+                provider="openai-codex",
+                code=code,
+            )
+        chunks.append(chunk)
+
+    try:
+        payload = json.loads(b"".join(chunks).decode("utf-8"))
+    except Exception as exc:
+        raise AuthError(
+            f"Codex {label} response returned invalid JSON: {exc}",
+            provider="openai-codex",
+            code=code,
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise AuthError(
+            f"Codex {label} response must be a JSON object.",
+            provider="openai-codex",
+            code=code,
+        )
+    return payload
+
+
+def _post_codex_auth_json(
+    client: httpx.Client,
+    url: str,
+    *,
+    label: str,
+    code: str,
+    **kwargs: Any,
+) -> _CodexAuthJsonResponse:
+    with client.stream("POST", url, **kwargs) as response:
+        payload = None
+        if response.status_code == 200:
+            payload = _read_codex_auth_json_response(response, label=label, code=code)
+        return _CodexAuthJsonResponse(
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            payload=payload,
+        )
 
 
 def format_auth_error(error: Exception) -> str:
@@ -7304,12 +7364,17 @@ def _codex_device_code_login() -> Dict[str, Any]:
     for attempt in range(1, max_attempts + 1):
         try:
             with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-                resp = client.post(
+                resp = _post_codex_auth_json(
+                    client,
                     f"{issuer}/api/accounts/deviceauth/usercode",
+                    label="device code",
+                    code="device_code_response_invalid",
                     json={"client_id": client_id},
                     headers={"Content-Type": "application/json"},
                 )
         except Exception as exc:
+            if isinstance(exc, AuthError):
+                raise
             raise AuthError(
                 f"Failed to request device code: {exc}",
                 provider="openai-codex", code="device_code_request_failed",
@@ -7353,7 +7418,7 @@ def _codex_device_code_login() -> Dict[str, Any]:
             provider="openai-codex", code="device_code_request_error",
         )
 
-    device_data = resp.json()
+    device_data = resp.payload or {}
     user_code = device_data.get("user_code", "")
     device_auth_id = device_data.get("device_auth_id", "")
     poll_interval = max(3, int(device_data.get("interval", "5")))
@@ -7381,14 +7446,17 @@ def _codex_device_code_login() -> Dict[str, Any]:
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
             while _time.monotonic() - start < max_wait:
                 _time.sleep(poll_interval)
-                poll_resp = client.post(
+                poll_resp = _post_codex_auth_json(
+                    client,
                     f"{issuer}/api/accounts/deviceauth/token",
+                    label="device auth poll",
+                    code="device_code_poll_invalid",
                     json={"device_auth_id": device_auth_id, "user_code": user_code},
                     headers={"Content-Type": "application/json"},
                 )
 
                 if poll_resp.status_code == 200:
-                    code_resp = poll_resp.json()
+                    code_resp = poll_resp.payload or {}
                     break
                 elif poll_resp.status_code in {403, 404}:
                     continue  # User hasn't completed login yet
@@ -7420,8 +7488,11 @@ def _codex_device_code_login() -> Dict[str, Any]:
 
     try:
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-            token_resp = client.post(
+            token_resp = _post_codex_auth_json(
+                client,
                 CODEX_OAUTH_TOKEN_URL,
+                label="token exchange",
+                code="token_exchange_invalid",
                 data={
                     "grant_type": "authorization_code",
                     "code": authorization_code,
@@ -7432,6 +7503,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
     except Exception as exc:
+        if isinstance(exc, AuthError):
+            raise
         raise AuthError(
             f"Token exchange failed: {exc}",
             provider="openai-codex", code="token_exchange_failed",
@@ -7459,7 +7532,7 @@ def _codex_device_code_login() -> Dict[str, Any]:
             provider="openai-codex", code="token_exchange_error",
         )
 
-    tokens = token_resp.json()
+    tokens = token_resp.payload or {}
     access_token = tokens.get("access_token", "")
     refresh_token = tokens.get("refresh_token", "")
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -147,6 +147,7 @@ except Exception:  # pragma: no cover - version import should always succeed
     _HERMES_CLI_VERSION = "unknown"
 CODEX_OAUTH_USER_AGENT = f"hermes-cli/{_HERMES_CLI_VERSION}"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+CODEX_AUTH_JSON_BODY_MAX_BYTES = 1024 * 1024
 XAI_OAUTH_ISSUER = "https://auth.x.ai"
 XAI_OAUTH_DISCOVERY_URL = f"{XAI_OAUTH_ISSUER}/.well-known/openid-configuration"
 XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
@@ -244,6 +245,19 @@ class ProviderConfig:
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
+
+
+@dataclass
+class _CodexAuthJsonResponse:
+    status_code: int
+    headers: Dict[str, str]
+    payload: Optional[Dict[str, Any]] = None
+    text: str = ""
+
+    def json(self) -> Dict[str, Any]:
+        if self.payload is None:
+            raise ValueError("Codex auth response body is not a JSON object")
+        return self.payload
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -952,6 +966,107 @@ def _parse_retry_after_seconds(headers: Any) -> Optional[int]:
 
     seconds = parse_retry_after_seconds(headers)
     return None if seconds is None else int(seconds)
+
+
+def _read_codex_auth_json_response(
+    response: httpx.Response,
+    *,
+    label: str,
+    code: str,
+    required: bool,
+    invalid_relogin_required: bool = False,
+) -> tuple[Optional[Dict[str, Any]], str]:
+    content_encoding = str(response.headers.get("content-encoding", "") or "").strip().lower()
+    if content_encoding and content_encoding != "identity":
+        if not required:
+            return None, ""
+        raise AuthError(
+            f"Codex {label} response used unsupported Content-Encoding {content_encoding}.",
+            provider="openai-codex",
+            code=code,
+        )
+
+    chunks: List[bytes] = []
+    total = 0
+    for chunk in response.iter_bytes():
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > CODEX_AUTH_JSON_BODY_MAX_BYTES:
+            if not required:
+                return None, ""
+            raise AuthError(
+                f"Codex {label} response exceeded {CODEX_AUTH_JSON_BODY_MAX_BYTES} bytes.",
+                provider="openai-codex",
+                code=code,
+            )
+        chunks.append(chunk)
+
+    text = b"".join(chunks).decode("utf-8", errors="replace")
+    try:
+        payload = json.loads(text)
+    except Exception as exc:
+        if not required:
+            return None, text
+        raise AuthError(
+            f"Codex {label} response returned invalid JSON: {exc}",
+            provider="openai-codex",
+            code=code,
+            relogin_required=invalid_relogin_required,
+        ) from exc
+
+    if not isinstance(payload, dict):
+        if not required:
+            return None, text
+        raise AuthError(
+            f"Codex {label} response must be a JSON object.",
+            provider="openai-codex",
+            code=code,
+            relogin_required=invalid_relogin_required,
+        )
+    return payload, text
+
+
+def _post_codex_auth_json(
+    client: httpx.Client,
+    url: str,
+    *,
+    label: str,
+    code: str,
+    read_error_body: bool = False,
+    read_rate_limit_body: bool = False,
+    invalid_relogin_required: bool = False,
+    **kwargs: Any,
+) -> _CodexAuthJsonResponse:
+    headers = httpx.Headers(kwargs.pop("headers", None))
+    headers["Accept-Encoding"] = "identity"
+    kwargs["headers"] = headers
+    with client.stream("POST", url, **kwargs) as response:
+        payload = None
+        text = ""
+        if response.status_code == 200:
+            payload, text = _read_codex_auth_json_response(
+                response,
+                label=label,
+                code=code,
+                required=True,
+                invalid_relogin_required=invalid_relogin_required,
+            )
+        elif read_error_body and (
+            response.status_code != 429 or read_rate_limit_body
+        ):
+            payload, text = _read_codex_auth_json_response(
+                response,
+                label=label,
+                code=code,
+                required=False,
+            )
+        return _CodexAuthJsonResponse(
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            payload=payload,
+            text=text,
+        )
 
 
 def format_auth_error(error: Exception) -> str:
@@ -3821,8 +3936,13 @@ def refresh_codex_oauth_pure(
             "User-Agent": CODEX_OAUTH_USER_AGENT,
         },
     ) as client:
-        response = client.post(
+        response = _post_codex_auth_json(
+            client,
             CODEX_OAUTH_TOKEN_URL,
+            label="token refresh",
+            code="codex_refresh_invalid_json",
+            read_error_body=True,
+            invalid_relogin_required=True,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             data={
                 "grant_type": "refresh_token",
@@ -3859,26 +3979,23 @@ def refresh_codex_oauth_pure(
         code = "codex_refresh_failed"
         message = f"Codex token refresh failed with status {response.status_code}."
         relogin_required = False
-        try:
-            err = response.json()
-            if isinstance(err, dict):
-                err_obj = err.get("error")
-                # OpenAI shape: {"error": {"code": "...", "message": "...", "type": "..."}}
-                if isinstance(err_obj, dict):
-                    nested_code = err_obj.get("code") or err_obj.get("type")
-                    if isinstance(nested_code, str) and nested_code.strip():
-                        code = nested_code.strip()
-                    nested_msg = err_obj.get("message")
-                    if isinstance(nested_msg, str) and nested_msg.strip():
-                        message = f"Codex token refresh failed: {nested_msg.strip()}"
-                # OAuth spec shape: {"error": "code_str", "error_description": "..."}
-                elif isinstance(err_obj, str) and err_obj.strip():
-                    code = err_obj.strip()
-                    err_desc = err.get("error_description") or err.get("message")
-                    if isinstance(err_desc, str) and err_desc.strip():
-                        message = f"Codex token refresh failed: {err_desc.strip()}"
-        except Exception:
-            pass
+        err = response.payload
+        if isinstance(err, dict):
+            err_obj = err.get("error")
+            # OpenAI shape: {"error": {"code": "...", "message": "...", "type": "..."}}
+            if isinstance(err_obj, dict):
+                nested_code = err_obj.get("code") or err_obj.get("type")
+                if isinstance(nested_code, str) and nested_code.strip():
+                    code = nested_code.strip()
+                nested_msg = err_obj.get("message")
+                if isinstance(nested_msg, str) and nested_msg.strip():
+                    message = f"Codex token refresh failed: {nested_msg.strip()}"
+            # OAuth spec shape: {"error": "code_str", "error_description": "..."}
+            elif isinstance(err_obj, str) and err_obj.strip():
+                code = err_obj.strip()
+                err_desc = err.get("error_description") or err.get("message")
+                if isinstance(err_desc, str) and err_desc.strip():
+                    message = f"Codex token refresh failed: {err_desc.strip()}"
         if code in {"invalid_grant", "invalid_token", "invalid_request"}:
             relogin_required = True
         if code == "refresh_token_reused":
@@ -3901,15 +4018,7 @@ def refresh_codex_oauth_pure(
             relogin_required=relogin_required,
         )
 
-    try:
-        refresh_payload = response.json()
-    except Exception as exc:
-        raise AuthError(
-            "Codex token refresh returned invalid JSON.",
-            provider="openai-codex",
-            code="codex_refresh_invalid_json",
-            relogin_required=True,
-        ) from exc
+    refresh_payload = response.payload or {}
 
     refreshed_access = refresh_payload.get("access_token")
     if not isinstance(refreshed_access, str) or not refreshed_access.strip():
@@ -8122,12 +8231,17 @@ def _codex_device_code_login() -> Dict[str, Any]:
     for attempt in range(1, max_attempts + 1):
         try:
             with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-                resp = client.post(
+                resp = _post_codex_auth_json(
+                    client,
                     f"{issuer}/api/accounts/deviceauth/usercode",
+                    label="device code",
+                    code="device_code_response_invalid",
                     json={"client_id": client_id},
                     headers={"Content-Type": "application/json"},
                 )
         except Exception as exc:
+            if isinstance(exc, AuthError):
+                raise
             raise AuthError(
                 f"Failed to request device code: {exc}",
                 provider="openai-codex", code="device_code_request_failed",
@@ -8171,7 +8285,7 @@ def _codex_device_code_login() -> Dict[str, Any]:
             provider="openai-codex", code="device_code_request_error",
         )
 
-    device_data = resp.json()
+    device_data = resp.payload or {}
     user_code = device_data.get("user_code", "")
     device_auth_id = device_data.get("device_auth_id", "")
     poll_interval = max(3, int(device_data.get("interval", "5")))
@@ -8199,14 +8313,17 @@ def _codex_device_code_login() -> Dict[str, Any]:
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
             while _time.monotonic() - start < max_wait:
                 _time.sleep(poll_interval)
-                poll_resp = client.post(
+                poll_resp = _post_codex_auth_json(
+                    client,
                     f"{issuer}/api/accounts/deviceauth/token",
+                    label="device auth poll",
+                    code="device_code_poll_invalid",
                     json={"device_auth_id": device_auth_id, "user_code": user_code},
                     headers={"Content-Type": "application/json"},
                 )
 
                 if poll_resp.status_code == 200:
-                    code_resp = poll_resp.json()
+                    code_resp = poll_resp.payload or {}
                     break
                 elif poll_resp.status_code in {403, 404}:
                     continue  # User hasn't completed login yet
@@ -8238,8 +8355,11 @@ def _codex_device_code_login() -> Dict[str, Any]:
 
     try:
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-            token_resp = client.post(
+            token_resp = _post_codex_auth_json(
+                client,
                 CODEX_OAUTH_TOKEN_URL,
+                label="token exchange",
+                code="token_exchange_invalid",
                 data={
                     "grant_type": "authorization_code",
                     "code": authorization_code,
@@ -8250,6 +8370,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
     except Exception as exc:
+        if isinstance(exc, AuthError):
+            raise
         raise AuthError(
             f"Token exchange failed: {exc}",
             provider="openai-codex", code="token_exchange_failed",
@@ -8277,7 +8399,7 @@ def _codex_device_code_login() -> Dict[str, Any]:
             provider="openai-codex", code="token_exchange_error",
         )
 
-    tokens = token_resp.json()
+    tokens = token_resp.payload or {}
     access_token = tokens.get("access_token", "")
     refresh_token = tokens.get("refresh_token", "")
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7509,19 +7509,23 @@ def _codex_full_login_worker(session_id: str) -> None:
             CODEX_OAUTH_CLIENT_ID,
             CODEX_OAUTH_TOKEN_URL,
             DEFAULT_CODEX_BASE_URL,
+            _post_codex_auth_json,
         )
         issuer = "https://auth.openai.com"
 
         # Step 1: request device code
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-            resp = client.post(
+            resp = _post_codex_auth_json(
+                client,
                 f"{issuer}/api/accounts/deviceauth/usercode",
+                label="dashboard device code",
+                code="dashboard_device_code_response_invalid",
                 json={"client_id": CODEX_OAUTH_CLIENT_ID},
                 headers={"Content-Type": "application/json"},
             )
         if resp.status_code != 200:
             raise RuntimeError(f"deviceauth/usercode returned {resp.status_code}")
-        device_data = resp.json()
+        device_data = resp.payload or {}
         user_code = device_data.get("user_code", "")
         device_auth_id = device_data.get("device_auth_id", "")
         poll_interval = max(3, int(device_data.get("interval", "5")))
@@ -7545,13 +7549,16 @@ def _codex_full_login_worker(session_id: str) -> None:
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
             while time.monotonic() < deadline:
                 time.sleep(poll_interval)
-                poll = client.post(
+                poll = _post_codex_auth_json(
+                    client,
                     f"{issuer}/api/accounts/deviceauth/token",
+                    label="dashboard device auth poll",
+                    code="dashboard_device_code_poll_invalid",
                     json={"device_auth_id": device_auth_id, "user_code": user_code},
                     headers={"Content-Type": "application/json"},
                 )
                 if poll.status_code == 200:
-                    code_resp = poll.json()
+                    code_resp = poll.payload or {}
                     break
                 if poll.status_code in {403, 404}:
                     continue  # user hasn't authorized yet
@@ -7569,8 +7576,11 @@ def _codex_full_login_worker(session_id: str) -> None:
         if not authorization_code or not code_verifier:
             raise RuntimeError("device-auth response missing authorization_code/code_verifier")
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-            token_resp = client.post(
+            token_resp = _post_codex_auth_json(
+                client,
                 CODEX_OAUTH_TOKEN_URL,
+                label="dashboard token exchange",
+                code="dashboard_token_exchange_invalid",
                 data={
                     "grant_type": "authorization_code",
                     "code": authorization_code,
@@ -7582,7 +7592,7 @@ def _codex_full_login_worker(session_id: str) -> None:
             )
         if token_resp.status_code != 200:
             raise RuntimeError(f"token exchange returned {token_resp.status_code}")
-        tokens = token_resp.json()
+        tokens = token_resp.payload or {}
         access_token = tokens.get("access_token", "")
         refresh_token = tokens.get("refresh_token", "")
         if not access_token:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10963,19 +10963,25 @@ def _codex_full_login_worker(session_id: str) -> None:
         from hermes_cli.auth import (
             CODEX_OAUTH_CLIENT_ID,
             CODEX_OAUTH_TOKEN_URL,
+            _post_codex_auth_json,
         )
         issuer = "https://auth.openai.com"
 
         # Step 1: request device code
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-            resp = client.post(
+            resp = _post_codex_auth_json(
+                client,
                 f"{issuer}/api/accounts/deviceauth/usercode",
+                label="dashboard device code",
+                code="dashboard_device_code_response_invalid",
+                read_error_body=True,
+                read_rate_limit_body=True,
                 json={"client_id": CODEX_OAUTH_CLIENT_ID},
                 headers={"Content-Type": "application/json"},
             )
         if resp.status_code != 200:
             raise RuntimeError(_codex_device_code_start_error(resp))
-        device_data = resp.json()
+        device_data = resp.payload or {}
         user_code = device_data.get("user_code", "")
         device_auth_id = device_data.get("device_auth_id", "")
         poll_interval = max(3, int(device_data.get("interval", "5")))
@@ -11009,13 +11015,16 @@ def _codex_full_login_worker(session_id: str) -> None:
                 if sess.get("cancelled"):
                     _log.info("oauth/device: openai-codex login cancelled (session=%s)", session_id)
                     return
-                poll = client.post(
+                poll = _post_codex_auth_json(
+                    client,
                     f"{issuer}/api/accounts/deviceauth/token",
+                    label="dashboard device auth poll",
+                    code="dashboard_device_code_poll_invalid",
                     json={"device_auth_id": device_auth_id, "user_code": user_code},
                     headers={"Content-Type": "application/json"},
                 )
                 if poll.status_code == 200:
-                    code_resp = poll.json()
+                    code_resp = poll.payload or {}
                     break
                 if poll.status_code in {403, 404}:
                     continue  # user hasn't authorized yet
@@ -11037,8 +11046,11 @@ def _codex_full_login_worker(session_id: str) -> None:
         if not authorization_code or not code_verifier:
             raise RuntimeError("device-auth response missing authorization_code/code_verifier")
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-            token_resp = client.post(
+            token_resp = _post_codex_auth_json(
+                client,
                 CODEX_OAUTH_TOKEN_URL,
+                label="dashboard token exchange",
+                code="dashboard_token_exchange_invalid",
                 data={
                     "grant_type": "authorization_code",
                     "code": authorization_code,
@@ -11050,7 +11062,7 @@ def _codex_full_login_worker(session_id: str) -> None:
             )
         if token_resp.status_code != 200:
             raise RuntimeError(f"token exchange returned {token_resp.status_code}")
-        tokens = token_resp.json()
+        tokens = token_resp.payload or {}
         access_token = tokens.get("access_token", "")
         refresh_token = tokens.get("refresh_token", "")
         if not access_token:

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -1020,6 +1020,23 @@ class _FakeResp:
     def json(self):
         return self._json
 
+    def iter_bytes(self):
+        if isinstance(self._json, bytes):
+            yield self._json
+        else:
+            yield json.dumps(self._json).encode("utf-8")
+
+
+class _FakeStream:
+    def __init__(self, response):
+        self.response = response
+
+    def __enter__(self):
+        return self.response
+
+    def __exit__(self, *args):
+        return False
+
 
 def _patch_httpx_post(monkeypatch, responses):
     """Patch hermes_cli.auth.httpx.Client so .post() returns queued responses."""
@@ -1034,6 +1051,9 @@ def _patch_httpx_post(monkeypatch, responses):
 
         def post(self, *args, **kwargs):
             return next(seq)
+
+        def stream(self, *args, **kwargs):
+            return _FakeStream(next(seq))
 
     monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **k: _FakeClient())
 
@@ -1093,3 +1113,55 @@ def test_device_code_login_non_429_error_unchanged(monkeypatch):
         auth_mod._codex_device_code_login()
 
     assert exc_info.value.code == "device_code_request_error"
+
+
+def test_device_code_login_bounds_device_code_json(monkeypatch):
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    monkeypatch.setattr(auth_mod, "CODEX_AUTH_JSON_BODY_MAX_BYTES", 8)
+    _patch_httpx_post(monkeypatch, [_FakeResp(200, b"x" * 9)])
+
+    with pytest.raises(AuthError, match="device code response exceeded 8 bytes") as exc_info:
+        auth_mod._codex_device_code_login()
+
+    assert exc_info.value.code == "device_code_response_invalid"
+
+
+def test_device_code_login_bounds_poll_json(monkeypatch):
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    monkeypatch.setattr(auth_mod, "CODEX_AUTH_JSON_BODY_MAX_BYTES", 128)
+    _patch_httpx_post(
+        monkeypatch,
+        [
+            _FakeResp(200, {"user_code": "ABCD", "device_auth_id": "dev-1", "interval": "5"}),
+            _FakeResp(200, b"x" * 129),
+        ],
+    )
+
+    with pytest.raises(AuthError, match="device auth poll response exceeded 128 bytes") as exc_info:
+        auth_mod._codex_device_code_login()
+
+    assert exc_info.value.code == "device_code_poll_invalid"
+
+
+def test_device_code_login_bounds_token_exchange_json(monkeypatch):
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    monkeypatch.setattr(auth_mod, "CODEX_AUTH_JSON_BODY_MAX_BYTES", 128)
+    _patch_httpx_post(
+        monkeypatch,
+        [
+            _FakeResp(200, {"user_code": "ABCD", "device_auth_id": "dev-1", "interval": "5"}),
+            _FakeResp(200, {"authorization_code": "auth-code", "code_verifier": "verifier"}),
+            _FakeResp(200, b"x" * 129),
+        ],
+    )
+
+    with pytest.raises(AuthError, match="token exchange response exceeded 128 bytes") as exc_info:
+        auth_mod._codex_device_code_login()
+
+    assert exc_info.value.code == "token_exchange_invalid"

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -488,6 +488,27 @@ class _StubHTTPResponse:
             raise self._payload
         return self._payload
 
+    def iter_bytes(self):
+        if self.headers.get("content-encoding"):
+            raise AssertionError("encoded bodies must not be decoded")
+        if isinstance(self._payload, bytes):
+            yield self._payload
+        elif isinstance(self._payload, Exception):
+            yield b"not-json"
+        else:
+            yield json.dumps(self._payload).encode()
+
+
+class _FakeStream:
+    def __init__(self, response):
+        self.response = response
+
+    def __enter__(self):
+        return self.response
+
+    def __exit__(self, *args):
+        return False
+
 
 class _StubHTTPClient:
     def __init__(self, response):
@@ -501,6 +522,10 @@ class _StubHTTPClient:
 
     def post(self, *args, **kwargs):
         return self._response
+
+    def stream(self, *args, **kwargs):
+        assert kwargs["headers"]["accept-encoding"] == "identity"
+        return _FakeStream(self._response)
 
 
 def _patch_httpx(monkeypatch, response):
@@ -562,6 +587,68 @@ def test_refresh_429_without_retry_after_header(monkeypatch):
     assert "quota exhausted" in str(err).lower()
 
 
+def test_refresh_rejects_oversized_streamed_json(monkeypatch):
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr(auth_mod, "CODEX_AUTH_JSON_BODY_MAX_BYTES", 8, raising=False)
+    _patch_httpx(monkeypatch, _StubHTTPResponse(200, b"x" * 9))
+
+    with pytest.raises(AuthError, match="token refresh response exceeded 8 bytes") as exc_info:
+        refresh_codex_oauth_pure("a-tok", "r-tok")
+
+    assert exc_info.value.code == "codex_refresh_invalid_json"
+    assert exc_info.value.relogin_required is False
+
+
+def test_refresh_preserves_structured_error_from_bounded_body(monkeypatch):
+    _patch_httpx(
+        monkeypatch,
+        _StubHTTPResponse(
+            400,
+            {"error": {"code": "invalid_grant", "message": "refresh token expired"}},
+        ),
+    )
+
+    with pytest.raises(AuthError) as exc_info:
+        refresh_codex_oauth_pure("a-tok", "r-tok")
+
+    assert exc_info.value.code == "invalid_grant"
+    assert exc_info.value.relogin_required is True
+    assert "refresh token expired" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        _StubHTTPResponse(401, b"x" * 9),
+        _StubHTTPResponse(401, {}, headers={"content-encoding": "gzip"}),
+    ],
+)
+def test_refresh_preserves_401_relogin_when_error_body_is_unreadable(monkeypatch, response):
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr(auth_mod, "CODEX_AUTH_JSON_BODY_MAX_BYTES", 8, raising=False)
+    _patch_httpx(monkeypatch, response)
+
+    with pytest.raises(AuthError) as exc_info:
+        refresh_codex_oauth_pure("a-tok", "r-tok")
+
+    assert exc_info.value.code == "codex_refresh_failed"
+    assert exc_info.value.relogin_required is True
+
+
+def test_refresh_rejects_encoded_success_before_decoding(monkeypatch):
+    response = _StubHTTPResponse(
+        200,
+        {"access_token": "at", "refresh_token": "rt"},
+        headers={"content-encoding": "gzip"},
+    )
+    _patch_httpx(monkeypatch, response)
+
+    with pytest.raises(AuthError, match="unsupported Content-Encoding gzip"):
+        refresh_codex_oauth_pure("a-tok", "r-tok")
+
+
 def test_is_rate_limited_auth_error_distinguishes_credential_errors():
     """Missing/expired credentials must NOT be treated as rate-limit errors."""
     from hermes_cli.auth import CODEX_RATE_LIMITED_CODE, is_rate_limited_auth_error
@@ -591,6 +678,12 @@ class _FakeResp:
     def json(self):
         return self._json
 
+    def iter_bytes(self):
+        if isinstance(self._json, bytes):
+            yield self._json
+        else:
+            yield json.dumps(self._json).encode()
+
 
 def _patch_httpx_post(monkeypatch, responses):
     """Patch hermes_cli.auth.httpx.Client so .post() returns queued responses."""
@@ -606,7 +699,46 @@ def _patch_httpx_post(monkeypatch, responses):
         def post(self, *args, **kwargs):
             return next(seq)
 
+        def stream(self, *args, **kwargs):
+            return _FakeStream(next(seq))
+
     monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **k: _FakeClient())
+
+
+@pytest.mark.parametrize(
+    ("responses", "label", "code"),
+    [
+        ([_FakeResp(200, b"x" * 257)], "device code", "device_code_response_invalid"),
+        (
+            [
+                _FakeResp(200, {"user_code": "ABCD", "device_auth_id": "dev", "interval": 3}),
+                _FakeResp(200, b"x" * 257),
+            ],
+            "device auth poll",
+            "device_code_poll_invalid",
+        ),
+        (
+            [
+                _FakeResp(200, {"user_code": "ABCD", "device_auth_id": "dev", "interval": 3}),
+                _FakeResp(200, {"authorization_code": "code", "code_verifier": "verifier"}),
+                _FakeResp(200, b"x" * 257),
+            ],
+            "token exchange",
+            "token_exchange_invalid",
+        ),
+    ],
+)
+def test_device_code_login_bounds_each_json_response(monkeypatch, responses, label, code):
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(auth_mod, "CODEX_AUTH_JSON_BODY_MAX_BYTES", 256, raising=False)
+    _patch_httpx_post(monkeypatch, responses)
+
+    with pytest.raises(AuthError, match=rf"{label} response exceeded 256 bytes") as exc_info:
+        auth_mod._codex_device_code_login()
+
+    assert exc_info.value.code == code
 
 
 

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -20,6 +20,7 @@ The fix:
 These tests pin the corrected behavior.
 """
 import asyncio
+import json
 import time
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -225,9 +226,26 @@ def test_codex_dashboard_worker_persists_runtime_provider(tmp_path, monkeypatch)
         def __init__(self, status_code, payload):
             self.status_code = status_code
             self._payload = payload
+            self.headers = {}
 
         def json(self):
             return self._payload
+
+        def iter_bytes(self):
+            if isinstance(self._payload, bytes):
+                yield self._payload
+            else:
+                yield json.dumps(self._payload).encode("utf-8")
+
+    class _Stream:
+        def __init__(self, response):
+            self.response = response
+
+        def __enter__(self):
+            return self.response
+
+        def __exit__(self, *args):
+            return False
 
     class _Client:
         def __init__(self, *args, **kwargs):
@@ -255,6 +273,9 @@ def test_codex_dashboard_worker_persists_runtime_provider(tmp_path, monkeypatch)
                 "access_token": access_token,
                 "refresh_token": "codex-refresh",
             })
+
+        def stream(self, method, url, **kwargs):
+            return _Stream(self.post(url, **kwargs))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setattr(httpx, "Client", _Client)
@@ -286,9 +307,26 @@ def test_codex_dashboard_worker_persists_inside_session_profile(tmp_path, monkey
         def __init__(self, status_code, payload):
             self.status_code = status_code
             self._payload = payload
+            self.headers = {}
 
         def json(self):
             return self._payload
+
+        def iter_bytes(self):
+            if isinstance(self._payload, bytes):
+                yield self._payload
+            else:
+                yield json.dumps(self._payload).encode("utf-8")
+
+    class _Stream:
+        def __init__(self, response):
+            self.response = response
+
+        def __enter__(self):
+            return self.response
+
+        def __exit__(self, *args):
+            return False
 
     class _Client:
         def __init__(self, *args, **kwargs):
@@ -317,6 +355,9 @@ def test_codex_dashboard_worker_persists_inside_session_profile(tmp_path, monkey
                 "refresh_token": "codex-refresh",
             })
 
+        def stream(self, method, url, **kwargs):
+            return _Stream(self.post(url, **kwargs))
+
     saved_homes = []
     monkeypatch.setattr(httpx, "Client", _Client)
     monkeypatch.setattr(ws.time, "sleep", lambda _: None)
@@ -336,6 +377,54 @@ def test_codex_dashboard_worker_persists_inside_session_profile(tmp_path, monkey
 
         assert ws._oauth_sessions[sid]["status"] == "approved"
         assert saved_homes == [profile_home]
+    finally:
+        ws._oauth_sessions.pop(sid, None)
+
+
+def test_codex_dashboard_worker_bounds_device_code_json(tmp_path, monkeypatch):
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server as ws
+
+    class _Resp:
+        status_code = 200
+        headers = {}
+
+        def iter_bytes(self):
+            yield b"x" * 9
+
+    class _Stream:
+        def __enter__(self):
+            return _Resp()
+
+        def __exit__(self, *args):
+            return False
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def stream(self, *args, **kwargs):
+            return _Stream()
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(httpx, "Client", _Client)
+    monkeypatch.setattr(auth_mod, "CODEX_AUTH_JSON_BODY_MAX_BYTES", 8)
+
+    sid, _ = ws._new_oauth_session("openai-codex", "device_code")
+    try:
+        ws._codex_full_login_worker(sid)
+
+        assert ws._oauth_sessions[sid]["status"] == "error"
+        assert (
+            "dashboard device code response exceeded 8 bytes"
+            in ws._oauth_sessions[sid]["error_message"]
+        )
     finally:
         ws._oauth_sessions.pop(sid, None)
 

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -35,6 +35,17 @@ client = TestClient(app)
 HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}
 
 
+class _ResponseStream:
+    def __init__(self, response):
+        self.response = response
+
+    def __enter__(self):
+        return self.response
+
+    def __exit__(self, *args):
+        return False
+
+
 def _make_profile_home(tmp_path, monkeypatch, profile="coder"):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     profile_home = tmp_path / "profiles" / profile
@@ -173,13 +184,15 @@ def test_oauth_start_stores_profile_for_background_completion(tmp_path, monkeypa
 
 
 
-def test_codex_dashboard_start_rewords_device_authorization_error(monkeypatch):
+@pytest.mark.parametrize("provider_status", [400, 429])
+def test_codex_dashboard_start_rewords_device_authorization_error(monkeypatch, provider_status):
     from hermes_cli import web_server as ws
 
     before_sessions = set(ws._oauth_sessions)
 
     class _Resp:
-        status_code = 400
+        status_code = provider_status
+        headers = {}
         text = "Enable device code authorization"
 
         def json(self):
@@ -189,6 +202,9 @@ def test_codex_dashboard_start_rewords_device_authorization_error(monkeypatch):
                     "code": "device_authorization_not_enabled",
                 }
             }
+
+        def iter_bytes(self):
+            yield json.dumps(self.json()).encode()
 
     class _Client:
         def __init__(self, *args, **kwargs):
@@ -200,9 +216,12 @@ def test_codex_dashboard_start_rewords_device_authorization_error(monkeypatch):
         def __exit__(self, *args):
             return False
 
-        def post(self, url, **kwargs):
+        def stream(self, method, url, **kwargs):
             assert url.endswith("/deviceauth/usercode")
-            return _Resp()
+            return _ResponseStream(_Resp())
+
+        def post(self, url, **kwargs):
+            return self.stream("POST", url, **kwargs).response
 
     monkeypatch.setattr(httpx, "Client", _Client)
 
@@ -221,6 +240,66 @@ def test_codex_dashboard_start_rewords_device_authorization_error(monkeypatch):
     finally:
         for sid in set(ws._oauth_sessions) - before_sessions:
             ws._oauth_sessions.pop(sid, None)
+
+
+@pytest.mark.parametrize(
+    ("responses", "label"),
+    [
+        ([{"user_code": "code", "device_auth_id": "dev", "pad": "x" * 300}], "dashboard device code"),
+        (
+            [
+                {"user_code": "code", "device_auth_id": "dev", "interval": 0},
+                {"authorization_code": "code", "code_verifier": "verifier", "pad": "x" * 300},
+            ],
+            "dashboard device auth poll",
+        ),
+        (
+            [
+                {"user_code": "code", "device_auth_id": "dev", "interval": 0},
+                {"authorization_code": "code", "code_verifier": "verifier"},
+                {"access_token": "at", "refresh_token": "rt", "pad": "x" * 300},
+            ],
+            "dashboard token exchange",
+        ),
+    ],
+)
+def test_codex_dashboard_worker_bounds_each_json_response(tmp_path, monkeypatch, responses, label):
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server as ws
+
+    class _Resp:
+        status_code = 200
+        headers = {}
+
+        def __init__(self, payload):
+            self.body = json.dumps(payload).encode()
+
+        def iter_bytes(self):
+            yield self.body
+
+        def json(self):
+            return json.loads(self.body)
+
+    queued = iter(_Resp(payload) for payload in responses)
+
+    class _Client:
+        def __enter__(self): return self
+        def __exit__(self, *args): return False
+        def post(self, *args, **kwargs): return next(queued)
+        def stream(self, *args, **kwargs): return _ResponseStream(next(queued))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(httpx, "Client", lambda *args, **kwargs: _Client())
+    monkeypatch.setattr(ws.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(auth_mod, "CODEX_AUTH_JSON_BODY_MAX_BYTES", 256, raising=False)
+    monkeypatch.setattr(auth_mod, "_save_codex_tokens", lambda _tokens: None)
+
+    sid, _ = ws._new_oauth_session("openai-codex", "device_code")
+    try:
+        ws._codex_full_login_worker(sid)
+        assert f"{label} response exceeded 256 bytes" in ws._oauth_sessions[sid]["error_message"]
+    finally:
+        ws._oauth_sessions.pop(sid, None)
 
 
 def test_codex_dashboard_worker_stops_polling_after_cancel(tmp_path, monkeypatch):
@@ -245,9 +324,13 @@ def test_codex_dashboard_worker_stops_polling_after_cancel(tmp_path, monkeypatch
         def __init__(self, status_code, payload):
             self.status_code = status_code
             self._payload = payload
+            self.headers = {}
 
         def json(self):
             return self._payload
+
+        def iter_bytes(self):
+            yield json.dumps(self._payload).encode()
 
     class _Client:
         def __init__(self, *args, **kwargs):
@@ -259,16 +342,19 @@ def test_codex_dashboard_worker_stops_polling_after_cancel(tmp_path, monkeypatch
         def __exit__(self, *args):
             return False
 
-        def post(self, url, **kwargs):
+        def stream(self, method, url, **kwargs):
             if url.endswith("/deviceauth/usercode"):
-                return _Resp(200, {
+                return _ResponseStream(_Resp(200, {
                     "device_auth_id": "device-auth-id",
                     "interval": 3,
                     "user_code": "CODEX-1234",
-                })
+                }))
             raise AssertionError(
                 f"worker must stop before calling {url} once cancelled"
             )
+
+        def post(self, url, **kwargs):
+            return self.stream("POST", url, **kwargs).response
 
     saved = []
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -315,9 +401,13 @@ def test_codex_worker_final_save_is_atomic_with_cancel_delete(tmp_path, monkeypa
         def __init__(self, status_code, payload):
             self.status_code = status_code
             self._payload = payload
+            self.headers = {}
 
         def json(self):
             return self._payload
+
+        def iter_bytes(self):
+            yield json.dumps(self._payload).encode()
 
     class _Client:
         def __init__(self, *args, **kwargs):
@@ -329,21 +419,31 @@ def test_codex_worker_final_save_is_atomic_with_cancel_delete(tmp_path, monkeypa
         def __exit__(self, *args):
             return False
 
-        def post(self, url, **kwargs):
+        def stream(self, method, url, **kwargs):
             if url.endswith("/deviceauth/usercode"):
-                return _Resp(200, {
+                response = _Resp(200, {
                     "device_auth_id": "device-auth-id",
                     "interval": 0,
                     "user_code": "CODEX-1234",
                 })
-            return _Resp(200, {
-                "authorization_code": "auth-code",
-                "code_verifier": "verifier",
-            })
+            else:
+                response = _Resp(200, {
+                    "authorization_code": "auth-code",
+                    "code_verifier": "verifier",
+                })
+            return _ResponseStream(response)
+
+        def post(self, url, **kwargs):
+            return self.stream("POST", url, **kwargs).response
 
     class _TokenClient(_Client):
+        def stream(self, method, url, **kwargs):
+            return _ResponseStream(
+                _Resp(200, {"access_token": "at", "refresh_token": "rt"})
+            )
+
         def post(self, url, **kwargs):
-            return _Resp(200, {"access_token": "at", "refresh_token": "rt"})
+            return self.stream("POST", url, **kwargs).response
 
     clients = iter([_Client, _Client, _TokenClient])
     _make_profile_home(tmp_path, monkeypatch, profile="coder")


### PR DESCRIPTION
## Summary
- add a streamed bounded JSON reader for OpenAI Codex device-code auth responses
- route CLI device-code creation, auth polling, and token exchange through the bounded reader
- route the dashboard Codex full-login worker through the same bounded reader
- preserve existing 429/non-200 status handling while capping successful JSON bodies at 1 MiB
- add regression tests for oversized JSON at all three CLI stages plus the dashboard entry point

Fixes #55253.

## Validation
- `PYTHONPATH=$PWD C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests\hermes_cli\test_auth_codex_provider.py tests\hermes_cli\test_web_oauth_dispatch.py -q --basetemp .pytest-tmp-codex-auth-json-web` -> 61 passed
- `PYTHONPATH=$PWD C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check hermes_cli\auth.py hermes_cli\web_server.py tests\hermes_cli\test_auth_codex_provider.py tests\hermes_cli\test_web_oauth_dispatch.py` -> passed
- `git diff --check` -> passed

## Notes
This is separate from #54750, which bounds `hermes_cli.copilot_auth`. This PR covers the `openai-codex` device-code flow in both `hermes_cli.auth` and the dashboard login worker in `hermes_cli.web_server`.