### PR TITLE
fix(gateway): treat trailing non-whitespace after ``` as code content, not fence close

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5329,8 +5329,13 @@ class BasePlatformAdapter(ABC):
                 stripped = line.strip()
                 if stripped.startswith("```"):
                     if in_code:
-                        in_code = False
-                        lang = ""
+                        # Only close if trailing content is whitespace
+                        # (CommonMark spec: closing fence may be followed
+                        # only by whitespace)
+                        after_ticks = stripped[3:]
+                        if not after_ticks or after_ticks.isspace():
+                            in_code = False
+                            lang = ""
                     else:
                         in_code = True
                         tag = stripped[3:].strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1417,6 +1417,30 @@ class TestTruncateMessage:
                 f"Chunk {i} has unbalanced fences ({fence_count})"
             )
 
+    def test_fence_like_line_inside_code_block_not_closing(self):
+        """Regression: a ``` line with trailing non-whitespace is content,
+        not a closing fence (CommonMark spec, issue #55292)."""
+        adapter = self._adapter()
+        # Code block contains "``` not a close" which should be treated as
+        # content, not a fence boundary.
+        inner_lines = "inside line\n" * 80
+        msg = (
+            "Before\n```text\n"
+            "``` not a close\n"
+            + inner_lines
+            + "```\nAfter"
+        )
+        chunks = adapter.truncate_message(msg, max_length=300)
+        assert len(chunks) > 1
+        # The code block should still be considered open after the
+        # "``` not a close" line — continuation chunks must reopen with
+        # the original language tag.
+        has_text_reopen = any("```text\n" in chunk for chunk in chunks[1:])
+        assert has_text_reopen, (
+            "Continuation chunk should reopen with ```text — "
+            "the ``` not a close line is content, not a fence"
+        )
+
     def test_each_chunk_under_max_length(self):
         adapter = self._adapter()
         msg = "word " * 500


### PR DESCRIPTION
## What does this PR do?

Fixes the fence-boundary scanner in `truncate_message()` so that lines beginning with triple backticks followed by non-whitespace text are treated as code content, not closing fences. Per CommonMark, a closing code fence may be followed only by whitespace.

Previously, any line starting with ``` inside an open code block would close the fence tracker, even if the line was ordinary code content like "``` not a close". This caused continuation chunks to omit the reopened code block, breaking Markdown rendering on platforms that split long messages.

## Related Issue

Fixes #55292

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Added a whitespace-only check on the trailing content after ``` when inside a code block. Only lines where everything after the backticks is whitespace (or empty) are treated as closing fences.
- `tests/gateway/test_platform_base.py`: Added regression test `test_fence_like_line_inside_code_block_not_closing` that verifies a ``` line with trailing non-whitespace text inside a code block does not prematurely close the fence.

## How to Test

1. Run `pytest tests/gateway/test_platform_base.py::TestTruncateMessage -xvs` — all 9 tests should pass, including the new regression test.
2. Run `pytest tests/gateway/test_platform_base.py::TestTruncateMessageUtf16 -xvs` — all 5 tests should pass (no regression in UTF-16 path).
3. The new test constructs a message with "``` not a close" inside a code block and verifies continuation chunks still reopen with the original language tag (`\`\`\`text`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
