### PR TITLE
fix(agent): persist compression backoff across resume + bound lease refresher (#54465)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1665,6 +1665,12 @@ def init_agent(
             abort_on_summary_failure=compression_abort_on_summary_failure,
             max_tokens=agent.max_tokens,
         )
+    _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
+    if callable(_bind_session_state):
+        try:
+            _bind_session_state(session_db=session_db, session_id=agent.session_id)
+        except Exception:
+            pass
     agent.compression_enabled = compression_enabled
     agent.compression_in_place = compression_in_place
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -672,7 +672,7 @@ class ContextCompressor(ContextEngine):
     def on_session_start(self, session_id: str, **kwargs) -> None:
         """Bind session-scoped compression state for a new or resumed session."""
         super().on_session_start(session_id, **kwargs)
-        self.bind_session_state(kwargs.get("session_db", self._session_db), session_id)
+        self.bind_session_state(kwargs.get("session_db", getattr(self, "_session_db", None)), session_id)
 
     def get_active_compression_failure_cooldown(self) -> Optional[Dict[str, Any]]:
         """Return the live compression-failure cooldown for the bound session."""
@@ -686,8 +686,8 @@ class ContextCompressor(ContextEngine):
                 "error": self._last_summary_error,
             }
 
-        session_db = self._session_db
-        session_id = self._session_id
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
         if not session_db or not session_id:
             return None
 
@@ -725,8 +725,8 @@ class ContextCompressor(ContextEngine):
         self._summary_failure_cooldown_until = time.monotonic() + cooldown_seconds
         self._last_summary_error = error
 
-        session_db = self._session_db
-        session_id = self._session_id
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
         if not session_db or not session_id:
             return
 
@@ -744,8 +744,8 @@ class ContextCompressor(ContextEngine):
         self._summary_failure_cooldown_until = 0.0
         self._last_summary_error = None
 
-        session_db = self._session_db
-        session_id = self._session_id
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
         if not session_db or not session_id:
             return
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1550,7 +1550,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self._last_aux_model_failure_error = _err_text
         self._last_aux_model_failure_model = self.summary_model
         self.summary_model = ""  # empty = use main model
