### PR TITLE
fix(active-sessions): reject zombie PIDs in _pid_alive to prevent session lease deadlocks

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -185,6 +185,28 @@ def _optional_float(value: Any) -> Optional[float]:
         return None
 
 
+def _is_zombie(pid: int) -> bool:
+    """Return True when *pid* is a zombie (defunct) process.
+
+    ``os.kill(pid, 0)`` (and therefore ``psutil.pid_exists``) returns
+    ``True`` for zombies because the PID still occupies a slot in the
+    kernel's process table — it will not be recycled until the parent
+    calls ``waitpid``.  A zombie can never release its session lease, so
+    ``_pid_alive`` must treat it as dead.
+
+    psutil's ``Process.status()`` reads ``/proc/<pid>/stat`` on Linux
+    and the equivalent on macOS/BSD.  Any failure (process vanished,
+    permission error, unsupported platform) is treated as *not a zombie*
+    so the remaining checks in ``_pid_alive`` can still run.
+    """
+    try:
+        import psutil  # type: ignore
+
+        return psutil.Process(pid).status() == psutil.STATUS_ZOMBIE
+    except Exception:
+        return False
+
+
 def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
     try:
         pid_int = int(pid)
@@ -199,6 +221,8 @@ def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
     except Exception:
         return False
     if not exists:
+        return False
+    if _is_zombie(pid_int):
         return False
     expected_start = _optional_float(process_start_time)
     if expected_start is None:

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -157,6 +157,79 @@ def test_pid_alive_uses_safe_pid_exists_without_signalling(monkeypatch):
     assert checked == [12345]
 
 
+def test_is_zombie_returns_true_for_zombie_process(monkeypatch):
+    """_is_zombie() should return True when psutil reports STATUS_ZOMBIE."""
+    import types
+
+    fake_psutil = types.ModuleType("psutil")
+    fake_psutil.STATUS_ZOMBIE = "zombie"
+
+    class FakeProcess:
+        def __init__(self, pid):
+            pass
+
+        def status(self):
+            return "zombie"
+
+    fake_psutil.Process = FakeProcess
+    monkeypatch.setitem(__import__("sys").modules, "psutil", fake_psutil)
+
+    assert active_sessions._is_zombie(99999) is True
+
+
+def test_is_zombie_returns_false_for_running_process(monkeypatch):
+    """_is_zombie() should return False when psutil reports a normal status."""
+    import types
+
+    fake_psutil = types.ModuleType("psutil")
+    fake_psutil.STATUS_ZOMBIE = "zombie"
+
+    class FakeProcess:
+        def __init__(self, pid):
+            pass
+
+        def status(self):
+            return "running"
+
+    fake_psutil.Process = FakeProcess
+    monkeypatch.setitem(__import__("sys").modules, "psutil", fake_psutil)
+
+    assert active_sessions._is_zombie(99999) is False
+
+
+def test_is_zombie_returns_false_on_exception(monkeypatch):
+    """_is_zombie() should return False when psutil raises (process vanished)."""
+    import types
+
+    fake_psutil = types.ModuleType("psutil")
+    fake_psutil.STATUS_ZOMBIE = "zombie"
+
+    class FakeProcess:
+        def __init__(self, pid):
+            raise ProcessLookupError("no such process")
+
+    fake_psutil.Process = FakeProcess
+    monkeypatch.setitem(__import__("sys").modules, "psutil", fake_psutil)
+
+    assert active_sessions._is_zombie(99999) is False
+
+
+def test_pid_alive_rejects_zombie_processes(monkeypatch):
+    """_pid_alive() must return False for zombie PIDs even when _pid_exists
+    reports True — zombies occupy a PID slot but can never do work."""
+    monkeypatch.setattr(
+        "gateway.status._pid_exists",
+        lambda pid: True,
+    )
+    monkeypatch.setattr(
+        active_sessions,
+        "_is_zombie",
+        lambda pid: True,
+    )
+
+    assert active_sessions._pid_alive(12345) is False
+
+
 def test_active_session_hard_exit_is_reclaimed(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     monkeypatch.setenv("HERMES_HOME", str(home))


### PR DESCRIPTION
## What does this PR do?

Fixes a session lease deadlock caused by zombie (defunct) processes. `psutil.pid_exists()` returns `True` for zombies because the PID still occupies a slot in the kernel process table — it will not be recycled until the parent calls `waitpid`. A zombie can never release its session lease, so `_prune_dead` fails to evict them and new workers cannot spawn. When enough zombies accumulate, the board silently stops dispatching.

## Related Issue

Fixes #55444

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/active_sessions.py`: Added `_is_zombie()` helper that uses `psutil.Process.status()` to detect zombie processes. Integrated into `_pid_alive()` as an early rejection after `_pid_exists` returns True but before the start-time comparison. Any psutil exception (process vanished, permission error) is treated as "not a zombie" so remaining checks still run.
- `tests/hermes_cli/test_active_sessions.py`: Added 4 tests — `_is_zombie` returns True for zombies, False for running processes, False on exceptions; `_pid_alive` rejects zombie PIDs even when `_pid_exists` reports True.

## How to Test

1. Run `pytest tests/hermes_cli/test_active_sessions.py -v` — all 13 tests should pass, including the 4 new zombie-related tests.
2. The new tests mock `psutil.Process.status()` to simulate zombie processes without requiring actual zombie PIDs in the test environment.
3. On a Linux system with a zombie process, `_pid_alive(zombie_pid)` should return `False` whereas previously it returned `True`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `psutil.Process.status()` is cross-platform; zombie detection works on Linux/macOS/BSD. On Windows, zombie processes don't exist in the same way, so the check safely returns False.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
