### PR TITLE
fix(delegate): merge persistent + runtime delegation config sources

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1194,6 +1194,83 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["provider"])
 
 
+class TestLoadConfigMergesSources(unittest.TestCase):
+    """#55380: _load_config must merge persistent + runtime delegation config.
+
+    ``load_cli_config()`` seeds ``CLI_CONFIG['delegation']`` from schema
+    defaults, so it is always truthy with empty-string credential fields. The
+    old "first non-empty source wins" early-return therefore shadowed
+    ``delegation.provider`` / ``model`` / ``base_url`` / ``api_key`` set only in
+    the persistent ``config.yaml``, and subagents fell back to the parent model.
+    """
+
+    def _patch(self, persistent, runtime):
+        """Patch the two config sources _load_config reads."""
+        import tools.delegate_tool as dt
+        persistent_patch = patch(
+            "hermes_cli.config.load_config",
+            return_value=({"delegation": persistent} if persistent is not None else {}),
+        )
+        # CLI_CONFIG is imported inside _load_config via ``from cli import
+        # CLI_CONFIG``; patch the attribute on the cli module.
+        import cli
+        runtime_patch = patch.object(
+            cli, "CLI_CONFIG",
+            {"delegation": runtime} if runtime is not None else {},
+        )
+        return dt, persistent_patch, runtime_patch
+
+    def test_runtime_default_skeleton_does_not_shadow_persistent_creds(self):
+        # Real config.yaml has the credentials; the in-memory runtime block is
+        # the default skeleton (empty-string fields). Persistent must survive.
+        persistent = {
+            "provider": "siliconflow",
+            "model": "deepseek-ai/DeepSeek-V4-Pro",
+            "base_url": "https://api.siliconflow.cn/v1",
+            "api_key": "sk-real",
+        }
+        runtime = {"provider": "", "model": "", "base_url": "", "api_key": "", "subagent_auto_approve": False}
+        dt, pp, rp = self._patch(persistent, runtime)
+        with pp, rp:
+            cfg = dt._load_config()
+        self.assertEqual(cfg["provider"], "siliconflow")
+        self.assertEqual(cfg["model"], "deepseek-ai/DeepSeek-V4-Pro")
+        self.assertEqual(cfg["base_url"], "https://api.siliconflow.cn/v1")
+        self.assertEqual(cfg["api_key"], "sk-real")
+
+    def test_runtime_real_value_overrides_persistent(self):
+        persistent = {"provider": "openrouter", "model": "old"}
+        runtime = {"provider": "minimax-cn", "model": "MiniMax-M2"}
+        dt, pp, rp = self._patch(persistent, runtime)
+        with pp, rp:
+            cfg = dt._load_config()
+        self.assertEqual(cfg["provider"], "minimax-cn")
+        self.assertEqual(cfg["model"], "MiniMax-M2")
+
+    def test_runtime_only(self):
+        dt, pp, rp = self._patch(None, {"provider": "nous"})
+        with pp, rp:
+            cfg = dt._load_config()
+        self.assertEqual(cfg["provider"], "nous")
+
+    def test_persistent_only(self):
+        dt, pp, rp = self._patch({"provider": "zai", "api_key": "k"}, None)
+        with pp, rp:
+            cfg = dt._load_config()
+        self.assertEqual(cfg["provider"], "zai")
+        self.assertEqual(cfg["api_key"], "k")
+
+    def test_bool_and_int_keys_overlay_when_present(self):
+        # Non-string operational keys keep the prior "runtime wins" behavior.
+        persistent = {"max_concurrent_children": 3, "subagent_auto_approve": False}
+        runtime = {"max_concurrent_children": 8, "subagent_auto_approve": True}
+        dt, pp, rp = self._patch(persistent, runtime)
+        with pp, rp:
+            cfg = dt._load_config()
+        self.assertEqual(cfg["max_concurrent_children"], 8)
+        self.assertTrue(cfg["subagent_auto_approve"])
+
+
 class TestDelegationProviderIntegration(unittest.TestCase):
     """Integration tests: delegation config → _run_single_child → AIAgent construction."""
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2859,28 +2859,57 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config, merging the persistent and runtime sources.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Two sources can hold ``delegation.*``: the persistent on-disk config
+    (``hermes_cli.config.load_config`` → ``~/.hermes/config.yaml``) and the
+    in-memory runtime config (``cli.CLI_CONFIG``). Both must be honored so
+    ``delegation.provider`` / ``model`` / ``base_url`` / ``api_key`` take effect
+    regardless of the entry point (CLI, gateway, cron).
+
+    The old "return the first non-empty source" approach silently dropped
+    persistent delegation credentials (#55380): ``load_cli_config()`` seeds
+    ``CLI_CONFIG['delegation']`` from the schema defaults, so it is *always*
+    truthy — with empty-string credential fields. That early-returned the
+    default skeleton and made the persistent fallback dead code whenever ``cli``
+    was importable, so a subagent ignored ``delegation.provider`` set only in
+    ``config.yaml`` and fell back to the parent model.
+
+    Fix: overlay the persistent base with runtime values, but let a runtime
+    value win only when it actually carries something. Empty strings are the
+    "unset" sentinel for the credential fields (defaults are ``""``), so they
+    must not shadow a real persistent value. Bool/int operational keys overlay
+    when present, matching the previous "runtime wins" behavior for them.
     """
-    try:
-        from cli import CLI_CONFIG
-
-        cfg = CLI_CONFIG.get("delegation") or {}
-        if cfg:
-            return cfg
-    except Exception:
-        pass
+    persistent: dict = {}
     try:
         from hermes_cli.config import load_config
 
-        full = load_config()
-        return full.get("delegation") or {}
+        persistent = load_config().get("delegation") or {}
     except Exception:
-        return {}
+        persistent = {}
+
+    runtime: dict = {}
+    try:
+        from cli import CLI_CONFIG
+
+        runtime = CLI_CONFIG.get("delegation") or {}
+    except Exception:
+        runtime = {}
+
+    if not runtime:
+        return persistent
+    if not persistent:
+        return runtime
+
+    merged = dict(persistent)
+    for key, value in runtime.items():
+        if isinstance(value, str):
+            if value.strip():
+                merged[key] = value
+        elif value is not None:
+            merged[key] = value
+    return merged
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`delegate_task` ignored `delegation.provider` / `model` / `base_url` / `api_key` set in `~/.hermes/config.yaml`, so subagents silently fell back to the **parent model's** provider and credentials (401s when the parent and intended delegation provider differ).

## Root cause

Not a hardcoded provider (the issue title's premise) — the resolver `_resolve_delegation_credentials` and the `effective_x = override_x or parent_x` chain are correct. The bug is in `_load_config()` in `tools/delegate_tool.py`.

Two sources can hold `delegation.*`: the persistent on-disk config (`hermes_cli.config.load_config` → `config.yaml`) and the in-memory runtime config (`cli.CLI_CONFIG`). `load_cli_config()` seeds `CLI_CONFIG['delegation']` from the **schema defaults**, so that dict is *always truthy* — populated with empty-string credential fields. The old logic:

```python
cfg = CLI_CONFIG.get("delegation") or {}
if cfg:
    return cfg            # always taken when cli is importable
# ... persistent fallback is dead code
```

early-returned the default skeleton and made the persistent fallback **dead code** whenever `cli` was importable. Delegation credentials present only in `config.yaml` (not mirrored into the in-memory snapshot — e.g. a long-running gateway/cron process, or values added after import) were dropped, and the child inherited the parent.

## Fix

Merge the two sources instead of returning the first non-empty one: overlay the persistent base with runtime values, letting a runtime value win **only when it carries something**. Empty strings are the unset sentinel for the credential fields (defaults are `""`), so they no longer shadow a real persistent value. Bool/int operational keys (`max_concurrent_children`, `subagent_auto_approve`, …) still overlay when present, preserving the prior "runtime wins" behavior for them. The only behavior change is that an empty-string runtime credential field stops shadowing a populated persistent one.

## Related Issue

Fixes #55380

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py`: rewrite `_load_config()` to merge persistent + runtime delegation config (non-empty overlay) instead of first-non-empty-source-wins.
- `tests/tools/test_delegate.py`: add `TestLoadConfigMergesSources` (5 tests) — default runtime skeleton no longer shadows persistent creds; real runtime value still overrides; runtime-only; persistent-only; bool/int overlay.

## How to Test

1. `uv run python -m pytest tests/tools/test_delegate.py -q` → 149 passed.
2. Set `model.provider` to provider A and `delegation.provider`/`base_url`/`api_key` to provider B in `config.yaml`; dispatch `delegate_task` — the subagent now uses provider B instead of inheriting A.

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the suite and all tests pass (`tests/tools/test_delegate.py`, 149 passed, ruff clean)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 14
- [x] Cross-platform impact considered — pure config-merge logic, platform-independent