### PR TITLE
fix(desktop): load remote model options before session

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -14,35 +14,22 @@ beforeAll(() => {
   Element.prototype.releasePointerCapture = vi.fn()
 })
 
-const getMoaModels = vi.fn()
 const getGlobalModelOptions = vi.fn()
 
 vi.mock('@/hermes', () => ({
-  getGlobalModelOptions: (...args: unknown[]) => getGlobalModelOptions(...args),
-  getMoaModels: (...args: unknown[]) => getMoaModels(...args)
+  getGlobalModelOptions: (...args: unknown[]) => getGlobalModelOptions(...args)
 }))
 
-function moaPreset() {
-  return {
-    aggregator: { provider: 'deepseek', model: 'deepseek-v4-pro' },
-    aggregator_temperature: 0.7,
-    enabled: true,
-    max_tokens: 4096,
-    reference_models: [{ provider: 'zai', model: 'glm-5.2' }],
-    reference_temperature: 0.7
-  }
-}
+// MoA presets now arrive as the catalog's virtual `moa` provider row (the same
+// payload a remote gateway's model.options returns), not the /api/model/moa
+// REST config.
+const MOA_PROVIDER = { models: ['default', 'BeastMode'], name: 'Mixture of Agents', slug: 'moa' }
 
 beforeEach(() => {
   $activeSessionId.set('runtime-1')
   $currentModel.set('')
   $currentProvider.set('')
-  getGlobalModelOptions.mockResolvedValue({ providers: [] })
-  getMoaModels.mockResolvedValue({
-    default_preset: 'default',
-    active_preset: 'default',
-    presets: { default: moaPreset(), BeastMode: moaPreset() }
-  })
+  getGlobalModelOptions.mockResolvedValue({ providers: [MOA_PROVIDER] })
 })
 
 afterEach(() => {
@@ -88,5 +75,28 @@ describe('ModelMenuPanel MoA presets', () => {
     // The check codicon renders as a sibling within the same row item.
     const item = row.closest('[role="menuitem"]') ?? row.parentElement
     expect(item?.querySelector('.codicon-check')).not.toBeNull()
+  })
+
+  it('keeps the virtual moa provider out of the main model groups (presets section only)', async () => {
+    renderPanel()
+
+    await findByText(document.body, 'MoA: BeastMode')
+
+    // The provider group header would read "Mixture of Agents"; the presets
+    // section header reads "MoA presets". Only the latter should exist.
+    expect(document.body.textContent).toContain('MoA presets')
+    expect(document.body.textContent).not.toContain('Mixture of Agents')
+  })
+
+  it('renders presets from the catalog even before a session exists', async () => {
+    $activeSessionId.set('')
+    const onSelectModel = renderPanel()
+
+    const row = await findByText(document.body, 'MoA: BeastMode')
+    fireEvent.click(row)
+
+    // Pre-session picks are UI state shipped on the next session.create — the
+    // row must not be disabled and must still route through onSelectModel.
+    expect(onSelectModel).toHaveBeenCalledWith({ model: 'BeastMode', provider: 'moa' })
   })
 })

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -16,8 +16,8 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
-import { getGlobalModelOptions, getMoaModels } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { requestModelOptions } from '@/lib/model-options'
 import {
   currentPickerSelection,
   displayModelName,
@@ -42,7 +42,7 @@ import {
   $currentProvider,
   $currentReasoningEffort
 } from '@/store/session'
-import type { MoaConfigResponse, ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
+import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
 import { ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
 
@@ -82,18 +82,10 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 
   const modelOptions = useQuery({
     queryKey: ['model-options', activeSessionId || 'global'],
-    queryFn: (): Promise<ModelOptionsResponse> => {
-      if (gateway && activeSessionId) {
-        return gateway.request<ModelOptionsResponse>('model.options', { session_id: activeSessionId })
-      }
-
-      return getGlobalModelOptions()
-    }
-  })
-
-  const moaOptions = useQuery({
-    queryKey: ['moa-presets'],
-    queryFn: (): Promise<MoaConfigResponse> => getMoaModels()
+    // Gateway-first even with no session yet: a connected (possibly remote)
+    // gateway owns the model catalog, including virtual providers like `moa`
+    // that the local REST fallback can't know about (#53817).
+    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway, sessionId: activeSessionId })
   })
 
   const { model: optionsModel, provider: optionsProvider } = currentPickerSelection(
@@ -112,9 +104,22 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 
   const providers = modelOptions.data?.providers
 
+  // The catalog carries MoA presets as a virtual `moa` provider row. Render
+  // them in their dedicated section below and keep the row out of the main
+  // provider groups so presets don't show up twice.
+  const moaPresets = useMemo(
+    () => providers?.find(provider => provider.slug.toLowerCase() === 'moa')?.models ?? [],
+    [providers]
+  )
+
+  const pickerProviders = useMemo(
+    () => providers?.filter(provider => provider.slug.toLowerCase() !== 'moa') ?? [],
+    [providers]
+  )
+
   const effectiveVisibleModels = useMemo(
-    () => effectiveVisibleKeys(visibleModels, providers ?? []),
-    [visibleModels, providers]
+    () => effectiveVisibleKeys(visibleModels, pickerProviders),
+    [visibleModels, pickerProviders]
   )
 
   // The composer picker never persists the profile default. With a session it
@@ -136,13 +141,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
     try {
       const queryKey = ['model-options', activeSessionId || 'global']
 
-      const next =
-        gateway && activeSessionId
-          ? await gateway.request<ModelOptionsResponse>('model.options', {
-              session_id: activeSessionId,
-              refresh: true
-            })
-          : await getGlobalModelOptions({ refresh: true })
+      const next = await requestModelOptions({ gateway, refresh: true, sessionId: activeSessionId })
 
       queryClient.setQueryData<ModelOptionsResponse>(queryKey, next)
     } catch {
@@ -185,18 +184,20 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
   // Previously this dispatched the one-shot `/moa` command, which ran a single
   // turn through MoA and then silently reverted to the prior model (#54670) —
   // the dropdown presented presets like persistent selections but they weren't.
+  // No session gate: like regular model rows, a pre-session pick is UI state
+  // shipped on the next session.create.
   const selectMoaPreset = async (preset: string) => {
-    if (!activeSessionId) {
+    if ((await switchTo(preset, 'moa')) === false) {
       return
     }
 
-    await switchTo(preset, 'moa')
+    closeMenu()
   }
 
   const groups = useMemo(
     () =>
-      groupModels(providers ?? [], search, { model: optionsModel, provider: optionsProvider }, effectiveVisibleModels),
-    [providers, search, optionsModel, optionsProvider, effectiveVisibleModels]
+      groupModels(pickerProviders, search, { model: optionsModel, provider: optionsProvider }, effectiveVisibleModels),
+    [pickerProviders, search, optionsModel, optionsProvider, effectiveVisibleModels]
   )
 
   return (
@@ -222,7 +223,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
         <DropdownMenuItem className={dropdownMenuRow} disabled>
           {error}
         </DropdownMenuItem>
-      ) : groups.length === 0 ? (
+      ) : groups.length === 0 && moaPresets.length === 0 ? (
         <DropdownMenuItem className={dropdownMenuRow} disabled>
           {copy.noModels}
         </DropdownMenuItem>
@@ -322,16 +323,15 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 
       <DropdownMenuSeparator className="mx-0" />
 
-      {moaOptions.data && Object.keys(moaOptions.data.presets ?? {}).length > 0 ? (
+      {moaPresets.length > 0 ? (
         <>
           <DropdownMenuLabel className={dropdownMenuSectionLabel}>MoA presets</DropdownMenuLabel>
-          {Object.keys(moaOptions.data.presets).map(preset => {
-            const isCurrentMoa = currentProvider === 'moa' && currentModel === preset
+          {moaPresets.map(preset => {
+            const isCurrentMoa = optionsProvider === 'moa' && optionsModel === preset
 
             return (
               <DropdownMenuItem
                 className={dropdownMenuRow}
-                disabled={!activeSessionId}
                 key={`moa:${preset}`}
                 onSelect={event => {
                   event.preventDefault()

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -2,11 +2,11 @@ import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 
 import { useI18n } from '@/i18n'
+import { requestModelOptions } from '@/lib/model-options'
 import { currentPickerSelection } from '@/lib/model-status-label'
-import type { ModelOptionProvider, ModelOptionsResponse, ModelPricing } from '@/types/hermes'
+import type { ModelOptionProvider, ModelPricing } from '@/types/hermes'
 
 import type { HermesGateway } from '../hermes'
-import { getGlobalModelOptions } from '../hermes'
 import { cn } from '../lib/utils'
 import { startManualOnboarding } from '../store/onboarding'
 
@@ -54,15 +54,7 @@ export function ModelPickerDialog({
 
   const modelOptions = useQuery({
     queryKey: ['model-options', sessionId || 'global'],
-    queryFn: () => {
-      if (gw && sessionId) {
-        return gw.request<ModelOptionsResponse>('model.options', {
-          session_id: sessionId
-        })
-      }
-
-      return getGlobalModelOptions()
-    },
+    queryFn: () => requestModelOptions({ gateway: gw, sessionId }),
     enabled: open
   })
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getGlobalModelOptions } from '@/hermes'
+
+import { requestModelOptions } from './model-options'
+
+const globalOptions = { model: 'hermes-4', provider: 'nous', providers: [] }
+
+vi.mock('@/hermes', () => ({
+  getGlobalModelOptions: vi.fn(() => Promise.resolve(globalOptions))
+}))
+
+describe('requestModelOptions', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the connected gateway even before a session exists', async () => {
+    const gatewayPayload = { model: 'BeastMode', provider: 'moa', providers: [] }
+
+    const gateway = {
+      request: vi.fn(() => Promise.resolve(gatewayPayload))
+    }
+
+    await expect(requestModelOptions({ gateway: gateway as never, sessionId: null })).resolves.toBe(gatewayPayload)
+
+    expect(gateway.request).toHaveBeenCalledWith('model.options', {})
+    expect(getGlobalModelOptions).not.toHaveBeenCalled()
+  })
+
+  it('passes the active session id and refresh flag through the gateway', async () => {
+    const gateway = {
+      request: vi.fn(() => Promise.resolve(globalOptions))
+    }
+
+    await requestModelOptions({ gateway: gateway as never, refresh: true, sessionId: 'session-1' })
+
+    expect(gateway.request).toHaveBeenCalledWith('model.options', {
+      refresh: true,
+      session_id: 'session-1'
+    })
+  })
+
+  it('falls back to REST when no gateway is connected', async () => {
+    await requestModelOptions({ refresh: true })
+
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ refresh: true })
+  })
+})

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -1,0 +1,25 @@
+import { getGlobalModelOptions, type HermesGateway, type ModelOptionsResponse } from '@/hermes'
+
+interface ModelOptionsRequest {
+  gateway?: HermesGateway
+  refresh?: boolean
+  sessionId?: null | string
+}
+
+export function requestModelOptions({ gateway, refresh = false, sessionId }: ModelOptionsRequest): Promise<ModelOptionsResponse> {
+  if (gateway) {
+    const params: Record<string, unknown> = {}
+
+    if (sessionId) {
+      params.session_id = sessionId
+    }
+
+    if (refresh) {
+      params.refresh = true
+    }
+
+    return gateway.request<ModelOptionsResponse>('model.options', params)
+  }
+
+  return getGlobalModelOptions(refresh ? { refresh: true } : undefined)
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop model picker path used with a remote gateway before a chat session exists.

The Desktop picker already uses the connected gateway's JSON-RPC `model.options` once there is an active session, but before that it falls back to Desktop REST/global model options. For a Windows Desktop app connected to a remote Linux gateway, that can miss virtual providers exposed by the remote gateway, including the MoA `BeastMode` preset from #53817.

This PR centralizes the Desktop model-options fetch rule so both picker surfaces prefer the connected gateway whenever one is available, even with no session id yet. REST/global model options remain the fallback when no gateway is connected.

It also fixes the status-bar MoA preset section to switch via the normal provider/model path (`provider=moa`, `model=<preset>`) instead of dispatching `/moa <preset>`, which is now one-shot prompt sugar rather than sticky model selection.

## Related Issue

Fixes #53817

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/model-options.ts`: add shared `requestModelOptions()` helper.
- `apps/desktop/src/components/model-picker.tsx`: use gateway `model.options` whenever a gateway is connected, not only when a session id exists.
- `apps/desktop/src/app/shell/model-menu-panel.tsx`: same remote-aware model-options path for the status-bar picker, plus MoA preset selection through the standard model switch path.
- `apps/desktop/src/lib/model-options.test.ts`: cover the no-session connected-gateway regression and refresh/session parameter forwarding.

## How to Test

1. Connect Desktop to a remote gateway whose `model.options` includes the virtual `moa` provider.
2. Open the Desktop model picker before creating/resuming a session.
3. Confirm the picker reads the remote gateway catalog and shows/selects the remote `moa` presets.

Automated check run locally:

`npm --workspace apps/desktop run test:ui -- src/lib/model-options.test.ts`

Result: 3/3 passed.

Note: `npm --workspace apps/desktop run typecheck` was attempted, but this checkout currently fails before this patch on missing workspace dependency/type resolution, starting with `@testing-library/react`, `@assistant-ui/core`, and `@tanstack/react-query`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2/Linux checkout with focused Desktop vitest; native Windows remote-gateway manual verification pending

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression test:

`npm --workspace apps/desktop run test:ui -- src/lib/model-options.test.ts`

`Test Files 1 passed (1); Tests 3 passed (3)`
