### PR TITLE
Resolve symlinks in the ACP auto-approve sensitive-path guard

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -138,11 +138,27 @@ def build_edit_proposal(tool_name: str, arguments: dict[str, Any]) -> EditPropos
 
 
 def _is_sensitive_auto_approve_path(path: str) -> bool:
-    parts = Path(path).expanduser().parts
-    lowered = {part.lower() for part in parts}
-    if ".git" in lowered or ".ssh" in lowered:
-        return True
-    return Path(path).name.lower() in SENSITIVE_AUTO_APPROVE_NAMES
+    raw = Path(path).expanduser()
+    # Check the path as written *and* its symlink-resolved target. A symlink
+    # whose own name is innocuous (e.g. ``notes.txt`` -> ``~/.ssh/authorized_keys``)
+    # slips past a literal-only check, letting an auto-approving session write to
+    # a sensitive file without ever prompting. resolve() also follows a symlinked
+    # parent directory and normalizes ``..``.
+    candidates = [raw]
+    try:
+        resolved = raw.resolve(strict=False)
+    except (OSError, RuntimeError):
+        resolved = None
+    if resolved is not None and resolved != raw:
+        candidates.append(resolved)
+
+    for candidate in candidates:
+        lowered = {part.lower() for part in candidate.parts}
+        if ".git" in lowered or ".ssh" in lowered:
+            return True
+        if candidate.name.lower() in SENSITIVE_AUTO_APPROVE_NAMES:
+            return True
+    return False
 
 
 def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | None = None) -> bool:

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -205,3 +205,42 @@ def test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive(tmp_
         "session",
         str(tmp_path),
     )
+
+
+def test_symlink_to_sensitive_path_is_not_auto_approved(tmp_path):
+    """A symlink whose own name is innocuous must not let an auto-approving
+    session write to a sensitive target. The sensitive-path guard has to resolve
+    the link, not just inspect the literal path string."""
+    import os
+
+    secret = tmp_path / "outside" / ".ssh" / "authorized_keys"
+    secret.parent.mkdir(parents=True)
+    secret.write_text("original")
+
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    link = workspace / "notes.txt"  # innocuous name, points at the secret
+    os.symlink(secret, link)
+
+    # Under the most permissive policy the link target is still sensitive.
+    assert not should_auto_approve_edit(
+        EditProposal("write_file", str(link), None, "ssh-rsa AAAA attacker", {}),
+        "session",
+        str(workspace),
+    )
+    # A symlinked parent directory is covered too.
+    dir_link = tmp_path / "cfg"
+    os.symlink(secret.parent, dir_link)
+    assert not should_auto_approve_edit(
+        EditProposal("write_file", str(dir_link / "known_hosts"), None, "x", {}),
+        "session",
+        str(tmp_path),
+    )
+    # A genuinely ordinary file is unaffected.
+    plain = workspace / "src.py"
+    plain.write_text("x")
+    assert should_auto_approve_edit(
+        EditProposal("write_file", str(plain), None, "x", {}),
+        "session",
+        str(workspace),
+    )


### PR DESCRIPTION
Fixes #55367

`_is_sensitive_auto_approve_path` only inspected the path string as written:

```python
parts = Path(path).expanduser().parts
...
return Path(path).name.lower() in SENSITIVE_AUTO_APPROVE_NAMES
```

A `..` component was already caught (the sensitive directory name appears literally), but a symlink whose own name is innocuous was not. So under the `session` auto-approve policy an edit to `project/notes.txt`, where `notes.txt` is a symlink to `~/.ssh/authorized_keys`, was treated as non-sensitive and approved without prompting — the write landing on the symlink target.

### Change

- Resolve the path with `Path.resolve(strict=False)` (follows symlinks, including a symlinked parent directory, and normalizes `..`) and run the `.git` / `.ssh` / sensitive-name checks against both the literal and resolved forms. `resolve()` failures fall back to the literal check, so behavior never regresses for ordinary paths.

### Test

`test_symlink_to_sensitive_path_is_not_auto_approved`: an innocuously named symlink (and a symlinked parent directory) pointing at a sensitive path is not auto-approved under the `session` policy, while an ordinary workspace file still is. It fails on the current code (the symlink is approved) and passes with this change. The existing sensitive-path and workspace-policy assertions continue to pass.

Note: four unrelated tests in this file (`test_write_file_*`, `test_patch_replace_approval_*`, `test_acp_permission_tool_call_*`) fail on macOS only, before and after this change, because the system temp dir resolves under `/private/var/...` which `file_operations._is_write_denied` treats as a system path. They are unaffected by this change and pass on a Linux temp root.
