### PR TITLE
fix(bluebubbles): bound REST JSON responses

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -43,6 +43,7 @@ DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 DEFAULT_WEBHOOK_PORT = 8645
 DEFAULT_WEBHOOK_PATH = "/bluebubbles-webhook"
 MAX_TEXT_LENGTH = 4000
+BLUEBUBBLES_JSON_BODY_MAX_BYTES = 16 * 1024 * 1024
 
 # BlueBubbles/iMessage does not expose a stable bot mention identity like
 # Slack (<@U...>), Telegram (@botname), or Matrix (MXID). When users opt into
@@ -217,16 +218,51 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return text
 
     async def _api_get(self, path: str) -> Dict[str, Any]:
-        assert self.client is not None
-        res = await self.client.get(self._api_url(path))
-        res.raise_for_status()
-        return res.json()
+        return await self._api_request_json("GET", path)
 
     async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         assert self.client is not None
-        res = await self.client.post(self._api_url(path), json=payload)
-        res.raise_for_status()
-        return res.json()
+        return await self._api_request_json("POST", path, json=payload)
+
+    async def _api_request_json(
+        self,
+        method: str,
+        path: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        assert self.client is not None
+        async with self.client.stream(method, self._api_url(path), **kwargs) as res:
+            res.raise_for_status()
+            return await self._read_limited_json_response(res, label=path)
+
+    @staticmethod
+    async def _read_limited_json_response(
+        res: "httpx.Response",
+        *,
+        label: str,
+    ) -> Dict[str, Any]:
+        chunks: List[bytes] = []
+        total = 0
+        async for chunk in res.aiter_bytes():
+            total += len(chunk)
+            if total > BLUEBUBBLES_JSON_BODY_MAX_BYTES:
+                await res.aclose()
+                raise RuntimeError(
+                    f"BlueBubbles {label} response exceeds "
+                    f"{BLUEBUBBLES_JSON_BODY_MAX_BYTES} bytes"
+                )
+            chunks.append(chunk)
+
+        body = b"".join(chunks)
+        try:
+            data = json.loads(body.decode(res.encoding or "utf-8"))
+        except Exception as exc:
+            raise RuntimeError(
+                f"BlueBubbles {label} returned invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(data, dict):
+            raise RuntimeError(f"BlueBubbles {label} returned non-object JSON")
+        return data
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -583,14 +619,18 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 }
                 if is_audio_message:
                     data["isAudioMessage"] = "true"
-                res = await self.client.post(
+                async with self.client.stream(
+                    "POST",
                     self._api_url("/api/v1/message/attachment"),
                     files=files,
                     data=data,
                     timeout=120,
-                )
-                res.raise_for_status()
-                result = res.json()
+                ) as res:
+                    res.raise_for_status()
+                    result = await self._read_limited_json_response(
+                        res,
+                        label="/api/v1/message/attachment",
+                    )
 
             if caption:
                 await self.send(chat_id, caption)

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -23,6 +23,45 @@ def _make_adapter(monkeypatch, **extra):
     return BlueBubblesAdapter(cfg)
 
 
+class _JsonStreamResponse:
+    encoding = "utf-8"
+
+    def __init__(self, payload=None, chunks=None, status_code=200):
+        self.payload = payload if payload is not None else {"status": 200, "data": {}}
+        self.chunks = chunks
+        self.status_code = status_code
+        self.closed = False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("request failed")
+
+    def json(self):
+        return self.payload
+
+    async def aiter_bytes(self):
+        chunks = self.chunks
+        if chunks is None:
+            chunks = [json.dumps(self.payload).encode()]
+        for chunk in chunks:
+            yield chunk
+
+    async def aclose(self):
+        self.closed = True
+
+
+class _JsonStreamContext:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.response.aclose()
+        return False
+
+
 class TestBlueBubblesConfigLoading:
     def test_apply_env_overrides_bluebubbles(self, monkeypatch):
         monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
@@ -103,6 +142,84 @@ class TestBlueBubblesHelpers:
 
         assert result.success is True
         assert sent == ["first thought", "second thought"]
+
+    @pytest.mark.asyncio
+    async def test_api_get_reads_json_via_stream(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        class Client:
+            def __init__(self):
+                self.calls = []
+
+            def stream(self, method, url, **kwargs):
+                self.calls.append((method, url, kwargs))
+                return _JsonStreamContext(
+                    _JsonStreamResponse({"status": 200, "data": {"ok": True}})
+                )
+
+        client = Client()
+        adapter.client = client
+
+        result = await adapter._api_get("/api/v1/ping")
+
+        assert result == {"status": 200, "data": {"ok": True}}
+        assert client.calls[0][0] == "GET"
+        assert "password=secret" in client.calls[0][1]
+
+    @pytest.mark.asyncio
+    async def test_api_json_reader_closes_oversized_stream(self, monkeypatch):
+        from gateway.platforms import bluebubbles
+
+        monkeypatch.setattr(bluebubbles, "BLUEBUBBLES_JSON_BODY_MAX_BYTES", 12)
+        adapter = _make_adapter(monkeypatch)
+        response = _JsonStreamResponse(chunks=[b'{"data":"', b"x" * 20])
+
+        with pytest.raises(RuntimeError, match="response exceeds"):
+            await adapter._read_limited_json_response(
+                response,
+                label="/api/v1/ping",
+            )
+
+        assert response.closed is True
+
+    @pytest.mark.asyncio
+    async def test_send_attachment_reads_upload_response_via_stream(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        adapter = _make_adapter(monkeypatch)
+        file_path = tmp_path / "photo.jpg"
+        file_path.write_bytes(b"jpeg")
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        class Client:
+            def __init__(self):
+                self.calls = []
+
+            def stream(self, method, url, **kwargs):
+                self.calls.append((method, url, kwargs))
+                return _JsonStreamContext(
+                    _JsonStreamResponse({"status": 200, "data": {"guid": "msg-1"}})
+                )
+
+        client = Client()
+        adapter.client = client
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+
+        result = await adapter._send_attachment(
+            "user@example.com",
+            str(file_path),
+            filename="photo.jpg",
+        )
+
+        assert result.success is True
+        assert result.message_id == "msg-1"
+        assert client.calls[0][0] == "POST"
+        assert "files" in client.calls[0][2]
+        assert client.calls[0][2]["timeout"] == 120
 
     def test_format_message_strips_markdown(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
@@ -636,9 +753,20 @@ class TestBlueBubblesWebhookRegistration:
                         raise Exception("delete failed")
             return R()
 
+        def mock_stream(self_inner, method, *args, **kwargs):
+            response = post_response if method.upper() == "POST" else get_response
+            return _JsonStreamContext(
+                _JsonStreamResponse(response or {"status": 200, "data": []})
+            )
+
         return type(
             "MockClient", (),
-            {"get": mock_get, "post": mock_post, "delete": mock_delete},
+            {
+                "get": mock_get,
+                "post": mock_post,
+                "delete": mock_delete,
+                "stream": mock_stream,
+            },
         )()
 
     # -- _find_registered_webhooks --


### PR DESCRIPTION
Fixes #55274

## Summary

- Switch BlueBubbles REST JSON helpers from buffered `get()` / `post()` calls to `client.stream(...)`.
- Add a 16 MiB cap while reading JSON response bytes and close the stream immediately when the cap is exceeded.
- Apply the same bounded JSON reader to the attachment-upload response body.
- Update BlueBubbles tests with stream-aware fakes and coverage for normal JSON reads, oversized stream closure, and attachment-upload response parsing.

## Scope

This intentionally does not change inbound attachment downloads. That is a separate media/cache-helper boundary and overlaps historical work such as #35297 / #42931.

## Validation

- `C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests\gateway\test_bluebubbles.py -q --basetemp .pytest-tmp-bluebubbles-response-cap-venv` → 59 passed
- `C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check gateway\platforms\bluebubbles.py tests\gateway\test_bluebubbles.py` → All checks passed
- `git diff --check`