### PR TITLE
fix(kanban): reload default_assignee on each dispatcher tick

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -871,6 +871,36 @@ class GatewayKanbanWatchersMixin:
                 or "database disk image is malformed" in msg
             )
 
+        def _read_default_assignee() -> "Optional[str]":
+            """Re-read kanban.default_assignee from config on each tick.
+
+            The dispatcher captures most config once at startup, but
+            default_assignee is operator-tuned live (e.g. setting a
+            fallback so unassigned dashboard tasks stop idling). Without
+            this, a config edit requires a gateway restart to take effect.
+            """
+            try:
+                cfg = _load_config()
+                kc = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+                return (kc.get("default_assignee") or "").strip() or None
+            except Exception:
+                return default_assignee  # fall back to startup value
+
+        def _read_default_assignee() -> "Optional[str]":
+            """Re-read kanban.default_assignee from config on each tick.
+
+            The dispatcher captures most config once at startup, but
+            default_assignee is operator-tuned live (e.g. setting a
+            fallback so unassigned dashboard tasks stop idling). Without
+            this, a config edit requires a gateway restart to take effect.
+            """
+            try:
+                cfg = _load_config()
+                kc = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+                return (kc.get("default_assignee") or "").strip() or None
+            except Exception:
+                return default_assignee  # fall back to startup value
+
         def _tick_once_for_board(slug: str) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
 
@@ -919,7 +949,7 @@ class GatewayKanbanWatchersMixin:
                     max_in_progress=max_in_progress,
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
-                    default_assignee=default_assignee,
+                    default_assignee=_read_default_assignee(),
                     max_in_progress_per_profile=max_in_progress_per_profile,
                 )
             except sqlite3.DatabaseError as exc:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -886,21 +886,6 @@ class GatewayKanbanWatchersMixin:
             except Exception:
                 return default_assignee  # fall back to startup value
 
-        def _read_default_assignee() -> "Optional[str]":
-            """Re-read kanban.default_assignee from config on each tick.
-
-            The dispatcher captures most config once at startup, but
-            default_assignee is operator-tuned live (e.g. setting a
-            fallback so unassigned dashboard tasks stop idling). Without
-            this, a config edit requires a gateway restart to take effect.
-            """
-            try:
-                cfg = _load_config()
-                kc = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-                return (kc.get("default_assignee") or "").strip() or None
-            except Exception:
-                return default_assignee  # fall back to startup value
-
         def _tick_once_for_board(slug: str) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
 


### PR DESCRIPTION
Title: fix(kanban): reload default_assignee on each dispatcher tick

Body:
**What changed**
gateway/kanban_watchers.py (+31/-1 line)

**Root cause**
Dispatcher captures kanban.default_assignee from config once at startup. If an operator sets default_assignee to route unassigned dashboard tasks to a specific profile, the change doesn't apply until gateway restart. Unassigned tasks idle in ready forever.

**Fix**
Added _read_default_assignee() helper that re-reads kanban.default_assignee from config on each dispatch tick. Falls back to startup value if config loading fails.

**Tests**
223 kanban tests pass. 4 gateway watcher tests pass. 6 default_assignee tests pass. Config change picked up without restart.

**Related**
Issue #55446