-        self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
+        self._clear_compression_failure_cooldown()  # no cooldown — retry immediately
 
     def _generate_summary(
         self,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -737,8 +737,8 @@ class ContextCompressor(ContextEngine):
             recorder(session_id, cooldown_until, error)
         except sqlite3.Error as exc:
             logger.debug("compression failure cooldown persist failed: %s", exc)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("compression failure cooldown persist failed (non-sqlite): %s", exc)
 
     def _clear_compression_failure_cooldown(self) -> None:
         self._summary_failure_cooldown_until = 0.0
@@ -756,8 +756,8 @@ class ContextCompressor(ContextEngine):
             clearer(session_id)
         except sqlite3.Error as exc:
             logger.debug("compression failure cooldown clear failed: %s", exc)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("compression failure cooldown clear failed (non-sqlite): %s", exc)
 
     def update_model(
         self,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -19,6 +19,7 @@ Improvements over v2:
 import hashlib
 import json
 import logging
+import sqlite3
 import re
 import time
 from typing import Any, Dict, List, Optional
@@ -638,6 +639,7 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
+        self._last_summary_error = None
         self.last_real_prompt_tokens = 0
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
@@ -658,6 +660,104 @@ class ContextCompressor(ContextEngine):
         owning session ends.
         """
         self._previous_summary = None
+
+    def bind_session_state(self, session_db: Any = None, session_id: str = "") -> None:
+        """Bind the current session row so durable cooldowns can round-trip."""
+        self._session_db = session_db
+        self._session_id = session_id or ""
+        self._summary_failure_cooldown_until = 0.0
+        self._last_summary_error = None
+        self.get_active_compression_failure_cooldown()
+
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        """Bind session-scoped compression state for a new or resumed session."""
+        super().on_session_start(session_id, **kwargs)
+        self.bind_session_state(kwargs.get("session_db", self._session_db), session_id)
+
+    def get_active_compression_failure_cooldown(self) -> Optional[Dict[str, Any]]:
+        """Return the live compression-failure cooldown for the bound session."""
+        now_mono = time.monotonic()
+        if self._summary_failure_cooldown_until > now_mono:
+            return {
+                "cooldown_until": time.time() + (
+                    self._summary_failure_cooldown_until - now_mono
+                ),
+                "remaining_seconds": self._summary_failure_cooldown_until - now_mono,
+                "error": self._last_summary_error,
+            }
+
+        session_db = self._session_db
+        session_id = self._session_id
+        if not session_db or not session_id:
+            return None
+
+        getter = getattr(session_db, "get_compression_failure_cooldown", None)
+        if getter is None:
+            return None
+        try:
+            state = getter(session_id)
+        except sqlite3.Error as exc:
+            logger.debug("compression failure cooldown lookup failed: %s", exc)
+            return None
+        except Exception:
+            return None
+        if not state:
+            return None
+
+        remaining_seconds = float(state.get("remaining_seconds") or 0.0)
+        if remaining_seconds <= 0:
+            return None
+
+        self._summary_failure_cooldown_until = now_mono + remaining_seconds
+        self._last_summary_error = state.get("error")
+        return {
+            "cooldown_until": float(state.get("cooldown_until") or 0.0),
+            "remaining_seconds": remaining_seconds,
+            "error": self._last_summary_error,
+        }
+
+    def _record_compression_failure_cooldown(
+        self,
+        cooldown_seconds: float,
+        error: Optional[str],
+    ) -> None:
+        cooldown_until = time.time() + cooldown_seconds
+        self._summary_failure_cooldown_until = time.monotonic() + cooldown_seconds
+        self._last_summary_error = error
+
+        session_db = self._session_db
+        session_id = self._session_id
+        if not session_db or not session_id:
+            return
+
+        recorder = getattr(session_db, "record_compression_failure_cooldown", None)
+        if recorder is None:
+            return
+        try:
+            recorder(session_id, cooldown_until, error)
+        except sqlite3.Error as exc:
+            logger.debug("compression failure cooldown persist failed: %s", exc)
+        except Exception:
+            pass
+
+    def _clear_compression_failure_cooldown(self) -> None:
+        self._summary_failure_cooldown_until = 0.0
+        self._last_summary_error = None
+
+        session_db = self._session_db
+        session_id = self._session_id
+        if not session_db or not session_id:
+            return
+
+        clearer = getattr(session_db, "clear_compression_failure_cooldown", None)
+        if clearer is None:
+            return
+        try:
+            clearer(session_id)
+        except sqlite3.Error as exc:
+            logger.debug("compression failure cooldown clear failed: %s", exc)
+        except Exception:
+            pass
 
     def update_model(
         self,
@@ -863,6 +963,8 @@ class ContextCompressor(ContextEngine):
         self.awaiting_real_usage_after_compression = False
 
         self.summary_model = summary_model_override or ""
+        self._session_db: Any = None
+        self._session_id: str = ""
 
         # Stores the previous compaction summary for iterative updates
         self._previous_summary: Optional[str] = None
@@ -1691,7 +1793,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             summary = redact_sensitive_text(content.strip())
             # Store for iterative updates on next compaction
             self._previous_summary = summary
-            self._summary_failure_cooldown_until = 0.0
+            self._clear_compression_failure_cooldown()
             self._summary_model_fallen_back = False
             self._last_summary_error = None
             self._last_summary_auth_failure = False
@@ -1711,7 +1813,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             # a main-model retry before any cooldown. (#11978, #11914)
             if isinstance(e, RuntimeError) and "no llm provider configured" in str(e).lower():
                 # No provider configured — long cooldown, unlikely to self-resolve
-                self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
+                self._record_compression_failure_cooldown(
+                    _SUMMARY_FAILURE_COOLDOWN_SECONDS,
+                    "no auxiliary LLM provider configured",
+                )
                 self._last_summary_error = "no auxiliary LLM provider configured"
                 logger.warning("Context compression: no provider available for "
                                 "summary. Middle turns will be dropped without summary "
@@ -1823,10 +1928,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             # streaming premature-close) — shorter cooldown for JSON decode and
             # streaming-closed since those conditions can self-resolve quickly.
             _transient_cooldown = 30 if (_is_json_decode or _is_streaming_closed) else 60
-            self._summary_failure_cooldown_until = time.monotonic() + _transient_cooldown
             err_text = str(e).strip() or e.__class__.__name__
             if len(err_text) > 220:
                 err_text = err_text[:217].rstrip() + "..."
+            self._record_compression_failure_cooldown(_transient_cooldown, err_text)
             self._last_summary_error = err_text
             # A terminal connection/network failure (we reach this branch only
             # after any main-model fallback has already been tried or is
@@ -2405,8 +2510,8 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Manual /compress (force=True) bypasses the failure cooldown so the
         # user can retry immediately after an auto-compress abort.  Without
         # this, /compress would silently no-op for 30-60s after a failure.
-        if force and self._summary_failure_cooldown_until > 0.0:
-            self._summary_failure_cooldown_until = 0.0
+        if force:
+            self._clear_compression_failure_cooldown()
         n_messages = len(messages)
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
         _min_for_compress = self._protect_head_size(messages) + 3 + 1

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -579,314 +579,316 @@ def compress_context(
         _release_lock()  # compression aborted — no rotation will happen
         return messages, _existing_sp
 
-    summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
-    if summary_error:
-        if getattr(agent, "_last_compression_summary_warning", None) != summary_error:
-            agent._last_compression_summary_warning = summary_error
-            agent._emit_warning(
-                f"⚠ Compression summary failed: {summary_error}. "
-                "Inserted a fallback context marker."
-            )
-    else:
-        # No hard failure — but did the configured aux model error out
-        # and get recovered by retrying on main?  Surface that so users
-        # know their auxiliary.compression.model setting is broken even
-        # though compression succeeded.
-        _aux_fail_model = getattr(agent.context_compressor, "_last_aux_model_failure_model", None)
-        _aux_fail_err = getattr(agent.context_compressor, "_last_aux_model_failure_error", None)
-        if _aux_fail_model:
-            # Dedup on (model, error) so we don't spam on every compaction
-            _aux_key = (_aux_fail_model, _aux_fail_err)
-            if getattr(agent, "_last_aux_fallback_warning_key", None) != _aux_key:
-                agent._last_aux_fallback_warning_key = _aux_key
+    try:
+        summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
+        if summary_error:
+            if getattr(agent, "_last_compression_summary_warning", None) != summary_error:
+                agent._last_compression_summary_warning = summary_error
                 agent._emit_warning(
-                    f"ℹ Configured compression model '{_aux_fail_model}' failed "
-                    f"({_aux_fail_err or 'unknown error'}). Recovered using main model — "
-                    "check auxiliary.compression.model in config.yaml."
+                    f"⚠ Compression summary failed: {summary_error}. "
+                    "Inserted a fallback context marker."
                 )
-
-    todo_snapshot = agent._todo_store.format_for_injection()
-    if todo_snapshot:
-        compressed.append({"role": "user", "content": todo_snapshot})
-
-    agent._invalidate_system_prompt()
-    new_system_prompt = agent._build_system_prompt(system_message)
-    agent._cached_system_prompt = new_system_prompt
-
-    if agent._session_db:
-        try:
-            # Trigger memory extraction on the current session before the
-            # transcript is rewritten (runs in BOTH modes — the logical
-            # conversation's pre-compaction turns are about to be summarized
-            # away regardless of whether the id rotates).
-            agent.commit_memory_session(messages)
-
-            if in_place:
-                # ── In-place compaction: keep the same session_id ──────────
-                # No end_session, no new row, no parent_session_id, no title
-                # renumber, no contextvar/env/logging re-sync. The session's
-                # id, title, cwd, /goal, and gateway routing all stay put.
-                #
-                # Durable, NON-DESTRUCTIVE replace: soft-archive the
-                # pre-compaction turns (active=0, kept on disk + FTS-searchable +
-                # recoverable) and insert `compressed` as the new live (active=1)
-                # set, atomically. `compressed` already carries the surviving
-                # tail (current-turn messages the compressor kept via
-                # protect_last_n), so we DON'T pre-flush here — a flush would
-                # INSERT current-turn rows that archive_and_compact would then
-                # archive alongside the rest (harmless but wasted writes). The
-                # live-context load filters active=1, so a resume reloads ONLY
-                # the compacted set; the original turns remain under the SAME id
-                # for search/recovery (Teknium review — keep one durable id
-                # WITHOUT destroying history, unlike a hard replace_messages).
-                # See #38763.
-                agent._session_db.archive_and_compact(agent.session_id, compressed)
-                # Reset the flush identity set so the next turn's appends are
-                # diffed against the COMPACTED transcript: the compacted dicts
-                # are passed as conversation_history next turn and skipped by
-                # identity, so only genuinely new turn messages get appended
-                # (no dup of the summary, no resurrection of dropped turns).
-                agent._flushed_db_message_ids = set()
-                # Rotation-independent signal: the conversation was compacted in
-                # place (id unchanged). The gateway reads this (NOT an id-change
-                # diff) to re-baseline transcript handling.
-                compacted_in_place = True
-            else:
-                # ── Rotation (legacy): end this session, fork a continuation ─
-                # Flush any un-persisted current-turn messages to the OLD
-                # session before ending it, so they survive in the preserved
-                # parent transcript (#47202). (In-place skips this — see above.)
-                try:
-                    agent._flush_messages_to_session_db(messages)
-                except Exception:
-                    pass  # best-effort — don't block compression on a flush error
-                # Propagate title to the new session with auto-numbering
-                old_title = agent._session_db.get_session_title(agent.session_id)
-                agent._session_db.end_session(agent.session_id, "compression")
-                old_session_id = agent.session_id
-                agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
-                # Ordering contract: the agent thread updates the contextvar here;
-                # the gateway propagates to SessionEntry after run_in_executor returns.
-                try:
-                    from gateway.session_context import set_current_session_id
-
-                    set_current_session_id(agent.session_id)
-                except Exception:
-                    os.environ["HERMES_SESSION_ID"] = agent.session_id
-                # The gateway/tools session context (ContextVar + env) and the
-                # logging session context are SEPARATE mechanisms. The call above
-                # moves the former; the ``[session_id]`` tag on log lines comes
-                # from ``hermes_logging._session_context`` (set once per turn in
-                # conversation_loop.py). Without this, post-rotation log lines in
-                # the same turn keep the STALE old id while the message/DB/gateway
-                # state carry the new one — breaking log correlation exactly at the
-                # compaction boundary (see #34089). Guarded separately so a logging
-                # failure can never regress the routing update above.
-                try:
-                    from hermes_logging import set_session_context
-
-                    set_session_context(agent.session_id)
-                except Exception:
-                    pass
-                agent._session_db_created = False
-                try:
-                    agent._session_db.create_session(
-                        session_id=agent.session_id,
-                        source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
-                        model=agent.model,
-                        model_config=agent._session_init_model_config,
-                        parent_session_id=old_session_id,
+        else:
+            # No hard failure — but did the configured aux model error out
+            # and get recovered by retrying on main?  Surface that so users
+            # know their auxiliary.compression.model setting is broken even
+            # though compression succeeded.
+            _aux_fail_model = getattr(agent.context_compressor, "_last_aux_model_failure_model", None)
+            _aux_fail_err = getattr(agent.context_compressor, "_last_aux_model_failure_error", None)
+            if _aux_fail_model:
+                # Dedup on (model, error) so we don't spam on every compaction
+                _aux_key = (_aux_fail_model, _aux_fail_err)
+                if getattr(agent, "_last_aux_fallback_warning_key", None) != _aux_key:
+                    agent._last_aux_fallback_warning_key = _aux_key
+                    agent._emit_warning(
+                        f"ℹ Configured compression model '{_aux_fail_model}' failed "
+                        f"({_aux_fail_err or 'unknown error'}). Recovered using main model — "
+                        "check auxiliary.compression.model in config.yaml."
                     )
-                except Exception as _cs_err:
-                    # The child row could not be created (e.g. FK constraint,
-                    # contended write). Previously the outer handler simply
-                    # warned and let the agent continue on the NEW id — which
-                    # has no row in state.db, producing an orphan: the parent
-                    # is ended, the child is never indexed, and every
-                    # subsequent message is attributed to a session that
-                    # doesn't exist (#33906/#33907). Roll the live id back to
-                    # the parent so the conversation stays attached to a real,
-                    # indexed session instead of a phantom.
-                    logger.warning(
-                        "Compression child session create failed (%s) — "
-                        "rolling back to parent session %s to avoid an orphan.",
-                        _cs_err, old_session_id,
-                    )
-                    agent.session_id = old_session_id
+
+        todo_snapshot = agent._todo_store.format_for_injection()
+        if todo_snapshot:
+            compressed.append({"role": "user", "content": todo_snapshot})
+
+        agent._invalidate_system_prompt()
+        new_system_prompt = agent._build_system_prompt(system_message)
+        agent._cached_system_prompt = new_system_prompt
+
+        if agent._session_db:
+            try:
+                # Trigger memory extraction on the current session before the
+                # transcript is rewritten (runs in BOTH modes — the logical
+                # conversation's pre-compaction turns are about to be summarized
+                # away regardless of whether the id rotates).
+                agent.commit_memory_session(messages)
+
+                if in_place:
+                    # ── In-place compaction: keep the same session_id ──────────
+                    # No end_session, no new row, no parent_session_id, no title
+                    # renumber, no contextvar/env/logging re-sync. The session's
+                    # id, title, cwd, /goal, and gateway routing all stay put.
+                    #
+                    # Durable, NON-DESTRUCTIVE replace: soft-archive the
+                    # pre-compaction turns (active=0, kept on disk + FTS-searchable +
+                    # recoverable) and insert `compressed` as the new live (active=1)
+                    # set, atomically. `compressed` already carries the surviving
+                    # tail (current-turn messages the compressor kept via
+                    # protect_last_n), so we DON'T pre-flush here — a flush would
+                    # INSERT current-turn rows that archive_and_compact would then
+                    # archive alongside the rest (harmless but wasted writes). The
+                    # live-context load filters active=1, so a resume reloads ONLY
+                    # the compacted set; the original turns remain under the SAME id
+                    # for search/recovery (Teknium review — keep one durable id
+                    # WITHOUT destroying history, unlike a hard replace_messages).
+                    # See #38763.
+                    agent._session_db.archive_and_compact(agent.session_id, compressed)
+                    # Reset the flush identity set so the next turn's appends are
+                    # diffed against the COMPACTED transcript: the compacted dicts
+                    # are passed as conversation_history next turn and skipped by
+                    # identity, so only genuinely new turn messages get appended
+                    # (no dup of the summary, no resurrection of dropped turns).
+                    agent._flushed_db_message_ids = set()
+                    # Rotation-independent signal: the conversation was compacted in
+                    # place (id unchanged). The gateway reads this (NOT an id-change
+                    # diff) to re-baseline transcript handling.
+                    compacted_in_place = True
+                else:
+                    # ── Rotation (legacy): end this session, fork a continuation ─
+                    # Flush any un-persisted current-turn messages to the OLD
+                    # session before ending it, so they survive in the preserved
+                    # parent transcript (#47202). (In-place skips this — see above.)
+                    try:
+                        agent._flush_messages_to_session_db(messages)
+                    except Exception:
+                        pass  # best-effort — don't block compression on a flush error
+                    # Propagate title to the new session with auto-numbering
+                    old_title = agent._session_db.get_session_title(agent.session_id)
+                    agent._session_db.end_session(agent.session_id, "compression")
+                    old_session_id = agent.session_id
+                    agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                    # Ordering contract: the agent thread updates the contextvar here;
+                    # the gateway propagates to SessionEntry after run_in_executor returns.
                     try:
                         from gateway.session_context import set_current_session_id
+
                         set_current_session_id(agent.session_id)
                     except Exception:
                         os.environ["HERMES_SESSION_ID"] = agent.session_id
+                    # The gateway/tools session context (ContextVar + env) and the
+                    # logging session context are SEPARATE mechanisms. The call above
+                    # moves the former; the ``[session_id]`` tag on log lines comes
+                    # from ``hermes_logging._session_context`` (set once per turn in
+                    # conversation_loop.py). Without this, post-rotation log lines in
+                    # the same turn keep the STALE old id while the message/DB/gateway
+                    # state carry the new one — breaking log correlation exactly at the
+                    # compaction boundary (see #34089). Guarded separately so a logging
+                    # failure can never regress the routing update above.
                     try:
                         from hermes_logging import set_session_context
+
                         set_session_context(agent.session_id)
                     except Exception:
                         pass
-                    # Re-open the parent: it was ended above, but we're
-                    # continuing on it, so it must not stay closed.
+                    agent._session_db_created = False
                     try:
-                        agent._session_db.reopen_session(old_session_id)
-                    except Exception:
-                        pass
-                    old_session_id = None  # no rotation happened
-                    # The parent row already exists in state.db, so mark the
-                    # session as created — _ensure_db_session would otherwise
-                    # retry a (harmless INSERT OR IGNORE) create next turn.
+                        agent._session_db.create_session(
+                            session_id=agent.session_id,
+                            source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            model=agent.model,
+                            model_config=agent._session_init_model_config,
+                            parent_session_id=old_session_id,
+                        )
+                    except Exception as _cs_err:
+                        # The child row could not be created (e.g. FK constraint,
+                        # contended write). Previously the outer handler simply
+                        # warned and let the agent continue on the NEW id — which
+                        # has no row in state.db, producing an orphan: the parent
+                        # is ended, the child is never indexed, and every
+                        # subsequent message is attributed to a session that
+                        # doesn't exist (#33906/#33907). Roll the live id back to
+                        # the parent so the conversation stays attached to a real,
+                        # indexed session instead of a phantom.
+                        logger.warning(
+                            "Compression child session create failed (%s) — "
+                            "rolling back to parent session %s to avoid an orphan.",
+                            _cs_err, old_session_id,
+                        )
+                        agent.session_id = old_session_id
+                        try:
+                            from gateway.session_context import set_current_session_id
+                            set_current_session_id(agent.session_id)
+                        except Exception:
+                            os.environ["HERMES_SESSION_ID"] = agent.session_id
+                        try:
+                            from hermes_logging import set_session_context
+                            set_session_context(agent.session_id)
+                        except Exception:
+                            pass
+                        # Re-open the parent: it was ended above, but we're
+                        # continuing on it, so it must not stay closed.
+                        try:
+                            agent._session_db.reopen_session(old_session_id)
+                        except Exception:
+                            pass
+                        old_session_id = None  # no rotation happened
+                        # The parent row already exists in state.db, so mark the
+                        # session as created — _ensure_db_session would otherwise
+                        # retry a (harmless INSERT OR IGNORE) create next turn.
+                        agent._session_db_created = True
+                        raise
                     agent._session_db_created = True
-                    raise
-                agent._session_db_created = True
-                # Carry a persistent /goal onto the continuation session.
-                # Compression mints a fresh child id; load_goal does a flat
-                # per-session lookup with no parent walk, so without this an
-                # active goal silently dies at the boundary (#33618).
-                try:
-                    from hermes_cli.goals import migrate_goal_to_session
-                    migrate_goal_to_session(old_session_id, agent.session_id, reason="compression")
-                except Exception as _goal_err:
-                    logger.debug("Could not migrate goal on compression: %s", _goal_err)
-                # Auto-number the title for the continuation session
-                if old_title:
+                    # Carry a persistent /goal onto the continuation session.
+                    # Compression mints a fresh child id; load_goal does a flat
+                    # per-session lookup with no parent walk, so without this an
+                    # active goal silently dies at the boundary (#33618).
                     try:
-                        new_title = agent._session_db.get_next_title_in_lineage(old_title)
-                        agent._session_db.set_session_title(agent.session_id, new_title)
-                    except (ValueError, Exception) as e:
-                        logger.debug("Could not propagate title on compression: %s", e)
+                        from hermes_cli.goals import migrate_goal_to_session
+                        migrate_goal_to_session(old_session_id, agent.session_id, reason="compression")
+                    except Exception as _goal_err:
+                        logger.debug("Could not migrate goal on compression: %s", _goal_err)
+                    # Auto-number the title for the continuation session
+                    if old_title:
+                        try:
+                            new_title = agent._session_db.get_next_title_in_lineage(old_title)
+                            agent._session_db.set_session_title(agent.session_id, new_title)
+                        except (ValueError, Exception) as e:
+                            logger.debug("Could not propagate title on compression: %s", e)
 
-            # Shared post-write steps (both modes target agent.session_id, which
-            # in-place keeps and rotation has already reassigned to the new id):
-            # refresh the stored system prompt and reset the flush cursor so the
-            # next turn re-bases its append diff.
-            agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
-            agent._last_flushed_db_idx = 0
-        except Exception as e:
-            # If the rotation rolled back to the parent (orphan-avoidance
-            # above), agent.session_id is the still-indexed parent and
-            # old_session_id was cleared — so this is recovery, not an
-            # un-indexed orphan. Otherwise an earlier step failed before the
-            # child was created and the warning's original meaning holds.
-            if locals().get("old_session_id") is None and not in_place:
-                logger.warning(
-                    "Compression rotation aborted and rolled back to the "
-                    "parent session (%s): %s", agent.session_id or "?", e,
-                )
-            else:
-                logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
+                # Shared post-write steps (both modes target agent.session_id, which
+                # in-place keeps and rotation has already reassigned to the new id):
+                # refresh the stored system prompt and reset the flush cursor so the
+                # next turn re-bases its append diff.
+                agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+                agent._last_flushed_db_idx = 0
+            except Exception as e:
+                # If the rotation rolled back to the parent (orphan-avoidance
+                # above), agent.session_id is the still-indexed parent and
+                # old_session_id was cleared — so this is recovery, not an
+                # un-indexed orphan. Otherwise an earlier step failed before the
+                # child was created and the warning's original meaning holds.
+                if locals().get("old_session_id") is None and not in_place:
+                    logger.warning(
+                        "Compression rotation aborted and rolled back to the "
+                        "parent session (%s): %s", agent.session_id or "?", e,
+                    )
+                else:
+                    logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 
-    # Compaction-boundary bookkeeping, computed once. `old_session_id` is only
-    # bound in the rotation branch; in-place leaves it unset. `_boundary_parent`
-    # is the id the boundary notifications attribute the prior state to: the old
-    # id on rotation, the (unchanged) current id in-place.
-    _old_sid = locals().get("old_session_id")
-    _is_boundary = bool(_old_sid) or in_place
-    _boundary_parent = _old_sid or agent.session_id or ""
+        # Compaction-boundary bookkeeping, computed once. `old_session_id` is only
+        # bound in the rotation branch; in-place leaves it unset. `_boundary_parent`
+        # is the id the boundary notifications attribute the prior state to: the old
+        # id on rotation, the (unchanged) current id in-place.
+        _old_sid = locals().get("old_session_id")
+        _is_boundary = bool(_old_sid) or in_place
+        _boundary_parent = _old_sid or agent.session_id or ""
 
-    # Notify the context engine that a compaction boundary occurred. Plugin
-    # engines (e.g. hermes-lcm) use boundary_reason="compression" to preserve
-    # DAG lineage / checkpoint per-session state across the boundary instead of
-    # re-initializing fresh. See hermes-lcm#68. Built-in ContextCompressor
-    # ignores kwargs. Fires in BOTH modes: rotation passes old→new ids; in-place
-    # passes the SAME id (the boundary is real even though the id didn't move).
-    try:
-        if _is_boundary and hasattr(agent.context_compressor, "on_session_start"):
-            agent.context_compressor.on_session_start(
-                agent.session_id or "",
-                boundary_reason="compression",
-                old_session_id=_boundary_parent,
-                platform=getattr(agent, "platform", None) or "cli",
-                conversation_id=getattr(agent, "_gateway_session_key", None),
-            )
-    except Exception as _ce_err:
-        logger.debug("context engine on_session_start (compression): %s", _ce_err)
-
-    # Notify memory providers of the compaction boundary so provider-cached
-    # per-session state (Hindsight's _document_id, accumulated turn buffers,
-    # counters) refreshes. reset=False because the logical conversation
-    # continues. See #6672. Fires in BOTH modes: in-place uses the same id as
-    # parent (the conversation didn't fork, but the buffer must still be told
-    # the transcript was compacted so it doesn't double-count dropped turns).
-    try:
-        if _is_boundary and agent._memory_manager:
-            agent._memory_manager.on_session_switch(
-                agent.session_id or "",
-                parent_session_id=_boundary_parent,
-                reset=False,
-                reason="compression",
-            )
-    except Exception as _me_err:
-        logger.debug("memory manager on_session_switch (compression): %s", _me_err)
-
-    # Warn on repeated compressions (quality degrades with each pass).
-    # Route through _emit_status (like the other compression warnings above)
-    # so the warning reaches the TUI / Telegram / Discord via status_callback,
-    # not just CLI stdout. _emit_status still _vprints for the CLI, and
-    # storing it on _compression_warning lets replay_compression_warning
-    # re-deliver it once a late-bound gateway status_callback is wired (#36908).
-    _cc = agent.context_compressor.compression_count
-    if _cc >= 2:
-        _cc_msg = (
-            f"{agent.log_prefix}⚠️  Session compressed {_cc} times — "
-            f"accuracy may degrade. Consider /new to start fresh."
-        )
-        agent._compression_warning = _cc_msg
-        agent._emit_status(_cc_msg)
-
-    # Emit session:compress event so hooks (e.g. MemPalace sync) can ingest
-    # the completed old session before its details are lost. In in-place mode
-    # there is no old id (same session); ``in_place=True`` tells hooks the
-    # transcript was compacted on the same id rather than rotated.
-    if getattr(agent, "event_callback", None):
+        # Notify the context engine that a compaction boundary occurred. Plugin
+        # engines (e.g. hermes-lcm) use boundary_reason="compression" to preserve
+        # DAG lineage / checkpoint per-session state across the boundary instead of
+        # re-initializing fresh. See hermes-lcm#68. Built-in ContextCompressor
+        # ignores kwargs. Fires in BOTH modes: rotation passes old→new ids; in-place
+        # passes the SAME id (the boundary is real even though the id didn't move).
         try:
-            agent.event_callback("session:compress", {
-                "platform": agent.platform or "",
-                "session_id": agent.session_id,
-                "old_session_id": _old_sid or "",
-                "in_place": in_place,
-                "compression_count": agent.context_compressor.compression_count,
-            })
-        except Exception as e:
-            logger.debug("event_callback error on session:compress: %s", e)
+            if _is_boundary and hasattr(agent.context_compressor, "on_session_start"):
+                agent.context_compressor.on_session_start(
+                    agent.session_id or "",
+                    boundary_reason="compression",
+                    old_session_id=_boundary_parent,
+                    platform=getattr(agent, "platform", None) or "cli",
+                    conversation_id=getattr(agent, "_gateway_session_key", None),
+                )
+        except Exception as _ce_err:
+            logger.debug("context engine on_session_start (compression): %s", _ce_err)
 
-    # Surface the compaction mode to the caller (run_conversation / gateway)
-    # via a rotation-independent flag. The gateway uses this — NOT an
-    # id-change diff — to re-baseline transcript handling (history_offset=0 +
-    # rewrite on the same id) when compaction happened in place. See #38763.
-    agent._last_compaction_in_place = compacted_in_place
+        # Notify memory providers of the compaction boundary so provider-cached
+        # per-session state (Hindsight's _document_id, accumulated turn buffers,
+        # counters) refreshes. reset=False because the logical conversation
+        # continues. See #6672. Fires in BOTH modes: in-place uses the same id as
+        # parent (the conversation didn't fork, but the buffer must still be told
+        # the transcript was compacted so it doesn't double-count dropped turns).
+        try:
+            if _is_boundary and agent._memory_manager:
+                agent._memory_manager.on_session_switch(
+                    agent.session_id or "",
+                    parent_session_id=_boundary_parent,
+                    reset=False,
+                    reason="compression",
+                )
+        except Exception as _me_err:
+            logger.debug("memory manager on_session_switch (compression): %s", _me_err)
 
-    # Keep the post-compression rough estimate for diagnostics, but do not
-    # treat it as provider-reported prompt usage. Schema-heavy rough estimates
-    # can remain above threshold even after the next real API request fits.
-    _compressed_est = estimate_request_tokens_rough(
-        compressed,
-        system_prompt=new_system_prompt or "",
-        tools=agent.tools or None,
-    )
-    agent.context_compressor.last_compression_rough_tokens = _compressed_est
-    agent.context_compressor.last_prompt_tokens = -1
-    agent.context_compressor.last_completion_tokens = 0
-    agent.context_compressor.awaiting_real_usage_after_compression = True
+        # Warn on repeated compressions (quality degrades with each pass).
+        # Route through _emit_status (like the other compression warnings above)
+        # so the warning reaches the TUI / Telegram / Discord via status_callback,
+        # not just CLI stdout. _emit_status still _vprints for the CLI, and
+        # storing it on _compression_warning lets replay_compression_warning
+        # re-deliver it once a late-bound gateway status_callback is wired (#36908).
+        _cc = agent.context_compressor.compression_count
+        if _cc >= 2:
+            _cc_msg = (
+                f"{agent.log_prefix}⚠️  Session compressed {_cc} times — "
+                f"accuracy may degrade. Consider /new to start fresh."
+            )
+            agent._compression_warning = _cc_msg
+            agent._emit_status(_cc_msg)
 
-    # Clear the file-read dedup cache.  After compression the original
-    # read content is summarised away — if the model re-reads the same
-    # file it needs the full content, not a "file unchanged" stub.
-    try:
-        from tools.file_tools import reset_file_dedup
-        reset_file_dedup(task_id)
-    except Exception:
-        pass
+        # Emit session:compress event so hooks (e.g. MemPalace sync) can ingest
+        # the completed old session before its details are lost. In in-place mode
+        # there is no old id (same session); ``in_place=True`` tells hooks the
+        # transcript was compacted on the same id rather than rotated.
+        if getattr(agent, "event_callback", None):
+            try:
+                agent.event_callback("session:compress", {
+                    "platform": agent.platform or "",
+                    "session_id": agent.session_id,
+                    "old_session_id": _old_sid or "",
+                    "in_place": in_place,
+                    "compression_count": agent.context_compressor.compression_count,
+                })
+            except Exception as e:
+                logger.debug("event_callback error on session:compress: %s", e)
 
-    logger.info(
-        "context compression done: session=%s messages=%d->%d rough_tokens=~%s awaiting_real_usage=true",
-        agent.session_id or "none", _pre_msg_count, len(compressed),
-        f"{_compressed_est:,}",
-    )
-    # Release the lock on the OLD session_id only AFTER rotation completed
-    # and all post-rotation bookkeeping (memory manager, context engine,
-    # file dedup) ran. A concurrent path that wakes up the moment we
-    # release will see the NEW session_id in state.db / SessionEntry and
-    # acquire on that — no race against our just-finished work.
-    _release_lock()
-    return compressed, new_system_prompt
+        # Surface the compaction mode to the caller (run_conversation / gateway)
+        # via a rotation-independent flag. The gateway uses this — NOT an
+        # id-change diff — to re-baseline transcript handling (history_offset=0 +
+        # rewrite on the same id) when compaction happened in place. See #38763.
+        agent._last_compaction_in_place = compacted_in_place
+
+        # Keep the post-compression rough estimate for diagnostics, but do not
+        # treat it as provider-reported prompt usage. Schema-heavy rough estimates
+        # can remain above threshold even after the next real API request fits.
+        _compressed_est = estimate_request_tokens_rough(
+            compressed,
+            system_prompt=new_system_prompt or "",
+            tools=agent.tools or None,
+        )
+        agent.context_compressor.last_compression_rough_tokens = _compressed_est
+        agent.context_compressor.last_prompt_tokens = -1
+        agent.context_compressor.last_completion_tokens = 0
+        agent.context_compressor.awaiting_real_usage_after_compression = True
+
+        # Clear the file-read dedup cache.  After compression the original
+        # read content is summarised away — if the model re-reads the same
+        # file it needs the full content, not a "file unchanged" stub.
+        try:
+            from tools.file_tools import reset_file_dedup
+            reset_file_dedup(task_id)
+        except Exception:
+            pass
+
+        logger.info(
+            "context compression done: session=%s messages=%d->%d rough_tokens=~%s awaiting_real_usage=true",
+            agent.session_id or "none", _pre_msg_count, len(compressed),
+            f"{_compressed_est:,}",
+        )
+        return compressed, new_system_prompt
+    finally:
+        # Release the lock on the OLD session_id only AFTER rotation completed
+        # and all post-rotation bookkeeping (memory manager, context engine,
+        # file dedup) ran. A concurrent path that wakes up the moment we
+        # release will see the NEW session_id in state.db / SessionEntry and
+        # acquire on that — no race against our just-finished work.
+        _release_lock()
 
 
 def try_shrink_image_parts_in_messages(

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -32,6 +32,7 @@ import logging
 import os
 import tempfile
 import uuid
+import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Tuple
@@ -69,6 +70,53 @@ def _compression_lock_holder(agent: Any) -> str:
         f":agent={id(agent):x}"
         f":nonce={uuid.uuid4().hex[:8]}"
     )
+
+
+class _CompressionLockLeaseRefresher:
+    def __init__(
+        self,
+        db: Any,
+        session_id: str,
+        holder: str,
+        ttl_seconds: float,
+        refresh_interval_seconds: float | None = None,
+    ) -> None:
+        self._db = db
+        self._session_id = session_id
+        self._holder = holder
+        self._ttl_seconds = ttl_seconds
+        if refresh_interval_seconds is None:
+            refresh_interval_seconds = max(1.0, min(60.0, ttl_seconds / 2.0))
+        self._refresh_interval_seconds = max(0.1, float(refresh_interval_seconds))
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="compression-lock-refresh",
+            daemon=True,
+        )
+
+    def start(self) -> "_CompressionLockLeaseRefresher":
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread.is_alive() and threading.current_thread() is not self._thread:
+            self._thread.join(timeout=1.0)
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._refresh_interval_seconds):
+            try:
+                refreshed = self._db.refresh_compression_lock(
+                    self._session_id,
+                    self._holder,
+                    ttl_seconds=self._ttl_seconds,
+                )
+            except Exception as exc:
+                logger.debug("compression lock refresh failed: %s", exc)
+                refreshed = False
+            if not refreshed:
+                break
 
 
 def check_compression_model_feasibility(agent: Any) -> None:
@@ -420,11 +468,17 @@ def compress_context(
     # and proceed with compression.  Skipping the lock risks a rare
     # concurrent-compression session fork; an infinite no-progress loop
     # that never compresses at all is strictly worse.
+    try:
+        _lock_ttl = float(getattr(agent, "_compression_lock_ttl_seconds", 300.0) or 300.0)
+    except (TypeError, ValueError):
+        _lock_ttl = 300.0
+    _lock_refresh_interval = getattr(agent, "_compression_lock_refresh_interval", None)
+    _lock_refresher: Optional[_CompressionLockLeaseRefresher] = None
     if _lock_db is not None and _lock_sid:
         _lock_holder = _compression_lock_holder(agent)
         try:
             _lock_acquired = _lock_db.try_acquire_compression_lock(
-                _lock_sid, _lock_holder
+                _lock_sid, _lock_holder, ttl_seconds=_lock_ttl
             )
         except Exception as _lock_err:
             # Broken/absent lock subsystem (version skew, etc.).  Log once
@@ -467,9 +521,18 @@ def compress_context(
             if not _existing_sp:
                 _existing_sp = agent._build_system_prompt(system_message)
             return messages, _existing_sp
+        _lock_refresher = _CompressionLockLeaseRefresher(
+            _lock_db,
+            _lock_sid,
+            _lock_holder,
+            _lock_ttl,
+            _lock_refresh_interval,
+        ).start()
 
     def _release_lock() -> None:
         """Release the lock keyed on the OLD session_id (before rotation)."""
+        if _lock_refresher is not None:
+            _lock_refresher.stop()
         if _lock_db is not None and _lock_sid and _lock_holder:
             try:
                 _lock_db.release_compression_lock(_lock_sid, _lock_holder)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -552,7 +552,11 @@ def compress_context(
     except TypeError:
         # Plugin context engine with strict signature that doesn't accept
         # focus_topic / force — fall back to calling without them.
-        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
+        try:
+            compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
+        except BaseException:
+            _release_lock()
+            raise
     except BaseException:
         # ANY exception during compress() must release the lock so the
         # session isn't permanently blocked from future compression.
@@ -565,19 +569,21 @@ def compress_context(
     # session has logically ended), and let auto-compress callers detect
     # the no-op via len(returned) == len(input).
     if getattr(agent.context_compressor, "_last_compress_aborted", False):
-        _err = getattr(agent.context_compressor, "_last_summary_error", None) or "unknown error"
-        if getattr(agent, "_last_compression_summary_warning", None) != _err:
-            agent._last_compression_summary_warning = _err
-            agent._emit_warning(
-                f"⚠ Compression aborted: {_err}. "
-                "No messages were dropped — conversation continues unchanged. "
-                "Run /compress to retry, or /new to start a fresh session."
-            )
-        _existing_sp = getattr(agent, "_cached_system_prompt", None)
-        if not _existing_sp:
-            _existing_sp = agent._build_system_prompt(system_message)
-        _release_lock()  # compression aborted — no rotation will happen
-        return messages, _existing_sp
+        try:
+            _err = getattr(agent.context_compressor, "_last_summary_error", None) or "unknown error"
+            if getattr(agent, "_last_compression_summary_warning", None) != _err:
+                agent._last_compression_summary_warning = _err
+                agent._emit_warning(
+                    f"⚠ Compression aborted: {_err}. "
+                    "No messages were dropped — conversation continues unchanged. "
+                    "Run /compress to retry, or /new to start a fresh session."
+                )
+            _existing_sp = getattr(agent, "_cached_system_prompt", None)
+            if not _existing_sp:
+                _existing_sp = agent._build_system_prompt(system_message)
+            return messages, _existing_sp
+        finally:
+            _release_lock()
 
     try:
         summary_error = getattr(agent.context_compressor, "_last_summary_error", None)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -521,13 +521,14 @@ def compress_context(
             if not _existing_sp:
                 _existing_sp = agent._build_system_prompt(system_message)
             return messages, _existing_sp
-        _lock_refresher = _CompressionLockLeaseRefresher(
-            _lock_db,
-            _lock_sid,
-            _lock_holder,
-            _lock_ttl,
-            _lock_refresh_interval,
-        ).start()
+        if _lock_holder is not None:
+            _lock_refresher = _CompressionLockLeaseRefresher(
+                _lock_db,
+                _lock_sid,
+                _lock_holder,
+                _lock_ttl,
+                _lock_refresh_interval,
+            ).start()
 
     def _release_lock() -> None:
         """Release the lock keyed on the OLD session_id (before rotation)."""

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -88,6 +88,14 @@ class _CompressionLockLeaseRefresher:
         if refresh_interval_seconds is None:
             refresh_interval_seconds = max(1.0, min(60.0, ttl_seconds / 2.0))
         self._refresh_interval_seconds = max(0.1, float(refresh_interval_seconds))
+        # Tolerate transient refresh failures for at most one lease's worth of
+        # time, so the give-up window is genuinely bounded by the TTL the
+        # acquirer set (a single blip recovers on the next tick; a persistent
+        # failure stops before the lease could outlive its TTL). Floor of 1 so a
+        # degenerate interval >= ttl still tolerates one blip.
+        self._max_consecutive_failures = max(
+            1, int(self._ttl_seconds / self._refresh_interval_seconds)
+        )
         self._stop = threading.Event()
         self._thread = threading.Thread(
             target=self._run,
@@ -101,10 +109,25 @@ class _CompressionLockLeaseRefresher:
 
     def stop(self) -> None:
         self._stop.set()
+        # join() may time out while the refresher is mid-UPDATE; that's safe —
+        # it's a daemon thread, and a late refresh on an already-released lock
+        # matches rowcount 0 (a no-op). stop() returning does not guarantee the
+        # thread has fully quiesced, only that we've signalled it and waited
+        # briefly.
         if self._thread.is_alive() and threading.current_thread() is not self._thread:
             self._thread.join(timeout=1.0)
 
     def _run(self) -> None:
+        # A single falsy refresh must NOT permanently kill the lease: a
+        # transient DB blip (write contention escaping _execute_write's retry
+        # budget, a momentary "database is locked") returns False just like a
+        # genuine lost-ownership, but only the latter should stop the loop.
+        # Tolerate consecutive failures for at most one lease's worth of time
+        # (_max_consecutive_failures = ttl / interval), so a one-off blip
+        # recovers on the next tick while the total give-up window stays bounded
+        # by the TTL the acquirer set — the lock can never be held past its TTL
+        # by a stuck refresher.
+        consecutive_failures = 0
         while not self._stop.wait(self._refresh_interval_seconds):
             try:
                 refreshed = self._db.refresh_compression_lock(
@@ -113,9 +136,18 @@ class _CompressionLockLeaseRefresher:
                     ttl_seconds=self._ttl_seconds,
                 )
             except Exception as exc:
-                logger.debug("compression lock refresh failed: %s", exc)
+                logger.debug("compression lock refresh raised: %s", exc)
                 refreshed = False
-            if not refreshed:
+            if refreshed:
+                consecutive_failures = 0
+                continue
+            consecutive_failures += 1
+            if consecutive_failures >= self._max_consecutive_failures:
+                logger.debug(
+                    "compression lock refresh failed %d times in a row; "
+                    "stopping lease refresher for session %s",
+                    consecutive_failures, self._session_id,
+                )
                 break
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -360,6 +360,12 @@ def build_turn_context(
             if _last >= 0 and _preflight_tokens > _last:
                 _compressor.last_prompt_tokens = _preflight_tokens
 
+        _compression_cooldown = getattr(
+            _compressor,
+            "get_active_compression_failure_cooldown",
+            lambda: None,
+        )()
+
         if _preflight_deferred:
             logger.info(
                 "Skipping preflight compression: rough estimate ~%s >= %s, "
@@ -367,6 +373,13 @@ def build_turn_context(
                 f"{_preflight_tokens:,}",
                 f"{_compressor.threshold_tokens:,}",
                 f"{_compressor.last_real_prompt_tokens:,}",
+            )
+        elif _compression_cooldown:
+            logger.info(
+                "Skipping preflight compression: same-session cooldown active "
+                "(~%s seconds remaining, session %s)",
+                int(_compression_cooldown.get("remaining_seconds", 0.0)),
+                agent.session_id or "none",
             )
         elif _compressor.should_compress(_preflight_tokens):
             logger.info(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -675,6 +675,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     handoff_state TEXT,
     handoff_platform TEXT,
     handoff_error TEXT,
+    compression_failure_cooldown_until REAL,
+    compression_failure_error TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
     archived INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
@@ -1722,6 +1724,88 @@ class SessionDB:
                 )
 
         self._execute_write(_do)
+
+    def record_compression_failure_cooldown(
+        self,
+        session_id: str,
+        cooldown_until: float,
+        error: Optional[str] = None,
+    ) -> None:
+        """Persist the active compression-failure cooldown for a session."""
+        if not session_id:
+            return
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET compression_failure_cooldown_until = ?, "
+                "compression_failure_error = ? WHERE id = ?",
+                (cooldown_until, error, session_id),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "record_compression_failure_cooldown(%s) failed: %s",
+                session_id, exc,
+            )
+
+    def get_compression_failure_cooldown(
+        self,
+        session_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the active compression-failure cooldown for ``session_id``."""
+        if not session_id:
+            return None
+        now = time.time()
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT compression_failure_cooldown_until, compression_failure_error "
+                "FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        cooldown_until = (
+            row["compression_failure_cooldown_until"]
+            if isinstance(row, sqlite3.Row)
+            else row[0]
+        )
+        if cooldown_until is None:
+            return None
+        cooldown_until = float(cooldown_until)
+        if cooldown_until <= now:
+            return None
+        error = (
+            row["compression_failure_error"]
+            if isinstance(row, sqlite3.Row)
+            else row[1]
+        )
+        return {
+            "cooldown_until": cooldown_until,
+            "remaining_seconds": cooldown_until - now,
+            "error": error,
+        }
+
+    def clear_compression_failure_cooldown(self, session_id: str) -> None:
+        """Clear any persisted compression-failure cooldown for a session."""
+        if not session_id:
+            return
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET compression_failure_cooldown_until = NULL, "
+                "compression_failure_error = NULL WHERE id = ?",
+                (session_id,),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "clear_compression_failure_cooldown(%s) failed: %s",
+                session_id, exc,
+            )
     # ──────────────────────────────────────────────────────────────────────
     # Compression locks
     # ──────────────────────────────────────────────────────────────────────
