### PR TITLE
fix: surface tool-result-only turn endings

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -121,6 +121,33 @@ def finalize_turn(
                     exc_info=True,
                 )
 
+    # If the loop stopped after executing tools but before a follow-up model
+    # response, close the turn with a visible assistant message.  Without this
+    # guard, Desktop/TUI can return to a ready composer while the persisted
+    # transcript ends in ``role=tool`` (the user sees a silent stop, and the
+    # next turn resumes from an invalid-looking tail).  This is distinct from
+    # an interrupted /stop path, which is handled below by
+    # close_interrupted_tool_sequence().
+    if final_response is None and not interrupted and messages:
+        try:
+            _tail_role = messages[-1].get("role") if isinstance(messages[-1], dict) else None
+        except Exception:
+            _tail_role = None
+        if _tail_role == "tool":
+            _turn_exit_reason = "pending_tool_result"
+            failed = True
+            try:
+                final_response = agent._format_turn_completion_explanation(_turn_exit_reason)
+            except Exception:
+                final_response = ""
+            if not final_response:
+                final_response = (
+                    "⚠️ No reply: the turn stopped after a tool result and the "
+                    "model produced no follow-up text. Send `continue` to let "
+                    "it summarize."
+                )
+            messages.append({"role": "assistant", "content": final_response})
+
     # Determine if conversation completed successfully
     normal_text_response = str(_turn_exit_reason).startswith("text_response(")
     completed = (

--- a/tests/agent/test_turn_finalizer_interrupt_alternation.py
+++ b/tests/agent/test_turn_finalizer_interrupt_alternation.py
@@ -93,6 +93,11 @@ class _StubAgent:
     def _turn_completion_explainer_enabled(self):
         return False
 
+    def _format_turn_completion_explanation(self, reason):
+        if reason == "pending_tool_result":
+            return "⚠️ No reply: the turn stopped while a tool result was still pending."
+        return ""
+
     def _drain_pending_steer(self):
         return None
 
@@ -174,14 +179,23 @@ def test_interrupt_after_tool_keeps_delivered_text_when_present():
     assert messages[-1]["content"] == "Partial answer so far"
 
 
-def test_non_interrupted_tool_tail_is_left_untouched():
-    # A turn that ends on a tool tail WITHOUT an interrupt (mid-progress
-    # tool loop) must not get a synthetic close — that is normal dialog
-    # state handled elsewhere.
+def test_non_interrupted_tool_tail_gets_visible_no_reply_close():
+    # A turn that falls out of the loop after a tool result but without a
+    # follow-up assistant response is the Desktop/TUI "ready but no output"
+    # failure mode. Close it with a visible assistant message before
+    # persistence so the user sees the stop reason and the next user turn
+    # follows an assistant, not a raw tool result.
     agent = _StubAgent()
     messages = _interrupted_tool_tail()
-    _finalize(agent, messages, interrupted=False, final_response=None)
-    assert messages[-1]["role"] == "tool"
+    result = _finalize(agent, messages, interrupted=False, final_response=None)
+    assert messages[-1]["role"] == "assistant"
+    assert "No reply" in messages[-1]["content"]
+    assert result["final_response"] == messages[-1]["content"]
+    assert result["turn_exit_reason"] == "pending_tool_result"
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert agent.persisted_messages is not None
+    assert agent.persisted_messages[-1]["role"] == "assistant"
 
 
 def test_interrupt_without_tool_tail_adds_nothing():


### PR DESCRIPTION
## Summary

- close non-interrupted tool-result-only turn tails with a visible assistant "No reply" message
- mark those turns as `pending_tool_result`/failed instead of silently completing with a raw tool tail
- update the turn finalizer regression test to cover the Desktop/TUI ready-with-no-output failure mode

Fixes #55316.

## Test plan

- `./venv/bin/python -m pytest tests/agent/test_turn_finalizer_interrupt_alternation.py -q -o 'addopts='`
- `./venv/bin/python -m pytest tests/run_agent/test_turn_completion_explainer.py tests/agent/test_turn_finalizer_cleanup_guard.py tests/agent/test_turn_finalizer_interrupt_alternation.py -q -o 'addopts='`
