### PR TITLE
fix(line): bound reply and push error body reads

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -106,6 +106,7 @@ LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push"
 LINE_LOADING_URL = "https://api.line.me/v2/bot/chat/loading/start"
 LINE_CONTENT_URL_FMT = "https://api-data.line.me/v2/bot/message/{message_id}/content"
 LINE_BOT_INFO_URL = "https://api.line.me/v2/bot/info"
+_LINE_ERROR_BODY_LIMIT_BYTES = 8 * 1024
 
 # LINE Messaging API hard limits
 LINE_PER_BUBBLE_CHARS = 5000  # Hard limit per text message object
@@ -438,6 +439,33 @@ def _allowed_for_source(
     return False
 
 
+async def _read_line_error_text_limited(
+    response: Any,
+    *,
+    limit: int = _LINE_ERROR_BODY_LIMIT_BYTES,
+) -> str:
+    content = getattr(response, "content", None)
+    if content is not None and hasattr(content, "read"):
+        chunks: List[bytes] = []
+        total = 0
+        while total <= limit:
+            size = min(4096, limit + 1 - total)
+            chunk = await content.read(size)
+            if not chunk:
+                break
+            data = bytes(chunk)
+            chunks.append(data)
+            total += len(data)
+        if total > limit:
+            release = getattr(response, "release", None)
+            if callable(release):
+                release()
+        return b"".join(chunks)[:limit].decode("utf-8", errors="replace")
+
+    text = await response.text()
+    return str(text)[:limit]
+
+
 # ---------------------------------------------------------------------------
 # LINE Reply / Push HTTP client
 # ---------------------------------------------------------------------------
@@ -468,7 +496,7 @@ class _LineClient:
                 json={"replyToken": reply_token, "messages": messages},
             ) as resp:
                 if resp.status >= 400:
-                    body = await resp.text()
+                    body = await _read_line_error_text_limited(resp)
                     raise RuntimeError(f"LINE reply {resp.status}: {body[:200]}")
 
     async def push(self, chat_id: str, messages: List[Dict[str, Any]]) -> None:
@@ -481,7 +509,7 @@ class _LineClient:
                 json={"to": chat_id, "messages": messages},
             ) as resp:
                 if resp.status >= 400:
-                    body = await resp.text()
+                    body = await _read_line_error_text_limited(resp)
                     raise RuntimeError(f"LINE push {resp.status}: {body[:200]}")
 
     async def loading(self, chat_id: str, seconds: int = 60) -> None:

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -134,6 +134,7 @@ LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push"
 LINE_LOADING_URL = "https://api.line.me/v2/bot/chat/loading/start"
 LINE_CONTENT_URL_FMT = "https://api-data.line.me/v2/bot/message/{message_id}/content"
 LINE_BOT_INFO_URL = "https://api.line.me/v2/bot/info"
+_LINE_ERROR_BODY_LIMIT_BYTES = 8 * 1024
 
 # LINE Messaging API hard limits
 LINE_PER_BUBBLE_CHARS = 5000  # Hard limit per text message object
@@ -491,6 +492,38 @@ def _allowed_for_source(
     return False
 
 
+async def _read_line_error_text_limited(
+    response: Any,
+    *,
+    limit: int = _LINE_ERROR_BODY_LIMIT_BYTES,
+) -> str:
+    content = getattr(response, "content", None)
+    if content is not None and hasattr(content, "read"):
+        chunks: List[bytes] = []
+        total = 0
+        while total <= limit:
+            size = min(4096, limit + 1 - total)
+            chunk = await content.read(size)
+            if not chunk:
+                break
+            data = bytes(chunk)
+            chunks.append(data)
+            total += len(data)
+        if total > limit:
+            release = getattr(response, "release", None)
+            if callable(release):
+                release()
+        body = b"".join(chunks)[:limit]
+        encoding = getattr(response, "charset", None) or "utf-8"
+        try:
+            return body.decode(encoding, errors="replace")
+        except LookupError:
+            return body.decode("utf-8", errors="replace")
+
+    text = await response.text()
+    return str(text)[:limit]
+
+
 # ---------------------------------------------------------------------------
 # LINE Reply / Push HTTP client
 # ---------------------------------------------------------------------------
@@ -521,7 +554,7 @@ class _LineClient:
                 json={"replyToken": reply_token, "messages": messages},
             ) as resp:
                 if resp.status >= 400:
-                    body = await resp.text()
+                    body = await _read_line_error_text_limited(resp)
                     raise RuntimeError(f"LINE reply {resp.status}: {body[:200]}")
 
     async def push(self, chat_id: str, messages: List[Dict[str, Any]]) -> None:
