### PR TITLE
fix(desktop): use stable project collapse icon

### DIFF
--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -171,7 +171,7 @@ function FilesystemTab({
           title={r.collapseAll}
           variant="ghost"
         >
-          <Codicon name="collapse-all" size="0.8125rem" />
+          <CollapseAllIcon />
         </Button>
       </RightSidebarSectionHeader>
       <FileTreeBody
@@ -189,6 +189,15 @@ function FilesystemTab({
         openState={openState}
       />
     </div>
+  )
+}
+
+function CollapseAllIcon() {
+  return (
+    <svg aria-hidden="true" className="h-[0.8125rem] w-[0.8125rem]" fill="none" viewBox="0 0 16 16">
+      <rect height="10" rx="1.5" stroke="currentColor" strokeWidth="1.5" width="10" x="3" y="3" />
+      <path d="M5.5 6.5h5M5.5 8h5M5.5 9.5h5" stroke="currentColor" strokeLinecap="round" strokeWidth="1.25" />
+    </svg>
   )
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Projects sidebar collapse-all icon rendering asymmetry reported on Windows. The existing `codicon-collapse-all` glyph can render with a visibly shorter top horizontal line in the sidebar header; this replaces that specific header icon with a local SVG whose three inner horizontal lines have equal geometry.

## Related Issue

Fixes #55358

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/right-sidebar/index.tsx`
  - Replace the Projects sidebar header's `codicon-collapse-all` font glyph with a small inline SVG.
  - Preserve the existing button behavior, disabled state, title, and accessible label.
  - Keep the icon size matched to the surrounding header actions.

## How to Test

1. Run `npm run typecheck` in `apps/desktop`.
2. Run `npx eslint src/app/right-sidebar/index.tsx` in `apps/desktop`.
3. Open the Desktop Projects sidebar and verify the collapse-all icon shows three equal-length horizontal lines.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux dev environment for typecheck/lint; visual issue reported on Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Local verification:

```bash
npm run typecheck
npx eslint src/app/right-sidebar/index.tsx
```
