### PR TITLE
fix(kimi-coding): never send thinking{type:disabled} on the api.kimi.com/coding endpoint

### DIFF
--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -16,6 +16,13 @@ from providers.base import OMIT_TEMPERATURE, ProviderProfile
 class KimiProfile(ProviderProfile):
     """Kimi/Moonshot — temperature omitted, thinking xor reasoning_effort."""
 
+    def _is_coding_endpoint(self, base_url: str | None) -> bool:
+        """True for the Anthropic-shaped api.kimi.com/coding endpoint, which
+        only allows thinking {"type": "enabled"} (vs the OpenAI-compat /v1
+        endpoint, which accepts both enabled and disabled)."""
+        eff = (base_url or self.base_url or "")
+        return "/coding" in eff
+
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, **context
     ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -40,7 +47,16 @@ class KimiProfile(ProviderProfile):
 
         enabled = reasoning_config.get("enabled", True)
         if enabled is False:
-            extra_body["thinking"] = {"type": "disabled"}
+            # The api.kimi.com/coding endpoint (Anthropic Messages-shaped) only
+            # accepts thinking {"type": "enabled"} and 400s on {"type":
+            # "disabled"} ("invalid thinking: only type=enabled is allowed for
+            # this model"). Thinking can't be turned off there, so emit the legal
+            # enabled toggle rather than a request the server rejects. The
+            # OpenAI-compat /v1 endpoint still honours disabled.
+            if self._is_coding_endpoint(context.get("base_url")):
+                extra_body["thinking"] = {"type": "enabled"}
+            else:
+                extra_body["thinking"] = {"type": "disabled"}
             return extra_body, top_level
 
         # Enabled: prefer an explicit effort; only fall back to extra_body

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -84,6 +84,17 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "disabled"}}
         assert top_level == {}
 
+    def test_coding_endpoint_never_disables_thinking(self, kimi_profile):
+        """api.kimi.com/coding (Anthropic-shaped) 400s on thinking
+        {"type": "disabled"} ("only type=enabled is allowed for this model"),
+        so a disable request must degrade to the legal enabled toggle there."""
+        for rc in ({"enabled": False}, {"enabled": False, "effort": "high"}):
+            extra_body, top_level = kimi_profile.build_api_kwargs_extras(
+                reasoning_config=rc, base_url="https://api.kimi.com/coding"
+            )
+            assert extra_body == {"thinking": {"type": "enabled"}}
+            assert top_level == {}
+
     @pytest.mark.parametrize(
         "reasoning_config",
         [


### PR DESCRIPTION
## Problem

The Anthropic-Messages-shaped Kimi coding endpoint (`api.kimi.com/coding`) rejects `thinking: {"type": "disabled"}` with:

```
HTTP 400: invalid thinking: only type=enabled is allowed for this model
```

`KimiProfile.build_api_kwargs_extras` emits `{"type": "disabled"}` whenever a turn requests reasoning-off (`reasoning_config={"enabled": False}`). Any cron/agent run that disables reasoning mid-session therefore 400s **intermittently** — the default `reasoning_effort` path sends a top-level `reasoning_effort` instead and is unaffected, so it only fails on the disable-reasoning turns.

Observed in production on a daily cron using `provider: kimi-coding` + `base_url: https://api.kimi.com/coding`: most days errored, days that never disabled reasoning succeeded.

## Fix

Detect the `/coding` endpoint from the resolved `base_url` and degrade a disable request to the only value that endpoint accepts, `{"type": "enabled"}` (thinking cannot be turned off there anyway). The OpenAI-compat `/v1` endpoint keeps emitting `disabled` unchanged, so no behavior changes for Moonshot `/v1` users.

## Tests

Adds `test_coding_endpoint_never_disables_thinking`; all existing kimi-profile assertions still pass.