### PR TITLE
fix(cron): preserve next_run_at when re-saving unchanged schedule

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1127,7 +1127,19 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     "schedule_display",
                     updated_schedule.get("display", updated.get("schedule_display")),
                 )
-                if updated.get("state") != "paused":
+                # Only recompute next_run_at when the schedule's run-affecting
+                # fields actually changed.  Re-saving the same schedule (common
+                # in dashboard/tool edits that touch unrelated fields) would
+                # otherwise advance a due run into the future.
+                old_schedule = job.get("schedule", {})
+                if isinstance(old_schedule, str):
+                    old_schedule = parse_schedule(old_schedule)
+                _run_affecting = {"kind", "minutes", "expr", "run_at"}
+                schedule_semantically_changed = (
+                    {k: old_schedule.get(k) for k in _run_affecting}
+                    != {k: updated_schedule.get(k) for k in _run_affecting}
+                )
+                if schedule_semantically_changed and updated.get("state") != "paused":
                     updated["next_run_at"] = compute_next_run(updated_schedule)
 
             if inference_fields_changed:


### PR DESCRIPTION
Fixes #55313

`update_job()` recomputed `next_run_at` whenever the update payload included a `schedule` field, even when the schedule was semantically unchanged. Dashboard/tool saves often re-submit the existing schedule alongside unrelated edits, silently advancing a due run into the future.

**Fix**: Compare run-affecting fields (`kind`, `minutes`, `expr`, `run_at`) between old and new schedule dicts. Only recompute `next_run_at` when they actually differ.

**Reproduction** (before fix):
1. Create recurring job `every 1h`
2. Let `next_run_at` become due
3. Save unrelated edit that includes same schedule
4. Due run is skipped — `next_run_at` advances to next slot

**After fix**: Unchanged schedule preserves existing `next_run_at`, so the due run fires normally.