### PR TITLE
fix(qqbot): accept is_reconnect kwarg in connect() to fix reconnect

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,16 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        Accepts ``is_reconnect`` to match the ``PlatformAdapter.connect()``
+        contract (the gateway's reconnect watcher always forwards it). QQ keeps
+        its own server-side resume state (``_session_id`` / ``_last_seq``) and
+        has no separate update queue to preserve, so the flag is accepted and
+        ignored per the base-class note that adapters with no such queue may
+        ignore it.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2220,3 +2220,40 @@ class TestReadEventsClosedWsGuard:
         adapter._ws = None
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
+
+
+# ---------------------------------------------------------------------------
+# QQAdapter.connect() signature contract (issue #54679)
+# ---------------------------------------------------------------------------
+
+class TestQQConnectIsReconnectKwarg:
+    """The gateway reconnect watcher always calls
+    ``adapter.connect(is_reconnect=...)`` via
+    ``_connect_adapter_with_timeout``. QQAdapter.connect() must accept the
+    keyword to match the PlatformAdapter contract; before the fix its
+    signature was ``async def connect(self)`` and the reconnect call raised
+    ``TypeError: connect() got an unexpected keyword argument 'is_reconnect'``
+    (QQ Bot failed to reconnect after a disconnect)."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    def test_connect_signature_accepts_is_reconnect(self):
+        import inspect
+        from gateway.platforms.qqbot import QQAdapter
+        sig = inspect.signature(QQAdapter.connect)
+        assert "is_reconnect" in sig.parameters
+        param = sig.parameters["is_reconnect"]
+        # Keyword-only with a False default, matching PlatformAdapter.connect().
+        assert param.kind == inspect.Parameter.KEYWORD_ONLY
+        assert param.default is False
+
+    def test_connect_callable_with_is_reconnect_kwarg(self):
+        # Calling connect(is_reconnect=True) must not raise TypeError for the
+        # unexpected keyword. We force an early, dependency-style return so the
+        # call exercises only the signature/binding, not real networking.
+        adapter = self._make_adapter()
+        with mock.patch("gateway.platforms.qqbot.adapter.AIOHTTP_AVAILABLE", False):
+            result = asyncio.run(adapter.connect(is_reconnect=True))
+        assert result is False


### PR DESCRIPTION
## Summary

- `QQAdapter.connect()` now accepts the keyword-only `is_reconnect` flag, matching the `PlatformAdapter.connect()` contract every other adapter already implements.
- Fixes QQ Bot failing to reconnect after any disconnect on v0.17.0.

## Root Cause

**Symptom** — After v0.17.0, QQ Bot fails to reconnect after a disconnection; the log shows `QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'`.

**Root cause** — `gateway/run.py::_connect_adapter_with_timeout()` always forwards `adapter.connect(is_reconnect=is_reconnect)` (added in #46621 so adapters can distinguish a cold boot from a watcher reconnect). Every platform adapter declares `async def connect(self, *, is_reconnect: bool = False)` — except `gateway/platforms/qqbot/adapter.py`, which still had the old signature `async def connect(self)`. On the reconnect path (`run.py` line ~6855, `is_reconnect=True`) the keyword binding raises `TypeError`, so the reconnect attempt dies and QQ never comes back.

**Evidence** — `grep "async def connect" gateway/platforms/*.py gateway/platforms/*/adapter.py` shows qqbot is the lone outlier; `run.py:3132/3135` always pass the kwarg. New test `test_connect_callable_with_is_reconnect_kwarg` reproduces the exact `TypeError` on the old signature.

**Fix + why this level** — Fix at the adapter signature (the source of the contract violation), not by wrapping the call site in `try/except TypeError` (the issue’s alternative). The base class already documents the flag; bringing qqbot into line is the correct, narrowest fix and avoids masking real `TypeError`s at the call site. QQ keeps its own server-side resume state (`_session_id`/`_last_seq`) and has no separate update queue to preserve, so the flag is accepted and ignored per the base-class note that adapters without such a queue may ignore it.

**Scope / risk** — One-line signature change + docstring; behavior is unchanged for the existing cold-boot path (`is_reconnect` defaults to `False`). No other call sites touched.

## Tests

Added `TestQQConnectIsReconnectKwarg` (2 cases) in `tests/gateway/test_qqbot.py`:
- `test_connect_signature_accepts_is_reconnect` — asserts the keyword-only param with `False` default.
- `test_connect_callable_with_is_reconnect_kwarg` — calls `connect(is_reconnect=True)` (forced early return via `AIOHTTP_AVAILABLE=False`), asserts no `TypeError`.

Real captured output:

Without the fix:
```
>           result = asyncio.run(adapter.connect(is_reconnect=True))
E           TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
FAILED tests/gateway/test_qqbot.py::TestQQConnectIsReconnectKwarg::test_connect_signature_accepts_is_reconnect
FAILED tests/gateway/test_qqbot.py::TestQQConnectIsReconnectKwarg::test_connect_callable_with_is_reconnect_kwarg
2 failed, 161 deselected in 0.27s
```

With the fix (full qqbot suite):
```
163 passed, 4 warnings in 2.99s
```
(the 4 warnings are pre-existing coroutine-cleanup warnings unrelated to this change)

Fixes #54679