### PR TITLE
fix(cron): close stale cron sessions on startup after process restart

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -309,6 +309,12 @@ _running_lock = threading.Lock()
 _interrupted_job_ids: set = set()
 
 
+# One-shot startup session cleanup: close cron sessions left open by a
+# previous process lifecycle where the finally block in run_job() could
+# not execute (SIGTERM / SIGKILL / crash).
+_startup_session_cleanup_done = False
+
+
 def get_running_job_ids() -> "frozenset[str]":
     """Thread-safe snapshot of cron job IDs currently executing.
 
@@ -3557,6 +3563,37 @@ def _notify_provider_jobs_changed() -> None:
         logger.debug("on_jobs_changed notify failed: %s", e)
 
 
+def _cleanup_stale_cron_sessions() -> int:
+    """Close cron sessions left open from a previous process lifecycle.
+
+    When the scheduler/gateway process is killed (SIGTERM/SIGKILL/crash)
+    before ``run_job()``'s finally block executes, cron session rows stay
+    with ``ended_at IS NULL`` forever — there is no startup cleanup nor
+    orphan reaper for pure cron sessions.  This makes Run History
+    unreliable (sessions appear stuck) and inflates the "open sessions"
+    count.
+
+    Called once per process lifetime at the first ``tick()`` invocation.
+    Returns the number of sessions closed.
+    """
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        count = db.close_stale_sessions(
+            end_reason="process_restart", source="cron"
+        )
+        if count:
+            logger.info(
+                "Closed %d stale cron session(s) from a previous process",
+                count,
+            )
+        db.close()
+        return count
+    except Exception as exc:
+        logger.debug("Failed to clean up stale cron sessions: %s", exc)
+        return 0
+
+
 def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> int:
     """
     Check and run all due jobs.
@@ -3588,6 +3625,14 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         if lock_fd is not None:
             lock_fd.close()
         return 0
+
+    # ── Startup session cleanup (runs once per process lifetime) ──────
+    # Close cron sessions left open by a previous process lifecycle
+    # (SIGTERM/SIGKILL/crash before run_job() finally could execute).
+    global _startup_session_cleanup_done
+    if not _startup_session_cleanup_done:
+        _startup_session_cleanup_done = True
+        _cleanup_stale_cron_sessions()
 
     try:
         due_jobs = get_due_jobs()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2028,6 +2028,32 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def close_stale_sessions(self, end_reason: str = "process_restart",
+                             source: Optional[str] = None) -> int:
+        """Close sessions left open by a previous process lifecycle.
+
+        Updates all rows where ``ended_at IS NULL``, setting
+        ``ended_at = started_at`` and ``end_reason`` to *end_reason*.
+        Optionally scoped to a single ``source`` column value.
+
+        Returns the number of rows updated.
+        """
+        def _do(conn):
+            if source:
+                cursor = conn.execute(
+                    """UPDATE sessions SET ended_at = started_at,
+                       end_reason = ? WHERE ended_at IS NULL AND source = ?""",
+                    (end_reason, source),
+                )
+            else:
+                cursor = conn.execute(
+                    """UPDATE sessions SET ended_at = started_at,
+                       end_reason = ? WHERE ended_at IS NULL""",
+                    (end_reason,),
+                )
+            return cursor.rowcount if cursor.rowcount >= 0 else 0
+        return self._execute_write(_do)
+
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""
         def _do(conn):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -228,6 +228,47 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["end_reason"] == "user_exit"
 
+    def test_close_stale_sessions_closes_only_unended(self, db):
+        """close_stale_sessions should close sessions with ended_at IS NULL,
+        skip already-ended sessions, and respect the source filter."""
+        # Create mix of sessions
+        db.create_session("cron_open", source="cron")          # should close
+        db.create_session("cron_done", source="cron")          # already ended — skip
+        db.end_session("cron_done", end_reason="cron_complete")
+        db.create_session("cli_open", source="cli")             # wrong source — skip
+        db.create_session("cron_open2", source="cron")         # should close
+
+        count = db.close_stale_sessions(
+            end_reason="process_restart", source="cron"
+        )
+        assert count == 2
+
+        assert db.get_session("cron_open")["end_reason"] == "process_restart"
+        assert db.get_session("cron_open2")["end_reason"] == "process_restart"
+        assert db.get_session("cron_done")["end_reason"] == "cron_complete"
+        assert db.get_session("cli_open")["ended_at"] is None
+
+    def test_close_stale_sessions_no_source_closes_all(self, db):
+        """Without a source filter, close_stale_sessions closes all unended rows."""
+        db.create_session("c1", source="cron")
+        db.create_session("c2", source="cli")
+        db.create_session("c3", source="telegram")
+        db.end_session("c3", end_reason="user_exit")
+
+        count = db.close_stale_sessions(end_reason="process_restart")
+        assert count == 2
+        assert db.get_session("c1")["end_reason"] == "process_restart"
+        assert db.get_session("c2")["end_reason"] == "process_restart"
+        assert db.get_session("c3")["end_reason"] == "user_exit"
+
+    def test_close_stale_sessions_idempotent(self, db):
+        """Second call should be a no-op (return 0)."""
+        db.create_session("s1", source="cron")
+        count1 = db.close_stale_sessions(source="cron")
+        assert count1 == 1
+        count2 = db.close_stale_sessions(source="cron")
+        assert count2 == 0
+
     def test_update_system_prompt(self, db):
         db.create_session(session_id="s1", source="cli")
         db.update_system_prompt("s1", "You are a helpful assistant.")


### PR DESCRIPTION
## Problem

When the scheduler/gateway process is killed (SIGTERM/SIGKILL/crash) before `run_job()`'s `finally` block executes, cron session rows stay with `ended_at IS NULL` forever. There is no startup cleanup nor orphan reaper for pure cron sessions — the `ws_orphan_reap` mechanism in `tui_gateway/server.py` only catches WS-attached TUI sessions.

This makes Run History unreliable (sessions appear stuck/never-ending) and inflates the "open sessions" count.

**Fixes #12029** — the core of the session leak issue (the remaining gap after #2972 and #8777).

## Reproduction

Run a cron job, kill the process before completion, and observe:

```sql
SELECT id, end_reason, started_at, ended_at FROM sessions
WHERE source = 'cron' AND ended_at IS NULL;
```

Rows stay open indefinitely.

## Changes

This PR is now scoped to **only 2 commits, 4 files, +304 lines**:

| Commit | Files | Description |
|--------|-------|-------------|
| `3cbc0cf` record no_agent runs as sessions | 2 | `no_agent=True` cron jobs now create session rows so they appear in Run History |
| `9561a25` close stale cron sessions on startup | 3 | `SessionDB.close_stale_sessions()` + `_cleanup_stale_cron_sessions()` in scheduler startup |

## Verification

```
python -m pytest tests/cron/test_cron_no_agent.py tests/test_hermes_state.py -q
323 passed in 11.59s
```

## Scope

This fix is intentionally scoped to `source='cron'` for the startup cleanup — it's the most impactful and least risky scope. The `SessionDB.close_stale_sessions()` method also supports global cleanup (no source filter) so future PRs can extend this to CLI/gateway sources if desired.
