### PR TITLE
fix(kanban): reclassify rate-limited clean exits via worker log inspection (#55445)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6332,6 +6332,31 @@ def detect_stale_running(
     return reclaimed
 
 
+def _worker_log_has_rate_limit(task_id: str, max_bytes: int = 4096) -> bool:
+    """Check if a worker's log tail contains rate-limit / quota patterns.
+
+    Defensive heuristic for ``hermes chat -q`` workers that exit rc=0
+    despite hitting a provider rate-limit wall (the ``-q`` path does not
+    map ``run_conversation`` failure reasons to exit codes).  Reads only
+    the tail of the log to avoid loading multi-MB files into memory.
+    """
+    try:
+        log_path = worker_logs_dir() / f"{task_id}.log"
+        if not log_path.is_file():
+            return False
+        with open(log_path, "rb") as f:
+            try:
+                f.seek(0, 2)  # SEEK_END
+                size = f.tell()
+                f.seek(max(0, size - max_bytes))
+            except OSError:
+                return False
+            tail = f.read().decode("utf-8", errors="replace")
+        return bool(_RESPAWN_BLOCKER_RE.search(tail))
+    except Exception:
+        return False
+
+
 def _error_fingerprint(error_text: str) -> str:
     """Normalize an error message for grouping identical failures.
 
@@ -6410,17 +6435,41 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # ``running`` in the DB — it exited without calling
                 # ``kanban_complete`` / ``kanban_block``. Retrying won't
                 # help.
-                protocol_violation = True
-                error_text = (
-                    "worker exited cleanly (rc=0) without calling "
-                    "kanban_complete or kanban_block — protocol violation"
-                )
-                event_kind = "protocol_violation"
-                event_payload = {
-                    "pid": pid,
-                    "claimer": row["claim_lock"],
-                    "exit_code": code,
-                }
+                #
+                # Defensive: ``hermes chat -q`` (single-query mode) does
+                # not map ``run_conversation`` failure reasons to exit
+                # codes, so a rate-limited worker exits 0 and lands here.
+                # Check the worker log tail for quota/rate-limit patterns
+                # before tripping the circuit breaker — if found, treat
+                # this as a rate-limited exit and requeue without counting
+                # a failure (#55445, #48000).
+                if _worker_log_has_rate_limit(row["id"]):
+                    protocol_violation = False
+                    rate_limited_exit = True
+                    error_text = (
+                        f"pid {pid} exited rc=0 but worker log shows "
+                        f"rate-limit/quota wall — requeued without "
+                        f"counting a failure"
+                    )
+                    event_kind = "rate_limited"
+                    event_payload = {
+                        "pid": pid,
+                        "claimer": row["claim_lock"],
+                        "exit_code": code,
+                        "detected_via": "worker_log_tail",
+                    }
+                else:
+                    protocol_violation = True
+                    error_text = (
+                        "worker exited cleanly (rc=0) without calling "
+                        "kanban_complete or kanban_block — protocol violation"
+                    )
+                    event_kind = "protocol_violation"
+                    event_payload = {
+                        "pid": pid,
+                        "claimer": row["claim_lock"],
+                        "exit_code": code,
+                    }
             elif kind == "rate_limited":
                 # Worker bailed because the provider rate-limited / exhausted
                 # quota (EX_TEMPFAIL sentinel). This is NOT a task failure —

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -952,6 +952,82 @@ def test_rate_limit_exit_requeues_without_counting_failure(
         assert "crashed" not in outcomes
 
 
+def test_detect_crashed_workers_reclassifies_clean_exit_via_worker_log(
+    kanban_home, monkeypatch, tmp_path,
+):
+    """When a ``-q`` worker exits rc=0 despite hitting a rate-limit wall,
+    ``detect_crashed_workers`` should inspect the worker log tail and
+    reclassify the exit as ``rate_limited`` instead of ``protocol_violation``
+    (#55445)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(_kb, "worker_logs_dir", lambda board=None: tmp_path)
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="rl-log", assignee="a")
+        pid = 80000
+        conn.execute(
+            "UPDATE tasks SET status='running', worker_pid=?, "
+            "claim_lock=? WHERE id=?",
+            (pid, f"{host}:w0", tid),
+        )
+        conn.commit()
+        # Worker exited cleanly (rc=0) — no exit code mapping for rate limit.
+        _kb._record_worker_exit(pid, _exited_status(0))
+        # But the worker log shows the actual rate-limit error.
+        log_path = tmp_path / f"{tid}.log"
+        log_path.write_text(
+            "Error: 429 Too Many Requests — quota exhausted for today\n"
+        )
+
+        crashed = kb.detect_crashed_workers(conn)
+        assert tid not in crashed, "rate-limited log should prevent crash"
+        rl = getattr(_kb.detect_crashed_workers, "_last_rate_limited", [])
+        assert tid in rl, "should be reclassified as rate_limited"
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready", (
+            f"should requeue ready, got {task.status}"
+        )
+        assert task.consecutive_failures == 0
+
+
+def test_detect_crashed_workers_protocol_violation_when_no_rate_limit_in_log(
+    kanban_home, monkeypatch, tmp_path,
+):
+    """When a ``-q`` worker exits rc=0 and the log shows NO rate-limit
+    patterns, the original protocol-violation classification is preserved."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(_kb, "worker_logs_dir", lambda board=None: tmp_path)
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="pv", assignee="a")
+        pid = 90000
+        conn.execute(
+            "UPDATE tasks SET status='running', worker_pid=?, "
+            "claim_lock=? WHERE id=?",
+            (pid, f"{host}:w0", tid),
+        )
+        conn.commit()
+        _kb._record_worker_exit(pid, _exited_status(0))
+        # Log shows normal output — no rate-limit pattern.
+        log_path = tmp_path / f"{tid}.log"
+        log_path.write_text("Hello from the agent.\n")
+
+        crashed = kb.detect_crashed_workers(conn)
+        assert tid in crashed, "should remain protocol_violation"
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked", (
+            f"protocol_violation should block, got {task.status}"
+        )
+
+
 def test_real_crash_still_counts_and_trips_breaker(kanban_home, monkeypatch):
     """Sanity: a genuine non-zero crash (not the sentinel) still increments
     the failure counter and trips the breaker — the rate-limit carve-out is


