### PR TITLE
fix(dashboard): hint when basic plugin is disabled but basic_auth is configured

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19995,7 +19995,7 @@ def start_server(
                 "There is no unauthenticated public-bind option — to keep it "
                 "local, bind 127.0.0.1 and tunnel in (SSH / Tailscale)."
             )
-            # Hint when credentials exist but the bundled provider is blocked
+# Hint when credentials exist but the bundled provider is blocked
             # (#54489).
             try:
                 from hermes_cli.config import load_config as _load_cfg


### PR DESCRIPTION
When dashboard bind fails with no auth providers registered, the error message did not hint that the basic plugin might be in plugins.disabled.

Added a diagnostic check that detects dashboard.basic_auth configured but basic plugin disabled, and prepends a specific fix hint.

Fixes #54489