### PR TITLE
fix(redact): strip controls from masked secrets

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -305,6 +305,8 @@ _PREFIX_RE = re.compile(
     r"(?<![A-Za-z0-9_-])(" + "|".join(_PREFIX_PATTERNS) + r")(?![A-Za-z0-9_-])"
 )
 
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
 
 def mask_secret(
     value: str,
@@ -346,6 +348,9 @@ def mask_secret(
         >>> mask_secret("long-token", head=6, tail=4, floor=18)
         '***'
     """
+    if not value:
+        return empty
+    value = _CONTROL_CHARS_RE.sub("", value)
     if not value:
         return empty
     if len(value) < floor:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from agent.redact import redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import mask_secret, redact_cdp_url, redact_sensitive_text, RedactingFormatter
 
 
 @pytest.fixture(autouse=True)
@@ -13,6 +13,21 @@ def _ensure_redaction_enabled(monkeypatch):
     monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
     # Also patch the module-level snapshot so it reflects the cleared env var
     monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+
+
+class TestMaskSecret:
+    def test_printable_secret_mask_shape_is_unchanged(self):
+        assert mask_secret("abcd0123456789zzzz") == "abcd...zzzz"
+
+    def test_strips_controls_from_visible_segments(self):
+        masked = mask_secret("ab\ncd0123456789zz\x85q", empty="missing")
+
+        assert "\n" not in masked
+        assert "\x85" not in masked
+        assert masked == "abcd...9zzq"
+
+    def test_all_control_input_uses_empty_fallback(self):
+        assert mask_secret("\x00\n\x85", empty="missing") == "missing"
 
 
 class TestKnownPrefixes:


### PR DESCRIPTION
## Summary
- strip ASCII/C1 control characters before rendering the visible head/tail of `mask_secret()` output
- keep printable secret masks unchanged
- return the configured empty fallback when a value only contains controls

Closes #55319

## Validation
- `python -m pytest tests\agent\test_redact.py -q -k MaskSecret --basetemp .pytest-tmp-mask-secret-controls` -> 3 passed
- `python -m ruff check agent\redact.py tests\agent\test_redact.py` -> passed
- `python -m pytest tests\agent\test_redact.py -q --basetemp .pytest-tmp-redact-full` -> 125 passed
- `git diff --check` -> clean

## Agent transcript (redacted)
- Compared the OpenClaw control-character masking fix with Hermes' `agent/redact.py` implementation.
- Confirmed Hermes reproduced the same visible-control issue in masked head/tail output before the patch.
- Added focused regression coverage for unchanged printable masks, stripped newline/C1 controls, and all-control input fallback.