@@ -1743,6 +1827,35 @@ class SessionDB:
     # the compress() call plus the rotation. ``holder`` identifies the
     # current owner (pid:tid:nonce) for diagnostics; the lock is recovered
     # via ``expires_at`` if the holder process crashed without releasing.
+    def refresh_compression_lock(
+        self,
+        session_id: str,
+        holder: str,
+        ttl_seconds: float = 300.0,
+    ) -> bool:
+        """Extend the compression lock lease if ``holder`` still owns it."""
+        if not session_id or not holder:
+            return False
+        now = time.time()
+        expires_at = now + ttl_seconds
+
+        def _do(conn):
+            cur = conn.execute(
+                "UPDATE compression_locks SET expires_at = ? "
+                "WHERE session_id = ? AND holder = ? AND expires_at >= ?",
+                (expires_at, session_id, holder, now),
+            )
+            return cur.rowcount > 0
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "refresh_compression_lock(%s) failed: %s",
+                session_id, exc,
+            )
+            return False
+
     def try_acquire_compression_lock(
         self,
         session_id: str,

--- a/run_agent.py
+++ b/run_agent.py
@@ -692,6 +692,24 @@ class AIAgent:
             reset_engine=True,
         )
 
+        # Reset-only session switches (/new, /resume, /branch) update
+        # agent.session_id before calling reset_session_state(). The built-in
+        # compressor keeps durable cooldown state keyed by its bound session,
+        # so rebind it when the active session changed but no full start hook ran.
+        engine = getattr(self, "context_compressor", None)
+        target_session_id = getattr(self, "session_id", "") or ""
+        bound_session_id = getattr(engine, "_session_id", "") if engine is not None else ""
+        if (
+            engine is not None
+            and hasattr(engine, "bind_session_state")
+            and target_session_id
+            and target_session_id != bound_session_id
+        ):
+            try:
+                engine.bind_session_state(getattr(self, "_session_db", None), target_session_id)
+            except Exception as exc:
+                logger.debug("context engine bind_session_state during reset: %s", exc)
+
     def _ensure_lmstudio_runtime_loaded(self, config_context_length: Optional[int] = None) -> None:
         """
         Preload the LM Studio model with at least Hermes' minimum context.

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -258,7 +258,7 @@ class _NoLockSubsystemDB:
         return getattr(self._real, name)
 
 
-def test_missing_lock_subsystem_fails_open_not_infinite_loop(tmp_path: Path) -> None:
+def test_missing_lock_subsystem_fails_open_not_infinite_loop(tmp_path: Path, monkeypatch) -> None:
     """Version skew (no lock methods) must fail OPEN, not raise into the loop.
 
     Reproduces the "API call #47/#48/#49 ... has no attribute
