### PR TITLE
fix(gateway): normalize table fallback headings

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -370,7 +370,7 @@ def _render_table_block(table_block: list[str]) -> str:
                 continue
             bullets.append(f"• {header}: {value}")
 
-        group_lines = [f"**{heading}**", *bullets]
+        group_lines = [f"**{strip_markdown(heading)}**", *bullets]
         rendered_groups.append("\n".join(group_lines))
 
     return "\n\n".join(rendered_groups)

--- a/tests/gateway/test_table_helpers.py
+++ b/tests/gateway/test_table_helpers.py
@@ -67,4 +67,23 @@ class TestConvertTableToBullets:
         assert "• head1: a" not in out
         assert "• head2: b" in out
 
+    def test_heading_markdown_is_normalized_before_group_bold(self):
+        cases = [
+            ("**넷플릭스파**", "**넷플릭스파**"),
+            ("__Netflix__", "**Netflix**"),
+            ("***Title***", "**Title**"),
+            ("[Netflix](https://example.com)", "**Netflix**"),
+            ("`code`", "**code**"),
+            ("Copy **Hands**", "**Copy Hands**"),
+        ]
+        for heading, expected in cases:
+            text = (
+                "| Type | Notes |\n"
+                "|------|-------|\n"
+                f"| {heading} | ok |"
+            )
+            out = convert_table_to_bullets(text)
+            assert out.splitlines()[0] == expected
+            assert f"**{heading}**" not in out
+
 

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -455,6 +455,16 @@ class TestFormatMessageTables:
         assert "```" not in out
         assert "\\|" not in out
 
+    def test_embedded_heading_markdown_is_normalized(self, adapter):
+        text = (
+            "| Type | Notes |\n"
+            "|------|-------|\n"
+            "| Copy **Hands** | ok |"
+        )
+        out = adapter.format_message(text)
+        assert out.splitlines()[0] == "*Copy Hands*"
+        assert "• Notes: ok" in out
+
 
 @pytest.mark.asyncio
 async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):


### PR DESCRIPTION
## Summary

Fix fallback table headings that contain inline Markdown, including embedded formatting such as `Copy **Hands**`.

The renderer now reuses `strip_markdown()` before adding the fallback bold wrapper, with coverage through Telegram MarkdownV2 formatting.

## Tests

- `scripts/run_tests.sh tests/gateway/test_table_helpers.py tests/gateway/test_telegram_format.py -q` - 129 passed
- `scripts/run_tests.sh tests/gateway/test_telegram_rich_messages.py -q` - 72 passed