### PR TITLE
feat: add container skills runtime API

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11189,6 +11189,311 @@ class SkillToggle(BaseModel):
     profile: Optional[str] = None
 
 
+class ContainerSkillUploadFile(BaseModel):
+    path: str
+    content: str
+
+
+class ContainerSkillUploadRequest(BaseModel):
+    slug: str
+    files: List[ContainerSkillUploadFile]
+
+
+_CONTAINER_SKILL_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$")
+_CONTAINER_SKILL_MAX_FILES = 80
+_CONTAINER_SKILL_MAX_BYTES = 512 * 1024
+
+
+def _container_skill_error(status_code: int, code: str, message: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": {"code": code, "message": message}},
+    )
+
+
+def _verify_container_token(request: Request) -> Optional[JSONResponse]:
+    expected = os.getenv("CONTAINER_INTERNAL_TOKEN", "")
+    x_token = request.headers.get("X-Container-Token", "")
+    auth = request.headers.get("Authorization", "")
+    bearer = auth.removeprefix("Bearer ").strip() if auth.startswith("Bearer ") else ""
+    if not expected or not x_token or not bearer or x_token != expected or bearer != expected:
+        return _container_skill_error(401, "invalid_container_token", "invalid container token")
+    return None
+
+
+def _container_skills_dir() -> Path:
+    return get_hermes_home() / "skills"
+
+
+def _read_container_bundled_names(skills_dir: Path) -> set[str]:
+    manifest = skills_dir / ".bundled_manifest"
+    if not manifest.exists():
+        return set()
+    names: set[str] = set()
+    try:
+        for line in manifest.read_text(encoding="utf-8").splitlines():
+            name = line.strip().split(":", 1)[0].strip()
+            if name:
+                names.add(name)
+    except OSError:
+        return set()
+    return names
+
+
+def _safe_container_skill_path(path: str) -> str | None:
+    if not path or "\\" in path or "//" in path:
+        return None
+    candidate = Path(path)
+    if candidate.is_absolute() or any(part in {"", ".", ".."} for part in candidate.parts):
+        return None
+    return candidate.as_posix()
+
+
+def _container_skill_source(slug: str, bundled_names: set[str]) -> str:
+    return "bundled" if slug in bundled_names else "workspace"
+
+
+def _parse_container_skill_frontmatter(skill_md: Path) -> tuple[dict, str]:
+    try:
+        content = skill_md.read_text(encoding="utf-8")[:4000]
+    except OSError:
+        return {}, ""
+    try:
+        from tools.skills_tool import _parse_frontmatter
+        return _parse_frontmatter(content)
+    except Exception:
+        return {}, content
+
+
+def _list_container_skill_dirs(skills_dir: Path) -> list[tuple[str, Path]]:
+    if not skills_dir.exists():
+        return []
+    result: list[tuple[str, Path]] = []
+    seen: set[str] = set()
+    for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+        if any(part.startswith(".") for part in skill_md.relative_to(skills_dir).parts):
+            continue
+        skill_dir = skill_md.parent
+        slug = skill_dir.name
+        if slug in seen:
+            continue
+        seen.add(slug)
+        result.append((slug, skill_dir))
+    return result
+
+
+def _container_skill_payload(slug: str, skill_dir: Path, bundled_names: set[str]) -> dict:
+    frontmatter, body = _parse_container_skill_frontmatter(skill_dir / "SKILL.md")
+    name = str(frontmatter.get("name") or slug)
+    description = str(frontmatter.get("description") or "")
+    if not description:
+        for line in body.strip().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                description = line
+                break
+    source = _container_skill_source(slug, bundled_names)
+    payload = {
+        "slug": slug,
+        "name": name,
+        "description": description,
+        "source": source,
+        "bundled": source == "bundled",
+    }
+    for src, dst in (
+        ("version", "version"),
+        ("bundledStatus", "bundledStatus"),
+        ("bundled_status", "bundledStatus"),
+        ("reviewStatus", "reviewStatus"),
+        ("review_status", "reviewStatus"),
+        ("requiredTools", "requiredTools"),
+        ("required_tools", "requiredTools"),
+        ("permissions", "permissions"),
+    ):
+        if src in frontmatter and dst not in payload:
+            payload[dst] = frontmatter[src]
+    return payload
+
+
+def _find_container_skill(slug: str, skills_dir: Path) -> Path | None:
+    for found_slug, skill_dir in _list_container_skill_dirs(skills_dir):
+        if found_slug == slug:
+            return skill_dir
+    return None
+
+
+@app.get("/skills")
+async def list_container_skills(request: Request):
+    auth_error = _verify_container_token(request)
+    if auth_error:
+        return auth_error
+
+    skills_dir = _container_skills_dir()
+    bundled_names = _read_container_bundled_names(skills_dir)
+    skills = [
+        _container_skill_payload(slug, skill_dir, bundled_names)
+        for slug, skill_dir in _list_container_skill_dirs(skills_dir)
+    ]
+    return {"skills": skills}
+
+
+@app.post("/skills/upload", status_code=201)
+async def upload_container_skill(request: Request, body: ContainerSkillUploadRequest):
+    auth_error = _verify_container_token(request)
+    if auth_error:
+        return auth_error
+
+    slug = body.slug.strip()
+    if not _CONTAINER_SKILL_SLUG_RE.fullmatch(slug):
+        return _container_skill_error(
+            400,
+            "invalid_slug",
+            "slug must match /^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$/",
+        )
+    if len(body.files) > _CONTAINER_SKILL_MAX_FILES:
+        return _container_skill_error(400, "too_many_files", "max 80 files")
+
+    normalized_files: list[tuple[str, str, int]] = []
+    total_bytes = 0
+    seen_paths: set[str] = set()
+    for file in body.files:
+        safe_path = _safe_container_skill_path(file.path)
+        if safe_path is None:
+            return _container_skill_error(
+                400,
+                "unsafe_path",
+                "path contains .. or is absolute",
+            )
+        size = len(file.content.encode("utf-8"))
+        total_bytes += size
+        if total_bytes > _CONTAINER_SKILL_MAX_BYTES:
+            return _container_skill_error(
+                400,
+                "payload_too_large",
+                "total size exceeds 512KB",
+            )
+        if safe_path not in seen_paths:
+            seen_paths.add(safe_path)
+            normalized_files.append((safe_path, file.content, size))
+
+    if "SKILL.md" not in seen_paths:
+        return _container_skill_error(400, "missing_skill_md", "SKILL.md is required")
+
+    skills_dir = _container_skills_dir()
+    bundled_names = _read_container_bundled_names(skills_dir)
+    if slug in bundled_names:
+        return _container_skill_error(
+            403,
+            "bundled_skill_immutable",
+            "bundled skill is immutable",
+        )
+
+    skill_dir = skills_dir / slug
+    tmp_dir = skills_dir / f".{slug}.upload-{secrets.token_hex(8)}"
+    try:
+        tmp_dir.mkdir(parents=True, exist_ok=False)
+        for safe_path, content, _size in normalized_files:
+            dest = tmp_dir / safe_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(content, encoding="utf-8")
+        if skill_dir.exists() or skill_dir.is_symlink():
+            shutil.rmtree(skill_dir)
+        tmp_dir.replace(skill_dir)
+    except OSError as exc:
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        return _container_skill_error(500, "write_failed", str(exc))
+
+    payload = _container_skill_payload(slug, skill_dir, bundled_names)
+    return JSONResponse(
+        status_code=201,
+        content={
+            "skill": {
+                "slug": slug,
+                "source": "workspace",
+                "path": str(skill_dir),
+                "name": payload["name"],
+                "description": payload["description"],
+                "version": str(payload.get("version") or "1.0"),
+                "bundled": False,
+                "files": [
+                    {"path": path, "sizeBytes": size}
+                    for path, _content, size in normalized_files
+                ],
+                "totalBytes": total_bytes,
+            }
+        },
+    )
+
+
+@app.get("/skills/{slug}/files")
+async def read_container_skill_file(request: Request, slug: str, path: str):
+    auth_error = _verify_container_token(request)
+    if auth_error:
+        return auth_error
+
+    safe_path = _safe_container_skill_path(path)
+    if safe_path is None:
+        return _container_skill_error(400, "unsafe_path", "path traversal denied")
+
+    skills_dir = _container_skills_dir()
+    bundled_names = _read_container_bundled_names(skills_dir)
+    skill_dir = _find_container_skill(slug, skills_dir)
+    if skill_dir is None:
+        return _container_skill_error(404, "skill_not_found", "skill not found")
+
+    file_path = skill_dir / safe_path
+    try:
+        rel_parts = Path(safe_path).parts
+        current = skill_dir
+        for part in rel_parts:
+            current = current / part
+            if current.is_symlink():
+                return _container_skill_error(400, "unsafe_path", "path traversal denied")
+        stat_result = file_path.stat()
+        if not stat.S_ISREG(stat_result.st_mode):
+            return _container_skill_error(404, "file_not_found", "file not found")
+        content = file_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return _container_skill_error(404, "file_not_found", "file not found")
+    except OSError:
+        return _container_skill_error(404, "file_not_found", "file not found")
+
+    source = _container_skill_source(slug, bundled_names)
+    return {
+        "slug": slug,
+        "source": source,
+        "bundled": source == "bundled",
+        "path": safe_path,
+        "sizeBytes": stat_result.st_size,
+        "content": content,
+    }
+
+
+@app.delete("/skills/{slug}")
+async def delete_container_skill(request: Request, slug: str):
+    auth_error = _verify_container_token(request)
+    if auth_error:
+        return auth_error
+
+    skills_dir = _container_skills_dir()
+    bundled_names = _read_container_bundled_names(skills_dir)
+    skill_dir = _find_container_skill(slug, skills_dir)
+    if skill_dir is None:
+        return _container_skill_error(404, "skill_not_found", "skill not found")
+    if _container_skill_source(slug, bundled_names) == "bundled":
+        return _container_skill_error(
+            403,
+            "bundled_skill_immutable",
+            "bundled skill is immutable",
+        )
+    if skill_dir.is_symlink():
+        return _container_skill_error(400, "unsafe_path", "path traversal denied")
+
+    shutil.rmtree(skill_dir)
+    return {"slug": slug, "source": "workspace", "deleted": True}
+
+
 @app.get("/api/skills")
 async def get_skills(profile: Optional[str] = None):
     from tools.skills_tool import _find_all_skills

