### PR TITLE
fix(qqbot): accept shared-context group session keys in approval auth gate

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1084,7 +1084,16 @@ class QQAdapter(BasePlatformAdapter):
             event: InteractionEvent,
             session_key: str,
     ) -> bool:
-        """Authorize approval/update interactions against session + operator."""
+        """Authorize approval/update interactions against session + operator.
+
+        Behavior depends on the gateway's ``group_sessions_per_user`` config:
+
+        * ``True``  (default, per-user isolation) — group/guild session keys
+          carry a ``user_id`` suffix; the operator must match it.
+        * ``False`` (shared group context) — group/guild session keys have
+          no user_id suffix; any operator from that chat is accepted, since
+          all members share one context by design.
+        """
         parsed = self._parse_gateway_session_key(session_key)
         operator = str(event.operator_openid or "").strip()
         if not parsed or parsed.get("platform") != "qqbot" or not operator:
@@ -1100,7 +1109,14 @@ class QQAdapter(BasePlatformAdapter):
             if not event_chat or event_chat != chat_id:
                 return False
             session_user = str(parsed.get("user_id", "")).strip()
-            return bool(session_user) and operator == session_user
+            if session_user:
+                # Per-user isolation mode: key carries user_id, must match.
+                return operator == session_user
+            # Shared-context mode (group_sessions_per_user=False):
+            # key has no user_id; any operator in this chat may resolve.
+            # Safety note: real authorization still happens at the platform
+            # allowlist layer (operator must be in QQ_ALLOWED_USERS).
+            return True
 
         return False
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1307,6 +1307,131 @@ class TestAdapterInteractionDispatch:
 
 
 # ---------------------------------------------------------------------------