@@ -534,7 +567,7 @@ class _LineClient:
                 json={"to": chat_id, "messages": messages},
             ) as resp:
                 if resp.status >= 400:
-                    body = await resp.text()
+                    body = await _read_line_error_text_limited(resp)
                     raise RuntimeError(f"LINE push {resp.status}: {body[:200]}")
 
     async def loading(self, chat_id: str, seconds: int = 60) -> None:

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -19,6 +19,8 @@ import hashlib
 import hmac
 import base64
 import json
+import sys
+import types
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -45,6 +47,78 @@ validate_config = _line.validate_config
 _standalone_send = _line._standalone_send
 _env_enablement = _line._env_enablement
 _MessageDeduplicator = _line._MessageDeduplicator
+_LineClient = _line._LineClient
+
+
+class _FakeLineAiohttpContent:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self._offset = 0
+        self.bytes_read = 0
+
+    async def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            size = len(self._payload) - self._offset
+        chunk = self._payload[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        self.bytes_read += len(chunk)
+        return chunk
+
+
+class _FakeLineAiohttpResponse:
+    def __init__(self, status: int, payload: bytes) -> None:
+        self.status = status
+        self._payload = payload
+        self.content = _FakeLineAiohttpContent(payload)
+        self.released = False
+        self.text_calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self) -> str:
+        self.text_calls += 1
+        return self._payload.decode("utf-8", errors="replace")
+
+    def release(self) -> None:
+        self.released = True
+
+
+class _FakeLineAiohttpSession:
+    def __init__(self, response: _FakeLineAiohttpResponse, *args, **kwargs) -> None:
+        self.response = response
+        self.init_args = args
+        self.init_kwargs = kwargs
+        self.posts = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, *args, **kwargs):
+        self.posts.append((args, kwargs))
+        return self.response
+
+
+def _install_fake_line_aiohttp(monkeypatch, response: _FakeLineAiohttpResponse):
+    sessions = []
+
+    class _ClientSession(_FakeLineAiohttpSession):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(response, *args, **kwargs)
+            sessions.append(self)
+
+    fake_aiohttp = types.SimpleNamespace(
+        ClientSession=_ClientSession,
+        ClientTimeout=lambda **kwargs: kwargs,
+    )
+    monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+    return sessions
 
 
 # ---------------------------------------------------------------------------
@@ -490,6 +564,51 @@ class TestEnvEnablement:
         monkeypatch.setenv("LINE_PUBLIC_URL", "https://my-tunnel.example.com")
         result = _env_enablement()
         assert result["public_url"] == "https://my-tunnel.example.com"
+
+
+class TestLineClientHttpErrors:
+
+    def test_reply_error_reads_limited_body(self, monkeypatch):
+        payload = b"line reply failure " * 1000
+        response = _FakeLineAiohttpResponse(500, payload)
+        sessions = _install_fake_line_aiohttp(monkeypatch, response)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            asyncio.run(
+                _LineClient("tok").reply(
+                    "reply-token",
+                    [{"type": "text", "text": "hello"}],
+                )
+            )
+
+        assert "LINE reply 500" in str(exc_info.value)
+        assert response.text_calls == 0
+        assert response.content.bytes_read == _line._LINE_ERROR_BODY_LIMIT_BYTES + 1
+        assert response.released is True
+        args, kwargs = sessions[0].posts[0]
+        assert args[0] == _line.LINE_REPLY_URL
+        assert kwargs["json"]["replyToken"] == "reply-token"
+
+    def test_push_error_reads_limited_body(self, monkeypatch):
+        payload = b"line push failure " * 1000
+        response = _FakeLineAiohttpResponse(503, payload)
+        sessions = _install_fake_line_aiohttp(monkeypatch, response)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            asyncio.run(
+                _LineClient("tok").push(
+                    "Uchat",
+                    [{"type": "text", "text": "hello"}],
+                )
+            )
+
+        assert "LINE push 503" in str(exc_info.value)
+        assert response.text_calls == 0
+        assert response.content.bytes_read == _line._LINE_ERROR_BODY_LIMIT_BYTES + 1
+        assert response.released is True
+        args, kwargs = sessions[0].posts[0]
+        assert args[0] == _line.LINE_PUSH_URL
+        assert kwargs["json"]["to"] == "Uchat"
 
 
 class TestStandaloneSend:

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -20,6 +20,8 @@ import hashlib
 import hmac
 import base64
 import json
+import sys
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -46,6 +48,78 @@ validate_config = _line.validate_config
 _standalone_send = _line._standalone_send
 _env_enablement = _line._env_enablement
 _MessageDeduplicator = _line._MessageDeduplicator
