### PR TITLE
fix(logging): refresh file handlers on forced setup

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -553,8 +553,11 @@ def _add_rotating_handler(
     formatter: logging.Formatter,
     log_filter: Optional[logging.Filter] = None,
 ) -> None:
-    """Add a ``RotatingFileHandler`` to *logger*, skipping if one already
-    exists for the same resolved file path (idempotent).
+    """Add or update a ``RotatingFileHandler`` on *logger*.
+
+    The function is idempotent by resolved file path: re-calls do not attach
+    duplicate handlers, but they do refresh handler settings so forced logging
+    reconfiguration can change the file log level at runtime.
 
     Parameters
     ----------
@@ -568,6 +571,17 @@ def _add_rotating_handler(
             isinstance(existing, RotatingFileHandler)
             and Path(getattr(existing, "baseFilename", "")).resolve() == resolved
         ):
+            existing.setLevel(level)
+            existing.setFormatter(formatter)
+            if hasattr(existing, "maxBytes"):
+                existing.maxBytes = max_bytes
+            if hasattr(existing, "backupCount"):
+                existing.backupCount = backup_count
+            if log_filter is not None and not _has_equivalent_filter(
+                existing,
+                log_filter,
+            ):
+                existing.addFilter(log_filter)
             return  # already attached
 
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -580,6 +594,22 @@ def _add_rotating_handler(
     if log_filter is not None:
         handler.addFilter(log_filter)
     logger.addHandler(handler)
+
+
+def _has_equivalent_filter(
+    handler: logging.Handler,
+    log_filter: logging.Filter,
+) -> bool:
+    for existing in handler.filters:
+        if existing is log_filter:
+            return True
+        if (
+            isinstance(existing, _ComponentFilter)
+            and isinstance(log_filter, _ComponentFilter)
+            and existing._prefixes == log_filter._prefixes
+        ):
+            return True
+    return False
 
 
 def _read_logging_config():

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -325,6 +325,7 @@ def setup_logging(
         max_bytes=max_bytes,
         backup_count=backups,
         formatter=RedactingFormatter(_LOG_FORMAT),
+        refresh_existing=force,
     )
 
     # --- errors.log (WARNING+) — quick triage log --------------------------
@@ -335,6 +336,7 @@ def setup_logging(
         max_bytes=2 * 1024 * 1024,
         backup_count=2,
         formatter=RedactingFormatter(_LOG_FORMAT),
+        refresh_existing=force,
     )
 
     # --- gateway.log (INFO+, gateway component only) ------------------------
@@ -347,6 +349,7 @@ def setup_logging(
             backup_count=3,
             formatter=RedactingFormatter(_LOG_FORMAT),
             log_filter=_ComponentFilter(COMPONENT_PREFIXES["gateway"]),
+            refresh_existing=force,
         )
 
     # --- gui.log (INFO+, dashboard/tui-gateway components) -----------------
@@ -359,6 +362,7 @@ def setup_logging(
             backup_count=5,
             formatter=RedactingFormatter(_LOG_FORMAT),
             log_filter=_ComponentFilter(COMPONENT_PREFIXES["gui"]),
+            refresh_existing=force,
         )
 
     if _logging_initialized and not force:
@@ -727,15 +731,21 @@ def _add_rotating_handler(
     backup_count: int,
     formatter: logging.Formatter,
     log_filter: Optional[logging.Filter] = None,
+    refresh_existing: bool = False,
 ) -> None:
-    """Add a ``RotatingFileHandler`` to *logger*, skipping if one already
-    exists for the same resolved file path (idempotent).
+    """Add or update a ``RotatingFileHandler`` on *logger*.
+
+    The function is idempotent by resolved file path: re-calls do not attach
+    duplicate handlers, and requested refreshes update handler settings so
+    forced logging reconfiguration can change the file log level at runtime.
 
     Parameters
     ----------
     log_filter
         Optional filter to attach to the handler (e.g. ``_ComponentFilter``
         for gateway.log).
+    refresh_existing
+        Update a matching handler instead of preserving its current settings.
     """
     resolved = path.resolve()
     for existing in _queued_file_handlers:
@@ -743,6 +753,18 @@ def _add_rotating_handler(
             isinstance(existing, RotatingFileHandler)
             and Path(getattr(existing, "baseFilename", "")).resolve() == resolved
         ):
+            if refresh_existing:
+                existing.setLevel(level)
+                existing.setFormatter(formatter)
+                if hasattr(existing, "maxBytes"):
+                    existing.maxBytes = max_bytes
+                if hasattr(existing, "backupCount"):
+                    existing.backupCount = backup_count
+                if log_filter is not None and not _has_equivalent_filter(
+                    existing,
+                    log_filter,
+                ):
+                    existing.addFilter(log_filter)
             return  # already attached
 
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -757,6 +779,22 @@ def _add_rotating_handler(
     # Route through the async queue instead of ``logger.addHandler(handler)`` so
     # the rotation-lock wait never runs on the caller's (often event-loop) thread.
     _register_queued_handler(handler)
+
+
+def _has_equivalent_filter(
+    handler: logging.Handler,
+    log_filter: logging.Filter,
+) -> bool:
+    for existing in handler.filters:
+        if existing is log_filter:
+            return True
+        if (
+            isinstance(existing, _ComponentFilter)
+            and isinstance(log_filter, _ComponentFilter)
+            and existing._prefixes == log_filter._prefixes
+        ):
+            return True
+    return False
 
 
 def _read_logging_config():

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -126,6 +126,32 @@ class TestSetupLogging:
         ]
         assert len(agent_handlers) == 1
 
+    def test_force_updates_existing_agent_handler_level(self, hermes_home):
+        hermes_logging.setup_logging(hermes_home=hermes_home, log_level="INFO")
+        hermes_logging.setup_logging(
+            hermes_home=hermes_home,
+            log_level="DEBUG",
+            force=True,
+        )
+
+        root = logging.getLogger()
+        agent_handlers = [
+            h for h in root.handlers
+            if isinstance(h, RotatingFileHandler)
+            and "agent.log" in getattr(h, "baseFilename", "")
+        ]
+        assert len(agent_handlers) == 1
+        assert agent_handlers[0].level == logging.DEBUG
+
+        logging.getLogger("plugins.platforms.matrix.adapter").debug(
+            "debug after forced log-level change"
+        )
+        for h in root.handlers:
+            h.flush()
+
+        content = (hermes_home / "logs" / "agent.log").read_text(encoding="utf-8")
+        assert "debug after forced log-level change" in content
+
     def test_custom_log_level(self, hermes_home):
         hermes_logging.setup_logging(hermes_home=hermes_home, log_level="DEBUG")
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -100,6 +100,42 @@ class TestSetupLogging:
 
 
 
+    def test_force_updates_existing_async_agent_handler(self, hermes_home):
+        hermes_logging.setup_logging(
+            hermes_home=hermes_home,
+            log_level="INFO",
+            max_size_mb=1,
+            backup_count=1,
+        )
+        agent_handlers = [
+            h for h in hermes_logging.rotating_file_handlers()
+            if isinstance(h, RotatingFileHandler)
+            and "agent.log" in getattr(h, "baseFilename", "")
+        ]
+        assert len(agent_handlers) == 1
+
+        hermes_logging.setup_logging(hermes_home=hermes_home, log_level="DEBUG")
+        assert agent_handlers[0].level == logging.INFO
+
+        hermes_logging.setup_logging(
+            hermes_home=hermes_home,
+            log_level="DEBUG",
+            max_size_mb=2,
+            backup_count=4,
+            force=True,
+        )
+
+        assert agent_handlers[0].level == logging.DEBUG
+        assert agent_handlers[0].maxBytes == 2 * 1024 * 1024
+        assert agent_handlers[0].backupCount == 4
+
+        logging.getLogger("plugins.platforms.matrix.adapter").debug(
+            "debug after forced log-level change"
+        )
+        hermes_logging.flush_log_queue()
+
+        content = (hermes_home / "logs" / "agent.log").read_text(encoding="utf-8")
+        assert "debug after forced log-level change" in content
 
 
     def test_writes_to_agent_log(self, hermes_home):


### PR DESCRIPTION
﻿## Summary

Fixes #55341.

`setup_logging(force=True, log_level="DEBUG")` now refreshes existing rotating file handlers instead of only deduplicating by path and returning early.

Before this change, a process that started with INFO logging could later force DEBUG setup and end up with:

- root logger level: DEBUG
- existing `agent.log` handler level: still INFO

That meant plugin/channel DEBUG records were accepted by the root logger but still dropped by the file handler.

## Changes

- Update `_add_rotating_handler()` so an existing same-path handler is refreshed instead of skipped.
- Refresh level, formatter, and rotation settings on existing handlers.
- Avoid duplicate component filters when re-entering gateway/gui setup.
- Add a regression test that forces INFO -> DEBUG and verifies a plugin logger DEBUG line reaches `agent.log`.

## Validation

- Before the fix, the new regression test failed with handler level `20` (INFO) instead of `10` (DEBUG).
- `python -m pytest tests/test_hermes_logging.py::TestSetupLogging::test_force_updates_existing_agent_handler_level -q --basetemp .pytest-tmp-focused` -> 1 passed
- `python -m pytest tests/test_hermes_logging.py -q -k "not managed_mode" --basetemp .pytest-tmp-logging-nomanaged` -> 64 passed, 2 deselected
- Direct repro script after the fix printed a DEBUG line from `plugins.platforms.matrix.adapter` in `agent.log`.
- `ruff check hermes_logging.py tests/test_hermes_logging.py` -> passed
- `git diff --check` -> passed

Local note: the full `tests/test_hermes_logging.py` file has two existing Windows-only managed-mode failures in this checkout around chmod/file creation with the Windows concurrent log handler. The non-managed logging suite and the touched regression pass.

## Agent transcript

- Started from OpenClaw's runtime plugin log-level fix and checked whether Hermes has the same tslog child-logger issue. It does not.
- Found the analogous Hermes boundary in stdlib logging: existing rotating handlers are reused without refreshing their level.
- Searched Hermes issues/PRs for duplicate runtime/debug/log-level reports and found no matching handler refresh fix.
- Reproduced the stale handler level before changing code, then kept the fix scoped to `_add_rotating_handler()` and its tests.
