### PR TITLE
fix(diagnostics): show masked API key and correct URL in request dumps for anthropic_messages mode

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1240,6 +1240,22 @@ def dump_api_request_debug(
             api_key = getattr(agent.client, "api_key", None)
         except Exception as e:
             _ra().logger.debug("Could not extract API key for debug dump: %s", e)
+        # Anthropic-mode providers store the client in
+        # ``agent._anthropic_client`` and set ``agent.client = None``.
+        # Fall back to ``agent.api_key`` (set by init_agent for all modes)
+        # so the dump shows a masked key instead of ``Bearer None``.
+        if not api_key:
+            api_key = getattr(agent, "api_key", None)
+
+        # Build the dump URL to match the actual outbound endpoint.
+        # Anthropic SDK posts to ``/v1/messages`` (base_url already has /v1
+        # stripped by the normalizer); Codex uses ``/responses``.
+        if agent.api_mode == "anthropic_messages":
+            _dump_url = f"{agent.base_url.rstrip('/')}/v1/messages"
+        elif agent.api_mode == "codex_responses":
+            _dump_url = f"{agent.base_url.rstrip('/')}/responses"
+        else:
+            _dump_url = f"{agent.base_url.rstrip('/')}/chat/completions"
 
         dump_payload: Dict[str, Any] = {
             "timestamp": datetime.now().isoformat(),
@@ -1247,7 +1263,7 @@ def dump_api_request_debug(
             "reason": reason,
             "request": {
                 "method": "POST",
-                "url": f"{agent.base_url.rstrip('/')}{'/responses' if agent.api_mode == 'codex_responses' else '/chat/completions'}",
+                "url": _dump_url,
                 "headers": {
                     "Authorization": f"Bearer {agent._mask_api_key_for_logs(api_key)}",
                     "Content-Type": "application/json",

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1965,6 +1965,77 @@ def test_dump_api_request_debug_redacts_request_and_error_secrets(monkeypatch, t
     assert "***" in dumped_text or "..." in dumped_text
 
 
+def test_dump_api_request_debug_anthropic_mode_shows_masked_key(monkeypatch, tmp_path):
+    """Debug dumps for anthropic_messages mode should show a masked key, not 'None'.
+
+    For Anthropic-mode providers (MiniMax, Kimi, etc.) ``agent.client`` is
+    ``None`` — the real client lives in ``agent._anthropic_client``.  The dump
+    must fall back to ``agent.api_key`` so the Authorization header shows a
+    masked key instead of ``Bearer None``.
+    """
+    import json
+
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="MiniMax-M3",
+        provider="minimax-cn",
+        api_mode="anthropic_messages",
+        base_url="https://api.minimaxi.com/anthropic",
+        api_key="sk-cp-abcdef0123456789",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.logs_dir = tmp_path
+    # Anthropic mode sets agent.client = None
+    assert agent.client is None
+
+    dump_file = agent._dump_api_request_debug(
+        {"model": "MiniMax-M3", "messages": [{"role": "user", "content": "hi"}]},
+        reason="preflight",
+    )
+
+    assert dump_file is not None
+    payload = json.loads(dump_file.read_text())
+    auth_header = payload["request"]["headers"]["Authorization"]
+    # Must NOT be "Bearer None"
+    assert auth_header != "Bearer None", f"Expected masked key, got: {auth_header}"
+    # Must show a masked representation of the key
+    assert auth_header.startswith("Bearer sk-cp-ab...")
+    assert "None" not in auth_header
+
+
+def test_dump_api_request_debug_anthropic_mode_shows_messages_url(monkeypatch, tmp_path):
+    """Debug dumps for anthropic_messages mode should show /v1/messages URL.
+
+    The Anthropic SDK posts to ``/v1/messages``, not ``/chat/completions``.
+    """
+    import json
+
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="MiniMax-M3",
+        provider="minimax-cn",
+        api_mode="anthropic_messages",
+        base_url="https://api.minimaxi.com/anthropic",
+        api_key="sk-cp-abcdef0123456789",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.logs_dir = tmp_path
+
+    dump_file = agent._dump_api_request_debug(
+        {"model": "MiniMax-M3", "messages": [{"role": "user", "content": "hi"}]},
+        reason="preflight",
+    )
+
+    payload = json.loads(dump_file.read_text())
+    assert payload["request"]["url"] == "https://api.minimaxi.com/anthropic/v1/messages"
+
+
 # --- Reasoning-only response tests (fix for empty content retry loop) ---
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the request debug dump (`request_dump_*.json`) for Anthropic-mode providers (MiniMax, Kimi, etc.) where `agent.client` is `None`. The dump previously read `api_key` from `agent.client` (which is `None` for anthropic_messages mode), producing `"Bearer None"` in the Authorization header of the dump — even though the actual HTTP request used the correct key via `agent._anthropic_client`. The dump also showed the wrong URL (`/chat/completions` instead of `/v1/messages`).

## Related Issue

Fixes #55539

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_runtime_helpers.py`: In `dump_api_request_debug()`, fall back to `agent.api_key` when `agent.client` is `None` (Anthropic mode). Also build the dump URL based on `api_mode`: `/v1/messages` for anthropic_messages, `/responses` for codex_responses, `/chat/completions` otherwise.
- `tests/run_agent/test_run_agent_codex_responses.py`: Add two tests verifying the dump shows a masked key (not "None") and the correct `/v1/messages` URL for anthropic_messages mode.

## How to Test

1. Run: `python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_anthropic_mode_shows_masked_key tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_anthropic_mode_shows_messages_url -xvs`
2. Both tests should pass — the dump shows a masked key (e.g. `Bearer sk-cp-ab...6789`) and the URL `https://api.minimaxi.com/anthropic/v1/messages`.
3. Run existing dump tests to verify no regression: `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -k "dump_api_request" -xvs` — all 5 should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (dump logic is platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
