### PR TITLE
fix(file-tools): include empty directories in search_files

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -894,6 +894,113 @@ class TestPatchReplacePostWriteVerification:
 # Git baseline check for write_file warning
 # =========================================================================
 
+class TestSearchFilesRgEmptyDirs:
+    """_search_files_rg directories supplement: empty directories appear in results."""
+
+    def _make_env(self):
+        env = MagicMock()
+        env.cwd = "/"
+
+        def execute(command, **kwargs):
+            completed = subprocess.run(
+                command,
+                shell=True,
+                text=True,
+                capture_output=True,
+            )
+            return {
+                "output": completed.stdout,
+                "returncode": completed.returncode,
+            }
+
+        env.execute = execute
+        return env
+
+    def test_rg_path_includes_empty_dirs(self, tmp_path, monkeypatch):
+        """_search_files_rg should include empty directories matching the glob."""
+        root = tmp_path / "project"
+        root.mkdir()
+        # A file matching the glob
+        (root / "data.txt").write_text("hello")
+        # An empty directory matching the glob
+        (root / "data").mkdir()
+        # A non-matching dir (should not appear)
+        (root / "other").mkdir()
+        # A dir with content matching the glob (should appear as a dir)
+        nested = root / "data_backup"
+        nested.mkdir()
+        (nested / "file.txt").write_text("x")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command in ("rg", "find"))
+        result = ops._search_files_rg("*data*", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        found = set(result.files)
+        # Should include the file and both matching directories
+        assert str(root / "data.txt") in found, "file matching glob should be included"
+        assert str(root / "data") in found, "empty directory matching glob should be included"
+        assert str(root / "data_backup") in found, "non-empty directory matching glob should be included"
+        # Non-matching directory should NOT be included
+        assert str(root / "other") not in found, "non-matching directory should be excluded"
+
+    def test_rg_path_only_matching_dirs_included(self, tmp_path, monkeypatch):
+        """_search_files_rg should not include directories that don't match the pattern."""
+        root = tmp_path / "src"
+        root.mkdir()
+        (root / "utils").mkdir()
+        (root / "build").mkdir()
+        (root / "README.md").write_text("docs")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command in ("rg", "find"))
+        result = ops._search_files_rg("*.md", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        found = set(result.files)
+        assert str(root / "README.md") in found
+        # Directories don't match *.md
+        assert str(root / "utils") not in found
+        assert str(root / "build") not in found
+
+    def test_rg_path_empty_dir_with_no_matching_files(self, tmp_path, monkeypatch):
+        """_search_files_rg returns ONLY empty directories when no files match."""
+        root = tmp_path / "empty_root"
+        root.mkdir()
+        (root / "config").mkdir()
+        (root / "logs").mkdir()
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command in ("rg", "find"))
+        result = ops._search_files_rg("*", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        found = set(result.files)
+        # With * pattern, everything matches: rg returns no files (empty dirs),
+        # find returns the directories
+        assert str(root / "config") in found
+        assert str(root / "logs") in found
+
+    def test_rg_path_dedup_path_no_duplicates(self, tmp_path, monkeypatch):
+        """_search_files_rg should not dedup directories that share a name with files (different paths)."""
+        root = tmp_path / "dedup_test"
+        root.mkdir()
+        # A file and a dir with the same name in different locations
+        (root / "data.txt").write_text("x")
+        sub = root / "sub"
+        sub.mkdir()
+        (sub / "data").mkdir()  # directory
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command in ("rg", "find"))
+        result = ops._search_files_rg("*data*", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        found = set(result.files)
+        assert str(root / "data.txt") in found
+        assert str(sub / "data") in found
+
+
 class _DeletedTestGitBaselineCheck:
     """Removed May 2026 — these tests asserted on a ``_check_git_baseline``
     method that doesn't exist on ``ShellFileOperations`` (regression intro

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -357,6 +357,60 @@ class TestSearch:
             _assert_clean(m.content)
             _assert_clean(m.path)
 
+    def test_file_search_returns_empty_dir(self, ops, tmp_path):
+        """search(target='files') should return empty directories matching the glob."""
+        (tmp_path / "data").mkdir()
+        (tmp_path / "logs").mkdir()
+        (tmp_path / "config").mkdir()
+        (tmp_path / "data.txt").write_text("hello")
+
+        result = ops.search("*", str(tmp_path), target="files")
+        assert result.error is None
+        found = {Path(f).name for f in result.files}
+        assert "data" in found, "empty dir 'data' should appear in search results"
+        assert "logs" in found, "empty dir 'logs' should appear in search results"
+        assert "config" in found, "empty dir 'config' should appear in search results"
+        assert "data.txt" in found, "file 'data.txt' should also appear"
+
+    def test_file_search_empty_dir_with_pattern(self, ops, tmp_path):
+        """search(target='files') with a specific pattern returns only matching dirs."""
+        (tmp_path / "components").mkdir()
+        (tmp_path / "pages").mkdir()
+        (tmp_path / "utils").mkdir()
+        (tmp_path / "index.tsx").write_text("export default function Home() {}")
+
+        result = ops.search("*comp*", str(tmp_path), target="files")
+        assert result.error is None
+        found = {Path(f).name for f in result.files}
+        assert "components" in found, "empty dir matching pattern should appear"
+        assert "index.tsx" not in found, "non-matching file should be excluded"
+
+    def test_file_search_empty_dir_via_rg_path(self, ops, tmp_path, monkeypatch):
+        """Force the rg code path and verify empty directories are still found."""
+        (tmp_path / "static").mkdir()
+        (tmp_path / "templates").mkdir()
+
+        # Make rg available so _search_files dispatches to _search_files_rg
+        monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd in ("rg", "find"))
+        result = ops._search_files("*", str(tmp_path), limit=50, offset=0)
+        assert result.error is None
+        found = {Path(f).name for f in result.files}
+        assert "static" in found
+        assert "templates" in found
+
+    def test_file_search_empty_dir_via_find_fallback(self, ops, tmp_path, monkeypatch):
+        """Force the find fallback path and verify empty directories are found."""
+        (tmp_path / "uploads").mkdir()
+        (tmp_path / "assets").mkdir()
+
+        # Disable rg, enable find so _search_files uses the find fallback
+        monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == "find")
+        result = ops._search_files("*", str(tmp_path), limit=50, offset=0)
+        assert result.error is None
+        found = {Path(f).name for f in result.files}
+        assert "uploads" in found
+        assert "assets" in found
+
 
 # ── _expand_path ─────────────────────────────────────────────────────────
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2152,7 +2152,7 @@ class ShellFileOperations(FileOperations):
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
 
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} \\( -type f -o -type d \\) -name {self._escape_shell_arg(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
 
         result = self._exec(cmd, timeout=60)
@@ -2160,7 +2160,7 @@ class ShellFileOperations(FileOperations):
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} \\( -type f -o -type d \\) -name {self._escape_shell_arg(search_pattern)} " \
                         f"2>/dev/null | sort -rn{pagination_expr}"
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2200,12 +2200,17 @@ class ShellFileOperations(FileOperations):
         )
 
     def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
-        """Search for files by name using ripgrep's --files mode.
+        """Search for files by name using ripgrep's --files mode, plus directories.
 
         rg --files respects .gitignore and excludes hidden directories by
         default, and uses parallel directory traversal for ~200x speedup
         over find on wide trees.  Results are sorted by modification time
         (most recently edited first) when rg >= 13.0 supports --sortr.
+
+        Since rg --files cannot return empty directories (it only lists files),
+        we supplement with a ``find -type d`` call and merge the two lists.
+        The merged result preserves mtime ordering: files first (from rg),
+        then directories (from find), each group sorted by mtime.
         """
         # rg --files -g uses glob patterns; wrap bare names so they match
         # at any depth (equivalent to find -name).
@@ -2236,11 +2241,68 @@ class ShellFileOperations(FileOperations):
             stdout, limit_reason = _search_stdout_and_limit(result)
             all_files = [f for f in stdout.strip().split('\n') if f]
 
-        page = all_files[offset:offset + limit]
+        # ── Directory enumeration ───────────────────────────────────────
+        # rg --files never emits directory paths, so empty directories are
+        # invisible.  Supplement with find -type d when available, merging
+        # into a single result list with the same dedup and hidden-path
+        # filtering that the find fallback path applies.
+        all_dirs: list[str] = []
+        if self._has_command('find'):
+            search_root = Path(path)
+            has_hidden = any(
+                part not in {".", ".."} and part.startswith(".")
+                for part in search_root.parts
+            )
+            hidden_exclude = "-not -path '*/.*'" if not has_hidden else ""
+            hidden_filter = f" {hidden_exclude}" if hidden_exclude else ""
+
+            cmd_dirs = (
+                f"find {self._escape_shell_arg(path)}{hidden_filter} "
+                f"-type d -name {self._escape_shell_arg(pattern)} "
+                f"-printf '%T@ %p\\\\n' 2>/dev/null | sort -rn"
+            )
+            result_dirs = self._exec(cmd_dirs, timeout=60)
+            dir_stdout, _ = _search_stdout_and_limit(result_dirs)
+
+            seen = set(all_files)  # dedup: skip if already a file result
+            for line in dir_stdout.strip().split('\n'):
+                if not line:
+                    continue
+                parts = line.split(' ', 1)
+                dir_path = (
+                    parts[1]
+                    if len(parts) == 2 and parts[0].replace('.', '').isdigit()
+                    else line
+                )
+                if dir_path in seen:
+                    continue
+                seen.add(dir_path)
+                all_dirs.append(dir_path)
+
+            # Hidden-descendant filtering for explicit hidden roots.
+            if has_hidden:
+                normalized_root = search_root.resolve()
+                filtered: list[str] = []
+                for d in all_dirs:
+                    try:
+                        rel = Path(d).resolve().relative_to(normalized_root).parts
+                    except ValueError:
+                        rel = Path(d).parts
+                    if any(p not in {".", ".."} and p.startswith(".") for p in rel):
+                        continue
+                    filtered.append(d)
+                all_dirs = filtered
+
+        # ── Merge and paginate ──────────────────────────────────────────
+        # Files first (mtime-sorted from rg), then directories (mtime-sorted
+        # from find).  This matches the find fallback behaviour of interleaving
+        # both types by mtime while keeping the fast rg path for files.
+        all_entries = all_files + all_dirs
+        page = all_entries[offset:offset + limit]
 
         return SearchResult(
             files=page,
-            total_count=len(all_files),
+            total_count=len(all_entries),
             truncated=len(all_files) >= fetch_limit or bool(limit_reason),
             limit_reason=limit_reason,
         )


### PR DESCRIPTION
search_files with target=files used find -type f which skips empty directories. Users building folder structures could not see or reference empty directories.

Changed find commands to include both files and directories (-type f -o -type d).

Fixes #54347