### PR TITLE
fix(browser): type with real input events

### DIFF
--- a/tests/tools/test_browser_type.py
+++ b/tests/tools/test_browser_type.py
@@ -1,0 +1,77 @@
+"""Tests for browser_type wrapper behaviour."""
+
+import json
+import os
+import sys
+from unittest.mock import patch
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+class TestBrowserType:
+    def test_browser_type_clears_with_keystrokes_then_types(self, monkeypatch):
+        from tools.browser_tool import browser_type
+
+        monkeypatch.setattr("tools.browser_tool.sys.platform", "linux")
+        side_effect = [
+            {"success": True},
+            {"success": True},
+            {"success": True},
+            {"success": True},
+        ]
+
+        with (
+            patch("tools.browser_tool._last_session_key", return_value="sess"),
+            patch("tools.browser_tool._run_browser_command", side_effect=side_effect) as mock_cmd,
+        ):
+            result = json.loads(browser_type("e3", "hello", task_id="task"))
+
+        assert result["success"] is True
+        assert result["typed"] == "hello"
+        assert result["element"] == "@e3"
+        assert mock_cmd.call_args_list[0][0] == ("sess", "click", ["@e3"])
+        assert mock_cmd.call_args_list[1][0] == ("sess", "press", ["Control+a"])
+        assert mock_cmd.call_args_list[2][0] == ("sess", "press", ["Backspace"])
+        assert mock_cmd.call_args_list[3][0] == ("sess", "type", ["@e3", "hello"])
+
+    def test_browser_type_empty_text_only_clears(self, monkeypatch):
+        from tools.browser_tool import browser_type
+
+        monkeypatch.setattr("tools.browser_tool.sys.platform", "darwin")
+        side_effect = [
+            {"success": True},
+            {"success": True},
+            {"success": True},
+        ]
+
+        with (
+            patch("tools.browser_tool._last_session_key", return_value="sess"),
+            patch("tools.browser_tool._run_browser_command", side_effect=side_effect) as mock_cmd,
+        ):
+            result = json.loads(browser_type("@e7", "", task_id="task"))
+
+        assert result["success"] is True
+        assert result["typed"] == ""
+        assert result["element"] == "@e7"
+        assert len(mock_cmd.call_args_list) == 3
+        assert mock_cmd.call_args_list[1][0] == ("sess", "press", ["Meta+a"])
+        assert mock_cmd.call_args_list[2][0] == ("sess", "press", ["Backspace"])
+
+    def test_browser_type_reports_type_failure(self):
+        from tools.browser_tool import browser_type
+
+        side_effect = [
+            {"success": True},
+            {"success": True},
+            {"success": True},
+            {"success": False, "error": "type failed"},
+        ]
+
+        with (
+            patch("tools.browser_tool._last_session_key", return_value="sess"),
+            patch("tools.browser_tool._run_browser_command", side_effect=side_effect),
+        ):
+            result = json.loads(browser_type("@e1", "hello", task_id="task"))
+
+        assert result == {"success": False, "error": "type failed"}

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -904,7 +904,7 @@ def _lightpanda_fallback_reason(engine: str, command: str, result: Dict[str, Any
     # result. Session-management commands (close, record) are tied to the
     # engine's daemon and can't be retried on a different engine.
     _FALLBACK_ELIGIBLE = {"open", "snapshot", "screenshot", "eval", "click",
-                          "fill", "scroll", "back", "press", "console", "errors"}
+                          "fill", "type", "scroll", "back", "press", "console", "errors"}
     if command not in _FALLBACK_ELIGIBLE:
         return None
 
@@ -2996,8 +2996,18 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
     if not ref.startswith("@"):
         ref = f"@{ref}"
 
-    # Use fill command (clears then types)
-    result = _run_browser_command(effective_task_id, "fill", [ref, text])
+    # ``fill`` mutates DOM values directly, which can leave React/Vue state
+    # stale. Clear with real key events, then type with the native command.
+    select_all = "Meta+a" if sys.platform == "darwin" else "Control+a"
+    _run_browser_command(effective_task_id, "click", [ref])
+    _run_browser_command(effective_task_id, "press", [select_all])
+    clear_result = _run_browser_command(effective_task_id, "press", ["Backspace"])
+
+    result = clear_result if text == "" else _run_browser_command(
+        effective_task_id,
+        "type",
+        [ref, text],
+    )
 
     from agent.display import (
         redact_browser_typed_text_for_display,


### PR DESCRIPTION
## What does this PR do?

Fixes `browser_type` so framework-controlled inputs receive real keystroke-driven updates instead of a DOM-only `fill`. Hermes now clears text fields with native key events and then uses agent-browser's `type` command, which lets React/Vue state track the typed value.

## Related Issue

Fixes #55075

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Thinking Path

- Re-checked issue state immediately before coding and again before PR creation; the issue remained open, unassigned, uncommented, and had no linked open PR.
- Verified the current Hermes wrapper was calling agent-browser `fill`, while the installed agent-browser CLI already exposes a distinct `type` command for real keystrokes.
- Kept the fix wrapper-local instead of changing a backend: preserve Hermes' existing `browser_type` contract by clearing with native key events, then switch the final input path to `type`.
- Added `type` to the Lightpanda fallback-eligible command set so the new path keeps the same backend fallback behavior as the old `fill` path.

## Changes Made

- Updated [`tools/browser_tool.py`](/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-316-55075-browser-type-react/tools/browser_tool.py) so `browser_type`:
  - focuses the target via `click`
  - selects existing text with platform-aware `Meta+a` / `Control+a`
  - clears with `Backspace`
  - types the new value with agent-browser `type`
- Added a regression test file [`tests/tools/test_browser_type.py`](/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-316-55075-browser-type-react/tests/tools/test_browser_type.py) covering:
  - clear-then-type command sequencing
  - empty-string clear behavior
  - surfaced failure on the final `type` command
- Extended Lightpanda fallback eligibility to include the new `type` command path.

## How to Test

1. Run `uv run pytest tests/tools/test_browser_type.py`
2. Run `./.venv/bin/python -m py_compile tools/browser_tool.py tests/tools/test_browser_type.py`
3. On a React-controlled form, use `browser_type` on a text input and confirm submit-time validation sees the typed value instead of an empty field.

## Risks

- The clear step now relies on select-all key chords plus `Backspace`; unusual custom editors may still require platform-specific handling beyond standard text inputs.
- The targeted automated proof is wrapper-level rather than an end-to-end live React-form test, so browser-runtime edge cases could still exist on some sites.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / local repo worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Model Used

OpenAI GPT-5 Codex

## For New Skills

N/A

## Screenshots / Logs

- `uv run pytest tests/tools/test_browser_type.py` → `3 passed in 0.17s`
- `./.venv/bin/python -m py_compile tools/browser_tool.py tests/tools/test_browser_type.py` → passed with Python 3.11.14
- `uv run ruff check tools/browser_tool.py tests/tools/test_browser_type.py` → `All checks passed!`
- `git diff --check` → clean
