### PR TITLE
fix(browser): skip Browserbase-specific warnings in local mode

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2985,18 +2985,26 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         title_lower = title.lower()
 
         if any(pattern in title_lower for pattern in blocked_patterns):
+            warning_opts = [
+                "1) Try adding delays between actions",
+                "2) Access different pages first",
+                "3) Some sites have very aggressive bot detection that may be unavoidable",
+            ]
+            if not _is_local_mode():
+                warning_opts.append(
+                    "4) Enable advanced stealth (BROWSERBASE_ADVANCED_STEALTH=true, requires Scale plan)"
+                )
             response["bot_detection_warning"] = (
                 f"Page title '{title}' suggests bot detection. The site may have blocked this request. "
-                "Options: 1) Try adding delays between actions, 2) Access different pages first, "
-                "3) Enable advanced stealth (BROWSERBASE_ADVANCED_STEALTH=true, requires Scale plan), "
-                "4) Some sites have very aggressive bot detection that may be unavoidable."
+                + "; ".join(warning_opts) + "."
             )
 
-        # Include feature info on first navigation so model knows what's active
+        # Include feature info on first navigation so model knows what's active.
+        # Skip Browserbase-specific warnings when running in local mode (#54197).
         if is_first_nav and "features" in session_info:
             features = session_info["features"]
             active_features = [k for k, v in features.items() if v]
-            if not features.get("proxies"):
+            if not _is_local_mode() and not features.get("proxies"):
                 response["stealth_warning"] = (
                     "Running WITHOUT residential proxies. Bot detection may be more aggressive. "
                     "Consider upgrading Browserbase plan for proxy support."


### PR DESCRIPTION
## Summary

`stealth_warning` and `bot_detection_warning` referenced Browserbase features (residential proxies, advanced stealth) even when running in local mode. Local-only browser setups have zero interaction with Browserbase.

Skip the stealth_warning when `_is_local_mode()` is true, and remove the Browserbase-specific option (`BROWSERBASE_ADVANCED_STEALTH`) from `bot_detection_warning` in local mode.

## Changes

- **File:** `tools/browser_tool.py`
  - Added `_is_local_mode()` guard before stealth_warning
  - Made bot_detection_warning dynamically exclude Browserbase-specific option in local mode

## Testing

- Python compilation clean

## Related

Fixes #54197