### PR TITLE
feat(optional-skills): add trial — gated judging that stops false-done

### DIFF
--- a/optional-skills/software-development/trial/SKILL.md
+++ b/optional-skills/software-development/trial/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: trial
+description: Use before final responses to block unproven completion.
+version: 0.5.1
+author: Abdulrahman Qasem (Da7-Tech), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [verification, judging, false-done, quality-assurance, evidence, high-stakes]
+    related_skills: [subagent-driven-development, test-driven-development, systematic-debugging]
+---
+
+# Trial Skill
+
+Trial is a pre-delivery evidence gate: the final response remains a private draft
+until every user-visible claim is accepted. It sends unsupported claims back to
+proof or repair instead of telling the user that the agent almost lied.
+
+## When to Use
+
+- Before every final response about code, file changes, tests, or completion.
+- When a green suite may not exercise the behavior the user requested.
+- For high-stakes work involving auth, payments, permissions, user data,
+  migrations, deletion, security, test edits, or repeated failure.
+- Use the fast path for trivial work, but never skip the gate.
+
+## Prerequisites
+
+- No external dependency is required for the gate.
+- Run proving commands with `terminal` and inspect related code with
+  `search_files`.
+- High-stakes work uses `delegate_task` for a fresh-eyes judgment when that tool
+  is available; otherwise perform a separate adversarial self-review.
+
+## How to Run
+
+Apply Trial after implementation but before the final response. Hold the proposed
+response as a private draft, extract every claim about what changed, what works,
+what ran, and whether the task is complete, then bind each claim to a fresh
+receipt. Release the response only after every visible claim is accepted.
+
+## Quick Reference
+
+A **receipt** is the exact command run for this task, its exit status, and the
+decisive output lines. A named test that was not freshly executed is not a
+receipt.
+
+| Internal verdict | Required action |
+|---|---|
+| `ACCEPTED` | release only accepted claims with concise receipts |
+| `NOT_PROVEN` / `NEEDS_EVIDENCE` | keep the draft internal and gather proof or remove the claim |
+| `NEEDS_FIX` | keep the draft internal, repair, rerun, and judge again |
+| `ESCALATE` | withhold completion until the required review or decision exists |
+
+**Coverage beats green:** evidence counts only when the command would fail if
+the user-facing acceptance criterion were false.
+
+## Procedure
+
+1. **Frame** — restate the request as testable acceptance criteria at the
+   boundary where the user experiences the result.
+2. **Build** — implement the work and use `search_files` to inspect every
+   relevant copy, caller, and side effect.
+3. **Prove** — use `terminal` to run a fresh proving command for every criterion.
+   Add a meaningful check when none would fail on the old behavior.
+4. **Draft privately** — prepare the proposed final response without sending it,
+   then list every factual and completion claim it contains.
+5. **Judge** — reject the draft unless every claim has a covering receipt and
+   the receipts agree with the current tree and each other. For high-stakes work,
+   use `delegate_task` with only the criteria, claims, diff, and receipts; any
+   disagreement keeps the draft blocked.
+6. **Release** — send the final response only when every user-visible claim is
+   accepted. Negative verdicts remain internal and return the agent to work.
+
+After a bounded repair effort, if proof is still impossible, send only a precise
+incomplete status containing the blocker and remaining work. Do not expose
+internal courtroom labels, accuse the agent, or soften uncertainty into implied
+success.
+
+## Pitfalls
+
+- **A receipt is auditable evidence, not cryptographic proof.** A portable skill
+  cannot physically restrain a model that ignores its instructions or fabricates
+  tool output; host-captured traces and continuous integration are stronger.
+- **Reject stale proof.** Output from another revision or a passing command
+  contradicted by a relevant failure blocks release.
+- **Gate all visible work claims.** Changed files, test counts, command results,
+  current state, and completion are all claims, not just the word "done".
+- **Keep trivial work cheap.** One proportionate proving check and a private
+  claim scan are enough; no ceremony is required.
+
+## Verification
+
+The published controlled benchmark measured the version 0.4 receipt-and-coverage
+rule: agents left a covering test 6/6 with Trial versus 4/6 without it, and the
+sampled Trial reports contained no false verification claim. The current fixture,
+behavioral mutation grader, and prompts can rerun the protocol, but the historical
+run trees and complete reports were not retained, so the aggregate cannot be
+independently re-scored.
+
+Version 0.5 preserves that measured rule and adds the private-draft, fail-closed
+delivery contract. That contract has deterministic policy, synchronization, and
+packed-install coverage in the standalone repository, but has not yet been
+re-measured on live agents: https://github.com/Da7-Tech/trial.

