### PR TITLE
fix(desktop): recover degraded skill slash chips

### DIFF
--- a/apps/desktop/src/app/chat/composer/rich-editor.test.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.test.ts
@@ -8,7 +8,8 @@ import {
   normalizeComposerEditorDom,
   refChipElement,
   renderComposerContents,
-  RICH_INPUT_SLOT
+  RICH_INPUT_SLOT,
+  slashChipElement
 } from './rich-editor'
 
 const caretIn = (editor: HTMLElement) => {
@@ -33,6 +34,16 @@ describe('renderComposerContents', () => {
     expect(editor.textContent).toContain('<img src=x onerror=alert(1)>')
     expect(editor.textContent).toContain('<b>raw</b>')
     expect(composerPlainText(editor)).toBe('@file:`<img src=x onerror=alert(1)>` <b>raw</b>')
+  })
+})
+
+describe('composerPlainText', () => {
+  it('recovers a slash chip command from its visible label when ref text is a bare slash', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    editor.append(slashChipElement('/', 'skill', 'some-skill'), document.createTextNode(' do something'))
+
+    expect(composerPlainText(editor)).toBe('/some-skill do something')
   })
 })
 

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -272,6 +272,23 @@ export function composerPlainText(node: Node): string {
 
   const el = node as HTMLElement
 
+  if (el.dataset.slashKind) {
+    const refText = el.dataset.refText?.trim() ?? ''
+
+    if (refText && !/^\/+$/.test(refText)) {
+      return el.dataset.refText ?? ''
+    }
+
+    // A degraded slash chip payload of "/" would submit as "/ arg", which the
+    // dispatcher parses as an empty command. The visible chip label still names
+    // the command, so recover it here before submit.
+    const label = el.textContent?.trim() ?? ''
+
+    if (label) {
+      return label.startsWith('/') ? label : `/${label}`
+    }
+  }
+
   if (el.dataset.refText) {
     return el.dataset.refText
   }

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -6,7 +6,8 @@ import {
   attachmentDisplayText,
   coerceThinkingText,
   optimisticAttachmentRef,
-  parseCommandDispatch
+  parseCommandDispatch,
+  parseSlashCommand
 } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
@@ -109,5 +110,22 @@ describe('parseCommandDispatch', () => {
 
   it('rejects a prefill directive missing its message', () => {
     expect(parseCommandDispatch({ type: 'prefill', notice: 'x' })).toBeNull()
+  })
+})
+
+describe('parseSlashCommand', () => {
+  it('parses a non-empty slash command even when whitespace follows the slash', () => {
+    expect(parseSlashCommand('/ some-skill do something')).toEqual({
+      arg: 'do something',
+      name: 'some-skill'
+    })
+  })
+
+  it('keeps truly empty slash input empty', () => {
+    expect(parseSlashCommand('/   ')).toEqual({ arg: '', name: '' })
+  })
+
+  it('does not treat a command on the next line as the slash command name', () => {
+    expect(parseSlashCommand('/\nsome-skill do something')).toEqual({ arg: '', name: '' })
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -223,7 +223,7 @@ export function normalizePersonalityValue(value: string): string {
 }
 
 export function parseSlashCommand(command: string) {
-  const match = command.replace(/^\/+/, '').match(/^(\S+)\s*(.*)$/)
+  const match = command.replace(/^\/+[^\S\r\n]*/, '').match(/^(\S+)\s*(.*)$/)
 
   return match ? { name: match[1], arg: match[2].trim() } : { name: '', arg: '' }
 }


### PR DESCRIPTION
## Summary
- recover slash chip plain text from the visible chip label when its command payload degrades to a bare `/`
- make desktop slash parsing tolerate accidental horizontal whitespace between `/` and a non-empty command name without changing newline/multiline behavior
- cover both regressions so non-empty skill slash commands do not reach the empty-command branch

Fixes #55510

## Test Plan
- npm --workspace apps/desktop run test:ui -- src/app/chat/composer/rich-editor.test.ts src/app/chat/composer/enter-submit-dom-race.test.tsx src/app/chat/composer/slash-nav-dom-repro.test.tsx src/lib/desktop-slash-commands.test.ts src/lib/chat-runtime.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop exec eslint src/app/chat/composer/rich-editor.ts src/app/chat/composer/rich-editor.test.ts src/lib/chat-runtime.ts src/lib/chat-runtime.test.ts
- git diff --check