### PR TITLE
fix: handle Google Chat app command payloads

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1064,6 +1064,18 @@ class GoogleChatAdapter(BasePlatformAdapter):
             space = msg_payload_wrapper.get("space") or msg.get("space") or {}
             return msg, space, "workspace_addons"
 
+        # Format 1b: Workspace Add-ons app commands. Native Chat slash
+        # commands arrive as ``chat.appCommandPayload`` instead of
+        # ``chat.messagePayload``. The payload still contains a normal Chat
+        # ``message`` with ``text`` (e.g. "/status"), annotations, and a
+        # ``slashCommand.commandId``. Treat it as a message so the existing
+        # gateway slash-command dispatcher handles it.
+        app_command_payload = chat_block.get("appCommandPayload") if chat_block else None
+        if app_command_payload:
+            msg = app_command_payload.get("message") or {}
+            space = app_command_payload.get("space") or msg.get("space") or {}
+            return msg, space, "workspace_addons_app_command"
+
         # Format 2: Native Chat API Pub/Sub. Detected by a top-level
         # ``message`` object plus a ``type`` field; only MESSAGE events
         # flow through here.
@@ -1552,10 +1564,26 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # Slash command: emit MessageType.COMMAND with normalized text.
         slash = msg.get("slashCommand") or {}
         is_slash = bool(slash)
-        if is_slash:
-            command_id = str(slash.get("commandId") or "")
-            if command_id and not text.startswith("/"):
-                text = f"/cmd_{command_id} {text}".strip()
+        if is_slash and not text.startswith("/"):
+            # Native Google Chat app commands sometimes put only the
+            # argument text in ``message.text`` (e.g. "2" for
+            # ``/commands 2``). The actual command name lives in the
+            # SLASH_COMMAND annotation, so prefer that over the opaque
+            # commandId fallback when present.
+            command_name = ""
+            for ann in msg.get("annotations") or []:
+                slash_ann = ann.get("slashCommand") or {}
+                command_name = str(slash_ann.get("commandName") or "").strip()
+                if command_name:
+                    break
+            if command_name:
+                if not command_name.startswith("/"):
+                    command_name = f"/{command_name}"
+                text = f"{command_name} {text}".strip()
+            else:
+                command_id = str(slash.get("commandId") or "")
+                if command_id:
+                    text = f"/cmd_{command_id} {text}".strip()
 
         # Attachments: download and cache.
         media_urls: List[str] = []

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -604,6 +604,46 @@ class TestExtractMessagePayload:
         assert space.get("name") == "spaces/S"
         assert space.get("spaceType") == "DIRECT_MESSAGE"
 
+    def test_workspace_addons_app_command_payload_extracts_message(self):
+        """Format 1b: native Chat app commands use appCommandPayload.
+
+        Commands configured from the Google Chat API Console can arrive as
+        ``chat.appCommandPayload`` instead of ``chat.messagePayload``. The
+        embedded message still carries the literal slash text (e.g.
+        ``/status``), so routing it through the normal message path lets the
+        gateway slash-command dispatcher handle it.
+        """
+        envelope = {
+            "chat": {
+                "appCommandPayload": {
+                    "appCommandMetadata": {
+                        "appCommandId": 1,
+                        "appCommandType": "SLASH_COMMAND",
+                    },
+                    "space": {"name": "spaces/S", "spaceType": "DIRECT_MESSAGE"},
+                    "message": {
+                        "name": "spaces/S/messages/M.M",
+                        "sender": {
+                            "name": "users/12345",
+                            "email": "alice@example.com",
+                            "displayName": "Alice",
+                            "type": "HUMAN",
+                        },
+                        "text": "/status",
+                        "slashCommand": {"commandId": "1"},
+                        "thread": {"name": "spaces/S/threads/T"},
+                    },
+                }
+            }
+        }
+        result = GoogleChatAdapter._extract_message_payload(envelope, ce_type="")
+        assert result is not None
+        msg, space, fmt = result
+        assert fmt == "workspace_addons_app_command"
+        assert msg.get("text") == "/status"
+        assert msg.get("slashCommand", {}).get("commandId") == "1"
+        assert space.get("name") == "spaces/S"
+
     def test_native_chat_api_format_drops_non_message_events(self):
         """Format 2 with ``type != MESSAGE`` returns None — caller acks."""
         envelope = {
@@ -731,6 +771,37 @@ class TestExtractMessagePayload:
 
 
 class TestBuildMessageEvent:
+    @pytest.mark.asyncio
+    async def test_native_slash_command_uses_annotation_name_with_arguments(self, adapter):
+        """Native Chat commands can put args in text and command name in annotation.
+
+        Google Chat sent `/commands 2` as text `2` plus slashCommand.commandId,
+        with the real `/commands` name only in the SLASH_COMMAND annotation.
+        The adapter must rebuild `/commands 2`, not fall back to `/cmd_<id> 2`.
+        """
+        env = _make_chat_envelope(text="2", thread_name="spaces/S/threads/T1")
+        msg = env["chat"]["messagePayload"]["message"]
+        msg["slashCommand"] = {"commandId": "4"}
+        msg["annotations"] = [
+            {
+                "type": "SLASH_COMMAND",
+                "startIndex": 0,
+                "length": 9,
+                "slashCommand": {
+                    "type": "INVOKE",
+                    "commandName": "/commands",
+                    "commandId": "4",
+                },
+            }
+        ]
+
+        event = await adapter._build_message_event(msg, env)
+
+        assert event.message_type == MessageType.COMMAND
+        assert event.text == "/commands 2"
+        assert event.get_command() == "commands"
+        assert event.get_command_args() == "2"
+
     @pytest.mark.asyncio
     async def test_dm_first_message_in_thread_is_main_flow(self, adapter):
         """Google Chat DMs spawn a fresh thread per top-level user


### PR DESCRIPTION
## Summary

Google Chat native commands configured via the Cloud Console Commands button can arrive in Pub/Sub as `chat.appCommandPayload.message` instead of the normal `chat.messagePayload.message`.

The Google Chat adapter previously ignored these envelopes, so native Chat slash commands like `/status` did not reach the Hermes gateway slash-command dispatcher.

This change treats `chat.appCommandPayload.message` as a normal inbound Chat message. The payload includes either the literal command text (e.g. `/status`) or, for commands with arguments, the argument text plus a `SLASH_COMMAND` annotation containing `slashCommand.commandName`. The adapter now reconstructs commands like `/commands 2` instead of falling back to opaque `/cmd_<id>` names.

## Verification

```bash
/Users/nizar.habbal/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_google_chat.py -q -o 'addopts='
```

Result:

```text
162 passed, 3 warnings in 2.70s
```

The warnings are existing coroutine mock warnings in the Google Chat tests.

## Example payload shapes

Native command with literal command text:

```json
{
  "chat": {
    "appCommandPayload": {
      "appCommandMetadata": {
        "appCommandId": 1,
        "appCommandType": "SLASH_COMMAND"
      },
      "message": {
        "text": "/status",
        "slashCommand": {
          "commandId": "1"
        }
      }
    }
  }
}
```

Native command with argument text and command name in annotation:

```json
{
  "chat": {
    "appCommandPayload": {
      "message": {
        "text": "2",
        "annotations": [
          {
            "type": "SLASH_COMMAND",
            "slashCommand": {
              "commandName": "/commands",
              "commandId": "4"
            }
          }
        ],
        "slashCommand": {
          "commandId": "4"
        }
      }
    }
  }
}
```
