### PR TITLE
fix(bedrock): normalize image format for Converse API (#55429)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -528,9 +528,17 @@ def _convert_content_to_converse(content) -> List[Dict]:
                         mime_part = header[5:].split(";")[0]
                         if mime_part:
                             media_type = mime_part
+                    # Bedrock Converse only accepts {png, jpeg, gif, webp}.
+                    # Normalize common aliases (jpg → jpeg) and validate.
+                    _CONVERSE_FORMATS = {"png", "jpeg", "gif", "webp"}
+                    raw_fmt = media_type.split("/")[-1].lower() if "/" in media_type else "jpeg"
+                    _FORMAT_ALIASES = {"jpg": "jpeg", "jpe": "jpeg", "jfif": "jpeg", "pjpeg": "jpeg"}
+                    fmt = _FORMAT_ALIASES.get(raw_fmt, raw_fmt)
+                    if fmt not in _CONVERSE_FORMATS:
+                        fmt = "jpeg"
                     blocks.append({
                         "image": {
-                            "format": media_type.split("/")[-1] if "/" in media_type else "jpeg",
+                            "format": fmt,
                             "source": {"bytes": data},
                         }
                     })

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1712,3 +1712,54 @@ class TestRequireBoto3VersionCheck:
         with patch.dict("sys.modules", {"boto3": fake_boto3}):
             result = _require_boto3()
             assert result is fake_boto3
+
+    def test_image_jpg_normalized_to_jpeg(self):
+        """image/jpg (non-standard) should normalize to jpeg for Bedrock Converse."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this"},
+                {"type": "image_url", "image_url": {
+                    "url": "data:image/jpg;base64,/9j/4AAQ",
+                }},
+            ],
+        }]
+        _, msgs = convert_messages_to_converse(messages)
+        image_blocks = [b for b in msgs[0]["content"] if "image" in b]
+        assert len(image_blocks) == 1
+        assert image_blocks[0]["image"]["format"] == "jpeg"
+
+    def test_unsupported_image_format_defaults_to_jpeg(self):
+        """Unsupported formats (svg, tiff) should default to jpeg."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        for mime in ("image/svg+xml", "image/x-icon", "image/tiff"):
+            messages = [{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {
+                        "url": f"data:{mime};base64,QUJD",
+                    }},
+                ],
+            }]
+            _, msgs = convert_messages_to_converse(messages)
+            image_blocks = [b for b in msgs[0]["content"] if "image" in b]
+            assert len(image_blocks) == 1, f"Expected 1 image block for {mime}"
+            assert image_blocks[0]["image"]["format"] == "jpeg", f"Expected jpeg for {mime}"
+
+    def test_supported_formats_preserved(self):
+        """Supported formats (png, jpeg, gif, webp) should pass through."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        for fmt in ("png", "jpeg", "gif", "webp"):
+            messages = [{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {
+                        "url": f"data:image/{fmt};base64,QUJD",
+                    }},
+                ],
+            }]
+            _, msgs = convert_messages_to_converse(messages)
+            image_blocks = [b for b in msgs[0]["content"] if "image" in b]
+            assert len(image_blocks) == 1
+            assert image_blocks[0]["image"]["format"] == fmt, f"Expected {fmt} preserved"


### PR DESCRIPTION
## What does this PR do?

Normalizes the image format sent to Bedrock Converse API. The previous code forwarded the raw MIME subtype (e.g., `"jpg"` from `image/jpg`), but Bedrock Converse only accepts `{png, jpeg, gif, webp}`. Common non-standard labels like `image/jpg` (emitted by many pasteboards and image tools) produced `"jpg"` which Converse rejects with a `ValidationException`.

## Related Issue

Fixes #55429

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py`: Added format normalization before building the Converse image block — maps `jpg`/`jpe`/`jfif`/`pjpeg` → `jpeg`, validates against `{png, jpeg, gif, webp}`, defaults to `jpeg` for unsupported formats (e.g., `svg+xml`, `tiff`).
- `tests/agent/test_bedrock_adapter.py`: Added 3 regression tests:
  - `test_image_jpg_normalized_to_jpeg`: `image/jpg` → `"jpeg"`
  - `test_unsupported_image_format_defaults_to_jpeg`: `svg+xml`, `x-icon`, `tiff` → `"jpeg"`
  - `test_supported_formats_preserved`: `png`, `jpeg`, `gif`, `webp` pass through unchanged

## How to Test

1. Run `python -m pytest tests/agent/test_bedrock_adapter.py -q` — all 135 tests should pass (132 existing + 3 new)
2. Verify the format normalization logic:
   - `image/jpg` → `jpeg` (was `"jpg"`, rejected by Converse)
   - `image/svg+xml` → `jpeg` (was `"svg+xml"`, rejected)
   - `image/jpeg` → `jpeg` (unchanged, was already correct)
   - `image/png` → `png` (unchanged)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — pure normalization logic with no visual change.
