### PR TITLE
fix(cli): skip auto-SSO redirect for password-only auth providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,11 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers (e.g. basic) have no OAuth redirect flow;
+    # /auth/login would call start_login() which raises NotImplementedError.
+    # Let the normal /login page render instead.
+    if getattr(provider, "supports_password", False):
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
Fixes #55130

`_auto_sso_response()` redirects unauthenticated HTML loads directly to `/auth/login` when exactly one provider is registered. For password-only providers (e.g. `basic`), `/auth/login` calls `start_login()` which raises `NotImplementedError`, producing HTTP 500.

**Fix**: Check `supports_password` on the sole provider and return `None` (fall through to the normal `/login` page with the password form) when it is a password-only provider.