+# Authorization gate for group shared-context session keys
+# (_is_authorized_interaction_for_session)
+# ---------------------------------------------------------------------------
+#
+# When the gateway runs with ``group_sessions_per_user: false`` (i.e. the
+# group is treated as a single shared context), the agent writes group
+# session keys *without* a trailing ``user_id``. The earlier implementation
+# hard-required a user_id suffix for group/guild chat_type and silently
+# dropped the click — the agent thread then blocked forever.
+#
+# These tests lock in the corrected behavior: when the session_key has no
+# user_id, any operator from the matching chat is accepted; when it does
+# have a user_id, the existing per-user match is preserved.
+
+
+class TestGroupSharedContextAuthorization:
+    """_is_authorized_interaction_for_session: group_sessions_per_user=False path."""
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    def _make_event(self, *, chat_type, group_openid="", guild_id="",
+                    group_member_openid="", user_openid=""):
+        from gateway.platforms.qqbot.keyboards import InteractionEvent
+        return InteractionEvent(
+            id="i",
+            chat_type=chat_type,
+            scene={0: "guild", 1: "group", 2: "c2c"}.get(chat_type, ""),
+            group_openid=group_openid,
+            guild_id=guild_id,
+            group_member_openid=group_member_openid,
+            user_openid=user_openid,
+        )
+
+    def test_group_session_without_user_id_accepts_any_operator(self):
+        # Shared-context key (no user_id suffix). group_sessions_per_user=False
+        # is the agent's signal that all members share one session.
+        adapter = self._make_adapter()
+        event = self._make_event(
+            chat_type=1,  # group
+            group_openid="chat-1",
+            group_member_openid="member-A",  # different from session key
+        )
+        session_key = "agent:main:qqbot:group:chat-1"  # no user_id
+        assert adapter._is_authorized_interaction_for_session(event, session_key) is True
+
+    def test_guild_session_without_user_id_accepts_any_operator(self):
+        adapter = self._make_adapter()
+        event = self._make_event(
+            chat_type=0,  # guild
+            guild_id="guild-1",
+            group_member_openid="member-A",
+        )
+        session_key = "agent:main:qqbot:guild:guild-1"
+        assert adapter._is_authorized_interaction_for_session(event, session_key) is True
+
+    def test_group_session_with_user_id_requires_matching_operator(self):
+        # Per-user isolation key. The existing strict-match contract must
+        # remain intact — only the user_id encoded in the key can resolve.
+        adapter = self._make_adapter()
+        event_matching = self._make_event(
+            chat_type=1,
+            group_openid="chat-1",
+            group_member_openid="member-A",
+        )
+        event_other = self._make_event(
+            chat_type=1,
+            group_openid="chat-1",
+            group_member_openid="member-B",
+        )
+        session_key = "agent:main:qqbot:group:chat-1:member-A"
+        assert adapter._is_authorized_interaction_for_session(
+            event_matching, session_key
+        ) is True
+        assert adapter._is_authorized_interaction_for_session(
+            event_other, session_key
+        ) is False
+
+    def test_group_session_chat_mismatch_is_rejected_even_without_user_id(self):
+        # Even in shared-context mode, the chat must match. An operator
+        # from a different group cannot resolve a session in chat-1.
+        adapter = self._make_adapter()
+        event = self._make_event(
+            chat_type=1,
+            group_openid="chat-2",  # different group
+            group_member_openid="member-A",
+        )
+        session_key = "agent:main:qqbot:group:chat-1"
+        assert adapter._is_authorized_interaction_for_session(event, session_key) is False
+
+    def test_c2c_requires_operator_to_match_chat_id(self):
+        # C2C contract unchanged: operator must equal the chat_id.
+        adapter = self._make_adapter()
+        event = self._make_event(chat_type=2, user_openid="user-1")
+        # user-1 == chat_id → allowed
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:c2c:user-1"
+        ) is True
+        # user-1 != chat_id → denied
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:c2c:user-2"
+        ) is False
+
+    def test_non_qqbot_platform_key_is_rejected(self):
+        adapter = self._make_adapter()
+        event = self._make_event(chat_type=1, group_openid="chat-1",
+                                  group_member_openid="member-A")
+        # Even with shared-context shape, a non-qqbot platform key is rejected.
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:telegram:group:chat-1"
+        ) is False
+
+    def test_empty_operator_is_rejected(self):
+        adapter = self._make_adapter()
+        event = self._make_event(chat_type=1, group_openid="chat-1",
+                                  group_member_openid="")
+        # group_member_openid falls back to user_openid, also empty.
+        # operator_openid resolves to "" → reject.
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:group:chat-1"
+        ) is False
+
+
+# ---------------------------------------------------------------------------
 # Quoted-message handling (message_type=103 → msg_elements)
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1777,6 +1777,66 @@ class TestDefaultInteractionDispatch:
         assert resolve_calls == []
 
     @pytest.mark.asyncio
+    async def test_approval_click_accepts_group_shared_context(self):
+        """Regression test for the follow-up to #30737.
+
+        When the agent uses group_sessions_per_user=false, the session_key
+        has no user_id suffix. Any operator in the matching group should
+        be able to resolve the approval.
+        """
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i", "chat_type": 1,  # group
+                "group_openid": "g-1",
+                "group_member_openid": "any-member",  # any member, not encoded in key
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:group:g-1:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:main:qqbot:group:g-1", "once", False)]
+
+    @pytest.mark.asyncio
+    async def test_approval_click_rejects_group_mismatch_in_shared_context(self):
+        """Even in shared-context mode, an operator from a different group
+        cannot resolve a session in chat-1."""
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i", "chat_type": 1,  # group
+                "group_openid": "g-other",  # NOT the group in the session_key
+                "group_member_openid": "any-member",
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:group:g-1:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == []
+
+    @pytest.mark.asyncio
     async def test_update_prompt_click_writes_response_file(self, tmp_path, monkeypatch):
         """update_prompt:y click writes 'y' to ~/.hermes/.update_response."""
         adapter = self._make_adapter()


