### PR TITLE
fix(tui): preserve blocked overlay anchor

### DIFF
--- a/ui-tui/src/__tests__/appLayout.test.ts
+++ b/ui-tui/src/__tests__/appLayout.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import type { OverlayState } from '../app/interfaces.js'
+import { hasFloatingOverlay } from '../components/appLayout.js'
+
+function overlayState(overrides: Partial<OverlayState> = {}): OverlayState {
+  return {
+    agents: false,
+    agentsInitialHistoryIndex: 0,
+    approval: null,
+    billing: null,
+    clarify: null,
+    confirm: null,
+    journey: false,
+    modelPicker: false,
+    pager: null,
+    petPicker: false,
+    pluginsHub: false,
+    secret: null,
+    sessions: false,
+    skillsHub: false,
+    sudo: null,
+    ...overrides
+  }
+}
+
+describe('hasFloatingOverlay', () => {
+  it('returns true for blocking floating overlays rendered above the composer', () => {
+    expect(hasFloatingOverlay(overlayState({ sessions: true }))).toBe(true)
+    expect(hasFloatingOverlay(overlayState({ modelPicker: true }))).toBe(true)
+    expect(hasFloatingOverlay(overlayState({ petPicker: true }))).toBe(true)
+    expect(hasFloatingOverlay(overlayState({ skillsHub: true }))).toBe(true)
+    expect(hasFloatingOverlay(overlayState({ pluginsHub: true }))).toBe(true)
+    expect(hasFloatingOverlay(overlayState({ pager: { lines: ['x'], offset: 0 } }))).toBe(true)
+  })
+
+  it('returns false for non-floating overlays or an idle overlay state', () => {
+    expect(hasFloatingOverlay(overlayState())).toBe(false)
+    expect(
+      hasFloatingOverlay(overlayState({ approval: { command: 'ls', description: 'list files' } }))
+    ).toBe(false)
+    expect(hasFloatingOverlay(overlayState({ clarify: { choices: null, question: 'x', requestId: 'c1' } }))).toBe(
+      false
+    )
+    expect(
+      hasFloatingOverlay(overlayState({ secret: { envVar: 'TOKEN', prompt: 'x', requestId: 's1' } }))
+    ).toBe(false)
+    expect(hasFloatingOverlay(overlayState({ sudo: { requestId: 'sudo1' } }))).toBe(false)
+    expect(hasFloatingOverlay(overlayState({ agents: true }))).toBe(false)
+  })
+})

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -3,7 +3,7 @@ import { useStore } from '@nanostores/react'
 import { Fragment, memo, useEffect, useMemo, useRef } from 'react'
 
 import { useGateway } from '../app/gatewayContext.js'
-import type { AppLayoutProps } from '../app/interfaces.js'
+import type { AppLayoutProps, OverlayState } from '../app/interfaces.js'
 import { $isBlocked, $overlayState, patchOverlayState } from '../app/overlayStore.js'
 import { $petBox } from '../app/petFlashStore.js'
 import { $uiState } from '../app/uiStore.js'
@@ -32,6 +32,17 @@ import { PetKitty, PetSprite } from './petSprite.js'
 import { QueuedMessages } from './queuedMessages.js'
 import { LiveTodoPanel, StreamingAssistant } from './streamingAssistant.js'
 import { TextInput, type TextInputMouseApi } from './textInput.js'
+
+export function hasFloatingOverlay(overlay: OverlayState) {
+  return Boolean(
+    overlay.modelPicker ||
+    overlay.pager ||
+    overlay.petPicker ||
+    overlay.pluginsHub ||
+    overlay.sessions ||
+    overlay.skillsHub
+  )
+}
 
 // Box geometry, kept here so the transcript's reservation math matches the
 // rendered overlay exactly.
@@ -265,7 +276,9 @@ const ComposerPane = memo(function ComposerPane({
 }: Pick<AppLayoutProps, 'actions' | 'composer' | 'status'>) {
   const ui = useStore($uiState)
   const isBlocked = useStore($isBlocked)
+  const overlay = useStore($overlayState)
   const sh = (composer.inputBuf[0] ?? composer.input).startsWith('!')
+  const floatingOverlayActive = hasFloatingOverlay(overlay)
 
   const promptText = composerPromptText(
     ui.theme.brand.prompt,
@@ -367,6 +380,8 @@ const ComposerPane = memo(function ComposerPane({
         />
 
         {composer.input === '?' && !composer.inputBuf.length && <HelpHint t={ui.theme} />}
+
+        {isBlocked && floatingOverlayActive && <Box height={1} width={Math.max(1, composer.cols - 2)} />}
 
         {!isBlocked && (
           <>


### PR DESCRIPTION
## What changed and why

Per the reporter's clarification on 2026-05-17, there is still a residual TUI regression on current `main`: in some SSH/tmux terminal setups, opening the session or model picker makes the overlay keyboard-active but visually invisible. The remaining failure mode is that `FloatingOverlays` is absolutely positioned inside a relative composer container whose in-flow children disappear when `$isBlocked` hides the input subtree, allowing the anchor box to collapse.

This change keeps a one-row in-flow anchor whenever a floating overlay is active while the composer is blocked, so absolute-positioned overlays still have visible space to render against. It also factors the floating-overlay predicate into a small exported helper and adds a unit test covering which overlay states should keep that anchor alive.

## How to test

1. Start the TUI in an environment that reproduces the reporter's setup, especially SSH into Linux with Hermes running inside `tmux`.
2. Open a blocking floating overlay such as `/resume`, `/sessions`, `/model`, `/pet list`, `/skills`, or a pager-backed command.
3. Confirm the overlay list/popup is visible immediately instead of being keyboard-active but invisible.
4. Confirm normal input remains hidden while the blocking overlay is open.
5. Run `npm test --prefix ui-tui -- appLayout`.
6. Run `npm run typecheck --prefix ui-tui`.

## What platforms tested on

Not run in this worker environment. The `ui-tui` Node toolchain dependencies are not installed here, so `npm test --prefix ui-tui -- appLayout` failed with `vitest: command not found` and `npm run typecheck --prefix ui-tui` failed with `tsc: command not found`.

Refs #14907

<!-- autocontrib:worker-id=issue-followup-e841cf43 kind=pr-open -->