### PR TITLE
fix(acp): preserve invalid tool call text

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -302,19 +302,19 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessage
     extracted: list[ChatCompletionMessageToolCall] = []
     consumed_spans: list[tuple[int, int]] = []
 
-    def _try_add_tool_call(raw_json: str) -> None:
+    def _try_add_tool_call(raw_json: str) -> bool:
         try:
             obj = json.loads(raw_json)
         except Exception:
-            return
+            return False
         if not isinstance(obj, dict):
-            return
+            return False
         fn = obj.get("function")
         if not isinstance(fn, dict):
-            return
+            return False
         fn_name = fn.get("name")
         if not isinstance(fn_name, str) or not fn_name.strip():
-            return
+            return False
         fn_args = fn.get("arguments", "{}")
         if not isinstance(fn_args, str):
             fn_args = json.dumps(fn_args, ensure_ascii=False)
@@ -329,18 +329,19 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessage
                 arguments=fn_args,
             )
         )
+        return True
 
     for m in _TOOL_CALL_BLOCK_RE.finditer(text):
         raw = m.group(1)
-        _try_add_tool_call(raw)
-        consumed_spans.append((m.start(), m.end()))
+        if _try_add_tool_call(raw):
+            consumed_spans.append((m.start(), m.end()))
 
     # Only try bare-JSON fallback when no XML blocks were found.
     if not extracted:
         for m in _TOOL_CALL_JSON_RE.finditer(text):
             raw = m.group(0)
-            _try_add_tool_call(raw)
-            consumed_spans.append((m.start(), m.end()))
+            if _try_add_tool_call(raw):
+                consumed_spans.append((m.start(), m.end()))
 
     if not consumed_spans:
         return extracted, text.strip()

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -356,19 +356,19 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessage
     extracted: list[ChatCompletionMessageToolCall] = []
     consumed_spans: list[tuple[int, int]] = []
 
-    def _try_add_tool_call(raw_json: str) -> None:
+    def _try_add_tool_call(raw_json: str) -> bool:
         try:
             obj = json.loads(raw_json)
         except Exception:
-            return
+            return False
         if not isinstance(obj, dict):
-            return
+            return False
         fn = obj.get("function")
         if not isinstance(fn, dict):
-            return
+            return False
         fn_name = fn.get("name")
         if not isinstance(fn_name, str) or not fn_name.strip():
-            return
+            return False
         fn_args = fn.get("arguments", "{}")
         if not isinstance(fn_args, str):
             fn_args = json.dumps(fn_args, ensure_ascii=False)
@@ -383,18 +383,19 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessage
                 arguments=fn_args,
             )
         )
+        return True
 
     for m in _TOOL_CALL_BLOCK_RE.finditer(text):
         raw = m.group(1)
-        _try_add_tool_call(raw)
-        consumed_spans.append((m.start(), m.end()))
+        if _try_add_tool_call(raw):
+            consumed_spans.append((m.start(), m.end()))
 
     # Only try bare-JSON fallback when no XML blocks were found.
     if not extracted:
         for m in _TOOL_CALL_JSON_RE.finditer(text):
             raw = m.group(0)
-            _try_add_tool_call(raw)
-            consumed_spans.append((m.start(), m.end()))
+            if _try_add_tool_call(raw):
+                consumed_spans.append((m.start(), m.end()))
 
     if not consumed_spans:
         return extracted, text.strip()

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -56,6 +56,52 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertEqual(dict(tool_call.function)["name"], "read_file")
         self.assertEqual(choice.message.content, "I'll inspect that.")
 
+    def test_invalid_tool_call_block_remains_visible_as_text(self) -> None:
+        tool_response = (
+            "I tried to inspect that.\n"
+            "<tool_call>"
+            '{"id":"call_bad","type":"function",'
+            '"function":{"name":"read_file","arguments":{"path":"README.md",}}}'
+            "</tool_call>"
+            "\nPlease retry with valid JSON."
+        )
+
+        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+            response = self.client._create_chat_completion(
+                model="copilot-acp",
+                messages=[{"role": "user", "content": "read README.md"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "read_file", "parameters": {}},
+                    }
+                ],
+            )
+
+        choice = response.choices[0]
+        self.assertEqual(choice.finish_reason, "stop")
+        self.assertEqual(choice.message.tool_calls, [])
+        self.assertIn("<tool_call>", choice.message.content)
+        self.assertIn("Please retry with valid JSON.", choice.message.content)
+
+    def test_invalid_bare_tool_call_json_remains_visible_as_text(self) -> None:
+        tool_response = (
+            'Before {"id":"call_bad","type":"function",'
+            '"function":{"name":"read_file","arguments":{"path":"README.md",}}} after'
+        )
+
+        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+            response = self.client._create_chat_completion(
+                model="copilot-acp",
+                messages=[{"role": "user", "content": "read README.md"}],
+            )
+
+        choice = response.choices[0]
+        self.assertEqual(choice.finish_reason, "stop")
+        self.assertEqual(choice.message.tool_calls, [])
+        self.assertIn('"function"', choice.message.content)
+        self.assertIn("after", choice.message.content)
+
     def test_stream_true_returns_iterable_text_chunks(self) -> None:
         with patch.object(self.client, "_run_prompt", return_value=("Hello from ACP", "")):
             stream = self.client._create_chat_completion(

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -23,6 +23,49 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.client = CopilotACPClient(acp_cwd="/tmp")
 
 
+    def test_invalid_tool_call_block_remains_visible_as_text(self) -> None:
+        tool_response = (
+            "I tried to inspect that.\n"
+            "<tool_call>"
+            '{"id":"call_bad","type":"function",'
+            '"function":{"name":"read_file","arguments":{"path":"README.md",}}}'
+            "</tool_call>"
+            "\nPlease retry with valid JSON."
+        )
+
+        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+            response = self.client._create_chat_completion(
+                model="copilot-acp",
+                messages=[{"role": "user", "content": "read README.md"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "read_file", "parameters": {}},
+                    }
+                ],
+            )
+
+        choice = response.choices[0]
+        self.assertEqual(choice.finish_reason, "stop")
+        self.assertEqual(choice.message.tool_calls, [])
+        self.assertEqual(choice.message.content, tool_response)
+
+    def test_invalid_bare_tool_call_json_remains_visible_as_text(self) -> None:
+        tool_response = (
+            'Before {"id":"call_bad","type":"function",'
+            '"function":{"name":"read_file","arguments":{"path":"README.md",}}} after'
+        )
+
+        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+            response = self.client._create_chat_completion(
+                model="copilot-acp",
+                messages=[{"role": "user", "content": "read README.md"}],
+            )
+
+        choice = response.choices[0]
+        self.assertEqual(choice.finish_reason, "stop")
+        self.assertEqual(choice.message.tool_calls, [])
+        self.assertEqual(choice.message.content, tool_response)
 
     def test_stream_true_preserves_tool_call_deltas(self) -> None:
         tool_response = (


### PR DESCRIPTION
## Summary
- keep malformed `<tool_call>` blocks visible as assistant text instead of stripping them
- only consume ACP tool-call spans after successful JSON/function extraction
- add regressions for malformed XML-style and bare JSON tool-call text

Fixes #55431.

## Dedupe
Searched upstream PRs/issues before opening; no existing PR matched #55431.

## Tests
- `python -m pytest tests/agent/test_copilot_acp_client.py -q`