### PR TITLE
fix(windows): normalize native paths before bash file ops

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import tools.file_operations as file_ops_mod
 from tools.file_operations import (
     _is_write_denied,
     ReadResult,
@@ -467,6 +468,10 @@ class TestShellFileOpsHelpers:
         # Should be safely escaped
         assert result.count("'") >= 4  # wrapping + escaping
 
+    def test_escape_shell_arg_normalizes_windows_drive_paths(self, monkeypatch, file_ops):
+        monkeypatch.setattr(file_ops_mod, "_IS_WINDOWS", True)
+        assert file_ops._escape_shell_arg(r"C:\Users\alice\notes.txt") == "'C:/Users/alice/notes.txt'"
+
     def test_is_likely_binary_by_extension(self, file_ops):
         assert file_ops._is_likely_binary("photo.png") is True
         assert file_ops._is_likely_binary("data.db") is True
@@ -553,6 +558,32 @@ class TestShellFileOpsHelpers:
         assert "\x1b]" not in result.content
         assert "\x07" not in result.content
         assert "1|print('ok')" in result.content
+
+    def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
+        monkeypatch.setattr(file_ops_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if command.startswith("wc -c"):
+                return {"output": "5\n", "returncode": 0}
+            if command.startswith("head -c"):
+                return {"output": "hello", "returncode": 0}
+            if command.startswith("sed -n"):
+                return {"output": "hello\n", "returncode": 0}
+            if command.startswith("wc -l"):
+                return {"output": "1\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file(r"C:\Users\alice\notes.txt")
+
+        assert result.error is None
+        assert commands[0] == "wc -c < 'C:/Users/alice/notes.txt' 2>/dev/null"
+        assert commands[1] == "head -c 1000 'C:/Users/alice/notes.txt' 2>/dev/null"
+        assert commands[2] == "sed -n '1,500p' 'C:/Users/alice/notes.txt'"
+        assert commands[3] == "wc -l < 'C:/Users/alice/notes.txt'"
 
     def test_read_file_raw_strips_leaked_terminal_fence_markers(self, mock_env):
         leaked = (

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -21,6 +21,7 @@ on the real OS.
 from unittest.mock import patch
 
 
+from tools.environments import base as base_mod
 from tools.environments import local as local_mod
 from tools.environments.local import (
     LocalEnvironment,
@@ -94,6 +95,14 @@ class TestResolveSafeCwdWindows:
             local_mod, "_msys_to_windows_path", return_value=native
         ):
             assert _resolve_safe_cwd("/c/whatever") == native
+
+
+class TestWindowsCdPathQuoting:
+    def test_native_windows_cwd_is_rewritten_for_bash_cd(self, monkeypatch):
+        monkeypatch.setattr(base_mod, "_IS_WINDOWS", True)
+        assert base_mod.BaseEnvironment._quote_cwd_for_cd(
+            r"C:\Users\alice\my project"
+        ) == "'C:/Users/alice/my project'"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -10,6 +10,7 @@ import codecs
 import json
 import logging
 import os
+import platform
 import select
 import shlex
 import subprocess
@@ -25,6 +26,7 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.interrupt import is_interrupted
 
 logger = logging.getLogger(__name__)
+_IS_WINDOWS = platform.system() == "Windows"
 
 # Opt-in debug tracing for the interrupt/activity/poll machinery.  Set
 # HERMES_DEBUG_INTERRUPT=1 to log loop entry/exit, periodic heartbeats, and
@@ -435,6 +437,8 @@ class BaseEnvironment(ABC):
             return "$HOME"
         if cwd.startswith("~/"):
             return f"$HOME/{shlex.quote(cwd[2:])}"
+        if _IS_WINDOWS and len(cwd) >= 3 and cwd[1] == ":" and cwd[2] in ("\\", "/"):
+            return shlex.quote(cwd.replace("\\", "/"))
         return shlex.quote(cwd)
 
     def _wrap_command(self, command: str, cwd: str) -> str:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -28,6 +28,7 @@ Usage:
 import os
 import re
 import difflib
+import platform
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, ClassVar
@@ -54,6 +55,7 @@ WRITE_DENIED_PREFIXES = build_write_denied_prefixes(_HOME)
 
 _OSC_SEQUENCE_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
 _FENCE_MARKER_RE = re.compile(r"'?\x07?__HERMES_FENCE_[A-Za-z0-9]+__\x07?'?")
+_IS_WINDOWS = platform.system() == "Windows"
 
 
 def _strip_terminal_fence_leaks(text: str) -> str:
@@ -931,6 +933,8 @@ class ShellFileOperations(FileOperations):
     
     def _escape_shell_arg(self, arg: str) -> str:
         """Escape a string for safe use in shell commands."""
+        if _IS_WINDOWS and len(arg) >= 3 and arg[1] == ":" and arg[2] in ("\\", "/"):
+            arg = arg.replace("\\", "/")
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 


### PR DESCRIPTION
## What changed and why
Per the reporter's followup on June 29, 2026, this still reproduces on native Windows 11 in Hermes `2026.6.19`, especially when Hermes tries to enter or read from a user-profile path under `C:\Users\...`.

This patch fixes the path-form mismatch between Python and Git Bash on Windows:
- `LocalEnvironment`/`BaseEnvironment` still keep native Windows paths for Python subprocess `cwd=` handling.
- When Hermes hands that cwd back to Git Bash's `cd`, native `C:\...` paths are rewritten to bash-safe `C:/...` form.
- Shell-based file operations now do the same rewrite before quoting a path, so `read_file`/`wc`/`head`/`sed` stop passing raw backslash Windows paths into MSYS tools.

That matches the reported behavior: write paths could succeed through non-shell/Python paths while file reads and later shell navigation failed on native Windows user directories.

Fixes #17753

## How to test
- Run `pytest tests/tools/test_file_operations.py -q`
- Run `pytest tests/tools/test_local_env_windows_msys.py -q`
- On a native Windows install (no WSL), ask Hermes to `read_file` or terminal-read a file under `C:\Users\<username>\...` and confirm it no longer reports the path missing solely because it is a Windows-native path.

## What platforms tested on
- Linux CI-style environment for unit tests
- Native Windows behavior covered via mocked regression tests for Git Bash/MSYS path handling

<!-- autocontrib:worker-id=issue-followup-22e65a83 kind=pr-open -->