### PR TITLE
fix(desktop): prefer live backlog over last snapshot when reconciling agent-terminal output

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/agent-terminal-stream.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/agent-terminal-stream.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  registerAgentTerminalWriter,
+  syncAgentTerminalSnapshot,
+  writeAgentTerminalChunk
+} from './agent-terminal-stream'
+
+// The module keeps process-keyed module-level state (backlog/lastSnapshots), so
+// every case uses a UNIQUE procId. A tiny xterm emulator tracks what the live
+// terminal would show: `\x1bc<rest>` clears and reseeds, anything else appends.
+function mountScreen(procId: string): { screen: () => string } {
+  let screen = ''
+
+  registerAgentTerminalWriter(procId, (chunk) => {
+    if (chunk.startsWith('\x1bc')) {
+      screen = chunk.slice(2)
+    } else {
+      screen += chunk
+    }
+  })
+
+  return { screen: () => screen }
+}
+
+describe('syncAgentTerminalSnapshot', () => {
+  it('appends only the snapshot delta past live backlog, not past the stale last snapshot', () => {
+    // Register before the first snapshot so the backlog is empty and the screen
+    // tracks exactly the delta writes — matches a live tab that mounts, then
+    // receives live chunks and a catch-up snapshot.
+    const term = mountScreen('dup-proc')
+
+    syncAgentTerminalSnapshot('dup-proc', 'AB')
+    // Live chunks advance the backlog but NOT lastSnapshots.
+    writeAgentTerminalChunk('dup-proc', 'C')
+    writeAgentTerminalChunk('dup-proc', 'D')
+    // Catch-up snapshot is a prefix-superset of BOTH the backlog ('ABCD') and the
+    // stale last snapshot ('AB'). The backlog delta ('EF') is the correct one;
+    // using the last-snapshot delta ('CDEF') re-appends the already-shown 'CD'.
+    syncAgentTerminalSnapshot('dup-proc', 'ABCDEF')
+
+    expect(term.screen()).toBe('ABCDEF')
+  })
+
+  it('appends the delta for snapshot-only growth', () => {
+    const term = mountScreen('grow-proc')
+
+    syncAgentTerminalSnapshot('grow-proc', 'hello')
+    syncAgentTerminalSnapshot('grow-proc', 'hello world')
+
+    expect(term.screen()).toBe('hello world')
+  })
+
+  it('is a no-op when a snapshot equals already-streamed live output', () => {
+    const term = mountScreen('equal-proc')
+
+    writeAgentTerminalChunk('equal-proc', 'hi')
+    syncAgentTerminalSnapshot('equal-proc', 'hi')
+
+    expect(term.screen()).toBe('hi')
+  })
+
+  it('resets to the new tail when the snapshot is not a prefix-superset of the backlog', () => {
+    const term = mountScreen('reset-proc')
+
+    syncAgentTerminalSnapshot('reset-proc', 'abc')
+    syncAgentTerminalSnapshot('reset-proc', 'xyz')
+
+    expect(term.screen()).toBe('xyz')
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/terminal/agent-terminal-stream.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/agent-terminal-stream.ts
@@ -79,15 +79,15 @@ export function syncAgentTerminalSnapshot(procId: string, output: string): void 
     return
   }
 
-  if (output.startsWith(previous)) {
-    writeAgentTerminalChunk(procId, output.slice(previous.length))
+  if (output.startsWith(body)) {
+    writeAgentTerminalChunk(procId, output.slice(body.length))
     lastSnapshots.set(procId, output)
 
     return
   }
 
-  if (output.startsWith(body)) {
-    writeAgentTerminalChunk(procId, output.slice(body.length))
+  if (output.startsWith(previous)) {
+    writeAgentTerminalChunk(procId, output.slice(previous.length))
     lastSnapshots.set(procId, output)
 
     return


### PR DESCRIPTION
## What does this PR do?

Fixes duplicated output in read-only agent-terminal tabs. When a tab receives a catch-up `process.list` snapshot **after** live `agent.terminal.output` chunks have already streamed, the recently-streamed bytes were re-appended — corrupting the on-screen mirror, the replay backlog, and what the agent's own `read_terminal` observes of its output.

## Related Issue

<!-- No filed issue; author-found regression in a fresh module (apps/desktop/.../terminal/agent-terminal-stream.ts, added 2026-06-28). -->

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/right-sidebar/terminal/agent-terminal-stream.ts` — in `syncAgentTerminalSnapshot`, check the `body` (backlog) prefix-delta **before** the `previous` (`lastSnapshots`) prefix-delta. One-block reorder; the leading equality/no-op guard and the trailing full-reset path are unchanged.
- `apps/desktop/src/app/right-sidebar/terminal/agent-terminal-stream.test.ts` — new regression test.

### Root cause

`previous` (`lastSnapshots`) only advances on snapshots, while live `writeAgentTerminalChunk` calls extend the `backlog`/`body` without touching `lastSnapshots`. So once any live chunk has streamed since the last snapshot, `body` is strictly longer than `previous`, and a catch-up snapshot is a prefix-superset of **both**. With `previous` checked first, the staler/shorter delta wins and `output.slice(previous.length)` re-appends bytes already present in `body`. `body` is the authoritative on-screen state and is always ≥ `previous`, so its (smaller) delta is the correct one.

## How to Test

1. Register a writer, then `syncAgentTerminalSnapshot(p, 'AB')`.
2. Stream live chunks: `writeAgentTerminalChunk(p, 'C')`, `writeAgentTerminalChunk(p, 'D')` (backlog now `ABCD`, `lastSnapshots` still `AB`).
3. Deliver a catch-up snapshot `syncAgentTerminalSnapshot(p, 'ABCDEF')`.
4. Before the fix the screen shows `ABCDCDEF` (the `CD` is duplicated); after the fix it correctly shows `ABCDEF`.

The new `agent-terminal-stream.test.ts` automates this (fails before the reorder with `ABCDCDEF`, passes after) and additionally locks snapshot-only growth, the live-then-equal no-op, and the tail-slide full-reset path. Verified with `vitest run --environment jsdom` over the touched terminal area.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- N/A: TypeScript desktop change; ran the desktop vitest suite for the touched area instead -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A