### PR TITLE
fix(gateway): report model unavailable in chat replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -144,6 +144,18 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+_GATEWAY_MODEL_UNAVAILABLE_RE = re.compile(
+    r"("
+    r"model[_\s-]*not[_\s-]*found"
+    r"|unknown\s+model"
+    r"|no\s+such\s+model"
+    r"|unsupported\s+model"
+    r"|invalid\s+model"
+    r"|model\s+['\"]?[^'\"]+['\"]?\s+does\s+not\s+exist"
+    r")",
+    re.IGNORECASE,
+)
+
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -352,6 +364,11 @@ def _redact_approval_command(cmd: "str | None") -> str:
 
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
+    if _GATEWAY_MODEL_UNAVAILABLE_RE.search(text):
+        return (
+            "⚠️ The configured model is unavailable. Ask an operator to switch "
+            "to an available model; retrying or /new will not fix this."
+        )
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return (
             "⚠️ Provider authentication failed. Check the configured credentials; "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -399,6 +399,18 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+_GATEWAY_MODEL_UNAVAILABLE_RE = re.compile(
+    r"("
+    r"model[_\s-]*not[_\s-]*found"
+    r"|unknown\s+model"
+    r"|no\s+such\s+model"
+    r"|unsupported\s+model"
+    r"|invalid\s+model"
+    r"|model\s+['\"]?[^'\"]+['\"]?\s+does\s+not\s+exist"
+    r")",
+    re.IGNORECASE,
+)
+
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -660,6 +672,11 @@ def _format_exec_approval_fallback(
 
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
+    if _GATEWAY_MODEL_UNAVAILABLE_RE.search(text):
+        return (
+            "⚠️ The configured model is unavailable. Ask an operator to switch "
+            "to an available model; retrying or /new will not fix this."
+        )
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return (
             "⚠️ Provider authentication failed. Check the configured credentials; "

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -175,6 +175,22 @@ def test_telegram_final_response_sanitizes_raw_provider_errors():
     assert "req_abc" not in sanitized
 
 
+def test_telegram_final_response_reports_model_unavailable_actionably():
+    """Retired or renamed models need a config change, not retry or /new."""
+    raw = (
+        "API call failed after 3 retries: HTTP 404: model_not_found: "
+        "The model 'gpt-old-preview' does not exist"
+    )
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "configured model is unavailable" in sanitized.lower()
+    assert "switch" in sanitized.lower()
+    assert "/new will not fix this" in sanitized
+    assert "gpt-old-preview" not in sanitized
+    assert "HTTP 404" not in sanitized
+
+
 def test_telegram_final_response_redacts_auth_secrets():
     """Authentication errors should be useful without leaking key material."""
     raw = (

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -286,6 +286,22 @@ def test_telegram_final_response_sanitizes_raw_provider_errors():
     assert "req_abc" not in sanitized
 
 
+def test_telegram_final_response_reports_model_unavailable_actionably():
+    """Retired or renamed models need a config change, not retry or /new."""
+    raw = (
+        "API call failed after 3 retries: HTTP 404: model_not_found: "
+        "The model 'gpt-old-preview' does not exist"
+    )
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "configured model is unavailable" in sanitized.lower()
+    assert "switch" in sanitized.lower()
+    assert "/new will not fix this" in sanitized
+    assert "gpt-old-preview" not in sanitized
+    assert "HTTP 404" not in sanitized
+
+
 def test_telegram_final_response_redacts_auth_secrets():
     """Authentication errors should be useful without leaking key material."""
     raw = (


### PR DESCRIPTION
﻿## Summary
- add a gateway chat-sanitizer branch for model-unavailable provider errors
- keep raw HTTP/model details out of human-facing chat replies
- clarify that retrying or `/new` will not fix a retired/renamed configured model

Closes #55323

## Validation
- `python -m pytest tests\gateway\test_telegram_noise_filter.py -q -k "model_unavailable or provider_errors or auth_secrets" --basetemp .pytest-tmp-gateway-model-unavailable-focused` -> 3 passed
- `python -m pytest tests\gateway\test_telegram_noise_filter.py -q --basetemp .pytest-tmp-gateway-model-unavailable-full` -> 196 passed
- `python -m ruff check gateway\run.py tests\gateway\test_telegram_noise_filter.py` -> passed
- `git diff --check` -> clean

## Agent transcript (redacted)
- Compared OpenClaw's model-unavailable reply fix with Hermes' agent-layer classifier and gateway chat sanitizer.
- Confirmed Hermes already marks `model_not_found` as fallback-worthy at the agent layer, so this PR only adjusts the chat-facing safe copy for provider error envelopes.
- Reproduced the old generic gateway reply with a synthetic `HTTP 404: model_not_found` envelope before adding the regression test.