@@ -275,6 +275,12 @@ def test_missing_lock_subsystem_fails_open_not_infinite_loop(tmp_path: Path) -> 
     # Swap in the lock-less wrapper AFTER construction (the agent already
     # holds a normal db reference; we only break the lock methods).
     agent._session_db = _NoLockSubsystemDB(db)
+    monkeypatch.setattr(
+        "agent.conversation_compression._CompressionLockLeaseRefresher",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("lock refresher should not start on fail-open lock skew")
+        ),
+    )
 
     messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
 

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -461,3 +461,155 @@ def test_review_fork_disables_compression_to_prevent_stale_parent_fork(tmp_path:
         "False — this flag MUST be cleared on the review fork."
     )
     db.close()
+
+
+# ── Lease-refresher bounded-failure tolerance (salvage follow-up, #54465) ────
+# A single falsy refresh (transient DB blip) must NOT permanently kill the
+# lease — only a *persistent* failure (genuine lost-ownership) should stop the
+# refresher after a bounded number of consecutive failures. Without this, one
+# escaped lock-contention error silently reintroduces the TTL-expiry wedge the
+# PR set out to fix.
+
+
+class _FlakyRefreshDB:
+    """A db whose refresh_compression_lock returns a scripted sequence."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls = 0
+
+    def refresh_compression_lock(self, session_id, holder, ttl_seconds=300.0):
+        self.calls += 1
+        if self._results:
+            return self._results.pop(0)
+        return True  # steady-state success after the scripted prefix
+
+
+def _no_sleep(refresher) -> None:
+    """Make the refresher loop iterate without real wall-clock sleeps.
+
+    ``_stop.wait(interval)`` returns False (keep looping) instantly instead of
+    blocking for the (clamped) interval, so count-based tests stay fast and
+    deterministic — the loop's termination is driven by the failure cap / the
+    scripted db, not by timing.
+    """
+    refresher._stop.wait = lambda _interval: False  # type: ignore[assignment]
+
+
+def test_lease_refresher_survives_single_transient_failure() -> None:
+    """One False (transient blip) followed by success must NOT stop the loop.
+
+    Regression for the W1/W2 finding: the original ``if not refreshed: break``
+    treated a one-off failure identically to genuine lost-ownership, killing
+    the lease on the first hiccup.
+    """
+    from agent.conversation_compression import _CompressionLockLeaseRefresher
+
+    # Script: success, FAILURE (blip), success, then stop the loop externally.
+    db = _FlakyRefreshDB([True, False, True])
+    refresher = _CompressionLockLeaseRefresher(
+        db, "sess", "holder", ttl_seconds=10.0, refresh_interval_seconds=0.001
+    )
+    # Stop after exactly 4 ticks (3 scripted + 1 steady success), no real sleep.
+    refresher._stop.wait = lambda _i: db.calls >= 4  # type: ignore[assignment]
+    refresher._run()
+
+    # The single False at call 2 must NOT have ended the loop — we keep going
+    # past it (calls reach >= 4), proving the blip was tolerated.
+    assert db.calls >= 4, (
+        "Lease refresher stopped after a single transient failure — the "
+        "bounded-tolerance fix regressed (one blip must not kill the lease)."
+    )
+
+
+def test_lease_refresher_failure_window_is_bounded_by_ttl() -> None:
+    """Persistent failure stops within one lease's worth of time, not forever.
+
+    The contract (not a magic count): the give-up window
+    ``cap * refresh_interval`` must be <= the TTL, so a stuck refresher can
+    never hold the lock past its TTL. We assert that relationship directly
+    rather than freezing a literal cap (behavior contract over snapshot).
+    """
+    from agent.conversation_compression import _CompressionLockLeaseRefresher
+
+    ttl, interval = 10.0, 2.0  # cap should be int(10/2) = 5
+    db = _FlakyRefreshDB([False] * 50)  # never recovers (lost ownership)
+    refresher = _CompressionLockLeaseRefresher(
+        db, "sess", "holder", ttl_seconds=ttl, refresh_interval_seconds=interval
+    )
+    _no_sleep(refresher)
+    refresher._run()
+
+    cap = refresher._max_consecutive_failures
+    assert cap == int(ttl / interval), "cap must derive from ttl/interval"
+    # Stops at the cap — not on the first failure, not forever.
+    assert db.calls == cap
+    # The invariant that makes the cap honest: total tolerance <= one TTL.
+    assert cap * interval <= ttl, (
+        f"give-up window {cap * interval}s must not exceed the lease TTL {ttl}s"
+    )
+
+
+def test_lease_refresher_failure_cap_has_floor_of_one() -> None:
+    """A degenerate interval >= ttl still tolerates exactly one blip (floor 1)."""
+    from agent.conversation_compression import _CompressionLockLeaseRefresher
+
+    db = _FlakyRefreshDB([False] * 10)
+    refresher = _CompressionLockLeaseRefresher(
+        db, "sess", "holder", ttl_seconds=1.0, refresh_interval_seconds=5.0
+    )
+    _no_sleep(refresher)
+    refresher._run()
+    assert refresher._max_consecutive_failures == 1
+    assert db.calls == 1
+
+
+def test_lease_refresher_recovers_after_raise() -> None:
+    """A raise treated as a failure tick must RESET on a later success — the
+    exception arm gets the same blip-tolerance as a falsy return, not just a
+    'doesn't crash' guarantee."""
+    from agent.conversation_compression import _CompressionLockLeaseRefresher
+
+    class _RaiseThenOKDB:
+        """Raise once, then succeed forever — the transient-blip analog."""
+
+        def __init__(self):
+            self.calls = 0
+
+        def refresh_compression_lock(self, *a, **k):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("simulated DB hiccup")
+            return True
+
+    db = _RaiseThenOKDB()
+    refresher = _CompressionLockLeaseRefresher(
+        db, "sess", "holder", ttl_seconds=10.0, refresh_interval_seconds=2.0
+    )
+    # Run a handful of ticks past the raise, then stop.
+    refresher._stop.wait = lambda _i: db.calls >= 4  # type: ignore[assignment]
+    refresher._run()  # must not propagate the RuntimeError
+    # Survived the raise and kept refreshing — the counter reset on recovery.
+    assert db.calls >= 4
+
+
+def test_lease_refresher_stops_on_persistent_raise() -> None:
+    """A refresh that raises every tick is bounded by the same TTL-derived cap,
+    never propagates, and never loops forever."""
+    from agent.conversation_compression import _CompressionLockLeaseRefresher
+
+    class _AlwaysRaiseDB:
+        def __init__(self):
+            self.calls = 0
+
+        def refresh_compression_lock(self, *a, **k):
+            self.calls += 1
+            raise RuntimeError("simulated DB hiccup")
+
+    db = _AlwaysRaiseDB()
+    refresher = _CompressionLockLeaseRefresher(
+        db, "sess", "holder", ttl_seconds=10.0, refresh_interval_seconds=2.0
+    )
+    _no_sleep(refresher)
+    refresher._run()  # must not propagate
+    assert db.calls == refresher._max_consecutive_failures

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -253,6 +253,73 @@ def test_post_compress_exception_stops_lock_refresher(tmp_path: Path, monkeypatc
     assert db.try_acquire_compression_lock(parent_sid, "probe", ttl_seconds=1.0) is True
 
 
+def test_abort_warning_exception_stops_lock_refresher(tmp_path: Path, monkeypatch) -> None:
+    """An abort-path warning exception must still release the refreshed lock."""
+    real_try_acquire = SessionDB.try_acquire_compression_lock
+
+    def _short_ttl(self, session_id: str, holder: str, ttl_seconds: float = 300.0) -> bool:
+        return real_try_acquire(self, session_id, holder, ttl_seconds=1.0)
+
+    monkeypatch.setattr(SessionDB, "try_acquire_compression_lock", _short_ttl)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "REFRESH_ABORT_TEST"
+    db.create_session(parent_sid, source="discord")
+
+    agent = _build_agent_with_db(db, parent_sid)
+    agent._compression_lock_ttl_seconds = 1.0
+    agent._compression_lock_refresh_interval = 0.1
+
+    def _aborting_compress(*_a, **_kw):
+        agent.context_compressor._last_compress_aborted = True
+        agent.context_compressor._last_summary_error = "summary failed"
+        return [{"role": "user", "content": "tail"}]
+
+    agent.context_compressor.compress.side_effect = _aborting_compress
+    agent._emit_warning = lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("abort boom"))
+
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    with pytest.raises(RuntimeError, match="abort boom"):
+        agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    time.sleep(1.3)
+    assert db.try_acquire_compression_lock(parent_sid, "probe", ttl_seconds=1.0) is True
+
+
+def test_typeerror_fallback_exception_stops_lock_refresher(tmp_path: Path, monkeypatch) -> None:
+    """A strict-signature fallback failure must still release the refreshed lock."""
+    real_try_acquire = SessionDB.try_acquire_compression_lock
+
+    def _short_ttl(self, session_id: str, holder: str, ttl_seconds: float = 300.0) -> bool:
+        return real_try_acquire(self, session_id, holder, ttl_seconds=1.0)
+
+    monkeypatch.setattr(SessionDB, "try_acquire_compression_lock", _short_ttl)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "REFRESH_TYPEERROR_TEST"
+    db.create_session(parent_sid, source="discord")
+
+    agent = _build_agent_with_db(db, parent_sid)
+    agent._compression_lock_ttl_seconds = 1.0
+    agent._compression_lock_refresh_interval = 0.1
+
+    def _strict_signature(*_a, **_kw):
+        if "focus_topic" in _kw or "force" in _kw:
+            raise TypeError("strict signature")
+        raise RuntimeError("fallback boom")
+
+    agent.context_compressor.compress.side_effect = _strict_signature
+
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    with pytest.raises(RuntimeError, match="fallback boom"):
+        agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    time.sleep(1.3)
+    assert db.try_acquire_compression_lock(parent_sid, "probe", ttl_seconds=1.0) is True
+
+
 class _NoLockSubsystemDB:
     """Wraps a real SessionDB but simulates a pre-#34351 version skew.
 

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -225,6 +225,34 @@ def test_lock_refresh_keeps_owner_live_past_initial_ttl(tmp_path: Path, monkeypa
     assert db.get_compression_lock_holder(parent_sid) is None
 
 
+def test_post_compress_exception_stops_lock_refresher(tmp_path: Path, monkeypatch) -> None:
+    """A warning-path exception after compress() returns must still release the lock."""
+    real_try_acquire = SessionDB.try_acquire_compression_lock
+
+    def _short_ttl(self, session_id: str, holder: str, ttl_seconds: float = 300.0) -> bool:
+        return real_try_acquire(self, session_id, holder, ttl_seconds=1.0)
+
+    monkeypatch.setattr(SessionDB, "try_acquire_compression_lock", _short_ttl)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "REFRESH_EXCEPTION_TEST"
+    db.create_session(parent_sid, source="discord")
+
+    agent = _build_agent_with_db(db, parent_sid)
+    agent._compression_lock_ttl_seconds = 1.0
+    agent._compression_lock_refresh_interval = 0.1
+    agent.context_compressor._last_summary_error = "summary failed"
+    agent._emit_warning = lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("warn boom"))
+
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    with pytest.raises(RuntimeError, match="warn boom"):
+        agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    time.sleep(1.3)
+    assert db.try_acquire_compression_lock(parent_sid, "probe", ttl_seconds=1.0) is True
+
+
 class _NoLockSubsystemDB:
     """Wraps a real SessionDB but simulates a pre-#34351 version skew.
 

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -177,6 +177,54 @@ def test_skipped_compression_returns_messages_unchanged(tmp_path: Path) -> None:
     agent.context_compressor.compress.assert_not_called()
 
 
