### PR TITLE
fix(desktop): extend approval response timeout

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGateway } from '@/hermes'
+import { APPROVAL_RESPONSE_TIMEOUT_MS } from '@/lib/approval-response'
 import { $gateway } from '@/store/gateway'
 import { $approvalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
@@ -79,7 +80,11 @@ describe('PendingToolApproval', () => {
     fireEvent.click(screen.getByRole('button', { name: /Run/ }))
 
     await waitFor(() => {
-      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
+      expect(request).toHaveBeenCalledWith(
+        'approval.respond',
+        { choice: 'once', session_id: 'sess-1' },
+        APPROVAL_RESPONSE_TIMEOUT_MS
+      )
     })
     expect($approvalRequest.get()).toBeNull()
   })
@@ -105,7 +110,11 @@ describe('PendingToolApproval', () => {
     fireEvent.click(screen.getByRole('button', { name: /Reject/ }))
 
     await waitFor(() => {
-      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'sess-1' })
+      expect(request).toHaveBeenCalledWith(
+        'approval.respond',
+        { choice: 'deny', session_id: 'sess-1' },
+        APPROVAL_RESPONSE_TIMEOUT_MS
+      )
     })
   })
 

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGateway } from '@/hermes'
+import { APPROVAL_RESPONSE_TIMEOUT_MS } from '@/lib/approval-response'
 import { $gateway } from '@/store/gateway'
 import { $approvalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
@@ -83,7 +84,11 @@ describe('PendingToolApproval', () => {
     fireEvent.click(screen.getByRole('button', { name: /Run/ }))
 
     await waitFor(() => {
-      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
+      expect(request).toHaveBeenCalledWith(
+        'approval.respond',
+        { choice: 'once', session_id: 'sess-1' },
+        APPROVAL_RESPONSE_TIMEOUT_MS
+      )
     })
     expect($approvalRequest.get()).toBeNull()
   })
@@ -109,7 +114,11 @@ describe('PendingToolApproval', () => {
     fireEvent.click(screen.getByRole('button', { name: /Reject/ }))
 
     await waitFor(() => {
-      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'sess-1' })
+      expect(request).toHaveBeenCalledWith(
+        'approval.respond',
+        { choice: 'deny', session_id: 'sess-1' },
+        APPROVAL_RESPONSE_TIMEOUT_MS
+      )
     })
   })
 

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { useI18n } from '@/i18n'
+import { type ApprovalChoice, sendApprovalResponse } from '@/lib/approval-response'
 import { triggerHaptic } from '@/lib/haptics'
 import { AlertCircle, ChevronDown, Loader2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
@@ -43,9 +44,6 @@ import type { ToolPart } from './fallback-model'
 // raised it. The command/description text comes from `$approvalRequest` (the
 // event payload), which is the only place that data reliably exists.
 export const APPROVAL_TOOLS = new Set(['terminal', 'execute_code'])
-
-// Canonical gateway choices (ui-tui/src/components/prompts.tsx).
-type ApprovalChoice = 'once' | 'session' | 'always' | 'deny'
 
 export const PendingToolApproval: FC<{ part: ToolPart }> = ({ part }) => {
   const request = useStore($approvalRequest)
@@ -129,10 +127,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       setSubmitting(choice)
 
       try {
-        await gateway.request<{ resolved?: boolean }>('approval.respond', {
-          choice,
-          session_id: request.sessionId ?? undefined
-        })
+        await sendApprovalResponse(gateway, choice, request.sessionId)
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
         clearApprovalRequest(request.sessionId)
       } catch (error) {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/dialog'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { useI18n } from '@/i18n'
+import { type ApprovalChoice, sendApprovalResponse } from '@/lib/approval-response'
 import { triggerHaptic } from '@/lib/haptics'
 import { AlertCircle, ChevronDown, Loader2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
@@ -45,9 +46,6 @@ import type { ToolPart } from './fallback-model'
 // raised it. The command/description text comes from `$approvalRequest` (the
 // event payload), which is the only place that data reliably exists.
 export const APPROVAL_TOOLS = new Set(['terminal', 'execute_code'])
-
-// Canonical gateway choices (ui-tui/src/components/prompts.tsx).
-type ApprovalChoice = 'once' | 'session' | 'always' | 'deny'
 
 export const PendingToolApproval: FC<{ part: ToolPart }> = ({ part }) => {
   // The tool row lives in whichever session's transcript rendered it — read
@@ -143,11 +141,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       setSubmitting(choice)
 
       try {
-        await gateway.request<{ resolved?: boolean }>('approval.respond', {
-          choice,
-          request_id: request.requestId,
-          session_id: request.sessionId ?? undefined
-        })
+        await sendApprovalResponse(gateway, choice, request.sessionId, request.requestId)
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
         clearApprovalRequest(request.sessionId, request.requestId)
         void replayPendingApproval(gateway, request.sessionId).catch(() => undefined)

--- a/apps/desktop/src/lib/approval-response.ts
+++ b/apps/desktop/src/lib/approval-response.ts
@@ -1,0 +1,20 @@
+import type { HermesGateway } from '@/hermes'
+
+export type ApprovalChoice = 'once' | 'session' | 'always' | 'deny'
+
+export const APPROVAL_RESPONSE_TIMEOUT_MS = 310_000
+
+export function sendApprovalResponse(
+  gateway: HermesGateway,
+  choice: ApprovalChoice,
+  sessionId: null | string | undefined
+): Promise<{ resolved?: boolean }> {
+  return gateway.request<{ resolved?: boolean }>(
+    'approval.respond',
+    {
+      choice,
+      session_id: sessionId ?? undefined
+    },
+    APPROVAL_RESPONSE_TIMEOUT_MS
+  )
+}

--- a/apps/desktop/src/lib/approval-response.ts
+++ b/apps/desktop/src/lib/approval-response.ts
@@ -1,0 +1,31 @@
+import type { HermesGateway } from '@/hermes'
+
+export type ApprovalChoice = 'once' | 'session' | 'always' | 'deny'
+
+export const APPROVAL_RESPONSE_TIMEOUT_MS = 310_000
+
+export function sendApprovalResponse(
+  gateway: HermesGateway,
+  choice: ApprovalChoice,
+  sessionId: null | string | undefined,
+  requestId?: string
+): Promise<{ resolved?: boolean }> {
+  const payload: {
+    choice: ApprovalChoice
+    request_id?: string
+    session_id: null | string | undefined
+  } = {
+    choice,
+    session_id: sessionId ?? undefined
+  }
+
+  if (requestId) {
+    payload.request_id = requestId
+  }
+
+  return gateway.request<{ resolved?: boolean }>(
+    'approval.respond',
+    payload,
+    APPROVAL_RESPONSE_TIMEOUT_MS
+  )
+}

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { APPROVAL_RESPONSE_TIMEOUT_MS } from '@/lib/approval-response'
+
 import { $gateway } from './gateway'
 import {
   dispatchNativeNotification,
@@ -183,13 +185,21 @@ describe('respondToApprovalAction', () => {
 
     await respondToApprovalAction('bg', 'approve')
 
-    expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'bg' })
+    expect(request).toHaveBeenCalledWith(
+      'approval.respond',
+      { choice: 'once', session_id: 'bg' },
+      APPROVAL_RESPONSE_TIMEOUT_MS
+    )
     expect($approvalRequest.get()).toBeNull()
   })
 
   it('rejects via approval.respond {choice: "deny"}', async () => {
     await respondToApprovalAction('bg', 'reject')
-    expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'bg' })
+    expect(request).toHaveBeenCalledWith(
+      'approval.respond',
+      { choice: 'deny', session_id: 'bg' },
+      APPROVAL_RESPONSE_TIMEOUT_MS
+    )
   })
 
   it('ignores unknown action ids', async () => {

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { APPROVAL_RESPONSE_TIMEOUT_MS } from '@/lib/approval-response'
+
 import { $gateway } from './gateway'
 import {
   clearPluginNotifyHandlers,
@@ -320,13 +322,21 @@ describe('respondToApprovalAction', () => {
 
     await respondToApprovalAction('bg', 'approve')
 
-    expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'bg' })
+    expect(request).toHaveBeenCalledWith(
+      'approval.respond',
+      { choice: 'once', session_id: 'bg' },
+      APPROVAL_RESPONSE_TIMEOUT_MS
+    )
     expect($approvalRequest.get()).toBeNull()
   })
 
   it('rejects via approval.respond {choice: "deny"}', async () => {
     await respondToApprovalAction('bg', 'reject')
-    expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'bg' })
+    expect(request).toHaveBeenCalledWith(
+      'approval.respond',
+      { choice: 'deny', session_id: 'bg' },
+      APPROVAL_RESPONSE_TIMEOUT_MS
+    )
   })
 
   it('ignores unknown action ids', async () => {

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -1,5 +1,6 @@
 import { atom } from 'nanostores'
 
+import { sendApprovalResponse } from '@/lib/approval-response'
 import { persistString, storedString } from '@/lib/storage'
 
 import { $gateway } from './gateway'
@@ -193,7 +194,7 @@ export async function respondToApprovalAction(sessionId: null | string, actionId
   }
 
   try {
-    await gateway.request('approval.respond', { choice, session_id: sessionId ?? undefined })
+    await sendApprovalResponse(gateway, choice, sessionId)
     clearApprovalRequest(sessionId)
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -1,7 +1,7 @@
 import { atom } from 'nanostores'
 
-import { type HermesOpenTarget, resolveHermesOpenPath } from '@/lib/hermes-open-target'
 import { sendApprovalResponse } from '@/lib/approval-response'
+import { type HermesOpenTarget, resolveHermesOpenPath } from '@/lib/hermes-open-target'
 import { persistString, storedString } from '@/lib/storage'
 
 import { $gateway } from './gateway'

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 
 import { type HermesOpenTarget, resolveHermesOpenPath } from '@/lib/hermes-open-target'
+import { sendApprovalResponse } from '@/lib/approval-response'
 import { persistString, storedString } from '@/lib/storage'
 
 import { $gateway } from './gateway'
@@ -359,7 +360,7 @@ export async function respondToApprovalAction(sessionId: null | string, actionId
   }
 
   try {
-    await gateway.request('approval.respond', { choice, session_id: sessionId ?? undefined })
+    await sendApprovalResponse(gateway, choice, sessionId)
     clearApprovalRequest(sessionId)
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.


### PR DESCRIPTION
## Summary
- route desktop approval responses through a shared helper
- use a longer approval RPC timeout so the renderer does not give up before the backend approval wait can resolve
- cover both inline approval controls and native notification approval buttons

Fixes #55433.

## Dedupe
Checked open upstream PRs/issues first; related stall work exists, but no PR covered the desktop approval response timeout path.

## Tests
- `npm run test:ui -- src/components/assistant-ui/tool-approval.test.tsx src/store/native-notifications.test.ts`
- `npm run typecheck`
- `npx eslint src/lib/approval-response.ts src/components/assistant-ui/tool-approval.tsx src/components/assistant-ui/tool-approval.test.tsx src/store/native-notifications.ts src/store/native-notifications.test.ts`