--- a/tests/hermes_cli/test_container_skills_api.py
+++ b/tests/hermes_cli/test_container_skills_api.py
@@ -1,0 +1,180 @@
+from pathlib import Path
+
+import pytest
+
+
+SKILL_MD = """---
+name: {name}
+description: {description}
+version: 1.2.3
+---
+
+# {name}
+"""
+
+
+@pytest.fixture
+def client(monkeypatch, _isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app
+
+    monkeypatch.setenv("CONTAINER_INTERNAL_TOKEN", "test-token")
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    c = TestClient(app)
+    c.headers["X-Container-Token"] = "test-token"
+    c.headers["Authorization"] = "Bearer test-token"
+    return c
+
+
+def _write_skill(root: Path, slug: str, *, description: str = "test skill") -> Path:
+    skill_dir = root / slug
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        SKILL_MD.format(name=slug, description=description),
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def test_container_skills_requires_both_headers(client):
+    client.headers.pop("Authorization", None)
+    response = client.get("/skills")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_container_token"
+
+
+def test_container_skills_list_marks_bundled_and_workspace(client):
+    from hermes_constants import get_hermes_home
+
+    skills_dir = get_hermes_home() / "skills"
+    _write_skill(skills_dir, "static-site", description="Publish static sites")
+    _write_skill(skills_dir, "my-skill", description="User installed")
+    (skills_dir / ".bundled_manifest").write_text("static-site:abc123\n", encoding="utf-8")
+
+    response = client.get("/skills")
+    assert response.status_code == 200
+    skills = {skill["slug"]: skill for skill in response.json()["skills"]}
+
+    assert skills["static-site"]["source"] == "bundled"
+    assert skills["static-site"]["bundled"] is True
+    assert skills["static-site"]["description"] == "Publish static sites"
+    assert skills["my-skill"]["source"] == "workspace"
+    assert skills["my-skill"]["bundled"] is False
+
+
+def test_container_skill_upload_writes_and_can_overwrite_workspace(client):
+    from hermes_constants import get_hermes_home
+
+    response = client.post(
+        "/skills/upload",
+        json={
+            "slug": "my-skill",
+            "files": [
+                {"path": "SKILL.md", "content": SKILL_MD.format(name="my-skill", description="First")},
+                {"path": "references/api.md", "content": "# API"},
+            ],
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()["skill"]
+    assert data["slug"] == "my-skill"
+    assert data["source"] == "workspace"
+    assert data["totalBytes"] > 0
+    assert (get_hermes_home() / "skills" / "my-skill" / "references" / "api.md").exists()
+
+    response = client.post(
+        "/skills/upload",
+        json={
+            "slug": "my-skill",
+            "files": [
+                {"path": "SKILL.md", "content": SKILL_MD.format(name="my-skill", description="Second")},
+            ],
+        },
+    )
+    assert response.status_code == 201
+    assert not (get_hermes_home() / "skills" / "my-skill" / "references" / "api.md").exists()
+
+
+@pytest.mark.parametrize(
+    "payload,code",
+    [
+        ({"slug": "../bad", "files": [{"path": "SKILL.md", "content": "x"}]}, "invalid_slug"),
+        ({"slug": "my-skill", "files": [{"path": "nested/SKILL.md", "content": "x"}]}, "missing_skill_md"),
+        ({"slug": "my-skill", "files": [{"path": "../SKILL.md", "content": "x"}]}, "unsafe_path"),
+        ({"slug": "my-skill", "files": [{"path": "SKILL.md", "content": "x"}] * 81}, "too_many_files"),
+        ({"slug": "my-skill", "files": [{"path": "SKILL.md", "content": "x" * (512 * 1024 + 1)}]}, "payload_too_large"),
+    ],
+)
+def test_container_skill_upload_validation_errors(client, payload, code):
+    response = client.post("/skills/upload", json=payload)
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == code
+
+
+def test_container_skill_upload_rejects_bundled_overwrite(client):
+    from hermes_constants import get_hermes_home
+
+    skills_dir = get_hermes_home() / "skills"
+    _write_skill(skills_dir, "static-site")
+    (skills_dir / ".bundled_manifest").write_text("static-site:abc123\n", encoding="utf-8")
+
+    response = client.post(
+        "/skills/upload",
+        json={
+            "slug": "static-site",
+            "files": [{"path": "SKILL.md", "content": SKILL_MD.format(name="static-site", description="New")}],
+        },
+    )
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "bundled_skill_immutable"
+
+
+def test_container_skill_read_file_rejects_traversal_and_symlinks(client, tmp_path):
+    from hermes_constants import get_hermes_home
+
+    skills_dir = get_hermes_home() / "skills"
+    skill_dir = _write_skill(skills_dir, "my-skill")
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references" / "api.md").write_text("# API", encoding="utf-8")
+    (skill_dir / "leak").symlink_to(tmp_path / "outside")
+
+    response = client.get("/skills/my-skill/files", params={"path": "references/api.md"})
+    assert response.status_code == 200
+    assert response.json()["content"] == "# API"
+    assert response.json()["sizeBytes"] == 5
+
+    response = client.get("/skills/my-skill/files", params={"path": "../secret"})
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "unsafe_path"
+
+    response = client.get("/skills/my-skill/files", params={"path": "leak/file.txt"})
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "unsafe_path"
+
+
+def test_container_skill_delete_only_workspace(client):
+    from hermes_constants import get_hermes_home
+
+    skills_dir = get_hermes_home() / "skills"
+    _write_skill(skills_dir, "workspace-skill")
+    _write_skill(skills_dir, "bundled-skill")
+    (skills_dir / ".bundled_manifest").write_text("bundled-skill:abc123\n", encoding="utf-8")
+
+    response = client.delete("/skills/bundled-skill")
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "bundled_skill_immutable"
+
+    response = client.delete("/skills/workspace-skill")
+    assert response.status_code == 200
+    assert response.json() == {
+        "slug": "workspace-skill",
+        "source": "workspace",
+        "deleted": True,
+    }
+    assert not (skills_dir / "workspace-skill").exists()


### PR DESCRIPTION
## Summary
- add authenticated container runtime skills endpoints for list, upload, read, and delete
- distinguish bundled skills via .bundled_manifest and protect them from overwrite/delete
- validate upload slug, file count, payload size, and unsafe paths
- add tests for auth, bundled/workspace behavior, upload validation, symlink-safe reads, and deletion

## Tests
- uv run --extra dev pytest tests/hermes_cli/test_container_skills_api.py
- uv run --extra dev ruff check hermes_cli/web_server.py tests/hermes_cli/test_container_skills_api.py

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>