### PR TITLE
fix(memory): prevent holographic duplicate writes from locking db

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -115,6 +115,7 @@ class MemoryStore:
         self._conn: sqlite3.Connection = sqlite3.connect(
             str(self.db_path),
             check_same_thread=False,
+            isolation_level=None,
             timeout=10.0,
         )
         self._lock = threading.RLock()

--- a/tests/plugins/memory/test_holographic_store_transactions.py
+++ b/tests/plugins/memory/test_holographic_store_transactions.py
@@ -1,0 +1,26 @@
+import sqlite3
+
+from plugins.memory.holographic.store import MemoryStore
+
+
+def test_duplicate_add_does_not_leave_write_transaction_open(tmp_path):
+    db_path = tmp_path / "memory_store.db"
+    store = MemoryStore(db_path=db_path, hrr_dim=64)
+    store._hrr_available = False
+
+    try:
+        fact_id = store.add_fact("Jordan prefers concise docs")
+        assert store.add_fact("Jordan prefers concise docs") == fact_id
+        assert not store._conn.in_transaction
+
+        other = sqlite3.connect(str(db_path), timeout=0.1)
+        try:
+            other.execute(
+                "INSERT INTO facts (content) VALUES (?)",
+                ("A separate connection can still write",),
+            )
+            other.commit()
+        finally:
+            other.close()
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary
- Open the holographic memory SQLite connection in autocommit mode so failed single-statement writes do not leave the persistent connection inside an implicit transaction.
- Add a regression test for duplicate `fact_store add` writes, verifying the store is not left in a transaction and another SQLite connection can still write.

Closes #55503

## Root Cause
The duplicate-content path in `MemoryStore.add_fact()` catches `sqlite3.IntegrityError` and returns the existing row id. With sqlite3's default implicit transaction mode, that failed UNIQUE insert leaves `Connection.in_transaction` true.

Because the provider keeps one long-lived connection open, the process can keep a write transaction open after the tool call returns. That manifests as `database is locked` for other writers while reads continue.

The store already commits after each write statement and does not rely on multi-statement implicit transactions, so autocommit preserves the current behavior while preventing failed statements from leaking a transaction.

## Tests
- `python3 -m pytest tests/plugins/memory/test_holographic_store_transactions.py -q`
- `python3 -m pytest tests/plugins/memory/test_holographic_shutdown_closes_db.py -q`
- `env -i PATH="$PATH" HOME="$HOME" TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 PYTHONDONTWRITEBYTECODE=1 python3 scripts/run_tests_parallel.py tests/plugins/memory/test_holographic_store_transactions.py tests/plugins/memory/test_holographic_shutdown_closes_db.py -q`