### PR DESCRIPTION
## What does this PR do?

Fix a follow-up edge case from #30737: when the gateway runs with
`group_sessions_per_user: false` (shared group context, all members
share one session), QQ bot's approval-button authorization gate
silently rejects every click — the agent thread then blocks forever
on a dangerous-command approval, with no error surfaced to the user.

The agent writes group session keys *without* a trailing `user_id`
suffix in this mode:

  `agent:main:qqbot:group:<chat_id>`

The previous `_is_authorized_interaction_for_session` implementation
required a `user_id` suffix for all group/guild keys and dropped the
click. Result: every shared-context QQ group was unable to use
inline-keyboard approvals (3-minute freeze, then fallback to text
slash command, but the slash command itself works on `/approve once`).

This PR makes the authorization gate adapt to whichever key format
the agent produced: per-user isolation (`user_id` present) keeps the
existing strict-match contract; shared-context (no `user_id`) accepts
any operator in the matching chat — since real authorization still
happens at the platform allowlist layer (`QQ_ALLOWED_USERS`) above
this function.

## Related Issue

Closes the follow-up from #30737. Reproduction is identical:
set `group_sessions_per_user: false`, send a heredoc command in a
group chat, click "Allow once" — nothing happens, log shows
`Rejected unauthorized approval click`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/adapter.py` — `_is_authorized_interaction_for_session`:
  in the `group`/`guild` branch, accept a key without `user_id` (the
  shared-context shape). When `user_id` IS present, behavior is
  unchanged (per-user isolation still requires a strict match).
- `tests/gateway/test_qqbot.py` — new `TestGroupSharedContextAuthorization`
  class with 7 tests covering: group-without-user_id, guild-without-user_id,
  group-with-user_id, group-chat-mismatch, c2c, non-qqbot, empty-operator.
  All 166 tests in `test_qqbot.py` pass.

## How to Test

```bash
# 1. Unit tests
pytest tests/gateway/test_qqbot.py::TestGroupSharedContextAuthorization -v

# 2. Full QQ bot test suite (no regressions)
pytest tests/gateway/test_qqbot.py -v

# 3. End-to-end (requires running gateway)
#    a. Set group_sessions_per_user: false in config.yaml
#    b. Restart gateway
#    c. In a QQ group, send: python3 -c "print(1+1)"
#    d. Click "Allow once" on the approval button
#    e. Result: < 5s response with "2"
#    f. Pre-fix: agent blocks 3+ min, then log shows
#       "Rejected unauthorized approval click"
```

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_qqbot.py -v` and all 166 tests pass
- [x] I've added 7 tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 / Python 3.11.15

### Documentation & Housekeeping
- [x] I've updated relevant docstrings on the modified function
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow changes
- [x] N/A — the same contract likely exists in other adapters
      (telegram/slack/feishu/matrix/weixin/wecom/whatsapp), but
      that's out of scope here; happy to file follow-up issues
      with the same diagnosis if maintainers want
- [x] N/A — no tool behavior changed

## Screenshots / Logs

**Pre-fix log** (click silently rejected):
```
WARNING gateway.platforms.qqbot.adapter: [QQBot:1904122748]
  Rejected unauthorized approval click for session
  agent:main:qqbot:group:7A7AFFA3236085DD9252F7ED98418DC4
  (operator=C280211EF55D1642300850ADC0557A8C)
```

**Post-fix log** (click correctly resolved):
```
INFO gateway.platforms.qqbot.adapter: [QQBot:1904122748]
  Button resolved 1 approval(s) for session
  agent:main:qqbot:group:7A7AFFA3236085DD9252F7ED98418DC4
  (choice=once, operator=C280211EF55D1642300850ADC0557A8C)
```

End-to-end round-trip latency: < 1 second (tested with `heredoc`
triggering the approval, user clicks "Allow once", command output
arrives back in the chat within ~600ms).
