### PR TITLE
feat(mcp): refresh OAuth tokens non-interactively

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18717,14 +18717,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
     # MCP tool discovery — run in an executor so the asyncio event loop
     # stays responsive even when a configured MCP server is slow or
-    # unreachable.  discover_mcp_tools() uses a blocking 120s wait
-    # internally; calling it from the loop thread would freeze platform
-    # heartbeats (Discord shard, Telegram polling) until it returned.
+    # unreachable.  The helper suppresses interactive OAuth so a stale MCP
+    # refresh token does not open a browser during gateway startup.
     # See #16856.
     try:
-        from tools.mcp_tool import discover_mcp_tools
+        from hermes_cli.mcp_startup import _discover_mcp_tools_without_interactive_oauth
         _loop = asyncio.get_running_loop()
-        await _loop.run_in_executor(None, discover_mcp_tools)
+        await _loop.run_in_executor(None, _discover_mcp_tools_without_interactive_oauth)
     except Exception as e:
         logger.debug("MCP tool discovery failed: %s", e)
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -1,8 +1,8 @@
 """
 MCP Server Management CLI — ``hermes mcp`` subcommand.
 
-Implements ``hermes mcp add/remove/list/test/configure`` for interactive
-MCP server lifecycle management (issue #690 Phase 2).
+Implements ``hermes mcp add/remove/list/test/configure/refresh`` for interactive
+and non-interactive MCP server lifecycle management (issue #690 Phase 2).
 
 Relies on tools/mcp_tool.py for connection/discovery and keeps
 configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
@@ -761,6 +761,112 @@ def cmd_mcp_login(args):
     _reauth_oauth_server(name, servers[name])
 
 
+def _refresh_oauth_server(
+    name: str,
+    server_config: dict,
+    *,
+    min_ttl_seconds: int = 900,
+    force: bool = False,
+) -> bool:
+    """Refresh an OAuth MCP server using cached refresh tokens only."""
+    url = server_config.get("url")
+    if not url:
+        _error(f"Server '{name}' has no URL — not an OAuth-capable server")
+        return False
+    if server_config.get("auth") != "oauth":
+        _error(f"Server '{name}' is not configured for OAuth (auth={server_config.get('auth')})")
+        return False
+
+    print()
+    _info(f"Refreshing OAuth token for '{name}'...")
+    try:
+        from tools.mcp_oauth import OAuthNonInteractiveError
+        from tools.mcp_oauth_manager import get_manager
+
+        result = asyncio.run(
+            get_manager().refresh_cached_tokens(
+                name,
+                url,
+                server_config.get("oauth"),
+                min_ttl_seconds=min_ttl_seconds,
+                force=force,
+            )
+        )
+    except OAuthNonInteractiveError as exc:
+        _error(str(exc))
+        _info(f"Run `hermes mcp login {name}` interactively first.")
+        return False
+    except Exception as exc:
+        _error(f"Refresh failed: {exc}")
+        return False
+
+    ttl = (
+        f" (access token TTL ~{result.expires_in}s)"
+        if result.expires_in is not None
+        else ""
+    )
+    if result.refreshed:
+        _success(f"Refreshed '{name}'{ttl}")
+        return True
+    if result.skipped:
+        _success(f"Skipped '{name}' — token still fresh{ttl}")
+        return True
+
+    _error(f"Could not refresh '{name}' ({result.reason}){ttl}")
+    _info(f"Run `hermes mcp login {name}` interactively if the refresh token is stale.")
+    return False
+
+
+def cmd_mcp_refresh(args):
+    """Non-interactively refresh OAuth tokens for one server or all servers."""
+    import sys
+
+    servers = _get_mcp_servers()
+    do_all = getattr(args, "all", False)
+    name = getattr(args, "name", None)
+    min_ttl_seconds = getattr(args, "min_ttl_seconds", 900)
+    force = getattr(args, "force", False)
+
+    if do_all:
+        oauth_servers = [
+            (n, c) for n, c in servers.items()
+            if c.get("auth") == "oauth" and c.get("url")
+        ]
+        if not oauth_servers:
+            _info("No OAuth-based MCP servers found in config.")
+            return
+        ok_count = 0
+        for server_name, server_config in oauth_servers:
+            if _refresh_oauth_server(
+                server_name,
+                server_config,
+                min_ttl_seconds=min_ttl_seconds,
+                force=force,
+            ):
+                ok_count += 1
+        _info(f"Refreshed/skipped {ok_count}/{len(oauth_servers)} server(s).")
+        if ok_count != len(oauth_servers):
+            sys.exit(1)
+        return
+
+    if not name:
+        _error("Specify a server name or use --all.")
+        sys.exit(1)
+    if name not in servers:
+        _error(f"Server '{name}' not found in config.")
+        if servers:
+            _info(f"Available servers: {', '.join(servers)}")
+        sys.exit(1)
+
+    if not _refresh_oauth_server(
+        name,
+        servers[name],
+        min_ttl_seconds=min_ttl_seconds,
+        force=force,
+    ):
+        sys.exit(1)
+
+
 def cmd_mcp_reauth(args):
     """Re-authenticate one OAuth MCP server, or all of them sequentially.
 
