### PR TITLE
[codex] Make Mattermost post length configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -280,6 +280,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "HERMES_TOOL_PROGRESS", "HERMES_TOOL_PROGRESS_MODE",
     "WHATSAPP_MODE", "WHATSAPP_ENABLED",
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL_NAME", "MATTERMOST_REPLY_MODE",
+    "MATTERMOST_MAX_POST_LENGTH",
     "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
     "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD", "MATRIX_DM_AUTO_THREAD",
     "MATRIX_RECOVERY_KEY",
@@ -2244,6 +2245,7 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        "max_post_length": 4000,        # Max characters per Mattermost post chunk
         "channel_prompts": {},         # Per-channel ephemeral system prompts
     },
 
@@ -3669,6 +3671,13 @@ OPTIONAL_ENV_VARS = {
     "MATTERMOST_FREE_RESPONSE_CHANNELS": {
         "description": "Comma-separated Mattermost channel IDs where bot responds without @mention",
         "prompt": "Free-response channel IDs (comma-separated)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "MATTERMOST_MAX_POST_LENGTH": {
+        "description": "Maximum characters per Mattermost post chunk (default: 4000, range: 1000-60000)",
+        "prompt": "Maximum Mattermost post length",
         "url": None,
         "password": False,
         "category": "messaging",

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -32,9 +32,57 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
-# Mattermost post size limit (server default is 16383, but 4000 is the
-# practical limit for readable messages — matching OpenClaw's choice).
-MAX_POST_LENGTH = 4000
+# Mattermost post size limit. Keep the historic default conservative and
+# readable, while allowing self-hosted instances to opt into larger posts.
+DEFAULT_MAX_POST_LENGTH = 4000
+MIN_MAX_POST_LENGTH = 1000
+MAX_CONFIGURABLE_POST_LENGTH = 60000
+MAX_POST_LENGTH_ENV = "MATTERMOST_MAX_POST_LENGTH"
+
+
+def get_max_post_length() -> int:
+    """Return the configured Mattermost post chunk size.
+
+    The environment variable is intentionally bounded: Mattermost instances can
+    have different payload limits, and very large chat posts are hard to edit or
+    render. Invalid values fall back to the historic 4000-character default.
+    """
+    raw_value = os.getenv(MAX_POST_LENGTH_ENV, "").strip()
+    if not raw_value:
+        return DEFAULT_MAX_POST_LENGTH
+
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an integer; using default %d",
+            MAX_POST_LENGTH_ENV,
+            raw_value,
+            DEFAULT_MAX_POST_LENGTH,
+        )
+        return DEFAULT_MAX_POST_LENGTH
+
+    if value < MIN_MAX_POST_LENGTH:
+        logger.warning(
+            "%s=%d is below the minimum %d; using default %d",
+            MAX_POST_LENGTH_ENV,
+            value,
+            MIN_MAX_POST_LENGTH,
+            DEFAULT_MAX_POST_LENGTH,
+        )
+        return DEFAULT_MAX_POST_LENGTH
+
+    if value > MAX_CONFIGURABLE_POST_LENGTH:
+        logger.warning(
+            "%s=%d is above the maximum %d; clamping to %d",
+            MAX_POST_LENGTH_ENV,
+            value,
+            MAX_CONFIGURABLE_POST_LENGTH,
+            MAX_CONFIGURABLE_POST_LENGTH,
+        )
+        return MAX_CONFIGURABLE_POST_LENGTH
+
+    return value
 
 # Channel type codes returned by the Mattermost API.
 _CHANNEL_TYPE_MAP = {
@@ -71,7 +119,7 @@ def check_mattermost_requirements() -> bool:
 class MattermostAdapter(BasePlatformAdapter):
     """Gateway adapter for Mattermost (self-hosted or cloud)."""
 
-    splits_long_messages = True  # send() chunks via truncate_message(MAX_POST_LENGTH)
+    splits_long_messages = True  # send() chunks via truncate_message(self.max_post_length)
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.MATTERMOST)
@@ -100,6 +148,9 @@ class MattermostAdapter(BasePlatformAdapter):
 
         self._last_post_status: Optional[int] = None
         self._last_post_error: str = ""
+        self.max_post_length = get_max_post_length()
+        # StreamConsumer reads MAX_MESSAGE_LENGTH directly from adapters.
+        self.MAX_MESSAGE_LENGTH = self.max_post_length
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
@@ -342,7 +393,7 @@ class MattermostAdapter(BasePlatformAdapter):
             return SendResult(success=True)
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, MAX_POST_LENGTH)
+        chunks = self.truncate_message(formatted, self.max_post_length)
 
         last_id = None
         for chunk in chunks:
