### PR TITLE
Keep leading-zero union values as strings in tool-argument coercion

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -917,8 +917,16 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
         return None
 
     if isinstance(expected_type, list):
-        # Union type — try each in order, return first successful coercion
+        # Union type - try each in order, return first successful coercion.
+        # If the union also permits a string, a leading-zero value (a formatted
+        # code/id like "007" or "0123" the model meant as text) must stay a
+        # string: coercing it to a number drops the zeros and silently corrupts
+        # the argument. A plain string variant is a no-op, so without this skip
+        # the numeric branch wins regardless of the union order.
+        keep_as_string = "string" in expected_type and _has_leading_zero(value)
         for t in expected_type:
+            if keep_as_string and t in {"integer", "number"}:
+                continue
             result = _coerce_value(value, t, schema=schema)
             if result is not value:
                 return result
@@ -935,6 +943,21 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
     if expected_type == "null" and value.strip().lower() == "null":
         return None
     return value
+
+
+def _has_leading_zero(value: str) -> bool:
+    """True when *value* carries a meaningful leading zero.
+
+    ``"007"`` / ``"0123"`` are formatted codes or ids, not the integers 7 / 123
+    - the leading zero is information that a numeric coercion would discard.
+    ``"0"``, ``"0.5"`` and ``"0x1F"`` are ordinary values, not zero-padded.
+    """
+    if not isinstance(value, str):
+        return False
+    s = value.strip()
+    if s[:1] in {"+", "-"}:
+        s = s[1:]
+    return len(s) >= 2 and s[0] == "0" and s[1].isdigit()
 
 
 def _schema_allows_null(schema: dict | None) -> bool:

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -81,6 +81,22 @@ class TestCoerceValue:
 
 
 
+    def test_union_keeps_leading_zero_value_as_string(self):
+        """A leading-zero value (a formatted code/id like "007") in a union that
+        also permits a string must stay a string - coercing it to a number drops
+        the zeros and corrupts the argument. Plain numeric strings, "0", and
+        decimals are unaffected, and a pure integer field still coerces."""
+        assert _coerce_value("007", ["integer", "string"]) == "007"
+        assert _coerce_value("0123", ["string", "integer"]) == "0123"
+        assert _coerce_value("-007", ["integer", "string"]) == "-007"
+        # Unchanged cases:
+        assert _coerce_value("42", ["integer", "string"]) == 42
+        assert _coerce_value("0", ["integer", "string"]) == 0
+        assert _coerce_value("0.5", ["number", "string"]) == 0.5
+        # A field typed purely as integer has no string alternative, so a
+        # leading-zero value is still a (zero-less) integer.
+        assert _coerce_value("007", "integer") == 7
+
     def test_array_type_parsed_from_json_string(self):
         """Stringified JSON arrays are parsed into native lists."""
         assert _coerce_value('["a", "b"]', "array") == ["a", "b"]


### PR DESCRIPTION
Fixes #55369

For a union type like `["integer", "string"]`, `_coerce_value` returned the first member whose coercion changed the value. A `string` member is a no-op, so the numeric member always won, and a leading-zero value (`"007"`, `"0123"` — a zip code, area code, or zero-padded id the model meant as text) had its zeros stripped:

```python
_coerce_value("007", ["integer", "string"])   # 7  (loses the zeros)
_coerce_value("0123", ["string", "integer"])  # 123
```

The order of the union members did not matter, since the string variant never wins.

### Change

- In the union branch of `_coerce_value`, when the union also permits a string, skip the `integer`/`number` members for a leading-zero value (helper `_has_leading_zero`: optional sign, then `0` followed by another digit) so it stays the string the model intended. Plain numeric strings, `"0"`, decimals, and pure-`integer` fields are unchanged.

### Test

`test_union_keeps_leading_zero_value_as_string` covers the zero-padded cases (`"007"`, `"0123"`, `"-007"`) staying strings, plus the unchanged cases (`"42"` → 42, `"0"` → 0, `"0.5"` → 0.5, and a pure-`integer` field still yielding 7). It fails on the current code (`"007"` comes back as 7) and passes with this change. The existing `test_union_type_prefers_first_match` and the rest of `tests/run_agent/test_tool_arg_coercion.py` continue to pass.

```
$ python -m pytest tests/run_agent/test_tool_arg_coercion.py -q
62 passed
```
