### PR TITLE
fix(tools): pass language parameter to Groq STT API

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1289,20 +1289,35 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
         logger.info("Model %s not available on Groq, using %s", model_name, DEFAULT_GROQ_STT_MODEL)
         model_name = DEFAULT_GROQ_STT_MODEL
 
+    # Language: stt.groq.language > stt.local.language > env var > auto-detect.
+    _stt_cfg = _load_stt_config()
+    _forced_lang = (
+        _stt_cfg.get("groq", {}).get("language")
+        or _stt_cfg.get("local", {}).get("language")
+        or os.getenv(LOCAL_STT_LANGUAGE_ENV)
+        or None
+    )
+
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
         client = OpenAI(api_key=api_key, base_url=GROQ_BASE_URL, timeout=30, max_retries=0)
         try:
             with open(file_path, "rb") as audio_file:
+                transcribe_kwargs: Dict[str, Any] = {
+                    "model": model_name,
+                    "file": audio_file,
+                    "response_format": "text",
+                }
+                if _forced_lang:
+                    transcribe_kwargs["language"] = _forced_lang
+
                 transcription = client.audio.transcriptions.create(
-                    model=model_name,
-                    file=audio_file,
-                    response_format="text",
+                    **transcribe_kwargs,
                 )
 
             transcript_text = str(transcription).strip()
-            logger.info("Transcribed %s via Groq API (%s, %d chars)",
-                         Path(file_path).name, model_name, len(transcript_text))
+            logger.info("Transcribed %s via Groq API (%s, lang=%s, %d chars)",
+                         Path(file_path).name, model_name, _forced_lang or "auto", len(transcript_text))
 
             return {"success": True, "transcript": transcript_text, "provider": "groq"}
         finally:


### PR DESCRIPTION
## What does this PR do?

Passes the `language` parameter to the Groq Whisper API in `_transcribe_groq()`. Without this, the API defaults to auto-detection, which produces garbled transcriptions for non-English audio (e.g., Hebrew detected as English).

## Related Issue

Fixes #55551

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/transcription_tools.py`: Read language from `stt.groq.language` → `stt.local.language` → `HERMES_LOCAL_STT_LANGUAGE` env var, and pass it to `client.audio.transcriptions.create()`. Also include language in the log message for debugging.

## How to Test

1. Set config: `stt: enabled: true, provider: groq, local: language: he`
2. Set `GROQ_API_KEY` in `.env`
3. Send a Hebrew voice message via Telegram gateway
4. Observed result: transcription should produce Hebrew text, not garbled English
5. Gateway log should show `lang=he` instead of `lang=auto`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (107 passed in tests/tools/test_transcription_tools.py, 111 passed in related transcription tests)
- [x] I've added tests for my changes — N/A (existing tests cover the API call path; this is a config-read addition)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (stt.local.language already documented)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (config read is platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before** (no language parameter):
```
INFO tools.transcription_tools: Transcribed via Groq API (whisper-large-v3-turbo, 47 chars)
```

**After** (with language parameter):
```
INFO tools.transcription_tools: Transcribed via Groq API (whisper-large-v3-turbo, lang=he, 47 chars)
```
