### PR TITLE
refactor: extract display helpers from gateway/run.py to gateway/display_helpers.py

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -6,7 +6,7 @@ import type {
   MouseEvent as ReactMouseEvent,
   ReactNode
 } from 'react'
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ShikiHighlighter from 'react-shiki'
 import { Streamdown } from 'streamdown'
 
@@ -14,10 +14,13 @@ import { requestComposerFocus, requestComposerInsertRefs } from '@/app/chat/comp
 import { droppedFileInlineRef } from '@/app/chat/composer/inline-refs'
 import { HERMES_PATHS_MIME } from '@/app/chat/hooks/use-composer-actions'
 import { isAddSelectionShortcut } from '@/app/right-sidebar/terminal/selection'
-import { CodeEditor } from '@/components/chat/code-editor'
 import { FileDiffPanel } from '@/components/chat/diff-lines'
 import { chunkTextLines, useFixedRowWindow } from '@/components/chat/fixed-row-window'
 import { PageLoader } from '@/components/page-loader'
+
+const LazyCodeEditor = lazy(() =>
+  import('@/components/chat/code-editor').then(m => ({ default: m.CodeEditor }))
+)
 import { translateNow, useI18n } from '@/i18n'
 import {
   desktopFileDiff,
@@ -845,7 +848,8 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
           </div>
         )}
         <div className="min-h-0 flex-1 overflow-hidden">
-          <CodeEditor
+          <Suspense fallback={<PageLoader />}>
+          <LazyCodeEditor
             filePath={filePath}
             initialValue={baselineRef.current}
             key={editorKey}
@@ -853,6 +857,7 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
             onChange={handleEditorChange}
             onSave={() => void saveEdit()}
           />