@@ -1172,8 +1223,9 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
 
     The MattermostAdapter reads its runtime configuration via
     ``os.getenv()`` for ``MATTERMOST_REQUIRE_MENTION``,
-    ``MATTERMOST_FREE_RESPONSE_CHANNELS``, and
-    ``MATTERMOST_ALLOWED_CHANNELS``.  Rather than rewrite those call sites
+    ``MATTERMOST_FREE_RESPONSE_CHANNELS``,
+    ``MATTERMOST_ALLOWED_CHANNELS``, and ``MATTERMOST_MAX_POST_LENGTH``.
+    Rather than rewrite those call sites
     to read from ``PlatformConfig.extra``, this hook keeps the env-driven
     model and merely owns the YAML→env translation here, next to the
     adapter that consumes it.
@@ -1196,6 +1248,9 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
+    mpl = mattermost_cfg.get("max_post_length")
+    if mpl is not None and not os.getenv(MAX_POST_LENGTH_ENV):
+        os.environ[MAX_POST_LENGTH_ENV] = str(mpl)
     return None  # all settings flow through env; nothing to merge into extras
 
 
@@ -1260,10 +1315,10 @@ def register(ctx) -> None:
         # adapter" when cron runs separately from the gateway.  Mirrors
         # the Discord / Teams pattern.
         standalone_sender_fn=_standalone_send,
-        # Mattermost practical post-length limit (server default is 16383
-        # but 4000 is the readable threshold the adapter has used since
-        # day one).
-        max_message_length=MAX_POST_LENGTH,
+        # Mattermost practical post-length limit. Defaults to the historic
+        # 4000-character readable threshold, configurable for self-hosted
+        # deployments via MATTERMOST_MAX_POST_LENGTH / config.yaml.
+        max_message_length=get_max_post_length(),
         # Display
         emoji="💬",
         allow_update_command=True,

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -47,3 +47,7 @@ optional_env:
     description: "If set, the bot only responds in these channels (whitelist)."
     prompt: "Allowed channel IDs (comma-separated)"
     password: false
+  - name: MATTERMOST_MAX_POST_LENGTH
+    description: "Maximum characters per Mattermost post chunk. Default: 4000. Range: 1000-60000."
+    prompt: "Maximum Mattermost post length"
+    password: false

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -199,6 +199,87 @@ def _make_adapter():
     return adapter
 
 
