### PR TITLE
feat(video-gen): add provider lifecycle callbacks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2019,6 +2019,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
+                tool_progress_callback=getattr(agent, "tool_progress_callback", None),
             )
 
     from hermes_cli.middleware import run_tool_execution_middleware

--- a/agent/video_gen_provider.py
+++ b/agent/video_gen_provider.py
@@ -52,7 +52,7 @@ import datetime
 import logging
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -165,6 +165,23 @@ class VideoGenProvider(abc.ABC):
             "max_reference_images": 0,
         }
 
+    def pre_generate(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[Dict[str, Any]]:
+        """Run optional checks before dispatching generation.
+
+        Return a provider-shaped result dict to short-circuit ``generate()``
+        (for quota, budget, policy, or rate-limit gates). Return ``None`` to
+        continue with normal generation. The tool layer invokes this after it
+        has resolved the active provider/model and normalized tool arguments,
+        but before any backend request is made.
+        """
+        return None
+
     @abc.abstractmethod
     def generate(
         self,
@@ -179,6 +196,7 @@ class VideoGenProvider(abc.ABC):
         negative_prompt: Optional[str] = None,
         audio: Optional[bool] = None,
         seed: Optional[int] = None,
+        on_progress: Optional[Callable[[float, str], None]] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Generate a video from a prompt (text-to-video) or animate an image
@@ -189,10 +207,13 @@ class VideoGenProvider(abc.ABC):
         is responsible for picking the right underlying endpoint within
         the user's chosen model family.
 
-        Implementations should return the dict from :func:`success_response`
-        or :func:`error_response`. ``kwargs`` may contain forward-compat
-        parameters future versions of the schema will expose —
-        implementations MUST ignore unknown keys (no TypeError).
+        ``on_progress`` is optional. When provided, call it with a percentage
+        from 0 to 100 and a short status message during long-running work; the
+        tool layer relays those events to Hermes clients that expose tool
+        progress. Implementations should return the dict from
+        :func:`success_response` or :func:`error_response`. ``kwargs`` may
+        contain forward-compat parameters future versions of the schema will
+        expose — implementations MUST ignore unknown keys (no TypeError).
         """
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -27,7 +27,7 @@ import asyncio
 import logging
 import threading
 import time
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Optional, Tuple, Callable
 
 from tools.registry import discover_builtin_tools, registry
 from toolsets import resolve_toolset, validate_toolset
@@ -912,6 +912,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    tool_progress_callback: Optional[Callable[..., None]] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1016,6 +1017,7 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                tool_progress_callback=tool_progress_callback,
             )
 
     _tool_original_args = dict(function_args)
@@ -1144,11 +1146,16 @@ def handle_function_call(
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    dispatch_kwargs = {
+                        "task_id": task_id,
+                        "session_id": session_id,
+                        "user_task": user_task,
+                    }
+                    if function_name == "video_generate":
+                        dispatch_kwargs["tool_progress_callback"] = tool_progress_callback
                     return registry.dispatch(
                         function_name, next_args,
-                        task_id=task_id,
-                        session_id=session_id,
-                        user_task=user_task,
+                        **dispatch_kwargs,
                     )
             from hermes_cli.middleware import run_tool_execution_middleware
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2657,6 +2657,7 @@ class TestConcurrentToolExecution:
                 enabled_toolsets=agent.enabled_toolsets,
                 disabled_toolsets=agent.disabled_toolsets,
                 tool_request_middleware_trace=[],
+                tool_progress_callback=agent.tool_progress_callback,
             )
             assert result == "result"
 

--- a/tests/tools/test_video_generation_dispatch.py
+++ b/tests/tools/test_video_generation_dispatch.py
@@ -62,8 +62,41 @@ class _RaisingProvider(VideoGenProvider):
         raise RuntimeError("boom")
 
 
+class _PreGenerateProvider(_RecordingProvider):
+    def pre_generate(self, prompt, **kwargs):
+        return {
+            "success": False,
+            "video": None,
+            "error": f"blocked before dispatch: {prompt}",
+            "error_type": "quota_exceeded",
+            "model": kwargs.get("model") or "",
+            "prompt": prompt,
+            "aspect_ratio": kwargs.get("aspect_ratio", ""),
+            "provider": self.name,
+        }
+
+    def generate(self, prompt, **kwargs):
+        raise AssertionError("generate should not run after pre_generate short-circuits")
+
+
+class _ProgressProvider(_RecordingProvider):
+    def generate(self, prompt, **kwargs):
+        on_progress = kwargs.get("on_progress")
+        if on_progress:
+            on_progress(10, "queued")
+            on_progress(50, "rendering")
+            on_progress(120, "")
+        return super().generate(prompt, **kwargs)
+
+
 class TestUnifiedDispatch:
-    def _run(self, args: Dict[str, Any], *, configured: Optional[str] = None) -> Dict[str, Any]:
+    def _run(
+        self,
+        args: Dict[str, Any],
+        *,
+        configured: Optional[str] = None,
+        tool_progress_callback=None,
+    ) -> Dict[str, Any]:
         from tools import video_generation_tool
         import hermes_cli.plugins as plugins_module
 
@@ -72,7 +105,10 @@ class TestUnifiedDispatch:
         saved_discover = plugins_module._ensure_plugins_discovered
         plugins_module._ensure_plugins_discovered = lambda *_a, **_k: None  # type: ignore
         try:
-            raw = video_generation_tool._handle_video_generate(args)
+            raw = video_generation_tool._handle_video_generate(
+                args,
+                tool_progress_callback=tool_progress_callback,
+            )
         finally:
             video_generation_tool._read_configured_video_provider = saved  # type: ignore
             plugins_module._ensure_plugins_discovered = saved_discover  # type: ignore
@@ -133,7 +169,37 @@ class TestUnifiedDispatch:
         assert result["success"] is False
         assert result["error_type"] == "provider_exception"
 
+    def test_pre_generate_can_short_circuit_before_generate(self):
+        provider = _PreGenerateProvider("guarded")
+        video_gen_registry.register_provider(provider)
+        result = self._run({"prompt": "expensive render"})
+        assert result["success"] is False
+        assert result["error_type"] == "quota_exceeded"
+        assert result["provider"] == "guarded"
+        assert provider.last_kwargs == {}
+
+    def test_provider_progress_events_relay_to_tool_progress_callback(self):
+        provider = _ProgressProvider("progress")
+        video_gen_registry.register_provider(provider)
+        events = []
+
+        def on_tool_progress(event_type, name=None, preview=None, args=None, **kwargs):
+            events.append((event_type, name, preview, args, kwargs))
+
+        result = self._run(
+            {"prompt": "a happy dog"},
+            tool_progress_callback=on_tool_progress,
+        )
+
+        assert result["success"] is True
+        assert [event[0] for event in events] == ["progress", "progress", "progress"]
+        assert [event[1] for event in events] == ["video_generate"] * 3
+        assert [event[2] for event in events] == ["queued", "rendering", "100% complete"]
+        assert [event[4]["percent"] for event in events] == [10.0, 50.0, 100.0]
+        assert all(event[3]["provider"] == "progress" for event in events)
+
     def test_edit_extend_fields_not_in_schema(self):
+        """Make sure edit/extend fields stay out of the unified schema."""
         from tools.video_generation_tool import VIDEO_GENERATE_SCHEMA
         props = VIDEO_GENERATE_SCHEMA["parameters"]["properties"]
         assert "operation" not in props

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -353,9 +353,45 @@ def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
     }
     # Drop None entries so providers see clean defaults.
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    tool_progress_callback = _kw.get("tool_progress_callback")
+
+    def _on_progress(percent: float, message: str) -> None:
+        if not callable(tool_progress_callback):
+            return
+        try:
+            numeric_percent = float(percent)
+        except (TypeError, ValueError):
+            numeric_percent = 0.0
+        numeric_percent = max(0.0, min(100.0, numeric_percent))
+        preview = (message or "").strip() or f"{numeric_percent:.0f}% complete"
+        try:
+            tool_progress_callback(
+                "progress",
+                name="video_generate",
+                preview=preview,
+                args={"prompt": prompt, "provider": getattr(provider, "name", "")},
+                percent=numeric_percent,
+                message=preview,
+            )
+        except Exception:
+            logger.debug("video_gen progress callback failed", exc_info=True)
 
     try:
-        result = provider.generate(prompt=prompt, **kwargs)
+        result = provider.pre_generate(prompt=prompt, **kwargs)
+        if result is None:
+            try:
+                result = provider.generate(
+                    prompt=prompt,
+                    on_progress=_on_progress if callable(tool_progress_callback) else None,
+                    **kwargs,
+                )
+            except TypeError as exc:
+                # Standalone providers predating this lifecycle extension may
+                # have a narrow generate() signature. Keep them running when
+                # only the new callback kwarg was rejected.
+                if "on_progress" not in str(exc):
+                    raise
+                result = provider.generate(prompt=prompt, **kwargs)
     except TypeError as exc:
         # A provider that hasn't widened its signature is a bug, not a
         # caller error — log and surface a clear contract message.

--- a/website/docs/developer-guide/video-gen-provider-plugin.md
+++ b/website/docs/developer-guide/video-gen-provider-plugin.md
@@ -45,7 +45,7 @@ Subclass `agent.video_gen_provider.VideoGenProvider`. Required: `name` property 
 
 ```python
 # plugins/video_gen/my-backend/__init__.py
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 import os
 
 from agent.video_gen_provider import (
@@ -124,6 +124,7 @@ class MyVideoGenProvider(VideoGenProvider):
         negative_prompt: Optional[str] = None,
         audio: Optional[bool] = None,
         seed: Optional[int] = None,
+        on_progress: Optional[Callable[[float, str], None]] = None,
         **kwargs: Any,  # always ignore unknown kwargs for forward-compat
     ) -> Dict[str, Any]:
         # ROUTE: image_url presence picks the endpoint.
@@ -133,6 +134,9 @@ class MyVideoGenProvider(VideoGenProvider):
         else:
             endpoint = "my-backend/text-to-video"
             modality_used = "text"
+
+        if on_progress:
+            on_progress(10, "queued")
 
         # ... call your API ...
 
@@ -150,6 +154,13 @@ class MyVideoGenProvider(VideoGenProvider):
 def register(ctx) -> None:
     ctx.register_video_gen_provider(MyVideoGenProvider())
 ```
+
+Override `pre_generate(prompt, model=None, **kwargs)` when a backend needs to
+check quota, budget, policy, or rate limits before dispatching the remote job.
+Return a normal provider result dict to short-circuit `generate()`, or `None`
+to continue. During `generate()`, call `on_progress(percent, message)` when the
+optional callback is present; Hermes relays those updates to clients that show
+tool progress.
 
 ## The plugin manifest
 


### PR DESCRIPTION
## What does this PR do?

Adds lifecycle callbacks to the video generation provider API: providers can short-circuit before dispatch with `pre_generate()` and can emit in-flight progress from `generate()` through an optional `on_progress` callback.

## Related Issue

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Shared root cause

- The `VideoGenProvider` API only exposed blocking `generate()` dispatch, so provider plugins had no lifecycle surface for checks that should happen before remote job submission or progress events that happen while waiting for long-running video jobs.
- The shared mechanism is the `video_generate` tool dispatch path in `tools/video_generation_tool.py`, which resolves the provider/model and called `provider.generate()` directly.

## How this fixes each issue

- #30000: `generate()` now receives an optional `on_progress(percent, message)` callback. Hermes forwards those provider events to the existing `tool_progress_callback` channel so UI clients can render progress without a separate direct-to-provider path.
- #30003: `VideoGenProvider.pre_generate()` runs after Hermes resolves and normalizes generation arguments but before `generate()` is called. Returning a provider-shaped result dict short-circuits dispatch for quota, budget, policy, or rate-limit gates.

## Changes Made

- `agent/video_gen_provider.py`: adds optional `pre_generate()` and documents the `on_progress` callback contract on `generate()`.
- `tools/video_generation_tool.py`: calls `pre_generate()` before dispatch, passes `on_progress` to providers, clamps progress percentages, and keeps compatibility with older standalone providers that reject only the new callback kwarg.
- `agent/agent_runtime_helpers.py` and `model_tools.py`: thread the existing agent `tool_progress_callback` into `video_generate` without exposing it as a model-visible tool argument.
- `tests/tools/test_video_generation_dispatch.py`: covers pre-generation short-circuiting and provider progress forwarding.
- `website/docs/developer-guide/video-gen-provider-plugin.md`: updates the provider author example and lifecycle guidance.

## How to Test

- `python -m py_compile agent/video_gen_provider.py tools/video_generation_tool.py model_tools.py agent/agent_runtime_helpers.py tests/tools/test_video_generation_dispatch.py tests/run_agent/test_run_agent.py`
- `HERMES_HOME=/private/tmp/hermes-pr-spanning-test /opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/tools/test_video_generation_dispatch.py tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_invoke_tool_dispatches_to_handle_function_call -q --timeout=60'`
- `HERMES_HOME=/private/tmp/hermes-pr-spanning-test /opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/tools/test_video_generation_dispatch.py tests/tools/test_video_generation_dynamic_schema.py tests/agent/test_video_gen_registry.py tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_invoke_tool_dispatches_to_handle_function_call -q --timeout=60'`
- `BASE=$(git merge-base origin/main HEAD); { git diff --name-only --diff-filter=d "$BASE"; git ls-files --others --exclude-standard; } | grep -E '\.pyi?$' | sort -u | xargs ruff check`
- `/opt/homebrew/bin/timeout -k 30 480 python scripts/check-windows-footguns.py --all`

The required full-suite command `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` was run and aborted during collection before reaching this change because `hermes_cli.web_server` requires missing dashboard dependencies (`fastapi`/`uvicorn`) and lazy installation is blocked by the externally managed Homebrew Python environment.

An additional broader video-gen subset including FAL surface/plugin tests also hit the same environment class: FAL fake-client routing tests returned `fal_client Python package not installed`, so the final green subset was limited to the changed dispatch contracts and non-FAL video registry/schema coverage.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched the source for the existing video generation provider surface before changing it
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS on darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.

Refs #30000
Refs #30003

<!-- autocontrib:worker-id=pr-spanning-05636d45 kind=pr-open -->