### PR TITLE
Fix/slack pre auth media download

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2572,22 +2572,25 @@ class SlackAdapter(BasePlatformAdapter):
             channel_type = "im"
         is_dm = channel_type in {"im", "mpim"}  # Both 1:1 and group DMs
 
-        # Early auth check: reject unauthorized users before any API calls
-        # (thread context fetch, user name resolution, file downloads).
-        # Pattern matches Telegram fix #54164 — gate at the adapter level
-        # BEFORE event construction consumes resources.
-        if user_id:
+        # Reject unauthorized users before thread lookups, name resolution,
+        # or file downloads.  The final gateway runner auth check happens
+        # after MessageEvent construction, so adapter-side media fetches need
+        # the same auth chain up front.
+        _runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        _auth_fn = getattr(_runner, "_is_user_authorized", None)
+        if user_id and callable(_auth_fn):
             _source = self.build_source(
-                chat_id=channel_id, chat_name="",
+                chat_id=channel_id,
+                chat_name="",
                 chat_type="dm" if is_dm else "group",
-                user_id=user_id, user_name="",
+                user_id=user_id,
+                user_name="",
             )
-            _runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
-            _auth_fn = getattr(_runner, "_is_user_authorized", None)
-            if callable(_auth_fn) and not _auth_fn(_source):
+            if not _auth_fn(_source):
                 logger.warning(
                     "[Slack] Early reject of unauthorized user %s in channel %s",
-                    user_id, channel_id,
+                    user_id,
+                    channel_id,
                 )
                 return
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2572,6 +2572,25 @@ class SlackAdapter(BasePlatformAdapter):
             channel_type = "im"
         is_dm = channel_type in {"im", "mpim"}  # Both 1:1 and group DMs
 
+        # Early auth check: reject unauthorized users before any API calls
+        # (thread context fetch, user name resolution, file downloads).
+        # Pattern matches Telegram fix #54164 — gate at the adapter level
+        # BEFORE event construction consumes resources.
+        if user_id:
+            _source = self.build_source(
+                chat_id=channel_id, chat_name="",
+                chat_type="dm" if is_dm else "group",
+                user_id=user_id, user_name="",
+            )
+            _runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+            _auth_fn = getattr(_runner, "_is_user_authorized", None)
+            if callable(_auth_fn) and not _auth_fn(_source):
+                logger.warning(
+                    "[Slack] Early reject of unauthorized user %s in channel %s",
+                    user_id, channel_id,
+                )
+                return
+
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
         #   new thread/session (the bot always replies in a thread).

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1526,6 +1526,49 @@ class TestIncomingDocumentHandling:
         assert msg_event.media_types == [SUPPORTED_VIDEO_TYPES[".mp4"]]
 
     @pytest.mark.asyncio
+    async def test_unauthorized_message_does_not_fetch_file_info(
+        self,
+        adapter,
+        monkeypatch,
+    ):
+        """Global gateway auth must run before Slack file metadata fetches."""
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_ALLOWED")
+
+        class Runner:
+            def _is_user_authorized(self, source):
+                return source.user_id == "U_ALLOWED"
+
+            async def handle(self, _event):
+                raise AssertionError("gateway handler should not run")
+
+        adapter._message_handler = Runner().handle
+        adapter._app.client.files_info = AsyncMock()
+
+        await adapter._handle_slack_message(
+            {
+                "type": "message",
+                "channel": "D123",
+                "channel_type": "im",
+                "user": "U_INTRUDER",
+                "text": "please read this",
+                "ts": "1234567890.000001",
+                "files": [
+                    {
+                        "id": "FSECRET",
+                        "mimetype": "text/plain",
+                        "name": "secret.txt",
+                    }
+                ],
+            }
+        )
+
+        adapter._app.client.files_info.assert_not_awaited()
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_download_failure_is_surfaced_in_message_text(self, adapter):
         """Attachment download failures (401/403/HTML-body/etc.) should be
         translated into a user-facing `[Slack attachment notice]` block so


### PR DESCRIPTION
## Summary

This rejects unauthorized Slack message events before the adapter performs file metadata fetches or media processing.

The gateway runner performs the final `_is_user_authorized` check after the adapter has already constructed a `MessageEvent`. For Slack messages with files, that meant an unauthorized sender could still trigger Slack `files_info` calls and file-processing work before the runner rejected the event.

## Changes

- Reuse the bound gateway runner auth check at the start of `_handle_slack_message()`.
- Return before thread lookup, user resolution, `files_info`, or file download work when the sender is unauthorized.
- Preserve existing behavior when the adapter is used without a bound gateway runner.
- Add a regression test proving unauthorized Slack file messages do not call `files_info`.

## Tests

```text
python -m pytest tests/gateway/test_slack.py -k "unauthorized_message_does_not_fetch_file_info or file_shared_video_fallback_fetches_file_info" -q --timeout-method=thread
2 passed