### PR TITLE
fix(gateway): only treat all-whitespace trailing content as closing fence

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5329,8 +5329,14 @@ class BasePlatformAdapter(ABC):
                 stripped = line.strip()
                 if stripped.startswith("```"):
                     if in_code:
-                        in_code = False
-                        lang = ""
+                        # A closing fence must consist solely of backtick/
+                        # tilde characters and whitespace (CommonMark spec
+                        # §4.5).  Trailing non-whitespace content means
+                        # this is ordinary code, not a closing fence.
+                        after = stripped.lstrip("`")
+                        if not after or after.isspace():
+                            in_code = False
+                            lang = ""
                     else:
                         in_code = True
                         tag = stripped[3:].strip()


### PR DESCRIPTION
Fixes #55292

The fenced-code-block scanner in `truncate_message()` treated any line starting with ` ``` ` as a fence boundary. In CommonMark, a closing fence may be followed only by whitespace — a line like ` ```text ` inside a backtick-delimited block is ordinary content, not a fence.

When such a line appeared before a chunk boundary, the code block was marked as closed too early and continuation chunks were emitted without reopening the still-active fence.

**Fix**: Check that trailing content after the opening ` ``` ` is all whitespace before toggling the `in_code` state.