### PR TITLE
fix(lsp): strip credentials from installer env

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -35,6 +35,8 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from tools.environments.local import hermes_subprocess_env
+
 logger = logging.getLogger("agent.lsp.install")
 
 # Package-name → install-strategy hint registry.  Each entry is a
@@ -267,6 +269,7 @@ def _install_npm(
             capture_output=True,
             text=True,
             timeout=300,
+            env=hermes_subprocess_env(inherit_credentials=False),
             stdin=subprocess.DEVNULL,
         )
         if proc.returncode != 0:
@@ -305,7 +308,7 @@ def _install_go(pkg: str, bin_name: str) -> Optional[str]:
         logger.info("[install] cannot install %s: go not on PATH", pkg)
         return None
     staging = hermes_lsp_bin_dir()
-    env = dict(os.environ)
+    env = hermes_subprocess_env(inherit_credentials=False)
     env["GOBIN"] = str(staging)
     try:
         logger.info("[install] go install %s (GOBIN=%s)", pkg, staging)
@@ -348,15 +351,18 @@ def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
     pip_target.mkdir(parents=True, exist_ok=True)
     try:
         logger.info("[install] pip install --target %s %s", pip_target, pkg)
-        from hermes_cli.tools_config import _pip_install
-
-        proc = _pip_install(
-            ["--target", str(pip_target), "--quiet", pkg],
+        proc = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--target", str(pip_target), "--quiet", pkg],
+            check=False,
+            capture_output=True,
+            text=True,
             timeout=300,
+            env=hermes_subprocess_env(inherit_credentials=False),
+            stdin=subprocess.DEVNULL,
         )
         if proc.returncode != 0:
             logger.warning(
-                "[install] pip install failed for %s: %s", pkg, (proc.stderr or "").strip()[:500]
+                "[install] pip install failed for %s: %s", pkg, proc.stderr.strip()[:500]
             )
             return None
     except (subprocess.TimeoutExpired, OSError) as e:

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -94,6 +94,73 @@ def test_install_npm_works_without_extras(tmp_path, monkeypatch):
     assert install_targets == ["pyright"]
 
 
+def test_install_npm_strips_parent_credentials(tmp_path, monkeypatch):
+    """NPM install scripts must not inherit Hermes/API credentials."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-parent-openai")
+    monkeypatch.setenv("GH_TOKEN", "gh-parent-token")
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs["env"]
+        return MagicMock(returncode=0, stderr="")
+
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda c: "/usr/bin/npm" if c == "npm" else None)
+
+    install_mod._install_npm("pyright", "pyright-langserver")
+
+    assert "OPENAI_API_KEY" not in captured["env"]
+    assert "GH_TOKEN" not in captured["env"]
+
+
+def test_install_go_strips_parent_credentials_and_keeps_gobin(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-parent-anthropic")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-parent-token")
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs["env"]
+        return MagicMock(returncode=0, stderr="")
+
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda c: "/usr/bin/go" if c == "go" else None)
+
+    install_mod._install_go("golang.org/x/tools/gopls@latest", "gopls")
+
+    assert "ANTHROPIC_API_KEY" not in captured["env"]
+    assert "TELEGRAM_BOT_TOKEN" not in captured["env"]
+    assert captured["env"]["GOBIN"] == str(install_mod.hermes_lsp_bin_dir())
+
+
+def test_install_pip_strips_parent_credentials(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-parent-openrouter")
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "dashboard-token")
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs["env"]
+        return MagicMock(returncode=0, stderr="")
+
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+
+    install_mod._install_pip("fake-lsp", "fake-language-server")
+
+    assert "OPENROUTER_API_KEY" not in captured["env"]
+    assert "HERMES_DASHBOARD_SESSION_TOKEN" not in captured["env"]
+
+
 def test_existing_binary_finds_windows_wrapper_in_staging(tmp_path, monkeypatch):
     """Installed Windows shims should satisfy later status/probe calls."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes credentials from being inherited by LSP auto-install subprocesses.

`agent/lsp/install.py` can auto-install language servers with `npm install`, `go install`, or `pip install`. All three subprocess paths now use `hermes_subprocess_env(inherit_credentials=False)` instead of inheriting `os.environ`, so secrets like `OPENAI_API_KEY`, `GH_TOKEN`, and `HERMES_DASHBOARD_SESSION_TOKEN` are not passed to installer subprocesses.

### Changes

- `agent/lsp/install.py`:
  - `_install_npm()`: pass `env=hermes_subprocess_env(inherit_credentials=False)` to subprocess
  - `_install_go()`: use `hermes_subprocess_env(inherit_credentials=False)` instead of `dict(os.environ)`
  - `_install_pip()`: bypass `hermes_cli.tools_config._pip_install()` (which uses credential-bearing `os.environ`), call `subprocess.run` directly with sanitized env
- `tests/agent/lsp/test_install_and_lint_fixes.py`: add credential-strip tests for npm, go, and pip paths

## How to Test

`pytest tests/agent/lsp/test_install_and_lint_fixes.py -v`