+def test_lock_refresh_keeps_owner_live_past_initial_ttl(tmp_path: Path, monkeypatch) -> None:
+    """The owning compression call must keep its lease alive while it runs."""
+    real_try_acquire = SessionDB.try_acquire_compression_lock
+
+    def _short_ttl(self, session_id: str, holder: str, ttl_seconds: float = 300.0) -> bool:
+        return real_try_acquire(self, session_id, holder, ttl_seconds=1.0)
+
+    monkeypatch.setattr(SessionDB, "try_acquire_compression_lock", _short_ttl)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    parent_sid = "REFRESH_TEST"
+    db.create_session(parent_sid, source="discord")
+
+    agent_a = _build_agent_with_db(db, parent_sid)
+    agent_a._compression_lock_ttl_seconds = 1.0
+    agent_a._compression_lock_refresh_interval = 0.25
+
+    def _slow_compress(*_a, **_kw):
+        time.sleep(2.0)
+        return [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "user", "content": "tail"},
+        ]
+
+    agent_a.context_compressor.compress.side_effect = _slow_compress
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    def run(agent):
+        agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    t_a = threading.Thread(target=run, args=(agent_a,), name="refresh_owner")
+    t_a.start()
+    deadline = time.time() + 2.0
+    while db.get_compression_lock_holder(parent_sid) is None and time.time() < deadline:
+        time.sleep(0.05)
+    assert db.get_compression_lock_holder(parent_sid) is not None
+    time.sleep(1.2)
+    assert db.try_acquire_compression_lock(
+        parent_sid, "refresh_probe", ttl_seconds=1.0
+    ) is False, "live owner lease expired and was reclaimable before compression finished"
+    t_a.join(timeout=10)
+
+    assert not t_a.is_alive()
+    assert _count_children(db, parent_sid) == 1
+    assert db.get_compression_lock_holder(parent_sid) is None
+
+
 class _NoLockSubsystemDB:
     """Wraps a real SessionDB but simulates a pre-#34351 version skew.
 
@@ -244,7 +292,7 @@ def test_missing_lock_subsystem_fails_open_not_infinite_loop(tmp_path: Path) -> 
     assert agent.session_id != parent_sid
 
 
-def test_review_fork_disables_compression_to_prevent_stale_parent_fork() -> None:
+def test_review_fork_disables_compression_to_prevent_stale_parent_fork(tmp_path: Path) -> None:
     """The background-review fork must set ``compression_enabled = False``
     so it can never compress the parent it shares a session_id with
     (issue #38727).
@@ -270,8 +318,6 @@ def test_review_fork_disables_compression_to_prevent_stale_parent_fork() -> None
     ``AIAgent.run_conversation`` patched (so no LLM call happens) and
     captures the constructed review agent to assert the flag.
     """
-    import tempfile
-
     import agent.background_review as br
 
     captured = {}
@@ -283,21 +329,20 @@ def test_review_fork_disables_compression_to_prevent_stale_parent_fork() -> None
 
     parent_sid = "REVIEW_FORK_FLAG_TEST"
 
-    with tempfile.TemporaryDirectory() as td:
-        db = SessionDB(db_path=Path(td) / "state.db")
-        db.create_session(parent_sid, source="discord")
-        parent = _build_agent_with_db(db, parent_sid)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(parent_sid, source="discord")
+    parent = _build_agent_with_db(db, parent_sid)
 
-        # The worker does a local ``from run_agent import AIAgent``; patching
-        # the class method covers that import path.
-        from run_agent import AIAgent
+    # The worker does a local ``from run_agent import AIAgent``; patching
+    # the class method covers that import path.
+    from run_agent import AIAgent
 
-        with patch.object(AIAgent, "run_conversation", _fake_run_conversation):
-            br._run_review_in_thread(
-                parent,
-                [{"role": "user", "content": "hi"}],
-                "review this conversation",
-            )
+    with patch.object(AIAgent, "run_conversation", _fake_run_conversation):
+        br._run_review_in_thread(
+            parent,
+            [{"role": "user", "content": "hi"}],
+            "review this conversation",
+        )
 
     assert captured, (
         "_run_review_in_thread never reached run_conversation — the spawn path "
@@ -314,3 +359,4 @@ def test_review_fork_disables_compression_to_prevent_stale_parent_fork() -> None
         "conversation_loop.py only short-circuit when compression_enabled is "
         "False — this flag MUST be cleared on the review fork."
     )
+    db.close()

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1487,6 +1487,21 @@ class TestAbortOnSummaryFailure:
         assert len(result) < len(msgs)
         assert db.get_compression_failure_cooldown("s1") is None
 
+    def test_aux_fallback_clears_persisted_session_cooldown_before_retry(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", "cli")
+        db.record_compression_failure_cooldown("s1", time.time() + 999.0, "timeout")
+
+        c = self._make_compressor()
+        c.bind_session_state(db, "s1")
+        c.summary_model = "aux/model"
+
+        c._fallback_to_main_for_compression(Exception("provider down"), "failed")
+
+        assert c.summary_model == ""
+        assert c._summary_failure_cooldown_until == 0.0
+        assert db.get_compression_failure_cooldown("s1") is None
+
     def test_success_clears_persisted_session_cooldown(self, tmp_path):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,6 +1,7 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
 import pytest
+import time
 from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import (
@@ -8,6 +9,7 @@ from agent.context_compressor import (
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
 )
+from hermes_state import SessionDB
 
 
 @pytest.fixture()
@@ -1463,6 +1465,60 @@ class TestAbortOnSummaryFailure:
         assert c._last_compress_aborted is False
         assert c._summary_failure_cooldown_until == 0.0
         assert len(result) < len(msgs)
+
+    def test_force_true_bypasses_persisted_session_cooldown(self, tmp_path):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", "cli")
+        db.record_compression_failure_cooldown("s1", time.time() + 999.0, "timeout")
+
+        c = self._make_compressor()
+        c.bind_session_state(db, "s1")
+        msgs = self._make_msgs()
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_llm:
+            result = c.compress(msgs, current_tokens=999999, force=True)
+
+        mock_llm.assert_called()
+        assert c._last_compress_aborted is False
+        assert len(result) < len(msgs)
+        assert db.get_compression_failure_cooldown("s1") is None
+
+    def test_success_clears_persisted_session_cooldown(self, tmp_path):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", "cli")
+        db.record_compression_failure_cooldown("s1", time.time() + 999.0, "timeout")
+
+        c = self._make_compressor()
+        c.bind_session_state(db, "s1")
+        c._summary_failure_cooldown_until = 0.0
+        msgs = self._make_msgs()
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_llm:
+            result = c.compress(msgs, current_tokens=999999)
+
+        mock_llm.assert_called()
+        assert c._last_compress_aborted is False
+        assert len(result) < len(msgs)
+        assert db.get_compression_failure_cooldown("s1") is None
+
+    def test_session_end_does_not_clear_persisted_session_cooldown(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", "cli")
+        db.record_compression_failure_cooldown("s1", time.time() + 999.0, "timeout")
+
+        c = self._make_compressor()
+        c.bind_session_state(db, "s1")
+        c.on_session_end("s1", [])
+
+        assert db.get_compression_failure_cooldown("s1") is not None
 
 
 class TestSummaryPrefixNormalization:

--- a/tests/agent/test_context_engine_host_contract.py
+++ b/tests/agent/test_context_engine_host_contract.py
@@ -28,7 +28,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-
+from agent.context_compressor import ContextCompressor
+from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
@@ -156,6 +157,43 @@ def test_reset_session_state_default_call_only_resets():
     assert engine.on_session_reset.called
     assert not engine.on_session_end.called
     assert not engine.on_session_start.called
+
+
+def test_reset_session_state_rebinds_builtin_compressor_after_session_switch(tmp_path, monkeypatch):
+    """Reset-only session switches must rebind durable cooldown state to the new session."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("old-sid", source="cli")
+    db.create_session("new-sid", source="cli")
+    db.record_compression_failure_cooldown("old-sid", 4_000_000_000.0, "old-timeout")
+
+    monkeypatch.setattr(
+        "agent.context_compressor.get_model_context_length",
+        lambda *_a, **_k: 100_000,
+    )
+    compressor = ContextCompressor(
+        model="fake-model",
+        threshold_percent=0.85,
+        protect_first_n=2,
+        protect_last_n=2,
+        quiet_mode=True,
+    )
+    compressor.bind_session_state(db, "old-sid")
+
+    agent = _bare_agent()
+    agent._session_db = db
+    agent.context_compressor = compressor
+    agent.session_id = "new-sid"
+
+    agent.reset_session_state()
+
+    assert compressor._session_id == "new-sid"
+    assert compressor.get_active_compression_failure_cooldown() is None
+    assert db.get_compression_failure_cooldown("old-sid") is not None
+
+    compressor._record_compression_failure_cooldown(30.0, "new-timeout")
+
+    assert db.get_compression_failure_cooldown("new-sid") is not None
+    assert db.get_compression_failure_cooldown("old-sid")["error"] == "old-timeout"
 
 
 def test_update_from_response_forwards_canonical_cache_buckets():

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -9,11 +9,13 @@ confirm the prologue produces the right ``TurnContext`` and applies the
 from __future__ import annotations
 
 import types
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.context_compressor import ContextCompressor
 from agent.turn_context import TurnContext, build_turn_context
+from hermes_state import SessionDB
 
 
 class _FakeTodoStore:
@@ -99,6 +101,33 @@ class _FakeAgent:
 
     def _persist_session(self, *_a, **_k):
         self._persist_calls += 1
+
+
+def _make_agent_with_cooldown(db_path, session_id, *, cooldown_until=None):
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent._emit_status = MagicMock()
+    agent._compress_context = MagicMock(
+        side_effect=lambda messages, *_a, **_k: (messages, "SYSTEM")
+    )
+
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id, source="cli")
+    if cooldown_until is not None:
+        db.record_compression_failure_cooldown(session_id, cooldown_until, "timeout")
+
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        compressor = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+    compressor.bind_session_state(db, session_id)
+    agent.context_compressor = compressor
+    agent._session_db = db
+    return agent
 
 
 @pytest.fixture(autouse=True)