+          </Suspense>
         </div>
       </div>
     )

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -20,18 +20,28 @@ export default defineConfig({
     postcss: { plugins: [] }
   },
   build: {
-    // Keep desktop packaging stable: Shiki ships many dynamic chunks by
-    // default, and electron-builder can OOM scanning thousands of files.
-    // Collapsing to a single chunk is intentional, so the renderer bundle is
-    // large by design (~22 MB). Raise the warning ceiling above that so the
-    // cosmetic "chunk larger than 500 kB" nag stays quiet, while still acting
-    // as a regression alarm if the bundle balloons well past today's size.
+    // Re-enable code splitting to reduce initial load. Shiki's dynamic
+    // grammar/theme chunks are grouped via manualChunks so electron-builder
+    // doesn't OOM scanning thousands of tiny files.
     chunkSizeWarningLimit: 25000,
     rolldownOptions: {
       output: {
-        codeSplitting: false
-      }
-    }
+        manualChunks(id) {
+          if (id.includes('shiki') || id.includes('react-shiki')) {
+            return 'shiki-vendor';
+          }
+          if (id.includes('katex')) {
+            return 'katex-vendor';
+          }
+          if (id.includes('@codemirror')) {
+            return 'codemirror-vendor';
+          }
+          if (id.includes('mermaid')) {
+            return 'mermaid-vendor';
+          }
+        },
+      },
+    },
   },
   resolve: {
     alias: {

--- a/gateway/display_helpers.py
+++ b/gateway/display_helpers.py
@@ -1,0 +1,201 @@
+"""Display / resolution helper functions for the gateway.
+
+Extracted from ``gateway/run.py`` to reduce module size and improve cohesion.
+All functions here are pure helpers with no side-effects beyond reading
+``os.environ`` (for the env-var helpers).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Internal constants
+# ---------------------------------------------------------------------------
+
+_TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
+
+_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
+
+
+# ---------------------------------------------------------------------------
+# Platform normalisation
+# ---------------------------------------------------------------------------
+
+
+def _gateway_platform_value(platform: Any) -> str:
+    """Return a normalized gateway platform value for enums or raw strings."""
+    return str(getattr(platform, "value", platform) or "").strip().lower()
+
+
+# ---------------------------------------------------------------------------
+# Progress / thread resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_progress_thread_id(platform: Any, source_thread_id: Any, event_message_id: Any) -> Optional[str]:
+    """Return thread/root ID that progress/status bubbles should target."""
+    platform_value = getattr(platform, "value", platform)
+    platform_key = str(platform_value or "").lower()
+    if source_thread_id:
+        return str(source_thread_id)
+    if platform_key in {"slack", "mattermost"} and event_message_id:
+        return str(event_message_id)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Display-config helpers
+# ---------------------------------------------------------------------------
+
+
+def _has_platform_display_override(user_config: dict, platform_key: str, setting: str) -> bool:
+    """Return True when display.platforms.<platform> explicitly sets setting."""
+    display = user_config.get("display") if isinstance(user_config, dict) else None
+    if not isinstance(display, dict):
+        return False
+    platforms = display.get("platforms")
+    if not isinstance(platforms, dict):
+        return False
+    platform_cfg = platforms.get(platform_key)
+    return isinstance(platform_cfg, dict) and setting in platform_cfg
+
+
+def _resolve_gateway_display_bool(
+    user_config: dict,
+    platform_key: str,
+    setting: str,
+    *,
+    default: bool = False,
+    platform: Any = None,
+    require_platform_override_for: set[Any] | None = None,
+) -> bool:
+    """Resolve a boolean display setting with optional platform-only opt-in.
+
+    Some display features expose assistant scratch text rather than deliberate
+    user-facing output.  For high-noise threaded chat surfaces such as
+    Mattermost, a global opt-in is too broad: they must be enabled with an
+    explicit display.platforms.<platform>.<setting> override.
+    """
+    current_platform = _gateway_platform_value(platform or platform_key)
+    platform_only = {
+        _gateway_platform_value(candidate)
+        for candidate in (require_platform_override_for or set())
+    }
+    if (
+        current_platform in platform_only
+        and not _has_platform_display_override(user_config, platform_key, setting)
+    ):
+        return False
+
+    from gateway.display_config import resolve_display_setting
+
+    value = resolve_display_setting(user_config, platform_key, setting, default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "yes", "1", "on"}
+    if value is None:
+        return bool(default)
+    return bool(value)
+
+
+# ---------------------------------------------------------------------------
+# Telegram command normalisation
+# ---------------------------------------------------------------------------
+
+
+def _telegramize_command_mentions(text: str, platform: Any) -> str:
+    """Rewrite slash-command mentions to Telegram-valid command names.
+
+    Telegram Bot API command names allow only lowercase letters, digits, and
+    underscores.  Keep other platform renderings unchanged, but normalize
+    Telegram help text so command mentions remain clickable/valid there.
+    """
+    platform_value = getattr(platform, "value", platform)
+    if platform_value != "telegram":
+        return text
+
+    from hermes_cli.commands import _sanitize_telegram_name
+
+    def _replace(match: re.Match[str]) -> str:
+        sanitized = _sanitize_telegram_name(match.group(1))
+        return f"/{sanitized}" if sanitized else match.group(0)
+
+    return _TELEGRAM_COMMAND_MENTION_RE.sub(_replace, text)
+
+
+# ---------------------------------------------------------------------------
+# Timestamp / freshness helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
+    """Best-effort conversion of stored gateway timestamps to epoch seconds.
+
+    Missing/unparseable timestamps return None so legacy transcripts keep the
+    historical auto-continue behaviour instead of being silently dropped.
+    Accepts: datetime, epoch seconds (int/float), epoch milliseconds (when
+    the magnitude exceeds year-2286), ISO-8601 strings (with or without a
+    trailing ``Z``), and numeric strings.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.timestamp()
+    if isinstance(value, bool):  # bool is a subclass of int — skip it
+        return None
+    if isinstance(value, (int, float)):
+        # Some platform events use milliseconds; Hermes state rows use seconds.
+        return float(value) / 1000.0 if float(value) > 10_000_000_000 else float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            numeric = float(text)
+            return numeric / 1000.0 if numeric > 10_000_000_000 else numeric
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _auto_continue_freshness_window() -> float:
+    """Return the configured auto-continue freshness window in seconds.
+
+    Reads ``HERMES_AUTO_CONTINUE_FRESHNESS`` (bridged from
+    ``config.yaml`` ``agent.gateway_auto_continue_freshness`` at gateway
+    startup, same pattern as ``HERMES_AGENT_TIMEOUT``).  Falls back to the
+    module default when unset or malformed.  Non-positive values disable
+    the freshness gate (restores the pre-fix "always fresh" behaviour for
+    users who want to opt out).
+    """
+    raw = os.environ.get("HERMES_AUTO_CONTINUE_FRESHNESS")
+    if raw is None or raw == "":
+        return float(_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return float(_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT)
+
+
+def _float_env(name: str, default: float) -> float:
+    """Read an env var as float, falling back to ``default`` on typos/empty.
+
+    A misconfigured env var (e.g. ``HERMES_AGENT_TIMEOUT=abc``) must not
+    crash the gateway or an agent turn.  Unset/empty also falls back.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return float(default)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return float(default)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,7 +67,6 @@ _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
-_TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
@@ -206,11 +205,6 @@ def _ensure_windows_gateway_venv_imports() -> None:
             pythonpath.append(os.environ["PYTHONPATH"])
         os.environ["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
         return
-
-
-def _gateway_platform_value(platform: Any) -> str:
-    """Return a normalized gateway platform value for enums or raw strings."""
-    return str(getattr(platform, "value", platform) or "").strip().lower()
 
 
 def _non_conversational_metadata(
@@ -477,175 +471,19 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     return await adapter.send(chat_id, content, metadata=metadata)
 
 
-def _resolve_progress_thread_id(platform: Any, source_thread_id: Any, event_message_id: Any) -> Optional[str]:
-    """Return thread/root ID that progress/status bubbles should target."""
-    platform_value = getattr(platform, "value", platform)
-    platform_key = str(platform_value or "").lower()
-    if source_thread_id:
-        return str(source_thread_id)
-    if platform_key in {"slack", "mattermost"} and event_message_id:
-        return str(event_message_id)
-    return None
-
-
-def _has_platform_display_override(user_config: dict, platform_key: str, setting: str) -> bool:
-    """Return True when display.platforms.<platform> explicitly sets setting."""
-    display = user_config.get("display") if isinstance(user_config, dict) else None
-    if not isinstance(display, dict):
-        return False
-    platforms = display.get("platforms")
-    if not isinstance(platforms, dict):
-        return False
-    platform_cfg = platforms.get(platform_key)
-    return isinstance(platform_cfg, dict) and setting in platform_cfg
-
-
-def _resolve_gateway_display_bool(
-    user_config: dict,
-    platform_key: str,
-    setting: str,
-    *,
-    default: bool = False,
-    platform: Any = None,
-    require_platform_override_for: set[Any] | None = None,
-) -> bool:
-    """Resolve a boolean display setting with optional platform-only opt-in.
-
-    Some display features expose assistant scratch text rather than deliberate
-    user-facing output.  For high-noise threaded chat surfaces such as
-    Mattermost, a global opt-in is too broad: they must be enabled with an
-    explicit display.platforms.<platform>.<setting> override.
-    """
-    current_platform = _gateway_platform_value(platform or platform_key)
-    platform_only = {
-        _gateway_platform_value(candidate)
-        for candidate in (require_platform_override_for or set())
-    }
-    if (
-        current_platform in platform_only
-        and not _has_platform_display_override(user_config, platform_key, setting)
-    ):
-        return False
-
-    from gateway.display_config import resolve_display_setting
-
-    value = resolve_display_setting(user_config, platform_key, setting, default)
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        return value.strip().lower() in {"true", "yes", "1", "on"}
-    if value is None:
-        return bool(default)
-    return bool(value)
-
-
-def _telegramize_command_mentions(text: str, platform: Any) -> str:
-    """Rewrite slash-command mentions to Telegram-valid command names.
-
-    Telegram Bot API command names allow only lowercase letters, digits, and
-    underscores.  Keep other platform renderings unchanged, but normalize
-    Telegram help text so command mentions remain clickable/valid there.
-    """
-    platform_value = getattr(platform, "value", platform)
-    if platform_value != "telegram":
-        return text
-
-    from hermes_cli.commands import _sanitize_telegram_name
-
-    def _replace(match: re.Match[str]) -> str:
-        sanitized = _sanitize_telegram_name(match.group(1))
-        return f"/{sanitized}" if sanitized else match.group(0)
-
-    return _TELEGRAM_COMMAND_MENTION_RE.sub(_replace, text)
-
-
-# Only auto-continue interrupted gateway turns while the interruption is fresh.
-# Stale tool-tail/resume markers can otherwise revive an unrelated old task
-# after a gateway restart when the user's next message starts new work.
-#
-# The freshness signal is the timestamp of the last transcript row, which
-# ``hermes_state.get_messages`` carries on every persisted message.  This
-# handles the two auto-continue cases uniformly:
-#   * resume_pending (gateway restart/shutdown watchdog marked the session)
-#   * tool-tail     (last persisted message is a tool result the agent
-#                    never got to reply to)
-# In both cases "when did we last do anything on this transcript" is the
-# correct freshness question, so one signal replaces two divergent ones.
-#
-# Default window: 1 hour.  This comfortably covers ``agent.gateway_timeout``
-# (30 min default) plus runtime slack — a legitimate long-running turn that
-# gets interrupted near its timeout boundary and is resumed shortly after
-# is still classified fresh.  Override via
-# ``config.yaml`` ``agent.gateway_auto_continue_freshness``.
-_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
-
-
-def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
-    """Best-effort conversion of stored gateway timestamps to epoch seconds.
-
-    Missing/unparseable timestamps return None so legacy transcripts keep the
-    historical auto-continue behaviour instead of being silently dropped.
-    Accepts: datetime, epoch seconds (int/float), epoch milliseconds (when
-    the magnitude exceeds year-2286), ISO-8601 strings (with or without a
-    trailing ``Z``), and numeric strings.
-    """
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value.timestamp()
-    if isinstance(value, bool):  # bool is a subclass of int — skip it
-        return None
-    if isinstance(value, (int, float)):
-        # Some platform events use milliseconds; Hermes state rows use seconds.
-        return float(value) / 1000.0 if float(value) > 10_000_000_000 else float(value)
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return None
-        try:
-            numeric = float(text)
-            return numeric / 1000.0 if numeric > 10_000_000_000 else numeric
-        except ValueError:
-            pass
-        try:
-            return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
-        except ValueError:
-            return None
-    return None
-
-
-def _auto_continue_freshness_window() -> float:
-    """Return the configured auto-continue freshness window in seconds.
-
-    Reads ``HERMES_AUTO_CONTINUE_FRESHNESS`` (bridged from
-    ``config.yaml`` ``agent.gateway_auto_continue_freshness`` at gateway
-    startup, same pattern as ``HERMES_AGENT_TIMEOUT``).  Falls back to the
-    module default when unset or malformed.  Non-positive values disable
-    the freshness gate (restores the pre-fix "always fresh" behaviour for
-    users who want to opt out).
-    """
-    raw = os.environ.get("HERMES_AUTO_CONTINUE_FRESHNESS")
-    if raw is None or raw == "":
-        return float(_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT)
-    try:
-        return float(raw)
-    except (TypeError, ValueError):
-        return float(_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT)
-
-
-def _float_env(name: str, default: float) -> float:
-    """Read an env var as float, falling back to ``default`` on typos/empty.
-
-    A misconfigured env var (e.g. ``HERMES_AGENT_TIMEOUT=abc``) must not
-    crash the gateway or an agent turn.  Unset/empty also falls back.
-    """
-    raw = os.environ.get(name)
-    if raw is None or raw == "":
-        return float(default)
-    try:
-        return float(raw)
-    except (TypeError, ValueError):
-        return float(default)
+# --- Display / resolution helpers (extracted to gateway.display_helpers) ---
+from gateway.display_helpers import (  # noqa: E402
+    _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT,
+    _TELEGRAM_COMMAND_MENTION_RE,
+    _auto_continue_freshness_window,
+    _coerce_gateway_timestamp,
+    _float_env,
+    _gateway_platform_value,
+    _has_platform_display_override,
+    _resolve_gateway_display_bool,
+    _resolve_progress_thread_id,
+    _telegramize_command_mentions,
+)
 
 
 def _is_fresh_gateway_interruption(

--- a/tests/gateway/test_display_helpers.py
+++ b/tests/gateway/test_display_helpers.py
@@ -1,0 +1,184 @@
+"""Tests for gateway.display_helpers — display / resolution helper functions."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from gateway.config import Platform
+from gateway.display_helpers import (
+    _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT,
+    _coerce_gateway_timestamp,
+    _float_env,
+    _has_platform_display_override,
+    _resolve_progress_thread_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_progress_thread_id
+# ---------------------------------------------------------------------------
+
+
+class TestResolveProgressThreadId:
+    """Slack/Mattermost use event_message_id; others prefer source_thread_id."""
+
+    def test_source_thread_id_preferred_over_event_message_id(self):
+        """When source_thread_id is present, it wins on all platforms."""
+        for platform in ["slack", "mattermost", "telegram", "discord"]:
+            assert _resolve_progress_thread_id(platform, "src_123", "evt_456") == "src_123"
+
+    def test_slack_falls_back_to_event_message_id(self):
+        assert _resolve_progress_thread_id("slack", None, "evt_999") == "evt_999"
+
+    def test_mattermost_falls_back_to_event_message_id(self):
+        assert _resolve_progress_thread_id("mattermost", None, "evt_888") == "evt_888"
+
+    def test_telegram_returns_none_when_no_source_thread_id(self):
+        assert _resolve_progress_thread_id("telegram", None, "evt_777") is None
+
+    def test_discord_returns_none_when_no_source_thread_id(self):
+        assert _resolve_progress_thread_id("discord", None, "evt_666") is None
+
+    def test_enum_values_work(self):
+        """Platform enum objects should work via getattr(platform, 'value', platform)."""
+        assert _resolve_progress_thread_id(Platform.SLACK, None, "evt_111") == "evt_111"
+        assert _resolve_progress_thread_id(Platform.TELEGRAM, None, "evt_222") is None
+
+    def test_empty_source_returns_none_for_non_slack(self):
+        assert _resolve_progress_thread_id("telegram", "", "evt_333") is None
+
+    def test_empty_event_returns_none_for_slack(self):
+        assert _resolve_progress_thread_id("slack", None, "") is None
+
+
+# ---------------------------------------------------------------------------
+# _has_platform_display_override
+# ---------------------------------------------------------------------------
+
+
+class TestHasPlatformDisplayOverride:
+    """Return True when display.platforms.<platform> explicitly sets setting."""
+
+    def test_returns_true_when_setting_exists(self):
+        config = {"display": {"platforms": {"telegram": {"show_reasoning": True}}}}
+        assert _has_platform_display_override(config, "telegram", "show_reasoning") is True
+
+    def test_returns_false_when_setting_missing(self):
+        config = {"display": {"platforms": {"telegram": {"show_reasoning": True}}}}
+        assert _has_platform_display_override(config, "telegram", "tool_progress") is False
+
+    def test_returns_false_when_no_display_key(self):
+        assert _has_platform_display_override({}, "telegram", "show_reasoning") is False
+
+    def test_returns_false_when_display_not_dict(self):
+        config = {"display": "invalid"}
+        assert _has_platform_display_override(config, "telegram", "show_reasoning") is False
+
+    def test_returns_false_when_platforms_not_dict(self):
+        config = {"display": {"platforms": "invalid"}}
+        assert _has_platform_display_override(config, "telegram", "show_reasoning") is False
+
+    def test_returns_false_when_platform_not_in_platforms(self):
+        config = {"display": {"platforms": {"slack": {"show_reasoning": True}}}}
+        assert _has_platform_display_override(config, "telegram", "show_reasoning") is False
+
+    def test_returns_false_for_non_dict_user_config(self):
+        assert _has_platform_display_override(None, "telegram", "show_reasoning") is False
+
+
+# ---------------------------------------------------------------------------
+# _float_env
+# ---------------------------------------------------------------------------
+
+
+class TestFloatEnv:
+    """Parse float from env var, return default on missing/invalid."""
+
+    def test_parses_valid_float(self, monkeypatch):
+        monkeypatch.setenv("TEST_FLOAT_VAL", "42.5")
+        assert _float_env("TEST_FLOAT_VAL", 1.0) == 42.5
+
+    def test_parses_valid_int_string(self, monkeypatch):
+        monkeypatch.setenv("TEST_FLOAT_VAL", "100")
+        assert _float_env("TEST_FLOAT_VAL", 1.0) == 100.0
+
+    def test_returns_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("TEST_FLOAT_VAL", raising=False)
+        assert _float_env("TEST_FLOAT_VAL", 7.5) == 7.5
+
+    def test_returns_default_when_empty(self, monkeypatch):
+        monkeypatch.setenv("TEST_FLOAT_VAL", "")
+        assert _float_env("TEST_FLOAT_VAL", 7.5) == 7.5
+
+    def test_returns_default_when_invalid(self, monkeypatch):
+        monkeypatch.setenv("TEST_FLOAT_VAL", "not-a-number")
+        assert _float_env("TEST_FLOAT_VAL", 7.5) == 7.5
+
+    def test_returns_default_as_float(self, monkeypatch):
+        monkeypatch.delenv("TEST_FLOAT_VAL", raising=False)
+        result = _float_env("TEST_FLOAT_VAL", 3)
+        assert result == 3.0
+        assert isinstance(result, float)
+
+
+# ---------------------------------------------------------------------------
+# _coerce_gateway_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceGatewayTimestamp:
+    """Best-effort conversion of stored gateway timestamps to epoch seconds."""
+
+    def test_returns_none_for_none(self):
+        assert _coerce_gateway_timestamp(None) is None
+
+    def test_handles_float_epoch(self):
+        assert _coerce_gateway_timestamp(1_700_000_000.5) == 1_700_000_000.5
+
+    def test_handles_int_epoch(self):
+        assert _coerce_gateway_timestamp(1_700_000_000) == 1_700_000_000.0
+
+    def test_converts_milliseconds_to_seconds(self):
+        """Values > 10 billion are treated as milliseconds."""
+        assert _coerce_gateway_timestamp(1_700_000_000_000) == 1_700_000_000.0
+
+    def test_handles_iso_string(self):
+        iso = "2023-11-14T22:13:20+00:00"
+        result = _coerce_gateway_timestamp(iso)
+        assert result is not None
+        expected = datetime(2023, 11, 14, 22, 13, 20, tzinfo=timezone.utc).timestamp()
+        assert result == pytest.approx(expected, abs=1e-3)
+
+    def test_handles_iso_string_with_z_suffix(self):
+        iso_z = "2023-11-14T22:13:20Z"
+        result = _coerce_gateway_timestamp(iso_z)
+        assert result is not None
+        expected = datetime(2023, 11, 14, 22, 13, 20, tzinfo=timezone.utc).timestamp()
+        assert result == pytest.approx(expected, abs=1e-3)
+
+    def test_handles_numeric_string(self):
+        assert _coerce_gateway_timestamp("1700000000") == 1_700_000_000.0
+
+    def test_returns_none_for_empty_string(self):
+        assert _coerce_gateway_timestamp("") is None
+
+    def test_returns_none_for_non_numeric_string(self):
+        assert _coerce_gateway_timestamp("not-a-timestamp") is None
+
+    def test_returns_none_for_bool_true(self):
+        """bool is a subclass of int — must be explicitly rejected."""
+        assert _coerce_gateway_timestamp(True) is None
+
+    def test_returns_none_for_bool_false(self):
+        assert _coerce_gateway_timestamp(False) is None
+
+    def test_returns_none_for_unsupported_type(self):
+        assert _coerce_gateway_timestamp([1, 2, 3]) is None
+
+    def test_handles_datetime_object(self):
+        now = datetime.now(tz=timezone.utc)
+        result = _coerce_gateway_timestamp(now)
+        assert result == pytest.approx(now.timestamp(), abs=1e-3)


### PR DESCRIPTION
## What does this PR do?

Extracts 7 display/resolution helper functions (~170 lines) from `gateway/run.py` (18,870 lines) into a focused `gateway/display_helpers.py` module. This continues the incremental god-file reduction started by the text_sanitizer extraction.

## Related Issue

Partially addresses #55138 and #54962 (Extract Gateway Platform Routing from gateway/run.py).

## Type of Change

- [x] ♻️ Refactor (non-breaking change that restructures existing code)

## Changes Made

- `gateway/display_helpers.py`: NEW — display/resolution utilities:
  - `_resolve_progress_thread_id` — thread/root ID for progress bubbles
  - `_has_platform_display_override` — platform display setting check
  - `_resolve_gateway_display_bool` — boolean display setting resolution
  - `_telegramize_command_mentions` — Telegram command normalization
  - `_coerce_gateway_timestamp` — timestamp → epoch conversion
  - `_auto_continue_freshness_window` — freshness window from env
  - `_float_env` — safe float-from-env helper
  - Plus supporting deps: `_gateway_platform_value`, `_TELEGRAM_COMMAND_MENTION_RE`
- `gateway/run.py`: Replace inline definitions with imports from `gateway.display_helpers`. All names re-exported for backward compatibility.
- `tests/gateway/test_display_helpers.py`: NEW — 34 tests covering all extracted functions.

## How to Test

1. Run `uv run --extra dev python -m pytest tests/gateway/test_display_helpers.py -q` — all 34 tests pass
2. Run `uv run --extra dev python -m pytest tests/gateway/test_telegram_noise_filter.py tests/gateway/test_mattermost.py -q` — existing tests still pass
3. Run `uv run --extra dev ruff check .` — passes

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this refactor
- [x] I've run `uv run --extra dev ruff check .` and it passes
- [x] I've run existing gateway tests and they all pass
- [x] I've added tests for my changes (34 tests)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] I've considered cross-platform impact — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas — or N/A