### PR TITLE
fix(browser): sync framework state after browser_type fill

### DIFF
--- a/tests/tools/test_browser_type_framework_sync.py
+++ b/tests/tools/test_browser_type_framework_sync.py
@@ -1,0 +1,81 @@
+"""Tests for React/framework input sync after browser_type."""
+
+import json
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+class TestControlledInputSyncExpression:
+    def test_expression_uses_native_setter_and_input_event(self):
+        from tools.browser_input_sync import build_controlled_input_sync_expression
+
+        js = build_controlled_input_sync_expression("Jane Doe")
+        assert "HTMLInputElement.prototype" in js
+        assert "insertText" in js
+        assert '"Jane Doe"' in js
+        assert "change" in js
+
+
+class TestBrowserTypeFrameworkSync:
+    def test_successful_type_runs_fill_focus_and_sync_eval(self):
+        from tools.browser_tool import browser_type
+
+        fill_ok = {"success": True}
+        focus_ok = {"success": True}
+        eval_ok = json.dumps({"success": True, "result": {"ok": True, "value": "Jane"}})
+
+        with (
+            patch("tools.browser_tool._run_browser_command") as mock_cmd,
+            patch("tools.browser_tool._browser_eval", return_value=eval_ok) as mock_eval,
+        ):
+            mock_cmd.side_effect = [fill_ok, focus_ok]
+            result = json.loads(browser_type("@e3", "Jane", task_id="sess"))
+
+        assert result["success"] is True
+        assert result["framework_synced"] is True
+        assert "framework_sync_warning" not in result
+
+        assert mock_cmd.call_args_list[0][0][1] == "fill"
+        assert mock_cmd.call_args_list[0][0][2] == ["@e3", "Jane"]
+        assert mock_cmd.call_args_list[1][0][1] == "focus"
+        assert mock_cmd.call_args_list[1][0][2] == ["@e3"]
+        mock_eval.assert_called_once()
+        assert "insertText" in mock_eval.call_args[0][0]
+
+    def test_sync_failure_surfaces_warning_but_keeps_success(self):
+        from tools.browser_tool import browser_type
+
+        with (
+            patch("tools.browser_tool._run_browser_command") as mock_cmd,
+            patch(
+                "tools.browser_tool._browser_eval",
+                return_value=json.dumps(
+                    {"success": True, "result": {"ok": False, "reason": "no active element"}}
+                ),
+            ),
+        ):
+            mock_cmd.side_effect = [{"success": True}, {"success": True}]
+            result = json.loads(browser_type("@e3", "Jane", task_id="sess"))
+
+        assert result["success"] is True
+        assert result["framework_synced"] is False
+        assert "no active element" in result["framework_sync_warning"]
+
+    def test_fill_failure_skips_sync(self):
+        from tools.browser_tool import browser_type
+
+        with (
+            patch(
+                "tools.browser_tool._run_browser_command",
+                return_value={"success": False, "error": "element not found"},
+            ) as mock_cmd,
+            patch("tools.browser_tool._browser_eval") as mock_eval,
+        ):
+            result = json.loads(browser_type("@e9", "Jane", task_id="sess"))
+
+        assert result["success"] is False
+        assert mock_cmd.call_count == 1
+        mock_eval.assert_not_called()

