### PR TITLE
fix(mcp): coerce string args to list in _run_stdio (#55385)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -998,6 +998,46 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_string_args_coerced_to_list(self):
+        """String ``args`` in config is coerced to a single-element list.
+
+        YAML flow-style or config normalisation can store a list as its
+        string repr (e.g. ``'[C:/path/script.py]'``).  ``StdioServerParameters``
+        requires ``list[str]`` and rejects a bare string.  (#55385)
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[])
+        )
+
+        p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
+
+        async def _test():
+            with patch("tools.mcp_tool.StdioServerParameters") as mock_params, \
+                 p_stdio, p_cs:
+                server = MCPServerTask("srv")
+                # Pass args as a string (simulates YAML flow-style corruption)
+                await server.start({
+                    "command": "node",
+                    "args": "C:/Users/test/script.py",
+                })
+
+                call_kwargs = mock_params.call_args
+                args_arg = call_kwargs.kwargs.get("args")
+                # Must be a list, not a string
+                assert isinstance(args_arg, list), (
+                    f"Expected list, got {type(args_arg).__name__}: {args_arg!r}"
+                )
+                assert args_arg == ["C:/Users/test/script.py"]
+
+                await server.shutdown()
+
+        asyncio.run(_test())
+
+
     def test_shutdown_signals_task_exit(self):
         """shutdown() signals the event and waits for task completion."""
         from tools.mcp_tool import MCPServerTask

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1807,6 +1807,13 @@ class MCPServerTask:
 
         command = config.get("command")
         args = config.get("args", [])
+        # Guard: YAML flow-style or config normalisation can store a list as
+        # its string repr (e.g. ``'[C:/path/script.py]'``).  Pydantic's
+        # ``StdioServerParameters`` requires ``list[str]`` and rejects a bare
+        # string with ``Input should be a valid list``.  Coerce transparently
+        # so users don't have to hand-edit config.yaml.  (#55385)
+        if isinstance(args, str):
+            args = [args]
         user_env = config.get("env")
 
         if not command:


### PR DESCRIPTION
## What does this PR do?

Coerces `args` from `str` to `list[str]` in `_run_stdio()` before passing to `StdioServerParameters`. When YAML flow-style parsing or config normalisation stores a list as its string repr (e.g. `'[C:/path/script.py]'`), Pydantic rejects it with `Input should be a valid list`. This one-line guard transparently fixes the type mismatch so users don't have to hand-edit their config.yaml.

## Related Issue

Fixes #55385

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: Added `isinstance(args, str)` guard in `_run_stdio()` to coerce string args to a single-element list before passing to `StdioServerParameters`
- `tests/tools/test_mcp_tool.py`: Added `test_string_args_coerced_to_list` regression test that verifies string args are coerced to list

## How to Test

1. Run `pytest tests/tools/test_mcp_tool.py::TestMCPServerTask::test_string_args_coerced_to_list -xvs` — should pass
2. Run `pytest tests/tools/test_mcp_tool.py -x -q` — all 201 tests should pass
3. Configure an MCP server with `args` as a YAML flow-style string (e.g. `args: "[script.py]"`) — should connect without Pydantic validation error

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
