### PR TITLE
fix(gateway): prefer canonical launchd label

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1262,20 +1262,7 @@ def _probe_launchd_service_running() -> bool:
     We additionally require a PID in the output to confirm launchd is actually
     managing a live process, not just holding a static definition.
     """
-    if not get_launchd_plist_path().exists():
-        return False
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired:
-        return False
-    if result.returncode != 0:
-        return False
-    return _parse_launchd_pid_from_list_output(result.stdout) is not None
+    return _launchd_label_state(get_launchd_label())[1]
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -2464,19 +2451,55 @@ def _launchd_plist_path_for_label(label: str) -> Path:
     return _launchd_user_home() / "Library" / "LaunchAgents" / f"{label}.plist"
 
 
+def _launchd_label_state(label: str) -> tuple[bool, bool]:
+    """Return ``(registered, running)`` for a launchd job label."""
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False, False
+    if result.returncode != 0:
+        return False, False
+    return True, _parse_launchd_pid_from_list_output(result.stdout) is not None
+
+
+_resolved_launchd_label: str | None = None
+
+
 def _default_launchd_label() -> str:
+    global _resolved_launchd_label
+    if _resolved_launchd_label is not None:
+        return _resolved_launchd_label
+
     canonical = _LAUNCHD_CANONICAL_DEFAULT_LABEL
     legacy = _LAUNCHD_LEGACY_DEFAULT_LABEL
 
+    states = {
+        canonical: _launchd_label_state(canonical),
+        legacy: _launchd_label_state(legacy),
+    }
+    registered = [label for label, state in states.items() if state[0]]
+    if len(registered) == 1:
+        _resolved_launchd_label = registered[0]
+        return _resolved_launchd_label
+    if len(registered) > 1:
+        running = [label for label in registered if states[label][1]]
+        _resolved_launchd_label = running[0] if len(running) == 1 else canonical
+        return _resolved_launchd_label
+
     canonical_plist = _launchd_plist_path_for_label(canonical)
-    if canonical_plist.exists():
-        return canonical
-
     legacy_plist = _launchd_plist_path_for_label(legacy)
-    if legacy_plist.exists():
-        return legacy
-
-    return canonical
+    if legacy_plist.exists() and not canonical_plist.exists():
+        _resolved_launchd_label = legacy
+    else:
+        # Canonical wins when both stale plists exist, when only its plist
+        # exists, and for a fresh installation with no prior service.
+        _resolved_launchd_label = canonical
+    return _resolved_launchd_label
 
 
 def get_launchd_plist_path() -> Path:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1702,6 +1702,8 @@ def _windows_gateway_should_absorb_console_controls() -> bool:
 
 _SERVICE_BASE = "hermes-gateway"
 SERVICE_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
+_LAUNCHD_CANONICAL_DEFAULT_LABEL = "io.nousresearch.hermes-agent.gateway"
+_LAUNCHD_LEGACY_DEFAULT_LABEL = "ai.hermes.gateway"
 
 
 def _profile_suffix() -> str:
@@ -2458,15 +2460,33 @@ def _launchd_user_home() -> Path:
     return Path(pwd.getpwuid(os.getuid()).pw_dir)  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
+def _launchd_plist_path_for_label(label: str) -> Path:
+    return _launchd_user_home() / "Library" / "LaunchAgents" / f"{label}.plist"
+
+
+def _default_launchd_label() -> str:
+    canonical = _LAUNCHD_CANONICAL_DEFAULT_LABEL
+    legacy = _LAUNCHD_LEGACY_DEFAULT_LABEL
+
+    canonical_plist = _launchd_plist_path_for_label(canonical)
+    if canonical_plist.exists():
+        return canonical
+
+    legacy_plist = _launchd_plist_path_for_label(legacy)
+    if legacy_plist.exists():
+        return legacy
+
+    return canonical
+
+
 def get_launchd_plist_path() -> Path:
     """Return the launchd plist path, scoped per profile.
 
