### PR TITLE
fix: pass through reasoning_effort for custom/vLLM/Ollama providers (#55276)

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -30,12 +30,19 @@ class CustomProfile(ProviderProfile):
             options["num_ctx"] = ollama_num_ctx
             extra_body["options"] = options
 
-        # Disable thinking when reasoning is turned off
+        # Reasoning / thinking support for custom providers (vLLM, Ollama, etc.)
         if reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
                 extra_body["think"] = False
+            else:
+                # Pass through thinking enabled — vLLM/Ollama use this to
+                # enable chain-of-thought reasoning on compatible models.
+                extra_body["think"] = True
+                # Pass through effort level if specified
+                if _effort and _effort not in ("none", ""):
+                    extra_body["reasoning_effort"] = _effort
 
         return extra_body, {}
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4989,6 +4989,11 @@ class AIAgent:
             opts = self._lmstudio_reasoning_options_cached()
             # "off-only" (or absent) means no real reasoning capability.
             return any(opt and opt != "off" for opt in opts)
+        # Custom/vLLM/Ollama providers: pass through reasoning if user
+        # explicitly configured it.  The CustomProfile.build_api_kwargs_extras()
+        # handles the wire format (think=True/False + reasoning_effort).
+        if (self.provider or "").strip().lower() in ("custom", "ollama", "vllm", "local"):
+            return True
         if "openrouter" not in self._base_url_lower:
             return False
         if "api.mistral.ai" in self._base_url_lower:


### PR DESCRIPTION
## What does this PR do?

Fixes #55276 — enables reasoning control for custom providers (vLLM, Ollama, local models) by passing through `reasoning_effort` config instead of silently dropping it.

## Related Issue

Fixes #55276

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

### 1. `CustomProfile.build_api_kwargs_extras()`
When reasoning is enabled, now sends:
- `think=True` (vLLM/Ollama convention for enabling chain-of-thought)
- `reasoning_effort=<level>` (pass through low/medium/high/xhigh)

Previously only `think=False` was sent when reasoning was disabled.

### 2. `_supports_reasoning_extra_body()`
Added check for custom/ollama/vllm local providers so reasoning `extra_body` is not gated out by the OpenRouter domain check.

## How to Test

1. Configure a custom provider with reasoning:
   ```yaml
   provider: custom
   base_url: http://localhost:8000/v1
   agent:
     reasoning_effort: high
   ```
2. Verify the API call includes `think=True` and `reasoning_effort=high`

## Platforms Tested

- [x] Windows 11