### PR TITLE
feat(skills): add --yes/-y flag to hermes skills uninstall

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1711,7 +1711,7 @@ def skills_command(args) -> None:
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))
     elif action == "uninstall":
-        do_uninstall(args.name)
+        do_uninstall(args.name, skip_confirm=getattr(args, "yes", False))
     elif action == "reset":
         do_reset(args.name, restore=getattr(args, "restore", False),
                  skip_confirm=getattr(args, "yes", False))

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -156,6 +156,12 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         "uninstall", help="Remove a hub-installed skill"
     )
     skills_uninstall.add_argument("name", help="Skill name to remove")
+    skills_uninstall.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
 
     skills_reset = skills_subparsers.add_parser(
         "reset",


### PR DESCRIPTION
## Problem or Use Case

`hermes skills install` and `hermes skills reset` both expose a `--yes`/`-y` flag to skip the confirmation prompt for non-interactive use (scripts, CI, TUI mode). `hermes skills uninstall` is missing this flag, which is a blocker to automate uninstalling a skill.

## Proposed Solution

Add `--yes`/`-y` to `hermes skills uninstall`, matching the existing pattern on `install` and `reset`.

```bash
hermes skills uninstall my-skill --yes   # skip confirmation
hermes skills uninstall my-skill -y      # short form
hermes skills uninstall my-skill         # still prompts (unchanged)
```

## Implementation

`do_uninstall` in `hermes_cli/skills_hub.py` already accepted a `skip_confirm: bool = False` parameter, and the `/skills uninstall` slash command already passed `skip_confirm=True`. The CLI argparse path simply never wired up the flag.

Two files changed:
- `hermes_cli/subcommands/skills.py` — add `--yes`/`-y` to the `uninstall` subparser
- `hermes_cli/skills_hub.py` — pass `skip_confirm=args.yes` in `skills_command`

## Feature Type

CLI improvement

## Scope

Small (single file, < 50 lines)