### PR TITLE
fix(cron): raise default pre-run script timeout from 120s to 1h

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1507,7 +1507,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     return None
 
 
-_DEFAULT_SCRIPT_TIMEOUT = 120  # seconds
+_DEFAULT_SCRIPT_TIMEOUT = 3600  # seconds (1 hour)
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
 

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -206,12 +206,14 @@ import requests, json
 # Print summary to stdout — agent analyzes and reports
 ```
 
-The script timeout defaults to 120 seconds. `_get_script_timeout()` resolves the limit through a three-layer chain:
+The script timeout defaults to 3600 seconds (1 hour). `_get_script_timeout()` resolves the limit through a three-layer chain:
 
 1. **Module-level override** — `_SCRIPT_TIMEOUT` (for tests/monkeypatching). Only used when it differs from the default.
 2. **Environment variable** — `HERMES_CRON_SCRIPT_TIMEOUT`
 3. **Config** — `cron.script_timeout_seconds` in `config.yaml` (read via `load_config()`)
-4. **Default** — 120 seconds
+4. **Default** — 3600 seconds (1 hour)
+
+This timeout bounds the **pre-run script only**, not the agent. Skill-based / LLM-driven jobs run on a separate *inactivity*-based budget (`HERMES_CRON_TIMEOUT`, default 600s of idle time, `0` = unlimited) — they can run for hours as long as they keep calling tools or streaming tokens, and are only killed after the configured idle period with no activity. Scripts are dispatched to a persistent thread pool (not held under the tick lock), so a long-running script does not block other due jobs from firing.
 
 ### Provider Recovery
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -702,7 +702,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `GATEWAY_RELAY_ROUTE_KEYS` | Comma-separated relay route keys advertised to the connector. Mirrors `gateway.relay_route_keys`. |
 | `HERMES_FILE_MUTATION_VERIFIER` | Enable the per-turn file-mutation verifier footer (default: `true`). When enabled, Hermes appends an advisory listing any `write_file` / `patch` calls that failed during the turn and were not superseded by a successful write. Set to `0`, `false`, `no`, or `off` to suppress. Mirrors `display.file_mutation_verifier` in `config.yaml`; the env var wins when set. |
 | `HERMES_CRON_TIMEOUT` | Inactivity timeout for cron job agent runs in seconds (default: `600`). The agent can run indefinitely while actively calling tools or receiving stream tokens — this only triggers when idle. Set to `0` for unlimited. |
-| `HERMES_CRON_SCRIPT_TIMEOUT` | Timeout for pre-run scripts attached to cron jobs in seconds (default: `120`). Override for scripts that need longer execution (e.g., randomized delays for anti-bot timing). Also configurable via `cron.script_timeout_seconds` in `config.yaml`. |
+| `HERMES_CRON_SCRIPT_TIMEOUT` | Timeout for pre-run scripts attached to cron jobs in seconds (default: `3600`). Bounds the script only — skill/agent jobs use the separate `HERMES_CRON_TIMEOUT` inactivity budget. Also configurable via `cron.script_timeout_seconds` in `config.yaml`. |
 | `HERMES_CRON_MAX_PARALLEL` | Max cron jobs run in parallel per tick (default: `4`). |
 
 ## Agent Behavior

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -346,15 +346,15 @@ Failed jobs always deliver regardless of the `[SILENT]` marker — only successf
 
 ## Script timeout
 
-Pre-run scripts (attached via the `script` parameter) have a default timeout of 120 seconds. If your scripts need longer — for example, to include randomized delays that avoid bot-like timing patterns — you can increase this:
+Pre-run scripts (attached via the `script` parameter) have a default timeout of 3600 seconds (1 hour). This bounds the **script only** — skill-based / LLM-driven jobs run on a separate inactivity budget and are not capped by this value. If your scripts need a different limit, you can change it:
 
 ```yaml
 # ~/.hermes/config.yaml
 cron:
-  script_timeout_seconds: 300   # 5 minutes
+  script_timeout_seconds: 1800   # 30 minutes
 ```
 
-Or set the `HERMES_CRON_SCRIPT_TIMEOUT` environment variable. The resolution order is: env var → config.yaml → 120s default.
+Or set the `HERMES_CRON_SCRIPT_TIMEOUT` environment variable. The resolution order is: env var → config.yaml → 3600s default.
 
 ## No-agent mode (script-only jobs)
 


### PR DESCRIPTION
## Summary
Cron pre-run scripts now default to a 1-hour timeout instead of 120s, so long-running data-collection scripts on crons don't get killed mid-run.

The 120s cap only ever bounded the **pre-run script** — but users putting long jobs on crons (the whole point of offloading work) hit it unexpectedly. Bumped `_DEFAULT_SCRIPT_TIMEOUT` 120 → 3600.

## Changes
- `cron/scheduler.py`: `_DEFAULT_SCRIPT_TIMEOUT` 120 → 3600s (1 hour).
- docs (cron-internals, cron user-guide, environment-variables): updated default + made the **script-vs-agent** timeout distinction explicit (the old docs let the reader infer it).

## Notes
- **Script ≠ agent.** This timeout bounds the pre-run script only. Skill/LLM-driven jobs already run on a separate *inactivity* budget (`HERMES_CRON_TIMEOUT`, default 600s idle, `0` = unlimited) — they can run for hours as long as they keep calling tools / streaming.
- **No job starvation.** Scripts dispatch to a persistent thread pool and do not hold the `.tick.lock`, so a long script doesn't block other due jobs from firing (verified in `tick()`'s fire-and-forget dispatch + in-flight guard).
- env/config overrides (`HERMES_CRON_SCRIPT_TIMEOUT`, `cron.script_timeout_seconds`) unchanged and still take precedence.

## Validation
| | Before | After |
|---|---|---|
| script default | 120s | 3600s |
| env override (`=300`) | 300s | 300s |
| module override (`=45`) | 45s | 45s |
| agent inactivity budget | 600s (unchanged) | 600s (unchanged) |

E2E-verified the full `_get_script_timeout()` resolution chain with real imports (default / env / module-override layers). No tests pinned the old default.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa0582a/M7O-TB-cnr2vfFTcuzzSw_pzfUj2ZW.png)
