### PR TITLE
fix(gateway): disable WS keepalive pings for localhost, configurable write timeout

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13928,6 +13928,21 @@ def _maybe_open_browser(
     threading.Thread(target=_open, daemon=True).start()
 
 
+def _ws_ping_val(env_val, host, *, default=30):
+    """Resolve WebSocket ping interval/timeout.
+
+    Returns None (disabled) for localhost when no env override is set,
+    the env value when explicitly provided (0 means disabled), or
+    ``default`` for remote hosts.
+    """
+    if env_val is not None:
+        v = float(env_val)
+        return None if v <= 0 else v
+    if host in ("127.0.0.1", "localhost", "::1"):
+        return None
+    return float(default)
+
+
 def start_server(
     host: str = "127.0.0.1",
     port: int = 9119,
@@ -14054,11 +14069,11 @@ def start_server(
         # mode.
         proxy_headers=bool(app.state.auth_required),
         # Detect half-open WS connections (reverse-proxy 524, dropped
-        # tunnels) within ~20-40s so WebSocketDisconnect fires the
-        # disconnect→reap path.  20s stays under Cloudflare Tunnel's idle
-        # timeout, keeping it warm.
-        ws_ping_interval=20.0,
-        ws_ping_timeout=20.0,
+        # tunnels).  Disabled for localhost (no silent drops on loopback);
+        # enabled with generous defaults for remote.  Set env to 0 to disable,
+        # or any positive value to override.
+        ws_ping_interval=_ws_ping_val(os.environ.get("HERMES_WS_PING_INTERVAL"), host),
+        ws_ping_timeout=_ws_ping_val(os.environ.get("HERMES_WS_PING_TIMEOUT"), host, default=60),
     )
     server = uvicorn.Server(config)
 

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -27,6 +27,7 @@ import asyncio
 import concurrent.futures
 import json
 import logging
+import os
 import socket
 from typing import Any
 
@@ -37,7 +38,10 @@ _log = logging.getLogger(__name__)
 # Max seconds a pool-dispatched handler will block waiting for the event loop
 # to flush a WS frame before we mark the transport dead. Protects handler
 # threads from a wedged socket.
-_WS_WRITE_TIMEOUT_S = 10.0
+try:
+    _WS_WRITE_TIMEOUT_S = float(os.environ.get("HERMES_WS_WRITE_TIMEOUT", "3"))
+except (ValueError, TypeError):
+    _WS_WRITE_TIMEOUT_S = 3.0
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
 # Keep starlette optional at import time; handle_ws uses the real class when


### PR DESCRIPTION
## What does this PR do?

Desktop WebSocket connections drop during heavy tool work (long `shell.exec`, builds, patches). The root cause is uvicorn's `ws_ping_interval=20` / `ws_ping_timeout=20` — when the event loop is stalled by GIL contention from agent tool threads, pong frames can't be processed within the 40s window and uvicorn closes the socket.

This is especially aggressive on Windows where `ProactorEventLoop` has higher scheduling latency than Unix `SelectorEventLoop`, but the same starvation pattern reproduces on macOS (#48445 commenters rod-nxtlevel, claudeschneider).

## Related Issue

Fixes #48445
Related: #50005, #51860, #12607, #53773, #55433

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

### `hermes_cli/web_server.py`
- Added `_ws_ping_val()` helper that **disables** WS pings for localhost (`127.0.0.1`, `localhost`, `::1`) — loopback connections don't silently die, so keepalive pings only create a failure mode
- Remote hosts default to **30s interval / 60s timeout** (up from 20/20)
- Env-configurable via `HERMES_WS_PING_INTERVAL` / `HERMES_WS_PING_TIMEOUT` (set to `0` to disable)

### `tui_gateway/ws.py`
- Made `_WS_WRITE_TIMEOUT_S` env-configurable via `HERMES_WS_WRITE_TIMEOUT`
- Default lowered from **10s → 3s** — threads unblock faster when the event loop is under GIL contention; the frame stays in-flight and still gets delivered once the loop breathes
- Tuned progressively (10 → 7 → 3); below 3 risks false "loop stalled" warnings

### What was tried and reverted

Adding `prompt.submit` to `_LONG_HANDLERS` caused pool saturation — the 4-thread RPC pool fills with `shell.exec`/`cli.exec`/`slash.exec` during heavy agent turns, and `prompt.submit` queues behind them. `prompt.submit` already spawns a daemon thread internally and doesn't need pool routing.

## How to Test

1. Start Desktop on localhost
2. Run a heavy multi-tool agent session (builds, long shell commands, patches)
3. Verify WS stays connected throughout (no "Gateway disconnected" in activity log)
4. Verify streaming responsiveness during tool work

Env vars for tuning without code changes:

| Variable | Default (localhost) | Default (remote) |
|---|---|---|
| `HERMES_WS_PING_INTERVAL` | disabled | 30s |
| `HERMES_WS_PING_TIMEOUT` | disabled | 60s |
| `HERMES_WS_WRITE_TIMEOUT` | 3s | 3s |

## Platform Tested

- Windows 10 IoT Enterprise LTSC 2021 (native Desktop install, Hermes v0.17.0)
- Sustained multi-tool agent sessions over several hours