### PR TITLE
fix(tui): add missing draft and show subcommands to /goal

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15066,6 +15066,23 @@ def _(rid, params: dict) -> dict:
         lower = arg.strip().lower()
         if not arg.strip() or lower == "status":
             return _ok(rid, {"type": "exec", "output": mgr.status_line()})
+        if lower == "show":
+            return _ok(rid, {"type": "exec", "output": mgr.status_line() + "\n" + mgr.render_contract()})
+        if lower.startswith("draft"):
+            objective = arg.strip()[len("draft"):].strip()
+            if not objective:
+                return _ok(rid, {"type": "exec", "output": "Usage: /goal draft <objective in plain language>"})
+            # Import the draft handler from CLI mixin
+            try:
+                from hermes_cli.goals import GoalManager as _GM
+                _gm = _GM(session_id=sid_key, default_max_turns=max_turns)
+                contract = _gm.draft_contract(objective)
+                if contract:
+                    _gm.set_contract(contract)
+                    return _ok(rid, {"type": "exec", "output": f"✓ Contract drafted: {contract.objective}"})
+                return _ok(rid, {"type": "exec", "output": "Failed to draft contract — try a more specific objective."})
+            except Exception as exc:
+                return _err(rid, 5030, f"draft failed: {exc}")
         if lower == "pause":
             state = mgr.pause(reason="user-paused")
             out = "No goal set." if state is None else f"⏸ Goal paused: {state.goal}"


### PR DESCRIPTION
The TUI gateway goal handler only supported status, pause, resume, and clear. The CLI handler also supports draft and show subcommands, but the TUI fell through to set as new goal for unrecognized subcommands.

Added draft and show subcommand handling to match the CLI behavior.

Fixes #54985