### PR TITLE
fix: normalize paths in test_media_files_routed_by_type for Windows 8.3 names

### DIFF
--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -338,13 +338,13 @@ class TestRunBackgroundTask:
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            assert _os.path.normpath(mock_adapter.send_voice.call_args.kwargs["audio_path"]) == _os.path.normpath(_ogg)
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            assert _os.path.normpath(mock_adapter.send_video.call_args.kwargs["video_path"]) == _os.path.normpath(_mp4)
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            assert _os.path.normpath(mock_adapter.send_image_file.call_args.kwargs["image_path"]) == _os.path.normpath(_png)
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            assert _os.path.normpath(mock_adapter.send_document.call_args.kwargs["file_path"]) == _os.path.normpath(_pdf)
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)


### PR DESCRIPTION
## What does this PR do?

On Windows with 8.3 shortname generation enabled, `tempfile.mkdtemp()` returns the shortname form (e.g. `IVANPE~1`) while the rest of the code passes through the long form (e.g. `Ivan Pervushin`). This caused `test_media_files_routed_by_type` to fail on Windows dev machines with spaces in their profile path.

Normalize both sides of the assertion with `os.path.normpath()` so the comparison works regardless of 8.3 shortname normalization.

## Related Issue

Fixes #44301

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/gateway/test_background_command.py`: Wrap 4 path assertions with `os.path.normpath()` on both sides to handle Windows 8.3 shortname normalization

## How to Test

1. On Windows with a profile path containing a space (e.g. `C:\Users\Ivan Pervushin\`):
   ```bash
   uv run --extra dev python -m pytest tests/gateway/test_background_command.py::TestRunBackgroundTask::test_media_files_routed_by_type -q
   ```
2. Should pass on both Windows (with/without 8.3 names) and POSIX

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the test and it passes on my platform: Windows
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] I've considered cross-platform impact — this IS a Windows-specific fix
- [x] I've updated tool descriptions/schemas — or N/A