--- a/tools/browser_input_sync.py
+++ b/tools/browser_input_sync.py
@@ -1,0 +1,79 @@
+"""Framework-aware input sync for browser_type.
+
+agent-browser's ``fill`` command uses CDP ``Input.insertText``, which updates
+the DOM ``value`` but does not notify React/Vue/Angular controlled components.
+After fill succeeds, we focus the target ref and re-apply the value with the
+native prototype setter plus bubbling ``input``/``change`` events — the same
+pattern Playwright uses for ``fill()`` on controlled inputs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def build_controlled_input_sync_expression(text: str) -> str:
+    """Return a self-invoking JS expression for the focused input element."""
+    text_json = json.dumps(text)
+    return f"""(() => {{
+  const text = {text_json};
+  const el = document.activeElement;
+  if (!el) return {{ok: false, reason: "no active element"}};
+  const tag = (el.tagName || "").toUpperCase();
+  if (tag !== "INPUT" && tag !== "TEXTAREA") {{
+    return {{ok: false, reason: "active element is not a text input", tag: tag}};
+  }}
+  const proto = tag === "TEXTAREA" ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
+  if (setter) setter.call(el, text);
+  else el.value = text;
+  try {{
+    el.dispatchEvent(new InputEvent("input", {{
+      bubbles: true,
+      cancelable: true,
+      inputType: "insertText",
+      data: text,
+    }}));
+  }} catch (_err) {{
+    el.dispatchEvent(new Event("input", {{ bubbles: true }}));
+  }}
+  el.dispatchEvent(new Event("change", {{ bubbles: true }}));
+  return {{ok: true, value: el.value}};
+}})()"""
+
+
+def sync_controlled_input_value(ref: str, text: str, task_id: str) -> dict[str, Any]:
+    """Focus *ref* and dispatch framework-friendly input events for *text*."""
+    from tools.browser_tool import _browser_eval, _run_browser_command
+
+    focus = _run_browser_command(task_id, "focus", [ref])
+    if not focus.get("success"):
+        return {
+            "ok": False,
+            "error": focus.get("error") or "focus failed before framework input sync",
+        }
+
+    eval_raw = _browser_eval(build_controlled_input_sync_expression(text), task_id)
+    try:
+        eval_payload = json.loads(eval_raw)
+    except json.JSONDecodeError:
+        return {"ok": False, "error": "framework input sync returned invalid JSON"}
+
+    if not eval_payload.get("success"):
+        return {
+            "ok": False,
+            "error": eval_payload.get("error") or "framework input sync eval failed",
+        }
+
+    result = eval_payload.get("result")
+    if isinstance(result, dict) and result.get("ok"):
+        return {"ok": True}
+
+    if isinstance(result, dict):
+        return {
+            "ok": False,
+            "error": result.get("reason") or "framework input sync rejected active element",
+        }
+
+    return {"ok": False, "error": "framework input sync returned unexpected result"}

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2996,7 +2996,9 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
     if not ref.startswith("@"):
         ref = f"@{ref}"
 
-    # Use fill command (clears then types)
+    # agent-browser fill updates the DOM value via Input.insertText but does
+    # not notify React/Vue/Angular controlled components.  Sync framework state
+    # after a successful fill (see tools/browser_input_sync.py, #55075).
     result = _run_browser_command(effective_task_id, "fill", [ref, text])
 
     from agent.display import (
@@ -3007,6 +3009,9 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
     display_text = (redact_tool_args_for_display("browser_type", {"text": text}) or {})["text"]
 
     if result.get("success"):
+        from tools.browser_input_sync import sync_controlled_input_value
+
+        sync = sync_controlled_input_value(ref, text, effective_task_id)
         response = {
             "success": True,
             # Run typed text through the secret-pattern redactor so API keys /
@@ -3014,8 +3019,11 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
             # text passes through unchanged.  The raw value was already sent
             # to the browser command above.
             "typed": display_text,
-            "element": ref
+            "element": ref,
+            "framework_synced": bool(sync.get("ok")),
         }
+        if not sync.get("ok"):
+            response["framework_sync_warning"] = sync.get("error")
         response = _copy_fallback_warning(response, result)
         response = redact_browser_typed_text_for_display(response, text)
         return json.dumps(response, ensure_ascii=False)


### PR DESCRIPTION
## Summary

`browser_type` delegates to agent-browser's `fill` command, which updates the DOM `input.value` via CDP `Input.insertText` but does **not** notify React/Vue/Angular controlled components. The text appears on screen, yet the framework's internal state stays empty — form validation fails on submit even though `browser_type` reports success.

This PR adds a post-fill sync step: focus the target ref, then re-apply the value with the native input setter plus bubbling `input`/`change` events (same pattern Playwright uses for `fill()` on controlled inputs).

## Changes

- New `tools/browser_input_sync.py` — framework-aware input sync helper
- `browser_type` runs sync after a successful `fill` and reports `framework_synced` (with `framework_sync_warning` if sync fails)
- Tests in `tests/tools/test_browser_type_framework_sync.py`

## Steps to Reproduce

1. Navigate to a React-based form (e.g. CVS Vets prescription form)
2. `browser_snapshot` → get ref IDs
3. `browser_type` to fill text fields
4. `browser_console`: `document.querySelector('input').value` → text visible
5. React props on same input → `value` empty
6. Click submit → validation fails ("Please enter your first name", etc.)

## Test plan

- [x] `scripts/run_tests.sh tests/tools/test_browser_type_framework_sync.py -q`
- [ ] Fill a React form and confirm submit validation passes