### PR TITLE
fix(gateway): stop media-send fallbacks from leaking host paths into chat

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3148,12 +3148,20 @@ class BasePlatformAdapter(ABC):
     ) -> SendResult:
         """
         Send an audio file as a native voice message via the platform API.
-        
+
         Override in subclasses to send audio as voice bubbles (Telegram)
-        or file attachments (Discord). Default falls back to sending the
-        file path as text.
+        or file attachments (Discord). Default falls back to a friendly
+        notice — never echo the local audio_path into chat, since it is a
+        host filesystem path that would leak the Hermes home layout.
         """
-        text = f"🔊 Audio: {audio_path}"
+        # audio_path is intentionally NOT included in the chat text — it is a
+        # host-local path that leaks filesystem layout. The path is logged for
+        # operator diagnostics instead.
+        logger.warning(
+            "[%s] send_voice fallback: native audio send unavailable for %s",
+            self.name, audio_path,
+        )
+        text = "⚠️ Couldn't deliver the audio attachment."
         if caption:
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
@@ -3192,9 +3200,16 @@ class BasePlatformAdapter(ABC):
         Send a video natively via the platform API.
 
         Override in subclasses to send videos as inline playable media.
-        Default falls back to sending the file path as text.
+        Default falls back to a friendly notice — never echo the local
+        video_path into chat, since it is a host filesystem path that
+        would leak the Hermes home layout.
         """
-        text = f"🎬 Video: {video_path}"
+        # See send_voice for the rationale: do not echo host paths into chat.
+        logger.warning(
+            "[%s] send_video fallback: native video send unavailable for %s",
+            self.name, video_path,
+        )
+        text = "⚠️ Couldn't deliver the video attachment."
         if caption:
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
@@ -3213,9 +3228,22 @@ class BasePlatformAdapter(ABC):
         Send a document/file natively via the platform API.
 
         Override in subclasses to send files as downloadable attachments.
-        Default falls back to sending the file path as text.
+        Default falls back to a friendly notice — never echo the local
+        file_path into chat, since it is a host filesystem path that
+        would leak the Hermes home layout.
         """
-        text = f"📎 File: {file_path}"
+        # See send_voice for the rationale: do not echo host paths into chat.
+        logger.warning(
+            "[%s] send_document fallback: native file send unavailable for %s",
+            self.name, file_path,
+        )
+        # file_name is supplied by callers and represents the user-facing
+        # filename (already non-sensitive — it is what the agent named the
+        # output). Only show it when the caller passed one explicitly.
+        if file_name:
+            text = f"⚠️ Couldn't deliver the file attachment ({file_name})."
+        else:
+            text = "⚠️ Couldn't deliver the file attachment."
         if caption:
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
@@ -3233,10 +3261,17 @@ class BasePlatformAdapter(ABC):
         Send a local image file natively via the platform API.
 
         Unlike send_image() which takes a URL, this takes a local file path.