+class TestMattermostMaxPostLength:
+    def test_default_max_post_length(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_MAX_POST_LENGTH", raising=False)
+
+        from plugins.platforms.mattermost.adapter import get_max_post_length
+
+        adapter = _make_adapter()
+        assert get_max_post_length() == 4000
+        assert adapter.max_post_length == 4000
+        assert adapter.MAX_MESSAGE_LENGTH == 4000
+
+    def test_env_override_max_post_length(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_MAX_POST_LENGTH", "12000")
+
+        from plugins.platforms.mattermost.adapter import get_max_post_length
+
+        adapter = _make_adapter()
+        assert get_max_post_length() == 12000
+        assert adapter.max_post_length == 12000
+        assert adapter.MAX_MESSAGE_LENGTH == 12000
+
+    def test_invalid_max_post_length_uses_default(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_MAX_POST_LENGTH", "not-a-number")
+
+        from plugins.platforms.mattermost.adapter import get_max_post_length
+
+        assert get_max_post_length() == 4000
+
+    def test_too_small_max_post_length_uses_default(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_MAX_POST_LENGTH", "999")
+
+        from plugins.platforms.mattermost.adapter import get_max_post_length
+
+        assert get_max_post_length() == 4000
+
+    def test_too_large_max_post_length_is_clamped(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_MAX_POST_LENGTH", "999999")
+
+        from plugins.platforms.mattermost.adapter import get_max_post_length
+
+        assert get_max_post_length() == 60000
+
+    def test_yaml_max_post_length_sets_env(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_MAX_POST_LENGTH", raising=False)
+
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        _apply_yaml_config({}, {"max_post_length": 12000})
+
+        assert os.environ["MATTERMOST_MAX_POST_LENGTH"] == "12000"
+
+    def test_env_max_post_length_takes_precedence_over_yaml(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_MAX_POST_LENGTH", "16000")
+
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        _apply_yaml_config({}, {"max_post_length": 12000})
+
+        assert os.environ["MATTERMOST_MAX_POST_LENGTH"] == "16000"
+
+    def test_send_uses_configured_max_post_length(self, monkeypatch):
+        import asyncio
+
+        monkeypatch.setenv("MATTERMOST_MAX_POST_LENGTH", "12000")
+        adapter = _make_adapter()
+        sent_messages = []
+
+        async def fake_post(_chat_id, payload, _metadata):
+            sent_messages.append(payload["message"])
+            return {"id": f"post_{len(sent_messages)}"}
+
+        adapter._post_preserving_thread = AsyncMock(side_effect=fake_post)
+        adapter._thread_root_for_send = AsyncMock(return_value=None)
+
+        result = asyncio.run(adapter.send("chan_123", "x" * 9000))
+
+        assert result.success is True
+        assert len(sent_messages) == 1
+        assert sent_messages[0] == "x" * 9000
+
+
 class TestMattermostFormatMessage:
     def setup_method(self):
         self.adapter = _make_adapter()

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -406,6 +406,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
+| `MATTERMOST_MAX_POST_LENGTH` | Maximum characters per Mattermost post chunk (default: `4000`, range: `1000`-`60000`) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |
 | `MATRIX_USER_ID` | Matrix user ID (e.g. `@hermes:matrix.org`) — required for password login, optional with access token |

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -155,6 +155,9 @@ MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c
 
 # Optional: channels where bot responds without @mention (comma-separated channel IDs)
 # MATTERMOST_FREE_RESPONSE_CHANNELS=channel_id_1,channel_id_2
+
+# Optional: maximum characters per Mattermost post chunk (default: 4000)
+# MATTERMOST_MAX_POST_LENGTH=12000
 ```
 
 Optional behavior settings in `~/.hermes/config.yaml`:
@@ -220,6 +223,7 @@ By default, the bot only responds in channels when `@mentioned`. You can change 
 |----------|---------|-------------|
 | `MATTERMOST_REQUIRE_MENTION` | `true` | Set to `false` to respond to all messages in channels (DMs always work). |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | _(none)_ | Comma-separated channel IDs where the bot responds without `@mention`, even when require_mention is true. |
+| `MATTERMOST_MAX_POST_LENGTH` | `4000` | Maximum characters per Mattermost post chunk. Values below `1000` are ignored; values above `60000` are clamped. |
 
 To find a channel ID in Mattermost: open the channel, click the channel name header, and look for the ID in the URL or channel details.
 
@@ -251,6 +255,27 @@ Behavior:
 - Find a channel ID via the Mattermost UI → channel header → "View Info", or read it from the channel URL.
 
 See also: [admin/user slash command split](../../reference/slash-commands.md#permissions-and-adminuser-split).
+
+## Long replies (`max_post_length`)
+
+By default, Hermes splits Mattermost replies into 4000-character chunks. This
+keeps chat messages readable and avoids API limits on many installations. If
+your self-hosted Mattermost server accepts larger posts, you can raise the chunk
+size:
+
+```yaml
+mattermost:
+  max_post_length: 12000
+```
+
+Or via env var:
+
+```bash
+MATTERMOST_MAX_POST_LENGTH=12000
+```
+
+Valid values are `1000` through `60000`. Invalid values fall back to the
+default. Values above `60000` are clamped to `60000`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Add `MATTERMOST_MAX_POST_LENGTH` to configure Mattermost post chunk size.
- Wire config.yaml `mattermost.max_post_length` through to the adapter while keeping environment variables authoritative.
- Document the new setting and cover defaults, validation, clamping, and sending long messages in tests.

## Why
The Mattermost adapter previously split messages at a hard-coded 4000 character limit, which can break larger tables or structured responses into multiple posts. This lets deployments raise the limit without patching the plugin.

## Validation
- `uv run --extra dev --with aiohttp python -m pytest tests/gateway/test_mattermost.py -q`
- `uv run --extra dev ruff check plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py hermes_cli/config.py`
- `git diff --check`