### PR TITLE
fix(telegram): honor UTF-16 entity offsets

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6111,7 +6111,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 if offset < 0 or length <= 0:
                     continue
 
-                entity_text = source_text[offset:offset + length].strip()
+                entity_text = TelegramAdapter._telegram_entity_text(source_text, offset, length).strip()
                 if entity_type == "mention":
                     handle = entity_text.lstrip("@").lower()
                     if re.fullmatch(r"[a-z0-9_]{2,29}bot", handle, re.IGNORECASE):
@@ -6140,6 +6140,19 @@ class TelegramAdapter(BasePlatformAdapter):
 
         return mentioned_bot_usernames
 
+    @staticmethod
+    def _telegram_entity_text(source_text: str, offset: int, length: int) -> str:
+        """Return a Telegram entity span using UTF-16 code-unit offsets."""
+        if offset < 0 or length <= 0:
+            return ""
+        try:
+            raw = source_text.encode("utf-16-le")
+            start = offset * 2
+            end = (offset + length) * 2
+            return raw[start:end].decode("utf-16-le")
+        except UnicodeDecodeError:
+            return ""
+
     def _message_mentions_bot(self, message: Message) -> bool:
         if not self._bot:
             return False
@@ -6166,7 +6179,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     length = int(getattr(entity, "length", 0))
                     if offset < 0 or length <= 0:
                         continue
-                    if source_text[offset:offset + length].strip().lower() == expected:
+                    if self._telegram_entity_text(source_text, offset, length).strip().lower() == expected:
                         return True
                 elif entity_type == "text_mention":
                     user = getattr(entity, "user", None)
@@ -6186,7 +6199,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     length = int(getattr(entity, "length", 0))
                     if offset < 0 or length <= 0:
                         continue
-                    command_text = source_text[offset:offset + length]
+                    command_text = self._telegram_entity_text(source_text, offset, length)
                     at_index = command_text.find("@")
                     if at_index < 0:
                         continue

--- a/tests/gateway/test_telegram_mention_boundaries.py
+++ b/tests/gateway/test_telegram_mention_boundaries.py
@@ -31,6 +31,14 @@ def _mention_entity(text, mention="@hermes_bot"):
     return SimpleNamespace(type="mention", offset=offset, length=len(mention))
 
 
+def _telegram_mention_entity(text, mention="@hermes_bot", entity_type="mention"):
+    """Build an entity with Telegram UTF-16 code-unit offset/length values."""
+    start = text.index(mention)
+    offset = len(text[:start].encode("utf-16-le")) // 2
+    length = len(mention.encode("utf-16-le")) // 2
+    return SimpleNamespace(type=entity_type, offset=offset, length=length)
+
+
 def _text_mention_entity(offset, length, user_id):
     """Build a TEXT_MENTION entity (used when the target user has no public @handle)."""
     return SimpleNamespace(
@@ -78,6 +86,12 @@ class TestRealMentionsAreDetected:
         adapter = _make_adapter()
         caption = "photo for @hermes_bot"
         msg = _message(caption=caption, caption_entities=[_mention_entity(caption)])
+        assert adapter._message_mentions_bot(msg) is True
+
+    def test_mention_after_non_bmp_characters_uses_telegram_offsets(self):
+        adapter = _make_adapter()
+        text = "\U0001f680\U0001f680 @hermes_bot hello"
+        msg = _message(text=text, entities=[_telegram_mention_entity(text)])
         assert adapter._message_mentions_bot(msg) is True
 
     def test_text_mention_entity_targets_bot(self):
@@ -183,3 +197,23 @@ class TestCaseInsensitivity:
         text = "hi @Hermes_Bot"
         msg = _message(text=text, entities=[_mention_entity(text, mention="@Hermes_Bot")])
         assert adapter._message_mentions_bot(msg) is True
+
+
+class TestTelegramUtf16EntityOffsets:
+    def test_extracts_bot_mention_username_after_non_bmp_characters(self):
+        text = "\U0001f9ea\U0001f9ea @hermes_bot please"
+        msg = _message(text=text, entities=[_telegram_mention_entity(text)])
+        assert TelegramAdapter._extract_bot_mention_usernames(msg) == {"hermes_bot"}
+
+    def test_bot_command_suffix_after_non_bmp_characters_mentions_bot(self):
+        adapter = _make_adapter()
+        text = "\U0001f9ea\U0001f9ea /new@hermes_bot"
+        entity = _telegram_mention_entity(text, mention="/new@hermes_bot", entity_type="bot_command")
+        msg = _message(text=text, entities=[entity])
+        assert adapter._message_mentions_bot(msg) is True
+
+    def test_extracts_bot_command_target_after_non_bmp_characters(self):
+        text = "\U0001f9ea\U0001f9ea /new@hermes_bot"
+        entity = _telegram_mention_entity(text, mention="/new@hermes_bot", entity_type="bot_command")
+        msg = _message(text=text, entities=[entity])
+        assert TelegramAdapter._extract_bot_mention_usernames(msg) == {"hermes_bot"}


### PR DESCRIPTION
## Summary
- slice Telegram mention and bot-command entities using UTF-16 code-unit offsets
- preserve existing mention and command routing behavior for ASCII text
- add regressions for non-BMP characters before mentions and `/cmd@bot` suffixes

Fixes #55439.

## Dedupe
Checked open upstream PRs/issues first; no existing PR matched #55439.

## Tests
- `python -m pytest tests/gateway/test_telegram_mention_boundaries.py -q`