### PR TITLE
fix(model_normalize): only fold DeepSeek V4+ as first-class IDs (V1-V3 -> deepseek-chat)

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -141,8 +141,11 @@ _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
 # Verified empirically 2026-04-24: DeepSeek's Chat Completions API returns
 # ``provider: DeepSeek`` / ``model: deepseek-v4-flash-20260423`` when called
 # with ``model=deepseek/deepseek-v4-flash``, so these names are not aliases
-# of ``deepseek-chat`` and must not be folded into it.
-_DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
+# of ``deepseek-chat`` and must not be folded into it. Only V4 and above are
+# first-class; V1-V3 are not accepted by the DeepSeek API (HTTP 400 "Model Not
+# Exist") and are served as ``deepseek-chat``, so the major version is captured
+# and gated to ``>= 4`` at the call site.
+_DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v(\d+)([-.].+)?$")
 
 
 def _normalize_for_deepseek(model_name: str) -> str:
@@ -151,8 +154,9 @@ def _normalize_for_deepseek(model_name: str) -> str:
     Rules:
     - Already a known canonical (``deepseek-chat``/``deepseek-reasoner``/
       ``deepseek-v4-pro``/``deepseek-v4-flash``) -> pass through.
-    - Matches the V-series pattern ``deepseek-v<digit>...`` -> pass through
-      (covers future ``deepseek-v5-*`` and dated variants without a release).
+    - Matches the V4+ series pattern ``deepseek-v<major>...`` with major >= 4
+      -> pass through (covers ``deepseek-v4-*``, future ``deepseek-v5-*`` and
+      dated variants). V1-V3 are not first-class and fold to ``deepseek-chat``.
     - Contains a reasoner keyword (r1, think, reasoning, cot, reasoner)
       -> ``deepseek-reasoner``.
     - Everything else -> ``deepseek-chat``.
@@ -168,8 +172,11 @@ def _normalize_for_deepseek(model_name: str) -> str:
     if bare in _DEEPSEEK_CANONICAL_MODELS:
         return bare
 
-    # V-series first-class IDs (v4-pro, v4-flash, future v5-*, dated variants)
-    if _DEEPSEEK_V_SERIES_RE.match(bare):
+    # V-series first-class IDs are V4+ only (v4-pro, v4-flash, future v5-*,
+    # dated variants). V1-V3 are not accepted by the DeepSeek API and fold to
+    # deepseek-chat below.
+    _v_match = _DEEPSEEK_V_SERIES_RE.match(bare)
+    if _v_match and int(_v_match.group(1)) >= 4:
         return bare
 
     # Check for reasoner-like keywords anywhere in the name

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -231,6 +231,19 @@ class TestDeepseekVSeriesPassThrough:
         result = normalize_model_for_provider("deepseek-v4-flash", "deepseek")
         assert result == "deepseek-v4-flash"
 
+    @pytest.mark.parametrize("model", [
+        "deepseek-v3",
+        "deepseek-v2",
+        "deepseek-v1",
+        "deepseek-v3-0324",
+        "deepseek/deepseek-v3",
+    ])
+    def test_pre_v4_versions_fold_to_chat(self, model):
+        """V1-V3 are not first-class DeepSeek IDs (the API rejects them with
+        HTTP 400 "Model Not Exist"); only V4+ pass through. Pre-V4 names must
+        fold to ``deepseek-chat`` so the request reaches a model that exists."""
+        assert _normalize_for_deepseek(model) == "deepseek-chat"
+
 
 # ── DeepSeek regressions (existing behaviour still holds) ──────────────
 


### PR DESCRIPTION
## What does this PR do?

The V-series pass-through regex `^deepseek-v\d+` in `hermes_cli/model_normalize.py` (added in #15123 for the V4 launch) over-matches V1–V3. Its `\d+` accepts any version, so `_normalize_for_deepseek` passed `deepseek-v3` / `-v2` / `-v1` through unchanged instead of folding them to `deepseek-chat`. DeepSeek's direct API rejects those IDs with HTTP 400 "Model Not Exist" — V3 is served as `deepseek-chat`.

The module's own doctest documents the correct contract:

```
>>> normalize_model_for_provider("deepseek-v3", "deepseek")
'deepseek-chat'
```

and was **failing** before this change (`python3 -m doctest hermes_cli/model_normalize.py` → 20 passed / 1 failed; actual return `'deepseek-v3'`). This restores it.

The fix makes the gate version-aware: the regex now captures the major version (`^deepseek-v(\d+)`) and the call site requires `>= 4`. V4/V5/V10 and dated variants (`deepseek-v4-flash-20260423`) pass through unchanged; V1–V3 fold to `deepseek-chat`.

## Related Issue

Code-originated finding (no filed issue). The module's own doctest is the spec and was red.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_normalize.py`: capture the major version in `_DEEPSEEK_V_SERIES_RE` and gate the V-series pass-through to `>= 4` in `_normalize_for_deepseek`; updated the nearby comment/docstring to state V4+.
- `tests/hermes_cli/test_model_normalize.py`: added a parametrized regression `test_pre_v4_versions_fold_to_chat` (v1/v2/v3/v3-0324/vendor-prefixed).

## How to Test

1. **Fail-before:** on `origin/main`, `python3 -m doctest hermes_cli/model_normalize.py` → "20 passed and 1 failed" (`deepseek-v3` returns `deepseek-v3`). Stashing the prod hunk, the new test fails on all 5 cases.
2. **Pass-after:** with this change, `python3 -m doctest hermes_cli/model_normalize.py` → 0 failures, and `pytest tests/hermes_cli/test_model_normalize.py -q` → 85 passed.
3. The existing `TestDeepseekVSeriesPassThrough` (v4/v5/v10/dated) still passes — V4+ behavior from #15123 is preserved.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A