### PR TITLE
fix(desktop): copy full file content instead of truncated inline diff

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -9,6 +9,7 @@ import {
   inlineDiffFromResult,
   MAX_TOOL_RENDER_CHARS,
   prettyJson,
+  toolCopyPayload,
   type ToolPart
 } from './fallback-model'
 
@@ -448,5 +449,72 @@ describe('buildToolView memory status', () => {
     expect(view.status).toBe('warning')
     expect(view.title).toBe('Memory write noted')
     expect(view.subtitle).toContain('Memory is full')
+describe('toolCopyPayload file-edit copy', () => {
+  // The inline diff rendered in the tool row is capped at _MAX_INLINE_DIFF_LINES
+  // (80) for display. The Copy button must yield the full content, not the
+  // truncated slice — otherwise large write_file / patch results copy
+  // incomplete text.
+  it('copies full write_file content from args, not the truncated inline diff', () => {
+    const fullContent = 'line\n'.repeat(200)
+    const truncatedDiff = '--- /dev/null\n+++ b/file.txt\n' + '+line\n'.repeat(70) + '\n… omitted 130 diff line(s)'
+
+    const view = buildToolView(
+      part({
+        args: { content: fullContent, path: '/tmp/file.txt' },
+        result: { bytes_written: 1000, files_modified: ['/tmp/file.txt'] },
+        toolName: 'write_file'
+      }),
+      truncatedDiff
+    )
+
+    const payload = toolCopyPayload(
+      { args: { content: fullContent, path: '/tmp/file.txt' }, isError: false, result: { bytes_written: 1000 }, toolCallId: 'c1', toolName: 'write_file', type: 'tool-call' },
+      view
+    )
+
+    // Full content (200 lines) — not the truncated 70-line diff.
+    // firstStringField trims; compare against the trimmed full content.
+    expect(payload.text).toBe(fullContent.trim())
+    expect(payload.text).not.toContain('omitted')
+    expect(payload.text.split('\n')).toHaveLength(200)
+  })
+
+  it('copies full patch diff from result, not the truncated inline diff', () => {
+    const fullDiff = '--- a/x\n+++ b/x\n@@\n' + '+new\n'.repeat(200)
+    const truncatedDiff = '--- a/x\n+++ b/x\n@@\n' + '+new\n'.repeat(70) + '\n… omitted 130 diff line(s)'
+
+    const view = buildToolView(
+      part({
+        args: { mode: 'replace', new_string: 'new', old_string: 'old', path: 'x' },
+        result: { diff: fullDiff, success: true },
+        toolName: 'patch'
+      }),
+      truncatedDiff
+    )
+
+    const payload = toolCopyPayload(
+      { args: { mode: 'replace', path: 'x' }, isError: false, result: { diff: fullDiff, success: true }, toolCallId: 'c2', toolName: 'patch', type: 'tool-call' },
+      view
+    )
+
+    // inlineDiffFromResult trims; compare against the trimmed full diff.
+    expect(payload.text).toBe(fullDiff.trim())
+    expect(payload.text).not.toContain('omitted')
+  })
+
+  it('falls back to inline diff when write_file has no args.content', () => {
+    const inlineDiff = '--- /dev/null\n+++ b/file.txt\n+content'
+
+    const view = buildToolView(
+      part({ args: { path: '/tmp/file.txt' }, result: { bytes_written: 10 }, toolName: 'write_file' }),
+      inlineDiff
+    )
+
+    const payload = toolCopyPayload(
+      { args: { path: '/tmp/file.txt' }, isError: false, result: { bytes_written: 10 }, toolCallId: 'c3', toolName: 'write_file', type: 'tool-call' },
+      view
+    )
+
+    expect(payload.text).toBe(inlineDiff)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -449,6 +449,9 @@ describe('buildToolView memory status', () => {
     expect(view.status).toBe('warning')
     expect(view.title).toBe('Memory write noted')
     expect(view.subtitle).toContain('Memory is full')
+  })
+})
+
 describe('toolCopyPayload file-edit copy', () => {
   // The inline diff rendered in the tool row is capped at _MAX_INLINE_DIFF_LINES
   // (80) for display. The Copy button must yield the full content, not the
@@ -468,15 +471,48 @@ describe('toolCopyPayload file-edit copy', () => {
     )
 
     const payload = toolCopyPayload(
-      { args: { content: fullContent, path: '/tmp/file.txt' }, isError: false, result: { bytes_written: 1000 }, toolCallId: 'c1', toolName: 'write_file', type: 'tool-call' },
+      {
+        args: { content: fullContent, path: '/tmp/file.txt' },
+        isError: false,
+        result: { bytes_written: 1000 },
+        toolCallId: 'c1',
+        toolName: 'write_file',
+        type: 'tool-call'
+      },
       view
     )
 
     // Full content (200 lines) — not the truncated 70-line diff.
-    // firstStringField trims; compare against the trimmed full content.
-    expect(payload.text).toBe(fullContent.trim())
+    expect(payload.text).toBe(fullContent)
     expect(payload.text).not.toContain('omitted')
-    expect(payload.text.split('\n')).toHaveLength(200)
+  })
+
+  it('preserves leading and trailing whitespace from write_file args.content', () => {
+    const content = '\n  first line\nlast line  \n\n'
+    const inlineDiff = '--- /dev/null\n+++ b/file.txt\n+first line\n+last line'
+
+    const view = buildToolView(
+      part({
+        args: { content, path: '/tmp/file.txt' },
+        result: { bytes_written: content.length },
+        toolName: 'write_file'
+      }),
+      inlineDiff
+    )
+
+    const payload = toolCopyPayload(
+      {
+        args: { content, path: '/tmp/file.txt' },
+        isError: false,
+        result: { bytes_written: content.length },
+        toolCallId: 'c2',
+        toolName: 'write_file',
+        type: 'tool-call'
+      },
+      view
+    )
+
+    expect(payload.text).toBe(content)
   })
 
   it('copies full patch diff from result, not the truncated inline diff', () => {
@@ -486,19 +522,25 @@ describe('toolCopyPayload file-edit copy', () => {
     const view = buildToolView(
       part({
         args: { mode: 'replace', new_string: 'new', old_string: 'old', path: 'x' },
-        result: { diff: fullDiff, success: true },
+        result: { diff: fullDiff, inline_diff: truncatedDiff, success: true },
         toolName: 'patch'
       }),
       truncatedDiff
     )
 
     const payload = toolCopyPayload(
-      { args: { mode: 'replace', path: 'x' }, isError: false, result: { diff: fullDiff, success: true }, toolCallId: 'c2', toolName: 'patch', type: 'tool-call' },
+      {
+        args: { mode: 'replace', path: 'x' },
+        isError: false,
+        result: { diff: fullDiff, inline_diff: truncatedDiff, success: true },
+        toolCallId: 'c3',
+        toolName: 'patch',
+        type: 'tool-call'
+      },
       view
     )
 
-    // inlineDiffFromResult trims; compare against the trimmed full diff.
-    expect(payload.text).toBe(fullDiff.trim())
+    expect(payload.text).toBe(fullDiff)
     expect(payload.text).not.toContain('omitted')
   })
 
@@ -511,7 +553,14 @@ describe('toolCopyPayload file-edit copy', () => {
     )
 
     const payload = toolCopyPayload(
-      { args: { path: '/tmp/file.txt' }, isError: false, result: { bytes_written: 10 }, toolCallId: 'c3', toolName: 'write_file', type: 'tool-call' },
+      {
+        args: { path: '/tmp/file.txt' },
+        isError: false,
+        result: { bytes_written: 10 },
+        toolCallId: 'c4',
+        toolName: 'write_file',
+        type: 'tool-call'
+      },
       view
     )
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -1266,17 +1266,17 @@ export function toolCopyPayload(part: ToolPart, view: ToolView): { label: string
     // (80) for display. The Copy button must yield the full content, not the
     // truncated slice — same principle as clampForDisplay for tool output.
     if (part.toolName === 'write_file') {
-      const content = firstStringField(args, ['content'])
+      const content = args.content
 
-      if (content) {
+      if (typeof content === 'string') {
         return { label: copy.file, text: content }
       }
     }
 
     if (part.toolName === 'patch') {
-      const fullDiff = inlineDiffFromResult(part.result)
+      const fullDiff = result.diff
 
-      if (fullDiff.trim()) {
+      if (typeof fullDiff === 'string' && fullDiff.trim()) {
         return { label: copy.file, text: fullDiff }
       }
     }

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -1262,6 +1262,25 @@ export function toolCopyPayload(part: ToolPart, view: ToolView): { label: string
   }
 
   if (isFileEditTool(part.toolName)) {
+    // The inline diff shown in the tool row is capped at _MAX_INLINE_DIFF_LINES
+    // (80) for display. The Copy button must yield the full content, not the
+    // truncated slice — same principle as clampForDisplay for tool output.
+    if (part.toolName === 'write_file') {
+      const content = firstStringField(args, ['content'])
+
+      if (content) {
+        return { label: copy.file, text: content }
+      }
+    }
+
+    if (part.toolName === 'patch') {
+      const fullDiff = inlineDiffFromResult(part.result)
+
+      if (fullDiff.trim()) {
+        return { label: copy.file, text: fullDiff }
+      }
+    }
+
     if (view.inlineDiff.trim()) {
       return { label: copy.file, text: view.inlineDiff }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the Copy button on `write_file` / `patch` tool rows in the Desktop app copied a **truncated inline diff** instead of the full file content.

## Root Cause

The inline diff rendered in file-edit tool rows is capped at `_MAX_INLINE_DIFF_LINES` (80) for display performance (`agent/display.py:91`). The Copy button in `toolCopyPayload` (`tool/fallback-model.ts`) returned `view.inlineDiff` — the same truncated slice — so large file writes (>80 lines) copied incomplete content with a trailing `… omitted N diff line(s)` marker.

This contradicts the established pattern for tool output, where `clampForDisplay` bounds what is painted but the Copy button reads the uncapped `view.detail` for the full output (see comment at `tool/fallback-model.ts:364`).

## Fix

`toolCopyPayload` now prefers the full content from the **source of truth** before falling back to the truncated inline diff:

| Tool | Full source | Fallback |
|------|------------|----------|
| `write_file` | `args.content` (the content written to disk) | truncated `view.inlineDiff` |
| `patch` | `result.diff` (the full unified diff) | truncated `view.inlineDiff` |
| other file edits | — | `view.inlineDiff` (unchanged) |

## How to Test

1. `cd apps/desktop && npx vitest run src/components/assistant-ui/tool/fallback-model.test.ts`
2. 3 new tests verify: full `write_file` content, full `patch` diff, and fallback when `args.content` is absent.
3. Manual: have the agent `write_file` a 200-line file, expand the tool row, click Copy, then paste elsewhere — full 200 lines should be present (not 80 + an omission marker).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] Desktop tests pass: 27/29 (2 pre-existing browser_navigate failures unrelated to this change)
- [x] tsc --noEmit clean (1 pre-existing error in use-terminal-session.ts unrelated to this change)
- [x] I have added tests for my change (3 new test cases)
- [x] Cross-platform: pure renderer-side TS, no platform-specific code
