### PR TITLE
Import re in the SMS adapter (fixes NameError on every standalone SMS send)

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -24,6 +24,7 @@ import hashlib
 import hmac
 import logging
 import os
+import re
 import urllib.parse
 from typing import Any, Dict, Optional
 

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -75,6 +75,20 @@ class TestSmsFormatAndTruncate:
         result = adapter.format_message("a\n\n\n\nb")
         assert result == "a\n\nb"
 
+    def test_standalone_strip_markdown_does_not_raise(self):
+        """``_strip_markdown_for_sms`` runs in the registered standalone sender
+        (``_standalone_send``) on every agent-initiated / cron SMS. It uses the
+        ``re`` module, so a missing import makes every such send raise
+        NameError before the message is sent. Exercise it directly - the
+        ``format_message`` tests above only cover the separate adapter path."""
+        from plugins.platforms.sms.adapter import _strip_markdown_for_sms
+
+        out = _strip_markdown_for_sms(
+            "Hello **bold** and *italic* and `code` and [link](https://x.com)"
+        )
+        assert out == "Hello bold and italic and code and link"
+        assert _strip_markdown_for_sms("## Title\nbody") == "Title\nbody"
+
 
 # ── Echo prevention ────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #55377

`_strip_markdown_for_sms` uses `re.sub` nine times, but `plugins/platforms/sms/adapter.py` never imported `re`, so every call raised `NameError: name 're' is not defined`:

```python
from plugins.platforms.sms.adapter import _strip_markdown_for_sms
_strip_markdown_for_sms("Hello **world**")
# NameError: name 're' is not defined
```

`_standalone_send` — the registered `standalone_sender_fn` for the SMS platform — calls it before the `try` that wraps the Twilio request, so the error propagated out and the message was never sent. That breaks every agent-initiated (`send_message` tool) and cron SMS delivery. The gateway reply path uses the separate imported `strip_markdown` helper, which is why the existing markdown-strip tests passed while the real send path was broken.

### Change

- Add `import re` to the module.

### Test

`test_standalone_strip_markdown_does_not_raise` calls `_strip_markdown_for_sms` directly and asserts it strips markdown without raising. It fails on the current code (`NameError` at `sms/adapter.py:396`) and passes with this change. The existing `TestSmsFormatAndTruncate` tests continue to pass.

```
$ python -m pytest tests/gateway/test_sms.py::TestSmsFormatAndTruncate -q
8 passed
```
