### PR TITLE
fix: handle MCP args as string or list in stdio server config (#55385)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1810,7 +1810,8 @@ class MCPServerTask:
         # Ensure args is a list — YAML parsing can sometimes return a string
         # if the user writes args: "--flag value" instead of args: ["--flag", "value"]
         if isinstance(args, str):
-            args = args.split()
+            import shlex
+            args = shlex.split(args)
         user_env = config.get("env")
 
         if not command:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1807,6 +1807,10 @@ class MCPServerTask:
 
         command = config.get("command")
         args = config.get("args", [])
+        # Ensure args is a list — YAML parsing can sometimes return a string
+        # if the user writes args: "--flag value" instead of args: ["--flag", "value"]
+        if isinstance(args, str):
+            args = args.split()
         user_env = config.get("env")
 
         if not command:


### PR DESCRIPTION
## What does this PR do?

Fixes #55385 — YAML parsing can sometimes return MCP server args as a string instead of a list when the user writes `args: "--flag value"` instead of `args: ["--flag", "value"]`. This causes MCP tool injection to fail on Windows.

## Related Issue

Fixes #55385

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

Added validation in `tools/mcp_tool.py` to ensure `args` is always a list by splitting strings on whitespace when a string is received instead of a list.

## How to Test

1. Configure an MCP server with args as a string:
   ```yaml
   mcp_servers:
     test-server:
       command: python
       args: "-m some_module --port 8080"
   ```
2. Verify the MCP server starts correctly with args parsed as a list

## Platforms Tested

- [x] Windows 11