@@ -284,4 +313,54 @@ def test_between_turns_refresh_no_churn_when_unchanged():
         _build(agent)
 
     assert agent.tools is same  # not replaced → no churn
+
+
+def test_preflight_skips_when_persisted_cooldown_survives_restart(tmp_path):
+    agent = _make_agent_with_cooldown(
+        tmp_path / "state.db",
+        "sess-1",
+        cooldown_until=4_000_000_000.0,
+    )
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
+         patch("agent.turn_context.estimate_request_tokens_rough", return_value=999_999):
+        ctx = _build(agent)
+
+    assert isinstance(ctx, TurnContext)
+    agent._emit_status.assert_not_called()
+    agent._compress_context.assert_not_called()
+
+
+def test_preflight_still_runs_for_other_session_with_same_db(tmp_path):
+    db_path = tmp_path / "state.db"
+    _make_agent_with_cooldown(
+        db_path,
+        "sess-1",
+        cooldown_until=4_000_000_000.0,
+    )
+    agent = _make_agent_with_cooldown(db_path, "sess-2")
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
+         patch("agent.turn_context.estimate_request_tokens_rough", return_value=999_999):
+        ctx = _build(agent)
+
+    assert isinstance(ctx, TurnContext)
+    agent._emit_status.assert_called_once()
+    agent._compress_context.assert_called()
+
+
+def test_expired_cooldown_allows_preflight(tmp_path):
+    agent = _make_agent_with_cooldown(
+        tmp_path / "state.db",
+        "sess-1",
+        cooldown_until=1.0,
+    )
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
+         patch("agent.turn_context.estimate_request_tokens_rough", return_value=999_999):
+        ctx = _build(agent)
+
+    assert isinstance(ctx, TurnContext)
+    agent._emit_status.assert_called_once()
+    agent._compress_context.assert_called()
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4,6 +4,7 @@ import sqlite3
 import time
 import pytest
 
