### PR TITLE
fix: respect config.yaml enabled:false for HomeAssistant/Email/SMS (#55113)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2080,11 +2080,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Home Assistant
     hass_token = getenv("HASS_TOKEN")
     if hass_token:
-        if Platform.HOMEASSISTANT not in config.platforms:
-            config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
-        hass_url = getenv("HASS_URL")
+        hass_config = _enable_from_env(Platform.HOMEASSISTANT)
+        hass_config.token = hass_token
+        hass_url = os.getenv("HASS_URL")
         if hass_url:
             config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
 
@@ -2094,10 +2092,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_imap = getenv("EMAIL_IMAP_HOST")
     email_smtp = getenv("EMAIL_SMTP_HOST")
     if all([email_addr, email_pwd, email_imap, email_smtp]):
-        if Platform.EMAIL not in config.platforms:
-            config.platforms[Platform.EMAIL] = PlatformConfig()
-        config.platforms[Platform.EMAIL].enabled = True
-        config.platforms[Platform.EMAIL].extra.update({
+        email_config = _enable_from_env(Platform.EMAIL)
+        email_config.extra.update({
             "address": email_addr,
             "imap_host": email_imap,
             "smtp_host": email_smtp,
@@ -2114,11 +2110,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # SMS (Twilio)
     twilio_sid = getenv("TWILIO_ACCOUNT_SID")
     if twilio_sid:
-        if Platform.SMS not in config.platforms:
-            config.platforms[Platform.SMS] = PlatformConfig()
-        config.platforms[Platform.SMS].enabled = True
-        config.platforms[Platform.SMS].api_key = getenv("TWILIO_AUTH_TOKEN", "")
-    sms_home = getenv("SMS_HOME_CHANNEL")
+        sms_config = _enable_from_env(Platform.SMS)
+        sms_config.api_key = os.getenv("TWILIO_AUTH_TOKEN", "")
+    sms_home = os.getenv("SMS_HOME_CHANNEL")
     if sms_home and Platform.SMS in config.platforms:
         config.platforms[Platform.SMS].home_channel = HomeChannel(
             platform=Platform.SMS,


### PR DESCRIPTION
## What does this PR do?

Fixes #55113 — HomeAssistant, Email, and SMS platforms unconditionally set `enabled=True` when their env vars are present, even if the user explicitly disabled them in `config.yaml` (`platforms.*.enabled: false`).

## Related Issue

Fixes #55113

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

Applied the same `_enable_from_env()` pattern already used by Telegram and Slack, which checks the `_enabled_explicit` marker before enabling:

- **HomeAssistant**: `HASS_TOKEN` env var now respects `platforms.homeassistant.enabled: false`
- **Email**: `EMAIL_ADDRESS` + credentials now respect `platforms.email.enabled: false`
- **SMS**: `TWILIO_SID` env var now respect `platforms.sms.enabled: false`

## How to Test

1. Set `platforms.homeassistant.enabled: false` in config.yaml
2. Set `HASS_TOKEN` in environment
3. Verify HomeAssistant gateway platform is NOT enabled

## Platforms Tested

- [x] Windows 11