### PR TITLE
fix(whatsapp): bound bridge error body reads

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -39,6 +39,36 @@ logger = logging.getLogger(__name__)
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
 
+_WHATSAPP_ERROR_BODY_LIMIT_BYTES = 8 * 1024
+
+
+async def _read_error_text_limited(
+    response: Any,
+    *,
+    limit: int = _WHATSAPP_ERROR_BODY_LIMIT_BYTES,
+) -> str:
+    content = getattr(response, "content", None)
+    read = getattr(content, "read", None)
+    if callable(read):
+        chunks: list[bytes] = []
+        total = 0
+        while total <= limit:
+            size = min(4096, limit + 1 - total)
+            chunk = await read(size)
+            if not chunk:
+                break
+            data = bytes(chunk)
+            chunks.append(data)
+            total += len(data)
+        if total > limit:
+            release = getattr(response, "release", None)
+            if callable(release):
+                release()
+        return b"".join(chunks)[:limit].decode("utf-8", errors="replace")
+
+    text = await response.text()
+    return str(text)[:limit]
+
 
 def _listener_pids_on_port(port: int) -> list:
     """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
@@ -882,7 +912,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         if last_message_id:
                             sent_message_ids.append(str(last_message_id))
                     else:
-                        error = await resp.text()
+                        error = await _read_error_text_limited(resp)
                         return SendResult(success=False, error=error)
 
                 # Small delay between chunks to avoid rate limiting
@@ -926,7 +956,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 if resp.status == 200:
                     return SendResult(success=True, message_id=message_id)
                 else:
-                    error = await resp.text()
+                    error = await _read_error_text_limited(resp)
                     return SendResult(success=False, error=error)
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -974,7 +1004,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         raw_response=data,
                     )
                 else:
-                    error = await resp.text()
+                    error = await _read_error_text_limited(resp)
                     return SendResult(success=False, error=error)
 
         except Exception as e:
@@ -1020,7 +1050,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         message_id=data.get("messageId"),
                         raw_response=data,
                     )
-                error = await resp.text()
+                error = await _read_error_text_limited(resp)
                 return SendResult(success=False, error=error)
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -1107,7 +1137,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         message_id=data.get("messageId"),
                         raw_response=data,
                     )
-                error = await resp.text()
+                error = await _read_error_text_limited(resp)
                 return SendResult(success=False, error=error)
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -1595,7 +1625,7 @@ async def _standalone_send(
                     timeout=aiohttp.ClientTimeout(total=30),
                 ) as resp:
                     if resp.status != 200:
-                        body = await resp.text()
+                        body = await _read_error_text_limited(resp)
                         return {"error": f"WhatsApp bridge error ({resp.status}): {body}"}
                     data = await resp.json()
                     last_message_id = data.get("messageId")
@@ -1621,7 +1651,7 @@ async def _standalone_send(
                     timeout=aiohttp.ClientTimeout(total=120),
                 ) as resp:
                     if resp.status != 200:
-                        body = await resp.text()
+                        body = await _read_error_text_limited(resp)
                         return {"error": f"WhatsApp media error ({resp.status}): {body}"}
                     data = await resp.json()
                     last_message_id = data.get("messageId") or last_message_id

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -61,6 +61,36 @@ logger = logging.getLogger(__name__)
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
 
+_WHATSAPP_ERROR_BODY_LIMIT_BYTES = 8 * 1024
+
+
+async def _read_error_text_limited(
+    response: Any,
+    *,
+    limit: int = _WHATSAPP_ERROR_BODY_LIMIT_BYTES,
+) -> str:
+    content = getattr(response, "content", None)
+    read = getattr(content, "read", None)
+    if callable(read):
+        chunks: list[bytes] = []
+        total = 0
+        while total <= limit:
+            size = min(4096, limit + 1 - total)
+            chunk = await read(size)
+            if not chunk:
+                break
+            data = bytes(chunk)
+            chunks.append(data)
+            total += len(data)
+        if total > limit:
+            release = getattr(response, "release", None)
+            if callable(release):
+                release()
+        return b"".join(chunks)[:limit].decode("utf-8", errors="replace")
+
+    text = await response.text()
+    return str(text)[:limit]
+
 
 def _listener_pids_on_port(port: int) -> list:
     """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
@@ -966,7 +996,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         if last_message_id:
                             sent_message_ids.append(str(last_message_id))
                     else:
-                        error = await resp.text()
+                        error = await _read_error_text_limited(resp)
                         return SendResult(success=False, error=error)
 
                 # Small delay between chunks to avoid rate limiting
@@ -1010,7 +1040,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 if resp.status == 200:
                     return SendResult(success=True, message_id=message_id)
                 else:
