### PR TITLE
fix(lsp): strip credentials from language server env

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -62,6 +62,7 @@ from agent.lsp.protocol import (
     make_response,
     read_message,
 )
+from tools.environments.local import hermes_subprocess_env
 
 logger = logging.getLogger("agent.lsp.client")
 
@@ -254,7 +255,7 @@ class LSPClient:
         return cmd
 
     async def _spawn(self) -> None:
-        env = dict(os.environ)
+        env = hermes_subprocess_env(inherit_credentials=False)
         if self._env:
             env.update(self._env)
 

--- a/tests/agent/lsp/test_client_env.py
+++ b/tests/agent/lsp/test_client_env.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from agent.lsp.client import LSPClient
+from agent.lsp.protocol import LSPProtocolError
+
+
+async def _capture_spawn_env(monkeypatch: pytest.MonkeyPatch, client: LSPClient) -> dict[str, str]:
+    captured: dict[str, str] = {}
+
+    async def fake_create_subprocess_exec(*_args, **kwargs):
+        captured.update(kwargs["env"])
+        raise FileNotFoundError("stop after capturing env")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    with pytest.raises(LSPProtocolError):
+        await client.start()
+
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_lsp_subprocess_env_strips_parent_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-parent-openai")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-parent-anthropic")
+    monkeypatch.setenv("GH_TOKEN", "gh-parent-token")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-parent-token")
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "dashboard-parent-token")
+    monkeypatch.setenv("PATH", os.environ.get("PATH", ""))
+
+    client = LSPClient(
+        server_id="mock",
+        workspace_root=str(tmp_path),
+        command=["missing-lsp"],
+    )
+
+    env = await _capture_spawn_env(monkeypatch, client)
+
+    assert "OPENAI_API_KEY" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "GH_TOKEN" not in env
+    assert "TELEGRAM_BOT_TOKEN" not in env
+    assert "HERMES_DASHBOARD_SESSION_TOKEN" not in env
+    assert env.get("PATH") == os.environ.get("PATH", "")
+
+
+@pytest.mark.asyncio
+async def test_lsp_explicit_env_overrides_are_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-parent-openai")
+
+    client = LSPClient(
+        server_id="mock",
+        workspace_root=str(tmp_path),
+        command=["missing-lsp"],
+        env={
+            "OPENAI_API_KEY": "explicit-lsp-key",
+            "CUSTOM_LSP_SETTING": "enabled",
+        },
+    )
+
+    env = await _capture_spawn_env(monkeypatch, client)
+
+    assert env["OPENAI_API_KEY"] == "explicit-lsp-key"
+    assert env["CUSTOM_LSP_SETTING"] == "enabled"


### PR DESCRIPTION
## Summary

This prevents Hermes credentials from being inherited by LSP language-server subprocesses.

`agent/lsp/client.py` previously spawned each language server with `dict(os.environ)`, then applied explicit LSP env overrides. That copied provider keys, GitHub tokens, bot tokens, dashboard tokens, and other Hermes process credentials into workspace-scoped language server processes.

## Why

Language servers are external subprocesses running in the active project workspace. They may come from project tooling or package managers, and they do not need Hermes model/provider credentials by default. Passing the full parent environment crosses the same child-process credential boundary as other subprocess env leaks.

## Changes

- Build the default LSP subprocess environment with `hermes_subprocess_env(inherit_credentials=False)`.
- Preserve explicit `env={...}` overrides passed to `LSPClient`, so intentionally configured language-server variables still work.
- Add regression tests proving parent credentials are stripped and explicit LSP env overrides are preserved.

## Tests

```text
python -m pytest tests/agent/lsp/test_client_env.py -q --timeout-method=thread
2 passed

python -m pytest tests/agent/lsp/test_client_e2e.py -q --timeout-method=thread
6 passed