### PR TITLE
fix(google-chat): convert ~~strikethrough~~ to Chat's ~strikethrough~ dialect

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2078,6 +2078,13 @@ class GoogleChatAdapter(BasePlatformAdapter):
             text,
         )
 
+        # Strikethrough: ~~text~~ → ~text~ (Chat uses single tildes).
+        text = re.sub(
+            r"~~(.+?)~~",
+            lambda m: _ph(f"~{m.group(1)}~"),
+            text,
+        )
+
         # Markdown links [text](url) → <url|text> (Slack-style angle-bracket).
         text = re.sub(
             r"\[([^\]]+)\]\(([^)]+)\)",

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2396,6 +2396,17 @@ class TestFormatMessage:
         out = GoogleChatAdapter.format_message("hello **world**")
         assert out == "hello *world*"
 
+    def test_strikethrough_double_tilde_to_single(self):
+        """~~text~~ → ~text~ (Chat's strikethrough uses single tildes).
+
+        Standard Markdown / LLM output emits double-tilde; Chat renders
+        single-tilde, so doubled tildes reach the user as literal text.
+        Inline-code-protected `~~keep~~` stays intact.
+        """
+        assert GoogleChatAdapter.format_message("~~deleted~~") == "~deleted~"
+        assert GoogleChatAdapter.format_message("this is ~~gone~~ now") == "this is ~gone~ now"
+        assert GoogleChatAdapter.format_message("see `~~keep~~`") == "see `~~keep~~`"
+
     def test_bold_italic_combo_to_chat_dialect(self):
         """***x*** → *_x_* (bold-italic compound)."""
         out = GoogleChatAdapter.format_message("***fancy*** word")


### PR DESCRIPTION
## What does this PR do?

`GoogleChatAdapter.format_message` (`plugins/platforms/google_chat/adapter.py`) converts every other Markdown→Chat dialect difference — `***x***` → `*_x_*`, `**bold**` → `*bold*`, `# H` → `*H*`, `[t](u)` → `<u|t>` — but has **no rule for standard-Markdown strikethrough** `~~text~~`. The method's own docstring states Chat's subset includes single-tilde `~strikethrough~`. Standard Markdown / LLM output emits double-tilde `~~text~~`, so struck text reaches Chat as literal doubled tildes (`format_message("~~deleted~~")` returns `~~deleted~~`).

This adds the missing `~~text~~` → `~text~` conversion, placed after the bold rule and before the link rule, using the same `_ph` placeholder-protection pattern as its siblings — so inline/fenced `` `~~keep~~` `` is untouched. Single `~tilde~` (already Chat-native) has no `~~` pair and is left alone.

## Related Issue

Code-originated finding (no filed issue). The converter's own docstring documents the single-tilde dialect; the conversion was simply missing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/google_chat/adapter.py`: add a `~~text~~` → `~text~` substitution in `format_message`, between the bold and link rules, with code-block placeholder protection.
- `tests/gateway/test_google_chat.py`: add `test_strikethrough_double_tilde_to_single` (plain, mid-sentence, and code-protected cases) to `TestFormatMessage`.

## How to Test

1. **Fail-before:** stash the prod hunk; the new test fails (`format_message("~~deleted~~")` returns `~~deleted~~`).
2. **Pass-after:** with the change, `pytest tests/gateway/test_google_chat.py -q` → 161 passed; struck text converts to `~deleted~`, and `` see `~~keep~~` `` stays `` see `~~keep~~` `` (code protection holds).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_google_chat.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A