-                    error = await resp.text()
+                    error = await _read_error_text_limited(resp)
                     return SendResult(success=False, error=error)
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -1058,7 +1088,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         raw_response=data,
                     )
                 else:
-                    error = await resp.text()
+                    error = await _read_error_text_limited(resp)
                     return SendResult(success=False, error=error)
 
         except Exception as e:
@@ -1104,7 +1134,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         message_id=data.get("messageId"),
                         raw_response=data,
                     )
-                error = await resp.text()
+                error = await _read_error_text_limited(resp)
                 return SendResult(success=False, error=error)
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -1191,7 +1221,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         message_id=data.get("messageId"),
                         raw_response=data,
                     )
-                error = await resp.text()
+                error = await _read_error_text_limited(resp)
                 return SendResult(success=False, error=error)
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -1727,7 +1757,7 @@ async def _standalone_send(
                     timeout=aiohttp.ClientTimeout(total=30),
                 ) as resp:
                     if resp.status != 200:
-                        body = await resp.text()
+                        body = await _read_error_text_limited(resp)
                         return {"error": f"WhatsApp bridge error ({resp.status}): {body}"}
                     data = await resp.json()
                     last_message_id = data.get("messageId")
@@ -1770,7 +1800,7 @@ async def _standalone_send(
                     timeout=aiohttp.ClientTimeout(total=120),
                 ) as resp:
                     if resp.status != 200:
-                        body = await resp.text()
+                        body = await _read_error_text_limited(resp)
                         return {"error": f"WhatsApp media error ({resp.status}): {body}"}
                     data = await resp.json()
                     last_message_id = data.get("messageId") or last_message_id

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -7,7 +7,7 @@ Covers:
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -75,6 +75,66 @@ class _AsyncCM:
 
     async def __aexit__(self, *exc):
         return False