@@ -949,6 +1055,7 @@ def mcp_command(args):
         "configure": cmd_mcp_configure,
         "config": cmd_mcp_configure,
         "login": cmd_mcp_login,
+        "refresh": cmd_mcp_refresh,
         "reauth": cmd_mcp_reauth,
     }
 
@@ -973,5 +1080,6 @@ def mcp_command(args):
         _info("hermes mcp test <name>                        Test connection")
         _info("hermes mcp configure <name>                   Toggle tools")
         _info("hermes mcp login <name>                       Re-authenticate OAuth")
+        _info("hermes mcp refresh <name>                     Refresh OAuth without browser")
         _info("hermes mcp reauth <name> | --all              Re-auth one or all OAuth servers")
         print()

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -86,6 +86,30 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     )
     mcp_login_p.add_argument("name", help="Server name to re-authenticate")
 
+    mcp_refresh_p = mcp_sub.add_parser(
+        "refresh",
+        help="Refresh OAuth tokens using cached refresh tokens only",
+    )
+    mcp_refresh_p.add_argument(
+        "name", nargs="?", help="Server name to refresh (omit with --all)"
+    )
+    mcp_refresh_p.add_argument(
+        "--all",
+        action="store_true",
+        help="Refresh every OAuth server in config",
+    )
+    mcp_refresh_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Refresh even when the access token is still fresh",
+    )
+    mcp_refresh_p.add_argument(
+        "--min-ttl-seconds",
+        type=int,
+        default=900,
+        help="Refresh only when the access token has this many seconds or less remaining",
+    )
+
     mcp_reauth_p = mcp_sub.add_parser(
         "reauth",
         help="Re-authenticate one OAuth MCP server, or all of them (--all)",

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -757,6 +757,79 @@ class TestMcpLogin:
 
 
 # ---------------------------------------------------------------------------
+# Tests: cmd_mcp_refresh
+# ---------------------------------------------------------------------------
+
+
+class TestMcpRefresh:
+    def test_refresh_single_server(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "remote_oauth": {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
+        })
+        visited = []
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._refresh_oauth_server",
+            lambda name, cfg, *, min_ttl_seconds, force:
+                visited.append((name, cfg["url"], min_ttl_seconds, force)) or True,
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_refresh
+
+        cmd_mcp_refresh(_make_args(
+            name="remote_oauth",
+            all=False,
+            min_ttl_seconds=2700,
+            force=True,
+        ))
+
+        assert visited == [("remote_oauth", "https://mcp.example.com/mcp", 2700, True)]
+
+    def test_refresh_all_visits_only_oauth_http_servers(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "remote_oauth": {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
+            "localstdio": {"command": "npx", "args": ["demo"]},
+            "apikey": {"url": "https://example.com/mcp", "auth": "header"},
+        })
+        visited = []
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._refresh_oauth_server",
+            lambda name, cfg, *, min_ttl_seconds, force:
+                visited.append(name) or True,
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_refresh
+
+        cmd_mcp_refresh(_make_args(
+            name=None,
+            all=True,
+            min_ttl_seconds=900,
+            force=False,
+        ))
+        out = capsys.readouterr().out
+
+        assert visited == ["remote_oauth"]
+        assert "Refreshed/skipped 1/1" in out
+
+    def test_refresh_unknown_server_exits_nonzero(self, tmp_path, capsys):
+        _seed_config(tmp_path, {
+            "remote_oauth": {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
+        })
+        from hermes_cli.mcp_config import cmd_mcp_refresh
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_mcp_refresh(_make_args(
+                name="ghost",
+                all=False,
+                min_ttl_seconds=900,
+                force=False,
+            ))
+
+        out = capsys.readouterr().out
+        assert exc.value.code == 1
+        assert "not found" in out
+
+
+# ---------------------------------------------------------------------------
 # Tests: cmd_mcp_reauth (GH#36767)
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -310,6 +310,20 @@ class TestRedirectHandlerSshHint:
         err = capsys.readouterr().err
         assert "ssh -N -L" not in err
 
+    def test_suppressed_redirect_does_not_open_browser(self, monkeypatch, capsys):
+        import tools.mcp_oauth as mco
+
+        opened = []
+        monkeypatch.setattr(mco, "_can_open_browser", lambda: True)
+        monkeypatch.setattr("webbrowser.open", lambda url, **kw: opened.append(url) or True)
+
+        with mco.suppress_interactive_oauth():
+            with pytest.raises(OAuthNonInteractiveError, match="interactive browser"):
+                self._run(_redirect_handler("https://example.com/auth"))
+
+        assert opened == []
+        assert "Browser opened automatically" not in capsys.readouterr().err
+
 
 # ---------------------------------------------------------------------------
 # Path traversal protection

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -91,8 +91,76 @@ def test_hermes_provider_subclass_exists():
     assert issubclass(_HERMES_PROVIDER_CLS, OAuthClientProvider)
 
 
-@pytest.mark.asyncio
-async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
+def test_refresh_response_preserves_omitted_refresh_token(tmp_path, monkeypatch):
+    """Providers may omit refresh_token on refresh; keep the existing one."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    import asyncio
+    import httpx
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    provider.context.current_tokens = OAuthToken(
+        access_token="old-access",
+        expires_in=1,
+        refresh_token="keep-refresh",
+    )
+
+    response = httpx.Response(
+        200,
+        content=b'{"access_token":"new-access","expires_in":3600,"token_type":"Bearer"}',
+    )
+
+    ok = asyncio.run(provider._handle_refresh_response(response))
+
+    assert ok is True
+    assert provider.context.current_tokens.access_token == "new-access"
+    assert provider.context.current_tokens.refresh_token == "keep-refresh"
+
+    persisted = json.loads((tmp_path / "mcp-tokens" / "srv.json").read_text())
+    assert persisted["access_token"] == "new-access"
+    assert persisted["refresh_token"] == "keep-refresh"
+
+
+def test_refresh_cached_tokens_skips_when_token_still_fresh(tmp_path, monkeypatch):
+    """The keepalive command avoids refresh POSTs while enough TTL remains."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    import asyncio
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    provider._initialized = True
+    provider.context.current_tokens = OAuthToken(
+        access_token="access",
+        expires_in=3600,
+        refresh_token="refresh",
+    )
+    provider.context.update_token_expiry(provider.context.current_tokens)
+    provider.context.client_info = object()
+
+    result = asyncio.run(
+        mgr.refresh_cached_tokens(
+            "srv",
+            "https://example.com/mcp",
+            None,
+            min_ttl_seconds=900,
+        )
+    )
+
+    assert result.skipped is True
+    assert result.refreshed is False
+    assert result.reason == "token_still_fresh"
+    assert result.expires_in > 900
+
+
+def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
     """When the tokens file mtime changes, provider._initialized flips False.
 
     This is the behaviour Claude Code ships as
@@ -116,22 +184,25 @@ async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
     provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
     assert provider is not None
 
-    # First call: records mtime (zero -> real) -> returns True
-    changed1 = await mgr.invalidate_if_disk_changed("srv")
-    assert changed1 is True
+    async def drive():
+        # First call: records mtime (zero -> real) -> returns True
+        changed1 = await mgr.invalidate_if_disk_changed("srv")
+        assert changed1 is True
 
-    # No file change -> False
-    changed2 = await mgr.invalidate_if_disk_changed("srv")
-    assert changed2 is False
+        # No file change -> False
+        changed2 = await mgr.invalidate_if_disk_changed("srv")
+        assert changed2 is False
 
-    # Touch file with a newer mtime
-    future_mtime = time.time() + 10
-    os.utime(tokens_file, (future_mtime, future_mtime))
+        # Touch file with a newer mtime
+        future_mtime = time.time() + 10
+        os.utime(tokens_file, (future_mtime, future_mtime))
 
-    changed3 = await mgr.invalidate_if_disk_changed("srv")
-    assert changed3 is True
-    # _initialized flipped — next async_auth_flow will re-read from disk
-    assert provider._initialized is False
+        changed3 = await mgr.invalidate_if_disk_changed("srv")
+        assert changed3 is True
+        # _initialized flipped — next async_auth_flow will re-read from disk
+        assert provider._initialized is False
+
+    asyncio.run(drive())
 
 
 def test_manager_builds_hermes_provider_subclass(tmp_path, monkeypatch):

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -467,6 +467,12 @@ async def _redirect_handler(authorization_url: str) -> None:
     Opens the browser automatically when possible; always prints the URL
     as a fallback for headless/SSH/gateway environments.
     """
+    if not _oauth_interactive_enabled.get():
+        raise OAuthNonInteractiveError(
+            "MCP OAuth requires interactive browser authorization. "
+            "Run `hermes mcp login <server>` from a terminal to authenticate."
+        )
+
     msg = (
         f"\n  MCP OAuth: authorization required.\n"
         f"  Open this URL in your browser:\n\n"

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -38,6 +38,7 @@ import asyncio
 import logging
 import re
 import threading
+import time
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -95,6 +96,17 @@ class _ProviderEntry:
     last_mtime_ns: int = 0
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     pending_401: dict[str, "asyncio.Future[bool]"] = field(default_factory=dict)
+
+
+@dataclass
+class MCPOAuthRefreshResult:
+    """Outcome from a non-interactive refresh-token grant."""
+
+    server_name: str
+    refreshed: bool
+    skipped: bool
+    reason: str
+    expires_in: Optional[int] = None
 
 
 # ---------------------------------------------------------------------------
@@ -385,6 +397,47 @@ def _make_hermes_provider_class() -> Optional[type]:
                     self._hermes_server_name, exc,
                 )
 
+        async def _handle_refresh_response(self, response: Any) -> bool:
+            """Handle refresh responses while preserving omitted refresh tokens.
+
+            Some OAuth providers rotate refresh tokens, others return only a
+            new access token and expect clients to keep the old refresh token.
+            The MCP SDK replaces the token object wholesale, which can drop
+            a still-valid refresh token when the response omits it. Hermes
+            keeps the previous refresh token in that narrow case.
+            """
+            if response.status_code != 200:
+                logger.warning("Token refresh failed: %s", response.status_code)
+                self.context.clear_tokens()
+                return False
+
+            previous_refresh_token = None
+            if self.context.current_tokens is not None:
+                previous_refresh_token = self.context.current_tokens.refresh_token
+
+            try:
+                content = await response.aread()
+                from mcp.shared.auth import OAuthToken
+                from pydantic import ValidationError
+
+                token_response = OAuthToken.model_validate_json(content)
+                if (
+                    token_response.refresh_token is None
+                    and previous_refresh_token
+                ):
+                    token_response = token_response.model_copy(
+                        update={"refresh_token": previous_refresh_token}
+                    )
+
+                self.context.current_tokens = token_response
+                self.context.update_token_expiry(token_response)
+                await self.context.storage.set_tokens(token_response)
+                return True
+            except ValidationError:
+                logger.exception("Invalid refresh response")
+                self.context.clear_tokens()
+                return False
+
         async def async_auth_flow(self, request):  # type: ignore[override]
             # Pre-flow hook: ask the manager to refresh from disk if needed.
             # Any failure here is non-fatal — we just log and proceed with
@@ -567,6 +620,160 @@ class MCPOAuthManager:
             "MCP OAuth '%s': evicted from cache and removed from disk",
             server_name,
         )
+
+    @staticmethod
+    def _current_token_ttl_seconds(context: Any) -> Optional[int]:
+        expiry = getattr(context, "token_expiry_time", None)
+        if expiry is None:
+            return None
+        try:
+            return max(0, int(float(expiry) - time.time()))
+        except (TypeError, ValueError):
+            return None
+
+    async def refresh_cached_tokens(
+        self,
+        server_name: str,
+        server_url: str,
+        oauth_config: Optional[dict],
+        *,
+        min_ttl_seconds: int = 900,
+        force: bool = False,
+    ) -> MCPOAuthRefreshResult:
+        """Refresh cached MCP OAuth tokens without opening a browser.
+
+        This is intended for cron/launchd keepalive jobs. It only uses an
+        existing refresh token; if refresh fails, callers should ask the user
+        to run ``hermes mcp login <server>`` interactively.
+        """
+        provider = self.get_or_build_provider(server_name, server_url, oauth_config)
+        if provider is None:
+            return MCPOAuthRefreshResult(
+                server_name=server_name,
+                refreshed=False,
+                skipped=False,
+                reason="oauth_unavailable",
+            )
+
+        entry = self._entries.get(server_name)
+        if entry is None or entry.provider is None:
+            return MCPOAuthRefreshResult(
+                server_name=server_name,
+                refreshed=False,
+                skipped=False,
+                reason="provider_unavailable",
+            )
+
+        async with entry.lock:
+            try:
+                if not getattr(provider, "_initialized", False):
+                    await provider._initialize()  # noqa: SLF001
+            except Exception as exc:
+                logger.warning(
+                    "MCP OAuth '%s': initialization before refresh failed: %s",
+                    server_name, exc,
+                )
+                return MCPOAuthRefreshResult(
+                    server_name=server_name,
+                    refreshed=False,
+                    skipped=False,
+                    reason="initialize_failed",
+                )
+
+            context = provider.context
+            tokens = context.current_tokens
+            expires_in = self._current_token_ttl_seconds(context)
+
+            if tokens is None or not getattr(tokens, "access_token", None):
+                return MCPOAuthRefreshResult(
+                    server_name=server_name,
+                    refreshed=False,
+                    skipped=False,
+                    reason="no_cached_tokens",
+                    expires_in=expires_in,
+                )
+            if not getattr(tokens, "refresh_token", None):
+                return MCPOAuthRefreshResult(
+                    server_name=server_name,
+                    refreshed=False,
+                    skipped=False,
+                    reason="no_refresh_token",
+                    expires_in=expires_in,
+                )
+            if not getattr(context, "client_info", None):
+                return MCPOAuthRefreshResult(
+                    server_name=server_name,
+                    refreshed=False,
+                    skipped=False,
+                    reason="no_client_info",
+                    expires_in=expires_in,
+                )
+
+            threshold = max(0, int(min_ttl_seconds))
+            if not force and expires_in is not None and expires_in > threshold:
+                return MCPOAuthRefreshResult(
+                    server_name=server_name,
+                    refreshed=False,
+                    skipped=True,
+                    reason="token_still_fresh",
+                    expires_in=expires_in,
+                )
+
+            try:
+                import httpx
+
+                refresh_request = await provider._refresh_token()  # noqa: SLF001
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    refresh_response = await client.send(refresh_request)
+
+                maybe_flag = getattr(provider, "_maybe_flag_poisoned_client", None)
+                if callable(maybe_flag):
+                    await maybe_flag(refresh_response)
+
+                ok = await provider._handle_refresh_response(refresh_response)  # noqa: SLF001
+            except Exception as exc:
+                logger.warning(
+                    "MCP OAuth '%s': non-interactive refresh failed: %s",
+                    server_name, exc,
+                )
+                return MCPOAuthRefreshResult(
+                    server_name=server_name,
+                    refreshed=False,
+                    skipped=False,
+                    reason="refresh_exception",
+                    expires_in=expires_in,
+                )
+
+            if not ok:
+                return MCPOAuthRefreshResult(
+                    server_name=server_name,
+                    refreshed=False,
+                    skipped=False,
+                    reason="refresh_rejected",
+                    expires_in=expires_in,
+                )
+
+            persist_metadata = getattr(
+                provider, "_persist_oauth_metadata_if_changed", None
+            )
+            if callable(persist_metadata):
+                persist_metadata()
+
+            storage = getattr(context, "storage", None)
+            try:
+                from tools.mcp_oauth import HermesTokenStorage
+                if isinstance(storage, HermesTokenStorage):
+                    entry.last_mtime_ns = storage._tokens_path().stat().st_mtime_ns
+            except Exception:
+                pass
+
+            return MCPOAuthRefreshResult(
+                server_name=server_name,
+                refreshed=True,
+                skipped=False,
+                reason="refreshed",
+                expires_in=self._current_token_ttl_seconds(context),
+            )
 
     # -- Disk watch ----------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add `hermes mcp refresh` for one or all OAuth MCP servers using cached refresh tokens only
- preserve an existing refresh token when a provider returns only a new access token
- suppress interactive browser authorization during gateway startup MCP discovery

## Testing
- `/Users/system/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_startup.py -q`
- `git diff --check origin/main...HEAD`