### PR TITLE
Preserve large integers in tool-argument coercion (no float rounding)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -810,6 +810,14 @@ def _coerce_json(value: str, expected_python_type: type):
 
 def _coerce_number(value: str, integer_only: bool = False):
     """Try to parse *value* as a number.  Returns original string on failure."""
+    # Plain integer literals go through int() to preserve full precision.
+    # int(float(value)) silently rounds integers beyond 2**53 (e.g. 64-bit
+    # Discord/Telegram snowflake IDs or large DB row IDs the model emits as a
+    # string), corrupting the value the tool receives.
+    try:
+        return int(value.strip())
+    except (ValueError, TypeError):
+        pass
     try:
         f = float(value)
     except (ValueError, OverflowError):

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -60,6 +60,20 @@ class TestCoerceNumber:
     def test_large_number(self):
         assert _coerce_number("1000000") == 1000000
 
+    def test_large_integer_preserves_precision(self):
+        """Integers beyond 2**53 (64-bit Discord/Telegram snowflake IDs, large
+        DB row IDs) must round-trip exactly. int(float(value)) would silently
+        round them, so a tool would act on the wrong id."""
+        snowflake = "1234567890123456789"
+        result = _coerce_number(snowflake, integer_only=True)
+        assert result == 1234567890123456789
+        assert str(result) == snowflake
+
+        edge = "9007199254740993"  # 2**53 + 1
+        assert _coerce_number(edge, integer_only=True) == 9007199254740993
+        # The same must hold for an unconstrained "number" field.
+        assert _coerce_number(snowflake) == 1234567890123456789
+
     def test_scientific_notation(self):
         assert _coerce_number("1e5") == 100000
 


### PR DESCRIPTION
Fixes #55314

`coerce_tool_args` coerces model-emitted string arguments to their schema types. `_coerce_number` parsed every value through `float`:

```python
f = float(value)
...
if f == int(f):
    return int(f)
```

`float` has a 53-bit mantissa, so any integer beyond 2**53 is rounded before `int(f)`. A 64-bit id passed as a string therefore reaches the tool as a different number:

```python
_coerce_number("1234567890123456789", integer_only=True)  # -> 1234567890123456768
```

Models emit integers as strings often, and many real arguments are 64-bit ids (Discord/Telegram snowflakes ~1e18, large DB row ids, nanosecond timestamps). The tool then acts on the wrong id, silently, with a success result, on the default tool-call path for every provider.

### Change

- Parse plain integer literals with `int()` (arbitrary precision) before the `float` path. `int()` only accepts integer strings, so decimals, scientific notation, `inf`/`nan`, and non-numbers still take the existing `float` branch and behave exactly as before; only the lossy `int(float(...))` rounding of large integers is removed.

### Test

`test_large_integer_preserves_precision` checks a 64-bit snowflake id and `2**53 + 1` round-trip exactly, for both `integer` and `number` fields. It fails on the current code (the id comes back off by 21) and passes with this change. The rest of `tests/run_agent/test_tool_arg_coercion.py` continues to pass.

```
$ python -m pytest tests/run_agent/test_tool_arg_coercion.py -q
62 passed
```
