### PR TITLE
MC-LOCAL-028: add Kanban metadata exporter v1

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_metadata_exporter as kme
 from hermes_cli import kanban_swarm as ks
 from hermes_cli.profiles import get_active_profile_name
 
@@ -421,6 +422,30 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         dest="current_step_key",
         metavar="KEY",
         help="Restrict to tasks with this current_step_key",
+    )
+
+    # --- export-metadata ---
+    p_export_metadata = sub.add_parser(
+        "export-metadata",
+        help="Export read-only metadata-only task snapshots for source integrations",
+    )
+    p_export_metadata.add_argument("--json", action="store_true", required=True)
+    p_export_metadata.add_argument("--assignee", default=None)
+    p_export_metadata.add_argument(
+        "--status",
+        default=None,
+        choices=sorted(kb.VALID_STATUSES),
+    )
+    p_export_metadata.add_argument("--tenant", default=None)
+    p_export_metadata.add_argument(
+        "--archived",
+        action="store_true",
+        help="Include archived tasks",
+    )
+    p_export_metadata.add_argument(
+        "--lifecycle-event-type",
+        default=kme.DEFAULT_LIFECYCLE_EVENT_TYPE,
+        help="Lifecycle event type to stamp on the export (default: snapshot)",
     )
 
     # --- show ---
@@ -941,6 +966,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "swarm":    _cmd_swarm,
             "list":     _cmd_list,
             "ls":       _cmd_list,
+            "export-metadata": _cmd_export_metadata,
             "show":     _cmd_show,
             "assign":   _cmd_assign,
             "reclaim":  _cmd_reclaim,
@@ -1441,6 +1467,21 @@ def _cmd_list(args: argparse.Namespace) -> int:
         return 0
     for t in tasks:
         print(_fmt_task_line(t))
+    return 0
+
+
+def _cmd_export_metadata(args: argparse.Namespace) -> int:
+    payload = kme.export_metadata(
+        assignee=getattr(args, "assignee", None),
+        status=getattr(args, "status", None),
+        tenant=getattr(args, "tenant", None),
+        include_archived=bool(getattr(args, "archived", False)),
+        lifecycle_event_type=(
+            getattr(args, "lifecycle_event_type", None)
+            or kme.DEFAULT_LIFECYCLE_EVENT_TYPE
+        ),
+    )
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0
 
 

