### PR TITLE
fix(gateway): sync logging session context early

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
+import hermes_logging
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from hermes_cli.active_sessions import active_session_registry_snapshot
 from tui_gateway import server
@@ -296,6 +297,22 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
     monkeypatch.setattr(server, "_real_stdout", _BrokenStdout())
 
     assert server.write_json({"ok": True}) is False
+
+
+def test_set_session_context_syncs_gateway_and_logging_state():
+    from gateway.session_context import get_session_env
+
+    hermes_logging.clear_session_context()
+
+    tokens = server._set_session_context("sess-54897")
+    try:
+        assert get_session_env("HERMES_SESSION_KEY") == "sess-54897"
+        assert getattr(hermes_logging._session_context, "session_id", None) == "sess-54897"
+    finally:
+        server._clear_session_context(tokens)
+
+    assert get_session_env("HERMES_SESSION_KEY") == ""
+    assert getattr(hermes_logging._session_context, "session_id", None) is None
 
 
 def test_write_json_drops_detached_ws_frames(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1813,6 +1813,12 @@ def _cwd_for_session_key(session_key: str) -> str:
 
 def _set_session_context(session_key: str, cwd: str | None = None) -> list:
     try:
+        from hermes_logging import set_session_context as set_log_session_context
+
+        set_log_session_context(session_key)
+    except Exception:
+        pass
+    try:
         from gateway.session_context import set_session_vars
 
         # Ephemeral task IDs (background, preview) aren't in `_sessions`, so the
@@ -1832,6 +1838,12 @@ def _set_session_context(session_key: str, cwd: str | None = None) -> list:
 
 
 def _clear_session_context(tokens: list) -> None:
+    try:
+        from hermes_logging import clear_session_context as clear_log_session_context
+
+        clear_log_session_context()
+    except Exception:
+        pass
     if not tokens:
         return
     try:


### PR DESCRIPTION
## What does this PR do?

Fixes stale session IDs on early gateway-side log lines by synchronizing the TUI gateway session helper with `hermes_logging` before auxiliary-client logging can run.

The gateway already set request-scoped session ContextVars, but the log prefix used a separate thread-local session tag. On a fresh inbound session, early logs could therefore inherit the previous thread-local value until the conversation loop reset it later. This change keeps both session-context mechanisms aligned for the whole gateway turn.

## Related Issue

Fixes #54897

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tui_gateway/server.py` so `_set_session_context()` also sets `hermes_logging`'s session tag and `_clear_session_context()` always clears it.
- Added `tests/test_tui_gateway_server.py::test_set_session_context_syncs_gateway_and_logging_state` to verify the gateway ContextVar path and log-prefix thread-local stay in sync through set/clear.

## How to Test

1. Run `uv run pytest tests/test_tui_gateway_server.py -k session_context_syncs_gateway_and_logging_state`.
2. Confirm the new test passes and proves `HERMES_SESSION_KEY` plus the logging session tag both become `sess-54897`.
3. Confirm `server._clear_session_context(...)` clears both paths again so stale session tags cannot leak into the next inbound session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run pytest tests/test_tui_gateway_server.py -k session_context_syncs_gateway_and_logging_state` -> `1 passed, 299 deselected`
- `./.venv/bin/python -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py` -> clean
- `uv run ruff check tui_gateway/server.py tests/test_tui_gateway_server.py` -> clean
- `git diff --check` -> clean
