### PR TITLE
fix(agent): preserve verify-on-stop attempted final answer

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -73,6 +73,23 @@ logger = logging.getLogger(__name__)
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
 
+def _merge_verify_on_stop_final_response(
+    attempted_final: Optional[str],
+    verification_final: Optional[str],
+) -> str:
+    attempted = attempted_final.strip() if isinstance(attempted_final, str) else ""
+    verification = (
+        verification_final.strip() if isinstance(verification_final, str) else ""
+    )
+    if not attempted:
+        return verification
+    if not verification:
+        return attempted
+    if attempted in verification:
+        return verification
+    return f"{attempted}\n\n{verification}"
+
+
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
     """Extract a provider-reported image dimension ceiling, if present."""
     parts = []
@@ -586,6 +603,7 @@ def run_conversation(
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
+    verification_stop_pending_final_response: Optional[str] = None
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
 
     # Per-turn tally of consecutive successful credential-pool token refreshes,
@@ -4790,6 +4808,8 @@ def run_conversation(
                     agent._verification_stop_nudges = (
                         getattr(agent, "_verification_stop_nudges", 0) + 1
                     )
+                    if verification_stop_pending_final_response is None:
+                        verification_stop_pending_final_response = final_response
                     final_msg["finish_reason"] = "verification_required"
                     messages.append(final_msg)
                     # Keep the attempted final answer in model history so the
@@ -4809,6 +4829,16 @@ def run_conversation(
                     logger.debug("verification stop-loop nudge issued (attempt %d)",
                                  agent._verification_stop_nudges)
                     continue
+
+                if verification_stop_pending_final_response:
+                    final_response = _merge_verify_on_stop_final_response(
+                        verification_stop_pending_final_response,
+                        final_response,
+                    )
+                    final_msg["content"] = _merge_verify_on_stop_final_response(
+                        verification_stop_pending_final_response,
+                        final_msg.get("content"),
+                    )
 
                 messages.append(final_msg)
                 

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -1,6 +1,8 @@
 import json
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -25,6 +27,23 @@ def _node_project(root: Path) -> None:
 def _make_project(root: Path) -> None:
     root.mkdir()
     _node_project(root)
+
+
+def _chat_response(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        model="test-model",
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+        ),
+    )
 
 
 @pytest.fixture
@@ -339,3 +358,86 @@ def test_is_non_code_path_classification():
     assert _is_non_code_path("src/app.ts") is False
     assert _is_non_code_path("config.yaml") is False
     assert _is_non_code_path("run_agent.py") is False
+
+
+def test_verify_on_stop_followup_preserves_attempted_final_answer(tmp_path, monkeypatch):
+    """The verification follow-up must attach to, not replace, the answer.
+
+    This exercises the real conversation-loop state machine while stubbing the
+    nudge decision and provider. The first model response is the attempted
+    final answer that triggers verify-on-stop; the second is the verification
+    receipt/blocker. The user-facing final output must contain both.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "1")
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "cli")
+
+    import agent.verification_stop as verification_stop
+
+    nudge_calls = []
+
+    def _fake_verify_nudge(**kwargs):
+        nudge_calls.append(kwargs)
+        if len(nudge_calls) == 1:
+            return "[System: run verification before finalizing.]"
+        return None
+
+    monkeypatch.setattr(
+        verification_stop,
+        "build_verify_on_stop_nudge",
+        _fake_verify_nudge,
+    )
+
+    from run_agent import AIAgent
+
+    attempted_answer = "Implemented the requested parser fix."
+    verification_receipt = "Verification blocked: pytest is unavailable."
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _chat_response(attempted_answer),
+        _chat_response(verification_receipt),
+    ]
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://example.invalid/v1",
+        provider="openai-compat",
+        model="test-model",
+        max_iterations=4,
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        save_trajectories=False,
+        platform="cli",
+        session_id="verify-stop-preserve-test",
+    )
+    agent.client = client
+    agent._create_request_openai_client = MagicMock(return_value=client)
+    agent._close_request_openai_client = MagicMock()
+    agent._abort_request_openai_client = MagicMock()
+
+    result = agent.run_conversation(
+        "Fix the parser bug.",
+        conversation_history=[],
+        task_id="verify-stop-preserve-test",
+    )
+
+    final_response = result["final_response"]
+    assert attempted_answer in final_response
+    assert verification_receipt in final_response
+    assert final_response.index(attempted_answer) < final_response.index(
+        verification_receipt
+    )
+    assert client.chat.completions.create.call_count == 2
+    assert [call["attempts"] for call in nudge_calls] == [0, 1]
+
+    roles = [m["role"] for m in result["messages"]]
+    assert all(left != right for left, right in zip(roles, roles[1:]))
+    assert len(
+        [
+            m
+            for m in result["messages"]
+            if m.get("_verification_stop_synthetic")
+        ]
+    ) == 1


### PR DESCRIPTION
## Summary

Fix verify-on-stop follow-up handling so the user-facing final response preserves the model's attempted final answer instead of replacing it with only the verification follow-up.

When verify-on-stop triggers, the attempted final answer is kept in conversation history for role alternation, but it was not surfaced if the follow-up produced a verification receipt/blocker. This change stores the pending attempted answer and merges it into the eventual final response unless the follow-up already includes it.

## Changes

- Add `_merge_verify_on_stop_final_response()` helper.
- Preserve the first verify-on-stop attempted final answer while the internal verification nudge runs.
- Merge the attempted final answer with the verification follow-up before appending the final assistant message.
- Add a regression test exercising the real `AIAgent.run_conversation()` state machine with a stubbed provider.

## Verification

- `scripts/run_tests.sh tests/agent/test_verification_stop.py tests/agent/test_verification_evidence.py -q`
  - 65 passed
- `ruff check agent/conversation_loop.py tests/agent/test_verification_stop.py`
  - All checks passed
- `git diff --check`
  - passed
- Independent reviewer
  - Approved

## Notes

The static added-line scan flags `api_key="test-key"` in the new test fixture, but this is a fake test value and not a credential.