-    Default ``~/.hermes`` → ``ai.hermes.gateway.plist`` (backward compatible).
+    Default ``~/.hermes`` → canonical ``io.nousresearch.hermes-agent.gateway.plist``
+    unless an installed legacy default-profile plist is the only service present.
     Profile ``~/.hermes/profiles/coder`` → ``ai.hermes.gateway-coder.plist``.
     """
-    suffix = _profile_suffix()
-    name = f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
-    return _launchd_user_home() / "Library" / "LaunchAgents" / f"{name}.plist"
+    return _launchd_plist_path_for_label(get_launchd_label())
 
 
 def _detect_venv_dir() -> Path | None:
@@ -3513,7 +3533,7 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
 def get_launchd_label() -> str:
     """Return the launchd service label, scoped per profile."""
     suffix = _profile_suffix()
-    return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
+    return f"{_LAUNCHD_LEGACY_DEFAULT_LABEL}-{suffix}" if suffix else _default_launchd_label()
 
 
 # Cached launchd domain result — probing is cheap but should only run once per

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -615,6 +615,99 @@ class TestGatewayStopCleanup:
         assert kill_calls == [False]
 
 
+class TestLaunchdServiceIdentity:
+    def test_default_profile_uses_canonical_launchd_label_for_new_install(self, tmp_path, monkeypatch):
+        machine_home = tmp_path / "machine-home"
+        machine_home.mkdir()
+
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+
+        assert gateway_cli.get_launchd_label() == "io.nousresearch.hermes-agent.gateway"
+        assert (
+            gateway_cli.get_launchd_plist_path()
+            == machine_home
+            / "Library"
+            / "LaunchAgents"
+            / "io.nousresearch.hermes-agent.gateway.plist"
+        )
+
+    def test_default_profile_keeps_legacy_label_when_only_legacy_plist_exists(
+        self, tmp_path, monkeypatch
+    ):
+        machine_home = tmp_path / "machine-home"
+        launch_agents = machine_home / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        (launch_agents / "ai.hermes.gateway.plist").write_text("<plist/>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+
+        assert gateway_cli.get_launchd_label() == "ai.hermes.gateway"
+        assert gateway_cli.get_launchd_plist_path() == launch_agents / "ai.hermes.gateway.plist"
+
+    def test_default_profile_prefers_canonical_plist_over_legacy_plist(
+        self, tmp_path, monkeypatch
+    ):
+        machine_home = tmp_path / "machine-home"
+        launch_agents = machine_home / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        (launch_agents / "ai.hermes.gateway.plist").write_text("<plist/>", encoding="utf-8")
+        (launch_agents / "io.nousresearch.hermes-agent.gateway.plist").write_text(
+            "<plist/>", encoding="utf-8"
+        )
+
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+
+        assert gateway_cli.get_launchd_label() == "io.nousresearch.hermes-agent.gateway"
+        assert (
+            gateway_cli.get_launchd_plist_path()
+            == launch_agents / "io.nousresearch.hermes-agent.gateway.plist"
+        )
+
+    def test_launchd_running_probe_uses_canonical_label_when_canonical_plist_exists(
+        self, tmp_path, monkeypatch
+    ):
+        machine_home = tmp_path / "machine-home"
+        launch_agents = machine_home / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        (launch_agents / "io.nousresearch.hermes-agent.gateway.plist").write_text(
+            "<plist/>", encoding="utf-8"
+        )
+
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(
+                returncode=0,
+                stdout='{\n    "PID" = 12345;\n    "Label" = "io.nousresearch.hermes-agent.gateway";\n}',
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is True
+        assert calls == [["launchctl", "list", "io.nousresearch.hermes-agent.gateway"]]
+
+    def test_named_profiles_keep_legacy_launchd_label_shape(self, tmp_path, monkeypatch):
+        machine_home = tmp_path / "machine-home"
+        machine_home.mkdir()
+
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "coder")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+
+        assert gateway_cli.get_launchd_label() == "ai.hermes.gateway-coder"
+        assert (
+            gateway_cli.get_launchd_plist_path()
+            == machine_home / "Library" / "LaunchAgents" / "ai.hermes.gateway-coder.plist"
+        )
+
+
 class TestLaunchdServiceRecovery:
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -616,6 +616,10 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceIdentity:
+    @pytest.fixture(autouse=True)
+    def _reset_launchd_label_cache(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_resolved_launchd_label", None)
+
     def test_default_profile_uses_canonical_launchd_label_for_new_install(self, tmp_path, monkeypatch):
         machine_home = tmp_path / "machine-home"
         machine_home.mkdir()
@@ -646,7 +650,7 @@ class TestLaunchdServiceIdentity:
         assert gateway_cli.get_launchd_label() == "ai.hermes.gateway"
         assert gateway_cli.get_launchd_plist_path() == launch_agents / "ai.hermes.gateway.plist"
 
-    def test_default_profile_prefers_canonical_plist_over_legacy_plist(
+    def test_default_profile_prefers_canonical_when_both_plists_are_unregistered(
         self, tmp_path, monkeypatch
     ):
         machine_home = tmp_path / "machine-home"
@@ -666,6 +670,59 @@ class TestLaunchdServiceIdentity:
             == launch_agents / "io.nousresearch.hermes-agent.gateway.plist"
         )
 
+    def test_both_plists_choose_registered_running_legacy_job(
+        self, tmp_path, monkeypatch
+    ):
+        machine_home = tmp_path / "machine-home"
+        launch_agents = machine_home / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        for label in (
+            "ai.hermes.gateway",
+            "io.nousresearch.hermes-agent.gateway",
+        ):
+            (launch_agents / f"{label}.plist").write_text("<plist/>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_label_state",
+            lambda label: (True, True) if label == "ai.hermes.gateway" else (False, False),
+        )
+
+        assert gateway_cli.get_launchd_label() == "ai.hermes.gateway"
+        assert gateway_cli.get_launchd_plist_path() == launch_agents / "ai.hermes.gateway.plist"
+
+    def test_both_plists_choose_registered_running_canonical_job(
+        self, tmp_path, monkeypatch
+    ):
+        machine_home = tmp_path / "machine-home"
+        launch_agents = machine_home / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        for label in (
+            "ai.hermes.gateway",
+            "io.nousresearch.hermes-agent.gateway",
+        ):
+            (launch_agents / f"{label}.plist").write_text("<plist/>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_label_state",
+            lambda label: (
+                (True, True)
+                if label == "io.nousresearch.hermes-agent.gateway"
+                else (False, False)
+            ),
+        )
+
+        assert gateway_cli.get_launchd_label() == "io.nousresearch.hermes-agent.gateway"
+        assert (
+            gateway_cli.get_launchd_plist_path()
+            == launch_agents / "io.nousresearch.hermes-agent.gateway.plist"
+        )
+
     def test_launchd_running_probe_uses_canonical_label_when_canonical_plist_exists(
         self, tmp_path, monkeypatch
     ):
@@ -678,6 +735,11 @@ class TestLaunchdServiceIdentity:
 
         monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
         monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_resolved_launchd_label",
+            "io.nousresearch.hermes-agent.gateway",
+        )
 
         calls = []
 
@@ -693,6 +755,56 @@ class TestLaunchdServiceIdentity:
 
         assert gateway_cli._probe_launchd_service_running() is True
         assert calls == [["launchctl", "list", "io.nousresearch.hermes-agent.gateway"]]
+
+    def test_lifecycle_operations_target_selected_live_legacy_service(
+        self, tmp_path, monkeypatch
+    ):
+        machine_home = tmp_path / "machine-home"
+        launch_agents = machine_home / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        for label in (
+            "ai.hermes.gateway",
+            "io.nousresearch.hermes-agent.gateway",
+        ):
+            (launch_agents / f"{label}.plist").write_text("<plist/>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_label_state",
+            lambda label: (True, True) if label == "ai.hermes.gateway" else (False, False),
+        )
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_if_needed", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kwargs: True)
+        monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *args, **kwargs: None)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            stdout = (
+                '{\n    "PID" = 12345;\n    "Label" = "ai.hermes.gateway";\n}'
+                if cmd[:2] == ["launchctl", "list"]
+                else ""
+            )
+            return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_start()
+        gateway_cli.launchd_stop()
+        gateway_cli.launchd_restart()
+        gateway_cli.launchd_status()
+
+        target = "gui/501/ai.hermes.gateway"
+        assert ["launchctl", "kickstart", target] in calls
+        assert ["launchctl", "bootout", target] in calls
+        assert ["launchctl", "kickstart", "-k", target] in calls
+        assert ["launchctl", "list", "ai.hermes.gateway"] in calls
 
     def test_named_profiles_keep_legacy_launchd_label_shape(self, tmp_path, monkeypatch):
         machine_home = tmp_path / "machine-home"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1063,13 +1063,14 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
-    def test_launchd_domain_uses_user_domain(self, monkeypatch):
+    def test_launchd_domain_uses_user_domain(self, tmp_path, monkeypatch):
         # The user/<uid> domain (not gui/<uid>) is the one reachable from
         # non-Aqua/background sessions on macOS 26+ (issue #23387).
         # When gui/<uid> fails to probe and user/<uid> succeeds,
         # _launchd_domain() must return user/<uid>.
         gateway_cli._resolved_launchd_domain = None
         monkeypatch.setattr(os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
         label = gateway_cli.get_launchd_label()
 
         def fake_run(cmd, check=False, **kwargs):
@@ -1468,6 +1469,10 @@ class TestLaunchdDomainDetection:
     def _reset_domain_cache(self):
         """Clear any cached domain result between tests."""
         gateway_cli._resolved_launchd_domain = None
+
+    @pytest.fixture(autouse=True)
+    def _isolate_launchd_home(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
 
     def test_prefers_gui_domain_when_service_loaded_there(self, monkeypatch):
         """In an Aqua session where the service is loaded under gui/<uid>,

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -492,7 +492,14 @@ hermes gateway status                # Check status
 tail -f ~/.hermes/logs/gateway.log   # View logs
 ```
 
-The generated plist lives at `~/Library/LaunchAgents/ai.hermes.gateway.plist`. It includes three environment variables:
+Fresh default-profile installs use the canonical plist and label
+`~/Library/LaunchAgents/io.nousresearch.hermes-agent.gateway.plist` and
+`io.nousresearch.hermes-agent.gateway`. Existing installations that still use
+`ai.hermes.gateway.plist` / `ai.hermes.gateway` remain supported. When both
+identities are present, `hermes gateway start`, `stop`, `restart`, and `status`
+follow the job currently registered with launchd, preferring the actively
+running job when both are registered. The generated plist includes three
+environment variables:
 
 - **PATH** — your full shell PATH at install time, with the venv `bin/` and `node_modules/.bin` prepended. This ensures user-installed tools (Node.js, ffmpeg, etc.) are available to gateway subprocesses like the WhatsApp bridge.
 - **VIRTUAL_ENV** — points to the Python virtualenv so tools can resolve packages correctly.
@@ -503,7 +510,7 @@ launchd plists are static — if you install new tools (e.g. a new Node.js versi
 :::
 
 :::info Multiple installations
-Like the Linux systemd service, each `HERMES_HOME` directory gets its own launchd label. The default `~/.hermes` uses `ai.hermes.gateway`; other installations use `ai.hermes.gateway-<suffix>`.
+Like the Linux systemd service, each `HERMES_HOME` directory gets its own launchd label. Fresh default `~/.hermes` installations use `io.nousresearch.hermes-agent.gateway`; legacy default installations keep working with `ai.hermes.gateway`. Other installations use `ai.hermes.gateway-<suffix>`.
 :::
 
 ## Platform-Specific Toolsets

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
@@ -408,7 +408,13 @@ hermes gateway status                # 检查状态
 tail -f ~/.hermes/logs/gateway.log   # 查看日志
 ```
 