--- a/hermes_cli/kanban_metadata_exporter.py
+++ b/hermes_cli/kanban_metadata_exporter.py
@@ -1,0 +1,139 @@
+"""Metadata-only Kanban export surface for external source integrations.
+
+This module intentionally uses an explicit column allowlist and emits only
+coordination metadata. It must not read or serialize task bodies, comments,
+results, run output, logs, workspace paths, or other raw worker/client data.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from hermes_cli import kanban_db as kb
+
+SCHEMA_VERSION = "kanban-metadata-export-v1"
+SOURCE_SYSTEM = "Hermes Kanban"
+DEFAULT_LIFECYCLE_EVENT_TYPE = "snapshot"
+SAFE_SUMMARY_SENTINEL = "safe_summary"
+
+# Keep this SQL as the only database source for the exporter. It is deliberately
+# narrower than kb.list_tasks(), which hydrates full Task objects including body,
+# result, workspace_path, and other fields forbidden in metadata export output.
+_METADATA_TASK_SQL = """
+SELECT
+    id,
+    status,
+    assignee,
+    tenant,
+    priority,
+    created_by,
+    created_at,
+    started_at,
+    completed_at,
+    workflow_template_id,
+    current_step_key
+FROM tasks
+WHERE 1=1
+"""
+
+
+def _json_safe_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)
+
+
+def metadata_task_record(
+    source: Mapping[str, Any],
+    *,
+    lifecycle_event_type: str = DEFAULT_LIFECYCLE_EVENT_TYPE,
+) -> dict[str, Any]:
+    """Map one allowlisted Kanban metadata row to the export contract.
+
+    ``taskSummary`` is only carried when the caller has explicitly marked the
+    field with ``wendyFieldSafety == "safe_summary"``. The live Kanban DB query
+    does not select any summary/title/body field, so production exports default
+    this to ``None``.
+    """
+
+    wendy_field_safety = source.get("wendyFieldSafety")
+    task_summary = None
+    if wendy_field_safety == SAFE_SUMMARY_SENTINEL:
+        raw_summary = source.get("taskSummary")
+        task_summary = str(raw_summary) if raw_summary is not None else None
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "sourceSystem": SOURCE_SYSTEM,
+        "lifecycleEventType": lifecycle_event_type or DEFAULT_LIFECYCLE_EVENT_TYPE,
+        "sourceTaskId": source["id"],
+        "taskStatus": source["status"],
+        "assignee": source.get("assignee"),
+        "tenant": source.get("tenant"),
+        "priority": int(source.get("priority") or 0),
+        "createdBy": source.get("created_by"),
+        "createdAt": _json_safe_int(source.get("created_at")),
+        "startedAt": _json_safe_int(source.get("started_at")),
+        "completedAt": _json_safe_int(source.get("completed_at")),
+        "workflowTemplateId": source.get("workflow_template_id"),
+        "currentStepKey": source.get("current_step_key"),
+        "taskSummary": task_summary,
+        "wendyFieldSafety": wendy_field_safety,
+    }
+
+
+def metadata_export_payload(
+    tasks: list[dict[str, Any]],
+    *,
+    lifecycle_event_type: str = DEFAULT_LIFECYCLE_EVENT_TYPE,
+    exported_at: int | None = None,
+) -> dict[str, Any]:
+    """Build the metadata-only exporter envelope."""
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "sourceSystem": SOURCE_SYSTEM,
+        "lifecycleEventType": lifecycle_event_type or DEFAULT_LIFECYCLE_EVENT_TYPE,
+        "exportedAt": int(time.time()) if exported_at is None else int(exported_at),
+        "tasks": tasks,
+    }
+
+
+def export_metadata(
+    *,
+    assignee: str | None = None,
+    status: str | None = None,
+    tenant: str | None = None,
+    include_archived: bool = False,
+    lifecycle_event_type: str = DEFAULT_LIFECYCLE_EVENT_TYPE,
+) -> dict[str, Any]:
+    """Read and return a metadata-only Kanban export payload.
+
+    The query is read-only and uses an explicit allowlist of safe columns. Do
+    not replace it with kb.list_tasks() or any show/runs/context/log source.
+    """
+
+    query = _METADATA_TASK_SQL
+    params: list[Any] = []
+    if assignee is not None:
+        query += " AND assignee = ?"
+        params.append(kb._canonical_assignee(assignee))
+    if status is not None:
+        if status not in kb.VALID_STATUSES:
+            raise ValueError(f"status must be one of {sorted(kb.VALID_STATUSES)}")
+        query += " AND status = ?"
+        params.append(status)
+    if tenant is not None:
+        query += " AND tenant = ?"
+        params.append(tenant)
+    if not include_archived and status != "archived":
+        query += " AND status != 'archived'"
+    query += " ORDER BY priority DESC, created_at ASC, id ASC"
+
+    with kb.connect_closing() as conn:
+        rows = conn.execute(query, params).fetchall()
+
+    tasks = [metadata_task_record(dict(row), lifecycle_event_type=lifecycle_event_type) for row in rows]
+    return metadata_export_payload(tasks, lifecycle_event_type=lifecycle_event_type)

--- a/tests/hermes_cli/test_kanban_metadata_exporter.py
+++ b/tests/hermes_cli/test_kanban_metadata_exporter.py
@@ -1,0 +1,141 @@
+"""Tests for the metadata-only Kanban exporter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_metadata_exporter import metadata_export_payload, metadata_task_record
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_export_metadata_json_uses_v1_schema_and_safe_allowlist(kanban_home, tmp_path):
+    workspace_path = tmp_path / "private-client-workspace"
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="private client title must not leak",
+            body="secret body must not leak",
+            assignee="alice",
+            created_by="operator",
+            workspace_kind="dir",
+            workspace_path=str(workspace_path),
+            tenant="tenant-a",
+            priority=7,
+        )
+        kb.add_comment(conn, task_id, "reviewer", "comment must not leak")
+        kb.complete_task(
+            conn,
+            task_id,
+            result="result must not leak",
+            summary="run summary must not leak",
+            metadata={"raw": "worker output must not leak"},
+        )
+
+    payload = json.loads(kc.run_slash("export-metadata --json"))
+
+    assert payload["schemaVersion"] == "kanban-metadata-export-v1"
+    assert payload["sourceSystem"] == "Hermes Kanban"
+    assert payload["lifecycleEventType"] == "snapshot"
+    assert len(payload["tasks"]) == 1
+
+    row = payload["tasks"][0]
+    assert row == {
+        "schemaVersion": "kanban-metadata-export-v1",
+        "sourceSystem": "Hermes Kanban",
+        "lifecycleEventType": "snapshot",
+        "sourceTaskId": task_id,
+        "taskStatus": "done",
+        "assignee": "alice",
+        "tenant": "tenant-a",
+        "priority": 7,
+        "createdBy": "operator",
+        "createdAt": row["createdAt"],
+        "startedAt": None,
+        "completedAt": row["completedAt"],
+        "workflowTemplateId": None,
+        "currentStepKey": None,
+        "taskSummary": None,
+        "wendyFieldSafety": None,
+    }
+
+    serialized = json.dumps(payload, ensure_ascii=False)
+    forbidden_fragments = [
+        "private client title must not leak",
+        "secret body must not leak",
+        "comment must not leak",
+        "result must not leak",
+        "run summary must not leak",
+        "worker output must not leak",
+        str(workspace_path),
+        "workspace_path",
+        "body",
+        "result",
+        "comments",
+        "runs",
+        "events",
+    ]
+    for fragment in forbidden_fragments:
+        assert fragment not in serialized
+
+
+def test_task_summary_only_exports_when_wendy_field_safety_is_safe_summary():
+    unsafe = metadata_task_record(
+        {
+            "id": "t_unsafe",
+            "status": "ready",
+            "assignee": None,
+            "tenant": None,
+            "priority": 0,
+            "created_by": None,
+            "created_at": 1,
+            "started_at": None,
+            "completed_at": None,
+            "workflow_template_id": None,
+            "current_step_key": None,
+            "wendyFieldSafety": "unsafe",
+            "taskSummary": "must not leak",
+        }
+    )
+    safe = metadata_task_record(
+        {
+            "id": "t_safe",
+            "status": "ready",
+            "assignee": None,
+            "tenant": None,
+            "priority": 0,
+            "created_by": None,
+            "created_at": 1,
+            "started_at": None,
+            "completed_at": None,
+            "workflow_template_id": None,
+            "current_step_key": None,
+            "wendyFieldSafety": "safe_summary",
+            "taskSummary": "safe summary",
+        }
+    )
+
+    assert unsafe["taskSummary"] is None
+    assert safe["taskSummary"] == "safe summary"
+
+
+def test_metadata_export_payload_defaults_lifecycle_to_snapshot():
+    payload = metadata_export_payload([])
+
+    assert payload["schemaVersion"] == "kanban-metadata-export-v1"
+    assert payload["sourceSystem"] == "Hermes Kanban"
+    assert payload["lifecycleEventType"] == "snapshot"
+    assert payload["tasks"] == []


### PR DESCRIPTION
## Summary

Adds `hermes kanban export-metadata --json` as a metadata-only exporter v1 for Hermes Kanban source integration.

## Safety model

- metadata-only exporter v1
- explicit allowlist output model
- no task bodies/results/comments/raw worker output/logs/sessions/workspace paths/private paths
- `taskSummary` remains null unless `wendyFieldSafety == "safe_summary"`
- no real Kanban import/backfill
- no Mission Control ledger writes
- Kanban Auto remained off
- publication branch was rebuilt from current upstream `origin/main`

## Validation

- focused validation: `python -m pytest tests/hermes_cli/test_kanban_metadata_exporter.py -q` → 3 passed
- adjacent Kanban validation: `python -m pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_metadata_exporter.py -q` → 273 passed
- isolated synthetic smoke: schemaVersion=kanban-metadata-export-v1, sourceSystem=Hermes Kanban, lifecycleEventType=snapshot, taskCount=1, forbiddenLeaks=NONE
