### PR TITLE
fix(moa): forward resolved api_mode for MoA aggregator and reference slots

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5640,6 +5640,7 @@ def call_llm(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
+    api_mode: str = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     messages: list,
     temperature: float = None,
@@ -5674,6 +5675,11 @@ def call_llm(
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    # An explicit api_mode from the caller (e.g. a MoA slot that already
+    # resolved its provider's wire protocol) overrides the auto-derived one, so
+    # an Anthropic-Messages endpoint is not called as OpenAI chat.completions.
+    if api_mode:
+        resolved_api_mode = api_mode
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -109,6 +109,14 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
             out["base_url"] = rt["base_url"]
         if rt.get("api_key"):
             out["api_key"] = rt["api_key"]
+        # Forward the resolved api_mode so call_llm builds the request for the
+        # endpoint's actual wire protocol. Without this, an endpoint that speaks
+        # Anthropic Messages (api_mode="anthropic_messages") but whose host the
+        # URL heuristic doesn't recognize gets called as OpenAI chat.completions
+        # and returns 404. The reference path (_run_reference) and the
+        # aggregator both route through here, so both inherit correct transport.
+        if rt.get("api_mode"):
+            out["api_mode"] = rt["api_mode"]
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("MoA slot runtime resolution failed for %s: %s", _slot_label(slot), exc)
     return out

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -170,6 +170,37 @@ def test_moa_slots_routed_through_resolve_runtime_provider(monkeypatch):
     assert rt["model"] == "MiniMax-M2"
     assert rt["base_url"] == "https://minimax.example/v1"
     assert rt["api_key"] == "key-for-minimax"
+    assert rt["api_mode"] == "chat_completions"
+
+
+def test_moa_slot_runtime_forwards_anthropic_api_mode(monkeypatch):
+    """A slot resolving to an Anthropic-Messages endpoint must forward api_mode.
+
+    Regression for the aggregator 404: when a provider's endpoint speaks the
+    Anthropic Messages protocol but its host is not one the URL heuristic
+    recognizes, dropping api_mode makes call_llm build an OpenAI
+    chat.completions request against a /v1/messages-only endpoint, which 404s.
+    Forwarding the resolved api_mode keeps the slot on the correct wire format.
+    """
+    from agent import moa_loop
+
+    def fake_resolve(*, requested, target_model=None):
+        return {
+            "provider": "custom",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://anthropic-gateway.example",
+            "api_key": "key-anthropic",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve
+    )
+
+    rt = moa_loop._slot_runtime({"provider": "my-anthropic", "model": "claude-x"})
+
+    assert rt["api_mode"] == "anthropic_messages"
+    assert rt["base_url"] == "https://anthropic-gateway.example"
+    assert rt["api_key"] == "key-anthropic"
 
 
 def test_moa_codex_slot_preserves_provider_identity(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a Mixture-of-Agents aggregator failure where a turn dies with `HTTP 404` even though the reference models run fine.

A MoA slot is resolved through `resolve_runtime_provider`, which returns the provider's `base_url`, `api_key`, and `api_mode`. `agent/moa_loop.py::_slot_runtime` forwarded the first two but dropped `api_mode`. A comment claimed `call_llm` would re-derive the transport from `base_url`, but `call_llm` had no `api_mode` parameter and the only fallback is a URL heuristic that recognizes just `api.anthropic.com`, `*/anthropic` paths, and Kimi's `/coding` route.

The result: a provider whose endpoint speaks the Anthropic Messages protocol on any other host gets called as OpenAI `chat.completions`, the endpoint only answers `/v1/messages`, and the request 404s. The aggregator is the common victim since it's usually a Claude-family model. The reference path shares the same resolver, so it had the same latent gap; it just didn't surface when references resolved to OpenAI-wire endpoints.

The fix forwards the resolved `api_mode` and lets `call_llm` honor it. Both the aggregator and reference slots go through `_slot_runtime`, so both now build requests for the correct wire format. The new `call_llm` parameter defaults to `None`, so every existing caller behaves exactly as before.

## Related Issue

Fixes #55268

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moa_loop.py` (`_slot_runtime`): forward the resolved `api_mode` alongside `base_url`/`api_key`.
- `agent/auxiliary_client.py` (`call_llm`): add an optional `api_mode` parameter that overrides the auto-derived value before client resolution.
- `tests/run_agent/test_moa_loop_mode.py`: new test asserting `_slot_runtime` forwards `api_mode` for an Anthropic-wire slot, plus an added assertion on the existing slot-routing test.

## How to Test

1. Configure a MoA preset whose aggregator points at a provider with `api_mode: anthropic_messages` on a host that is not `api.anthropic.com` and not a `*/anthropic` path.
2. Before the fix: a MoA turn returns the reference draft, then fails with `API call failed after 3 retries: HTTP 404`.
3. After the fix: the aggregator call is built as an Anthropic Messages request and the turn completes.
4. Unit: `pytest tests/run_agent/test_moa_loop_mode.py -q` (18 passed locally, including the new regression test).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass (`tests/run_agent/test_moa_loop_mode.py`: 18 passed; the only failures in the wider auxiliary suite are pre-existing `pytest-asyncio` collection errors unrelated to this change)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (RHEL 8)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact or N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A
