### PR TITLE
fix: increase desktop fetch timeout to 30s on Windows (#54928)

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -3,7 +3,7 @@ const os = require('node:os')
 const path = require('node:path')
 const { fileURLToPath } = require('node:url')
 
-const DEFAULT_FETCH_TIMEOUT_MS = 15_000
+const DEFAULT_FETCH_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 15_000
 const DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
 const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 


### PR DESCRIPTION
## What does this PR do?

Fixes #54928 — on Windows, the Python/FastAPI backend frequently needs more than 15 seconds to fully initialize due to AV scanning and slower disk I/O. This increases `DEFAULT_FETCH_TIMEOUT_MS` from 15s to 30s on Windows to prevent false 'boot failed' errors.

## Related Issue

Fixes #54928

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

Modified `apps/desktop/electron/hardening.cjs` to use a platform-specific timeout:
- Windows: 30 seconds (was 15s)
- Other platforms: 15 seconds (unchanged)

## How to Test

1. On Windows, start Hermes Desktop
2. Verify the backend starts without 'boot failed' errors
3. On macOS/Linux, verify the timeout is still 15s

## Platforms Tested

- [x] Windows 11