### PR TITLE
fix(cron): preserve due runs on same-schedule saves

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -847,6 +847,30 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
     )
 
 
+def _schedule_run_identity(schedule: Any) -> Tuple[Any, ...]:
+    """Return the fields that affect next-run calculation for a schedule."""
+    if not isinstance(schedule, dict):
+        return ("raw", schedule)
+
+    kind = schedule.get("kind")
+    if kind == "interval":
+        return ("interval", schedule.get("minutes"))
+    if kind == "cron":
+        return ("cron", schedule.get("expr"))
+    if kind == "once":
+        return ("once", schedule.get("run_at"))
+    return (
+        "unknown",
+        tuple(
+            sorted(
+                (key, value)
+                for key, value in schedule.items()
+                if key != "display"
+            )
+        ),
+    )
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1104,6 +1128,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = _normalize_workdir(_wd)
 
             previous_inference_axes = _normalized_inference_axes(job)
+            previous_schedule_identity = _schedule_run_identity(job.get("schedule"))
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates
             inference_fields_changed = bool(
@@ -1127,7 +1152,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     "schedule_display",
                     updated_schedule.get("display", updated.get("schedule_display")),
                 )
-                if updated.get("state") != "paused":
+                scheduling_inputs_changed = (
+                    _schedule_run_identity(updated_schedule)
+                    != previous_schedule_identity
+                )
+                if scheduling_inputs_changed and updated.get("state") != "paused":
                     updated["next_run_at"] = compute_next_run(updated_schedule)
 
             if inference_fields_changed:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1566,6 +1566,21 @@ def _validate_job_mode_invariants(
         )
 
 
+def _same_recurring_schedule(previous: Any, updated: Any) -> bool:
+    """Return whether two interval/cron schedules have the same cadence."""
+    if not isinstance(previous, dict) or not isinstance(updated, dict):
+        return False
+
+    kind = previous.get("kind")
+    if updated.get("kind") != kind:
+        return False
+    if kind == "interval":
+        return previous.get("minutes") == updated.get("minutes")
+    if kind == "cron":
+        return previous.get("expr") == updated.get("expr")
+    return False
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1890,6 +1905,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates[_mon_field] = _mv or None
 
             previous_inference_axes = _normalized_inference_axes(job)
+            previous_schedule = job.get("schedule")
             updated = _apply_skill_fields({**job, **updates})
 
             # Re-check execution-mode invariants on the MERGED record when
@@ -1930,7 +1946,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     "schedule_display",
                     updated_schedule.get("display", updated.get("schedule_display")),
                 )
-                if updated.get("state") != "paused":
+                preserve_due_run = _same_recurring_schedule(
+                    previous_schedule, updated_schedule
+                )
+                if not preserve_due_run and updated.get("state") != "paused":
                     updated_next_run = compute_next_run(updated_schedule)
                     # Same guard as create_job: an UPDATE that sets a one-shot
                     # to a time >ONESHOT_GRACE_SECONDS in the past would store

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -353,6 +353,56 @@ class TestUpdateJob:
         assert fetched["schedule"]["minutes"] == 120
         assert fetched["schedule_display"] == "every 120m"
 
+    def test_resaving_same_interval_schedule_preserves_due_run(self, tmp_cron_dir, monkeypatch):
+        base = datetime(2026, 6, 29, 12, 0, tzinfo=timezone.utc)
+        due_at = (base + timedelta(hours=1)).isoformat()
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: base)
+        job = create_job(prompt="Hourly report", schedule="every 1h")
+
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = due_at
+        save_jobs(jobs)
+
+        monkeypatch.setattr(
+            "cron.jobs._hermes_now",
+            lambda: base + timedelta(hours=1, seconds=10),
+        )
+        updated = update_job(
+            job["id"],
+            {
+                "name": "Hourly report v2",
+                "schedule": parse_schedule("every 1h"),
+            },
+        )
+
+        assert updated["next_run_at"] == due_at
+        assert get_job(job["id"])["next_run_at"] == due_at
+
+    def test_resaving_same_cron_schedule_preserves_due_run(self, tmp_cron_dir, monkeypatch):
+        base = datetime(2026, 6, 29, 12, 0, tzinfo=timezone.utc)
+        due_at = (base + timedelta(hours=1)).isoformat()
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: base)
+        job = create_job(prompt="Hourly cron report", schedule="0 * * * *")
+
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = due_at
+        save_jobs(jobs)
+
+        monkeypatch.setattr(
+            "cron.jobs._hermes_now",
+            lambda: base + timedelta(hours=1, seconds=10),
+        )
+        updated = update_job(
+            job["id"],
+            {
+                "name": "Hourly cron report v2",
+                "schedule": parse_schedule("0 * * * *"),
+            },
+        )
+
+        assert updated["next_run_at"] == due_at
+        assert get_job(job["id"])["next_run_at"] == due_at
+
     def test_update_enable_disable(self, tmp_cron_dir):
         job = create_job(prompt="Toggle me", schedule="every 1h")
         assert job["enabled"] is True

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -277,6 +277,86 @@ class TestUpdateJob:
         fetched = get_job(job["id"])
         assert fetched["name"] == "New Name"
 
