### PR TITLE
fix(whatsapp): convert bold italic markdown first

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -373,6 +373,15 @@ class WhatsAppBehaviorMixin:
 
         # --- 3. Convert markdown formatting to WhatsApp syntax ---
         # Bold: **text** or __text__ → *text*
+        # Combined bold+italic must run before plain bold, or ***text***
+        # loses only one layer and leaves literal asterisks behind.
+        result = re.sub(r"\*\*\*(.+?)\*\*\*", r"*_\1_*", result)
+        result = re.sub(r"___(.+?)___", r"*_\1_*", result)
+        result = re.sub(r"\*\*_(.+?)_\*\*", r"*_\1_*", result)
+        result = re.sub(r"__\*(.+?)\*__", r"*_\1_*", result)
+        result = re.sub(r"_\*\*(.+?)\*\*_", r"*_\1_*", result)
+        result = re.sub(r"\*__(.+?)__\*", r"*_\1_*", result)
+
         result = re.sub(r"\*\*(.+?)\*\*", r"*\1*", result)
         result = re.sub(r"__(.+?)__", r"*\1*", result)
         # Strikethrough: ~~text~~ → ~text~

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -467,6 +467,15 @@ class WhatsAppBehaviorMixin:
             result,
         )
         # Bold: **text** or __text__ → *text*
+        # Combined bold+italic must run before plain bold, or ***text***
+        # loses only one layer and leaves literal asterisks behind.
+        result = re.sub(r"\*\*\*(.+?)\*\*\*", r"*_\1_*", result)
+        result = re.sub(r"___(.+?)___", r"*_\1_*", result)
+        result = re.sub(r"\*\*_(.+?)_\*\*", r"*_\1_*", result)
+        result = re.sub(r"__\*(.+?)\*__", r"*_\1_*", result)
+        result = re.sub(r"_\*\*(.+?)\*\*_", r"*_\1_*", result)
+        result = re.sub(r"\*__(.+?)__\*", r"*_\1_*", result)
+
         result = re.sub(r"\*\*(.+?)\*\*", r"*\1*", result)
         result = re.sub(r"__(.+?)__", r"*\1*", result)
         # Strikethrough: ~~text~~ → ~text~

--- a/tests/conformance/vectors/whatsapp.json
+++ b/tests/conformance/vectors/whatsapp.json
@@ -2,7 +2,7 @@
   "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_conformance_vectors.py; the native renderers are the oracle (executable spec).",
   "oracle": {
     "repo": "NousResearch/hermes-agent",
-    "commit": "40eebc7d70f3d8e95c429c8aa482f31ba6c867f6",
+    "commit": "f84ecd36071a83f3a56927b16643507079b74683",
     "generator": "scripts/generate_conformance_vectors.py",
     "generator_version": 1
   },
@@ -288,7 +288,7 @@
       "category": "adversarial",
       "expect": "parity",
       "input": "***what is this*** and ____that____",
-      "native_output": "**what is this** and *__that*__"
+      "native_output": "*_what is this_* and *__that_*_"
     },
     {
       "id": "empty-string",

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -81,6 +81,27 @@ class TestFormatMessage:
         adapter = _make_adapter()
         assert adapter.format_message("__hello__") == "*hello*"
 
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            ("***launch now***", "*_launch now_*"),
+            ("___launch now___", "*_launch now_*"),
+            ("**_launch now_**", "*_launch now_*"),
+            ("__*launch now*__", "*_launch now_*"),
+            ("_**launch now**_", "*_launch now_*"),
+            ("*__launch now__*", "*_launch now_*"),
+        ],
+    )
+    def test_bold_italic_markdown(self, source, expected):
+        adapter = _make_adapter()
+        assert adapter.format_message(source) == expected
+
+    def test_bold_italic_inside_inline_code_protected(self):
+        adapter = _make_adapter()
+        assert adapter.format_message("use `***raw***` then ***ok***") == (
+            "use `***raw***` then *_ok_*"
+        )
+
     def test_strikethrough(self):
         adapter = _make_adapter()
         assert adapter.format_message("~~deleted~~") == "~deleted~"

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -85,6 +85,27 @@ class TestFormatMessage:
     """WhatsApp markdown conversion."""
 
 
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            ("***launch now***", "*_launch now_*"),
+            ("___launch now___", "*_launch now_*"),
+            ("**_launch now_**", "*_launch now_*"),
+            ("__*launch now*__", "*_launch now_*"),
+            ("_**launch now**_", "*_launch now_*"),
+            ("*__launch now__*", "*_launch now_*"),
+        ],
+    )
+    def test_bold_italic_markdown(self, source, expected):
+        adapter = _make_adapter()
+        assert adapter.format_message(source) == expected
+
+    def test_bold_italic_inside_inline_code_protected(self):
+        adapter = _make_adapter()
+        assert adapter.format_message("use `***raw***` then ***ok***") == (
+            "use `***raw***` then *_ok_*"
+        )
+
     def test_strikethrough(self):
         adapter = _make_adapter()
         assert adapter.format_message("~~deleted~~") == "~deleted~"


### PR DESCRIPTION
## Summary

- convert GFM combined bold+italic forms before the plain bold rules in WhatsApp formatting
- map `***text***`, `___text___`, `**_text_**`, `__*text*__`, `_**text**_`, and `*__text__*` to WhatsApp's `*_text_*` form
- add formatter regressions, including inline-code protection

Closes #55296.

## Testing

- `python -m pytest tests/gateway/test_whatsapp_formatting.py -q --basetemp .pytest-tmp-whatsapp-bold-italic`
- `python -m ruff check gateway/platforms/whatsapp_common.py tests/gateway/test_whatsapp_formatting.py`
- `git diff --check`