### PR TITLE
fix(gateway): require whitespace-only trailing content for closing fence in truncate_message

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5329,8 +5329,13 @@ class BasePlatformAdapter(ABC):
                 stripped = line.strip()
                 if stripped.startswith("```"):
                     if in_code:
-                        in_code = False
-                        lang = ""
+                        # CommonMark: a closing code fence must have only
+                        # whitespace after the backticks.  A line like
+                        # ```` ``` not a close ```` is ordinary code content.
+                        after_backticks = stripped[3:]
+                        if not after_backticks or after_backticks.isspace():
+                            in_code = False
+                            lang = ""
                     else:
                         in_code = True
                         tag = stripped[3:].strip()

--- a/tests/gateway/test_truncate_message_fence_boundary.py
+++ b/tests/gateway/test_truncate_message_fence_boundary.py
@@ -1,0 +1,105 @@
+"""Regression tests for truncate_message fence-boundary detection.
+
+Issue #55292: lines starting with ``` followed by non-whitespace text
+inside a code block are ordinary content, not closing fences (CommonMark).
+"""
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the fence scanner (extracted logic from truncate_message)
+# ---------------------------------------------------------------------------
+
+def _scan_fences(lines: list[str], in_code: bool = False, lang: str = ""):
+    """Replicate the fence-detection loop from truncate_message."""
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            if in_code:
+                after_backticks = stripped[3:]
+                if not after_backticks or after_backticks.isspace():
+                    in_code = False
+                    lang = ""
+            else:
+                in_code = True
+                tag = stripped[3:].strip()
+                lang = tag.split()[0] if tag else ""
+    return in_code, lang
+
+
+class TestFenceDetection:
+    """Direct unit tests for the fence-detection invariant."""
+
+    def test_bare_close_fence(self):
+        ic, lang = _scan_fences(["aaa", "```"], in_code=True, lang="text")
+        assert ic is False and lang == ""
+
+    def test_close_fence_with_trailing_spaces(self):
+        ic, lang = _scan_fences(["aaa", "```   "], in_code=True, lang="text")
+        assert ic is False and lang == ""
+
+    def test_close_fence_with_trailing_tab(self):
+        ic, lang = _scan_fences(["aaa", "```\t"], in_code=True, lang="text")
+        assert ic is False and lang == ""
+
+    def test_fence_with_trailing_text_is_not_close(self):
+        ic, lang = _scan_fences(
+            ["aaa", "``` not a close", "bbb"], in_code=True, lang="text",
+        )
+        assert ic is True and lang == "text"
+
+    def test_fence_with_info_string_is_not_close(self):
+        ic, lang = _scan_fences(
+            ["aaa", "```python"], in_code=True, lang="text",
+        )
+        assert ic is True and lang == "text"
+
+    def test_fence_with_info_string_and_text_is_not_close(self):
+        ic, lang = _scan_fences(
+            ["aaa", "```python extra"], in_code=True, lang="text",
+        )
+        assert ic is True and lang == "text"
+
+    def test_opening_fence_sets_lang(self):
+        ic, lang = _scan_fences(["```ruby", "x = 1", "```"])
+        assert ic is False and lang == ""
+
+    def test_opening_fence_split_before_close(self):
+        ic, lang = _scan_fences(["```ruby", "x = 1"])
+        assert ic is True and lang == "ruby"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests for truncate_message
+# ---------------------------------------------------------------------------
+
+class TestTruncateMessageE2E:
+    """End-to-end tests verifying truncate_message chunk behavior."""
+
+    @staticmethod
+    def _truncate(content: str, max_length: int = 200) -> list[str]:
+        return BasePlatformAdapter.truncate_message(content, max_length)
+
+    def test_bare_close_fence_allows_proper_close(self):
+        """A bare ``` closes the block; continuation should NOT reopen."""
+        content = "pad\n```text\naaa\n```\noutside\n" + "B" * 300
+        chunks = self._truncate(content, max_length=120)
+        assert len(chunks) >= 2
+        # Block properly closed — continuation should NOT reopen.
+        assert all(not c.startswith("```text\n") for c in chunks)
+
+    def test_fence_with_trailing_text_keeps_block_open(self):
+        """``` followed by non-whitespace keeps the block open."""
+        content = "pad\n```ruby\nfirst\n``` not a close\nlast\n" + "A" * 300
+        chunks = self._truncate(content, max_length=120)
+        assert len(chunks) >= 2
+        # Block is still open — continuation must reopen with ```ruby.
+        assert any(c.startswith("```ruby\n") for c in chunks[1:])
+
+    def test_short_content_unchanged(self):
+        content = "```text\n``` not a close\nstill code\n```"
+        result = self._truncate(content, max_length=9999)
+        assert result == [content]


### PR DESCRIPTION
## What does this PR do?

Fixes the fence-boundary detector in `truncate_message()` to follow the CommonMark closing-fence specification. Previously, any line starting with ``` inside a code block was treated as a closing fence — including lines like ```` ``` not a close ```` which are ordinary code content. This caused continuation chunks to omit the fence reopen, breaking Markdown rendering on platforms like Telegram, Discord, and Slack.

## Related Issue

Fixes #55292

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: Added a whitespace-only check after the opening backticks when scanning for closing fences inside a code block. Per CommonMark, a closing code fence must have only whitespace (or nothing) after the backticks. Lines with non-whitespace content (e.g. ```` ```python ````, ```` ``` not a close ````) are now correctly treated as code content.
- `tests/gateway/test_truncate_message_fence_boundary.py`: Added 8 unit tests for the fence-detection invariant and 3 end-to-end tests for `truncate_message` chunk behavior.

## How to Test

1. Run the new tests: `python -m pytest tests/gateway/test_truncate_message_fence_boundary.py -v` — all 11 should pass.
2. Run the existing test suite: `python -m pytest tests/ -q` — no regressions.
3. Manual verification: a message containing ```` ```text\n``` not a close\nstill code\n``` ```` inside a code block should render correctly when chunked across multiple platform messages — the continuation chunk should reopen with ```` ```text ````.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
