### PR TITLE
fix(whatsapp): add lazy-deps entry and ensure() call for aiohttp

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -467,6 +467,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         
         This launches the Node.js bridge process and waits for it to be ready.
         """
+        # Lazy-install aiohttp and defusedxml if missing (#54217).
+        try:
+            from tools.lazy_deps import ensure
+            ensure("platform.whatsapp", prompt=False)
+        except Exception:
+            pass
+
         if not check_whatsapp_requirements():
             logger.warning("[%s] Node.js not found. WhatsApp requires Node.js.", self.name)
             self._set_fatal_error(

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -193,6 +193,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "lark-oapi==1.6.8",
         "qrcode==7.4.2",
     ),
+    "platform.whatsapp": (
+        "aiohttp==3.13.4",  # CVE-2026-34513/34518/34519/34520/34525
+        "defusedxml==0.7.1",
+    ),
     # WeCom callback-mode adapter — parses untrusted XML POST bodies. Pulls
     # defusedxml only; aiohttp/httpx are core dependencies of every messaging
     # adapter and ship via `platform.discord` / `platform.slack` / etc.


### PR DESCRIPTION
WhatsApp adapter crashed with ModuleNotFoundError: No module named aiohttp because the LAZY_DEPS allowlist had no platform.whatsapp entry, and the adapter did raw imports without calling ensure() first.

Added platform.whatsapp to LAZY_DEPS (aiohttp + defusedxml) and added an ensure() call at the top of connect() to lazy-install on demand.

Fixes #54217