### PR TITLE
fix: normalize tool_call_id whitespace in sanitizer

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2163,7 +2163,7 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     result_call_ids: set = set()
     for msg in messages:
         if msg.get("role") == "tool":
-            cid = msg.get("tool_call_id")
+            cid = (msg.get("tool_call_id") or "").strip()
             if cid:
                 result_call_ids.add(cid)
 
@@ -2172,7 +2172,7 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     if orphaned_results:
         messages = [
             m for m in messages
-            if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+            if not (m.get("role") == "tool" and (m.get("tool_call_id") or "").strip() in orphaned_results)
         ]
         _ra().logger.debug(
             "Pre-call sanitizer: removed %d orphaned tool result(s)",

--- a/run_agent.py
+++ b/run_agent.py
@@ -3429,8 +3429,8 @@ class AIAgent:
     def _get_tool_call_id_static(tc) -> str:
         """Extract call ID from a tool_call entry (dict or object)."""
         if isinstance(tc, dict):
-            return tc.get("call_id", "") or tc.get("id", "") or ""
-        return getattr(tc, "call_id", "") or getattr(tc, "id", "") or ""
+            return (tc.get("call_id", "") or tc.get("id", "") or "").strip()
+        return (getattr(tc, "call_id", "") or getattr(tc, "id", "") or "").strip()
 
     @staticmethod
     def _get_tool_call_name_static(tc) -> str:

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -108,6 +108,30 @@ class TestSanitizeApiMessages:
         assert len(out) == 2
         assert out[1]["tool_call_id"] == "c6"
 
+    def test_tool_result_with_leading_whitespace_preserved(self):
+        """Tool result IDs with leading/trailing whitespace should match assistant call IDs."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("functions.cronjob:24")]},
+            tool_result(" functions.cronjob:24"),  # leading whitespace
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        # Should NOT inject a stub — the tool result is valid after stripping
+        assert len(out) == 2
+        assert out[1]["role"] == "tool"
+        assert out[1]["content"] == "ok"
+
+    def test_truly_orphaned_with_whitespace_still_removed(self):
+        """Truly orphaned tool results with whitespace should still be removed."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("c_valid")]},
+            tool_result(" c_ORPHAN "),  # whitespace + no matching call
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert len(out) == 2  # assistant + stub for c_valid, orphan removed
+        tool_msgs = [m for m in out if m["role"] == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "c_valid"
+
 
 # ---------------------------------------------------------------------------
 # Phase 2a — _cap_delegate_task_calls


### PR DESCRIPTION
## Summary
A valid tool result is no longer dropped (and replaced with a `[Result unavailable]` stub) when its `tool_call_id` carries leading/trailing whitespace.

Root cause: `sanitize_api_messages()` compared raw `tool_call_id` strings. When assistant-side IDs and tool-result IDs diverged purely on surrounding whitespace, the real result was treated as orphaned.

## Changes
- `run_agent.py`: `_get_tool_call_id_static()` strips whitespace on both `call_id`/`id` paths (dict + object).
- `agent/agent_runtime_helpers.py`: strip whitespace when collecting `result_call_ids` and when filtering orphaned results in `sanitize_api_messages()`.
- `tests/run_agent/test_agent_guardrails.py`: 2 regression tests — whitespace-preserved result kept; whitespace orphan still removed.

## Validation
| | Before | After |
|---|---|---|
| ` functions.cronjob:24` result vs `functions.cronjob:24` call | dropped → stub | preserved |
| `  no_match  ` orphan | removed | removed |
| `tests/run_agent/test_agent_guardrails.py` | — | 37/37 pass |

E2E verified against the real `AIAgent._sanitize_api_messages` entry point.

Closes #9999

Salvaged from #10039 by @nightq — re-applied to current `main` (the sanitizer logic moved into `agent/agent_runtime_helpers.py` since the PR was filed). Authorship preserved.

## Infographic
![tool_call_id whitespace fix](https://v3b.fal.media/files/b/0aa05946/r2D24lRGXgABU5BaoibcR_vZbKfcRH.png)
