### PR TITLE
fix(cli): merge two timer fixes into one PR

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3728,7 +3728,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._resumed = False
         # Per-prompt elapsed timer — started at the beginning of each chat turn,
         # frozen when the agent thread completes, displayed in the status bar.
-        self._prompt_start_time: Optional[float] = None  # time.time() when turn started
+        self._prompt_start_time: Optional[float] = None  # time.monotonic() when turn started
         self._prompt_duration: float = 0.0  # frozen duration of last completed turn
         self._last_turn_finished_at: Optional[float] = None  # time.time() when the last agent loop finished
         # Initialize SQLite session store early so /title works before first message
@@ -4270,7 +4270,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """
         if prompt_start_time is None and prompt_duration == 0.0:
             return "⏲ 0s"
-        elapsed = time.time() - prompt_start_time if prompt_start_time is not None else prompt_duration
+        elapsed = time.monotonic() - prompt_start_time if prompt_start_time is not None else prompt_duration
         elapsed = max(0.0, elapsed)
 
         days = int(elapsed // 86400)
@@ -4536,6 +4536,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         t0 = getattr(self, "_tool_start_time", 0) or 0
         if t0 > 0:
             elapsed = time.monotonic() - t0
+            # Guard against a torn read across the unlocked UI fields: _spinner_text
+            # and _tool_start_time are best-effort UI state updated by different
+            # events without a lock, so a render can briefly observe a fresh label
+            # paired with a stale start timestamp from a prior turn. A negative
+            # value (reset/clock-edge race) or an implausibly large one (>24h for a
+            # single tool) means the pairing is untrustworthy this frame; show the
+            # label without a timer rather than flashing an absurd number.
+            if elapsed < 0 or elapsed > 86400:
+                return f"  {txt}"
             if elapsed >= 60:
                 _m, _s = int(elapsed // 60), int(elapsed % 60)
                 # Fixed-width timer to avoid status-line wrap jitter while
@@ -11899,7 +11908,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # exits the main thread and daemon threads are reaped automatically).
             # Start per-prompt elapsed timer — frozen after the agent thread
             # finishes; reset on the next turn.
-            self._prompt_start_time = time.time()
+            self._prompt_start_time = time.monotonic()
             self._prompt_duration = 0.0
             agent_thread = threading.Thread(target=run_agent, daemon=True)
             agent_thread.start()
@@ -11980,7 +11989,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Freeze per-prompt elapsed timer once the agent thread has
             # exited (or been abandoned as a daemon after interrupt).
             if self._prompt_start_time is not None:
-                self._prompt_duration = max(0.0, time.time() - self._prompt_start_time)
+                self._prompt_duration = max(0.0, time.monotonic() - self._prompt_start_time)
                 self._prompt_start_time = None
             # Record when this agent loop finished so the status bar can show
             # idle time since the last final response.
@@ -14596,7 +14605,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 if not self._app:
                     time.sleep(0.1)
                     continue
-                if self._command_running:
+                # Repaint on a fixed cadence whenever a live timer is on screen:
+                # slow slash commands (_command_running) OR an agent turn with a
+                # running tool (_agent_running + non-empty _spinner_text). The old
+                # condition only checked _command_running, so during agent tool
+                # calls the elapsed timer was never repainted on a clock — it only
+                # advanced when an agent event happened to fire _invalidate(),
+                # which is why the seconds appeared to "jump" by whole tool
+                # durations instead of ticking smoothly.
+                if self._command_running or (self._agent_running and self._spinner_text):
                     self._invalidate(min_interval=0.1)
                     time.sleep(0.1)
                 else:

--- a/tests/cli/test_cli_prompt_timer_clock.py
+++ b/tests/cli/test_cli_prompt_timer_clock.py
@@ -1,0 +1,48 @@
+"""Regression tests for the per-prompt status-bar timer formatter.
+
+The per-prompt elapsed timer is now driven by time.monotonic() instead of
+time.time(), so it no longer jumps when the wall clock is adjusted (NTP step,
+manual change) or across a suspend/resume. _format_prompt_elapsed therefore
+interprets a live prompt_start_time as a monotonic timestamp.
+"""
+
+import time
+
+from cli import HermesCLI
+
+fmt = HermesCLI._format_prompt_elapsed
+
+
+class TestFormatPromptElapsed:
+    def test_fresh_start_shows_zero(self):
+        assert fmt(None, 0.0) == "⏲ 0s"
+
+    def test_frozen_duration_seconds(self):
+        assert "5s" in fmt(None, 5.0)
+
+    def test_frozen_duration_minutes(self):
+        out = fmt(None, 65.0)
+        assert "1m" in out and "5s" in out
+
+    def test_frozen_duration_hours(self):
+        out = fmt(None, 3661.0)  # 1h 0m 1s
+        assert "1h" in out
+
+    def test_live_start_is_interpreted_as_monotonic(self):
+        # A live prompt with a start time 2s in the monotonic past must render
+        # ~2s elapsed. If the formatter still subtracted from time.time(), a
+        # monotonic start (a much smaller number than epoch seconds) would
+        # produce a huge bogus value.
+        start = time.monotonic() - 2.0
+        out = fmt(start, 0.0, live=True)
+        assert "2s" in out
+        # sanity: not an absurd wall-clock-vs-monotonic mismatch value
+        assert "h" not in out and "d" not in out
+
+    def test_negative_is_clamped_to_zero(self):
+        # Start slightly in the future (clock-edge race) clamps to 0s, never
+        # renders a negative timer.
+        start = time.monotonic() + 5.0
+        out = fmt(start, 0.0, live=True)
+        assert "0s" in out
+        assert "-" not in out

--- a/tests/cli/test_cli_spinner_timer.py
+++ b/tests/cli/test_cli_spinner_timer.py
@@ -1,0 +1,104 @@
+"""Regression tests for the inline tool spinner timer in the classic CLI.
+
+Covers two fixes:
+
+* ``_render_spinner_text`` torn-read guard — the live elapsed timer must never
+  render a negative or absurdly large number when a render observes a fresh
+  ``_spinner_text`` paired with a stale ``_tool_start_time`` (the two fields are
+  best-effort UI state updated by different events without a lock).
+
+* The ``spinner_loop`` repaint gate — the loop must repaint on a fixed cadence
+  while an agent turn is running a tool (``_agent_running`` + non-empty
+  ``_spinner_text``), not only while a slash command runs (``_command_running``).
+  Previously the agent-tool case was missed, so the timer only advanced when an
+  unrelated agent event happened to fire ``_invalidate()``, making the seconds
+  appear to jump by whole tool durations.
+"""
+
+import time
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj._spinner_text = ""
+    cli_obj._tool_start_time = 0.0
+    return cli_obj
+
+
+class TestRenderSpinnerText:
+    def test_empty_spinner_returns_empty(self):
+        cli_obj = _make_cli()
+        assert cli_obj._render_spinner_text() == ""
+
+    def test_label_without_start_time_has_no_timer(self):
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "🔧 terminal"
+        cli_obj._tool_start_time = 0.0
+        out = cli_obj._render_spinner_text()
+        assert "terminal" in out
+        assert "(" not in out  # no timer parens
+
+    def test_normal_elapsed_renders_seconds(self):
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "🔧 terminal"
+        cli_obj._tool_start_time = time.monotonic() - 3.2
+        out = cli_obj._render_spinner_text()
+        assert "terminal" in out
+        assert "s)" in out
+        assert "3." in out
+
+    def test_rollover_past_60s_uses_fixed_width(self):
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "🔧 terminal"
+        cli_obj._tool_start_time = time.monotonic() - 125
+        out = cli_obj._render_spinner_text()
+        assert "02m05s" in out
+
+    def test_stale_start_time_does_not_flash_absurd_number(self):
+        """Torn read: fresh label, very old start timestamp from a prior turn."""
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "🔧 read_file"
+        cli_obj._tool_start_time = time.monotonic() - 999999  # ~11.5 days
+        out = cli_obj._render_spinner_text()
+        assert "read_file" in out
+        assert "(" not in out  # timer suppressed, no giant number
+
+    def test_negative_elapsed_does_not_render_negative_timer(self):
+        """Clock-edge / reset race producing a start time slightly in the future."""
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "🔧 patch"
+        cli_obj._tool_start_time = time.monotonic() + 50
+        out = cli_obj._render_spinner_text()
+        assert "patch" in out
+        assert "-" not in out
+
+
+def _repaint_gate(command_running: bool, agent_running: bool, spinner_text: str) -> bool:
+    """Mirror of the repaint condition in cli.py ``spinner_loop``.
+
+    Kept in sync with::
+
+        if self._command_running or (self._agent_running and self._spinner_text):
+
+    so the truth table is locked by a test even though the live condition lives
+    inside a thread closure that cannot be invoked directly.
+    """
+    return command_running or (agent_running and bool(spinner_text))
+
+
+class TestSpinnerLoopRepaintGate:
+    def test_idle_prompt_does_not_repaint(self):
+        assert _repaint_gate(False, False, "") is False
+
+    def test_slow_slash_command_repaints(self):
+        assert _repaint_gate(True, False, "") is True
+
+    def test_agent_running_tool_repaints(self):
+        # The regression: agent turn with a live tool must repaint the timer.
+        assert _repaint_gate(False, True, "🔧 terminal") is True
+
+    def test_agent_thinking_without_tool_does_not_repaint(self):
+        # No tool label => no live timer => keep idle prompt stable.
+        assert _repaint_gate(False, True, "") is False


### PR DESCRIPTION
## Summary

Merges two previously separate timer fixes into a single changeset (supersedes #46178 and #46179):

### 1. Monotonic clock for prompt timer
Switches `_prompt_start_time` from `time.time()` to `time.monotonic()` so NTP steps, suspend/resume, or wall-clock changes don't cause the status-bar timer to jump or go backward.

### 2. Spinner timer torn-read guard + repaint gate
- Guards `_render_spinner_text()` against a stale `_tool_start_time` / `_spinner_text` pairing that would render a negative or implausibly large elapsed number.
- Updates the `spinner_loop` repaint condition so agent tool calls (not just slash commands) trigger a fixed-cadence repaint, making the seconds tick smoothly.

## Files

| File | Change |
|------|--------|
| `cli.py` | +22 / -5 |
| `tests/cli/test_cli_spinner_timer.py` | +104 (new) |
| `tests/cli/test_cli_prompt_timer_clock.py` | +48 (new) |

## Testing

```
tests/cli/test_cli_spinner_timer.py ........ 10 passed
tests/cli/test_cli_prompt_timer_clock.py ... 6 passed
```

Closes #46178, #46179