### PR TITLE
fix(cli): guard managed uv subprocess calls against OSError on wrong-platform binary

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -112,12 +112,17 @@ def _ensure_uv_path() -> Optional[str]:
     # Verify
     result = resolve_uv()
     if result:
-        version = subprocess.run(
-            [result, "--version"],
-            capture_output=True,
-            text=True,
-            check=False,
-        ).stdout.strip()
+        try:
+            version = subprocess.run(
+                [result, "--version"],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout.strip()
+        except OSError as exc:
+            logger.warning("Managed uv installed but not executable: %s", exc)
+            print(f"  ✗ Managed uv installed but not executable on this platform: {exc}")
+            return None
         print(f"  ✓ Managed uv installed ({version})")
     else:
         print("  ✗ Managed uv install appeared to succeed but binary not found")
@@ -167,19 +172,28 @@ def update_managed_uv() -> Optional[str]:
         # Not installed yet — ensure_uv() will handle that elsewhere.
         return None
 
-    result = subprocess.run(
-        [existing, "self", "update"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode == 0:
-        version = subprocess.run(
-            [existing, "--version"],
+    try:
+        result = subprocess.run(
+            [existing, "self", "update"],
             capture_output=True,
             text=True,
             check=False,
-        ).stdout.strip()
+        )
+    except OSError as exc:
+        # ENOEXEC — binary is not native to the host platform (e.g.
+        # x86-64 Linux ELF on macOS ARM).  Non-fatal: old uv still works.
+        logger.warning("Managed uv not executable on this platform: %s", exc)
+        return None
+    if result.returncode == 0:
+        try:
+            version = subprocess.run(
+                [existing, "--version"],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout.strip()
+        except OSError:
+            version = "unknown"
         print(f"  ✓ Managed uv updated ({version})")
     else:
         # Non-fatal — old uv still works fine.

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -102,6 +102,19 @@ class TestEnsureUv:
             # TestEnsureUvUpdateBoundary for why.
             assert not path
 
+    def test_wrong_platform_binary_returns_none(self, tmp_path):
+        """OSError (ENOEXEC) from a non-native binary after install is non-fatal."""
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv._install_uv") as mock_install:
+            def fake_install(target):
+                _make_executable(target)
+            mock_install.side_effect = fake_install
+            with patch("hermes_cli.managed_uv.subprocess.run",
+                       side_effect=OSError(8, "Exec format error")):
+                from hermes_cli.managed_uv import _ensure_uv_path
+                result = _ensure_uv_path()
+                assert result is None
+
 
 class TestEnsureUvUpdateBoundary:
     """``ensure_uv()`` must answer to both the single-value and the legacy
@@ -228,6 +241,16 @@ class TestUpdateManagedUv:
             result = update_managed_uv()
             # Still returns the path — failure is non-fatal
             assert result == str(tmp_path / "bin" / "uv")
+
+    def test_wrong_platform_binary_returns_none(self, tmp_path):
+        """OSError (ENOEXEC) from a non-native binary is non-fatal."""
+        _make_executable(tmp_path / "bin" / "uv")
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.subprocess.run",
+                   side_effect=OSError(8, "Exec format error")):
+            from hermes_cli.managed_uv import update_managed_uv
+            result = update_managed_uv()
+            assert result is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Guards `update_managed_uv()` and `_ensure_uv_path()` against `OSError` (ENOEXEC) when the managed `uv` binary at `$HERMES_HOME/bin/uv` is not native to the host platform. Previously, a wrong-platform binary (e.g. x86-64 Linux ELF on macOS ARM) would raise `OSError: [Errno 8] Exec format error` from `subprocess.run`, crashing the entire `hermes update` flow. Now the error is caught and handled gracefully — a warning is logged and the function returns `None` (non-fatal), matching the existing error-handling pattern in the module.

## Related Issue

Fixes #55420

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/managed_uv.py`: Wrapped `subprocess.run([existing, "self", "update"], ...)` in `update_managed_uv()` with `try/except OSError` — returns `None` on ENOEXEC (non-fatal)
- `hermes_cli/managed_uv.py`: Wrapped `subprocess.run([existing, "--version"], ...)` in `update_managed_uv()` success path with `try/except OSError` — falls back to `version = "unknown"`
- `hermes_cli/managed_uv.py`: Wrapped `subprocess.run([result, "--version"], ...)` verification in `_ensure_uv_path()` with `try/except OSError` — returns `None` on ENOEXEC
- `tests/hermes_cli/test_managed_uv.py`: Added `test_wrong_platform_binary_returns_none` to `TestUpdateManagedUv` — verifies OSError returns None
- `tests/hermes_cli/test_managed_uv.py`: Added `test_wrong_platform_binary_returns_none` to `TestEnsureUv` — verifies OSError returns None

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_managed_uv.py -q` — all 21 tests should pass
2. The new tests mock `subprocess.run` to raise `OSError(8, "Exec format error")` and verify the functions return `None` instead of crashing
3. On a system with a wrong-platform `uv` binary at `$HERMES_HOME/bin/uv`, `hermes update` should log a warning and continue instead of crashing with a traceback

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — OSError is cross-platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
Traceback (most recent call last):
  File ".../hermes_cli/main.py", line 9594, in _cmd_update_impl
    update_managed_uv()
  File ".../hermes_cli/managed_uv.py", line 170, in update_managed_uv
    result = subprocess.run(
OSError: [Errno 8] Exec format error: '/Users/user/.hermes/bin/uv'
```

After fix: the warning is logged and `hermes update` continues normally.
