### PR TITLE
test: fix flaky windows no-window-flag tests vs update-check daemon

### DIFF
--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -15,6 +15,26 @@ class _Completed:
         self.returncode = returncode
 
 
+def _spawns(captured, *needles):
+    """Captured ``subprocess.run`` calls whose argv contains every needle.
+
+    These tests patch ``<module>.subprocess.run``, which is the shared
+    ``subprocess`` module singleton — so the patch is process-wide. Importing
+    ``tui_gateway.server`` kicks off ``prefetch_update_check`` (a daemon thread
+    that shells out to ``git ... origin`` with ``text=True, timeout=5``), and
+    that call can land in ``captured`` mid-test. Matching the distinctive argv
+    tokens of the call under test (e.g. ``--show-toplevel``, ``ls-files``) keeps
+    each assertion scoped to its own contract and immune to that cross-talk —
+    otherwise a stray ``git`` spawn trips a bare ``KeyError: 'creationflags'``
+    or a call-count / full-list mismatch.
+    """
+    return [
+        (cmd, kwargs)
+        for cmd, kwargs in captured
+        if cmd and all(n in cmd for n in needles)
+    ]
+
+
 def test_tui_gateway_git_probe_hides_git_windows(monkeypatch):
     from tui_gateway import git_probe
 
@@ -30,7 +50,8 @@ def test_tui_gateway_git_probe_hides_git_windows(monkeypatch):
 
     assert git_probe.run_git("C:/repo", "branch", "--show-current") == "main"
 
-    assert captured == [
+    git_calls = _spawns(captured, "branch", "--show-current")
+    assert git_calls == [
         (
             ["git", "-C", "C:/repo", "branch", "--show-current"],
             {
@@ -66,10 +87,11 @@ def test_tui_gateway_fuzzy_file_listing_hides_git_windows(monkeypatch):
 
     assert server._list_repo_files("C:/repo") == ["src/main.py", "README.md"]
 
-    assert [kwargs["creationflags"] for _, kwargs in captured] == [
-        _CREATE_NO_WINDOW,
-        _CREATE_NO_WINDOW,
-    ]
+    toplevel = _spawns(captured, "rev-parse", "--show-toplevel")
+    ls_files = _spawns(captured, "ls-files")
+    assert len(toplevel) == 1 and len(ls_files) == 1, captured
+    assert toplevel[0][1].get("creationflags") == _CREATE_NO_WINDOW
+    assert ls_files[0][1].get("creationflags") == _CREATE_NO_WINDOW
 
 
 def test_coding_context_git_hides_git_windows(monkeypatch):
@@ -124,10 +146,11 @@ def test_context_reference_git_and_rg_hide_windows(monkeypatch):
         Path("src/main.py")
     ]
 
-    assert [kwargs["creationflags"] for _, kwargs in captured] == [
-        _CREATE_NO_WINDOW,
-        _CREATE_NO_WINDOW,
-    ]
+    git_calls = _spawns(captured, "diff")
+    rg_calls = _spawns(captured, "rg")
+    assert len(git_calls) == 1 and len(rg_calls) == 1, captured
+    assert git_calls[0][1].get("creationflags") == _CREATE_NO_WINDOW
+    assert rg_calls[0][1].get("creationflags") == _CREATE_NO_WINDOW
 
 
 def test_copilot_gh_cli_probe_hides_gh_windows(monkeypatch):
@@ -224,7 +247,8 @@ def test_gateway_force_kill_hides_taskkill_window(monkeypatch):
 
     status.terminate_pid(123, force=True)
 
-    assert captured == [
+    kill_calls = _spawns(captured, "taskkill")
+    assert kill_calls == [
         (
             ["taskkill", "/PID", "123", "/T", "/F"],
             {


### PR DESCRIPTION
## Summary

Fixes an intermittent failure of `tests/test_windows_subprocess_no_window_flags.py::test_tui_gateway_fuzzy_file_listing_hides_git_windows` (seen on PR CI, reproducible locally under the parallel test harness within ~1–2 runs).

## Root cause

These tests patch `<module>.subprocess.run`. Since `<module>.subprocess` is the shared `subprocess` **module** object, the patch is effectively **process-wide** — every `subprocess.run` in the process during the test gets captured.

`tui_gateway/server.py` calls `prefetch_update_check()` **at import time**:

```python
# tui_gateway/server.py
from hermes_cli.banner import prefetch_update_check
prefetch_update_check()
```

That spawns an unnamed daemon thread (`Thread-N (_run)`) which runs `check_for_updates()` → `git ... origin` commands (`remote get-url origin`, `rev-list --count HEAD..origin/main`, …) with `text=True, timeout=5, cwd=...`. When `test_tui_gateway_fuzzy_file_listing_hides_git_windows` imports `tui_gateway.server` and patches the global `subprocess.run`, that daemon's git call races the test and lands in the captured list, so the assertion sees **3** git calls instead of 2 — failing as either `KeyError: 'creationflags'` (the daemon call has no `creationflags`) or `assert 3 == 2`. The daemon also chokes on the test's fake `bytes` output (`[gateway-crash] ... TypeError: startswith first arg must be bytes`), which is how it announces itself in the log. It only reproduces under the parallel harness because of the extra concurrency/timing.

This is pre-existing and unrelated to any feature change — it's a test-isolation gap that trips whenever the one-shot update-check daemon overlaps the test window.

## Fix

Filter captured calls to the **distinctive argv tokens** of the call under test (`--show-toplevel`, `ls-files`, `branch --show-current`, `diff`, `rg`, `taskkill`) via a small `_spawns()` helper, and read `creationflags` with `.get`. This mirrors the existing hardening already applied to `test_gateway_pid_scan_hides_wmic_and_powershell_windows` in the same file. Production code is unchanged.

## Test plan

- [x] Stress-ran the file 40× under `scripts/run_tests.sh` (the harness that reproduced the flake): **0 failures / 40 runs** (was failing within 1–2 runs before).
- [x] Plain `pytest` run: 15 passed.
- [x] Lint clean.