-        Override in subclasses for native photo attachments.
-        Default falls back to sending the file path as text.
+        Override in subclasses for native photo attachments. Default falls
+        back to a friendly notice — never echo the local image_path into
+        chat, since it is a host filesystem path that would leak the
+        Hermes home layout.
         """
-        text = f"🖼️ Image: {image_path}"
+        # See send_voice for the rationale: do not echo host paths into chat.
+        logger.warning(
+            "[%s] send_image_file fallback: native image send unavailable for %s",
+            self.name, image_path,
+        )
+        text = "⚠️ Couldn't deliver the image attachment."
         if caption:
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2149,9 +2149,14 @@ class MatrixAdapter(BasePlatformAdapter):
         """Read a local file and upload it."""
         p = Path(file_path).expanduser()
         if not p.exists():
-            return await self.send(
-                room_id, f"{caption or ''}\n(file not found: {file_path})", reply_to
+            # file_path is a host-local path; never echo it into chat.
+            logger.warning(
+                "[%s] upload fallback: media file not found for %s",
+                self.name, file_path,
             )
+            text = f"{caption}\n⚠️ Couldn't deliver the attachment." if caption \
+                else "⚠️ Couldn't deliver the attachment."
+            return await self.send(room_id, text, reply_to)
         try:
             file_size = p.stat().st_size
         except OSError:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2012,7 +2012,8 @@ class SlackAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            text = f"🖼️ Image: {image_path}"
+            # image_path is a host-local path; never echo it into chat.
+            text = "⚠️ Couldn't deliver the image attachment."
             if caption:
                 text = f"{caption}\n{text}"
             return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
@@ -2164,7 +2165,8 @@ class SlackAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            text = f"🎬 Video: {video_path}"
+            # video_path is a host-local path; never echo it into chat.
+            text = "⚠️ Couldn't deliver the video attachment."
             if caption:
                 text = f"{caption}\n{text}"
             return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
@@ -2223,7 +2225,11 @@ class SlackAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            text = f"📎 File: {file_path}"
+            # file_path is a host-local path; never echo it into chat.
+            # display_name comes from caller-supplied file_name (or basename
+            # of the host path) and is the user-facing filename only — safe
+            # to surface so the user knows which file failed.
+            text = f"⚠️ Couldn't deliver the file attachment ({display_name})."
             if caption:
                 text = f"{caption}\n{text}"
             return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1702,3 +1702,126 @@ class TestMediaDeliveryDiagnosability:
         assert any(r.endswith("cache/documents") for r in roots)
         # Legacy layout still present.
         assert any(r.endswith("image_cache") for r in roots)
+
+
+# ---------------------------------------------------------------------------
+# Media-send fallback must not leak host filesystem paths into chat
+# ---------------------------------------------------------------------------
+
+
+class _CapturingAdapter(BasePlatformAdapter):
+    """Minimal concrete BasePlatformAdapter that records what send() sees.
+
+    The four media-send fallbacks (send_voice, send_video, send_document,
+    send_image_file) historically forwarded their *_path argument into the
+    chat text. That argument is a host filesystem path inside the Hermes
+    cache, so any subclass that fell back to super() — like the Telegram
+    adapter on a rejected video — would leak the host's directory layout
+    into the user's chat.
+    """
+
+    def __init__(self):
+        from gateway.config import Platform, PlatformConfig
+        super().__init__(PlatformConfig(enabled=True), Platform.TELEGRAM)
+        self.sent: list[dict] = []
+
+    async def connect(self) -> bool:  # pragma: no cover - not exercised
+        return True
+
+    async def disconnect(self) -> None:  # pragma: no cover - not exercised
+        return None
+
+    async def get_chat_info(self, chat_id):  # pragma: no cover - not exercised
+        return {"name": chat_id, "type": "dm"}
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        from gateway.platforms.base import SendResult
+        self.sent.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return SendResult(success=True, message_id="m1")
+
+
+class TestMediaFallbackDoesNotLeakHostPath:
+    """Regression: the four base-class media fallbacks must not echo *_path.
+
+    Telegram, Discord, and Slack adapters all fall back to these base
+    implementations on native-send failure. When they did, the user saw
+    a chat message like ``🎬 Video: /home/.../hermes/cache/video/abc.mp4``
+    — a host filesystem path with no actionable information.
+    """
+
+    SENSITIVE_PATH = "/home/jayne/.hermes/cache/media/sensitive_host_path_abc123.bin"
+
+    @pytest.mark.asyncio
+    async def test_send_voice_fallback_omits_audio_path(self):
+        adapter = _CapturingAdapter()
+        result = await adapter.send_voice(chat_id="123", audio_path=self.SENSITIVE_PATH)
+        assert result.success
+        assert len(adapter.sent) == 1
+        sent_text = adapter.sent[0]["content"]
+        assert self.SENSITIVE_PATH not in sent_text
+        assert "/home/" not in sent_text
+        assert "audio" in sent_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_video_fallback_omits_video_path(self):
+        adapter = _CapturingAdapter()
+        result = await adapter.send_video(chat_id="123", video_path=self.SENSITIVE_PATH)
+        assert result.success
+        sent_text = adapter.sent[0]["content"]
+        assert self.SENSITIVE_PATH not in sent_text
+        assert "/home/" not in sent_text
+        assert "video" in sent_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_document_fallback_omits_file_path(self):
+        adapter = _CapturingAdapter()
+        result = await adapter.send_document(chat_id="123", file_path=self.SENSITIVE_PATH)
+        assert result.success
+        sent_text = adapter.sent[0]["content"]
+        assert self.SENSITIVE_PATH not in sent_text
+        assert "/home/" not in sent_text
+        assert "file" in sent_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_document_fallback_includes_explicit_filename_only(self):
+        """A caller-supplied file_name is user-facing and may be shown — but
+        the host file_path argument must still be suppressed."""
+        adapter = _CapturingAdapter()
+        result = await adapter.send_document(
+            chat_id="123",
+            file_path=self.SENSITIVE_PATH,
+            file_name="report.pdf",
+        )
+        assert result.success
+        sent_text = adapter.sent[0]["content"]
+        assert self.SENSITIVE_PATH not in sent_text
+        assert "/home/" not in sent_text
+        assert "report.pdf" in sent_text
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_fallback_omits_image_path(self):
+        adapter = _CapturingAdapter()
+        result = await adapter.send_image_file(chat_id="123", image_path=self.SENSITIVE_PATH)
+        assert result.success
+        sent_text = adapter.sent[0]["content"]
+        assert self.SENSITIVE_PATH not in sent_text
+        assert "/home/" not in sent_text
+        assert "image" in sent_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_caption_is_preserved_in_fallback(self):
+        """The user-supplied caption is still shown — only the path is suppressed."""
+        adapter = _CapturingAdapter()
+        await adapter.send_video(
+            chat_id="123",
+            video_path=self.SENSITIVE_PATH,
+            caption="Here's the daily summary.",
+        )
+        sent_text = adapter.sent[0]["content"]
+        assert "Here's the daily summary." in sent_text
+        assert self.SENSITIVE_PATH not in sent_text


### PR DESCRIPTION
## Summary

Media-send fallbacks no longer echo the Hermes host filesystem path into chat when a native upload fails — the user gets a friendly notice and the path is logged at WARN for operators instead.

Previously, when a platform's native send raised (oversized video, bad codec, transient API error), the adapter fell back to a chat message like `🎬 Video: /home/<user>/.hermes/cache/video/ab12.mp4`, exposing the host's filesystem layout. Confirmed live on current `main`.

Salvage of #15517 by @UgwujaGeorge onto current `main` (Slack adapter relocated `gateway/platforms/slack.py` → `plugins/platforms/slack/adapter.py` since the PR was opened; re-applied there). Widened to the Matrix sibling site.

## Changes
- `gateway/platforms/base.py`: 4 base fallbacks (`send_voice`, `send_video`, `send_document`, `send_image_file`) replace the path-echo with `⚠️ Couldn't deliver the … attachment.`, log the path at WARN, preserve caption. `send_document` still surfaces an explicit caller-supplied `file_name` (a user-facing label, not a host path).
- `plugins/platforms/slack/adapter.py`: 3 sibling native-upload error paths fixed the same way.
- `plugins/platforms/matrix/adapter.py`: `_upload_file` no longer sends `(file not found: {file_path})` into the room — same bug class (sibling fix on top).
- `tests/gateway/test_platform_base.py`: `TestMediaFallbackDoesNotLeakHostPath` asserts the `*_path` argument never appears in fallback content, captions are preserved, and explicit `file_name` is still shown.

## Validation
| | Before | After |
|---|---|---|
| Native send fails | `🎬 Video: /home/.../cache/video/ab12.mp4` in chat | `⚠️ Couldn't deliver the video attachment.` |
| Host path | leaked to user | WARN log only (operator) |
| Caption / `file_name` | — | preserved |

- E2E: real `BasePlatformAdapter` subclass, all four fallbacks — sensitive path never reaches chat content, caption + `file_name` preserved.
- `scripts/run_tests.sh tests/gateway/test_platform_base.py` → 170 passed. Slack + Matrix adapter suites green.

Credit: @UgwujaGeorge (commit authorship preserved via cherry-pick).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa05bd4/oUmRR_XloY7bU_Kxs71ta_TMCT4GFF.png)
