### PR TITLE
fix(wecom): prevent busy-loop consuming 100% CPU on websocket disconnect

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -335,10 +335,25 @@ class WeComAdapter(BasePlatformAdapter):
     async def _listen_loop(self) -> None:
         """Read websocket events forever, reconnecting on errors."""
         backoff_idx = 0
+        consecutive_failures = 0
+        max_consecutive_failures = 50  # cap total retries to prevent infinite loops
         while self._running:
+            if consecutive_failures >= max_consecutive_failures:
+                logger.error(
+                    "[%s] WeCom reconnect exceeded %d attempts — giving up. "
+                    "Restart the gateway to recover.",
+                    self.name, max_consecutive_failures,
+                )
+                self._set_fatal_error(
+                    "wecom_reconnect_exhausted",
+                    f"WeCom reconnect failed after {max_consecutive_failures} attempts",
+                    retryable=True,
+                )
+                return
             try:
                 await self._read_events()
                 backoff_idx = 0
+                consecutive_failures = 0
             except asyncio.CancelledError:
                 return
             except Exception as exc:
@@ -346,18 +361,26 @@ class WeComAdapter(BasePlatformAdapter):
                     return
                 logger.warning("[%s] WebSocket error: %s", self.name, exc)
                 self._fail_pending_responses(RuntimeError("WeCom connection interrupted"))
+                # Clean up stale ws so _read_events won't see a zombie ref
+                await self._cleanup_ws()
 
                 delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
                 backoff_idx += 1
+                consecutive_failures += 1
                 await asyncio.sleep(delay)
 
                 try:
                     await self._open_connection()
                     backoff_idx = 0
+                    consecutive_failures = 0
                     self._mark_connected()
                     logger.info("[%s] Reconnected", self.name)
                 except Exception as reconnect_exc:
                     logger.warning("[%s] Reconnect failed: %s", self.name, reconnect_exc)
+                    # Clean up after failed _open_connection to avoid
+                    # leaving a closed ws that _read_events would silently
+                    # return from (busy-loop root cause).
+                    await self._cleanup_ws()
 
     async def _read_events(self) -> None:
         """Read websocket frames until the connection closes."""
@@ -372,6 +395,13 @@ class WeComAdapter(BasePlatformAdapter):
                     await self._dispatch_payload(payload)
             elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSING}:
                 raise RuntimeError("WeCom websocket closed")
+
+        # while loop exited without raising — ws closed externally (e.g.
+        # during handshake). If we don't raise here, _listen_loop sees a
+        # normal return, resets backoff to 0, and re-enters _read_events
+        # which exits immediately again → busy-loop consuming 100% CPU.
+        if self._running:
+            raise RuntimeError("WeCom websocket closed (loop exit without error frame)")
 
     async def _heartbeat_loop(self) -> None:
         """Send lightweight application-level pings."""

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -93,6 +93,9 @@ CONNECT_TIMEOUT_SECONDS = 20.0
 REQUEST_TIMEOUT_SECONDS = 15.0
 HEARTBEAT_INTERVAL_SECONDS = 30.0
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+# Worst-case reconnect budget with MAX_CONSECUTIVE_RECONNECT_FAILURES=50:
+# 2+5+10+30 + 46×60 = 2807s ≈ 47 min before _set_fatal_error trips.
+MAX_CONSECUTIVE_RECONNECT_FAILURES = 50
 
 DEDUP_MAX_SIZE = 1000
 
@@ -336,24 +339,29 @@ class WeComAdapter(BasePlatformAdapter):
         """Read websocket events forever, reconnecting on errors."""
         backoff_idx = 0
         consecutive_failures = 0
-        max_consecutive_failures = 50  # cap total retries to prevent infinite loops
         while self._running:
