### PR TITLE
fix(telegram): honor group user allowlists

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1028,6 +1028,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]
                 if "allow_from" in platform_cfg:
                     bridged["allow_from"] = platform_cfg["allow_from"]
+                elif plat == Platform.TELEGRAM and "allowed_users" in platform_cfg:
+                    bridged["allow_from"] = platform_cfg["allowed_users"]
                 if "allow_admin_from" in platform_cfg:
                     bridged["allow_admin_from"] = platform_cfg["allow_admin_from"]
                 if "user_allowed_commands" in platform_cfg:
@@ -1036,6 +1038,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_policy"] = platform_cfg["group_policy"]
                 if "group_allow_from" in platform_cfg:
                     bridged["group_allow_from"] = platform_cfg["group_allow_from"]
+                elif plat == Platform.TELEGRAM and "group_allowed_users" in platform_cfg:
+                    bridged["group_allow_from"] = platform_cfg["group_allowed_users"]
                 if "group_allow_admin_from" in platform_cfg:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -631,6 +631,38 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         return any(os.getenv(key, "").strip() for key in keys)
 
+    def _telegram_sender_auth_env_configured(self) -> bool:
+        """Return True when env can authorize a concrete sender, not just a chat."""
+        keys = (
+            "TELEGRAM_ALLOWED_USERS",
+            "TELEGRAM_GROUP_ALLOWED_USERS",
+            "TELEGRAM_ALLOW_ALL_USERS",
+            "GATEWAY_ALLOWED_USERS",
+            "GATEWAY_ALLOW_ALL_USERS",
+        )
+        return any(os.getenv(key, "").strip() for key in keys)
+
+    @staticmethod
+    def _coerce_telegram_allowlist(raw: Any) -> set[str]:
+        if raw is None:
+            return set()
+        if isinstance(raw, str):
+            values = raw.split(",")
+        elif isinstance(raw, (list, tuple, set)):
+            values = raw
+        else:
+            values = [raw]
+        return {str(value).strip() for value in values if str(value).strip()}
+
+    def _telegram_config_allowlist(self, *keys: str) -> set[str]:
+        extra = self.config.extra if self.config and self.config.extra else {}
+        for key in keys:
+            if key in extra:
+                values = self._coerce_telegram_allowlist(extra.get(key))
+                if values:
+                    return values
+        return set()
+
     def _is_user_authorized_from_message(self, message: Message) -> bool:
         """Check if the sender of a Telegram message is authorized.
 
@@ -651,11 +683,31 @@ class TelegramAdapter(BasePlatformAdapter):
         if not user_id:
             return True
 
-        # Adapter-level allow_from: when set, it is the sole authority.
-        adapter_allow_from = self.config.extra.get("allow_from")
-        if adapter_allow_from is not None:
-            allowed = {str(u).strip() for u in adapter_allow_from if str(u).strip()}
-            return user_id in allowed or "*" in allowed
+        adapter_allow_from = self._telegram_config_allowlist("allow_from", "allowed_users")
+        adapter_group_allow_from = self._telegram_config_allowlist(
+            "group_allow_from",
+            "group_allowed_users",
+        )
+        adapter_group_allowed_chats = self._telegram_config_allowlist("group_allowed_chats")
+
+        if adapter_allow_from:
+            if user_id in adapter_allow_from or "*" in adapter_allow_from:
+                return True
+            if source.chat_type not in {"group", "forum"}:
+                return False
+            if adapter_group_allow_from:
+                return user_id in adapter_group_allow_from or "*" in adapter_group_allow_from
+            if not self._telegram_sender_auth_env_configured():
+                return False
+
+        if source.chat_type in {"group", "forum"}:
+            if adapter_group_allow_from:
+                return user_id in adapter_group_allow_from or "*" in adapter_group_allow_from
+            if adapter_group_allowed_chats:
+                return (
+                    "*" in adapter_group_allowed_chats
+                    or bool(source.chat_id and source.chat_id in adapter_group_allowed_chats)
+                )
 
         # Test/custom injection only. The class method named
         # _is_callback_user_authorized is for inline button callbacks and must
@@ -693,10 +745,24 @@ class TelegramAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
+        if source.chat_type in {"group", "forum"}:
+            group_allowed_csv = os.getenv("TELEGRAM_GROUP_ALLOWED_USERS", "").strip()
+            if group_allowed_csv:
+                group_allowed_ids = self._coerce_telegram_allowlist(group_allowed_csv)
+                return "*" in group_allowed_ids or user_id in group_allowed_ids
+
+            group_chats_csv = os.getenv("TELEGRAM_GROUP_ALLOWED_CHATS", "").strip()
+            if group_chats_csv:
+                group_allowed_chats = self._coerce_telegram_allowlist(group_chats_csv)
+                return (
+                    "*" in group_allowed_chats
+                    or bool(source.chat_id and source.chat_id in group_allowed_chats)
+                )
+
         allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
         if not allowed_csv:
             return True
-        allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+        allowed_ids = self._coerce_telegram_allowlist(allowed_csv)
         return "*" in allowed_ids or user_id in allowed_ids
 
     @classmethod
@@ -7912,11 +7978,15 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
         _rtm_str = "off" if _telegram_rtm is False else str(_telegram_rtm).lower()
         os.environ["TELEGRAM_REPLY_TO_MODE"] = _rtm_str
     allowed_users = telegram_cfg.get("allow_from")
+    if allowed_users is None:
+        allowed_users = telegram_cfg.get("allowed_users")
     if allowed_users is not None and not os.getenv("TELEGRAM_ALLOWED_USERS"):
         if isinstance(allowed_users, list):
             allowed_users = ",".join(str(v) for v in allowed_users)
         os.environ["TELEGRAM_ALLOWED_USERS"] = str(allowed_users)
     group_allowed_users = telegram_cfg.get("group_allow_from")
+    if group_allowed_users is None:
+        group_allowed_users = telegram_cfg.get("group_allowed_users")
     if group_allowed_users is not None and not os.getenv("TELEGRAM_GROUP_ALLOWED_USERS"):
         if isinstance(group_allowed_users, list):
             group_allowed_users = ",".join(str(v) for v in group_allowed_users)

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -310,6 +310,51 @@ def test_runner_auth_gets_group_chat_allowlist_context(monkeypatch):
     assert seen_sources[0].chat_id == "-222"
 
 
+def test_config_allow_from_does_not_mask_group_env_allowlist(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_USERS", "333")
+    monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+
+    adapter = _make_adapter(allow_from=["111"])
+    msg = _make_message(from_user_id=333, chat_id=-100, chat_type="supergroup")
+    msg.chat.is_forum = True
+    msg.is_topic_message = True
+    msg.message_thread_id = 7
+
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_config_allow_from_still_blocks_group_sender_without_group_allowlist(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("TELEGRAM_GROUP_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("TELEGRAM_GROUP_ALLOWED_CHATS", raising=False)
+
+    adapter = _make_adapter(allow_from=["111"])
+    msg = _make_message(from_user_id=333, chat_id=-100, chat_type="supergroup")
+
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_config_group_allowed_users_alias_authorizes_group_sender(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("TELEGRAM_GROUP_ALLOWED_USERS", raising=False)
+
+    adapter = _make_adapter(allow_from=["111"], group_allowed_users=["333"])
+    msg = _make_message(from_user_id=333, chat_id=-100, chat_type="group")
+
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_config_allowed_users_alias_authorizes_dm_sender(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+
+    adapter = _make_adapter(allowed_users=["333"])
+    allowed = _make_message(from_user_id=333, chat_id=333, chat_type="private")
+    blocked = _make_message(from_user_id=444, chat_id=444, chat_type="private")
+
+    assert adapter._is_user_authorized_from_message(allowed) is True
+    assert adapter._is_user_authorized_from_message(blocked) is False
+
+
 def test_removed_dm_user_blocked_before_pairing_when_allowlist_exists(monkeypatch):
     """A user removed from TELEGRAM_ALLOWED_USERS should be blocked at intake."""
     monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "222")

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -797,6 +797,29 @@ def test_config_bridges_telegram_user_allowlists(monkeypatch, tmp_path):
     assert tg_cfg.extra.get("group_allowed_chats") == ["-100"]
 
 
+def test_config_bridges_telegram_allowed_users_aliases(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        "  allowed_users:\n"
+        "    - \"111\"\n"
+        "  group_allowed_users:\n"
+        "    - \"333\"\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("TELEGRAM_GROUP_ALLOWED_USERS", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    assert __import__("os").environ["TELEGRAM_ALLOWED_USERS"] == "111"
+    assert __import__("os").environ["TELEGRAM_GROUP_ALLOWED_USERS"] == "333"
+
+
 def test_config_env_overrides_telegram_user_allowlists(monkeypatch, tmp_path):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()


### PR DESCRIPTION
Summary
- Let Telegram group-scoped user allowlists authorize supergroup/forum senders even when a DM-wide allow_from list is configured.
- Keep group_allowed_chats chat-scoped so it does not widen a sender allowlist by itself.
- Accept allowed_users and group_allowed_users config aliases and bridge them to the existing auth variables.

Problem
Telegram intake auth checked config allow_from before the gateway auth resolver. If the owner was in allow_from, an additional supergroup user listed in TELEGRAM_GROUP_ALLOWED_USERS or group_allow_from could be rejected before the group-scoped allowlist was considered. Users also tried allowed_users / group_allowed_users in config.yaml, but those names were not bridged.

Validation
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/gateway/test_telegram_auth_check.py tests/gateway/test_telegram_group_gating.py
- $HOME/.hermes/hermes-agent/venv/bin/python -m ruff check plugins/platforms/telegram/adapter.py gateway/config.py tests/gateway/test_telegram_auth_check.py tests/gateway/test_telegram_group_gating.py
- $HOME/.hermes/hermes-agent/venv/bin/python -m py_compile plugins/platforms/telegram/adapter.py gateway/config.py tests/gateway/test_telegram_auth_check.py tests/gateway/test_telegram_group_gating.py

Refs #55462