--- a/tests/skills/test_trial_skill.py
+++ b/tests/skills/test_trial_skill.py
@@ -1,0 +1,154 @@
+"""Policy and integration tests for the optional Trial skill."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = ROOT / "optional-skills" / "software-development" / "trial"
+OLD_SKILL_DIR = ROOT / "optional-skills" / "autonomous-ai-agents" / "trial"
+OLD_SKILL_PATH = OLD_SKILL_DIR / "SKILL.md"
+SKILL_PATH = SKILL_DIR / "SKILL.md"
+DOC_PATH = (
+    ROOT
+    / "website"
+    / "docs"
+    / "user-guide"
+    / "skills"
+    / "optional"
+    / "software-development"
+    / "software-development-trial.md"
+)
+OLD_DOC_PATH = (
+    ROOT
+    / "website"
+    / "docs"
+    / "user-guide"
+    / "skills"
+    / "optional"
+    / "autonomous-ai-agents"
+    / "autonomous-ai-agents-trial.md"
+)
+
+
+def _skill_text() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _frontmatter_field(name: str) -> str:
+    match = re.search(
+        rf"^{re.escape(name)}:\s*(.+)$",
+        _skill_text(),
+        re.MULTILINE,
+    )
+    assert match, f"missing frontmatter field: {name}"
+    value = match.group(1).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def test_skill_is_in_software_development_only() -> None:
+    assert SKILL_PATH.is_file()
+    assert not OLD_SKILL_PATH.exists()
+    assert "category: autonomous-ai-agents" not in _skill_text()
+
+
+def test_frontmatter_meets_hardline_policy() -> None:
+    assert _frontmatter_field("name") == "trial"
+    description = _frontmatter_field("description")
+    assert description == "Use before final responses to block unproven completion."
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert _frontmatter_field("version") == "0.5.1"
+    assert (
+        _frontmatter_field("author")
+        == "Abdulrahman Qasem (Da7-Tech), Hermes Agent"
+    )
+    assert _frontmatter_field("license") == "MIT"
+    assert _frontmatter_field("platforms") == "[linux, macos, windows]"
+
+
+def test_body_uses_native_hermes_tools() -> None:
+    body = _skill_text().split("---", 2)[-1]
+    assert "`search_files`" in body
+    assert "`delegate_task`" in body
+    assert "`terminal`" in body
+    assert re.search(r"(?<![\w-])grep(?![\w-])", body, re.IGNORECASE) is None
+
+
+def test_modern_sections_are_complete_and_ordered() -> None:
+    text = _skill_text()
+    headings = [
+        "# Trial Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [text.index(heading) for heading in headings]
+    assert positions == sorted(positions)
+
+
+def test_verification_claim_links_to_the_measured_source() -> None:
+    text = _skill_text()
+    normalized = re.sub(r"\s+", " ", text)
+    assert "https://github.com/Da7-Tech/trial" in normalized
+    assert "version 0.4 receipt-and-coverage" in normalized
+    assert "6/6 with Trial versus 4/6 without it" in normalized
+    assert "auditable evidence, not cryptographic proof" in normalized
+    assert "historical" in normalized
+    assert "cannot be independently" in normalized
+    assert "Version 0.5" in normalized
+    assert "has not yet been" in normalized
+
+
+def test_pre_delivery_gate_is_fail_closed() -> None:
+    text = _skill_text()
+    normalized = re.sub(r"\s+", " ", text)
+
+    draft = normalized.index("Draft privately")
+    judge = normalized.index("Judge", draft)
+    release = normalized.index("Release", judge)
+    assert draft < judge < release
+    assert "final response remains a private draft" in normalized
+    assert (
+        "Release the response only after every visible claim is accepted"
+        in normalized
+    )
+    assert "keep the draft internal" in normalized
+    assert (
+        "Negative verdicts remain internal and return the agent to work"
+        in normalized
+    )
+    assert "Do not expose internal courtroom labels" in normalized
+    assert "telling the user that the agent almost lied" in normalized
+
+
+def test_generated_docs_use_the_new_install_identifier() -> None:
+    assert DOC_PATH.is_file()
+    assert not OLD_DOC_PATH.exists()
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    assert "official/software-development/trial" in doc
+    assert "`optional-skills/software-development/trial`" in doc
+    assert "`0.5.1`" in doc
+    assert "Abdulrahman Qasem (Da7-Tech), Hermes Agent" in doc
+    assert "final response remains a private draft" in doc
+    assert "Negative verdicts remain internal" in doc
+
+
+def test_catalog_and_sidebar_use_software_development_route() -> None:
+    catalog = (
+        ROOT / "website" / "docs" / "reference" / "optional-skills-catalog.md"
+    ).read_text(encoding="utf-8")
+    sidebar = (ROOT / "website" / "sidebars.ts").read_text(encoding="utf-8")
+    new_route = "software-development/software-development-trial"
+    old_route = "autonomous-ai-agents/autonomous-ai-agents-trial"
+    assert new_route in catalog
+    assert new_route in sidebar
+    assert old_route not in catalog
+    assert old_route not in sidebar

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -215,6 +215,7 @@ hermes skills uninstall <skill-name>
 | [**code-wiki**](/docs/user-guide/skills/optional/software-development/software-development-code-wiki) | Generate wiki docs + Mermaid diagrams for any codebase. |
 | [**rest-graphql-debug**](/docs/user-guide/skills/optional/software-development/software-development-rest-graphql-debug) | Debug REST/GraphQL APIs: status codes, auth, schemas, repro. |
 | [**subagent-driven-development**](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development) | Execute plans via delegate_task subagents (2-stage review). |
+| [**trial**](/docs/user-guide/skills/optional/software-development/software-development-trial) | Use before final responses to block unproven completion. |
 
 ## web-development
 

--- a/website/docs/user-guide/skills/optional/software-development/software-development-trial.md
+++ b/website/docs/user-guide/skills/optional/software-development/software-development-trial.md
@@ -1,0 +1,123 @@
+---
+title: "Trial — Use before final responses to block unproven completion"
+sidebar_label: "Trial"
+description: "Use before final responses to block unproven completion"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Trial
+
+Use before final responses to block unproven completion.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/software-development/trial` |
+| Path | `optional-skills/software-development/trial` |
+| Version | `0.5.1` |
+| Author | Abdulrahman Qasem (Da7-Tech), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `verification`, `judging`, `false-done`, `quality-assurance`, `evidence`, `high-stakes` |
+| Related skills | [`subagent-driven-development`](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development), [`test-driven-development`](/docs/user-guide/skills/bundled/software-development/software-development-test-driven-development), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Trial Skill
+
+Trial is a pre-delivery evidence gate: the final response remains a private draft
+until every user-visible claim is accepted. It sends unsupported claims back to
+proof or repair instead of telling the user that the agent almost lied.
+
+## When to Use
+
+- Before every final response about code, file changes, tests, or completion.
+- When a green suite may not exercise the behavior the user requested.
+- For high-stakes work involving auth, payments, permissions, user data,
+  migrations, deletion, security, test edits, or repeated failure.
+- Use the fast path for trivial work, but never skip the gate.
+
+## Prerequisites
+
+- No external dependency is required for the gate.
+- Run proving commands with `terminal` and inspect related code with
+  `search_files`.
+- High-stakes work uses `delegate_task` for a fresh-eyes judgment when that tool
+  is available; otherwise perform a separate adversarial self-review.
+
+## How to Run
+
+Apply Trial after implementation but before the final response. Hold the proposed
+response as a private draft, extract every claim about what changed, what works,
+what ran, and whether the task is complete, then bind each claim to a fresh
+receipt. Release the response only after every visible claim is accepted.
+
+## Quick Reference
+
+A **receipt** is the exact command run for this task, its exit status, and the
+decisive output lines. A named test that was not freshly executed is not a
+receipt.
+
+| Internal verdict | Required action |
+|---|---|
+| `ACCEPTED` | release only accepted claims with concise receipts |
+| `NOT_PROVEN` / `NEEDS_EVIDENCE` | keep the draft internal and gather proof or remove the claim |
+| `NEEDS_FIX` | keep the draft internal, repair, rerun, and judge again |
+| `ESCALATE` | withhold completion until the required review or decision exists |
+
+**Coverage beats green:** evidence counts only when the command would fail if
+the user-facing acceptance criterion were false.
+
+## Procedure
+
+1. **Frame** — restate the request as testable acceptance criteria at the
+   boundary where the user experiences the result.
+2. **Build** — implement the work and use `search_files` to inspect every
+   relevant copy, caller, and side effect.
+3. **Prove** — use `terminal` to run a fresh proving command for every criterion.
+   Add a meaningful check when none would fail on the old behavior.
+4. **Draft privately** — prepare the proposed final response without sending it,
+   then list every factual and completion claim it contains.
+5. **Judge** — reject the draft unless every claim has a covering receipt and
+   the receipts agree with the current tree and each other. For high-stakes work,
+   use `delegate_task` with only the criteria, claims, diff, and receipts; any
+   disagreement keeps the draft blocked.
+6. **Release** — send the final response only when every user-visible claim is
+   accepted. Negative verdicts remain internal and return the agent to work.
+
+After a bounded repair effort, if proof is still impossible, send only a precise
+incomplete status containing the blocker and remaining work. Do not expose
+internal courtroom labels, accuse the agent, or soften uncertainty into implied
+success.
+
+## Pitfalls
+
+- **A receipt is auditable evidence, not cryptographic proof.** A portable skill
+  cannot physically restrain a model that ignores its instructions or fabricates
+  tool output; host-captured traces and continuous integration are stronger.
+- **Reject stale proof.** Output from another revision or a passing command
+  contradicted by a relevant failure blocks release.
+- **Gate all visible work claims.** Changed files, test counts, command results,
+  current state, and completion are all claims, not just the word "done".
+- **Keep trivial work cheap.** One proportionate proving check and a private
+  claim scan are enough; no ceremony is required.
+
+## Verification
+
+The published controlled benchmark measured the version 0.4 receipt-and-coverage
+rule: agents left a covering test 6/6 with Trial versus 4/6 without it, and the
+sampled Trial reports contained no false verification claim. The current fixture,
+behavioral mutation grader, and prompts can rerun the protocol, but the historical
+run trees and complete reports were not retained, so the aggregate cannot be
+independently re-scored.
+
+Version 0.5 preserves that measured rule and adds the private-draft, fail-closed
+delivery contract. That contract has deterministic policy, synchronization, and
+packed-install coverage in the standalone repository, but has not yet been
+re-measured on live agents: https://github.com/Da7-Tech/trial.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -582,6 +582,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/software-development/software-development-code-wiki',
                     'user-guide/skills/optional/software-development/software-development-rest-graphql-debug',
                     'user-guide/skills/optional/software-development/software-development-subagent-driven-development',
+                    'user-guide/skills/optional/software-development/software-development-trial',
                   ],
                 },
                 {


### PR DESCRIPTION
## Summary

Adds Trial as an optional software-development skill that gates the final response before delivery.

The proposed response remains a private draft until every user-visible claim is accepted:

- Unsupported claims return the agent to proof or repair.
- Negative verdicts remain internal instead of being reported as an accusation.
- Only accepted claims may be released.
- If bounded repair cannot establish proof, the response must be an explicit incomplete status with the concrete blocker.

## Changes

- Added the canonical skill at `optional-skills/software-development/trial/SKILL.md`.
- Advertises the pre-delivery trigger in the always-visible skill description: `Use before final responses to block unproven completion.`
- Added the generated user-guide page under the software-development category.
- Updated the generated optional-skill catalog and sidebar route.
- Added mandatory policy and integration coverage in `tests/skills/test_trial_skill.py`.
- Uses native Hermes tools: `terminal`, `search_files`, and `delegate_task`.
- Synced the skill to standalone Trial version `0.5.1`.
- Credited the external contributor as `Abdulrahman Qasem (Da7-Tech)` in the required real-name-plus-handle format.

## Evidence and Limitations

The published live-agent benchmark measured the version `0.4` receipt-and-coverage rule. Version `0.5` preserves that rule and adds the private-draft, fail-closed delivery contract. Version `0.5.1` adds activation-metadata regression coverage without changing the canonical gate body.

The skill states explicitly that:

- The current fixture, behavioral mutation grader, and prompts can rerun the protocol.
- Historical temporary run trees and complete reports were not retained.
- The published historical aggregate cannot be independently reconstructed or rescored from the repository alone.
- The new pre-delivery contract has deterministic policy, activation, synchronization, and installation coverage but has not yet been re-measured on live agent sessions.
- A portable rules file cannot physically restrain a model that ignores its instructions or fabricates tool output; host-captured traces, continuous integration, and host-level pre-response hooks remain stronger enforcement.

## How to Test

```bash
./scripts/run_tests.sh \
  tests/skills/test_trial_skill.py \
  tests/website/test_extract_skills.py \
  tests/website/test_generate_skill_docs.py \
  tests/tools/test_skills_hub.py \
  tests/hermes_cli/test_skills_hub.py \
  -q

uvx ruff check tests/skills/test_trial_skill.py
python3 -m py_compile tests/skills/test_trial_skill.py
python3 scripts/check-windows-footguns.py --diff origin/main
git diff --check
```

## Verification Results

Three independent verification methods passed, with the final branch head at `4c96abb1e`:

1. **Repository tests:** 214 skill-policy, skill-hub, extraction, and documentation-generator tests passed during the final audit. The 8 dedicated Trial policy tests were rerun after the last unrelated upstream rebase.
2. **Static contract and mutation audit:** the source and generated copies agree on category, version, author, install identifier, native tools, section order, trigger metadata, historical measurement scope, and fail-closed pre-delivery behavior. Standalone Trial killed three isolated mutations: removing Cursor's always-on flag, weakening the pre-delivery trigger, and re-exposing an internal negative verdict.
3. **Isolated functional installation:** a clean Hermes home installed `official/software-development/trial`; the security scan returned a fresh `SAFE` verdict, the lock file recorded the expected identifier and path, and the installed skill loaded the `0.5.1` trigger, private-draft rule, and internal-verdict rule.

The standalone Trial `0.5.1` release passed all 17 repository tests, three canonical skill validators, JavaScript syntax checks, privacy checks, and its GitHub Actions workflow. Its packed 17-file artifact installed successfully into all twelve supported agent targets and preserved the private-draft, fail-closed rule in every target.

## Risk

Low. This adds an optional skill, generated documentation, and tests. It does not change core runtime behavior or add a runtime dependency.
