### PR TITLE
Tolerate an unknown email body charset in _extract_text_body

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -183,6 +183,20 @@ def _decode_header_value(raw: str) -> str:
     return " ".join(decoded)
 
 
+def _safe_payload_decode(payload: bytes, charset: "str | None") -> str:
+    """Decode an email payload, tolerating an unknown/invalid charset label.
+
+    ``charset`` comes from the attacker-controlled ``Content-Type``. An unknown
+    label (``charset=bogus``) makes ``bytes.decode`` raise ``LookupError``
+    *before* the ``errors="replace"`` handler ever runs, which would otherwise
+    abort the whole inbound fetch. Fall back to UTF-8 with replacement.
+    """
+    try:
+        return payload.decode(charset or "utf-8", errors="replace")
+    except LookupError:
+        return payload.decode("utf-8", errors="replace")
+
+
 def _extract_text_body(msg: email_lib.message.Message) -> str:
     """Extract the plain-text body from a potentially multipart email."""
     if msg.is_multipart():
@@ -195,8 +209,7 @@ def _extract_text_body(msg: email_lib.message.Message) -> str:
             if content_type == "text/plain":
                 payload = part.get_payload(decode=True)
                 if payload:
-                    charset = part.get_content_charset() or "utf-8"
-                    return payload.decode(charset, errors="replace")
+                    return _safe_payload_decode(payload, part.get_content_charset())
         # Fallback: try text/html and strip tags
         for part in msg.walk():
             content_type = part.get_content_type()
@@ -206,15 +219,13 @@ def _extract_text_body(msg: email_lib.message.Message) -> str:
             if content_type == "text/html":
                 payload = part.get_payload(decode=True)
                 if payload:
-                    charset = part.get_content_charset() or "utf-8"
-                    html = payload.decode(charset, errors="replace")
+                    html = _safe_payload_decode(payload, part.get_content_charset())
                     return _strip_html(html)
         return ""
     else:
         payload = msg.get_payload(decode=True)
         if payload:
-            charset = msg.get_content_charset() or "utf-8"
-            text = payload.decode(charset, errors="replace")
+            text = _safe_payload_decode(payload, msg.get_content_charset())
             if msg.get_content_type() == "text/html":
                 return _strip_html(text)
             return text

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -96,6 +96,24 @@ class TestExtractTextBody(unittest.TestCase):
         self.assertEqual(result, "Hello, this is a test.")
 
 
+    def test_unknown_body_charset_does_not_raise(self):
+        """The Content-Type charset is attacker-controlled. An unknown label
+        (``charset=bogus``) makes ``bytes.decode`` raise LookupError before the
+        ``errors='replace'`` handler runs, which would abort the inbound fetch.
+        It must fall back instead."""
+        import email as email_lib
+        from plugins.platforms.email.adapter import _extract_text_body
+
+        plain = email_lib.message_from_bytes(
+            b"Content-Type: text/plain; charset=bogus\n\nHello body"
+        )
+        self.assertEqual(_extract_text_body(plain), "Hello body")
+
+        html = email_lib.message_from_bytes(
+            b"Content-Type: text/html; charset=does-not-exist\n\n<p>Hi</p>"
+        )
+        self.assertIn("Hi", _extract_text_body(html))
+
     def test_multipart_prefers_plain(self):
         from plugins.platforms.email.adapter import _extract_text_body
         msg = MIMEMultipart("alternative")


### PR DESCRIPTION
Fixes #55383

`_extract_text_body` decoded the message body using the attacker-controlled `Content-Type` charset:

```python
charset = part.get_content_charset() or "utf-8"
return payload.decode(charset, errors="replace")
```

An unknown label (`charset=bogus`) makes `bytes.decode` raise `LookupError` *before* `errors="replace"` can run, so it does not protect against it. All three decode sites (plain part, HTML part, non-multipart) had this. `_fetch_new_messages` calls `_extract_text_body` for every message under only the function-level `try`, so a single crafted message aborted the whole IMAP fetch batch; the message was already marked `\Seen`, so it was dropped while the rest of the batch was deferred.

This is a distinct code path from #55381 (the header decoder) — here the trigger is the `Content-Type` charset rather than an RFC 2047 encoded-word.

### Change

- Add `_safe_payload_decode(payload, charset)` that tries the declared charset and falls back to UTF-8 with replacement on `LookupError`, used at all three decode sites.

### Test

`test_unknown_body_charset_does_not_raise` decodes a `text/plain` and a `text/html` body with an unknown charset. It raises `LookupError` on the current code and passes with this change. The existing body-extraction tests still pass.

```
$ python -m pytest tests/gateway/test_email.py -q
88 passed
```
