### PR TITLE
fix(slack): humanize inbound user mentions + ground bot identity

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -427,6 +427,10 @@ class SlackAdapter(BasePlatformAdapter):
         self._app: Optional[Any] = None
         self._handler: Optional[Any] = None
         self._bot_user_id: Optional[str] = None
+        # Bot identity per workspace, used to ground the agent ("you are @X on
+        # Slack") so it never mistakes a human's mention for a self-mention.
+        self._bot_display_name: Optional[str] = None  # primary workspace bot name
+        self._team_bot_names: Dict[str, str] = {}  # team_id → bot display name
         self._user_name_cache: Dict[str, str] = {}  # user_id → display name
         self._socket_mode_task: Optional[asyncio.Task] = None
         # Multi-workspace support
@@ -970,6 +974,8 @@ class SlackAdapter(BasePlatformAdapter):
             self._bot_user_id = None
             self._team_clients = {}
             self._team_bot_user_ids = {}
+            self._bot_display_name = None
+            self._team_bot_names = {}
 
             # First token is the primary — used for AsyncApp / Socket Mode
             primary_token = bot_tokens[0]
@@ -988,12 +994,15 @@ class SlackAdapter(BasePlatformAdapter):
 
                 self._team_clients[team_id] = client
                 self._team_bot_user_ids[team_id] = bot_user_id
+                self._team_bot_names[team_id] = bot_name
 
                 # First token always wins as the primary bot user id; we
                 # cleared ``_bot_user_id`` above so this picks up the current
                 # token's identity even on reconnect.
                 if self._bot_user_id is None:
                     self._bot_user_id = bot_user_id
+                if self._bot_display_name is None:
+                    self._bot_display_name = bot_name
 
                 logger.info(
                     "[Slack] Authenticated as @%s in workspace %s (team: %s)",
@@ -1921,6 +1930,67 @@ class SlackAdapter(BasePlatformAdapter):
             logger.debug("[Slack] users.info failed for %s: %s", user_id, e)
             self._user_name_cache[user_id] = user_id
             return user_id
+
+    async def _humanize_user_mentions(self, text: str, chat_id: str = "") -> str:
+        """Replace raw ``<@UID>`` user-mention tokens with ``@DisplayName``.
+
+        Slack delivers mentions as opaque IDs (``<@U123>``). Without this, the
+        agent sees ``<@U123>`` and has no way to tell one participant from
+        another — or from itself — which makes it misread a mention of a human
+        as a mention of the bot and reply to messages addressed to that person
+        (the "bot thinks it's @someone-else" bug). Discord avoids this entirely
+        by feeding the agent ``message.clean_content`` (IDs already rendered as
+        names); this is the Slack equivalent.
+
+        The bot's own mention is stripped separately before this runs, so any
+        tokens left here are other participants. Names are resolved via the
+        cached :meth:`_resolve_user_name`, so repeated tokens cost one
+        ``users.info`` lookup per distinct user per process.
+        """
+        if not text or "<@" not in text:
+            return text
+        # Capture the bare user ID inside <@...>; Slack IDs are alnum (U…/W…),
+        # optionally carrying a label like <@U123|alice> — keep only the ID.
+        ids = set(re.findall(r"<@([A-Z0-9]+)(?:\|[^>]*)?>", text))
+        if not ids:
+            return text
+        for uid in ids:
+            name = await self._resolve_user_name(uid, chat_id=chat_id)
+            # Fall back to the raw ID if resolution yields nothing usable
+            # (keeps the message intact rather than emptying a mention).
+            display = (name or uid).strip() or uid
+            # Replace both the bare and labelled forms of this exact ID.
+            text = re.sub(rf"<@{uid}(?:\|[^>]*)?>", f"@{display}", text)
+        return text
+
+    def _build_identity_prompt(self, team_id: str = "") -> str:
+        """Return an ephemeral system-prompt line grounding the bot's identity.
+
+        Injected via the per-turn ``channel_prompt`` seam (applied at API-call
+        time, never persisted to history — so it does NOT break per-conversation
+        prompt caching). Tells the agent its own Slack handle so it can
+        distinguish a mention OF ITSELF from a mention of another participant
+        whose name happens to resemble its own — the failure in the reported
+        bug, where the bot saw a human's mention and claimed it was the one
+        being addressed. Inbound mentions are rendered as ``@DisplayName``
+        (see :meth:`_humanize_user_mentions`), so naming the bot's own display
+        name here gives the agent a positive anchor for "that's me."
+        """
+        name = (
+            (team_id and self._team_bot_names.get(team_id))
+            or self._bot_display_name
+            or ""
+        ).strip()
+        if not name:
+            return ""
+        return (
+            f"You are connected to this Slack workspace as the bot "
+            f'"@{name}". In messages, each line is prefixed with the sender\'s '
+            f"name, and mentions are shown as @DisplayName. Only treat a "
+            f'message as directed at you when it mentions "@{name}" '
+            f"specifically; a mention of any other participant is not a "
+            f"mention of you, even if their name is similar."
+        )
 
     async def send_image_file(
         self,
@@ -2982,6 +3052,17 @@ class SlackAdapter(BasePlatformAdapter):
             channel_id,
             None,
         )
+        # Prepend the bot's Slack identity (ephemeral — applied at API-call
+        # time, never persisted, so prompt caching is preserved) so the agent
+        # knows its own handle and won't read a human's mention as a self-
+        # mention. Combine with any per-channel prompt rather than overwriting.
+        _identity_prompt = self._build_identity_prompt(team_id)
+        if _identity_prompt:
+            _channel_prompt = (
+                f"{_identity_prompt}\n\n{_channel_prompt}".strip()
+                if _channel_prompt
+                else _identity_prompt
+            )
         _auto_skill = resolve_channel_skills(
             self.config.extra,
             channel_id,
@@ -3004,8 +3085,21 @@ class SlackAdapter(BasePlatformAdapter):
                     )
                     or None
                 )