-            if consecutive_failures >= max_consecutive_failures:
+            if consecutive_failures >= MAX_CONSECUTIVE_RECONNECT_FAILURES:
                 logger.error(
                     "[%s] WeCom reconnect exceeded %d attempts — giving up. "
                     "Restart the gateway to recover.",
-                    self.name, max_consecutive_failures,
+                    self.name, MAX_CONSECUTIVE_RECONNECT_FAILURES,
                 )
                 self._set_fatal_error(
                     "wecom_reconnect_exhausted",
-                    f"WeCom reconnect failed after {max_consecutive_failures} attempts",
+                    f"WeCom reconnect failed after {MAX_CONSECUTIVE_RECONNECT_FAILURES} attempts",
                     retryable=True,
                 )
                 return
             try:
-                await self._read_events()
+                frames_seen = await self._read_events()
+                # Only reset failure counter after _read_events actually processed
+                # at least one frame.  A connection that opens and immediately
+                # closes (e.g. server accepts handshake then drops) must still
+                # count toward the cap — otherwise consecutive_failures never
+                # grows past 1 and _set_fatal_error never fires.
+                if frames_seen > 0:
+                    consecutive_failures = 0
                 backoff_idx = 0
-                consecutive_failures = 0
             except asyncio.CancelledError:
                 return
             except Exception as exc:
@@ -371,8 +379,10 @@ class WeComAdapter(BasePlatformAdapter):
 
                 try:
                     await self._open_connection()
+                    # Connection re-established — reset backoff but NOT the
+                    # failure counter.  The counter only resets once we have
+                    # evidence of a healthy connection (frames_seen > 0 above).
                     backoff_idx = 0
-                    consecutive_failures = 0
                     self._mark_connected()
                     logger.info("[%s] Reconnected", self.name)
                 except Exception as reconnect_exc:
@@ -382,26 +392,46 @@ class WeComAdapter(BasePlatformAdapter):
                     # return from (busy-loop root cause).
                     await self._cleanup_ws()
 
-    async def _read_events(self) -> None:
-        """Read websocket frames until the connection closes."""
+    async def _read_events(self) -> int:
+        """Read websocket frames until the connection closes.
+
+        Returns the number of frames successfully processed.  The caller
+        (``_listen_loop``) uses this to decide whether the connection was
+        healthy enough to reset the consecutive-failure counter.
+
+        Two exit paths:
+        - **Server-initiated close** (CLOSE/CLOSED/ERROR frame): returns
+          ``frames_seen`` so the caller knows the connection was healthy.
+        - **Silent close** (ws.closed flips True between while-check and
+          ``receive()``): raises to prevent the busy-loop that starved the
+          event loop at 100% CPU.
+        """
         if not self._ws:
             raise RuntimeError("WebSocket not connected")
 
+        frames_seen = 0
         while self._running and self._ws and not self._ws.closed:
             msg = await self._ws.receive()
             if msg.type == aiohttp.WSMsgType.TEXT:
                 payload = self._parse_json(msg.data)
                 if payload:
                     await self._dispatch_payload(payload)
+                    frames_seen += 1
             elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSING}:
-                raise RuntimeError("WeCom websocket closed")
+                # Server-initiated close — connection was valid, frames were
+                # processed.  Return (not raise) so _listen_loop can reset the
+                # consecutive-failure counter when frames_seen > 0.
+                return frames_seen
 
-        # while loop exited without raising — ws closed externally (e.g.
-        # during handshake). If we don't raise here, _listen_loop sees a
-        # normal return, resets backoff to 0, and re-enters _read_events
-        # which exits immediately again → busy-loop consuming 100% CPU.
+        # while loop exited without a close frame — ws closed externally
+        # between the loop condition check and receive().  This is the
+        # busy-loop trigger: without raising here, _listen_loop sees a normal
+        # return, resets backoff to 0, and re-enters _read_events which exits
+        # immediately again → 100% CPU.
         if self._running:
             raise RuntimeError("WeCom websocket closed (loop exit without error frame)")