+_LineClient = _line._LineClient
+
+
+class _FakeLineAiohttpContent:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self._offset = 0
+        self.bytes_read = 0
+
+    async def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            size = len(self._payload) - self._offset
+        chunk = self._payload[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        self.bytes_read += len(chunk)
+        return chunk
+
+
+class _FakeLineAiohttpResponse:
+    def __init__(self, status: int, payload: bytes) -> None:
+        self.status = status
+        self._payload = payload
+        self.content = _FakeLineAiohttpContent(payload)
+        self.released = False
+        self.text_calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self) -> str:
+        self.text_calls += 1
+        return self._payload.decode("utf-8", errors="replace")
+
+    def release(self) -> None:
+        self.released = True
+
+
+class _FakeLineAiohttpSession:
+    def __init__(self, response: _FakeLineAiohttpResponse, *args, **kwargs) -> None:
+        self.response = response
+        self.init_args = args
+        self.init_kwargs = kwargs
+        self.posts = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, *args, **kwargs):
+        self.posts.append((args, kwargs))
+        return self.response
+
+
+def _install_fake_line_aiohttp(monkeypatch, response: _FakeLineAiohttpResponse):
+    sessions = []
+
+    class _ClientSession(_FakeLineAiohttpSession):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(response, *args, **kwargs)
+            sessions.append(self)
+
+    fake_aiohttp = types.SimpleNamespace(
+        ClientSession=_ClientSession,
+        ClientTimeout=lambda **kwargs: kwargs,
+    )
+    monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+    return sessions
 
 
 # ---------------------------------------------------------------------------
@@ -312,6 +386,59 @@ class TestEnvEnablement:
         monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
         monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
         assert _env_enablement() is None
+
+
+class TestLineClientHttpErrors:
+
+    def test_error_body_preserves_declared_charset(self):
+        response = _FakeLineAiohttpResponse(500, "LINE failure: café".encode("iso-8859-1"))
+        response.charset = "iso-8859-1"
+
+        body = asyncio.run(_line._read_line_error_text_limited(response))
+
+        assert body == "LINE failure: café"
+
+    def test_reply_error_reads_limited_body(self, monkeypatch):
+        payload = b"line reply failure " * 1000
+        response = _FakeLineAiohttpResponse(500, payload)
+        sessions = _install_fake_line_aiohttp(monkeypatch, response)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            asyncio.run(
+                _LineClient("tok").reply(
+                    "reply-token",
+                    [{"type": "text", "text": "hello"}],
+                )
+            )
+
+        assert "LINE reply 500" in str(exc_info.value)
+        assert response.text_calls == 0
+        assert response.content.bytes_read == _line._LINE_ERROR_BODY_LIMIT_BYTES + 1
+        assert response.released is True
+        args, kwargs = sessions[0].posts[0]
+        assert args[0] == _line.LINE_REPLY_URL
+        assert kwargs["json"]["replyToken"] == "reply-token"
+
+    def test_push_error_reads_limited_body(self, monkeypatch):
+        payload = b"line push failure " * 1000
+        response = _FakeLineAiohttpResponse(503, payload)
+        sessions = _install_fake_line_aiohttp(monkeypatch, response)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            asyncio.run(
+                _LineClient("tok").push(
+                    "Uchat",
+                    [{"type": "text", "text": "hello"}],
+                )
+            )
+
+        assert "LINE push 503" in str(exc_info.value)
+        assert response.text_calls == 0
+        assert response.content.bytes_read == _line._LINE_ERROR_BODY_LIMIT_BYTES + 1
+        assert response.released is True
+        args, kwargs = sessions[0].posts[0]
+        assert args[0] == _line.LINE_PUSH_URL
+        assert kwargs["json"]["to"] == "Uchat"
 
 
 class TestStandaloneSend:


### PR DESCRIPTION
## Summary

Fixes #55350.

Bounds LINE outbound error-body reads for the Reply and Push API paths. Both branches previously used `await resp.text()` before raising, which buffered the full response even though the exception only reports a short snippet.

## Changes

- Add a LINE-local bounded error-body helper capped at 8 KiB.
- Use it from `_LineClient.reply()` and `_LineClient.push()` when `status >= 400`.
- Add fake-aiohttp regression tests that prove the error paths do not call `resp.text()`, read only `limit + 1` bytes, and release oversized responses.

## Validation

- `python -m pytest tests/gateway/test_line_plugin.py -q -k LineClientHttpErrors --basetemp .pytest-tmp-line-client` -> 2 passed, 76 deselected
- `python -m pytest tests/gateway/test_line_plugin.py -q --basetemp .pytest-tmp-line-full` -> 78 passed
- `ruff check plugins/platforms/line/adapter.py tests/gateway/test_line_plugin.py` -> passed
- `git diff --check` -> passed