### PR TITLE
fix(discord): bound server tool response reads

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tools import discord_tool as discord_tool_mod
 from tools.discord_tool import (
     DiscordAPIError,
     _ACTIONS,
@@ -127,6 +128,20 @@ class TestDiscordRequest:
         assert result is None
 
     @patch("tools.discord_tool.urllib.request.urlopen")
+    def test_success_response_body_is_bounded(self, mock_urlopen_fn, monkeypatch):
+        monkeypatch.setattr(discord_tool_mod, "DISCORD_RESPONSE_MAX_BYTES", 8)
+        mock_resp = _mock_urlopen({}, status=200)
+        mock_resp.read.return_value = b'{"oversized": true}'
+        mock_urlopen_fn.return_value = mock_resp
+
+        with pytest.raises(DiscordAPIError) as exc_info:
+            _discord_request("GET", "/test", "tok")
+
+        assert exc_info.value.status == 200
+        assert "exceeded 8 bytes" in exc_info.value.body
+        mock_resp.read.assert_called_once_with(9)
+
+    @patch("tools.discord_tool.urllib.request.urlopen")
     def test_http_error(self, mock_urlopen_fn):
         error_body = json.dumps({"message": "Missing Access"}).encode()
         http_error = urllib.error.HTTPError(
@@ -141,6 +156,27 @@ class TestDiscordRequest:
             _discord_request("GET", "/test", "tok")
         assert exc_info.value.status == 403
         assert "Missing Access" in exc_info.value.body
+
+    def test_http_error_body_is_bounded(self, monkeypatch):
+        monkeypatch.setattr(discord_tool_mod, "DISCORD_RESPONSE_MAX_BYTES", 8)
+        http_error = urllib.error.HTTPError(
+            url="https://discord.com/api/v10/test",
+            code=500,
+            msg="Server Error",
+            hdrs={},
+            fp=BytesIO(b"x" * 32),
+        )
+
+        with patch(
+            "tools.discord_tool.urllib.request.urlopen",
+            side_effect=http_error,
+        ):
+            with pytest.raises(DiscordAPIError) as exc_info:
+                _discord_request("GET", "/test", "tok")
+
+        assert exc_info.value.status == 500
+        assert "error body exceeded 8 bytes" in exc_info.value.body
+        assert "xxxxxxxxxxxxxxxx" not in exc_info.value.body
 
 
 # ---------------------------------------------------------------------------

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -38,6 +38,7 @@ from tools.registry import registry
 logger = logging.getLogger(__name__)
 
 DISCORD_API_BASE = "https://discord.com/api/v10"
+DISCORD_RESPONSE_MAX_BYTES = 8 * 1024 * 1024
 
 # Application flag bits (from GET /applications/@me → "flags").
 # Source: https://discord.com/developers/docs/resources/application#application-object-application-flags
@@ -53,6 +54,13 @@ _FLAG_GATEWAY_MESSAGE_CONTENT_LIMITED = 1 << 19
 def _get_bot_token() -> Optional[str]:
     """Resolve the Discord bot token from environment."""
     return os.getenv("DISCORD_BOT_TOKEN", "").strip() or None
+
+
+def _read_limited_response_body(stream: Any) -> Tuple[bytes, bool]:
+    raw = stream.read(DISCORD_RESPONSE_MAX_BYTES + 1)
+    if len(raw) > DISCORD_RESPONSE_MAX_BYTES:
+        return raw[:DISCORD_RESPONSE_MAX_BYTES], True
+    return raw, False
 
 
 def _discord_request(
@@ -87,11 +95,24 @@ def _discord_request(
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status == 204:
                 return None
-            return json.loads(resp.read().decode("utf-8"))
+            raw_body, truncated = _read_limited_response_body(resp)
+            if truncated:
+                raise DiscordAPIError(
+                    resp.status,
+                    f"Discord API response exceeded {DISCORD_RESPONSE_MAX_BYTES} bytes",
+                )
+            return json.loads(raw_body.decode("utf-8"))
     except urllib.error.HTTPError as e:
         error_body = ""
         try:
-            error_body = e.read().decode("utf-8", errors="replace")
+            raw_body, truncated = _read_limited_response_body(e)
+            if truncated:
+                error_body = (
+                    "Discord API error body exceeded "
+                    f"{DISCORD_RESPONSE_MAX_BYTES} bytes"
+                )
+            else:
+                error_body = raw_body.decode("utf-8", errors="replace")
         except Exception:
             pass
         raise DiscordAPIError(e.code, error_body) from e


### PR DESCRIPTION
## Summary
- cap `tools.discord_tool._discord_request()` success bodies with a bounded `read(limit + 1)`
- cap Discord HTTP error bodies before building `DiscordAPIError`
- add focused regression coverage for oversized success and error bodies

Fixes #55284.

This is separate from #54747 and #55209: those cover the Discord platform adapter / standalone send paths, while this PR only covers the Discord server tool in `tools/discord_tool.py`.

## Test plan
- `C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m pytest tests\tools\test_discord_tool.py -q --basetemp .pytest-tmp-discord-tool-cap`
- `C:\Users\Administrator\Documents\Codex\2026-06-29\hermes-main-latest-scan\.venv\Scripts\python.exe -m ruff check tools\discord_tool.py tests\tools\test_discord_tool.py`
- `git diff --check`