### PR TITLE
Bound Weixin iLink response body reads

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -94,6 +94,8 @@ BACKOFF_DELAY_SECONDS = 30
 SESSION_EXPIRED_ERRCODE = -14
 RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
+ILINK_JSON_BODY_MAX_BYTES = 1 * 1024 * 1024
+ILINK_ERROR_BODY_MAX_BYTES = 8 * 1024
 
 
 def _is_stale_session_ret(
@@ -169,6 +171,46 @@ def _safe_id(value: Optional[str], keep: int = 8) -> str:
 
 def _json_dumps(payload: Dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+async def _read_response_text_limited(
+    response: Any,
+    *,
+    max_bytes: int,
+    label: str,
+) -> str:
+    content = getattr(response, "content", None)
+    raw: bytes
+    if content is not None and hasattr(content, "iter_chunked"):
+        chunks: List[bytes] = []
+        total = 0
+        async for chunk in content.iter_chunked(64 * 1024):
+            if not chunk:
+                continue
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+            total += len(chunk)
+            if total > max_bytes:
+                close = getattr(response, "close", None)
+                if callable(close):
+                    close()
+                raise RuntimeError(f"{label} exceeded {max_bytes} bytes")
+            chunks.append(chunk)
+        raw = b"".join(chunks)
+    else:
+        read = getattr(response, "read", None)
+        if callable(read):
+            data = await read()
+        else:
+            data = await response.text()
+        if isinstance(data, str):
+            raw = data.encode("utf-8")
+        else:
+            raw = bytes(data or b"")
+        if len(raw) > max_bytes:
+            raise RuntimeError(f"{label} exceeded {max_bytes} bytes")
+    charset = getattr(response, "charset", None) or "utf-8"
+    return raw.decode(charset, errors="replace")
 
 
 def _pkcs7_pad(data: bytes, block_size: int = 16) -> bytes:
@@ -383,9 +425,18 @@ async def _api_post(
     # invoked via asyncio.run_coroutine_threadsafe() from cron jobs.
     async def _do() -> Dict[str, Any]:
         async with session.post(url, data=body, headers=_headers(token, body)) as response:
-            raw = await response.text()
             if not response.ok:
+                raw = await _read_response_text_limited(
+                    response,
+                    max_bytes=ILINK_ERROR_BODY_MAX_BYTES,
+                    label=f"iLink POST {endpoint} error response",
+                )
                 raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
+            raw = await _read_response_text_limited(
+                response,
+                max_bytes=ILINK_JSON_BODY_MAX_BYTES,
+                label=f"iLink POST {endpoint} response",
+            )
             return json.loads(raw)
     return await asyncio.wait_for(_do(), timeout=timeout_ms / 1000)
 
@@ -407,9 +458,18 @@ async def _api_get(
     # invoked via asyncio.run_coroutine_threadsafe() from cron jobs.
     async def _do() -> Dict[str, Any]:
         async with session.get(url, headers=headers) as response:
-            raw = await response.text()
             if not response.ok:
+                raw = await _read_response_text_limited(
+                    response,
+                    max_bytes=ILINK_ERROR_BODY_MAX_BYTES,
+                    label=f"iLink GET {endpoint} error response",
+                )
                 raise RuntimeError(f"iLink GET {endpoint} HTTP {response.status}: {raw[:200]}")
+            raw = await _read_response_text_limited(
+                response,
+                max_bytes=ILINK_JSON_BODY_MAX_BYTES,
+                label=f"iLink GET {endpoint} response",
+            )
             return json.loads(raw)
     return await asyncio.wait_for(_do(), timeout=timeout_ms / 1000)
 
@@ -567,11 +627,21 @@ async def _upload_ciphertext(
             if response.status == 200:
                 encrypted_param = response.headers.get("x-encrypted-param")
                 if encrypted_param:
-                    await response.read()
+                    release = getattr(response, "release", None)
+                    if callable(release):
+                        release()
                     return encrypted_param
-                raw = await response.text()
+                raw = await _read_response_text_limited(
+                    response,
+                    max_bytes=ILINK_ERROR_BODY_MAX_BYTES,
+                    label="CDN upload response",
+                )
                 raise RuntimeError(f"CDN upload missing x-encrypted-param header: {raw[:200]}")
-            raw = await response.text()
+            raw = await _read_response_text_limited(
+                response,
+                max_bytes=ILINK_ERROR_BODY_MAX_BYTES,
+                label="CDN upload error response",
+            )
             raise RuntimeError(f"CDN upload HTTP {response.status}: {raw[:200]}")
     return await asyncio.wait_for(_do_upload(), timeout=120)
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1062,12 +1062,33 @@ class TestWeixinTextDebounce:
         assert dispatched == ["one\ntwo\nthree"]
 
 
+class _StubContent:
+    def __init__(self, response):
+        self._response = response
+
+    async def iter_chunked(self, size):
+        if self._response._delay:
+            await asyncio.sleep(self._response._delay)
+        body = self._response._body
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        for idx in range(0, len(body), size):
+            yield body[idx:idx + size]
+
+
 class _StubResponse:
     def __init__(self, *, status=200, body="{}", delay=0.0):
         self.status = status
         self.ok = 200 <= status < 300
         self._body = body
         self._delay = delay
+        self.headers = {}
+        self.charset = "utf-8"
+        self.content = _StubContent(self)
+        self.closed = False
+        self.text_called = False
+        self.read_called = False
+        self.release_called = False
 
     async def __aenter__(self):
         return self
@@ -1076,9 +1097,23 @@ class _StubResponse:
         return False
 
     async def text(self):
+        self.text_called = True
         if self._delay:
             await asyncio.sleep(self._delay)
         return self._body
+
+    async def read(self):
+        self.read_called = True
+        body = self._body
+        if isinstance(body, str):
+            return body.encode("utf-8")
+        return body
+
+    def close(self):
+        self.closed = True
+
+    def release(self):
+        self.release_called = True
 
 
 class _StubSession:
@@ -1190,6 +1225,88 @@ class TestWeixinApiTimeout:
                     timeout_ms=5000,
                 )
             )
+
+    def test_api_post_bounds_oversized_success_response(self):
+        response = _StubResponse(body=b"x" * (weixin.ILINK_JSON_BODY_MAX_BYTES + 1))
+        session = _StubSession(response)
+
+        with pytest.raises(
+            RuntimeError,
+            match=f"iLink POST ep response exceeded {weixin.ILINK_JSON_BODY_MAX_BYTES} bytes",
+        ):
+            asyncio.run(
+                weixin._api_post(
+                    session,
+                    base_url="https://weixin.example.com",
+                    endpoint="ep",
+                    payload={"k": "v"},
+                    token="tok",
+                    timeout_ms=5000,
+                )
+            )
+
+        assert response.closed is True
+        assert response.text_called is False
+
+    def test_api_get_bounds_oversized_error_response(self):
+        response = _StubResponse(status=500, body=b"x" * (weixin.ILINK_ERROR_BODY_MAX_BYTES + 1))
+        session = _StubSession(response)
+
+        with pytest.raises(
+            RuntimeError,
+            match=(
+                f"iLink GET ep error response exceeded "
+                f"{weixin.ILINK_ERROR_BODY_MAX_BYTES} bytes"
+            ),
+        ):
+            asyncio.run(
+                weixin._api_get(
+                    session,
+                    base_url="https://weixin.example.com",
+                    endpoint="ep",
+                    timeout_ms=5000,
+                )
+            )
+
+        assert response.closed is True
+        assert response.text_called is False
+
+    def test_upload_ciphertext_bounds_oversized_error_response(self):
+        response = _StubResponse(status=500, body=b"x" * (weixin.ILINK_ERROR_BODY_MAX_BYTES + 1))
+        session = _StubSession(response)
+
+        with pytest.raises(
+            RuntimeError,
+            match=f"CDN upload error response exceeded {weixin.ILINK_ERROR_BODY_MAX_BYTES} bytes",
+        ):
+            asyncio.run(
+                weixin._upload_ciphertext(
+                    session,
+                    ciphertext=b"encrypted",
+                    upload_url="https://novac2c.cdn.weixin.qq.com/c2c/upload",
+                )
+            )
+
+        assert response.closed is True
+        assert response.text_called is False
+
+    def test_upload_ciphertext_success_releases_without_reading_body(self):
+        response = _StubResponse(body=b"x" * (weixin.ILINK_JSON_BODY_MAX_BYTES + 1))
+        response.headers["x-encrypted-param"] = "encrypted-param"
+        session = _StubSession(response)
+
+        result = asyncio.run(
+            weixin._upload_ciphertext(
+                session,
+                ciphertext=b"encrypted",
+                upload_url="https://novac2c.cdn.weixin.qq.com/c2c/upload",
+            )
+        )
+
+        assert result == "encrypted-param"
+        assert response.release_called is True
+        assert response.read_called is False
+        assert response.text_called is False
 
     def test_get_updates_returns_empty_sentinel_on_timeout(self):
         # wait_for raises asyncio.TimeoutError, which _get_updates swallows into


### PR DESCRIPTION
## Summary
- add a bounded aiohttp response-text reader for Weixin/iLink HTTP responses
- cap successful iLink JSON bodies at 1 MiB and diagnostic iLink/CDN bodies at 8 KiB
- stop reading unused CDN upload success bodies once `x-encrypted-param` is present
- add regression coverage that oversized responses close early and do not use the old `.text()` / `.read()` paths

Fixes #55257.

## Validation
- `PYTHONPATH=$PWD C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests\gateway\test_weixin.py -q --basetemp .pytest-tmp-weixin-response-cap` -> 73 passed
- `PYTHONPATH=$PWD C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check gateway\platforms\weixin.py tests\gateway\test_weixin.py` -> passed
- `git diff --check` -> passed

## Notes
This is a narrow response-body boundary fix for the Weixin/iLink adapter. It does not change Weixin session, retry, rate-limit, or message-delivery behavior.