### PR TITLE
fix(gemini): strip leading model turns to prevent 400 on assistant-first histories

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -337,6 +337,12 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
         if parts:
             contents.append({"role": gemini_role, "parts": parts})
 
+    # Gemini API rejects histories whose first content has role "model" —
+    # it requires the conversation to start with a user turn.  Strip any
+    # leading model entries so the request does not 400.
+    while contents and contents[0].get("role") == "model":
+        contents.pop(0)
+
     system_instruction = None
     joined_system = "\n".join(part for part in system_text_parts if part).strip()
     if joined_system:


### PR DESCRIPTION
## Summary

`_build_gemini_contents` in `agent/gemini_native_adapter.py` maps each message to a Gemini content entry (`assistant` -> `model`, `user`/`tool` -> `user`) but never guarantees the first entry has role `user`. The native Gemini `generateContent` API rejects histories whose first content is `model` with a 400 error.

This happens when a session is resumed/forked from a point whose earliest stored message is an assistant turn, or when the system prompt is stripped before the converter.

## Changes

- After building the contents list, strip any leading `model` entries so the request always starts with a user turn
- 6 lines added, 0 removed

Fixes #55427