### PR TITLE
fix(desktop): resolve Windows file:// drive-letter paths in local preview

### DIFF
--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { localPreviewTarget } from './local-preview'
+
+describe('localPreviewTarget file:// path resolution', () => {
+  it('strips the leading slash from a Windows drive-letter file URL', () => {
+    expect(localPreviewTarget('file:///C:/Users/x/index.html')?.path)
+      .toBe('C:/Users/x/index.html')
+  })
+
+  it('preserves a POSIX absolute file URL path', () => {
+    expect(localPreviewTarget('file:///home/u/a.html')?.path)
+      .toBe('/home/u/a.html')
+  })
+})

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -83,6 +83,10 @@ export function localPreviewTarget(rawTarget: string, cwd?: string | null): Prev
   if (/^file:\/\//i.test(raw)) {
     try {
       path = decodeURIComponent(new URL(raw).pathname)
+      // The WHATWG URL parser prefixes a "/" before a Windows drive letter
+      // (file:///C:/… → "/C:/…"), which the desktop file read can't locate.
+      // Strip it only when it precedes a drive letter; POSIX paths are kept.
+      path = path.replace(/^\/([A-Za-z]:)/, '$1')
     } catch {
       path = raw.replace(/^file:\/\//i, '')
     }


### PR DESCRIPTION
## What does this PR do?

`localPreviewTarget` (`apps/desktop/src/lib/local-preview.ts`) decodes `new URL(raw).pathname` for `file://` links. For a Windows file URL the WHATWG `URL` parser prefixes a spurious `/` before the drive letter:

```js
new URL('file:///C:/Users/x/index.html').pathname === '/C:/Users/x/index.html'
```

(deterministic on every host OS). That broken value becomes `target.path`, which `readDesktopFileText(target.path || target.source)` (remote-gateway mode) and the local open both consume — so on a Windows backend the file can't be located and the preview dead-ends with "file not found". POSIX paths (`/home/u/a.html`) are already correct and must be preserved.

The fix strips a single leading slash only when it precedes a drive letter (`/^\/([A-Za-z]:)/`); POSIX absolute paths are untouched.

## Related Issue

Code-originated finding (no filed issue). Same drive-letter fix family as in-flight #48620 (which handles `media.ts`); this is a net-new sibling in the untouched `local-preview.ts`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/local-preview.ts`: after decoding `new URL(raw).pathname`, strip the WHATWG-added leading slash before a Windows drive letter.
- `apps/desktop/src/lib/local-preview.test.ts` (new): vitest regression for the Windows drive-letter and POSIX cases.

## How to Test

1. **Fail-before:** stash the prod hunk and run `vitest run --environment jsdom src/lib/local-preview.test.ts` — the Windows assertion fails (`path === '/C:/Users/x/index.html'`).
2. **Pass-after:** with the change, both assertions pass.
3. Full `src/lib/` suite: 32 files / 244 tests pass; `tsc -p . --noEmit` and `eslint` clean. The POSIX assertion guards against over-stripping.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the desktop vitest suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (the fix is platform-independent and the test runs headless)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A