-生成的 plist 文件位于 `~/Library/LaunchAgents/ai.hermes.gateway.plist`。它包含三个环境变量：
+全新的默认配置安装使用规范 plist 和标签：
+`~/Library/LaunchAgents/io.nousresearch.hermes-agent.gateway.plist` 和
+`io.nousresearch.hermes-agent.gateway`。仍使用 `ai.hermes.gateway.plist` /
+`ai.hermes.gateway` 的旧安装继续受到支持。如果两种身份同时存在，
+`hermes gateway start`、`stop`、`restart` 和 `status` 会选择已向 launchd
+注册的作业；如果两者都已注册，则优先选择当前正在运行的作业。生成的 plist
+包含三个环境变量：
 
 - **PATH** — 安装时你的完整 shell PATH，并在前面添加了 venv `bin/` 和 `node_modules/.bin`。这确保用户安装的工具（Node.js、ffmpeg 等）可供网关子进程（如 WhatsApp 桥接）使用。
 - **VIRTUAL_ENV** — 指向 Python 虚拟环境，使工具能正确解析包。
@@ -419,7 +425,7 @@ launchd plist 是静态的——如果你在配置网关后安装了新工具（
 :::
 
 :::info 多个安装
-与 Linux systemd 服务类似，每个 `HERMES_HOME` 目录都有自己的 launchd 标签。默认的 `~/.hermes` 使用 `ai.hermes.gateway`；其他安装使用 `ai.hermes.gateway-<suffix>`。
+与 Linux systemd 服务类似，每个 `HERMES_HOME` 目录都有自己的 launchd 标签。全新的默认 `~/.hermes` 安装使用 `io.nousresearch.hermes-agent.gateway`；旧的默认安装仍可继续使用 `ai.hermes.gateway`。其他安装使用 `ai.hermes.gateway-<suffix>`。
 :::
 
 ## 平台专属工具集


### PR DESCRIPTION
## Summary

- Prefer the canonical default-profile launchd label `io.nousresearch.hermes-agent.gateway` when installing or managing the macOS gateway.
- Keep backward compatibility for existing default-profile installs that only have the legacy `ai.hermes.gateway.plist`.
- Keep named profiles on the existing `ai.hermes.gateway-<profile>` label shape.

## Root Cause

The macOS launchd helpers always derived the default-profile label/path as `ai.hermes.gateway`, so `hermes gateway status`, `start`, `stop`, and `restart` could target a stale legacy service even when the canonical `io.nousresearch.hermes-agent.gateway` LaunchAgent was installed and supervising the gateway.

## Tests

- `python -m pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceIdentity tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery tests/hermes_cli/test_gateway_service.py::TestLaunchdDomainDetection -q`
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `git diff --check`

Fixes #55441