### PR TITLE
fix(gateway): recognize FreeBSD rc.d supervised child in conflict guard

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4224,10 +4224,15 @@ def _running_under_gateway_supervisor() -> bool:
       - launchd sets ``XPC_SERVICE_NAME`` to the job label for jobs it spawns;
         interactive shells inherit the sentinel ``"0"`` instead.
       - the s6-overlay container longrun exports ``HERMES_S6_SUPERVISED_CHILD``.
+      - a FreeBSD rc.d service exports ``HERMES_RCD_SUPERVISED_CHILD`` from its
+        ``daemon(8)`` invocation, so the child can identify itself as the
+        supervised instance (daemon(8) sets none of the markers above).
     """
     if os.environ.get("INVOCATION_ID"):
         return True
     if os.environ.get("HERMES_S6_SUPERVISED_CHILD"):
+        return True
+    if os.environ.get("HERMES_RCD_SUPERVISED_CHILD"):
         return True
     xpc_service = os.environ.get("XPC_SERVICE_NAME", "")
     if xpc_service and xpc_service != "0":

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -295,6 +295,13 @@ def test_running_under_gateway_supervisor_markers(monkeypatch):
     monkeypatch.setenv("HERMES_S6_SUPERVISED_CHILD", "1")
     assert gateway._running_under_gateway_supervisor() is True
 
+    monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+    monkeypatch.setenv("HERMES_RCD_SUPERVISED_CHILD", "1")
+    assert gateway._running_under_gateway_supervisor() is True
+
+    monkeypatch.delenv("HERMES_RCD_SUPERVISED_CHILD", raising=False)
+    assert gateway._running_under_gateway_supervisor() is False
+
 
 def test_gateway_run_force_flag_survives_parser_extraction():
     from hermes_cli.subcommands.gateway import build_gateway_parser


### PR DESCRIPTION
Problem

`_running_under_gateway_supervisor()` recognizes supervised children from
systemd (`INVOCATION_ID`), launchd (`XPC_SERVICE_NAME`), and s6-overlay
(`HERMES_S6_SUPERVISED_CHILD`) — but not FreeBSD's `daemon(8)`/rc.d, which
exports none of those.

On FreeBSD, a gateway launched by an rc.d service fails the
supervised-child check in `_guard_supervised_gateway_conflict`, sees the
already-running service in the runtime snapshot, and refuses to start —
and `daemon(8) -r` respawns it in a tight loop (~30k iterations before the
supervisor gives up).

Fix

Recognize `HERMES_RCD_SUPERVISED_CHILD` alongside the existing markers. The
FreeBSD rc.d service exports it from its `daemon(8)` invocation, mirroring
how s6-overlay exports `HERMES_S6_SUPERVISED_CHILD` for its supervised
longrun — an external supervisor sets the marker; the code just
recognizes it.

No behavior change on Linux/macOS/containers — the new check only fires
when an rc.d service sets the variable.

Packaging note

This is the minimal code-side support; the rc.d service that exports the
marker lives in FreeBSD packaging (downstream), consistent with s6
handling. Happy to contribute the rc.d service files as a follow-up if of
interest.
