### PR TITLE
fix: bridge session context into subprocess env

### DIFF
--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -333,6 +333,27 @@ class TestSanitizeSubprocessEnvHomeInjection:
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
 
+    def test_session_context_overrides_stale_session_env(self, monkeypatch):
+        monkeypatch.setattr(hermes_constants, "is_container", lambda: False)
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.environments.local import _sanitize_subprocess_env
+
+        tokens = set_session_vars(session_key="current-key", session_id="current-id")
+        try:
+            result = _sanitize_subprocess_env(
+                {
+                    "HERMES_SESSION_KEY": "stale-key",
+                    "HERMES_SESSION_ID": "stale-id",
+                    "PATH": "/usr/bin",
+                }
+            )
+        finally:
+            clear_session_vars(tokens)
+
+        assert result["HERMES_SESSION_KEY"] == "current-key"
+        assert result["HERMES_SESSION_ID"] == "current-id"
+
 
 # ---------------------------------------------------------------------------
 # Profile bootstrap

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -217,6 +217,26 @@ def _inject_context_hermes_home(env: dict) -> None:
         pass
 
 
+def _inject_context_session_env(env: dict) -> None:
+    """Bridge live gateway session ContextVars into subprocess env.
+
+    Gateway/TUI turns bind session identity in ``ContextVar`` state rather than
+    ``os.environ`` so concurrent sessions do not clobber each other. Child
+    processes do not inherit ContextVars, so subprocess env builders must copy
+    the current values explicitly or they can expose stale/missing session
+    routing vars such as ``HERMES_SESSION_KEY`` and ``HERMES_SESSION_ID``.
+    """
+    try:
+        from gateway.session_context import _UNSET, _VAR_MAP
+
+        for var_name, var in _VAR_MAP.items():
+            value = var.get()
+            if value is not _UNSET and value:
+                env[var_name] = value
+    except Exception:
+        pass
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -240,6 +260,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             sanitized[key] = value
 
     _inject_context_hermes_home(sanitized)
+    _inject_context_session_env(sanitized)
 
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(sanitized)
@@ -622,20 +643,10 @@ def _make_run_env(env: dict) -> dict:
         run_env[path_key] = _prepend_hermes_bin_dir(new_path)
 
     _inject_context_hermes_home(run_env)
+    _inject_context_session_env(run_env)
 
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(run_env)
-
-    # Inject ContextVar-based session vars into subprocess env.
-    # ContextVars don't propagate to child processes, so we bridge them here.
-    try:
-        from gateway.session_context import _UNSET, _VAR_MAP
-        for var_name, var in _VAR_MAP.items():
-            value = var.get()
-            if value is not _UNSET and value:
-                run_env[var_name] = value
-    except Exception:
-        pass
 
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         run_env.pop(_marker, None)


### PR DESCRIPTION
## Summary
- inject live gateway session context into the shared subprocess environment sanitizer
- keep foreground and background subprocesses consistent when HERMES_SESSION_KEY / HERMES_SESSION_ID are already present but stale
- add a regression test covering stale env override with active session context

## Verification
- `uv run pytest tests/test_subprocess_home_isolation.py`
- `git diff --check`

Fixes #55202