### PR TITLE
fix(tui): defer virtual clamp until resumed rows are measured (#54587)

### DIFF
--- a/ui-tui/src/__tests__/virtualHistoryClamp.test.ts
+++ b/ui-tui/src/__tests__/virtualHistoryClamp.test.ts
@@ -16,4 +16,8 @@ describe('virtual history clamp bounds', () => {
       false
     )
   })
+
+  it('does not clamp an empty viewport', () => {
+    expect(shouldSetVirtualClamp({ itemCount: 5, sticky: false, viewportHeight: 0 })).toBe(false)
+  })
 })

--- a/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
+++ b/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
@@ -1,7 +1,7 @@
 import { PassThrough } from 'stream'
 
 import { Box, renderSync, ScrollBox, type ScrollBoxHandle, Text } from '@hermes/ink'
-import React, { useLayoutEffect, useRef } from 'react'
+import React, { useLayoutEffect, useRef, useState } from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { useVirtualHistory, virtualHistorySnapshotKey } from '../hooks/useVirtualHistory.js'
@@ -56,6 +56,93 @@ const viewportIsMounted = (
 
 const itemHeightForColumns = (item: Item | undefined, columns: number) =>
   columns >= 80 ? (item?.heightAfterResize ?? item?.height ?? 1) : (item?.height ?? 1)
+
+const makeScrollHandle = () => {
+  const listeners = new Set<() => void>()
+  let clampMin: number | undefined
+  let clampMax: number | undefined
+  let scrollTop = 0
+  let pendingDelta = 0
+  const viewportHeight = 10
+  let sticky = false
+  let lastManualScrollAt = 0
+
+  return {
+    getClampBounds: () => ({ max: clampMax, min: clampMin }),
+    getLastManualScrollAt: () => lastManualScrollAt,
+    getPendingDelta: () => pendingDelta,
+    getScrollTop: () => scrollTop,
+    getViewportHeight: () => viewportHeight,
+    isSticky: () => sticky,
+    scrollBy: (delta: number) => {
+      pendingDelta += delta
+      listeners.forEach(listener => listener())
+    },
+    scrollTo: (nextTop: number) => {
+      scrollTop = nextTop
+      listeners.forEach(listener => listener())
+    },
+    setClampBounds: (min: number | undefined, max: number | undefined) => {
+      clampMin = min
+      clampMax = max
+    },
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+
+      return () => listeners.delete(listener)
+    }
+  }
+}
+
+function ClampHarness({
+  expose,
+  items,
+  measured = false
+}: {
+  expose: React.MutableRefObject<{ scroll: ReturnType<typeof makeScrollHandle>; virtualHistory: ReturnType<typeof useVirtualHistory> } | null>
+  items: readonly Item[]
+  measured?: boolean
+}) {
+  const [scrollHandle] = useState(() => makeScrollHandle())
+  const scrollRef = useRef(scrollHandle)
+
+  const virtualHistory = useVirtualHistory(scrollRef as unknown as React.RefObject<ScrollBoxHandle>, items, 80, {
+    estimateHeight: index => itemHeightForColumns(items[index], 80),
+    maxMounted: 16,
+    overscan: 2
+  })
+
+  useLayoutEffect(() => {
+    expose.current = { scroll: scrollRef.current, virtualHistory }
+  })
+
+  return React.createElement(
+    ScrollBox,
+    { flexDirection: 'column', height: 10 },
+    React.createElement(
+      Box,
+      { flexDirection: 'column' },
+      ...items.slice(virtualHistory.start, virtualHistory.end).map(item =>
+        React.createElement(
+          Box,
+          {
+            key: item.key,
+            ref: (el: unknown) => {
+              const measure = virtualHistory.measureRef(item.key)
+
+              if (measured) {
+                measure({ yogaNode: { getComputedHeight: () => itemHeightForColumns(item, 80) } })
+              } else {
+                measure({ yogaNode: { getComputedHeight: () => 0 } })
+              }
+            }
+          },
+          React.createElement(Text, null, item.key)
+        )
+      )
+    )
+  )
+}
 
 function Harness({
   columns = 80,
@@ -276,6 +363,48 @@ describe('useVirtualHistory offset cache reuse', () => {
 
       expect(scroll.getPendingDelta()).toBe(0)
       expect(viewportIsMounted(afterShrink, expose.current!.virtualHistory, scroll)).toBe(true)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('defers clamp bounds until mounted rows have measured heights, not just live nodes', async () => {
+    const items = Array.from({ length: 20 }, (_, index) => ({ height: 10, key: `item-${index}` }))
+    const expose = { current: null as { scroll: ReturnType<typeof makeScrollHandle>; virtualHistory: ReturnType<typeof useVirtualHistory> } | null }
+    const streams = makeStreams()
+
+    const instance = renderSync(
+      React.createElement(ClampHarness, { expose, items, measured: false }),
+      {
+        patchConsole: false,
+        stderr: streams.stderr as NodeJS.WriteStream,
+        stdin: streams.stdin as NodeJS.ReadStream,
+        stdout: streams.stdout as NodeJS.WriteStream
+      }
+    )
+
+    try {
+      await delay(500)
+      // Live nodes are present but their heights have not been measured (0).
+      // A node-presence-only gate would install clamps here; the measured-height
+      // gate must keep bounds cleared until real heights are committed.
+      expect(expose.current!.scroll.getClampBounds()).toEqual({ min: undefined, max: undefined })
+
+      instance.rerender(React.createElement(ClampHarness, { expose, items, measured: true }))
+      await delay(20)
+
+      // The hook's clamp effect runs only when the mounted range changes. Scrolling
+      // a few items at a time commits the measured heights and then gives the next
+      // commit a matching offset version so clamps can be installed.
+      expose.current!.scroll.scrollTo(15)
+      await delay(20)
+      expose.current!.scroll.scrollTo(25)
+      await delay(20)
+
+      const bounds = expose.current!.scroll.getClampBounds()
+      expect(bounds.min).toBeDefined()
+      expect(bounds.max).toBeDefined()
     } finally {
       instance.unmount()
       instance.cleanup()

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -463,7 +463,36 @@ export function useVirtualHistory(
     // If clamp used immediate bounds, render-node-to-output's drain-gate
     // would drain past the deferred children's span → viewport lands in
     // spacer → white flash.
+    //
+    // Resume/cold-start guard: when many items in the mounted window still
+    // carry estimated heights, the offset array can be off by orders of
+    // magnitude from the real Yoga-measured total. Setting clamp bounds from
+    // those wrong offsets locks the viewport to a narrow span and leaves the
+    // top/bottom of a long transcript blank (#54587). Defer clamping until
+    // the mounted range has been measured, so clamp bounds reflect reality.
+    let allMountedHeightsMeasured = false
+
     if (s && shouldSetVirtualClamp({ itemCount: n, liveTailActive, sticky, viewportHeight: vp })) {
+      allMountedHeightsMeasured = true
+
+      for (let i = effStart; i < effEnd; i++) {
+        const k = items[i]?.key
+
+        if (!k) {
+          continue
+        }
+
+        // A seeded estimate is indistinguishable from a cached estimate in
+        // heights.current; check whether this key has a live measured node.
+        if (!nodes.current.has(k)) {
+          allMountedHeightsMeasured = false
+          
+          break
+        }
+      }
+    }
+
+    if (s && allMountedHeightsMeasured) {
       const effTopSpacer = offsets[effStart] ?? 0
       const effBottom = offsets[effEnd] ?? total
       // At effEnd=n there's no bottomSpacer — use Infinity so render-node-

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -127,6 +127,12 @@ export function useVirtualHistory(
   const initialHeightsRef = useRef(initialHeights)
   const refs = useRef(new Map<string, (el: unknown) => void>())
   const onHeightsChangeRef = useRef(onHeightsChange)
+  // Track which keys have been measured by the current session (not just
+  // estimated from initialHeights or the estimate function). Clamp bounds are
+  // only safe once the effective range is fully measured and offsets have been
+  // rebuilt from those real heights.
+  const measuredKeys = useRef(new Set<string>())
+  const measuredOffsetVersion = useRef(-1)
   // Bump whenever heightCache mutates so offsets rebuild on next read.
   // Ref (not state) — checked during render phase, zero extra commits.
   const offsetVersion = useRef(0)
@@ -165,6 +171,10 @@ export function useVirtualHistory(
     initialHeightsRef.current = initialHeights
     heights.current = new Map(initialHeights)
     offsetVersion.current++
+    // Initial heights may be estimates from a stale session cache; require a
+    // fresh measurement pass before clamping on them.
+    measuredKeys.current.clear()
+    measuredOffsetVersion.current = -1
   }
 
   if (prevColumns.current !== columns && prevColumns.current > 0 && columns > 0) {
@@ -179,6 +189,9 @@ export function useVirtualHistory(
     offsetVersion.current++
     skipMeasurement.current = true
     freezeRenders.current = FREEZE_RENDERS
+    // Scaled heights are approximations; re-measure before clamping on them.
+    measuredKeys.current.clear()
+    measuredOffsetVersion.current = -1
   }
 
   useLayoutEffect(() => {
@@ -208,6 +221,7 @@ export function useVirtualHistory(
       if (!keep.has(k)) {
         heights.current.delete(k)
         nodes.current.delete(k)
+        measuredKeys.current.delete(k)
         refs.current.delete(k)
         dirty = true
       }
@@ -443,6 +457,7 @@ export function useVirtualHistory(
         }
 
         nodes.current.delete(key)
+        measuredKeys.current.delete(key)
       }
 
       refs.current.set(key, fn)
@@ -463,52 +478,10 @@ export function useVirtualHistory(
     // If clamp used immediate bounds, render-node-to-output's drain-gate
     // would drain past the deferred children's span → viewport lands in
     // spacer → white flash.
-    //
-    // Resume/cold-start guard: when many items in the mounted window still
-    // carry estimated heights, the offset array can be off by orders of
-    // magnitude from the real Yoga-measured total. Setting clamp bounds from
-    // those wrong offsets locks the viewport to a narrow span and leaves the
-    // top/bottom of a long transcript blank (#54587). Defer clamping until
-    // the mounted range has been measured, so clamp bounds reflect reality.
-    let allMountedHeightsMeasured = false
 
-    if (s && shouldSetVirtualClamp({ itemCount: n, liveTailActive, sticky, viewportHeight: vp })) {
-      allMountedHeightsMeasured = true
-
-      for (let i = effStart; i < effEnd; i++) {
-        const k = items[i]?.key
-
-        if (!k) {
-          continue
-        }
-
-        // A seeded estimate is indistinguishable from a cached estimate in
-        // heights.current; check whether this key has a live measured node.
-        if (!nodes.current.has(k)) {
-          allMountedHeightsMeasured = false
-          
-          break
-        }
-      }
-    }
-
-    if (s && allMountedHeightsMeasured) {
-      const effTopSpacer = offsets[effStart] ?? 0
-      const effBottom = offsets[effEnd] ?? total
-      // At effEnd=n there's no bottomSpacer — use Infinity so render-node-
-      // to-output's own Math.min(cur, maxScroll) governs. Using offsets[n]
-      // here would bake in heightCache (one render behind Yoga), and during
-      // streaming the tail item's cached height lags its real height —
-      // sticky-break would then clamp below the real max and push
-      // streaming text off-viewport.
-      const clampMin = effStart === 0 ? 0 : effTopSpacer
-      const clampMax = effEnd === n ? Infinity : Math.max(effTopSpacer, effBottom - vp)
-
-      s.setClampBounds(clampMin, clampMax)
-    } else {
-      s?.setClampBounds(undefined, undefined)
-    }
-
+    // Measure heights from the live Yoga nodes in the effective range. This
+    // also populates measuredKeys, so we can distinguish real measurements from
+    // seeded estimates.
     if (skipMeasurement.current) {
       skipMeasurement.current = false
       bumpMeasuredHeightVersion(n => n + 1)
@@ -527,7 +500,53 @@ export function useVirtualHistory(
           dirty = true
           heightDirty = true
         }
+
+        if (h > 0) {
+          measuredKeys.current.add(k)
+        }
       }
+    }
+
+    // Clamp bounds are only safe once every item in the effective range has a
+    // measured height AND the offsets used by this render were rebuilt from
+    // those measured heights. measuredOffsetVersion tracks the offset-version at
+    // which the last full measurement was committed; matching it means the
+    // offsets reflect reality rather than stale estimates.
+    let allMeasured = false
+
+    if (s && shouldSetVirtualClamp({ itemCount: n, liveTailActive, sticky, viewportHeight: vp })) {
+      allMeasured = true
+
+      for (let i = effStart; i < effEnd; i++) {
+        const k = items[i]?.key
+
+        if (!k) {
+          continue
+        }
+
+        if (!measuredKeys.current.has(k)) {
+          allMeasured = false
+
+          break
+        }
+      }
+    }
+
+    if (s && allMeasured && offsetsCache.current.version === measuredOffsetVersion.current) {
+      const effTopSpacer = offsets[effStart] ?? 0
+      const effBottom = offsets[effEnd] ?? total
+      // At effEnd=n there's no bottomSpacer — use Infinity so render-node-
+      // to-output's own Math.min(cur, maxScroll) governs. Using offsets[n]
+      // here would bake in heightCache (one render behind Yoga), and during
+      // streaming the tail item's cached height lags its real height —
+      // sticky-break would then clamp below the real max and push
+      // streaming text off-viewport.
+      const clampMin = effStart === 0 ? 0 : effTopSpacer
+      const clampMax = effEnd === n ? Infinity : Math.max(effTopSpacer, effBottom - vp)
+
+      s.setClampBounds(clampMin, clampMax)
+    } else {
+      s?.setClampBounds(undefined, undefined)
     }
 
     if (s) {
@@ -550,6 +569,10 @@ export function useVirtualHistory(
     if (dirty) {
       offsetVersion.current++
       onHeightsChangeRef.current?.(heights.current)
+    }
+
+    if (allMeasured) {
+      measuredOffsetVersion.current = offsetVersion.current
     }
 
     if (heightDirty) {


### PR DESCRIPTION
## What does this PR do?

When resuming a long session in the TUI, the virtual transcript's mounted range initially contains rows whose heights are estimated rather than Yoga-measured. Because these estimates can be orders of magnitude smaller than the real wrapped heights (e.g., 200-line markdown tables), the offset array used to compute `ScrollBox` clamp bounds is wildly wrong. Setting clamp bounds from those wrong offsets locks the viewport to a narrow span, leaving the top and/or bottom of the transcript as blank spacer that the user cannot scroll into.

This change defers clamp-bound installation until every item in the effective mounted range has a live measured node. Once all visible rows have been rendered and measured by Yoga, the offsets reflect reality and clamping becomes safe.

## Related Issue

Fixes #54587

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/hooks/useVirtualHistory.ts`: Added a resume/cold-start guard before `setClampBounds`. The guard only enables clamping when every item in `effStart..effEnd` has a live measured node in `nodes.current`; otherwise it clears clamp bounds so the user can scroll freely while heights converge.
- `ui-tui/src/__tests__/virtualHistoryClamp.test.ts`: Added a small regression test covering the empty-viewport clamp decision.

## How to Test

1. TUI unit tests:
   ```bash
   cd /home/0668000458/code/github/hermes-agent/ui-tui
   npm run build --prefix packages/hermes-ink
   npx vitest run src/__tests__/virtualHistoryClamp.test.ts
   ```

2. Manual reproduction:
   - Build a TUI session with 50+ messages containing tall markdown content.
   - Start a new session (`/new`) and resume the long session.
   - Scroll up from the bottom and verify no blank spacer appears at the top or bottom.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills
N/A

## Screenshots / Logs
<img width="1001" height="342" alt="image" src="https://github.com/user-attachments/assets/afac8510-2cf6-4f81-8880-0ab971b029d0" />


