### PR TITLE
fix(kanban): allow triage tasks without assignee

### DIFF
--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1127,12 +1127,6 @@ def _handle_create(args: dict, **kw) -> str:
     title = args.get("title")
     if not title or not str(title).strip():
         return tool_error("title is required")
-    assignee = args.get("assignee")
-    if not assignee:
-        return tool_error(
-            "assignee is required — name the profile that should execute this "
-            "task (the dispatcher will only spawn tasks with an assignee)"
-        )
     body = args.get("body")
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
@@ -1169,6 +1163,13 @@ def _handle_create(args: dict, **kw) -> str:
     triage, bool_error = _parse_bool_arg(args, "triage")
     if bool_error:
         return tool_error(bool_error)
+    # Assignee is required unless triage mode (the dispatcher routes triaged tasks).
+    assignee = args.get("assignee")
+    if not assignee and not triage:
+        return tool_error(
+            "assignee is required — name the profile that should execute this "
+            "task (the dispatcher will only spawn tasks with an assignee)"
+        )
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"


### PR DESCRIPTION
## Summary

`kanban_create` rejected missing assignee before checking the triage flag. When `triage=True`, the dispatcher routes the task — assignee is optional.

Moved the triage parse before the assignee check and made assignee conditional on not triage.

## Changes

- **File:** `tools/kanban_tools.py`
  - Moved `_parse_bool_arg(args, "triage")` before the assignee check
  - Made assignee validation conditional: `if not assignee and not triage`

## Testing

- 90/90 kanban tools tests pass
- Python compilation clean

## Related

Fixes #54510