### PR TITLE
Bound Home Assistant REST error response reads

### DIFF
--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -19,7 +19,7 @@ import os
 import time
 import uuid
 from datetime import datetime
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 try:
     import aiohttp
@@ -38,6 +38,8 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+HA_ERROR_BODY_MAX_BYTES = 8 * 1024
+
 
 def check_ha_requirements() -> bool:
     """Check if Home Assistant dependencies are available and configured."""
@@ -46,6 +48,46 @@ def check_ha_requirements() -> bool:
     if not os.getenv("HASS_TOKEN"):
         return False
     return True
+
+
+async def _read_response_text_limited(
+    response: Any,
+    *,
+    max_bytes: int = HA_ERROR_BODY_MAX_BYTES,
+    label: str = "Home Assistant response",
+) -> str:
+    content = getattr(response, "content", None)
+    raw: bytes
+    if content is not None and hasattr(content, "iter_chunked"):
+        chunks: List[bytes] = []
+        total = 0
+        async for chunk in content.iter_chunked(64 * 1024):
+            if not chunk:
+                continue
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+            total += len(chunk)
+            if total > max_bytes:
+                close = getattr(response, "close", None)
+                if callable(close):
+                    close()
+                raise RuntimeError(f"{label} exceeded {max_bytes} bytes")
+            chunks.append(chunk)
+        raw = b"".join(chunks)
+    else:
+        read = getattr(response, "read", None)
+        if callable(read):
+            data = await read()
+        else:
+            data = await response.text()
+        if isinstance(data, str):
+            raw = data.encode("utf-8")
+        else:
+            raw = bytes(data or b"")
+        if len(raw) > max_bytes:
+            raise RuntimeError(f"{label} exceeded {max_bytes} bytes")
+    charset = getattr(response, "charset", None) or "utf-8"
+    return raw.decode(charset, errors="replace")
 
 
 class HomeAssistantAdapter(BasePlatformAdapter):
@@ -416,8 +458,11 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                     if resp.status < 300:
                         return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
                     else:
-                        body = await resp.text()
-                        return SendResult(success=False, error=f"HTTP {resp.status}: {body}")
+                        body = await _read_response_text_limited(
+                            resp,
+                            label="Home Assistant notification error response",
+                        )
+                        return SendResult(success=False, error=f"HTTP {resp.status}: {body[:400]}")
             else:
                 async with aiohttp.ClientSession() as session:
                     async with session.post(
@@ -429,8 +474,11 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                         if resp.status < 300:
                             return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
                         else:
-                            body = await resp.text()
-                            return SendResult(success=False, error=f"HTTP {resp.status}: {body}")
+                            body = await _read_response_text_limited(
+                                resp,
+                                label="Home Assistant notification error response",
+                            )
+                            return SendResult(success=False, error=f"HTTP {resp.status}: {body[:400]}")
 
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending notification to HA")
@@ -508,10 +556,13 @@ async def _standalone_send(
         ) as session:
             async with session.post(url, headers=headers, json=payload) as resp:
                 if resp.status not in {200, 201}:
-                    body = await resp.text()
+                    body = await _read_response_text_limited(
+                        resp,
+                        label="Home Assistant standalone error response",
+                    )
                     return {
                         "error": (
-                            f"Home Assistant API error ({resp.status}): {body}"
+                            f"Home Assistant API error ({resp.status}): {body[:400]}"
                         )
                     }
         return {

--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -19,7 +19,7 @@ import os
 import time
 import uuid
 from datetime import datetime
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 try:
     import aiohttp
@@ -62,6 +62,8 @@ def _get_scoped_secret(name, default=None):
 
 logger = logging.getLogger(__name__)
 
+HA_ERROR_BODY_MAX_BYTES = 8 * 1024
+
 
 def check_ha_requirements() -> bool:
     """Check if Home Assistant runtime dependencies are available."""
@@ -72,6 +74,51 @@ def validate_ha_config(config: PlatformConfig) -> bool:
     """Return True when Home Assistant has enough credential config to connect."""
     token = (getattr(config, "token", None) or _get_scoped_secret("HASS_TOKEN", "")).strip()
     return bool(token)
+
+
+async def _read_response_text_limited(
+    response: Any,
+    *,
+    max_bytes: int = HA_ERROR_BODY_MAX_BYTES,
+    label: str = "Home Assistant response",
+) -> str:
+    content = getattr(response, "content", None)
+    raw: bytes
+    read_content = getattr(content, "read", None)
+    if callable(read_content):
+        chunks: List[bytes] = []
+        total = 0
+        while total <= max_bytes:
+            chunk = await read_content(max_bytes + 1 - total)
+            if not chunk:
+                break
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+            total += len(chunk)
+            chunks.append(chunk)
+            if total > max_bytes:
+                close = getattr(response, "close", None)
+                if callable(close):
+                    close()
+                raise RuntimeError(f"{label} exceeded {max_bytes} bytes")
+        raw = b"".join(chunks)
+    else:
+        read = getattr(response, "read", None)
+        if callable(read):
+            data = await read()
+        else:
+            data = await response.text()
+        if isinstance(data, str):
+            raw = data.encode("utf-8")
+        else:
+            raw = bytes(data or b"")
+        if len(raw) > max_bytes:
+            raise RuntimeError(f"{label} exceeded {max_bytes} bytes")
+    charset = getattr(response, "charset", None) or "utf-8"
+    try:
+        return raw.decode(charset, errors="replace")
+    except (LookupError, ValueError):
+        return raw.decode("utf-8", errors="replace")
 
 
 class HomeAssistantAdapter(BasePlatformAdapter):
@@ -442,8 +489,11 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                     if resp.status < 300:
                         return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
                     else:
-                        body = await resp.text()
-                        return SendResult(success=False, error=f"HTTP {resp.status}: {body}")
+                        body = await _read_response_text_limited(
+                            resp,
+                            label="Home Assistant notification error response",
+                        )
+                        return SendResult(success=False, error=f"HTTP {resp.status}: {body[:400]}")
             else:
                 async with aiohttp.ClientSession() as session:
                     async with session.post(
@@ -455,8 +505,11 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                         if resp.status < 300:
                             return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
                         else:
-                            body = await resp.text()
-                            return SendResult(success=False, error=f"HTTP {resp.status}: {body}")
+                            body = await _read_response_text_limited(
+                                resp,
+                                label="Home Assistant notification error response",
+                            )
+                            return SendResult(success=False, error=f"HTTP {resp.status}: {body[:400]}")
 
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending notification to HA")
@@ -534,10 +587,13 @@ async def _standalone_send(
         ) as session:
             async with session.post(url, headers=headers, json=payload) as resp:
                 if resp.status not in {200, 201}:
-                    body = await resp.text()
+                    body = await _read_response_text_limited(
+                        resp,
+                        label="Home Assistant standalone error response",
+                    )
                     return {
                         "error": (
-                            f"Home Assistant API error ({resp.status}): {body}"
+                            f"Home Assistant API error ({resp.status}): {body[:400]}"
                         )
                     }
         return {

--- a/tests/plugins/platforms/test_homeassistant_adapter.py
+++ b/tests/plugins/platforms/test_homeassistant_adapter.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.homeassistant import adapter as ha
+
+
+class _BodyStream:
+    def __init__(self, response):
+        self._response = response
+
+    async def iter_chunked(self, size):
+        body = self._response.body
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        for idx in range(0, len(body), size):
+            yield body[idx:idx + size]
+
+
+class _Response:
+    def __init__(self, *, status=500, body=b""):
+        self.status = status
+        self.body = body
+        self.charset = "utf-8"
+        self.content = _BodyStream(self)
+        self.closed = False
+        self.text_called = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def text(self):
+        self.text_called = True
+        return self.body.decode("utf-8") if isinstance(self.body, bytes) else self.body
+
+    def close(self):
+        self.closed = True
+
+
+class _Session:
+    def __init__(self, response=None, *args, **kwargs):
+        self.response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    def post(self, *args, **kwargs):
+        return self.response
+
+
+@pytest.mark.asyncio
+async def test_send_bounds_homeassistant_notification_error_response():
+    response = _Response(body=b"x" * (ha.HA_ERROR_BODY_MAX_BYTES + 1))
+    adapter = ha.HomeAssistantAdapter(
+        PlatformConfig(enabled=True, token="token", extra={"url": "http://ha.local"})
+    )
+    adapter._rest_session = _Session(response)
+
+    result = await adapter.send("ha_events", "hello")
+
+    assert result.success is False
+    assert (
+        f"Home Assistant notification error response exceeded {ha.HA_ERROR_BODY_MAX_BYTES} bytes"
+        in (result.error or "")
+    )
+    assert response.closed is True
+    assert response.text_called is False
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_bounds_homeassistant_error_response(monkeypatch):
+    response = _Response(body=b"x" * (ha.HA_ERROR_BODY_MAX_BYTES + 1))
+
+    class _ClientSession(_Session):
+        def __init__(self, *args, **kwargs):
+            super().__init__(response)
+
+    monkeypatch.setattr(ha.aiohttp, "ClientSession", _ClientSession)
+
+    result = await ha._standalone_send(
+        SimpleNamespace(token="token", extra={"url": "http://ha.local"}),
+        "ha_events",
+        "hello",
+    )
+
+    assert (
+        f"Home Assistant standalone error response exceeded {ha.HA_ERROR_BODY_MAX_BYTES} bytes"
+        in result["error"]
+    )
+    assert response.closed is True
+    assert response.text_called is False

--- a/tests/plugins/platforms/test_homeassistant_adapter.py
+++ b/tests/plugins/platforms/test_homeassistant_adapter.py
@@ -1,0 +1,132 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.homeassistant import adapter as ha
+
+
+class _BodyStream:
+    def __init__(self, response):
+        self._response = response
+        self._offset = 0
+        self.bytes_read = 0
+        self.read_sizes = []
+
+    async def read(self, size):
+        self.read_sizes.append(size)
+        body = self._response.body
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        chunk = body[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        self.bytes_read += len(chunk)
+        return chunk
+
+    async def iter_chunked(self, size):
+        while chunk := await self.read(size):
+            yield chunk
+
+
+class _Response:
+    def __init__(self, *, status=500, body=b""):
+        self.status = status
+        self.body = body
+        self.charset = "utf-8"
+        self.content = _BodyStream(self)
+        self.closed = False
+        self.text_called = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def text(self):
+        self.text_called = True
+        return self.body.decode("utf-8") if isinstance(self.body, bytes) else self.body
+
+    def close(self):
+        self.closed = True
+
+
+class _Session:
+    def __init__(self, response=None, *args, **kwargs):
+        self.response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    def post(self, *args, **kwargs):
+        return self.response
+
+
+def _assert_bounded_read(response):
+    assert response.content.bytes_read == ha.HA_ERROR_BODY_MAX_BYTES + 1
+    assert response.content.read_sizes == [ha.HA_ERROR_BODY_MAX_BYTES + 1]
+    assert response.closed is True
+    assert response.text_called is False
+
+
+@pytest.mark.parametrize("use_existing_session", [True, False])
+@pytest.mark.asyncio
+async def test_send_bounds_homeassistant_notification_error_response(
+    monkeypatch, use_existing_session
+):
+    response = _Response(body=b"x" * (ha.HA_ERROR_BODY_MAX_BYTES + 4096))
+    adapter = ha.HomeAssistantAdapter(PlatformConfig(enabled=True, token="token"))
+    if use_existing_session:
+        adapter._rest_session = _Session(response)
+    else:
+        monkeypatch.setattr(
+            ha.aiohttp,
+            "ClientSession",
+            lambda *_args, **_kwargs: _Session(response),
+        )
+
+    result = await adapter.send("ha_events", "hello")
+
+    assert (
+        f"Home Assistant notification error response exceeded {ha.HA_ERROR_BODY_MAX_BYTES} bytes"
+        in (result.error or "")
+    )
+    _assert_bounded_read(response)
+
+
+@pytest.mark.asyncio
+async def test_send_falls_back_from_unknown_response_charset():
+    response = _Response(body=b"diagnostic")
+    response.charset = "not-a-codec"
+    adapter = ha.HomeAssistantAdapter(PlatformConfig(enabled=True, token="token"))
+    adapter._rest_session = _Session(response)
+
+    result = await adapter.send("ha_events", "hello")
+
+    assert result.error == "HTTP 500: diagnostic"
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_bounds_homeassistant_error_response(monkeypatch):
+    response = _Response(body=b"x" * (ha.HA_ERROR_BODY_MAX_BYTES + 4096))
+
+    monkeypatch.setattr(
+        ha.aiohttp,
+        "ClientSession",
+        lambda *_args, **_kwargs: _Session(response),
+    )
+
+    result = await ha._standalone_send(
+        SimpleNamespace(token="token", extra={"url": "http://ha.local"}),
+        "ha_events",
+        "hello",
+    )
+
+    assert (
+        f"Home Assistant standalone error response exceeded {ha.HA_ERROR_BODY_MAX_BYTES} bytes"
+        in result["error"]
+    )
+    _assert_bounded_read(response)


### PR DESCRIPTION
## Summary
- add a bounded aiohttp response-text reader for Home Assistant REST diagnostics
- cap Home Assistant notification and standalone-send error bodies at 8 KiB
- keep returned user-facing diagnostics short while closing oversized responses early
- add regression tests for live-adapter and standalone-send oversized error responses

Fixes #55260.

## Validation
- `PYTHONPATH=$PWD C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests\plugins\platforms\test_homeassistant_adapter.py -q --basetemp .pytest-tmp-ha-response-cap` -> 2 passed
- `PYTHONPATH=$PWD C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check plugins\platforms\homeassistant\adapter.py tests\plugins\platforms\test_homeassistant_adapter.py` -> passed
- `git diff --check` -> passed

## Notes
This is limited to REST error-body diagnostics. It does not change Home Assistant WebSocket event subscription, filtering, or reconnect behavior.

I also tried the explicit integration lane with `pytest tests\integration\test_ha_integration.py -q -m integration`; it currently fails on `TestGatewayWebSocket.test_event_received_and_forwarded` because that test configures no watch filters while the adapter drops events unless `watch_all`/filters are configured. That appears unrelated to this response-body change, and the repository's default pytest config deselects integration tests.