### PR TITLE
fix(sanitize): strip empty tool message name for strict providers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2084,17 +2084,25 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 for tc in msg.get("tool_calls") or []:
                     cid = _ra().AIAgent._get_tool_call_id_static(tc)
                     if cid in missing_results:
-                        patched.append({
+                        stub: Dict[str, Any] = {
                             "role": "tool",
-                            "name": _ra().AIAgent._get_tool_call_name_static(tc),
                             "content": "[Result unavailable — see context summary above]",
                             "tool_call_id": cid,
-                        })
+                        }
+                        tool_name = _ra().AIAgent._get_tool_call_name_static(tc)
+                        if tool_name:
+                            stub["name"] = tool_name
+                        patched.append(stub)
         messages = patched
         _ra().logger.debug(
             "Pre-call sanitizer: added %d stub tool result(s)",
             len(missing_results),
         )
+    # 3. Strip empty 'name' fields from tool messages.
+    #    Some providers (PackyAPI/GPT-5.5) reject name="" with HTTP 400.
+    for msg in messages:
+        if msg.get("role") == "tool" and msg.get("name") == "":
+            del msg["name"]
     return messages
 
 


### PR DESCRIPTION
PackyAPI's GPT-5.5 validates the optional  field on messages strictly and rejects empty strings with HTTP 400 ("Invalid input[N].name: empty string"), while OpenAI/Anthropic tolerate it.

The pre-call sanitizer in sanitize_api_messages injects stub tool results for compressed context with  from
_get_tool_call_name_static(), which returns "" as a best-effort fallback. These empty names trip PackyAPI.

Two changes:
1. Conditionally include  only when non-empty during stub injection (matches the existing pattern in context_compressor.py which omits it)
2. Add a safety-net strip at the end of sanitize_api_messages to drop empty  fields from ALL tool messages — catches any other path

Diagnosed and fixed by: 艾玛 (DeepSeek V4 Pro), Hermes AI assistant
  running on Akivilyan's VPS
Debugging credit: cross-referenced request dumps in
  ~/.hermes/sessions/request_dump_*.json

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