+
+
+class _FakeAiohttpContent:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+        self._offset = 0
+        self.bytes_read = 0
+
+    async def read(self, size: int = -1):
+        if size is None or size < 0:
+            size = len(self._payload) - self._offset
+        chunk = self._payload[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        self.bytes_read += len(chunk)
+        return chunk
+
+
+class _FakeErrorResponse:
+    def __init__(self, status: int = 500, text: str = ""):
+        self.status = status
+        self._text = text or (("whatsapp bridge failure " * 1000) + "tail-marker")
+        self.content = _FakeAiohttpContent(self._text.encode("utf-8"))
+        self.text_calls = 0
+        self.released = False
+
+    async def text(self):
+        self.text_calls += 1
+        return "should not be called"
+
+    def release(self):
+        self.released = True
+
+
+class _FakeClientSession:
+    def __init__(self, *responses):
+        self._responses = list(responses)
+        self.post = MagicMock(side_effect=self._post)
+
+    def _post(self, *args, **kwargs):
+        if not self._responses:
+            raise AssertionError("No scripted WhatsApp bridge response")
+        return _AsyncCM(self._responses.pop(0))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _assert_limited_error_response(response: _FakeErrorResponse, error: str):
+    from plugins.platforms.whatsapp import adapter as whatsapp_mod
+
+    assert "tail-marker" not in error
+    assert response.text_calls == 0
+    assert (
+        response.content.bytes_read
+        == whatsapp_mod._WHATSAPP_ERROR_BODY_LIMIT_BYTES + 1
+    )
+    assert response.released is True
 
 
 # ---------------------------------------------------------------------------
@@ -293,12 +353,97 @@ class TestSendChunking:
     async def test_bridge_error_returns_failure(self):
         adapter = _make_adapter()
         resp = MagicMock(status=500)
+        resp.content = None
         resp.text = AsyncMock(return_value="Internal Server Error")
         adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
 
         result = await adapter.send("chat1", "hello")
         assert not result.success
         assert "Internal Server Error" in result.error
+
+    @pytest.mark.asyncio
+    async def test_bridge_error_limits_response_body(self):
+        adapter = _make_adapter()
+        resp = _FakeErrorResponse(500)
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send("chat1", "hello")
+
+        assert not result.success
+        _assert_limited_error_response(resp, result.error)
+
+    @pytest.mark.asyncio
+    async def test_edit_message_limits_error_body(self):
+        adapter = _make_adapter()
+        resp = _FakeErrorResponse(500)
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.edit_message("chat1", "msg1", "updated")
+
+        assert not result.success
+        _assert_limited_error_response(resp, result.error)
+
+    @pytest.mark.asyncio
+    async def test_send_media_bridge_limits_error_body(self, tmp_path):
+        adapter = _make_adapter()
+        media_path = tmp_path / "image.png"
+        media_path.write_bytes(b"fake image")
+        resp = _FakeErrorResponse(500)
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter._send_media_to_bridge(
+            "chat1",
+            str(media_path),
+            "image",
+        )
+
+        assert not result.success
+        _assert_limited_error_response(resp, result.error)
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_limits_text_error_body(self):
+        from plugins.platforms.whatsapp.adapter import _standalone_send
+
+        resp = _FakeErrorResponse(503)
+        session = _FakeClientSession(resp)
+
+        with (
+            patch("aiohttp.ClientSession", return_value=session),
+            patch("aiohttp.ClientTimeout", lambda total: total),
+        ):
+            result = await _standalone_send(
+                MagicMock(extra={"bridge_port": 3000}),
+                "chat1",
+                "hello",
+            )
+
+        assert "error" in result
+        assert "503" in result["error"]
+        _assert_limited_error_response(resp, result["error"])
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_limits_media_error_body(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _standalone_send
+
+        media_path = tmp_path / "image.png"
+        media_path.write_bytes(b"fake image")
+        resp = _FakeErrorResponse(502)
+        session = _FakeClientSession(resp)
+
+        with (
+            patch("aiohttp.ClientSession", return_value=session),
+            patch("aiohttp.ClientTimeout", lambda total: total),
+        ):
+            result = await _standalone_send(
+                MagicMock(extra={"bridge_port": 3000}),
+                "chat1",
+                "",
+                media_files=[(str(media_path), False)],
+            )
+
+        assert "error" in result
+        assert "502" in result["error"]
+        _assert_limited_error_response(resp, result["error"])
 
     @pytest.mark.asyncio
     async def test_not_connected_returns_failure(self):

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -77,6 +77,39 @@ class _AsyncCM:
         return False
 
 
+class _FakeAiohttpContent:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+        self._offset = 0
+        self.bytes_read = 0
+
+    async def read(self, size: int = -1):
+        chunk = self._payload[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        self.bytes_read += len(chunk)
+        return chunk
+
+
+class _FakeErrorResponse:
+    def __init__(self):
+        self.status = 500
+        self.content = _FakeAiohttpContent(b"bridge failure " * 1000 + b"tail-marker")
+        self.text = AsyncMock(side_effect=AssertionError("unbounded text read"))
+        self.released = False
+
+    def release(self):
+        self.released = True
+
+
+def _assert_limited_error_response(response: _FakeErrorResponse, error: str):
+    from plugins.platforms.whatsapp import adapter as whatsapp_mod
+
+    assert "tail-marker" not in error
+    response.text.assert_not_awaited()
+    assert response.content.bytes_read == whatsapp_mod._WHATSAPP_ERROR_BODY_LIMIT_BYTES + 1
+    assert response.released is True
+
+
 # ---------------------------------------------------------------------------
 # format_message tests
 # ---------------------------------------------------------------------------
@@ -180,6 +213,30 @@ class TestSendChunking:
             payload = call.kwargs.get("json") or call[1].get("json")
             final_text = adapter.DEFAULT_REPLY_PREFIX + payload["message"]
             assert len(final_text) <= adapter.MAX_MESSAGE_LENGTH
+
+
+class TestBridgeErrorBodyLimits:
+    @pytest.mark.asyncio
+    async def test_send_poll_limits_error_body(self):
+        adapter = _make_adapter()
+        response = _FakeErrorResponse()
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(response))
+
+        result = await adapter.send_poll("chat1", "Choose", ["A", "B"])
+
+        assert not result.success
+        _assert_limited_error_response(response, result.error)
+
+    @pytest.mark.asyncio
+    async def test_send_location_limits_error_body(self):
+        adapter = _make_adapter()
+        response = _FakeErrorResponse()
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(response))
+
+        result = await adapter.send_location("chat1", 1.25, 2.5)
+
+        assert not result.success
+        _assert_limited_error_response(response, result.error)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #55359.

Bounds WhatsApp local bridge error-body reads across live adapter and standalone delivery paths. These paths previously used `await resp.text()` on bridge non-200 responses.

## Changes

- Add a WhatsApp bridge-local bounded aiohttp error-body reader capped at 8 KiB.
- Use it for live `/send`, `/edit`, and `/send-media` bridge failures.
- Use it for standalone text and media bridge failures.
- Add regression coverage for all five failure paths.

## Validation

- `python -m pytest tests/gateway/test_whatsapp_formatting.py -q --basetemp .pytest-tmp-whatsapp-formatting` -> 32 passed
- `python -m pytest tests/gateway/test_whatsapp_connect.py -q -k BridgeRuntimeFailure --basetemp .pytest-tmp-whatsapp-connect` -> 11 passed, 18 deselected
- `ruff check plugins/platforms/whatsapp/adapter.py tests/gateway/test_whatsapp_formatting.py` -> passed
- `git diff --check` -> passed