### PR TITLE
fix(tui_gateway): prevent Desktop WS disconnect under GIL pressure (#48445)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14060,6 +14060,15 @@ def start_server(
     # For explicit non-zero ports, if the port is taken uvicorn catches
     # OSError inside create_server() and exits with a clear error — no
     # separate preflight probe needed.
+    # Loopback binds are the Desktop case: a single local client, no reverse
+    # proxy in front. A GIL-heavy agent turn can stall the event loop past 20s,
+    # and uvicorn's ws keepalive ping runs on that same starved loop — so a
+    # 20s ping timeout kills an otherwise-healthy local connection over a
+    # recoverable stall (QW-1). Give loopback a longer 60s timeout / 30s
+    # interval to ride out those stalls. Non-loopback binds sit behind a
+    # Cloudflare Tunnel (idle timeout ~100s), so keep them at 20/20 to detect
+    # half-open connections promptly and stay under the tunnel's idle window.
+    _is_loopback = host in ("127.0.0.1", "localhost", "::1")
     config = uvicorn.Config(
         app, host=host, port=port, log_level="warning",
         # proxy_headers defaults to False so _ws_client_is_allowed sees
@@ -14073,9 +14082,9 @@ def start_server(
         # Detect half-open WS connections (reverse-proxy 524, dropped
         # tunnels) within ~20-40s so WebSocketDisconnect fires the
         # disconnect→reap path.  20s stays under Cloudflare Tunnel's idle
-        # timeout, keeping it warm.
-        ws_ping_interval=20.0,
-        ws_ping_timeout=20.0,
+        # timeout, keeping it warm.  Loopback gets a longer window (see above).
+        ws_ping_interval=30.0 if _is_loopback else 20.0,
+        ws_ping_timeout=60.0 if _is_loopback else 20.0,
     )
     server = uvicorn.Server(config)
 
@@ -14110,6 +14119,35 @@ def start_server(
                 install_loop_noise_filter(asyncio.get_running_loop())
             except Exception as exc:  # pragma: no cover - best-effort
                 _log.debug("loop noise filter install skipped: %s", exc)
+
+            # ── Loop heartbeat watchdog (CF-1) ───────────────────────────
+            # Confirm the GIL-pressure hypothesis in production. Re-arm a 2s
+            # tick and measure the drift between when it *should* fire and
+            # when it actually does: a healthy loop drifts ~0, but a turn that
+            # holds the GIL blocks the loop and the next tick fires late by the
+            # stall duration. We log that so a stalled-loop WS drop is
+            # diagnosable from the gateway log. Uses loop.time() (monotonic)
+            # for drift, and call_later (not a task) so it dies with the loop —
+            # nothing to cancel on shutdown.
+            _hb_interval = 2.0
+            _hb_stall_threshold = 5.0
+            _hb_loop = asyncio.get_running_loop()
+
+            def _loop_heartbeat(expected: float) -> None:
+                now = _hb_loop.time()
+                drift = now - expected
+                if drift > _hb_stall_threshold:
+                    _log.warning(
+                        "event loop stalled %.1fs (GIL pressure suspected)",
+                        drift,
+                    )
+                _hb_loop.call_later(
+                    _hb_interval, _loop_heartbeat, now + _hb_interval
+                )
+
+            _hb_loop.call_later(
+                _hb_interval, _loop_heartbeat, _hb_loop.time() + _hb_interval
+            )
 
             await server.main_loop()
             if server.started:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,8 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "cypher@augmentl.com": "Nickperillo",  # PR #8008 salvage (Discord channel-name matching + flush pending sends on shutdown)
     "tenoryang@outlook.com": "MarioYounger",  # PR #9028 salvage (bash/sh heredoc approval, NFKC homograph fold, execute_code CREDS/BEARER/APIKEY env filter)
+    "peet.wannasarnmetha@gmail.com": "peetwan",  # PR #51841 salvage (loopback ws-ping tuning + token-frame coalescing + loop heartbeat; #48445/#50005)
+    "297292863+Zyxxx-xxxyZ@users.noreply.github.com": "Zyxxx-xxxyZ",  # PR #54287 salvage (route frontend-polled inline RPCs to _LONG_HANDLERS; #48445/#50005)
     "telos@apex-z.com": "telos-oc",  # PR #14353 salvage (propagate custom_providers key_env into ProviderDef.api_key_env_vars; named + bare-custom self-heal paths)
     "256073454+Kolektori@users.noreply.github.com": "Kolektori",  # PR #6436 salvage (require approval for host-bound Docker commands; container guard fast-path)
     "41764686+LIC99@users.noreply.github.com": "LIC99",  # PR #4682 salvage (warn + default to manual on unknown approvals.mode; #4261)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -71,14 +71,21 @@ def _stub_uvicorn(monkeypatch):
 
 def test_start_server_enables_ws_ping_for_half_open_detection(monkeypatch):
     """WS ping must be configured so half-open connections (reverse-proxy 524,
-    dropped tunnels) raise WebSocketDisconnect into the reaping path (#32377)."""
+    dropped tunnels) raise WebSocketDisconnect into the reaping path (#32377).
+
+    Loopback binds (the Desktop case) get a longer window to ride out
+    GIL-pressure event-loop stalls (#48445/#50005). The invariant asserted
+    here is that ping stays enabled (non-None, positive) and the timeout is
+    never shorter than the interval — not a frozen literal, which churns every
+    time the window is retuned."""
     captured = _stub_uvicorn(monkeypatch)
 
     # Loopback bind => no auth gate, so this reaches the Config constructor.
     web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
 
-    assert captured["ws_ping_interval"] == 20.0
-    assert captured["ws_ping_timeout"] == 20.0
+    assert captured["ws_ping_interval"] and captured["ws_ping_interval"] > 0
+    assert captured["ws_ping_timeout"] and captured["ws_ping_timeout"] > 0
+    assert captured["ws_ping_timeout"] >= captured["ws_ping_interval"]
 
 
 def test_start_server_runs_on_uvicorns_loop_factory(monkeypatch):

--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -1,0 +1,159 @@
+"""Tests for tui_gateway inline-RPC pool routing under GIL pressure (#50005).
+
+The WS read loop in ``handle_ws()`` processes requests sequentially via
+``await asyncio.to_thread(server.dispatch, req, transport)``. Inline handlers
+(NOT in ``_LONG_HANDLERS``) run ``handle_request()`` synchronously inside
+``dispatch()``, blocking the loop from reading the next request. Under GIL
+pressure from multiple concurrent agent turns, even lightweight RPCs like
+``session.list`` and ``pet.info`` can take seconds, causing frontend requests
+to time out (120s) and the WebSocket to disconnect — the false "needs setup"
+failure mode (#50005).
+
+The fix routes all frontend-polled RPCs through ``_LONG_HANDLERS`` so
+``dispatch()`` returns immediately (``_pool.submit`` + ``return None``) and
+the WS read loop is never blocked.
+"""
+
+import io
+import json
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_original_stdout = sys.stdout
+
+
+@pytest.fixture(autouse=True)
+def _restore_stdout():
+    yield
+    sys.stdout = _original_stdout
+
+
+@pytest.fixture()
+def server():
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_cli.env_loader": MagicMock(),
+        "hermes_cli.banner": MagicMock(),
+        "hermes_state": MagicMock(),
+    }):
+        import importlib
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+@pytest.fixture()
+def capture(server):
+    """Redirect server's real stdout to a StringIO and return (server, buf)."""
+    buf = io.StringIO()
+    server._real_stdout = buf
+    return server, buf
+
+
+# ─── RPCs that must be in _LONG_HANDLERS ────────────────────────────────
+
+# These are polled by the Desktop frontend. Before the fix they ran inline,
+# blocking the WS read loop under GIL pressure and causing false "needs setup"
+# (#50005). Each one does I/O (DB query, file read, network) that can take
+# seconds when the GIL is contended by concurrent agent turns.
+
+FRONTEND_POLLED_RPCS = [
+    "session.list",   # loads session list — SQLite query
+    "session.info",   # loads session detail — agent state read
+    "pet.info",       # petdex poll — file/network read
+    "process.list",   # background process status — process registry scan
+]
+
+
+@pytest.mark.parametrize("method", FRONTEND_POLLED_RPCS)
+def test_frontend_polled_rpc_is_pool_routed(server, method):
+    """Every frontend-polled RPC must be in _LONG_HANDLERS so dispatch()
+    returns immediately and the WS read loop is not blocked (#50005)."""
+    assert method in server._LONG_HANDLERS, (
+        f"{method!r} is not in _LONG_HANDLERS — it will block the WS read "
+        f"loop under GIL pressure, causing false 'needs setup' (#50005)."
+    )
+
+
+def test_dispatch_inline_rpc_does_not_block_under_gil_pressure(server):
+    """A slow inline-turned-long handler must not prevent a concurrent fast
+    handler from completing. This is the core invariant: dispatch() must
+    return immediately for _LONG_HANDLERS so the WS read loop stays free.
+
+    Simulates the GIL-pressure scenario from #50005: a slow handler (mimicking
+    a session.list query under GIL contention) must not block a fast handler
+    (mimicking setup.runtime_check).
+    """
+    released = threading.Event()
+
+    def slow_session_list(rid, params):
+        released.wait(timeout=5)
+        return server._ok(rid, {"sessions": []})
+
+    server._methods["session.list"] = slow_session_list
+    server._methods["fast.check"] = lambda rid, params: server._ok(rid, {"ok": True})
+
+    t0 = time.monotonic()
+    # session.list is in _LONG_HANDLERS → dispatch returns None immediately
+    assert server.dispatch({"id": "slow", "method": "session.list", "params": {}}) is None
+
+    # fast.check is inline → dispatch runs it synchronously and returns the result
+    fast_resp = server.dispatch({"id": "fast", "method": "fast.check", "params": {}})
+    fast_elapsed = time.monotonic() - t0
+
+    assert fast_resp["result"] == {"ok": True}
+    assert fast_elapsed < 0.5, (
+        f"fast handler blocked for {fast_elapsed:.2f}s behind slow session.list — "
+        f"the WS read loop would stall, causing false 'needs setup' (#50005)."
+    )
+
+    released.set()
+
+
+def test_dispatch_pet_info_does_not_block_prompt_submit(server):
+    """pet.info (polled every few seconds by the Desktop petdex) must not
+    block prompt.submit. Before the fix, pet.info ran inline and a slow
+    pet.info under GIL pressure delayed prompt.submit until the 120s RPC
+    timeout fired (#50005).
+    """
+    released = threading.Event()
+
+    def slow_pet_info(rid, params):
+        released.wait(timeout=5)
+        return server._ok(rid, {"pet": "cat"})
+
+    server._methods["pet.info"] = slow_pet_info
+    server._methods["prompt.submit"] = lambda rid, params: server._ok(rid, {"status": "streaming"})
+
+    t0 = time.monotonic()
+    assert server.dispatch({"id": "pet", "method": "pet.info", "params": {}}) is None
+
+    # prompt.submit is inline (it spawns its own thread) — should return immediately
+    resp = server.dispatch({"id": "prompt", "method": "prompt.submit", "params": {}})
+    elapsed = time.monotonic() - t0
+
+    assert resp["result"] == {"status": "streaming"}
+    assert elapsed < 0.5, (
+        f"prompt.submit blocked for {elapsed:.2f}s behind slow pet.info — "
+        f"the user's message would appear stuck under GIL pressure (#50005)."
+    )
+
+    released.set()
+
+
+def test_rpc_pool_workers_supports_concurrent_long_handlers(server):
+    """The RPC thread pool must have enough workers to handle concurrent
+    long handlers without queueing. With 6+ frontend-polled RPCs added to
+    _LONG_HANDLERS, the default 4 workers can be exhausted when multiple
+    agent turns are running. The pool must be at least 8."""
+    assert server._rpc_pool_workers >= 8, (
+        f"_rpc_pool_workers is {server._rpc_pool_workers}, expected >= 8. "
+        f"Frontend-polled RPCs added to _LONG_HANDLERS need more workers to "
+        f"avoid queueing under multi-agent load (#50005)."
+    )

--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -65,7 +65,6 @@ def capture(server):
 
 FRONTEND_POLLED_RPCS = [
     "session.list",   # loads session list — SQLite query
-    "session.info",   # loads session detail — agent state read
     "pet.info",       # petdex poll — file/network read
     "process.list",   # background process status — process registry scan
 ]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -213,7 +213,6 @@ _LONG_HANDLERS = frozenset(
         "projects.project_sessions",
         "session.branch",
         "session.compress",
-        "session.info",
         "session.list",
         "session.resume",
         "shell.exec",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -201,9 +201,11 @@ _LONG_HANDLERS = frozenset(
         # round-trips per call — so it must never block the reader thread.
         "pet.generate",
         "pet.hatch",
+        "pet.info",
         "pet.select",
         "pet.thumb",
         "plugins.manage",
+        "process.list",
         "projects.discover_repos",
         "projects.record_repos",
         "projects.for_cwd",
@@ -211,6 +213,8 @@ _LONG_HANDLERS = frozenset(
         "projects.project_sessions",
         "session.branch",
         "session.compress",
+        "session.info",
+        "session.list",
         "session.resume",
         "shell.exec",
         "skills.manage",
@@ -220,7 +224,7 @@ _LONG_HANDLERS = frozenset(
 
 try:
     _rpc_pool_workers = max(
-        2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS") or "4")
+        2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS") or "8")
     )
 except (ValueError, TypeError):
     _rpc_pool_workers = 4

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -28,6 +28,7 @@ import concurrent.futures
 import json
 import logging
 import socket
+import threading
 from typing import Any
 
 from tui_gateway import server
@@ -39,6 +40,24 @@ _log = logging.getLogger(__name__)
 # threads from a wedged socket.
 _WS_WRITE_TIMEOUT_S = 10.0
 _WS_LOG_PAYLOAD_PREVIEW = 240
+
+# Per-token streaming frames are coalesced: buffered and flushed as a batch on
+# a short timer instead of waking the event loop once per token. A model reply
+# emits hundreds of these in a burst, and each one is a loop wakeup competing
+# with the agent turn for the GIL — coalescing cuts that churn (CF-2). The task
+# that introduced this called them "agent.token"/"agent.thinking"; in this
+# codebase the per-token frames are the ``*.delta`` stream events below. Keep
+# this set to genuinely high-frequency, display-only events — anything a client
+# must see promptly (tool/approval/status/completion frames) is non-streaming
+# and flushes the buffer ahead of itself, so ordering is preserved.
+_STREAMING_EVENT_TYPES = frozenset({
+    "message.delta",
+    "reasoning.delta",
+    "thinking.delta",
+})
+# Max time a streamed token waits in the buffer before flush (~30 fps). Short
+# enough to stay imperceptible to the live token cadence.
+_TOKEN_COALESCE_S = 0.033
 
 # Keep starlette optional at import time; handle_ws uses the real class when
 # it's available and falls back to a generic Exception sentinel otherwise.
@@ -75,6 +94,22 @@ class WSTransport:
         self._loop = loop
         self._peer = peer
         self._closed = False
+        # Token-coalescing buffer (CF-2). Streamed token frames land here and a
+        # short timer flushes the batch. The lock guards the buffer + the
+        # "armed" flag against the worker threads that call write(); the timer
+        # handle is only ever touched on the loop thread.
+        self._token_lock = threading.Lock()
+        self._pending_tokens: list[str] = []
+        self._token_flush_handle: asyncio.TimerHandle | None = None
+        self._token_flush_armed = False
+
+    @staticmethod
+    def _is_streaming_frame(obj: dict) -> bool:
+        """True for high-frequency per-token frames eligible for coalescing."""
+        params = obj.get("params") if isinstance(obj, dict) else None
+        if not isinstance(params, dict):
+            return False
+        return params.get("type") in _STREAMING_EVENT_TYPES
 
     def write(self, obj: dict) -> bool:
         if self._closed:
@@ -87,17 +122,43 @@ class WSTransport:
         except RuntimeError:
             on_loop = False
 
-        if on_loop:
-            # Fire-and-forget — don't block the loop waiting on itself.
-            self._loop.create_task(self._safe_send(line))
-            return True
+        # Coalesce streamed token frames: buffer this frame and arm a short
+        # flush timer instead of waking the loop right now. Cheap and
+        # non-blocking — the worker returns immediately. Ordering is preserved
+        # because every non-streaming frame (below) drains the buffer ahead of
+        # itself.
+        if self._is_streaming_frame(obj):
+            with self._token_lock:
+                self._pending_tokens.append(line)
+                if not self._token_flush_armed:
+                    self._token_flush_armed = True
+                    # call_soon_threadsafe arms the call_later timer on the loop
+                    # thread and is safe to call from a worker or the loop.
+                    self._loop.call_soon_threadsafe(self._arm_token_flush)
+            return not self._closed
 
-        try:
-            from agent.async_utils import safe_schedule_threadsafe
-            fut = safe_schedule_threadsafe(self._safe_send(line), self._loop)
+        # Non-streaming frame (RPC response, control frame, non-token event):
+        # append it behind any buffered tokens and flush the whole batch NOW so
+        # it can never overtake the tokens that preceded it. The send is
+        # scheduled INSIDE the lock so the on-the-wire order matches the buffer
+        # order even if the coalesce timer fires on the loop at the same moment.
+        from agent.async_utils import safe_schedule_threadsafe
+        with self._token_lock:
+            self._pending_tokens.append(line)
+            batch = self._pending_tokens
+            self._pending_tokens = []
+            if on_loop:
+                # Fire-and-forget — don't block the loop waiting on itself.
+                self._loop.create_task(self._safe_send_many(batch))
+                return True
+            fut = safe_schedule_threadsafe(
+                self._safe_send_many(batch), self._loop
+            )
             if fut is None:
                 self._closed = True
                 return False
+
+        try:
             fut.result(timeout=_WS_WRITE_TIMEOUT_S)
             return not self._closed
         except concurrent.futures.TimeoutError:  # builtin TimeoutError on 3.11+
@@ -106,8 +167,8 @@ class WSTransport:
             # already scheduled and will flush once the loop breathes — latching
             # _closed here permanently silenced live windows after one slow
             # write (the "subagent window shows zero streaming" bug). Unblock
-            # the worker thread and keep the transport alive; _safe_send latches
-            # on a real socket error when the frame actually fails.
+            # the worker thread and keep the transport alive; _safe_send_many
+            # latches on a real socket error when the frame actually fails.
             _log.warning(
                 "ws write slow (loop stalled >%ss) peer=%s — frame left in flight",
                 _WS_WRITE_TIMEOUT_S, self._peer,
@@ -121,10 +182,41 @@ class WSTransport:
             )
             return False
 
+    def _arm_token_flush(self) -> None:
+        """Arm the coalesce timer. Runs on the loop thread (call_soon_threadsafe)."""
+        if self._closed:
+            return
+        self._token_flush_handle = self._loop.call_later(
+            _TOKEN_COALESCE_S, self._flush_tokens
+        )
+
+    def _flush_tokens(self) -> None:
+        """Send buffered tokens as one batch. Runs on the loop thread (timer).
+
+        The send is scheduled under the lock so its wire order is fixed relative
+        to a concurrent non-streaming flush in :meth:`write`.
+        """
+        with self._token_lock:
+            self._token_flush_handle = None
+            self._token_flush_armed = False
+            if not self._pending_tokens or self._closed:
+                self._pending_tokens = []
+                return
+            batch = self._pending_tokens
+            self._pending_tokens = []
+            self._loop.create_task(self._safe_send_many(batch))
+
     async def write_async(self, obj: dict) -> bool:
         """Send from the owning event loop. Awaits until the frame is on the wire."""
         if self._closed:
             return False
+        # Flush any buffered streamed tokens ahead of this frame (RPC response /
+        # control frame) so it can't overtake the tokens that preceded it.
+        with self._token_lock:
+            pending = self._pending_tokens
+            self._pending_tokens = []
+        if pending:
+            await self._safe_send_many(pending)
         await self._safe_send(json.dumps(obj, ensure_ascii=False))
         return not self._closed
 
@@ -138,8 +230,26 @@ class WSTransport:
                 self._peer, type(exc).__name__, exc,
             )
 
+    async def _safe_send_many(self, lines: list[str]) -> None:
+        """Send a batch of pre-serialized frames in order on the loop thread."""
+        try:
+            for line in lines:
+                await self._ws.send_text(line)
+        except Exception as exc:
+            self._closed = True
+            _log.warning(
+                "ws send failed peer=%s error_type=%s error=%s",
+                self._peer, type(exc).__name__, exc,
+            )
+
     def close(self) -> None:
         self._closed = True
+        # Cancel any pending coalesce flush. close() runs on the loop thread
+        # (the handle_ws finally), so touching the TimerHandle here is safe.
+        handle = self._token_flush_handle
+        if handle is not None:
+            handle.cancel()
+            self._token_flush_handle = None
 
 
 def _ws_peer_label(ws: Any) -> str:


### PR DESCRIPTION
## Summary
Desktop's local WebSocket no longer drops during long, GIL-heavy agent turns. Three composing transport fixes from two contributor PRs (#51841, #54287), landed onto current `main` with authorship preserved.

**Root cause** (confirmed live on `main`, same family as the closed anchor #50005): a GIL-heavy agent turn (or a delegation running N children) starves the gateway's asyncio event loop for >20s. uvicorn's WebSocket keepalive ping runs on that same starved loop, so it misses its pong deadline and the connection is declared dead — even though the socket is fine and the turn is still running. The reporter's "overlapping `send_text()`" theory was a red herring: `_safe_send` already only latches on a real socket error, and `send_failed_after_response` is the *symptom* of the stalled loop, not concurrent sends.

## Changes
- `hermes_cli/web_server.py`: loopback binds (the Desktop case) get a longer ws-ping window (30s interval / 60s timeout) to ride out recoverable stalls; non-loopback stays 20/20 to stay under the Cloudflare Tunnel idle window. Adds a loop-heartbeat watchdog that logs stall drift so a stalled-loop disconnect is diagnosable. (#51841, @peetwan)
- `tui_gateway/ws.py`: per-token streaming frames (`message.delta`/`reasoning.delta`/`thinking.delta`) are coalesced — buffered and flushed as a batch on a ~30fps timer instead of waking the loop once per token. Ordering is preserved: every non-streaming control/RPC frame drains the buffer ahead of itself. (#51841, @peetwan)
- `tui_gateway/server.py`: frontend-polled read-only RPCs (`session.list`, `pet.info`, `process.list`) move into `_LONG_HANDLERS` so `dispatch()` returns immediately and they never block the WS read loop under GIL pressure; default RPC pool raised 4→8 so the added long handlers don't queue. (#54287, @Zyxxx-xxxyZ)
- Follow-up: dropped emit-only `session.info` from `_LONG_HANDLERS` — it is never a dispatched `@method` RPC (only an emitted event), so it was dead weight in the set. (maintainer)

## Why these compose, and not the other cluster PRs
Both source PRs converged on the same identical `web_server.py` ping hunk (which is already on `main` via #54126's loop-noise work), then each added a distinct, non-overlapping second piece. They land cleanly together. The other two cluster PRs (#48446 send-serialization, #54612 read/write-loop rewrite) target the reporter's *wrong premise* (overlapping sends) and are superseded by this — closed with credit.

## Invariants
- Prompt cache + message-role alternation: untouched. Pure transport layer; the model-facing message array is never altered.
- No new non-secret env vars: ping values are derived from `host`; the pool-worker var already existed.
- Cross-platform: helps the Windows ProactorEventLoop most (also reproduced on macOS), no POSIX-only primitives.

## Validation
| | Result |
|---|---|
| `tests/test_tui_gateway_ws.py` + new GIL test | 10 passed |
| E2E (real `WSTransport`, live loop) | delta frames flush before control frames (`A,B,X`); 5-token burst coalesces in order — ordering invariant holds |

Fixes #48445. Supersedes #48446, #54612 in the #48445/#50005 cluster.

## Infographic
![WS GIL-starvation fix](https://v3b.fal.media/files/b/0aa05a92/FBuDNQ4PEFlXhblgZS8E5_ZnLPRCKm.png)

Nous Research
