### PR TITLE
fix(desktop): proper agent icon for subagents + a queue icon

### DIFF
--- a/apps/desktop/src/app/chat/composer/queue-panel.tsx
+++ b/apps/desktop/src/app/chat/composer/queue-panel.tsx
@@ -1,6 +1,7 @@
 import { StatusRow } from '@/components/chat/status-row'
 import { StatusSection } from '@/components/chat/status-section'
 import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { ArrowUp, iconSize, Pencil, Trash2 } from '@/lib/icons'
@@ -28,7 +29,10 @@ export function QueuePanel({ busy, editingId, entries, onDelete, onEdit, onSendN
   }
 
   return (
-    <StatusSection label={c.queued(entries.length)}>
+    <StatusSection
+      icon={<Codicon className="text-muted-foreground/70" name="layers" size="0.8rem" />}
+      label={c.queued(entries.length)}
+    >
       {entries.map(entry => {
         const isEditing = editingId === entry.id
         const attachmentsCount = entry.attachments.length

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -35,11 +35,11 @@ const BACKGROUND_POLL_MS = 5_000
 // letting dead URLs pile up. File previews (a real on-disk artifact) stand alone.
 const isLocalhostPreview = (target: string): boolean => /\b(?:localhost|127\.0\.0\.1|0\.0\.0\.0)\b/i.test(target)
 
-// Real codicons per group (no sparkles): a checklist for todos, a bot for
-// subagents, a background process glyph for background tasks.
+// Real codicons per group (no sparkles): a checklist for todos, the agent glyph
+// for subagents, a background process glyph for background tasks.
 const GROUP_ICON: Record<StatusGroup['type'], string> = {
   todo: 'checklist',
-  subagent: 'hubot',
+  subagent: 'agent',
   background: 'server-process'
 }
 


### PR DESCRIPTION
## Summary
- Subagents used the `hubot` codicon — switch to the dedicated **`agent`** glyph.
- The queue section had **no icon** while every other status group (todos, subagents, background) has one. Give it **`layers`** (a stack of pending turns), styled identically (`Codicon`, `0.8rem`, `text-muted-foreground/70`) so all four sections are consistent.

## Test plan
- [ ] Subagent group header shows the agent icon.
- [ ] Queue ("Queued (N)") header shows the layers icon, aligned with the other groups.