### PR TITLE
fix(desktop): provision Node before snapshotting build env in cmd_gui

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5617,6 +5617,24 @@ def cmd_gui(args: argparse.Namespace):
 
     from hermes_constants import find_node_executable, with_hermes_node_path
 
+    source_mode = getattr(args, "source", False)
+    skip_build = getattr(args, "skip_build", False)
+    force_build = getattr(args, "force_build", False)
+
+    # When a build may run, make node/npm discoverable *before* the env
+    # snapshot below. A desktop rebuild launched from the GUI (Finder/launchd,
+    # e.g. the installer's `hermes desktop --build-only` update step) inherits a
+    # stripped PATH that omits version-manager and Homebrew Node (~/.nvm,
+    # ~/.fnm, /opt/homebrew/bin), so npm — and the `node` its shebang needs —
+    # are invisible even though a terminal launch finds them. Repairing
+    # os.environ["PATH"] here (via the same node-bootstrap cascade the TUI uses)
+    # fixes both npm resolution *and* the build subprocess, which runs with the
+    # `env` snapshotted just below: resolving npm alone is not enough, because
+    # npm's `#!/usr/bin/env node` shebang fails (exit 127) when `node`'s dir is
+    # absent from that env. No-op when node+npm are already on PATH.
+    if source_mode or not skip_build:
+        _ensure_tui_node()
+
     # with_hermes_node_path() copies os.environ when called with no arg.
     env = with_hermes_node_path()
     if getattr(args, "fake_boot", False):
@@ -5637,10 +5655,6 @@ def cmd_gui(args: argparse.Namespace):
     config_electron_flags, config_disable_gpu = _desktop_launch_options()
     if config_disable_gpu != "auto" and "HERMES_DESKTOP_DISABLE_GPU" not in os.environ:
         env["HERMES_DESKTOP_DISABLE_GPU"] = config_disable_gpu
-
-    source_mode = getattr(args, "source", False)
-    skip_build = getattr(args, "skip_build", False)
-    force_build = getattr(args, "force_build", False)
 
     packaged_executable = _desktop_packaged_executable(desktop_dir)
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -1056,3 +1056,67 @@ def test_desktop_launch_options_survives_config_error():
         flags, gpu = cli_main._desktop_launch_options()
     assert flags == []
     assert gpu == "auto"
