### PR TITLE
feat(cli): add --yes/-y flag to hermes skills uninstall

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1727,7 +1727,7 @@ def skills_command(args) -> None:
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))
     elif action == "uninstall":
-        do_uninstall(args.name)
+        do_uninstall(args.name, skip_confirm=getattr(args, "yes", False))
     elif action == "reset":
         do_reset(args.name, restore=getattr(args, "restore", False),
                  skip_confirm=getattr(args, "yes", False))

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -156,6 +156,12 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         "uninstall", help="Remove a hub-installed skill"
     )
     skills_uninstall.add_argument("name", help="Skill name to remove")
+    skills_uninstall.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
 
     skills_reset = skills_subparsers.add_parser(
         "reset",

--- a/tests/hermes_cli/test_skills_uninstall_flags.py
+++ b/tests/hermes_cli/test_skills_uninstall_flags.py
@@ -1,0 +1,58 @@
+"""
+Tests for --yes / -y flag in `hermes skills uninstall` CLI subcommand.
+
+Verifies the parser registers the flag and the value reaches
+``do_uninstall(skip_confirm=True)`` through the real ``skills_command``
+dispatch path (mirrors ``test_skills_install_flags.py``).
+"""
+
+import sys
+
+
+def _run_uninstall_cli(monkeypatch, argv):
+    captured = {}
+
+    def fake_do_uninstall(name, *, skip_confirm=False, **kwargs):
+        captured["name"] = name
+        captured["skip_confirm"] = skip_confirm
+
+    monkeypatch.setattr("hermes_cli.skills_hub.do_uninstall", fake_do_uninstall)
+    monkeypatch.setattr(sys, "argv", argv)
+
+    from hermes_cli.main import main
+
+    main()
+    return captured
+
+
+def test_cli_skills_uninstall_yes_sets_skip_confirm(monkeypatch):
+    """`--yes` should propagate to do_uninstall(skip_confirm=True)."""
+    captured = _run_uninstall_cli(
+        monkeypatch,
+        ["hermes", "skills", "uninstall", "test-skill", "--yes"],
+    )
+
+    assert captured["name"] == "test-skill"
+    assert captured["skip_confirm"] is True
+
+
+def test_cli_skills_uninstall_y_alias_sets_skip_confirm(monkeypatch):
+    """`-y` should behave the same as `--yes`."""
+    captured = _run_uninstall_cli(
+        monkeypatch,
+        ["hermes", "skills", "uninstall", "test-skill", "-y"],
+    )
+
+    assert captured["name"] == "test-skill"
+    assert captured["skip_confirm"] is True
+
+
+def test_cli_skills_uninstall_no_flags_keeps_prompt(monkeypatch):
+    """Without --yes, skip_confirm must be False (prompt preserved)."""
+    captured = _run_uninstall_cli(
+        monkeypatch,
+        ["hermes", "skills", "uninstall", "test-skill"],
+    )
+
+    assert captured["name"] == "test-skill"
+    assert captured["skip_confirm"] is False


### PR DESCRIPTION
## Problem or Use Case

`hermes skills install` and `hermes skills reset` both expose a `--yes`/`-y` flag to skip the confirmation prompt for non-interactive use (scripts, CI, TUI mode). `hermes skills uninstall` is missing this flag, forcing users to always answer an interactive prompt even in scripted workflows.

## Proposed Solution

Add `--yes`/`-y` to `hermes skills uninstall`, matching the existing pattern on `install` and `reset`.

```bash
hermes skills uninstall my-skill --yes   # skip confirmation
hermes skills uninstall my-skill -y      # short form
hermes skills uninstall my-skill         # still prompts (unchanged)
```

## Implementation

`do_uninstall` in `hermes_cli/skills_hub.py` already accepted a `skip_confirm: bool = False` parameter, and the `/skills uninstall` slash command already passed `skip_confirm=True`. The CLI argparse path simply never wired up the flag.

Two files changed:
- `hermes_cli/subcommands/skills.py` — add `--yes`/`-y` to the `uninstall` subparser
- `hermes_cli/skills_hub.py` — pass `skip_confirm=args.yes` in `skills_command`

## Feature Type

CLI improvement

## Scope

Small (single file, < 50 lines)