+    def test_resaving_same_interval_schedule_preserves_due_run(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        base = datetime(2026, 6, 29, 12, 0, tzinfo=timezone.utc)
+        due_at = (base + timedelta(hours=1)).isoformat()
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: base)
+        job = create_job(prompt="Hourly report", schedule="every 1h")
+
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = due_at
+        save_jobs(jobs)
+
+        monkeypatch.setattr(
+            "cron.jobs._hermes_now",
+            lambda: base + timedelta(hours=1, seconds=10),
+        )
+        updated = update_job(
+            job["id"],
+            {
+                "name": "Hourly report v2",
+                "schedule": parse_schedule("every 1h"),
+            },
+        )
+
+        assert updated["next_run_at"] == due_at
+        assert get_job(job["id"])["next_run_at"] == due_at
+
+    def test_resaving_same_cron_schedule_preserves_due_run(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        base = datetime(2026, 6, 29, 12, 0, tzinfo=timezone.utc)
+        due_at = (base + timedelta(hours=1)).isoformat()
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: base)
+        job = create_job(prompt="Hourly cron report", schedule="0 * * * *")
+
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = due_at
+        save_jobs(jobs)
+
+        monkeypatch.setattr(
+            "cron.jobs._hermes_now",
+            lambda: base + timedelta(hours=1, seconds=10),
+        )
+        updated = update_job(
+            job["id"],
+            {
+                "name": "Hourly cron report v2",
+                "schedule": parse_schedule("0 * * * *"),
+            },
+        )
+
+        assert updated["next_run_at"] == due_at
+        assert get_job(job["id"])["next_run_at"] == due_at
+
+    def test_resaving_same_stale_oneshot_still_rejected(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        base = datetime(2026, 6, 29, 12, 0, tzinfo=timezone.utc)
+        run_at = base + timedelta(minutes=5)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: base)
+        job = create_job(prompt="One-time report", schedule=run_at.isoformat())
+
+        monkeypatch.setattr(
+            "cron.jobs._hermes_now",
+            lambda: run_at + timedelta(minutes=5),
+        )
+
+        with pytest.raises(ValueError, match="past and cannot be scheduled"):
+            update_job(
+                job["id"],
+                {
+                    "name": "One-time report v2",
+                    "schedule": parse_schedule(run_at.isoformat()),
+                },
+            )
+
+        persisted = get_job(job["id"])
+        assert persisted["name"] == "One-time report"
+        assert persisted["next_run_at"] == run_at.isoformat()
+
 
 class TestPauseResumeJob:
     def test_pause_sets_state(self, tmp_cron_dir):


### PR DESCRIPTION
﻿## Summary

- preserve a recurring cron job's existing `next_run_at` when an update re-saves the same schedule
- compare only run-affecting schedule fields (`interval.minutes`, `cron.expr`, `once.run_at`) so display/name-only edits do not drop a due slot
- add interval and cron-expression regressions that fail on the previous unconditional recompute

Closes #55313.

## Why

Hermes `update_job()` recomputed `next_run_at` whenever `updates` included `schedule`. Dashboard/agent saves can include the existing schedule while changing unrelated fields; if the job was already due, that recompute advanced it to the next future slot and silently skipped the pending run. This mirrors the bug class fixed in openclaw/openclaw#96159, but the patch is scoped to Hermes' Python cron store.

## Validation

- `python -m pytest tests/cron/test_jobs.py -q -k "resaving_same or test_update_schedule or test_update_enable_disable" --basetemp .pytest-tmp-cron-resave-preserves-due-run` -> 4 passed
- `python -m pytest tests/cron/test_jobs.py -q --basetemp .pytest-tmp-cron-jobs-full` -> 105 passed
- `python -m ruff check cron/jobs.py tests/cron/test_jobs.py` -> All checks passed
- `git diff --check` -> clean

## Agent transcript (redacted)

- Mined recent OpenClaw cron fix openclaw/openclaw#96159 for an equivalent Hermes boundary.
- Confirmed Hermes `cron/jobs.py:update_job()` recomputed `next_run_at` solely because `schedule` was present.
- Added focused failing interval and cron-expression regression tests before changing implementation.
- Implemented a small schedule run-identity comparison and reran targeted plus full cron job tests.
