### PR TITLE
Fix/cron delivery credential leak

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -43,6 +43,8 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
 
+from agent.redact import redact_sensitive_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -54,7 +56,7 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     stack traces into the delivery channel.
     """
     job_name = job.get("name") or job.get("id") or "cron job"
-    text = (error or "unknown error").strip()
+    text = redact_sensitive_text((error or "unknown error").strip(), force=True)
     lower = text.lower()
 
     # Provider/API failures are the common noisy path. Keep these short.

--- a/tests/cron/test_cron_error_credential_leak.py
+++ b/tests/cron/test_cron_error_credential_leak.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from cron.scheduler import _summarize_cron_failure_for_delivery
+
+
+def test_cron_failure_delivery_summary_redacts_credentials():
+    summary = _summarize_cron_failure_for_delivery(
+        {"id": "job-1", "name": "daily digest"},
+        "OpenAI error: OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890",
+    )
+
+    assert "daily digest" in summary
+    assert "sk-proj-" not in summary
+    assert "abcdefghijklmnopqrstuvwxyz1234567890" not in summary
+    assert "OPENAI_API_KEY=***" in summary
+
+
+def test_cron_failure_delivery_summary_redacts_before_provider_compaction():
+    summary = _summarize_cron_failure_for_delivery(
+        {"id": "job-2", "name": "provider check"},
+        "Provider returned 401 Unauthorized: sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890",
+    )
+
+    assert "provider check" in summary
+    assert "sk-ant-api03" not in summary
+    assert "abcdefghijklmnopqrstuvwxyz1234567890" not in summary
+    assert "provider authentication error" in summary


### PR DESCRIPTION
## Summary

This redacts secrets from cron failure summaries before they are delivered to chat platforms.

`_summarize_cron_failure_for_delivery()` already compacts noisy provider/script failures before sending them to Discord, Slack, Telegram, and other delivery targets, but it previously used the raw error text. If a provider or tool error included an API key or token, that secret could be copied into the delivered failure message.

## Changes

- Apply `redact_sensitive_text(..., force=True)` before cron failure summaries are compacted for delivery.
- Add regression coverage for raw provider/key-shaped errors reaching `_summarize_cron_failure_for_delivery()`.

## Tests

```text
python -m pytest tests/cron/test_cron_error_credential_leak.py -q --timeout-method=thread
2 passed