+                if reply_to_text:
+                    reply_to_text = await self._humanize_user_mentions(
+                        reply_to_text, chat_id=channel_id
+                    )
             except Exception:  # pragma: no cover - defensive
                 reply_to_text = None
+
+        # Humanize remaining user mentions: the bot's own mention was already
+        # stripped above, so any ``<@UID>`` left in the trigger text refers to
+        # OTHER participants. Render them as ``@DisplayName`` so the agent can
+        # tell who is being addressed and never mistakes a human's mention for
+        # a mention of itself (the "bot thinks it's @someone-else" bug). Mirrors
+        # Discord's clean_content. Done last so it also covers any mention tokens
+        # pulled in from thread context above.
+        text = await self._humanize_user_mentions(text, chat_id=channel_id)
 
         msg_event = MessageEvent(
             text=text,

--- a/tests/gateway/test_slack_mention_humanization.py
+++ b/tests/gateway/test_slack_mention_humanization.py
@@ -1,0 +1,157 @@
+"""
+Tests for Slack inbound mention humanization + bot identity grounding.
+
+Slack delivers user mentions as opaque IDs (``<@U123>``). Passing those to the
+agent raw leaves it unable to tell one participant from another — or from
+itself — so it can misread a mention of a human as a self-mention and reply to
+messages addressed to that person (the reported "bot thinks it's @someone-else"
+bug). Two cooperating fixes:
+
+  * ``_humanize_user_mentions`` rewrites ``<@UID>`` → ``@DisplayName`` (the
+    Slack equivalent of Discord's ``clean_content``).
+  * ``_build_identity_prompt`` returns an ephemeral system-prompt line naming
+    the bot's own Slack handle so the agent has a positive "that's me" anchor.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Mock slack-bolt if not installed (same pattern as test_slack_mention.py)
+# ---------------------------------------------------------------------------
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        ("slack_bolt.adapter.socket_mode.async_handler",
+         slack_bolt.adapter.socket_mode.async_handler),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+
+def _make_adapter():
+    # object.__new__ skips __init__ (heavy setup) — established slack-test pattern.
+    return object.__new__(SlackAdapter)
+
+
+def _adapter_with_names(names):
+    """Adapter whose _resolve_user_name returns from a fixed UID→name map."""
+    adapter = _make_adapter()
+
+    async def _resolve(user_id, chat_id=""):
+        return names.get(user_id, user_id)
+
+    adapter._resolve_user_name = _resolve  # type: ignore[assignment]
+    return adapter
+
+
+# ----- _humanize_user_mentions -------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_humanizes_single_mention():
+    adapter = _adapter_with_names({"U07ALICE": "Alice Example"})
+    out = await adapter._humanize_user_mentions(
+        "<@U07ALICE> I think thread is prob the right default", chat_id="C1"
+    )
+    assert out == "@Alice Example I think thread is prob the right default"
+    assert "<@" not in out
+
+
+@pytest.mark.asyncio
+async def test_humanizes_multiple_distinct_mentions():
+    adapter = _adapter_with_names(
+        {"U07ALICE": "Alice Example", "U07BOB": "Bob Example"}
+    )
+    out = await adapter._humanize_user_mentions(
+        "hey <@U07ALICE> and <@U07BOB>", chat_id="C1"
+    )
+    assert out == "hey @Alice Example and @Bob Example"
+
+
+@pytest.mark.asyncio
+async def test_handles_labelled_mention_form():
+    # Slack sometimes sends <@UID|handle>; only the ID drives resolution.
+    adapter = _adapter_with_names({"U07ALICE": "Alice Example"})
+    out = await adapter._humanize_user_mentions("<@U07ALICE|alice> hi", chat_id="C1")
+    assert out == "@Alice Example hi"
+
+
+@pytest.mark.asyncio
+async def test_repeated_mention_all_replaced():
+    adapter = _adapter_with_names({"U07ALICE": "Alice Example"})
+    out = await adapter._humanize_user_mentions(
+        "<@U07ALICE> ping <@U07ALICE>", chat_id="C1"
+    )
+    assert out == "@Alice Example ping @Alice Example"
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_mention_falls_back_to_id():
+    # Resolution returns the bare ID; keep the message intact, don't empty it.
+    adapter = _adapter_with_names({})
+    out = await adapter._humanize_user_mentions("<@U07GHOST> hi", chat_id="C1")
+    assert out == "@U07GHOST hi"
+
+
+@pytest.mark.asyncio
+async def test_no_mentions_returns_unchanged():
+    adapter = _adapter_with_names({"U07ALICE": "Alice Example"})
+    out = await adapter._humanize_user_mentions("plain text, no pings", chat_id="C1")
+    assert out == "plain text, no pings"
+
+
+# ----- _build_identity_prompt --------------------------------------------------
+
+def test_identity_prompt_names_the_bot():
+    adapter = _make_adapter()
+    adapter._bot_display_name = "TestBot"
+    adapter._team_bot_names = {}
+    prompt = adapter._build_identity_prompt(team_id="T1")
+    assert "@TestBot" in prompt
+    # Must instruct that another participant's mention is not a self-mention.
+    assert "not a mention of you" in prompt
+
+
+def test_identity_prompt_prefers_per_team_name():
+    adapter = _make_adapter()
+    adapter._bot_display_name = "PrimaryBot"
+    adapter._team_bot_names = {"T2": "WorkspaceTwoBot"}
+    prompt = adapter._build_identity_prompt(team_id="T2")
+    assert "@WorkspaceTwoBot" in prompt
+    assert "PrimaryBot" not in prompt
+
+
+def test_identity_prompt_empty_when_name_unknown():
+    # Before connect (no name resolved) the prompt must be empty, not a
+    # half-formed line — callers skip injecting an empty string.
+    adapter = _make_adapter()
+    adapter._bot_display_name = None
+    adapter._team_bot_names = {}
+    assert adapter._build_identity_prompt(team_id="T1") == ""


### PR DESCRIPTION
## Infographic

![slack-identity-grounding](https://v3b.fal.media/files/b/0aa04fcb/cenj0LYhDd0qsVpIa8_S0_poRMfcqN.png)

## Problem

Slack delivers user mentions as **opaque IDs** (`<@U123>`). The adapter stripped only the bot's *own* mention and passed **every other participant's `<@U…>` token to the agent raw**:

```python
# the ONLY inbound mention rewrite — the bot's own UID, nothing else:
text = text.replace(f"<@{bot_uid}>", "").strip()
```

With no name map and no knowledge of its own handle, the agent receives something like:

```
[Alice Example] <@U07BOB> I think thread is prob the right default
```

In a thread the bot is already participating in (correctly auto-responding to follow-ups), the model has no way to tell that `<@U07BOB>` is a *human* and not itself — so it reads the mention as directed at it and replies. This is the reported symptom: the bot treats a participant's mention as if it named the bot, and even insists it was "explicitly mentioned." Discord never hits this because it feeds the agent `message.clean_content` (IDs already rendered as `@DisplayName`); Slack was the outlier.

> Note: this is **not** a mention-gate routing collision — the channel gate is a literal `f"<@{bot_uid}>" in text` match that a human's ID cannot satisfy. The bug is in what the agent *perceives*, not in whether the message was routed. (The separate user-token-vs-bot-token guard is #55332; this PR is the actual fix for the reported symptom.)

## Fix (two cooperating parts)

**1. Humanize inbound mentions** — `_humanize_user_mentions()` rewrites remaining `<@UID>` and `<@UID|label>` tokens in the trigger text, thread context, and reply-to text to `@DisplayName`, resolved via the cached `_resolve_user_name()` (one `users.info` lookup per distinct user per process). Unresolvable IDs fall back to the bare ID rather than emptying the mention. This is the Slack equivalent of Discord's `clean_content`.

**2. Ground the bot's identity** — `_build_identity_prompt()` returns a line naming the bot's own Slack handle:

> *You are connected to this Slack workspace as the bot "@YourBot". … Only treat a message as directed at you when it mentions "@YourBot" specifically; a mention of any other participant is not a mention of you, even if their name is similar.*

It's injected through the per-turn **`channel_prompt` ephemeral seam** — applied at API-call time, **never persisted to history**, so per-conversation **prompt caching is preserved**. The bot display name is captured per-workspace at connect time (multi-workspace safe; cleared on reconnect alongside the existing `_bot_user_id` reset).

## Tests

`tests/gateway/test_slack_mention_humanization.py`:

- mention humanization: single, multiple-distinct, labelled (`<@UID|handle>`), repeated, unresolvable→ID fallback, and no-mention no-op
- identity prompt: names the bot, prefers the per-team name over the primary, and returns empty before connect (so callers skip injecting a half-formed line)

Prove-fail verified: all 9 fail with the adapter change stashed, all 9 pass with it. The existing **256** Slack tests stay green. An out-of-test E2E run against the real `_humanize_user_mentions` / `_build_identity_prompt` confirms a human's `<@UID>` is rendered to `@DisplayName` and the identity anchor names the bot's own handle.

## Reinstall caveat

None — this is a pure runtime change. No manifest/scope change, so no Slack app reinstall is required; it takes effect on the next gateway restart.
