### PR TITLE
fix(photon): don't kill sidecar at boot when legacy spectrum-ts dist is absent

### DIFF
--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -124,7 +124,12 @@ export function patchSpectrumTs(root = scriptDir()) {
     "dist"
   );
   if (!fs.existsSync(dist)) {
-    throw new Error(`@spectrum-ts/imessage dist not found: ${dist}`);
+    // Pinned SDK layout drift: newer spectrum-ts ships as top-level
+    // `spectrum-ts/dist` (+ `@photon-ai/*`) and no longer exposes the old
+    // `@spectrum-ts/imessage/dist` path this mixed-attachment shim targets.
+    // The shim only affects text+multi-attachment ordering; when the legacy
+    // path is absent, skip gracefully instead of killing the sidecar at boot.
+    return { patched: false, reason: "legacy @spectrum-ts/imessage dist absent" };
   }
   const files = fs.readdirSync(dist)
     .filter((name) => name.endsWith(".js"))


### PR DESCRIPTION
## Summary

The Photon Spectrum sidecar dies at every boot once the `spectrum-ts` SDK layout drifts away from the legacy `@spectrum-ts/imessage/dist` path (e.g. after the rename to top-level `spectrum-ts/dist` + `@photon-ai/*` scopes).

`patchSpectrumTs()` in `patch-spectrum-mixed-attachments.mjs` hard-codes that legacy path and does `throw new Error(...)` when it's missing. `index.mjs` catches that and turns it into `process.exit(3)` — so the sidecar exits immediately on startup.

User-visible symptoms:
- Gateway reports Photon `connected`, but the status is stale — the sidecar is actually dead.
- **No inbound iMessage is ever delivered.**
- Outbound fails with `Photon standalone send requires a running sidecar`.
- Gateway loops on `Reconnect photon failed, next retry in 300s`.

## Fix

The mixed-attachment shim only adjusts text + multi-attachment child ordering, so a missing legacy `dist` should be a no-op — not fatal. Return `{ patched: false }` and skip gracefully instead of throwing. The `spectrum-ts` package itself is intact in this scenario; only the patch's hard-coded old path is stale.

```diff
   if (!fs.existsSync(dist)) {
-    throw new Error(`@spectrum-ts/imessage dist not found: ${dist}`);
+    // Layout drift: newer spectrum-ts ships as top-level spectrum-ts/dist
+    // (+ @photon-ai/* scopes) and no longer exposes @spectrum-ts/imessage/dist.
+    // The shim only affects text+multi-attachment ordering; skip gracefully
+    // instead of killing the sidecar at boot.
+    return { patched: false, reason: "legacy @spectrum-ts/imessage dist absent" };
   }
```

## Test plan

- [x] With the legacy dist absent, the sidecar boots, listens on 127.0.0.1:8789, and `[photon] connected — streaming inbound over gRPC` appears in the gateway log.
- [x] `/healthz` returns `{"ok":false,"error":"unauthorized"}` (alive + enforcing the sidecar token).
- [x] Verified on macOS against a drifted SDK layout (`@photon-ai/*` scopes present, `@spectrum-ts/imessage/dist` absent).