### PR TITLE
fix(desktop): make ⌘K / session-switcher HUDs ignore the titlebar drag band

### DIFF
--- a/apps/desktop/src/app/floating-hud.ts
+++ b/apps/desktop/src/app/floating-hud.ts
@@ -6,7 +6,11 @@ export const HUD_POSITION = 'fixed left-1/2 top-3 -translate-x-1/2'
 
 // Matches the app's borderless-overlay surface (dialog, keybind panel, …):
 // hairline `--stroke-nous` paired with the soft `--shadow-nous` float.
-export const HUD_SURFACE = 'rounded-xl border border-(--stroke-nous) bg-(--ui-chat-bubble-background) shadow-nous'
+// `no-drag`: these HUDs overlap the titlebar's `[-webkit-app-region:drag]` band
+// (app-shell.tsx), which wins hit-testing over DOM regardless of z-index — so
+// without it the top of the surface (the search input) swallows clicks.
+export const HUD_SURFACE =
+  'rounded-xl border border-(--stroke-nous) bg-(--ui-chat-bubble-background) shadow-nous [-webkit-app-region:no-drag]'
 
 // One row/text size for both HUDs (compact — two notches under `text-sm`).
 export const HUD_TEXT = 'text-xs'


### PR DESCRIPTION
## Summary

In the desktop app you couldn't reliably click into the ⌘K command-palette search input (e.g. when searching themes) — only a ~2px strip at the bottom of the input was focusable.

**Root cause:** the titlebar (`apps/desktop/src/app/shell/app-shell.tsx`) lays down `[-webkit-app-region:drag]` bands across the top `--titlebar-height` (34px) of the window. In Electron, drag regions win hit-testing over DOM elements *regardless of z-index*. The command palette pins at `top-3` (12px) with a 44px input row, so the top ~22px of the input sits inside the drag band and the OS grabs those clicks for window-dragging instead of focusing the input.

**Fix:** add `[-webkit-app-region:no-drag]` to the shared `HUD_SURFACE` class in `apps/desktop/src/app/floating-hud.ts`. This is the surface shared by *both* top-center floating HUDs — the command palette (⌘K) and the session switcher — which overlap the same drag band, so the one-line change fixes the whole bug class.

## Test plan

- [ ] Open the desktop app, hit ⌘K, type a theme query, and confirm you can click anywhere in the search input to focus it.
- [ ] Open the session switcher (top-center HUD) and confirm its input is fully clickable too.
- [ ] Confirm the window can still be dragged by the titlebar outside the HUD surfaces.