### PR TITLE
fix(tts): synthesize mp3 then transcode to opus for .ogg targets

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1100,7 +1100,7 @@ def _generate_openai_tts(
         speed_default = tts_config.get("speed", 1.0) if isinstance(tts_config, dict) else 1.0
         speed = float(oai_config.get("speed", speed_default))
 
-    # The managed OpenAI audio gateway only proxies MANAGED_OPENAI_TTS_MODELS.
+# The managed OpenAI audio gateway only proxies MANAGED_OPENAI_TTS_MODELS.
     # A model set for direct OpenAI (e.g. "tts-1-hd") 400s there with
     # "Unsupported managed OpenAI speech model", so coerce it — unless the user
     # redirected base_url to their own endpoint, in which case respect it.
@@ -1118,7 +1118,13 @@ def _generate_openai_tts(
         )
         model = DEFAULT_OPENAI_MODEL
 
-    response_format = _tts_response_format_from_path(output_path)
+    # Determine response format from extension.
+    # Always request mp3 from the API — then transcode to OGG/Opus locally
+    # for .ogg targets.  This avoids breaking non-opus-compatible backends
+    # (e.g. Speaches/Kokoro) that reject response_format="opus".
+    wants_opus = output_path.endswith(".ogg")
+    response_format = "mp3"
+    synth_path = (output_path[:-4] + ".mp3") if wants_opus else output_path
 
     OpenAIClient = _import_openai_client()
     client = OpenAIClient(api_key=api_key, base_url=base_url)
@@ -1134,8 +1140,19 @@ def _generate_openai_tts(
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
         response = client.audio.speech.create(**create_kwargs)
 
-        response.stream_to_file(output_path)
-        return output_path
+        response.stream_to_file(synth_path)
+        if wants_opus:
+            converted = _convert_to_opus(synth_path)
+            # Clean up the intermediate mp3 if transcoding succeeded
+            if converted and converted != synth_path:
+                try:
+                    os.remove(synth_path)
+                except OSError:
+                    pass
+                return converted
+            # Transcoding failed — return the mp3 as best-effort
+            return synth_path
+        return synth_path
     finally:
         close = getattr(client, "close", None)
         if callable(close):


### PR DESCRIPTION
## Summary

`_generate_openai_tts()` hardcoded `response_format="opus"` for `.ogg` output paths. This breaks OpenAI-compatible TTS backends (e.g. Speaches/Kokoro) that do not support opus encoding.

Always request mp3 from the API, then transcode to OGG/Opus locally via the existing `_convert_to_opus()` helper when an `.ogg` target is requested. This mirrors the Edge TTS provider path and works with any backend.

## Changes

- **File:** `tools/tts_tool.py`
  - `_generate_openai_tts()`: always request `response_format="mp3"`, transcode to opus for `.ogg` targets using `_convert_to_opus()`
  - Clean up intermediate mp3 on successful transcoding
  - Fallback to mp3 if transcoding fails

## Testing

- 51/52 TTS tests pass (1 pre-existing test infrastructure failure unrelated to this change)
- Python compilation clean

## Related

Fixes #54589