### PR TITLE
fix(tui): submit voice transcripts synchronously

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -163,6 +163,34 @@ describe('createGatewayEventHandler', () => {
     }
   })
 
+  it('submits voice transcripts synchronously without deferring through a timer', () => {
+    const appended: Msg[] = []
+    const calls: string[] = []
+    const ctx = buildCtx(appended)
+    const timerSpy = vi.spyOn(globalThis, 'setTimeout')
+
+    ctx.composer.setInput = vi.fn(() => {
+      calls.push('setInput')
+    })
+    ctx.submission.submitRef.current = vi.fn((text: string) => {
+      calls.push(`submit:${text}`)
+    })
+
+    try {
+      createGatewayEventHandler(ctx)({
+        payload: { text: '  send this transcript  ' },
+        type: 'voice.transcript'
+      } as any)
+
+      expect(ctx.composer.setInput).toHaveBeenCalledWith('')
+      expect(ctx.submission.submitRef.current).toHaveBeenCalledWith('send this transcript')
+      expect(calls).toEqual(['setInput', 'submit:send this transcript'])
+      expect(timerSpy).not.toHaveBeenCalled()
+    } finally {
+      timerSpy.mockRestore()
+    }
+  })
+
   it('maps goal status.update prefixes to short status strings', () => {
     const ctx = buildCtx([])
     const onEvent = createGatewayEventHandler(ctx)

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -624,10 +624,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         //
         // We can't branch on composer input from inside a setInput updater
         // (React strict mode double-invokes it, duplicating the submit).
-        // Just clear + defer submit so the cleared input is committed before
-        // submit reads it.
+        // `submit()` already accepts the transcript value directly, so
+        // deferring it only opens a race with the busy->false queue drain.
         setInput('')
-        setTimeout(() => submitRef.current(text), 0)
+        submitRef.current(text)
 
         return
       }


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI voice transcript re-queue race by submitting voice transcripts synchronously instead of deferring them with `setTimeout(0)`.

When a transcript arrived while the session was busy, the deferred submit could race with the busy-to-idle queue drain and enqueue the same transcript twice. Removing the timer keeps the existing clear-input behavior but eliminates the duplicate-submit loop.

## Related Issue

Fixes #54917

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `ui-tui/src/app/createGatewayEventHandler.ts` so `voice.transcript` clears composer input and immediately calls `submitRef.current(text)` instead of deferring through `setTimeout(0)`.
- Added a regression test in `ui-tui/src/__tests__/createGatewayEventHandler.test.ts` that verifies the transcript submit happens synchronously and does not schedule a timer.

## How to Test

1. In `ui-tui/`, run `npm test -- --run src/__tests__/createGatewayEventHandler.test.ts`.
2. Confirm the new `submits voice transcripts synchronously without deferring through a timer` test passes.
3. Reproduce the busy-session voice path and verify a transcript is submitted once instead of being re-queued into an infinite loop.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `npm test --workspace ui-tui -- --run src/__tests__/createGatewayEventHandler.test.ts` -> `1 file passed, 78 tests passed`
- `./node_modules/.bin/eslint src/app/createGatewayEventHandler.ts src/__tests__/createGatewayEventHandler.test.ts` -> clean
- `git diff --check` -> clean