+
+
+def test_gui_repairs_path_before_env_snapshot(tmp_path, monkeypatch):
+    """A GUI-context rebuild (Finder/launchd, e.g. the installer's
+    ``hermes desktop --build-only`` update step) inherits a stripped PATH with
+    no node/npm on it. cmd_gui must repair PATH via ``_ensure_tui_node()``
+    *before* snapshotting the build env with ``with_hermes_node_path()`` —
+    otherwise npm resolves but the build subprocess can't find ``node`` (npm's
+    ``#!/usr/bin/env node`` shebang) and fails with exit 127. Regression for the
+    macOS desktop-rebuild gap in issue #49242.
+    """
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    call_order: list[str] = []
+
+    def _record_ensure():
+        call_order.append("ensure_tui_node")
+
+    def _record_snapshot(env=None):
+        call_order.append("with_hermes_node_path")
+        import os
+
+        return dict(os.environ if env is None else env)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._ensure_tui_node", side_effect=_record_ensure) as mock_ensure, \
+         patch("hermes_constants.with_hermes_node_path", side_effect=_record_snapshot), \
+         patch("hermes_constants.find_node_executable", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic",
+               return_value=subprocess.CompletedProcess([], 0)), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    mock_ensure.assert_called_once()
+    # PATH must be repaired before the env is snapshotted, not after.
+    assert call_order[:2] == ["ensure_tui_node", "with_hermes_node_path"], call_order
+
+
+def test_gui_skips_path_repair_when_skipping_build(tmp_path, monkeypatch):
+    """``--skip-build`` launches a prebuilt app and needs no node/npm, so the
+    PATH-repair (which may shell out to node-bootstrap.sh) must not run."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value=None), \
+         patch("hermes_cli.main._ensure_tui_node") as mock_ensure, \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    mock_ensure.assert_not_called()

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -1104,6 +1104,44 @@ def test_gui_repairs_path_before_env_snapshot(tmp_path, monkeypatch):
     assert call_order[:2] == ["ensure_tui_node", "with_hermes_node_path"], call_order
 
 
+def test_gui_rebuild_recovers_node_from_restricted_macos_path(tmp_path, monkeypatch):
+    """Exercise the real PATH repair used by a Finder/launchd rebuild."""
+    root = _make_desktop_tree(tmp_path)
+    helper = root / "scripts" / "lib" / "node-bootstrap.sh"
+    helper.parent.mkdir(parents=True)
+    helper.write_text("ensure_node() { :; }\n", encoding="utf-8")
+
+    node_bin = tmp_path / "managed-node" / "bin"
+    node_bin.mkdir(parents=True)
+    for executable in ("node", "npm"):
+        path = node_bin / executable
+        path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        path.chmod(0o755)
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+    monkeypatch.setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+
+    bootstrap_ok = subprocess.CompletedProcess(
+        ["bash", "-c", "ensure_node"], 0, stdout=f"{node_bin / 'node'}\n", stderr=""
+    )
+    pack_ok = subprocess.CompletedProcess([str(node_bin / "npm"), "run", "pack"], 0)
+
+    with patch("hermes_cli.main.subprocess.run", side_effect=[bootstrap_ok, pack_ok]) as mock_run, \
+         patch("hermes_cli.main._run_npm_install_deterministic",
+               return_value=subprocess.CompletedProcess([], 0)), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"):
+        cli_main.cmd_gui(_ns(build_only=True, force_build=True))
+
+    build_call = mock_run.call_args_list[1]
+    assert build_call.args[0] == [str(node_bin / "npm"), "run", "pack"]
+    assert build_call.kwargs["env"]["PATH"].split(":")[0] == str(node_bin)
+
+
 def test_gui_skips_path_repair_when_skipping_build(tmp_path, monkeypatch):
     """``--skip-build`` launches a prebuilt app and needs no node/npm, so the
     PATH-repair (which may shell out to node-bootstrap.sh) must not run."""


### PR DESCRIPTION
## What does this PR do?

Fixes a macOS desktop-update failure where the GUI updater rebuild aborts with
`Desktop GUI requires Node.js/npm, but npm was not found on PATH`, even though a
terminal can build the app fine.

**Root cause.** A desktop rebuild launched from the GUI (Finder/launchd) —
including the installer's `hermes desktop --build-only` update step — inherits
the launchd-default PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), which omits
version-manager and Homebrew Node (`~/.nvm`, `~/.fnm`, `/opt/homebrew/bin`).
When no Hermes-managed Node tree exists — the common case after a *terminal*
install, where `ensure_node` accepts the user's existing nvm/brew Node and never
provisions `$HERMES_HOME/node` — `cmd_gui`'s `find_node_executable("npm")` falls
through to `shutil.which("npm")` against that stripped PATH and finds nothing.

#49254 made Hermes *prefer* managed Node when it exists; this is the sibling
case where no managed Node exists at all and the system Node is invisible to a
non-shell launch.

**Fix.** `cmd_gui` already imports the node-bootstrap cascade the TUI self-heals
with (`_ensure_tui_node()`, which sources `scripts/lib/node-bootstrap.sh` and
runs `ensure_node` — fnm/proto/nvm/brew/bundled, discovering nvm by sourcing
`nvm.sh` directly rather than via PATH) but never called it. This calls it,
gated on a build actually running.

Placement is the subtle part: `_ensure_tui_node()` must run **before** the build
env is snapshotted via `with_hermes_node_path()`, not just before npm
resolution. The build runs as `subprocess.run([npm, "run", ...], env=env)`, and
npm's `#!/usr/bin/env node` shebang resolves `node` against that `env`'s PATH at
exec time. Repairing PATH only after the snapshot would let npm *resolve* yet
fail the build with `env: node: No such file` (exit 127). Repairing
`os.environ["PATH"]` before the snapshot fixes both at once.

## Related Issue

Refs #49242 (the POSIX/macOS sibling of that issue — intentionally **not**
`Fixes`, since #49242 also tracks the Windows WhatsApp paths and the #49259
resolver consolidation, which this PR does not touch).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/main.py` (`cmd_gui`): hoist the `source_mode`/`skip_build`/
  `force_build` flags above the env snapshot and call `_ensure_tui_node()` there
  when a build may run, so node/npm (and the `node` npm's shebang needs) are on
  PATH for both resolution and the build subprocess. No-op when node+npm are
  already present, or when `node-bootstrap.sh`/bash are absent (e.g. Windows,
  where managed Node under `%LOCALAPPDATA%\hermes\node` already covers this).
- `tests/hermes_cli/test_gui_command.py`: add `test_gui_repairs_path_before_env_snapshot`
  (asserts `_ensure_tui_node()` runs before `with_hermes_node_path()` — the
  exit-127 ordering guard) and `test_gui_skips_path_repair_when_skipping_build`.

## How to Test

Reproduce the GUI/launchd environment from a terminal (node visible normally, so
the bug needs a stripped PATH and no managed Node):

1. Have Node via nvm/fnm/Homebrew and **no** `$HERMES_HOME/node` tree.
2. Before the fix, with a stripped PATH:
   ```
   PATH=/usr/bin:/bin:/usr/sbin:/sbin HERMES_HOME=/tmp/scratch-home \
     hermes desktop --build-only --force-build
   ```
   → fails: `npm was not found on PATH`.
3. After the fix, the same command provisions/activates Node via
   `node-bootstrap.sh` and the rebuild proceeds.

Automated + mechanism proof run in this branch:

- `pytest tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_cmd_update.py -q` → 90 passed.
- `scripts/check-windows-footguns.py --diff upstream/main` → clean.
- Direct repro of the shebang/env mechanism under a real stripped PATH + real
  nvm + empty `HERMES_HOME`: with the buggy ordering (snapshot first) `npm` and
  `node` both resolve to `None`; with the fix, `npm`/`node` resolve and
  `npm --version` (the `#!/usr/bin/env node` path) returns rc 0.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (#49239 closed/superseded, #49254 merged — neither covers the no-managed-Node POSIX case)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the targeted `test_gui_command.py` + `test_cmd_update.py` suites (90 passed) and the footgun check; leaving the full suite to CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] Updated relevant documentation — N/A (behavior fix, no public API/config change)
- [x] Updated `cli-config.yaml.example` — N/A
- [x] Updated `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Considered cross-platform impact — yes; no-op on Windows (bash/`node-bootstrap.sh` absent → `_ensure_tui_node()` returns early), where managed Node already covers the case
- [x] Updated tool descriptions/schemas — N/A

## Notes for reviewers

`_build_web_ui()` (the `hermes serve` dashboard build) has the same
resolve-then-snapshot shape and would benefit from the same treatment, but it's
a different command and not normally launched from a GUI/launchd context — left
out to keep this PR single-concern; happy to follow up if you'd like it folded
in.
