### PR TITLE
fix(gateway): sanitize lone surrogates before platform delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -426,7 +426,10 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
-    return redacted
+    # Strip lone surrogate code points (U+D800-U+DFFF) that crash
+    # utf-16-le encoding in platform length checks (e.g. Telegram).
+    from agent.message_sanitization import _sanitize_surrogates
+    return _sanitize_surrogates(redacted)
 
 
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:


### PR DESCRIPTION
Fixes #55309

`_sanitize_gateway_final_response()` redacted secrets and classified provider errors but did not strip lone surrogate code points (U+D800-U+DFFF). These are invalid in UTF-8 and crash the `utf-16-le` length check in Telegram delivery, aborting the send for the entire reply.

The codebase already had `_sanitize_surrogates()` in `agent/message_sanitization.py` (used for history storage), but it was never applied to the delivered copy.

**Fix**: Apply `_sanitize_surrogates()` as the final step in `_sanitize_gateway_final_response()` so all chat surfaces receive surrogate-safe text.

**Reproduction** (before fix):
```python
content = "Here is your answer \ud800 done"
utf16_len(content)  # UnicodeEncodeError
```

**After fix**: lone surrogates are replaced with U+FFFD before reaching platform adapters.