### PR TITLE
fix(agent): deduplicate tool responses for same tool_call_id

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -408,6 +408,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             tc_id = msg.get("tool_call_id")
             if tc_id and tc_id in known_tool_ids:
                 filtered.append(msg)
+                known_tool_ids.discard(tc_id)
             else:
                 repairs += 1
         else:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3513,7 +3513,7 @@ class SessionDB:
             content = self._decode_content(row["content"])
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
-            msg = {"role": row["role"], "content": content}
+            msg = {"role": row["role"], "content": content, "_flushed_to_db": True}
             if row["timestamp"]:
                 msg["timestamp"] = row["timestamp"]
             if row["tool_call_id"]:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3179,6 +3179,7 @@ class SessionDB:
         result = []
         for row in rows:
             msg = dict(row)
+            msg["_flushed_to_db"] = True
             if "content" in msg:
                 msg["content"] = self._decode_content(msg["content"])
             if msg.get("tool_calls"):

--- a/run_agent.py
+++ b/run_agent.py
@@ -1676,6 +1676,8 @@ class AIAgent:
             for msg in messages:
                 if not isinstance(msg, dict):
                     continue
+                if msg.get("_flushed_to_db"):
+                    continue
                 msg_id = id(msg)
                 if msg_id in flushed_ids:
                     continue
@@ -1722,6 +1724,7 @@ class AIAgent:
                     timestamp=msg.get("timestamp"),
                 )
                 flushed_ids.add(msg_id)
+                msg["_flushed_to_db"] = True
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -298,3 +298,25 @@ def test_flush_guard_clamps_overshooting_cursor():
 
     # min(5, 2) = 2 → nothing skipped below start_idx, cursor settles at 2
     assert agent._last_flushed_db_idx == 2
+
+
+def test_repair_message_sequence_deduplicates_tool_call_ids():
+    """Duplicate tool response messages for the same tool_call_id should be dropped."""
+    from agent.agent_runtime_helpers import repair_message_sequence
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "run the tools"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_1", "function": {"name": "test", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "res1"},
+        {"role": "tool", "tool_call_id": "call_1", "content": "res1 duplicate"},
+    ]
+    repairs = repair_message_sequence(agent, messages)
+    assert repairs == 1
+    assert len(messages) == 3
+    assert messages[0] == {"role": "user", "content": "run the tools"}
+    assert messages[1]["role"] == "assistant"
+    assert messages[2] == {"role": "tool", "tool_call_id": "call_1", "content": "res1"}


### PR DESCRIPTION
## What does this PR do?

This PR fixes:
1. A critical 400 Bad Request error returned by strict API providers (like DeepSeek) when a conversation history contains duplicate tool responses for the same `tool_call_id` (e.g. from retries, crashes, or session-resume glitches). https://github.com/NousResearch/hermes-agent/issues/55442 
2. The root-cause **duplicate-write bug (#860)** where incremental database flushes from `tool_executor.py` write duplicate rows for the entire conversation history during asynchronous/gateway execution.

## Related Issue

Relates to session poisoning, duplicate database writes (#860), and HTTP 400 errors caused by malformed history.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- **Sequence Pruning**: Updated `repair_message_sequence` in `agent/agent_runtime_helpers.py` to discard `tool_call_id`s from the active list once they've been matched (first-seen wins).
- **Deduplicated DB Writes**: Added a stateful tracking property (`msg["_flushed_to_db"] = True`) to dictionary objects in `run_agent.py` and `hermes_state.py` to ensure already-persisted messages are never double-inserted during incremental flushes.
- **Regression Tests**: Added `test_repair_message_sequence_deduplicates_tool_call_ids` to `tests/run_agent/test_message_sequence_repair.py`.

## How to Test

You can verify the sequence repair change by running:
```bash
venv/bin/pytest tests/run_agent/test_message_sequence_repair.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
