### PR TITLE
fix: respect CommonMark closing fence rules in message truncation (#55292)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5329,8 +5329,13 @@ class BasePlatformAdapter(ABC):
                 stripped = line.strip()
                 if stripped.startswith("```"):
                     if in_code:
-                        in_code = False
-                        lang = ""
+                        # A closing fence must be ``` followed by only whitespace
+                        # (CommonMark spec). A line like ```text inside a code
+                        # block is content, not a fence boundary.
+                        after = stripped[3:]
+                        if not after or after.isspace():
+                            in_code = False
+                            lang = ""
                     else:
                         in_code = True
                         tag = stripped[3:].strip()


### PR DESCRIPTION
## What does this PR do?

Fixes #55292 — the message truncation code incorrectly treated ANY line starting with triple-backtick as a fence boundary, even when the line was content inside a code block (e.g., triple-backtick-text).

## Related Issue

Fixes #55292

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

When already inside a code block (in_code=True), the code now only toggles back to in_code=False when the triple-backtick is followed by whitespace or nothing (per CommonMark spec). Previously, any line starting with triple-backtick was treated as a closing fence.

## How to Test

1. Create a message with a code block containing lines that start with triple-backtick
2. Verify the message is truncated correctly without breaking the code block

## Platforms Tested

- [x] Windows 11