### PR TITLE
fix(dashboard): show provider setup guidance when no models are configured

### DIFF
--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -6,7 +6,7 @@ import { Input } from "@nous-research/ui/ui/components/input";
 import { Label } from "@nous-research/ui/ui/components/label";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import type { GatewayClient } from "@/lib/gatewayClient";
-import { Check, RefreshCw, Search, X } from "lucide-react";
+import { Check, RefreshCw, Search, X, ExternalLink } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn, themedBody } from "@/lib/utils";
@@ -40,7 +40,12 @@ interface ModelOptionProvider {
   models?: string[];
   total_models?: number;
   is_current?: boolean;
+  is_user_defined?: boolean;
+  source?: string;
   warning?: string;
+  authenticated?: boolean;
+  auth_type?: string;
+  key_env?: string;
 }
 
 interface ModelOptionsResponse {
@@ -165,6 +170,18 @@ export function ModelPickerDialog(props: Props) {
         setRefreshing(false);
       });
   };
+
+  // Detect whether any provider is actually authenticated
+  const hasAuthenticated = useMemo(
+    () => providers.some((p) => p.authenticated !== false),
+    [providers],
+  );
+
+  // The slug of the first unconfigured provider (for the setup banner link)
+  const firstUnconfigured = useMemo(
+    () => providers.find((p) => p.authenticated === false) ?? null,
+    [providers],
+  );
 
   // Load providers + models on open.
   useEffect(() => {
@@ -381,6 +398,33 @@ export function ModelPickerDialog(props: Props) {
           </p>
         </header>
 
+        {/* Setup banner — shown when no providers are authenticated */}
+        {!loading && !error && !hasAuthenticated && providers.length > 0 && (
+          <div className="px-5 pt-3 pb-0">
+            <div className="flex items-start gap-2 border border-warning/40 bg-warning/5 px-3 py-2 text-xs">
+              <div className="wrap-break-word min-w-0 flex-1 text-text-secondary">
+                <span className="font-medium text-warning">
+                  No model providers configured.
+                </span>{" "}
+                {firstUnconfigured?.key_env ? (
+                  <>
+                    Set the <span className="font-mono">{firstUnconfigured.key_env}</span> environment variable to
+                    activate <strong>{firstUnconfigured.name}</strong> and other providers.
+                  </>
+                ) : (
+                  "Add an API key in Environment settings to activate providers."
+                )}
+              </div>
+              <a
+                href="/env"
+                className="shrink-0 inline-flex items-center gap-1 font-medium underline hover:text-foreground text-warning"
+              >
+                Add key <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+          </div>
+        )}
+
         <div className="px-5 pt-3 pb-2 border-b border-border">
           <div className="relative">
             <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
@@ -534,6 +578,7 @@ function ProviderColumn({
 
       {providers.map((p) => {
         const active = p.slug === selectedSlug;
+        const unconfigured = p.authenticated === false;
         return (
           <ListItem
             key={p.slug}
@@ -545,11 +590,23 @@ function ProviderColumn({
           >
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-1.5">
-                <span className="font-medium truncate">{p.name}</span>
+                <span className={`font-medium truncate ${unconfigured ? "italic text-text-tertiary" : ""}`}>
+                  {p.name}
+                </span>
                 {p.is_current && <CurrentTag />}
+                {unconfigured && (
+                  <span className="inline-flex items-center text-display text-[10px] tracking-wider text-text-tertiary uppercase">
+                    not configured
+                  </span>
+                )}
               </div>
               <div className="text-xs text-text-secondary font-mono truncate">
                 {p.slug} · {p.total_models ?? p.models?.length ?? 0} models
+                {unconfigured && p.key_env && (
+                  <span className="text-text-tertiary ml-1">
+                    · set {p.key_env}
+                  </span>
+                )}
               </div>
             </div>
           </ListItem>
@@ -592,15 +649,39 @@ function ModelColumn({
     );
   }
 
+  const isUnconfigured = provider.authenticated === false;
+
   return (
     <div className="overflow-y-auto">
-      {provider.warning && (
+      {provider.warning && !isUnconfigured && (
         <div className="p-3 text-xs text-destructive border-b border-border">
           {provider.warning}
         </div>
       )}
 
-      {models.length === 0 ? (
+      {isUnconfigured ? (
+        <div className="p-5 text-center">
+          <div className="rounded border border-dashed border-border/60 bg-muted/10 px-4 py-5">
+            <p className="text-xs font-medium text-text-secondary mb-2">
+              {provider.name} is not configured
+            </p>
+            <p className="text-xs text-text-tertiary leading-relaxed mb-3">
+              {provider.warning || (
+                <>
+                  No API key found for {provider.name}.
+                  Add the required environment variable, then refresh this page.
+                </>
+              )}
+            </p>
+            <a
+              href="/env"
+              className="inline-flex items-center gap-1 text-xs font-medium underline hover:text-foreground text-primary"
+            >
+              Go to Environment settings <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
+        </div>
+      ) : models.length === 0 ? (
         <div className="p-4 text-xs text-muted-foreground italic">
           {allModels.length
             ? "no models match your filter"

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -1165,7 +1165,9 @@ export default function ModelsPage() {
       .then(([models, auxData, provAvailable]) => {
         setData(models);
         setAux(auxData);
-        setHasProviders(provAvailable);
+        if (provAvailable !== undefined) {
+          setHasProviders(provAvailable);
+        }
       })
       .catch((err) => setError(String(err)))
       .finally(() => setLoading(false));

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -1130,6 +1130,8 @@ export default function ModelsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saveKey, setSaveKey] = useState(0);
+  // Track whether any providers are configured — used to tailor the empty state.
+  const [hasProviders, setHasProviders] = useState<boolean | null>(null);
   // Gate the token/cost UI on `dashboard.show_token_analytics`.  See
   // hermes_cli/config.py for the rationale: the numbers exclude auxiliary
   // calls and retries, so they're misleading next to provider billing.
@@ -1156,10 +1158,14 @@ export default function ModelsPage() {
     Promise.all([
       api.getModelsAnalytics(days),
       api.getAuxiliaryModels().catch(() => null),
+      // Check whether any providers are configured — the empty state differs
+      // when there's no model usage vs. no providers at all.
+      api.getModelOptions().then((r) => (r.providers ?? []).some((p) => p.authenticated !== false)).catch(() => false),
     ])
-      .then(([models, auxData]) => {
+      .then(([models, auxData, provAvailable]) => {
         setData(models);
         setAux(auxData);
+        setHasProviders(provAvailable);
       })
       .catch((err) => setError(String(err)))
       .finally(() => setLoading(false));
@@ -1345,6 +1351,25 @@ export default function ModelsPage() {
                 />
               ))}
             </div>
+          ) : hasProviders === false ? (
+            <Card>
+              <CardContent className="py-12">
+                <div className="flex flex-col items-center text-muted-foreground max-w-md mx-auto text-center">
+                  <Cpu className="h-8 w-8 mb-3 opacity-40" />
+                  <p className="text-sm font-medium">
+                    No model providers configured
+                  </p>
+                  <p className="text-xs mt-1 text-text-tertiary leading-relaxed">
+                    Add an API key in{" "}
+                    <a href="/env" className="underline hover:text-foreground">
+                      Environment settings
+                    </a>{" "}
+                    to activate model providers. Once configured, you can pick a
+                    model and start a conversation.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
           ) : (
             <Card>
               <CardContent className="py-12">


### PR DESCRIPTION
Fixes #55396

## Description

When a dashboard profile has no model providers configured, the user deadlocks: the Model page shows empty analytics and the model picker shows "no authenticated providers" with no way to add one.

This fix surfaces a clear setup path from both the Model page and the model picker dialog:

**ModelPickerDialog.tsx:**
- Added a warning banner at the top when no providers are authenticated, directing the user to Environment settings to add an API key
- Unconfigured providers now show a "not configured" tag in the provider list with the expected env var name
- Selecting an unconfigured provider shows a setup card with the provider's warning message and a direct link to Environment settings

**ModelsPage.tsx:**
- Checks provider authentication state on load
- When no providers are authenticated, shows a dedicated empty state with a link to Environment settings instead of the generic "no usage data" message

## Verification
- S1 (Secrets): clean
- S2 (Personal refs): clean
- F1 (Focused): only 2 files changed, all dashboard frontend
- Build: TypeScript compiles clean (no type errors introduced)