### PR TITLE
Fix/discord pre auth media download

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5304,6 +5304,28 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _handle_message(self, message: DiscordMessage, role_authorized: bool = False) -> None:
         """Handle incoming Discord messages."""
+        # Early auth check: reject unauthorized users before any API calls
+        # (auto-thread creation, channel history backfill, file downloads).
+        # Pattern matches Telegram fix #54164 — gate at the adapter level
+        # BEFORE event construction consumes resources.
+        if message.author and not role_authorized:
+            _runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+            _auth_fn = getattr(_runner, "_is_user_authorized", None)
+            if callable(_auth_fn):
+                _is_dm = isinstance(message.channel, discord.DMChannel)
+                _source = self.build_source(
+                    chat_id=str(message.channel.id), chat_name="",
+                    chat_type="dm" if _is_dm else "group",
+                    user_id=str(message.author.id),
+                    user_name=getattr(message.author, "display_name", "") or "",
+                )
+                if not _auth_fn(_source):
+                    logger.warning(
+                        "[Discord] Early reject of unauthorized user %s in channel %s",
+                        message.author.id, message.channel.id,
+                    )
+                    return
+
         # In server channels (not DMs), require the bot to be @mentioned
         # UNLESS the channel is in the free-response list or the message is
         # in a thread where the bot has already participated.

--- a/tests/gateway/test_discord_attachment_download.py
+++ b/tests/gateway/test_discord_attachment_download.py
@@ -361,6 +361,56 @@ class TestHandleMessageUsesAuthenticatedRead:
         assert event.media_types == ["image/png"]
 
     @pytest.mark.asyncio
+    async def test_unauthorized_message_does_not_read_attachment(self, monkeypatch):
+        """Gateway auth must run before Discord attachment bytes are read."""
+        adapter = _make_adapter()
+        adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+        adapter.handle_message = AsyncMock()
+
+        class Runner:
+            def _is_user_authorized(self, source):
+                return source.user_id == "allowed-user"
+
+            async def handle(self, _event):
+                raise AssertionError("gateway handler should not run")
+
+        adapter._message_handler = Runner().handle
+
+        att = SimpleNamespace(
+            url="https://cdn.discordapp.com/attachments/fake/file.png",
+            filename="file.png",
+            content_type="image/png",
+            size=len(_PNG_BYTES),
+            read=AsyncMock(return_value=_PNG_BYTES),
+        )
+
+        from datetime import datetime, timezone
+
+        class _FakeDMChannel:
+            id = 100
+            name = "dm"
+
+        monkeypatch.setattr(
+            "plugins.platforms.discord.adapter.discord.DMChannel",
+            _FakeDMChannel,
+        )
+        msg = SimpleNamespace(
+            id=1,
+            content="",
+            attachments=[att],
+            mentions=[],
+            reference=None,
+            created_at=datetime.now(timezone.utc),
+            channel=_FakeDMChannel(),
+            author=SimpleNamespace(id=42, display_name="U", name="U"),
+        )
+
+        await adapter._handle_message(msg)
+
+        att.read.assert_not_awaited()
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_native_voice_note_is_classified_as_voice(self, monkeypatch):
         """Discord native voice notes must enter the auto-STT voice path."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

This rejects unauthorized Discord messages before attachment bytes are read or cached.

Discord already has adapter-level `DISCORD_ALLOWED_*` checks, but deployments that rely on the shared gateway authorization layer (`GATEWAY_ALLOWED_USERS`, pairing, etc.) previously reached `_handle_message()` attachment processing before the runner-level `_is_user_authorized` rejection. That allowed unauthorized senders to trigger bot-session attachment reads and media caching work.

## Changes

- Add an early runner auth check at the start of `_handle_message()`.
- Return before auto-threading, history/context work, and attachment read/cache paths when the sender is unauthorized.
- Preserve role-authorized Discord flows by skipping the extra check when `role_authorized=True`.
- Add a regression test proving unauthorized messages do not read attachment bytes.

## Tests

```text
python -m pytest tests/gateway/test_discord_attachment_download.py -k "unauthorized_message_does_not_read_attachment or image_downloads_via_att_read_not_url" -q --timeout-method=thread
2 passed