### PR TITLE
fix(slack): preserve DM safety on hybrid checkout

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12938,13 +12938,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         reply_to_message_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
-        return self._thread_metadata_for_target(
+        metadata = self._thread_metadata_for_target(
             getattr(source, "platform", None),
             getattr(source, "chat_id", None),
             getattr(source, "thread_id", None),
             chat_type=getattr(source, "chat_type", None),
             reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
         )
+        if getattr(source, "platform", None) == Platform.SLACK:
+            user_id = getattr(source, "user_id", None)
+            if user_id:
+                metadata = dict(metadata or {})
+                metadata["slack_user_id"] = str(user_id)
+        return metadata
 
     def _thread_metadata_for_target(
         self,
@@ -12976,6 +12982,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 metadata["direct_messages_topic_id"] = tid
             if reply_to_message_id is not None:
                 metadata["telegram_reply_to_message_id"] = str(reply_to_message_id)
+        if platform == Platform.SLACK and adapter is not None:
+            # Slack stale-DM recovery needs the event user so the adapter can
+            # reopen the current DM if Slack rejects an old D* channel id.
+            source_user_id = getattr(adapter, "_last_source_user_id", None)
+            if source_user_id:
+                metadata["slack_user_id"] = str(source_user_id)
         return metadata
 
     @staticmethod

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -468,6 +468,11 @@ class SlackAdapter(BasePlatformAdapter):
         self._slash_command_contexts: Dict[Tuple[str, str], Dict[str, Any]] = {}
         # Socket Mode resilience: track runtime connection state so we can
         # self-heal when Slack silently drops the websocket.
+        # Slack can deliver events for stale DM ids that the current bot token
+        # can no longer post to. Remember the user behind each DM so send()
+        # can reopen the current DM and retry instead of dropping the agent's
+        # completed response on chat.postMessage(channel_not_found).
+        self._dm_user_by_channel: Dict[str, str] = {}
         self._app_token: Optional[str] = None
         self._proxy_url: Optional[str] = None
         self._socket_watchdog_task: Optional[asyncio.Task] = None
@@ -1335,6 +1340,76 @@ class SlackAdapter(BasePlatformAdapter):
             return self._team_clients[team_id]
         return self._app.client  # fallback to primary
 
+
+    @staticmethod
+    def _slack_api_error_code(exc: Exception) -> str:
+        """Return a Slack Web API error code from SlackApiError-like exceptions."""
+        response = getattr(exc, "response", None)
+        if response is not None and hasattr(response, "get"):
+            error = str(response.get("error", "") or "").strip()
+            if error:
+                return error
+        return str(exc)
+
+    async def _resolve_replacement_dm_channel(
+        self,
+        stale_chat_id: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Resolve the current Slack DM channel for a stale DM send target."""
+        if not stale_chat_id.startswith("D"):
+            return None
+
+        user_id = ""
+        if metadata:
+            user_id = str(
+                metadata.get("slack_user_id")
+                or metadata.get("user_id")
+                or ""
+            ).strip()
+        if not user_id:
+            user_id = self._dm_user_by_channel.get(stale_chat_id, "")
+        if not user_id:
+            return None
+
+        try:
+            result = await self._get_client(stale_chat_id).conversations_open(users=user_id)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning(
+                "[Slack] Failed to reopen current DM for stale channel %s user %s: %s",
+                stale_chat_id,
+                user_id,
+                exc,
+            )
+            return None
+
+        if not result or not result.get("ok"):
+            logger.warning(
+                "[Slack] conversations.open failed while recovering stale DM %s for user %s: %s",
+                stale_chat_id,
+                user_id,
+                result.get("error") if hasattr(result, "get") else result,
+            )
+            return None
+
+        channel = result.get("channel") if hasattr(result, "get") else None
+        new_chat_id = str((channel or {}).get("id") or "").strip()
+        if not new_chat_id or new_chat_id == stale_chat_id:
+            return None
+
+        self._dm_user_by_channel[new_chat_id] = user_id
+        team_id = self._channel_team.get(stale_chat_id)
+        if team_id:
+            self._channel_team[new_chat_id] = team_id
+        logger.warning(
+            "[Slack] Recovered stale DM channel %s for user %s by retrying current DM %s",
+            stale_chat_id,
+            user_id,
+            new_chat_id,
+        )
+        return new_chat_id
+
     async def send(
         self,
         chat_id: str,
@@ -1366,6 +1441,8 @@ class SlackAdapter(BasePlatformAdapter):
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            effective_thread_ts = thread_ts
+            send_chat_id = chat_id
             last_result = None
 
             # reply_broadcast: also post thread replies to the main channel.
@@ -1374,20 +1451,43 @@ class SlackAdapter(BasePlatformAdapter):
 
             for i, chunk in enumerate(chunks):
                 kwargs = {
-                    "channel": chat_id,
+                    "channel": send_chat_id,
                     "text": chunk,
                     "mrkdwn": True,
                 }
-                if thread_ts:
-                    kwargs["thread_ts"] = thread_ts
+                if effective_thread_ts:
+                    kwargs["thread_ts"] = effective_thread_ts
                     # Only broadcast the first chunk of the first reply
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
 
-                last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+                try:
+                    last_result = await self._get_client(send_chat_id).chat_postMessage(**kwargs)
+                except Exception as exc:
+                    error_code = self._slack_api_error_code(exc)
+                    replacement_dm = None
+                    if error_code == "channel_not_found" and send_chat_id.startswith("D"):
+                        replacement_dm = await self._resolve_replacement_dm_channel(
+                            send_chat_id,
+                            metadata=metadata,
+                        )
+                    if not replacement_dm:
+                        raise
+                    send_chat_id = replacement_dm
+                    # A thread timestamp from the stale DM is not valid in the
+                    # freshly opened DM. Drop it so the recovery message lands
+                    # visibly instead of failing again with thread/channel errors.
+                    effective_thread_ts = None
+                    retry_kwargs = dict(kwargs)
+                    retry_kwargs["channel"] = send_chat_id
+                    retry_kwargs.pop("thread_ts", None)
+                    retry_kwargs.pop("reply_broadcast", None)
+                    last_result = await self._get_client(send_chat_id).chat_postMessage(
+                        **retry_kwargs
+                    )
 
             # Clear Slack Assistant status as soon as the final message is posted.
-            if thread_ts:
+            if effective_thread_ts:
                 await self.stop_typing(chat_id)
 
             # Track the sent message ts so we can auto-respond to thread
@@ -1396,8 +1496,8 @@ class SlackAdapter(BasePlatformAdapter):
             if sent_ts:
                 self._bot_message_ts.add(sent_ts)
                 # Also register the thread root so replies-to-my-replies work
-                if thread_ts:
-                    self._bot_message_ts.add(thread_ts)
+                if effective_thread_ts:
+                    self._bot_message_ts.add(effective_thread_ts)
                 if len(self._bot_message_ts) > self._BOT_TS_MAX:
                     excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
                     for old_ts in list(self._bot_message_ts)[:excess]:
@@ -1410,7 +1510,7 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[Slack] Send error: %s", e, exc_info=True)
+            logger.error("[Slack] Send error to %s: %s", chat_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     async def send_private_notice(
@@ -2636,6 +2736,14 @@ class SlackAdapter(BasePlatformAdapter):
         if not channel_type and channel_id.startswith("D"):
             channel_type = "im"
         is_dm = channel_type in {"im", "mpim"}  # Both 1:1 and group DMs
+        if is_dm and not self._slack_dm_channel_allowed(channel_id):
+            logger.warning(
+                "[Slack] Ignoring DM-like message in non-owner DM channel: %s",
+                channel_id,
+            )
+            return
+        if is_dm and channel_id and user_id:
+            self._dm_user_by_channel[channel_id] = user_id
 
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
@@ -4053,6 +4161,35 @@ class SlackAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+
+    def _slack_allowed_dm_channels(self) -> set:
+        """Return DM channel IDs where the Slack bot may process messages.
+
+        Slack can deliver assistant/app events for human-to-human DM channels
+        authored by an allowed user. Those are not conversations with the bot;
+        processing them leaks the bot into private DMs. Restrict DM handling to
+        the bot's owner/current DM unless explicitly configured otherwise.
+        """
+        raw = self.config.extra.get("allowed_dm_channels")
+        if raw is None:
+            raw = os.getenv("SLACK_ALLOWED_DM_CHANNELS", "")
+        parts = set()
+        if isinstance(raw, list):
+            parts.update(str(part).strip() for part in raw if str(part).strip())
+        elif raw is not None:
+            raw_s = str(raw).strip()
+            if raw_s:
+                parts.update(part.strip() for part in raw_s.split(",") if part.strip())
+        owner_dm = self.config.extra.get("owner_dm") or os.getenv("SLACK_OWNER_DM", "")
+        owner_dm_s = str(owner_dm).strip() if owner_dm is not None else ""
+        if owner_dm_s:
+            parts.add(owner_dm_s)
+        return parts
+
+    def _slack_dm_channel_allowed(self, channel_id: str) -> bool:
+        allowed = self._slack_allowed_dm_channels()
+        return not allowed or str(channel_id or "").strip() in allowed
 
     def _slack_mention_patterns(self) -> List["re.Pattern"]:
         """Compile optional regex wake-word patterns for channel triggers.

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1961,6 +1961,51 @@ class TestMessageRouting:
         adapter.handle_message.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_human_dm_channel_ignored_when_owner_dm_is_set(self, adapter):
+        """Allowed users in human-to-human DMs must not dispatch to the agent."""
+        adapter.config.extra["owner_dm"] = "D_OWNER"
+        event = {
+            "text": "hello from an allowed user in somebody else's DM",
+            "user": "U_ALLOWED",
+            "channel": "D_OTHER_PERSON",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_not_called()
+        assert "D_OTHER_PERSON" not in adapter._dm_user_by_channel
+
+    @pytest.mark.asyncio
+    async def test_owner_dm_channel_allowed_when_owner_dm_is_set(self, adapter):
+        """The configured owner/current bot DM remains processable."""
+        adapter.config.extra["owner_dm"] = "D_OWNER"
+        event = {
+            "text": "hello",
+            "user": "U_OWNER",
+            "channel": "D_OWNER",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_called_once()
+        assert adapter._dm_user_by_channel["D_OWNER"] == "U_OWNER"
+
+    @pytest.mark.asyncio
+    async def test_explicit_allowed_dm_channel_allowed(self, adapter):
+        """Multiple allowed DM channels can be configured intentionally."""
+        adapter.config.extra["owner_dm"] = "D_OWNER"
+        adapter.config.extra["allowed_dm_channels"] = "D_ALLOWED,D_OTHER"
+        event = {
+            "text": "hello",
+            "user": "U_ALLOWED",
+            "channel": "D_ALLOWED",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_channel_message_requires_mention(self, adapter):
         """Channel messages without a bot mention should be ignored."""
         event = {
@@ -3282,6 +3327,62 @@ class TestMessageSplitting:
         await adapter.send("C123", "See [Foo](https://en.wikipedia.org/wiki/Foo_(bar))")
         kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
         assert "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>" in kwargs["text"]
+
+
+    @pytest.mark.asyncio
+    async def test_stale_dm_channel_not_found_reopens_current_dm(self, adapter):
+        """A stale Slack DM should be resolved to the user's current DM and retried."""
+
+        class SlackApiException(Exception):
+            def __init__(self, error: str):
+                super().__init__(error)
+                self.response = {"ok": False, "error": error}
+
+        async def fake_post(**kwargs):
+            if kwargs["channel"] == "DOLD":
+                raise SlackApiException("channel_not_found")
+            return {"ts": "new_reply_ts"}
+
+        adapter._app.client.chat_postMessage = AsyncMock(side_effect=fake_post)
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"ok": True, "channel": {"id": "DNEW"}}
+        )
+        result = await adapter.send(
+            "DOLD",
+            "hello again",
+            metadata={"thread_id": "old_thread", "slack_user_id": "U123"},
+        )
+        assert result.success
+        assert result.message_id == "new_reply_ts"
+        adapter._app.client.conversations_open.assert_awaited_once_with(users="U123")
+        assert adapter._app.client.chat_postMessage.await_args_list[0].kwargs["channel"] == "DOLD"
+        retried = adapter._app.client.chat_postMessage.await_args_list[1].kwargs
+        assert retried["channel"] == "DNEW"
+        assert "thread_ts" not in retried
+
+    @pytest.mark.asyncio
+    async def test_stale_dm_channel_uses_cached_event_user(self, adapter):
+        """DM event processing caches channel→user for later send recovery."""
+
+        class SlackApiException(Exception):
+            def __init__(self, error: str):
+                super().__init__(error)
+                self.response = {"ok": False, "error": error}
+
+        async def fake_post(**kwargs):
+            if kwargs["channel"] == "DOLD":
+                raise SlackApiException("channel_not_found")
+            return {"ts": "new_reply_ts"}
+
+        adapter._dm_user_by_channel["DOLD"] = "U123"
+        adapter._app.client.chat_postMessage = AsyncMock(side_effect=fake_post)
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"ok": True, "channel": {"id": "DNEW"}}
+        )
+        result = await adapter.send("DOLD", "hello again")
+        assert result.success
+        adapter._app.client.conversations_open.assert_awaited_once_with(users="U123")
+        assert adapter._dm_user_by_channel["DNEW"] == "U123"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- port the local Slack DM safety hotfix onto current upstream where Slack now lives under `plugins/platforms/slack/adapter.py`
- block processing of non-owner human DM channels when an owner/current DM is configured
- recover stale Slack `D*` DM send targets by reopening the current DM for the source user and retrying without the stale thread timestamp
- carry the Slack source user id into send metadata for stale-DM recovery

## Verification
- `python3 -m py_compile plugins/platforms/slack/adapter.py gateway/run.py tests/gateway/test_slack.py`
- `PYTHONPATH=/opt/data/hermes-agent-candidate-inf758 uv run --no-project --with pytest --with pytest-asyncio --with filelock python -m pytest /opt/data/hermes-agent-candidate-inf758/tests/gateway/test_slack.py -q -o 'addopts=' -o cache_dir=/opt/data/.pytest-cache-inf758`
- result: `214 passed, 40 warnings`

## Notes
- This was ported from the local hybrid-checkout safety diff captured for INF-758.
- No profile config, secrets, runtime paths, or service restarts are touched.