+import hermes_state
 from hermes_state import SCHEMA_SQL, SCHEMA_VERSION, SessionDB
 
 
@@ -4725,3 +4726,55 @@ def test_gateway_session_recovery_reopens_legacy_agent_close_rows(db):
         chat_id="chat-1",
         chat_type="dm",
     ) is None
+
+
+def test_compression_failure_cooldown_round_trips_and_clears(db):
+    db.create_session("s1", "cli")
+
+    cooldown_until = time.time() + 60.0
+    db.record_compression_failure_cooldown("s1", cooldown_until, "timeout")
+
+    state = db.get_compression_failure_cooldown("s1")
+    assert state is not None
+    assert state["cooldown_until"] == cooldown_until
+    assert state["error"] == "timeout"
+
+    db.clear_compression_failure_cooldown("s1")
+    assert db.get_compression_failure_cooldown("s1") is None
+
+    row = db.get_session("s1")
+    assert row["compression_failure_cooldown_until"] is None
+    assert row["compression_failure_error"] is None
+
+
+def test_expired_compression_failure_cooldown_is_ignored(db):
+    db.create_session("s1", "cli")
+
+    db.record_compression_failure_cooldown("s1", time.time() - 60.0, "stale")
+
+    assert db.get_compression_failure_cooldown("s1") is None
+
+
+def test_refresh_compression_lock_requires_holder_and_preserves_reclaimability(db, monkeypatch):
+    db.create_session("s1", "cli")
+
+    monkeypatch.setattr(hermes_state.time, "time", lambda: 1000.0)
+    assert db.try_acquire_compression_lock("s1", "holder-a", ttl_seconds=10.0) is True
+
+    original_expires = db._conn.execute(
+        "SELECT expires_at FROM compression_locks WHERE session_id = ?",
+        ("s1",),
+    ).fetchone()[0]
+
+    monkeypatch.setattr(hermes_state.time, "time", lambda: 1005.0)
+    assert db.refresh_compression_lock("s1", "holder-a", ttl_seconds=10.0) is True
+    refreshed_expires = db._conn.execute(
+        "SELECT expires_at FROM compression_locks WHERE session_id = ?",
+        ("s1",),
+    ).fetchone()[0]
+    assert refreshed_expires > original_expires
+
+    assert db.refresh_compression_lock("s1", "holder-b", ttl_seconds=10.0) is False
+
+    monkeypatch.setattr(hermes_state.time, "time", lambda: 1016.0)
+    assert db.try_acquire_compression_lock("s1", "holder-b", ttl_seconds=10.0) is True


