### PR TITLE
fix(teams): bound standalone error body reads

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -462,6 +462,7 @@ _ALLOWED_TEAMS_SERVICE_HOSTS = frozenset({
     "smba.trafficmanager.net",
     "smba.infra.gov.teams.microsoft.us",
 })
+_TEAMS_STANDALONE_ERROR_BODY_LIMIT_BYTES = 8 * 1024
 
 # Conservative pattern for Bot Framework conversation IDs.  Real values
 # combine digits, colons, hyphens, dots, '@', and the ``thread.skype`` /
@@ -492,6 +493,34 @@ def _validate_teams_service_url(raw: str) -> Optional[str]:
         return None
     normalized = raw if raw.endswith("/") else raw + "/"
     return normalized
+
+
+async def _read_teams_error_text_limited(
+    response: Any,
+    *,
+    limit: int = _TEAMS_STANDALONE_ERROR_BODY_LIMIT_BYTES,
+) -> str:
+    """Read a bounded error snippet from an aiohttp response."""
+    content = getattr(response, "content", None)
+    if content is not None and hasattr(content, "read"):
+        chunks: list[bytes] = []
+        total = 0
+        while total <= limit:
+            chunk = await content.read(min(4096, limit + 1 - total))
+            if not chunk:
+                break
+            chunks.append(bytes(chunk))
+            total += len(chunk)
+        if total > limit:
+            release = getattr(response, "release", None)
+            if callable(release):
+                release()
+        return b"".join(chunks)[:limit].decode("utf-8", errors="replace")
+
+    # Test doubles or alternate aiohttp-compatible responses may only expose
+    # text(); keep that fallback bounded after conversion.
+    text = await response.text()
+    return str(text)[:limit]
 
 
 async def _standalone_send(
@@ -580,7 +609,7 @@ async def _standalone_send(
                 timeout=per_request_timeout,
             ) as token_resp:
                 if token_resp.status >= 400:
-                    body = await token_resp.text()
+                    body = await _read_teams_error_text_limited(token_resp)
                     return {"error": f"Teams standalone send: token request failed ({token_resp.status}): {body[:300]}"}
                 token_payload = await token_resp.json()
             access_token = token_payload.get("access_token")
@@ -602,7 +631,7 @@ async def _standalone_send(
                 timeout=per_request_timeout,
             ) as send_resp:
                 if send_resp.status >= 400:
-                    body = await send_resp.text()
+                    body = await _read_teams_error_text_limited(send_resp)
                     return {"error": f"Teams standalone send: activity post failed ({send_resp.status}): {body[:300]}"}
                 send_payload = await send_resp.json()
         return {

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -899,17 +899,42 @@ class TestTeamsAttachmentClassification:
 # ── _standalone_send (out-of-process cron delivery) ──────────────────────
 
 
+class _FakeAiohttpContent:
+    def __init__(self, data: str | bytes):
+        self._data = data.encode("utf-8") if isinstance(data, str) else bytes(data)
+        self._offset = 0
+        self.bytes_read = 0
+
+    async def read(self, n: int = -1):
+        if self._offset >= len(self._data):
+            return b""
+        if n is None or n < 0:
+            n = len(self._data) - self._offset
+        end = min(len(self._data), self._offset + n)
+        chunk = self._data[self._offset:end]
+        self._offset = end
+        self.bytes_read += len(chunk)
+        return chunk
+
+
 class _FakeAiohttpResponse:
     def __init__(self, status: int, payload, text_body: str = ""):
         self.status = status
         self._payload = payload
         self._text = text_body or (str(payload) if payload is not None else "")
+        self.content = _FakeAiohttpContent(self._text)
+        self.text_calls = 0
+        self.released = False
 
     async def json(self):
         return self._payload
 
     async def text(self):
+        self.text_calls += 1
         return self._text
+
+    def release(self):
+        self.released = True
 
     async def __aenter__(self):
         return self
@@ -1023,6 +1048,59 @@ class TestTeamsStandaloneSend:
         assert "error" in result
         assert "401" in result["error"]
         assert "token" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_token_failure_reads_bounded_error_body(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+
+        token_resp = _FakeAiohttpResponse(
+            401,
+            {"error": "oversized"},
+            text_body="token-error " * 2000,
+        )
+        session = _FakeAiohttpSession([token_resp])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:abc@thread.skype",
+            "hi",
+        )
+
+        assert "error" in result
+        assert "token-error" in result["error"]
+        assert token_resp.text_calls == 0
+        assert token_resp.content.bytes_read <= _teams_mod._TEAMS_STANDALONE_ERROR_BODY_LIMIT_BYTES + 1
+        assert token_resp.released is True
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_activity_failure_reads_bounded_error_body(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+
+        token_resp = _FakeAiohttpResponse(200, {"access_token": "the-token"})
+        activity_resp = _FakeAiohttpResponse(
+            503,
+            {"error": "oversized"},
+            text_body="activity-error " * 2000,
+        )
+        session = _FakeAiohttpSession([token_resp, activity_resp])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:abc@thread.skype",
+            "hi",
+        )
+
+        assert "error" in result
+        assert "activity-error" in result["error"]
+        assert activity_resp.text_calls == 0
+        assert activity_resp.content.bytes_read <= _teams_mod._TEAMS_STANDALONE_ERROR_BODY_LIMIT_BYTES + 1
+        assert activity_resp.released is True
 
     @pytest.mark.asyncio
     async def test_standalone_send_rejects_off_allowlist_service_url(self, monkeypatch):


### PR DESCRIPTION
﻿## Summary

Fixes #55347.

Teams standalone outbound delivery now reads token-request and activity-post error bodies with an 8 KiB cap before building the existing 300-character diagnostic snippet.

## What changed

- Added `_read_teams_error_text_limited()` for aiohttp responses.
- Swapped both `_standalone_send()` error branches from `await resp.text()` to the bounded reader.
- Added regression tests for oversized token and activity error bodies; the tests assert the unbounded `text()` fallback is not called and the response is released after the capped read.

## Why

`_standalone_send()` is used by out-of-process delivery paths like cron. A large error body from STS, Bot Framework, or a proxy was previously buffered in full before Hermes sliced it to 300 characters for display. This keeps the diagnostic useful while bounding memory exposure.

## Validation

- `python -m pytest tests/gateway/test_teams.py -q -k "standalone_send" --basetemp .pytest-tmp-teams-standalone` -> 7 passed, 52 deselected
- `python -m pytest tests/gateway/test_teams.py -q --basetemp .pytest-tmp-teams-full` -> 59 passed
- `ruff check plugins/platforms/teams/adapter.py tests/gateway/test_teams.py` -> passed
- `git diff --check` -> passed

## Agent Transcript

- Mapped recent OpenClaw bounded error-body-read fixes to Hermes platform send paths.
- Verified no existing Hermes issue/PR covered Teams standalone send token/activity error bodies.
- Implemented the smallest Teams-local bounded reader and kept the user-facing 300-character error snippet behavior.
- Ran focused and full Teams tests plus lint/diff checks locally.
