### PR TITLE
security(redact): add Google OAuth (ya29./1//) token prefixes

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -80,6 +80,8 @@ _PREFIX_PATTERNS = [
     r"xapp-\d+-[A-Za-z0-9-]{10,}",      # Slack app-Level token
     r"xox[baprs]-[A-Za-z0-9-]{10,}",    # Slack bot/app/user tokens
     r"AIza[A-Za-z0-9_-]{30,}",          # Google API keys
+    r"ya29\.[A-Za-z0-9._-]{20,}",       # Google OAuth access token
+    r"1//[A-Za-z0-9_-]{20,}",           # Google OAuth refresh token
     r"pplx-[A-Za-z0-9]{10,}",           # Perplexity
     r"fal_[A-Za-z0-9_-]{10,}",          # Fal.ai
     r"fc-[A-Za-z0-9]{10,}",             # Firecrawl

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -45,6 +45,21 @@ class TestKnownPrefixes:
         text = "fw-tooshort fw_tooshort fpk_tooshort"
         assert redact_sensitive_text(text) == text
 
+    def test_google_oauth_tokens(self):
+        samples = [
+            "ya29.a0AfH6SM" + "a" * 30,
+            "1//0eX" + "b" * 30,
+        ]
+
+        for token in samples:
+            result = redact_sensitive_text(f"auth error {token}")
+            assert token not in result
+            assert "..." in result
+
+    def test_short_google_oauth_like_text_unchanged(self):
+        text = "ya29.tooshort and a fraction 1//2 in prose"
+        assert redact_sensitive_text(text) == text
+
 
 
 


### PR DESCRIPTION
Adds `ya29.` (OAuth access) and `1//` (OAuth refresh) Google token prefixes to `_PREFIX_PATTERNS` in
`agent/redact.py`, so a bare Google OAuth token in logs / tool output is masked by prefix (previously
only caught via `_JSON_KEY_NAMES` adjacency).

Smallest of the three improvements proposed in #39654; scoped to just the prefix patterns. The
`state.db`-persistence redaction and the docs note are deliberately left as separate follow-ups.

- `_PREFIX_SUBSTRINGS` fast-gate auto-derives the `ya29` / `1//` literals (no false negatives).
- Grouped behavior tests cover both prefixes plus short-form/prose negatives, following the post-prune redaction-test style.

Per SECURITY.md this is a display/logging heuristic covering more sinks, not a boundary change — OS-level
isolation remains the boundary.

**Scope:** this covers the modern `ya29.` (access) and `1//` (refresh) prefixes only. Legacy single-slash
`1/…` Google OAuth tokens are intentionally **not** covered here — a bare `1/[A-Za-z0-9_-]{20,}` rule would
materially increase false positives on versioned paths / slugs, so it warrants separate false-positive
analysis as a follow-up.

Refs #39654.

