### PR TITLE
fix(moa): fit reference and aggregator context

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2353,6 +2353,9 @@ def run_conversation(
 
                 status_code = getattr(api_error, "status_code", None)
                 error_context = agent._extract_api_error_context(api_error)
+                _measured_context_tokens = getattr(api_error, "estimated_tokens", None)
+                if isinstance(_measured_context_tokens, int) and _measured_context_tokens > approx_tokens:
+                    approx_tokens = _measured_context_tokens
 
                 # ── Classify the error for structured recovery decisions ──
                 _compressor = getattr(agent, "context_compressor", None)

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -35,6 +35,8 @@ _MAX_REFERENCE_WORKERS = 8
 # back without replaying megabytes. The acting aggregator always gets the full,
 # untrimmed transcript; this budget only shapes the advisory copy.
 _REFERENCE_TOOL_RESULT_BUDGET = 4000
+_REFERENCE_OUTPUT_RESERVE_TOKENS = 4096
+_REFERENCE_MIN_INPUT_BUDGET_TOKENS = 512
 
 # System prompt prepended to every reference-model call. References are
 # advisory — they do NOT act, call tools, or own the task. Without this
@@ -62,6 +64,26 @@ _REFERENCE_SYSTEM_PROMPT = (
     "tools or access. Your response is private guidance handed to the "
     "aggregator, not an answer shown to the user."
 )
+
+
+class MoAAggregatorContextOverflow(RuntimeError):
+    """Raised before calling the aggregator when the measured request is too large."""
+
+    def __init__(
+        self,
+        *,
+        estimated_tokens: int,
+        context_length: int,
+        aggregator_label: str,
+    ) -> None:
+        self.estimated_tokens = estimated_tokens
+        self.context_length = context_length
+        self.aggregator_label = aggregator_label
+        super().__init__(
+            "MoA aggregator input exceeds the context window of this model: "
+            f"estimated request {estimated_tokens:,} tokens > context window "
+            f"{context_length:,} tokens (aggregator={aggregator_label})."
+        )
 
 
 
@@ -139,6 +161,7 @@ def _run_reference(
     """
     label = _slot_label(slot)
     try:
+        ref_messages = _fit_reference_messages_to_slot(slot, ref_messages)
         # Prepend the advisory-role system prompt so the reference understands
         # it is analyzing state for an aggregator, not acting on the task. The
         # trimmed view (_reference_messages) already strips the agent's own
@@ -358,6 +381,150 @@ def _extract_text(response: Any) -> str:
         return ""
 
 
+def _slot_context_length(slot: dict[str, str]) -> int | None:
+    try:
+        from agent.model_metadata import get_model_context_length
+
+        runtime = _slot_runtime(slot)
+        return get_model_context_length(
+            str(runtime.get("model") or slot.get("model") or ""),
+            base_url=str(runtime.get("base_url") or ""),
+            api_key=str(runtime.get("api_key") or ""),
+            provider=str(runtime.get("provider") or slot.get("provider") or ""),
+        )
+    except Exception:
+        logger.debug("MoA slot context budget resolution failed for %s", _slot_label(slot), exc_info=True)
+        return None
+
+
+def _reference_input_target_tokens(context_length: int) -> int:
+    if context_length <= _REFERENCE_MIN_INPUT_BUDGET_TOKENS:
+        return max(1, int(context_length * 0.75))
+    reserve = min(_REFERENCE_OUTPUT_RESERVE_TOKENS, max(0, context_length // 4))
+    return max(_REFERENCE_MIN_INPUT_BUDGET_TOKENS, context_length - reserve)
+
+
+def _reference_request_tokens(messages: list[dict[str, Any]]) -> int:
+    from agent.model_metadata import estimate_request_tokens_rough
+
+    return estimate_request_tokens_rough(
+        [{"role": "system", "content": _REFERENCE_SYSTEM_PROMPT}, *messages]
+    )
+
+
+def _fit_reference_messages_to_slot(
+    slot: dict[str, str],
+    ref_messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    context_length = _slot_context_length(slot)
+    if not context_length:
+        return ref_messages
+
+    target_tokens = _reference_input_target_tokens(context_length)
+    if _reference_request_tokens(ref_messages) <= target_tokens:
+        return ref_messages
+
+    note = {
+        "role": "assistant",
+        "content": (
+            "[Earlier MoA advisory context omitted to fit this reference "
+            "model's context window.]"
+        ),
+    }
+    kept_reversed: list[dict[str, Any]] = []
+    for msg in reversed(ref_messages):
+        candidate = [note, msg, *reversed(kept_reversed)]
+        if _reference_request_tokens(candidate) <= target_tokens:
+            kept_reversed.append(msg)
+
+    fitted = [note, *reversed(kept_reversed)]
+    if len(fitted) > 1:
+        logger.info(
+            "MoA reference context fitted for %s: %d -> %d messages "
+            "(target ~%s tokens, ctx %s)",
+            _slot_label(slot),
+            len(ref_messages),
+            len(fitted),
+            f"{target_tokens:,}",
+            f"{context_length:,}",
+        )
+        return fitted
+
+    latest = ref_messages[-1] if ref_messages else {"role": "user", "content": ""}
+    text = latest.get("content") if isinstance(latest, dict) else ""
+    if not isinstance(text, str):
+        text = str(text or "")
+    trimmed = _trim_reference_text_to_fit(
+        text,
+        role=str(latest.get("role") or "user") if isinstance(latest, dict) else "user",
+        note=note,
+        target_tokens=target_tokens,
+    )
+    return [note, trimmed]
+
+
+def _trim_reference_text_to_fit(
+    text: str,
+    *,
+    role: str,
+    note: dict[str, str],
+    target_tokens: int,
+) -> dict[str, str]:
+    marker = "\n[... truncated to fit reference model context ...]\n"
+    low = 0
+    high = len(text)
+    best = ""
+    while low <= high:
+        keep = (low + high) // 2
+        if keep >= len(text):
+            candidate_text = text
+        else:
+            head = keep // 2
+            tail = keep - head
+            candidate_text = f"{text[:head]}{marker}{text[-tail:] if tail else ''}"
+        candidate = {"role": role if role in {"user", "assistant"} else "user", "content": candidate_text}
+        if _reference_request_tokens([note, candidate]) <= target_tokens:
+            best = candidate_text
+            low = keep + 1
+        else:
+            high = keep - 1
+    return {"role": role if role in {"user", "assistant"} else "user", "content": best}
+
+
+def _latest_user_content(messages: list[dict[str, Any]]) -> str | None:
+    for msg in reversed(messages):
+        if msg.get("role") == "user" and isinstance(msg.get("content"), str):
+            return msg["content"]
+    return None
+
+
+def _aggregator_context_length(aggregator: dict[str, str]) -> int | None:
+    return _slot_context_length(aggregator)
+
+
+def _raise_if_aggregator_context_overflow(
+    *,
+    messages: list[dict[str, Any]],
+    aggregator: dict[str, str],
+    tools: list[dict[str, Any]] | None,
+) -> None:
+    context_length = _aggregator_context_length(aggregator)
+    if not context_length:
+        return
+
+    from agent.model_metadata import estimate_request_tokens_rough
+
+    estimated_tokens = estimate_request_tokens_rough(messages, tools=tools)
+    if estimated_tokens <= context_length:
+        return
+
+    raise MoAAggregatorContextOverflow(
+        estimated_tokens=estimated_tokens,
+        context_length=context_length,
+        aggregator_label=_slot_label(aggregator),
+    )
+
+
 def aggregate_moa_context(
     *,
     user_prompt: str,
@@ -455,6 +622,8 @@ class MoAChatCompletions:
         # for free, without re-firing on a pure no-op re-call.
         self._ref_cache_key: tuple | None = None
         self._ref_cache_outputs: list[tuple[str, str]] = []
+        self._reuse_reference_outputs_after_overflow = False
+        self._overflow_retry_user_content: str | None = None
 
     def _emit(self, event: str, **kwargs: Any) -> None:
         cb = self.reference_callback
@@ -500,9 +669,18 @@ class MoAChatCompletions:
         ).hexdigest()
         _cache_key = (self.preset_name, _sig, tuple(_slot_label(s) for s in reference_models))
         _refs_from_cache = _cache_key == self._ref_cache_key and bool(self._ref_cache_outputs)
+        _latest_user = _latest_user_content(messages)
+        _reuse_after_overflow = (
+            self._reuse_reference_outputs_after_overflow
+            and bool(self._ref_cache_outputs)
+            and _latest_user is not None
+            and _latest_user == self._overflow_retry_user_content
+        )
 
-        if _refs_from_cache:
+        if _refs_from_cache or _reuse_after_overflow:
             reference_outputs = list(self._ref_cache_outputs)
+            if _reuse_after_overflow:
+                self._ref_cache_key = _cache_key
         else:
             reference_outputs = _run_references_parallel(
                 reference_models,
@@ -535,6 +713,9 @@ class MoAChatCompletions:
                     ref_count=_ref_count,
                 )
 
+        if aggregator.get("provider") == "moa":
+            raise RuntimeError("MoA aggregator cannot be another MoA preset")
+        agg_kwargs = dict(api_kwargs)
         agg_messages = [dict(m) for m in messages]
         if reference_outputs:
             joined = "\n\n".join(
@@ -557,9 +738,19 @@ class MoAChatCompletions:
             else:
                 agg_messages.append({"role": "user", "content": guidance})
 
-        if aggregator.get("provider") == "moa":
-            raise RuntimeError("MoA aggregator cannot be another MoA preset")
-        agg_kwargs = dict(api_kwargs)
+        try:
+            _raise_if_aggregator_context_overflow(
+                messages=agg_messages,
+                aggregator=aggregator,
+                tools=agg_kwargs.get("tools"),
+            )
+        except MoAAggregatorContextOverflow:
+            self._reuse_reference_outputs_after_overflow = True
+            self._overflow_retry_user_content = _latest_user
+            raise
+
+        self._reuse_reference_outputs_after_overflow = False
+        self._overflow_retry_user_content = None
         agg_kwargs["messages"] = agg_messages
         # The aggregator is the acting model. Resolve its slot to the provider's
         # real runtime (base_url/api_key/api_mode) and call it through the same

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -423,6 +423,133 @@ moa:
     assert agg_call["tools"] is not None
 
 
+def test_moa_facade_measures_aggregator_context_before_call_and_reuses_references(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent import moa_loop
+    from agent.moa_loop import MoAAggregatorContextOverflow, MoAChatCompletions
+
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 1_000,
+    )
+
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if kwargs["task"] == "moa_reference":
+            return _response("reference advice")
+        return _response("aggregator acted")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+
+    facade = MoAChatCompletions("review")
+    current_user = "what should we do next?"
+    oversized_history = [
+        {"role": "user", "content": "old context " * 8_000},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": current_user},
+    ]
+
+    try:
+        facade.create(messages=oversized_history, tools=[{"type": "function"}])
+    except MoAAggregatorContextOverflow as exc:
+        assert exc.estimated_tokens > exc.context_length
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("expected MoA aggregator preflight overflow")
+
+    assert [c["task"] for c in calls] == ["moa_reference"]
+
+    compressed_history = [
+        {"role": "assistant", "content": "[summary of old context]"},
+        {"role": "user", "content": current_user},
+    ]
+    response = facade.create(messages=compressed_history, tools=[{"type": "function"}])
+
+    assert response.choices[0].message.content == "aggregator acted"
+    assert [c["task"] for c in calls] == ["moa_reference", "moa_aggregator"]
+
+
+def test_moa_reference_context_fits_each_reference_model(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openai-codex
+          model: gpt-small-context
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent import moa_loop
+    from agent.model_metadata import estimate_request_tokens_rough
+    from agent.moa_loop import MoAChatCompletions
+
+    def fake_context_length(model, **_kwargs):
+        if model == "gpt-small-context":
+            return 1_200
+        return 1_000_000
+
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", fake_context_length)
+
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if kwargs["task"] == "moa_reference":
+            return _response("reference advice")
+        return _response("aggregator acted")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+
+    facade = MoAChatCompletions("review")
+    current_user = "this current turn must remain visible to the reference"
+    facade.create(
+        messages=[
+            {"role": "user", "content": "old context " * 8_000},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": current_user},
+        ],
+        tools=[{"type": "function"}],
+    )
+
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    assert estimate_request_tokens_rough(ref_call["messages"]) <= 900
+    joined = "\n".join(m["content"] for m in ref_call["messages"])
+    assert "Earlier MoA advisory context omitted" in joined
+    assert current_user in joined
+    assert [c["task"] for c in calls] == ["moa_reference", "moa_aggregator"]
+
+
 def test_moa_disabled_preset_skips_references(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()


### PR DESCRIPTION
## What does this PR do?

Fixes MoA context handling in two places.

First, each reference model now gets an advisory transcript fitted to that reference slot's own context window. A small reference model can lose older advisory context, but it does not shrink the whole MoA preset or prevent the aggregator from using its larger context window.

Second, the MoA aggregator request is measured after reference outputs are appended and before the aggregator API call is made. If that real request is too large, Hermes raises a context-overflow signal before sending the aggregator request, then the existing compression path compacts the base conversation and retries with the already-collected reference outputs.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/moa_loop.py`
  - Resolves per-slot context windows for MoA references and aggregators.
  - Fits each reference model's advisory view to its own context budget.
  - Measures the fully built aggregator request, including reference outputs, before calling the aggregator.
  - Reuses completed reference outputs when the outer loop compresses and retries the same current user turn.
- `agent/conversation_loop.py`
  - Uses an exception-provided `estimated_tokens` value when context-overflow recovery needs the real measured request size.
- `tests/run_agent/test_moa_loop_mode.py`
  - Adds regression coverage for pre-aggregator overflow measurement/retry behavior.
  - Adds regression coverage for per-reference context fitting.

## How to Test

1. Configure an MoA preset whose aggregator has a larger context window than at least one reference model.
2. Run a long MoA turn where the reference outputs make the final aggregator request exceed the aggregator window.
3. Confirm Hermes compresses through the existing context-overflow path before the aggregator call, then retries without rerunning the completed references.
4. Confirm a small reference model receives a fitted advisory transcript while the aggregator still runs with its own context window.

Focused local checks run:

- `python -m py_compile agent\moa_loop.py agent\conversation_loop.py`
- `python -m pytest tests\run_agent\test_moa_loop_mode.py -k "measures_aggregator_context or reference_context_fits_each_reference_model or references_get_trimmed_messages" -q`
- `git diff --check -- agent\conversation_loop.py agent\moa_loop.py tests\run_agent\test_moa_loop_mode.py`

Note: a full local `tests\run_agent\test_moa_loop_mode.py` run on this Windows checkout still fails during `AIAgent` init because `concurrent_log_handler` is missing locally. The focused MoA regression coverage above passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

Focused test output:

```text
...                                                                      [100%]
3 passed, 16 deselected in 3.22s
```
