### PR TITLE
fix(gateway): respect trailing text on closing code fences

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5254,6 +5254,15 @@ class BasePlatformAdapter(ABC):
         INDICATOR_RESERVE = 10   # room for " (XX/XX)"
         FENCE_CLOSE = "\n```"
 
+        def _parse_backtick_fence_line(line: str) -> tuple[int, str] | None:
+            stripped = line.strip()
+            if not stripped.startswith("```"):
+                return None
+            marker_len = len(stripped) - len(stripped.lstrip("`"))
+            if marker_len < 3:
+                return None
+            return marker_len, stripped[marker_len:]
+
         chunks: List[str] = []
         remaining = content
         # When the previous chunk ended mid-code-block, this holds the
@@ -5326,14 +5335,18 @@ class BasePlatformAdapter(ABC):
             in_code = carry_lang is not None
             lang = carry_lang or ""
             for line in chunk_body.split("\n"):
-                stripped = line.strip()
-                if stripped.startswith("```"):
+                fence = _parse_backtick_fence_line(line)
+                if fence:
+                    _, trailing = fence
                     if in_code:
-                        in_code = False
-                        lang = ""
+                        # Per CommonMark, a closing fence may be followed only
+                        # by whitespace. Lines like "``` not a close" are code.
+                        if trailing.strip() == "":
+                            in_code = False
+                            lang = ""
                     else:
                         in_code = True
-                        tag = stripped[3:].strip()
+                        tag = trailing.strip()
                         lang = tag.split()[0] if tag else ""
 
             if in_code:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -7126,6 +7126,10 @@ class BasePlatformAdapter(ABC):
         INDICATOR_RESERVE = 10   # room for " (XX/XX)"
         FENCE_CLOSE = "\n```"
 
+        def _backtick_fence_suffix(line: str) -> str | None:
+            stripped = line.strip()
+            return stripped.lstrip("`") if stripped.startswith("```") else None
+
         chunks: List[str] = []
         remaining = content
         # When the previous chunk ended mid-code-block, this holds the
@@ -7156,14 +7160,15 @@ class BasePlatformAdapter(ABC):
                 _final_lang = carry_lang or ""
                 if _final_in_code:
                     for _line in remaining.split("\n"):
-                        _stripped = _line.strip()
-                        if _stripped.startswith("```"):
+                        _trailing = _backtick_fence_suffix(_line)
+                        if _trailing is not None:
                             if _final_in_code:
-                                _final_in_code = False
-                                _final_lang = ""
+                                if _trailing.strip() == "":
+                                    _final_in_code = False
+                                    _final_lang = ""
                             else:
                                 _final_in_code = True
-                                _tag = _stripped[3:].strip()
+                                _tag = _trailing.strip()
                                 _final_lang = _tag.split()[0] if _tag else ""
                     if _final_in_code:
                         final_chunk += FENCE_CLOSE
@@ -7237,14 +7242,17 @@ class BasePlatformAdapter(ABC):
             in_code = carry_lang is not None
             lang = carry_lang or ""
             for line in chunk_body.split("\n"):
-                stripped = line.strip()
-                if stripped.startswith("```"):
+                trailing = _backtick_fence_suffix(line)
+                if trailing is not None:
                     if in_code:
-                        in_code = False
-                        lang = ""
+                        # Per CommonMark, a closing fence may be followed only
+                        # by whitespace. Lines like "``` not a close" are code.
+                        if trailing.strip() == "":
+                            in_code = False
+                            lang = ""
                     else:
                         in_code = True
-                        tag = stripped[3:].strip()
+                        tag = trailing.strip()
                         lang = tag.split()[0] if tag else ""
 
             if in_code:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1417,6 +1417,21 @@ class TestTruncateMessage:
                 f"Chunk {i} has unbalanced fences ({fence_count})"
             )
 
+    def test_trailing_text_after_fence_marker_stays_inside_code_block(self):
+        adapter = self._adapter()
+        msg = (
+            "Before\n```text\n``` not a close\n"
+            + "inside line\n" * 60
+            + "```\nAfter"
+        )
+        chunks = adapter.truncate_message(msg, max_length=180)
+
+        assert len(chunks) > 1
+        assert "``` not a close" in chunks[0]
+        assert any(
+            chunk.startswith("```text\n") for chunk in chunks[1:]
+        ), "continuation chunks should reopen the still-active code block"
+
     def test_each_chunk_under_max_length(self):
         adapter = self._adapter()
         msg = "word " * 500

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1027,6 +1027,21 @@ class TestTruncateMessage:
                 "No continuation chunk reopened with language tag"
             )
 
+    def test_trailing_text_after_fence_marker_stays_inside_code_block(self):
+        adapter = self._adapter()
+        msg = (
+            "Before\n```text\n``` not a close\n"
+            + "inside line\n" * 60
+            + "``` still not a close\nAfter"
+        )
+        chunks = adapter.truncate_message(msg, max_length=180)
+
+        assert len(chunks) > 1
+        assert "``` not a close" in chunks[0]
+        assert any(
+            chunk.startswith("```text\n") for chunk in chunks[1:]
+        ), "continuation chunks should reopen the still-active code block"
+        assert chunks[-1].rsplit(" (", 1)[0].endswith("\n```")
 
 # ---------------------------------------------------------------------------
 # _get_human_delay


### PR DESCRIPTION
## Summary

- tighten `BasePlatformAdapter.truncate_message()` fence tracking so an active backtick fence only closes when the fence marker is followed by whitespace
- keep lines like ` ``` not a close` inside the current code block while preserving language carry-over for continuation chunks
- add a regression test for long messages that contain a fence-looking code-content line before a split boundary

Closes #55292.

## Testing

- `python -m pytest tests/gateway/test_platform_base.py::TestTruncateMessage -q --basetemp .pytest-tmp-truncate-fence-final`
- `python -m ruff check gateway/platforms/base.py tests/gateway/test_platform_base.py`
- `git diff --check`