+
+        return frames_seen
 
     async def _heartbeat_loop(self) -> None:
         """Send lightweight application-level pings."""

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -951,5 +951,151 @@ class TestTextBatchFlushRace:
 
         assert handle_calls == [event], "active task must call handle_message"
         assert adapter._pending_text_batches.get(key) is None, (
-            "active task must pop the event after processing"
+            "active task must pop the event"
+        )
+
+
+class TestWeComListenLoopBusyLoopPrevention:
+    """Regression tests for the busy-loop fix (PR #55486).
+
+    The invariant: ``_listen_loop`` must not reset ``consecutive_failures``
+    unless ``_read_events`` actually processed at least one frame.  A
+    connection that opens and immediately closes must still count toward
+    the fatal-error cap.
+    """
+
+    def _make_adapter(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._running = True
+        adapter._cleanup_ws = AsyncMock()
+        adapter._fail_pending_responses = MagicMock()
+        adapter._set_fatal_error = MagicMock()
+        adapter._mark_connected = MagicMock()
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_zero_frames_does_not_reset_failure_counter(self):
+        """consecutive_failures must grow when _read_events returns 0.
+
+        Scenario: _read_events raises (ws closed immediately after connect).
+        Even though _open_connection succeeds on each retry, the failure
+        counter must never be reset because no frames were processed.
+        """
+        import plugins.platforms.wecom.adapter as wecom_mod
+
+        adapter = self._make_adapter()
+        # _read_events always raises (ws closed, 0 frames processed)
+        adapter._read_events = AsyncMock(
+            side_effect=RuntimeError("WeCom websocket closed (loop exit without error frame)")
+        )
+        # _open_connection always succeeds (but produces 0 frames next time)
+        adapter._open_connection = AsyncMock()
+
+        call_count = 0
+        original_sleep = asyncio.sleep
+
+        async def fast_sleep(delay):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= wecom_mod.MAX_CONSECUTIVE_RECONNECT_FAILURES + 2:
+                adapter._running = False
+            await original_sleep(0)
+
+        with patch.object(wecom_mod.asyncio, "sleep", side_effect=fast_sleep):
+            await adapter._listen_loop()
+
+        assert adapter._set_fatal_error.called, (
+            "consecutive_failures must reach the cap even when reconnect succeeds, "
+            "because _read_events never processed any frames"
+        )
+        assert adapter._set_fatal_error.call_args[0][0] == "wecom_reconnect_exhausted"
+
+    @pytest.mark.asyncio
+    async def test_healthy_frames_reset_failure_counter(self):
+        """consecutive_failures must reset to 0 when _read_events returns >0.
+
+        Scenario: a transient failure followed by a healthy session (10 frames
+        processed) must clear the failure counter.
+        """
+        adapter = self._make_adapter()
+
+        # First call raises (transient failure), second returns 10 frames,
+        # third call: stop the loop.
+        adapter._read_events = AsyncMock(
+            side_effect=[
+                RuntimeError("WeCom websocket closed"),
+                10,   # healthy session, 10 frames processed
+                asyncio.CancelledError(),  # graceful shutdown
+            ]
+        )
+        adapter._open_connection = AsyncMock()
+
+        await adapter._listen_loop()
+
+        # After the healthy session, consecutive_failures should have been
+        # reset.  The loop should have exited via CancelledError, not fatal.
+        assert not adapter._set_fatal_error.called, (
+            "healthy session must reset consecutive_failures; no fatal error expected"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_close_with_frames_resets_counter(self):
+        """Server-initiated CLOSE after processing frames resets the counter.
+
+        _read_events returns frames_seen (not raises) on CLOSE/CLOSED frames,
+        so _listen_loop sees a normal return with frames_seen > 0 and resets.
+        """
+        adapter = self._make_adapter()
+
+        # First: raise (failure, counter=1). Second: server close after 5
+        # frames (return 5, counter=0). Third: cancel.
+        adapter._read_events = AsyncMock(
+            side_effect=[
+                RuntimeError("WeCom websocket closed"),
+                5,    # server CLOSE after 5 frames
+                asyncio.CancelledError(),
+            ]
+        )
+        adapter._open_connection = AsyncMock()
+
+        await adapter._listen_loop()
+
+        assert not adapter._set_fatal_error.called
+
+    @pytest.mark.asyncio
+    async def test_open_then_immediate_close_counts_toward_cap(self):
+        """The exact scenario from reviewer feedback: connect succeeds but
+        server drops immediately, _read_events returns 0 frames.
+
+        This must NOT loop forever — the cap must eventually trip.
+        """
+        import plugins.platforms.wecom.adapter as wecom_mod
+
+        adapter = self._make_adapter()
+
+        # _read_events returns 0 (connection opened, no frames, then silent close
+        # that gets caught by the post-loop raise)
+        adapter._read_events = AsyncMock(
+            side_effect=RuntimeError("WeCom websocket closed (loop exit without error frame)")
+        )
+        adapter._open_connection = AsyncMock()
+
+        iterations = 0
+        original_sleep = asyncio.sleep
+
+        async def counting_sleep(delay):
+            nonlocal iterations
+            iterations += 1
+            if iterations >= wecom_mod.MAX_CONSECUTIVE_RECONNECT_FAILURES + 2:
+                adapter._running = False
+            await original_sleep(0)
+
+        with patch.object(wecom_mod.asyncio, "sleep", side_effect=counting_sleep):
+            await adapter._listen_loop()
+
+        # The cap must have been reached — this is the core invariant.
+        assert adapter._set_fatal_error.called, (
+            f"After {iterations} reconnect cycles with 0 frames each, "
+            f"_set_fatal_error must fire (cap={wecom_mod.MAX_CONSECUTIVE_RECONNECT_FAILURES})"
         )


### PR DESCRIPTION
## Bug Description

The WeCom gateway adapter has a **busy-loop bug** that pins a CPU core at ~99% when the websocket disconnects externally (e.g., server-side close during handshake, network interruption). This starves the entire asyncio event loop, making **all** messaging platforms (including Telegram) unresponsive until the gateway is restarted.

## Root Cause

When `_read_events()` exits the `while self._running and self._ws and not self._ws.closed` loop without raising (because `self._ws.closed` becomes True between the while-check and `self._ws.receive()`), `_listen_loop()` sees a normal return, resets `backoff_idx` to 0, and re-enters `_read_events()` — which immediately exits again. This creates a tight busy-loop with no `await asyncio.sleep()` in between.

Additionally, after a failed `_open_connection()`, `self._ws` may still reference a closed socket object. The next `_read_events()` call sees `self._ws.closed == True`, skips the while loop entirely, returns normally, and the busy-loop starts again.

## Timeline of the Bug

```
1. WeCom ws closes externally (e.g. during handshake timeout)
2. _read_events() → while loop exits without raising → returns None
3. _listen_loop() → no exception → backoff_idx = 0
4. _open_connection() → fails (e.g. network issue) → self._ws left as closed socket
5. _listen_loop() → re-enters _read_events()
6. _read_events() → self._ws.closed is True → while loop skipped → returns None
7. Back to step 3 → infinite tight loop, no sleep → CPU 99%
```

## Fix (3 changes)

1. **`_read_events`**: After the while loop, if `self._running` is still True, raise `RuntimeError` — this means the ws closed externally, not a graceful `disconnect()` call.

2. **`_listen_loop`**: Call `_cleanup_ws()` after errors and failed reconnects to clear stale ws/session references, preventing `_read_events` from seeing a zombie closed socket.

3. **`_listen_loop`**: Add `consecutive_failures` counter with max 50 retries (~47 minutes of exponential backoff). After exhausting retries, call `_set_fatal_error()` and stop — making the failure observable in logs and `hermes gateway status`.

## Verification

Tested on a production gateway that was experiencing the busy-loop:
- Before fix: gateway CPU at 99%, all platforms frozen
- After fix: clean reconnect with backoff, graceful failure after 50 attempts, other platforms remain responsive

## Files Changed

- `plugins/platforms/wecom/adapter.py` — `_listen_loop()` and `_read_events()` methods