### PR TITLE
fix(desktop): detect native delegate_task completion from tool args

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -214,10 +214,30 @@ function delegateTaskPayloads(
   phase: 'running' | 'complete',
   sourceEventType?: string
 ): Record<string, unknown>[] {
-  if (payload?.name !== 'delegate_task') {
+  // Fast path: gateway-tagged delegate_task events.
+  if (payload?.name === 'delegate_task') {
+    return buildDelegatePayloads(payload, phase, sourceEventType)
+  }
+
+  // Fallback: native Hermes tool calls carry delegation in args (goal/tasks).
+  // The gateway tags them differently than tool responses do.
+  const args = parseMaybeRecord(payload?.args ?? payload?.input)
+  if (!args?.goal && !args?.tasks) {
     return []
   }
 
+  return buildDelegatePayloads(
+    { ...payload, name: 'delegate_task' } as GatewayEventPayload,
+    phase,
+    sourceEventType,
+  )
+}
+
+function buildDelegatePayloads(
+  payload: GatewayEventPayload,
+  phase: 'running' | 'complete',
+  sourceEventType?: string,
+): Record<string, unknown>[] {
   const args = parseMaybeRecord(payload.args ?? payload.input)
   const result = parseMaybeRecord(payload.result)
   const rawTasks = Array.isArray(args.tasks) ? args.tasks : []


### PR DESCRIPTION
The desktop delegation tree UI fails to update subagent status from running to completed when delegate_task is invoked as a native Hermes tool (not through the gateway event stream).

Root cause: delegateTaskPayloads() only processes events with payload.name === delegate_task (gateway-tagged path). Native tool responses carry payload.name = tool or function, so the guard returns [] and the subagent completion event is silently dropped. The UI tree remains stuck on running.

Fix: Split delegateTaskPayloads into a detection layer and a shared construction layer (buildDelegatePayloads). When payload.name !== delegate_task, fall back to inspecting args for goal/tasks fields. Both paths converge on the same buildDelegatePayloads logic.

Testing: Built successfully on Windows with tsc -b && vite build (4185 modules, 0 errors).