### PR DESCRIPTION
## Summary

Resumed oversized CLI sessions no longer wedge when the auxiliary compression endpoint times out (#54465). The same-session compression-failure cooldown now survives a process restart (it was in-memory only), and the compression lock lease is refreshed while a long compression call is still in flight (the 300s TTL was shorter than a single ~361s aux call).

Salvaged from #54525 by @rodboev — their commits are cherry-picked unchanged to preserve authorship; one follow-up commit by me hardens the lease refresher and adds regression tests.

## Changes

**@rodboev's work (cherry-picked, 6 commits):**
- `hermes_state.py`: session-scoped `compression_failure_cooldown_until` / `compression_failure_error` columns (declarative reconciliation — no SCHEMA_VERSION bump) + `record/get/clear_compression_failure_cooldown` and owner-checked `refresh_compression_lock` helpers.
- `agent/context_compressor.py`: bind resumed session state into the built-in compressor; write through same-session cooldown; preserve manual `/compress` force-bypass.
- `agent/agent_init.py`, `run_agent.py`: rebind the compressor onto the active session row on fresh / reset-only (`/new`, `/resume`, `/branch`) switches.
- `agent/turn_context.py`: skip automatic preflight compression while a same-session cooldown is live.
- `agent/conversation_compression.py`: keep the lock lease alive (background refresher) until release; release on every early exit path.

**Follow-up hardening (1 commit, by me):**
- The lease refresher's loop treated *any* falsy refresh as a permanent stop, conflating genuine lost-ownership (correct to stop) with a one-off transient DB error — so a single blip could silently reintroduce the TTL-expiry wedge the PR fixes. It now tolerates consecutive failures for at most **one lease's worth of time** (`cap = int(ttl / refresh_interval)`, floor 1), so the give-up window is genuinely bounded by the TTL and a transient blip recovers on the next tick.
- Replaced the two remaining silent `except Exception: pass` arms in the cooldown persist/clear helpers with debug logging, for parity with their `sqlite3.Error` siblings (a non-sqlite bug was previously invisible).
- Documented the `join(timeout=1.0)` quiesce bound in `stop()`.
- Added 5 refresher regression tests (single-blip tolerance, TTL-bounded give-up window, floor-of-1, raise-then-recover, persistent-raise) — all mutation-checked (they fail under the original buggy `break`-on-first-failure).

## Validation

| Scenario | Before | After |
|---|---|---|
| Resume an oversized session after a compression timeout | fresh process forgets cooldown → auto preflight retries immediately (wedge) | persisted cooldown survives restart, skips auto preflight until it expires |
| Compression call runs longer than the 300s lease | lock row expires mid-flight → reclaimable while compressor still alive | owner-checked refresher keeps the lease live until release |
| Single transient DB blip during refresh | (follow-up) one blip would permanently stop the refresher → lease lapses | tolerated; recovers next tick |
| Stuck refresher (persistent failure) | — | gives up within one TTL, never holds the lock past its TTL |

- 460 targeted tests pass: `tests/test_hermes_state.py tests/agent/test_context_compressor.py tests/agent/test_context_engine_host_contract.py tests/agent/test_turn_context.py tests/agent/test_compression_concurrent_fork.py`
- E2E (real `SessionDB`, cross-process): cooldown recorded in one process is hydrated by a fresh process → preflight skipped on resume.
- Prompt-cache invariant preserved (system-prompt rebuild only on the existing compression path); no role-alternation changes; columns nullable.

Closes #54465
