### PR TITLE
fix: preserve Anthropic provider identity in MoA

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -99,7 +99,7 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
         # provider-backed targets whose provider branch adds auth refresh,
         # request metadata, or request-shape adapters. Keep those providers
         # identified by name.
-        if resolved_provider in {"nous", "openai-codex", "xai-oauth"}:
+        if resolved_provider in {"nous", "openai-codex", "xai-oauth", "anthropic"}:
             return out
         # Pass the resolved endpoint through so call_llm builds the request for
         # the provider's actual API surface instead of auto-detecting. base_url

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -198,6 +198,32 @@ def test_moa_codex_slot_preserves_provider_identity(monkeypatch):
     assert rt == {"provider": "openai-codex", "model": "gpt-5.5"}
 
 
+def test_moa_anthropic_slot_preserves_provider_identity(monkeypatch):
+    """Anthropic slots must not become custom chat-completions endpoints.
+
+    call_llm treats explicit base_url as provider=custom. For Anthropic and
+    Anthropic-compatible providers this loses the Messages API adapter and can
+    send the request to the wrong path.
+    """
+    from agent import moa_loop
+
+    def fake_resolve(*, requested, target_model=None):
+        return {
+            "provider": requested,
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "test-token",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve
+    )
+
+    rt = moa_loop._slot_runtime({"provider": "anthropic", "model": "claude-sonnet-4"})
+
+    assert rt == {"provider": "anthropic", "model": "claude-sonnet-4"}
+
+
 def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     """A slot whose provider can't be resolved still attempts the call with the
     bare provider/model rather than aborting the whole MoA turn."""


### PR DESCRIPTION
## Summary

MoA reference/aggregator slots currently resolve provider runtime metadata with `resolve_runtime_provider()`. For providers whose resolved runtime includes a `base_url`, `_slot_runtime()` passes that `base_url` into `call_llm()`.

`call_llm()` treats an explicit `base_url` as a custom endpoint. That is correct for generic OpenAI-compatible custom endpoints, but it is wrong for first-class providers whose provider branch supplies a protocol adapter or special auth behavior.

This was already handled for `nous`, `openai-codex`, and `xai-oauth`. This PR adds `anthropic` to the same provider-identity-preserving path so MoA Anthropic slots continue through the Anthropic Messages adapter instead of being treated as custom chat-completions endpoints.

## Why

Without this, an Anthropic MoA slot can be downgraded into a custom chat-completions call. On Anthropic Messages-compatible endpoints this can route to the wrong wire protocol/path and fail before the aggregator receives useful reference output.

## Change

- Preserve provider identity for `anthropic` in `agent.moa_loop._slot_runtime()`.
- Add a regression test ensuring Anthropic MoA slots do not return `base_url`/`api_key` runtime kwargs and therefore do not force `call_llm()` into the custom endpoint path.

## Validation

```bash
python -m pytest \
  tests/run_agent/test_moa_loop_mode.py::test_moa_codex_slot_preserves_provider_identity \
  tests/run_agent/test_moa_loop_mode.py::test_moa_anthropic_slot_preserves_provider_identity \
  tests/run_agent/test_moa_loop_mode.py::test_moa_slots_routed_through_resolve_runtime_provider \
  -q
```

Result:

```text
3 passed
```
