### PR TITLE
fix(wecom): guard _cleanup_ws against exceptions from resource close()

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -270,13 +270,23 @@ class WeComAdapter(BasePlatformAdapter):
         logger.info("[%s] Disconnected", self.name)
 
     async def _cleanup_ws(self) -> None:
-        """Close the live websocket/session, if any."""
-        if self._ws and not self._ws.closed:
-            await self._ws.close()
+        """Close the live websocket/session, if any.
+
+        Each resource is cleaned up independently so that an exception from
+        one close() call does not prevent the other from being released.
+        """
+        try:
+            if self._ws and not self._ws.closed:
+                await self._ws.close()
+        except Exception:
+            logger.debug("[%s] websocket close error (ignored)", self.name)
         self._ws = None
 
-        if self._session and not self._session.closed:
-            await self._session.close()
+        try:
+            if self._session and not self._session.closed:
+                await self._session.close()
+        except Exception:
+            logger.debug("[%s] session close error (ignored)", self.name)
         self._session = None
 
     async def _open_connection(self) -> None:

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -123,6 +123,76 @@ class TestWeComConnect:
         assert "invalid secret" in (adapter.fatal_error_message or "")
 
 
+class TestWeComCleanupDefensive:
+    """_cleanup_ws must not propagate exceptions from resource close() calls."""
+
+    @staticmethod
+    def _make_adapter():
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        return WeComAdapter(PlatformConfig(enabled=True, extra={"bot_id": "b", "secret": "s"}))
+
+    @pytest.mark.asyncio
+    async def test_ws_close_error_does_not_prevent_session_close(self):
+        adapter = self._make_adapter()
+
+        ws = MagicMock()
+        ws.closed = False
+        ws.close = AsyncMock(side_effect=RuntimeError("network error"))
+        adapter._ws = ws
+
+        session = MagicMock()
+        session.closed = False
+        session.close = AsyncMock()
+        adapter._session = session
+
+        await adapter._cleanup_ws()
+
+        session.close.assert_awaited_once()
+        assert adapter._ws is None
+        assert adapter._session is None
+
+    @pytest.mark.asyncio
+    async def test_session_close_error_does_not_prevent_ws_close(self):
+        adapter = self._make_adapter()
+
+        ws = MagicMock()
+        ws.closed = False
+        ws.close = AsyncMock()
+        adapter._ws = ws
+
+        session = MagicMock()
+        session.closed = False
+        session.close = AsyncMock(side_effect=RuntimeError("network error"))
+        adapter._session = session
+
+        await adapter._cleanup_ws()
+
+        ws.close.assert_awaited_once()
+        assert adapter._ws is None
+        assert adapter._session is None
+
+    @pytest.mark.asyncio
+    async def test_both_close_errors_still_clears_references(self):
+        adapter = self._make_adapter()
+
+        ws = MagicMock()
+        ws.closed = False
+        ws.close = AsyncMock(side_effect=RuntimeError("ws boom"))
+        adapter._ws = ws
+
+        session = MagicMock()
+        session.closed = False
+        session.close = AsyncMock(side_effect=RuntimeError("session boom"))
+        adapter._session = session
+
+        # Must not raise
+        await adapter._cleanup_ws()
+
+        assert adapter._ws is None
+        assert adapter._session is None
+
+
 class TestWeComQrScan:
     @patch("plugins.platforms.wecom.adapter.time")
     @patch("plugins.platforms.wecom.adapter.json.loads")


### PR DESCRIPTION
## What does this PR do?

Makes `_cleanup_ws()` in the WeCom adapter defensive against exceptions from resource `close()` calls. Previously, if `self._ws.close()` raised (e.g. network error during graceful close), the entire cleanup aborted — `self._ws` and `self._session` remained as stale references and the exception propagated to the caller.

In `_listen_loop`, this is called from inside an `except` block. An unhandled exception from `_cleanup_ws` escapes the except handler, crashes the listener task, and permanently stops reconnection without logging a fatal error.

The fix wraps each resource cleanup in its own `try/except` so that a failure closing the WebSocket does not prevent the HTTP session from being released (and vice versa). Both references are always set to `None`.

## Related Issue

Fixes #55491

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/wecom/adapter.py`:
  - Wrapped `self._ws.close()` and `self._session.close()` in separate `try/except Exception` blocks
  - Errors are logged at DEBUG level (cleanup failures are expected during network issues)
  - Both `self._ws` and `self._session` are unconditionally set to `None` regardless of close errors
  - Updated docstring to document the defensive behavior
- `tests/gateway/test_wecom.py`:
  - Added `TestWeComCleanupDefensive` class with 3 regression tests:
    - `test_ws_close_error_does_not_prevent_session_close`: ws.close() raises → session.close() still called, both refs cleared
    - `test_session_close_error_does_not_prevent_ws_close`: session.close() raises → ws.close() still called, both refs cleared
    - `test_both_close_errors_still_clears_references`: both raise → no exception propagated, both refs cleared

## How to Test

1. Run `python -m pytest tests/gateway/test_wecom.py::TestWeComCleanupDefensive -v` — all 3 tests should pass
2. Run `python -m pytest tests/gateway/test_wecom.py -q` — all 49 tests should pass (no regression)
3. The fix is low-risk: cleanup code only, no behavior change for the happy path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is platform-independent (asyncio/aiohttp behavior is the same on all platforms)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The bug manifests as a permanent reconnection failure when `ws.close()` raises during cleanup. Example timeline:

```
[WeCom] WebSocket error: connection lost
[WeCom] Reconnecting in 2s...
[WeCom] WebSocket error: connection lost  ← _cleanup_ws() exception escapes
[WeCom] ← listener task crashes, no more reconnection attempts
```

After this fix, cleanup errors are silently absorbed and reconnection proceeds normally.
