### PR TITLE
fix(tui_gateway): add keep_transport guard to prompt.submit to prevent session transport hijack

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6019,6 +6019,69 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     assert text in {"", None}, f"expected empty text, got {text!r}"
 
 
+def test_prompt_submit_keep_transport_preserves_session_transport(monkeypatch):
+    """prompt.submit with keep_transport=true must NOT rebind session transport.
+
+    When an external client (ERP integration, bridge script) submits a prompt
+    via the WebSocket JSON-RPC API, the default behaviour rebinds the session
+    transport to the caller's WebSocket — stealing streaming events from the
+    Desktop app.  Passing ``keep_transport: true`` skips the rebind so the
+    Desktop keeps receiving events.
+    """
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    desktop_transport = object()
+    external_transport = object()
+
+    server._sessions["sid"] = _session(transport=desktop_transport)
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "current_transport", lambda: external_transport)
+
+    # WITH keep_transport — session transport should stay as desktop_transport
+    server.handle_request(
+        {
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "sid",
+                "text": "hello from ERP",
+                "keep_transport": True,
+            },
+        }
+    )
+    assert server._sessions["sid"]["transport"] is desktop_transport
+
+    # WITHOUT keep_transport — session transport should be rebound to external
+    server._sessions["sid"]["running"] = False
+    server.handle_request(
+        {
+            "id": "2",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello again"},
+        }
+    )
+    assert server._sessions["sid"]["transport"] is external_transport
+
+
 # ── active live TUI sessions ─────────────────────────────────────────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8084,7 +8084,9 @@ def _(rid, params: dict) -> dict:
     # Re-bind to the current client transport for this request. This keeps
     # streaming events on the active websocket even if an earlier disconnect
     # or fallback moved the session transport to stdio.
-    if (t := current_transport()) is not None:
+    # External callers (ERP integrations, bridge scripts) can set
+    # keep_transport to avoid hijacking the Desktop app's transport.
+    if (t := current_transport()) is not None and not params.get("keep_transport"):
         session["transport"] = t
     with session["history_lock"]:
         if session.get("running"):


### PR DESCRIPTION
## What does this PR do?

Adds an optional `keep_transport` parameter to `prompt.submit` that prevents the session's transport from being rebound to the caller's WebSocket. This fixes a bug where external clients (ERP integrations, bridge scripts, automation dashboards) calling `prompt.submit` via the WebSocket JSON-RPC API would hijack the Desktop app's transport, causing the Desktop UI to stop receiving streaming events and new messages.

## Related Issue

Fixes #55564

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: Added `not params.get("keep_transport")` guard to the transport rebind in `prompt.submit`. When `keep_transport` is `true`, the existing session transport is preserved so the Desktop app keeps receiving events. Default behaviour (no parameter) is unchanged for backward compatibility.
- `tests/test_tui_gateway_server.py`: Added `test_prompt_submit_keep_transport_preserves_session_transport` — verifies that with `keep_transport: true` the session transport is preserved, and without it the transport is rebound as before.

## How to Test

1. Run `python -m pytest tests/test_tui_gateway_server.py::test_prompt_submit_keep_transport_preserves_session_transport -xvs` — should pass
2. Run `python -m pytest tests/test_tui_gateway_server.py -k prompt_submit -x` — all 12 prompt.submit tests should pass (12 passed)
3. Manual verification: with Desktop open on a session, send `prompt.submit` via WebSocket with `keep_transport: true` — Desktop should continue receiving events

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_tui_gateway_server.py -k prompt_submit -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — the fix is a 1-line guard on the transport rebind path. The test verifies both branches (keep_transport=true preserves transport, default rebinds).
