### PR TITLE
fix: preserve leading zeros in union integer|string tool arg coercion (#55369)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -925,7 +925,16 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
         return value
 
     if expected_type in {"integer", "number"}:
-        return _coerce_number(value, integer_only=(expected_type == "integer"))
+        # ``_coerce_number`` preserves leading zeros (e.g. "007") only when
+        # the schema also admits ``string`` — a pure ``integer`` field must
+        # still coerce to ``int``, dropping the leading zeros. ``is_union``
+        # tells the helper whether ``string`` was one of the accepted types.
+        is_union = isinstance(expected_type, list) or _schema_allows_string(schema)
+        return _coerce_number(
+            value,
+            integer_only=(expected_type == "integer"),
+            is_union=is_union,
+        )
     if expected_type == "boolean":
         return _coerce_boolean(value)
     if expected_type == "array":
@@ -935,6 +944,30 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
     if expected_type == "null" and value.strip().lower() == "null":
         return None
     return value
+
+
+def _schema_allows_string(schema: dict | None) -> bool:
+    """Return True when a JSON Schema fragment also accepts ``string``.
+
+    Used by ``_coerce_value`` to decide whether a leading-zero string like
+    ``"007"`` should be preserved (union ``integer|string``) or coerced to
+    ``int`` (pure ``integer``).
+    """
+    if not isinstance(schema, dict):
+        return False
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list) and "string" in schema_type:
+        return True
+    if schema_type == "string":
+        return True
+    for union_key in ("anyOf", "oneOf"):
+        variants = schema.get(union_key)
+        if not isinstance(variants, list):
+            continue
+        for variant in variants:
+            if isinstance(variant, dict) and variant.get("type") == "string":
+                return True
+    return False
 
 
 def _schema_allows_null(schema: dict | None) -> bool:
@@ -992,8 +1025,22 @@ def _coerce_json(value: str, expected_python_type: type):
     return value
 
 
-def _coerce_number(value: str, integer_only: bool = False):
-    """Try to parse *value* as a number.  Returns original string on failure."""
+def _coerce_number(value: str, integer_only: bool = False, *, is_union: bool = False):
+    """Try to parse *value* as a number.  Returns original string on failure.
+
+    When ``is_union`` is True the schema also accepts ``string``, so
+    leading-zero strings like ``"007"`` are preserved verbatim (zip codes,
+    country codes, zero-padded IDs). When False (pure ``integer`` /
+    ``number``), leading zeros are dropped via normal numeric coercion.
+    """
+    stripped = value.strip()
+    if (
+        is_union
+        and stripped.lstrip("-").startswith("0")
+        and len(stripped) > 1
+        and stripped not in ("0", "-0")
+    ):
+        return value
     try:
         f = float(value)
     except (ValueError, OverflowError):

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -40,6 +40,40 @@ class TestCoerceNumber:
         assert result == "3.14"
         assert isinstance(result, str)
 
+    # ── Leading-zero preservation (#55369) ────────────────────────────
+
+    def test_pure_integer_drops_leading_zeros(self):
+        """A pure ``integer`` schema must coerce ``"007"`` to ``int(7)``.
+
+        Without ``is_union`` the helper uses normal numeric coercion; the
+        leading zeros are lost, matching the declared ``integer`` type.
+        Regression for the tekium1 review point on #55401.
+        """
+        result = _coerce_number("007", integer_only=True)
+        assert result == 7
+        assert isinstance(result, int)
+
+    def test_union_integer_string_preserves_leading_zeros(self):
+        """A union ``integer|string`` schema must keep ``"007"`` as a string.
+
+        The leading zeros are significant (zip codes, country codes, zero-
+        padded IDs). ``is_union=True`` preserves them verbatim.
+        """
+        result = _coerce_number("007", is_union=True)
+        assert result == "007"
+        assert isinstance(result, str)
+
+    def test_union_preserves_negative_zero_padded(self):
+        """``"-007"`` in a union schema stays a string too."""
+        result = _coerce_number("-007", is_union=True)
+        assert result == "-007"
+        assert isinstance(result, str)
+
+    def test_union_plain_zero_still_coerces(self):
+        """``"0"`` and ``"-0"`` have no leading zeros to preserve — coerce."""
+        assert _coerce_number("0", is_union=True) == 0
+        assert _coerce_number("-0", is_union=True) == 0
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #55369 — when a tool argument has union type `["integer", "string"]`, values with leading zeros like `"007"` (zip codes, country codes, zero-padded IDs) were incorrectly coerced to integer `7`, losing the significant leading zeros.

## Related Issue

Fixes #55369

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Added a guard in `_coerce_number()` that returns the original string when:
- The value starts with `0` (after stripping whitespace)
- The value has more than one character
- The value is not exactly `"0"` or `"-0"`

This preserves leading zeros for values like:
- `"007"` → stays `"007"` (not `7`)
- `"0123"` → stays `"0123"` (not `123`)
- `"0"` → still coerces to `0` (single zero is valid)

## How to Test

```python
from model_tools import _coerce_value

# Should preserve leading zeros for union type
assert _coerce_value("007", ["integer", "string"]) == "007"
assert _coerce_value("0123", ["integer", "string"]) == "0123"

# Should still coerce plain integers
assert _coerce_value("42", ["integer", "string"]) == 42
assert _coerce_value("0", ["integer", "string"]) == 0
```

## Platforms Tested

- [x] Windows 11