### PR TITLE
fix(desktop): avoid caching streaming markdown parses

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -1,6 +1,15 @@
+import { parseMarkdownIntoBlocks } from '@assistant-ui/react-streamdown'
 import { describe, expect, it } from 'vitest'
 
+import { markdownBlockParserForStreamingState } from '@/components/assistant-ui/markdown-text'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
+
+describe('markdownBlockParserForStreamingState', () => {
+  it('bypasses the block cache while streaming', () => {
+    expect(markdownBlockParserForStreamingState(true)).toBe(parseMarkdownIntoBlocks)
+    expect(markdownBlockParserForStreamingState(false)).not.toBe(parseMarkdownIntoBlocks)
+  })
+})
 
 describe('preprocessMarkdown', () => {
   it('strips inline accidental triple-backtick starts', () => {

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -73,9 +73,8 @@ function preprocessWithTailRepair(text: string): string {
 // (virtualizer scroll, session switch) and whenever multiple surfaces render
 // the same content (deferred + smooth reveal republish). A small module-level
 // LRU keyed by the exact source string removes all of those repeat parses
-// with zero correctness risk (same input → same output). Streaming tail
-// growth misses the cache by design (every flush is a new string) — that
-// single lex is the irreducible cost.
+// with zero correctness risk for stable content. Active streaming bypasses
+// this cache so skipped intermediate renders cannot seed a partial block split.
 const BLOCK_CACHE_MAX = 64
 const BLOCK_CACHE_MIN_LENGTH = 1024
 const blockCache = new Map<string, string[]>()
@@ -103,6 +102,10 @@ function parseMarkdownIntoBlocksCached(markdown: string): string[] {
   }
 
   return blocks
+}
+
+export function markdownBlockParserForStreamingState(isStreaming: boolean): typeof parseMarkdownIntoBlocks {
+  return isStreaming ? parseMarkdownIntoBlocks : parseMarkdownIntoBlocksCached
 }
 
 async function mediaSrc(path: string): Promise<string> {
@@ -639,7 +642,7 @@ function MarkdownTextSurface({ containerClassName, containerProps }: MarkdownTex
       // independently deferred via `defer={isStreaming}` on the
       // SyntaxHighlighter component.
       parseIncompleteMarkdown={false}
-      parseMarkdownIntoBlocksFn={parseMarkdownIntoBlocksCached}
+      parseMarkdownIntoBlocksFn={markdownBlockParserForStreamingState(isStreaming)}
       plugins={plugins}
       preprocess={preprocessWithTailRepair}
     />


### PR DESCRIPTION
Summary
- Bypass the desktop markdown block cache while assistant text is still streaming.
- Keep cached block parsing for completed or remounted markdown.
- Add regression coverage for streaming parser selection.

Problem
The desktop renderer reused the module-level markdown block cache during live streaming. Deferred rendering can skip intermediate text states, so a partial parse could be retained and reused by the same text surface, which showed up as garbled CJK output while messages streamed.

Validation
- npm --workspace apps/desktop run test:ui -- src/components/assistant-ui/markdown-text.test.ts
- npm --workspace apps/desktop exec eslint -- src/components/assistant-ui/markdown-text.tsx src/components/assistant-ui/markdown-text.test.ts

Refs #55482