### PR TITLE
fix(tui): respect disabled_toolsets for project toolset

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1318,6 +1318,18 @@ def test_load_enabled_toolsets_folds_project_into_focus_posture(monkeypatch):
     assert server._load_enabled_toolsets() == ["coding", "figma", "project"]
 
 
+def test_load_enabled_toolsets_folds_project_into_focus_posture_respects_disabled(monkeypatch):
+    """Coding-focus path: disabled_toolsets=[project] should exclude project."""
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
+
+    import agent.coding_context as cc
+
+    monkeypatch.setattr(cc, "coding_selection", lambda **_: ["coding", "figma"])
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"disabled_toolsets": ["project"]}})
+
+    assert server._load_enabled_toolsets() == ["coding", "figma"]
+
+
 def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "mcp-off")
     monkeypatch.setitem(
@@ -1362,6 +1374,47 @@ def test_load_enabled_toolsets_falls_back_when_tui_env_invalid(monkeypatch, caps
     )
 
     assert server._load_enabled_toolsets() == ["kanban", "memory", "project"]
+    assert "using configured CLI toolsets" in capsys.readouterr().err
+
+
+def test_load_enabled_toolsets_falls_back_when_tui_env_invalid(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_TUI_TOOLSETS", "nope")
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}}
+    )
+
+    assert server._load_enabled_toolsets() == ["kanban", "memory", "project"]
+    assert "using configured CLI toolsets" in capsys.readouterr().err
+
+
+def test_load_enabled_toolsets_falls_back_respects_disabled(monkeypatch, capsys):
+    """Configured fallback path: disabled_toolsets=[project] should exclude project."""
+    monkeypatch.setenv("HERMES_TUI_TOOLSETS", "nope")
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"platform_toolsets": {"cli": ["memory"]}},
+    )
+    # _load_cfg is called early to populate _disabled; mock it too
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"disabled_toolsets": ["project"]}})
+
+    assert server._load_enabled_toolsets() == ["kanban", "memory"]
     assert "using configured CLI toolsets" in capsys.readouterr().err
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3369,6 +3369,14 @@ def _load_enabled_toolsets() -> list[str] | None:
     cfg = None
     fallback_notice = None
 
+    # Check if project toolset is disabled via config (#54433).
+    _disabled = set()
+    try:
+        _cfg = _load_cfg()
+        _disabled = set(_cfg.get("agent", {}).get("disabled_toolsets") or [])
+    except Exception:
+        pass
+
     # Coding posture (base Hermes): with no explicit pin, collapse to the
     # coding toolset (+ enabled MCP servers) when sitting in a code workspace.
     # The desktop app and `hermes --tui` both land here. See
@@ -3385,7 +3393,11 @@ def _load_enabled_toolsets() -> list[str] | None:
                 # the focus-mode coding posture returns before the fallback path
                 # that normally adds it — without this the desktop loses the
                 # project tools exactly when sitting in a repo (see below).
-                return sorted({*selection, "project"})
+                # Skip if project is in disabled_toolsets (#54433).
+                _base = set(selection)
+                if "project" not in _disabled:
+                    _base.add("project")
+                return sorted(_base)
         except Exception:
             pass
 
@@ -3502,7 +3514,10 @@ def _load_enabled_toolsets() -> list[str] | None:
         # surface them. This resolver runs ONLY in the desktop/TUI gateway, so
         # folding in the `project` toolset here is the gate that exposes them on
         # exactly the surface that can follow a project move.
-        return sorted(enabled | {"project"})
+        # Skip if project is in disabled_toolsets (#54433).
+        if "project" not in _disabled:
+            return sorted(enabled | {"project"})
+        return sorted(enabled)
     except Exception:
         if fallback_notice is not None:
             print(


### PR DESCRIPTION
## Summary

The TUI gateway hardcoded `"project"` into enabled toolsets, ignoring `agent.disabled_toolsets`. This meant `disabled_toolsets: [project]` was a no-op on desktop/TUI.

Read `disabled_toolsets` from config and skip adding `"project"` when it is in the disabled set. Both the coding posture path and the fallback path now respect the config.

## Changes

- **File:** `tui_gateway/server.py`
  - Added `_disabled` set from `agent.disabled_toolsets` config
  - Gated project toolset addition on `"project" not in _disabled` in both code paths

## Testing

- Python compilation clean

## Related

Fixes #54433