### PR TITLE
feat(delegation): optional per-task model selection in delegate_task

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2073,6 +2073,15 @@ DEFAULT_CONFIG = {
                                      # (floor 30s) to enforce a hard cap.
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
+        # Allow the agent to pick a per-task model when fanning out work, e.g.
+        # comparing the same task across several models. When True, each
+        # delegate_task entry may carry a `model` field naming a model
+        # ("opus", "gpt-5", "glm") — resolved leniently against the parent's
+        # current provider (aggregator-aware), falling back to delegation.provider.
+        # Off by default: the documented contract is that subagents inherit the
+        # parent model, and per-task model selection can route work to a more
+        # expensive model than the user expects. Opt in deliberately.
+        "allow_model_selection": False,
         "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling
         "max_async_children": 3,  # max concurrent background (background=true) subagents; new dispatches rejected at capacity
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth

--- a/tests/tools/test_delegate_model_selection.py
+++ b/tests/tools/test_delegate_model_selection.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Tests for per-task model selection in delegate_task.
+
+Ported from Kilo-Org/kilocode#11786. The agent can name a model per task
+("opus", "gpt-5", "glm") when fanning work out; resolution reuses the shared
+``model_switch`` pipeline so names are matched leniently and the provider is
+resolved (not dictated). Gated behind ``delegation.allow_model_selection``
+(default off) to preserve the "subagents inherit the parent model" contract.
+
+Run with:  python -m pytest tests/tools/test_delegate_model_selection.py -v
+"""
+
+import unittest
+from unittest.mock import patch
+
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _build_dynamic_schema_overrides,
+    _get_allow_model_selection,
+    _resolve_task_model_creds,
+)
+
+
+class _FakeParent:
+    """Minimal parent agent for credential anchoring."""
+
+    provider = "openrouter"
+    model = "anthropic/claude-opus-4.8"
+    base_url = "https://openrouter.ai/api/v1"
+    api_key = "sk-test"
+
+
+_BASE_CREDS = {
+    "model": None,
+    "provider": None,
+    "base_url": None,
+    "api_key": None,
+    "api_mode": None,
+    "command": None,
+    "args": None,
+}
+
+
+class TestSchemaGating(unittest.TestCase):
+    """The per-task `model` field only appears when the flag is enabled."""
+
+    def test_flag_off_no_model_field(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertNotIn("model", props)
+        self.assertNotIn("model", props["tasks"]["items"]["properties"])
+
+    def test_flag_on_adds_model_field(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_model_selection": True},
+        ):
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertEqual(props["model"]["type"], "string")
+        self.assertIn("model", props["tasks"]["items"]["properties"])
+
+    def test_static_schema_never_mutated(self):
+        """Dynamic overrides must not leak the model field into the static schema."""
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_model_selection": True},
+        ):
+            _build_dynamic_schema_overrides()
+        static_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertNotIn("model", static_props)
+        self.assertNotIn(
+            "model", static_props["tasks"]["items"]["properties"]
+        )
+
+
+class TestFlagGetter(unittest.TestCase):
+    def test_default_off(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            self.assertFalse(_get_allow_model_selection())
+
+    def test_truthy_on(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_model_selection": True},
+        ):
+            self.assertTrue(_get_allow_model_selection())
+
+
+class TestModelResolution(unittest.TestCase):
+    """`_resolve_task_model_creds` reuses the model_switch pipeline."""
+
+    def test_empty_name_returns_base_unchanged(self):
+        out = _resolve_task_model_creds("", _FakeParent(), _BASE_CREDS)
+        self.assertIs(out, _BASE_CREDS)
+
+    def test_bare_name_stays_on_parent_aggregator(self):
+        """A bare name resolved on the parent's provider keeps inherited creds."""
+        out = _resolve_task_model_creds("sonnet", _FakeParent(), _BASE_CREDS)
+        # Resolved to a concrete OpenRouter slug...
+        self.assertTrue(out["model"].startswith("anthropic/claude-sonnet"))
+        # ...but provider stays None because it matched the parent provider,
+        # so _build_child_agent inherits the parent's credentials.
+        self.assertIsNone(out["provider"])
+
+    def test_full_slug_passthrough(self):
+        out = _resolve_task_model_creds(
+            "openai/gpt-5.4", _FakeParent(), _BASE_CREDS
+        )
+        self.assertEqual(out["model"], "openai/gpt-5.4")
+
+    def test_unresolvable_name_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_task_model_creds(
+                "zzznotarealmodel-xyz-123", _FakeParent(), _BASE_CREDS
+            )
+
+    def test_base_creds_not_mutated(self):
+        before = dict(_BASE_CREDS)
+        _resolve_task_model_creds("sonnet", _FakeParent(), _BASE_CREDS)
+        self.assertEqual(_BASE_CREDS, before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -543,6 +543,99 @@ def _get_inherit_mcp_toolsets() -> bool:
     return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
 
 
+def _get_allow_model_selection() -> bool:
+    """Whether delegate_task tasks may carry a per-task ``model`` field.
+
+    Config key: delegation.allow_model_selection (bool, default False).
+    Off by default — subagents inherit the parent model unless the user opts
+    in, since per-task model routing can send work to a more expensive model
+    than expected.
+    """
+    cfg = _load_config()
+    return is_truthy_value(cfg.get("allow_model_selection"), default=False)
+
+
+def _resolve_task_model_creds(model_name: str, parent_agent, base_creds: dict) -> dict:
+    """Resolve a per-task model NAME to a full credential bundle.
+
+    Ported (adapted) from Kilo-Org/kilocode#11786: the agent names a model
+    ("opus", "gpt-5", "glm") and we resolve it leniently — provider is
+    *resolved, not dictated*. Reuses the existing aggregator-aware
+    ``model_switch.switch_model()`` pipeline (the same resolution chain the
+    ``/model`` command uses) so name matching, vendor/model slug conversion,
+    fuzzy aliasing, and cross-provider fallback all come for free instead of
+    being reinvented here.
+
+    Resolution anchors on the parent agent's current provider/credentials, so
+    a bare name like "opus" stays on the parent's aggregator when available.
+    On failure, raises ValueError with the resolver's message so the caller can
+    surface a clear per-task error rather than silently falling back to the
+    default model (which would mask the agent's intent).
+
+    Returns a creds dict shaped like ``_resolve_delegation_credentials`` output
+    (model / provider / base_url / api_key / api_mode), starting from
+    ``base_creds`` and overriding only the fields the switch resolves.
+    """
+    name = (model_name or "").strip()
+    if not name:
+        return base_creds
+
+    from hermes_cli.model_switch import switch_model
+
+    parent_provider = getattr(parent_agent, "provider", "") or ""
+    parent_model = getattr(parent_agent, "model", "") or ""
+    parent_base_url = getattr(parent_agent, "base_url", "") or ""
+    parent_api_key = getattr(parent_agent, "api_key", "") or ""
+
+    # Pull user/custom provider config so user-defined endpoints resolve too.
+    user_providers = {}
+    custom_providers = None
+    try:
+        from cli import CLI_CONFIG
+
+        user_providers = CLI_CONFIG.get("providers") or {}
+        custom_providers = CLI_CONFIG.get("custom_providers")
+    except Exception:
+        try:
+            from hermes_cli.config import load_config
+
+            _full = load_config()
+            user_providers = _full.get("providers") or {}
+            custom_providers = _full.get("custom_providers")
+        except Exception:
+            pass
+
+    result = switch_model(
+        raw_input=name,
+        current_provider=parent_provider,
+        current_model=parent_model,
+        current_base_url=parent_base_url,
+        current_api_key=parent_api_key,
+        is_global=False,
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+
+    if not result.success:
+        raise ValueError(
+            result.error_message
+            or f"Could not resolve model '{name}' for this subagent."
+        )
+
+    creds = dict(base_creds)
+    creds["model"] = result.new_model or creds.get("model")
+    # Only override provider/credentials when the resolved provider actually
+    # differs from the parent — when it's the same aggregator, keep the
+    # inherited credential bundle (None values) so _build_child_agent's parent
+    # inheritance path handles auth, matching the no-override default.
+    if result.target_provider and result.target_provider != parent_provider:
+        creds["provider"] = result.target_provider
+        creds["base_url"] = result.base_url or None
+        creds["api_key"] = result.api_key or None
+        creds["api_mode"] = result.api_mode or None
+    return creds
+
+
 def _is_mcp_toolset_name(name: str) -> bool:
     """Return True for canonical MCP toolsets and their registered aliases."""
     if not name:
@@ -2130,6 +2223,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
@@ -2232,7 +2326,13 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "model": model,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2268,31 +2368,49 @@ def delegate_task(
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
     children = []
     try:
+        allow_model_selection = _get_allow_model_selection()
         for i, t in enumerate(task_list):
             task_acp_args = t.get("acp_args") if "acp_args" in t else None
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task model selection (ported from Kilo-Org/kilocode#11786,
+            # gated behind delegation.allow_model_selection). When enabled and a
+            # task names a model, resolve it leniently via the shared model_switch
+            # pipeline; otherwise fall back to the delegation default creds. The
+            # flag-off path is byte-identical to the prior behavior.
+            task_creds = creds
+            task_model_request = (t.get("model") or "").strip() if isinstance(t, dict) else ""
+            if task_model_request and allow_model_selection:
+                try:
+                    task_creds = _resolve_task_model_creds(
+                        task_model_request, parent_agent, creds
+                    )
+                except ValueError as exc:
+                    return tool_error(
+                        f"Task {i}: could not resolve model "
+                        f"'{task_model_request}': {exc}"
+                    )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -3058,6 +3176,40 @@ def _build_dynamic_schema_overrides() -> dict:
     }
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
     overrides_params["properties"]["role"]["description"] = _build_role_param_description()
+
+    # Per-task model selection (ported from Kilo-Org/kilocode#11786). Only
+    # advertise the `model` field to the model when the user has opted in via
+    # delegation.allow_model_selection — otherwise the schema is byte-identical
+    # to the prior behavior, preserving the "subagents inherit the parent model"
+    # contract. The flag is a stable per-session config value, so toggling it
+    # between sessions (not mid-conversation) keeps prompt caching valid.
+    if _get_allow_model_selection():
+        import copy as _copy
+
+        _model_prop = {
+            "type": "string",
+            "description": (
+                "Optional model for this subagent (e.g. 'opus', 'gpt-5', "
+                "'glm', or a full 'vendor/model' slug). Names are matched "
+                "leniently and resolved to a concrete provider automatically, "
+                "preferring your current provider. Omit to inherit the parent "
+                "model. Use this to fan work out across different models — e.g. "
+                "review the same code with several models in parallel."
+            ),
+        }
+        overrides_params["properties"]["model"] = _model_prop
+        # tasks.items.properties is shared with the static schema; deep-copy
+        # the items dict before adding the per-task `model` field so we never
+        # mutate DELEGATE_TASK_SCHEMA.
+        _tasks_prop = _copy.deepcopy(overrides_params["properties"]["tasks"])
+        _tasks_prop["items"]["properties"]["model"] = dict(_model_prop)
+        _tasks_prop["items"]["properties"]["model"]["description"] = (
+            "Optional per-task model (e.g. 'opus', 'gpt-5', 'glm', or a "
+            "'vendor/model' slug). Resolved leniently; omit to inherit the "
+            "parent model."
+        )
+        overrides_params["properties"]["tasks"] = _tasks_prop
+
     return {
         "description": _build_top_level_description(),
         "parameters": overrides_params,
@@ -3229,6 +3381,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        model=args.get("model"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
     ),

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -270,6 +270,7 @@ delegation:
   # max_concurrent_children: 3              # Parallel children per batch (default: 3)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
+  # allow_model_selection: false            # Let the agent pick a per-task model when fanning out (default: false)
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
   api_mode: anthropic_messages                       # optional; auto-detected from base_url for anthropic_messages endpoints
@@ -283,6 +284,19 @@ delegation:
 ```
 
 When `base_url` points at an Anthropic-compatible endpoint — for example a path ending in `/anthropic`, an Azure Foundry Claude route, or a MiniMax `/anthropic` proxy — `api_mode` is auto-detected as `anthropic_messages` so the subagent uses the right wire format without you setting anything. Set `api_mode` explicitly when the auto-detection guess is wrong (rare).
+
+### Per-task model selection
+
+By default every subagent inherits the parent's model (or `delegation.model` if set). Set `allow_model_selection: true` to let the agent name a model **per task** when it fans work out — for example, reviewing the same code with several models in parallel:
+
+```yaml
+delegation:
+  allow_model_selection: true
+```
+
+With the flag on, `delegate_task` gains an optional `model` field (on both the single-goal call and each entry in a `tasks` batch). The agent names a model the way a human would — `"opus"`, `"gpt-5"`, `"glm"`, or a full `"vendor/model"` slug — and Hermes resolves it leniently through the same pipeline as the `/model` command: the **provider is resolved, not dictated**, preferring whatever provider backs your current model. Unresolvable names return a clear per-task error instead of silently falling back to the default model.
+
+The flag is off by default because per-task routing can send work to a more expensive model than you expect, and because the schema field only appears when you opt in (keeping the tool surface minimal otherwise).
 
 :::tip
 The agent handles delegation automatically based on the task complexity. You don't need to explicitly ask it to delegate — it will do so when it makes sense.


### PR DESCRIPTION
## Summary
`delegate_task` can now fan a single task out across different models — review the same code with several models in parallel — when the user opts in via `delegation.allow_model_selection`.

Ported (adapted) from [Kilo-Org/kilocode#11786](https://github.com/Kilo-Org/kilocode/pull/11786), which added per-task model + reasoning-variant selection to that project's `agent_manager` chat tool (the direct analog of our `delegate_task`).

## What it does
With `delegation.allow_model_selection: true`, the agent can name a model **per task** — `"opus"`, `"gpt-5"`, `"glm"`, or a full `vendor/model` slug. The provider is **resolved, not dictated**: names are matched leniently against the parent's current provider (aggregator-aware), exactly the way the `/model` command resolves them. Off by default, so the documented "subagents inherit the parent model" contract is unchanged unless you opt in.

## How it was adapted
- **No new model tool.** Kilo Code shipped a separate `agent_manager_models` discovery tool. We skip it to respect the footprint ladder — the per-task `model` field rides on the existing `delegate_task` schema and is the only addition.
- **Reuse, don't reinvent.** Kilo Code reimplemented lenient name→provider resolution. We route through the existing `hermes_cli.model_switch.switch_model()` pipeline (`/model`'s resolution chain), so vendor/model slug conversion, fuzzy aliasing, and cross-provider fallback all come for free.
- **Cache-safe schema gating.** The `model` field is injected in `_build_dynamic_schema_overrides()` only when the flag is on. The flag is a stable per-session config value, so the system prompt stays byte-stable for the life of a conversation — prompt caching is preserved.
- **Fail loud, not silent.** An unresolvable model name returns a clear per-task tool error rather than silently falling back to the default model (which would mask the agent's intent).

## Changes
- `tools/delegate_tool.py`: `_get_allow_model_selection()`, `_resolve_task_model_creds()`, per-task creds resolution in the child-build loop, top-level `model` param, handler wiring, conditional schema injection.
- `hermes_cli/config.py`: `delegation.allow_model_selection` (default `False`).
- `website/docs/user-guide/features/delegation.md`: documents the flag + behavior.
- `tests/tools/test_delegate_model_selection.py`: 10 new tests.

## Validation
| | Flag off (default) | Flag on |
|---|---|---|
| `model` in tool schema | absent | present (top-level + per-task) |
| per-task `model` honored | no (inherits parent) | yes (resolved via `model_switch`) |
| static schema mutated | no | no (deep-copied) |

- 10 new tests pass; resolution E2E-verified with real imports (`"sonnet"` → `anthropic/claude-sonnet-4.6` on the parent aggregator; full slug passthrough; bad name → `ValueError`).
- 154 existing delegate tests + 1147 `tests/hermes_cli/` tests green (config validation, config drift, model_switch all unaffected).

## Infographic

![per-task-model-selection](https://v3b.fal.media/files/b/0aa04dba/v6qMgWRhwWhKWV_rzqpOu_X37ly14t.png)
