### PR TITLE
fix(anthropic): normalize image media_type for Messages API (#55432)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1694,6 +1694,13 @@ def _image_source_from_openai_url(url: str) -> Dict[str, str]:
             mime_part = header[len("data:"):].split(";", 1)[0].strip()
             if mime_part.startswith("image/"):
                 media_type = mime_part
+        # Anthropic Messages API only accepts {image/jpeg, image/png, image/gif, image/webp}.
+        # Normalize common aliases and validate.
+        _ANTHROPIC_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+        if media_type not in _ANTHROPIC_IMAGE_TYPES:
+            _TYPE_ALIASES = {"image/jpg": "image/jpeg", "image/jpe": "image/jpeg",
+                             "image/jfif": "image/jpeg", "image/pjpeg": "image/jpeg"}
+            media_type = _TYPE_ALIASES.get(media_type, "image/jpeg")
         return {
             "type": "base64",
             "media_type": media_type,

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -2313,3 +2313,29 @@ class TestConvertToolsToAnthropicDedup:
 
     def test_none_tools_returns_empty(self):
         assert convert_tools_to_anthropic(None) == []
+
+
+class TestImageSourceFormatNormalization:
+    """Regression tests for #55432: image/jpg normalization in Anthropic adapter."""
+
+    def test_jpg_normalized_to_jpeg(self):
+        from agent.anthropic_adapter import _image_source_from_openai_url
+        result = _image_source_from_openai_url("data:image/jpg;base64,QUJD")
+        assert result["media_type"] == "image/jpeg"
+
+    def test_unsupported_format_defaults_to_jpeg(self):
+        from agent.anthropic_adapter import _image_source_from_openai_url
+        for mime in ("image/svg+xml", "image/x-icon", "image/tiff"):
+            result = _image_source_from_openai_url(f"data:{mime};base64,QUJD")
+            assert result["media_type"] == "image/jpeg", f"Expected image/jpeg for {mime}"
+
+    def test_supported_formats_preserved(self):
+        from agent.anthropic_adapter import _image_source_from_openai_url
+        for fmt in ("image/jpeg", "image/png", "image/gif", "image/webp"):
+            result = _image_source_from_openai_url(f"data:{fmt};base64,QUJD")
+            assert result["media_type"] == fmt, f"Expected {fmt} preserved"
+
+    def test_data_url_with_params(self):
+        from agent.anthropic_adapter import _image_source_from_openai_url
+        result = _image_source_from_openai_url("data:image/jpg;charset=utf-8;base64,QUJD")
+        assert result["media_type"] == "image/jpeg"


### PR DESCRIPTION
## What does this PR do?

Normalizes the `media_type` sent to Anthropic Messages API in `_image_source_from_openai_url()`. The previous code forwarded the raw MIME subtype from data URLs verbatim, but Anthropic only accepts `{image/jpeg, image/png, image/gif, image/webp}`. Common non-standard labels like `image/jpg` (emitted by browsers, pasteboards, and many tools) were rejected with a 400 error.

## Related Issue

Fixes #55432

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py`: Added format normalization in `_image_source_from_openai_url()` — maps `image/jpg`/`jpe`/`jfif`/`pjpeg` → `image/jpeg`, defaults unsupported types (e.g., `svg+xml`) to `image/jpeg`.
- `tests/agent/test_anthropic_adapter.py`: Added 4 regression tests:
  - `test_jpg_normalized_to_jpeg`: `image/jpg` → `image/jpeg`
  - `test_unsupported_format_defaults_to_jpeg`: `svg+xml`, `x-icon`, `tiff` → `image/jpeg`
  - `test_supported_formats_preserved`: `jpeg`, `png`, `gif`, `webp` pass through unchanged
  - `test_data_url_with_params`: `image/jpg` with charset param normalizes correctly

## How to Test

1. Run `python -m pytest tests/agent/test_anthropic_adapter.py -q -k "ImageSource"` — 4/4 tests should pass
2. Verify the normalization logic:
   - `image/jpg` → `image/jpeg` (was passed verbatim, rejected by Anthropic)
   - `image/svg+xml` → `image/jpeg` (was passed verbatim, rejected)
   - `image/jpeg` → `image/jpeg` (unchanged)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/agent/test_anthropic_adapter.py -q` — 168 pass, 3 pre-existing failures in `TestRunOauthSetupToken` (unrelated)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] N/A — no docs, config, architecture, cross-platform, or tool schema changes

## Screenshots / Logs

N/A — pure normalization logic.