### PR DESCRIPTION
## What does this PR do?

When a kanban worker spawned via `hermes chat -q` (single-query mode) hits a provider rate-limit wall, the conversation loop returns `failed=rate_limit` but the process exits with code 0 — the exit-code mapping for rate-limit/billing only exists in the `-Q`/`--quiet` branch. `detect_crashed_workers` sees rc=0 + task still `running` and classifies it as `protocol_violation`, which trips the circuit breaker on the first occurrence and permanently blocks the card.

This fix adds a defensive check in `detect_crashed_workers`: before classifying a `clean_exit` as a protocol violation, read the worker log tail for rate-limit/quota patterns. If found, reclassify as `rate_limited` and requeue without counting a failure.

## Related Issue

Fixes #55445

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: Added `_worker_log_has_rate_limit()` helper that reads the last 4KB of the worker log and checks for quota/rate-limit patterns using the existing `_RESPAWN_BLOCKER_RE` regex
- `hermes_cli/kanban_db.py`: Modified the `clean_exit` branch in `detect_crashed_workers` to check the worker log before classifying as `protocol_violation`. If rate-limit patterns are found, reclassify as `rate_limited` and requeue without counting a failure
- `tests/hermes_cli/test_kanban_db.py`: Added `test_detect_crashed_workers_reclassifies_clean_exit_via_worker_log` — verifies that a clean-exit worker with rate-limit patterns in its log is reclassified as `rate_limited`
- `tests/hermes_cli/test_kanban_db.py`: Added `test_detect_crashed_workers_protocol_violation_when_no_rate_limit_in_log` — verifies that the original protocol-violation classification is preserved when the log shows no rate-limit patterns

## How to Test

1. Run the kanban_db test suite: `python -m pytest tests/hermes_cli/test_kanban_db.py -q --timeout=60` — all 225 tests should pass
2. The two new tests specifically verify the new path:
   - `test_detect_crashed_workers_reclassifies_clean_exit_via_worker_log`: creates a task with a dead worker (rc=0), writes a rate-limit error to the worker log, and verifies the task is requeued as `rate_limited` (not `protocol_violation`)
   - `test_detect_crashed_workers_protocol_violation_when_no_rate_limit_in_log`: creates a task with a dead worker (rc=0), writes normal log output, and verifies the task is still classified as `protocol_violation`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_kanban_db.py -q` and all 225 tests pass
- [x] I've added tests for my changes (2 new tests)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (log reading is cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
