### PR TITLE
fix(cron): log and redact on secrets-redaction failure

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1648,8 +1648,10 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             from agent.redact import redact_sensitive_text
             stdout = redact_sensitive_text(stdout)
             stderr = redact_sensitive_text(stderr)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to redact sensitive text from output: %s", e)
+            stdout = "[REDACTED - redaction failed]"
+            stderr = "[REDACTED - redaction failed]"
 
         if result.returncode != 0:
             parts = [f"Script exited with code {result.returncode}"]


### PR DESCRIPTION
## Summary
Cron script output no longer leaks secrets when redaction itself fails — `_run_job_script()` now fails closed instead of silently passing raw stdout/stderr through.

Root cause: the redaction block swallowed any exception with `except Exception: pass`, leaving `stdout`/`stderr` unredacted. If `redact_sensitive_text()` ever raised (import failure, regex bug), API keys/tokens could leak into cron delivery messages and logs.

Salvage of #25904 by @sprmn24, cherry-picked onto current main with authorship preserved.

## Changes
- `cron/scheduler.py` — redaction block in `_run_job_script()`: log the failure via `logger.warning` and replace both `stdout` and `stderr` with `[REDACTED - redaction failed]` instead of `pass`.

## Validation
| | Before | After |
|---|---|---|
| redaction raises | raw output (secrets leak) | `[REDACTED - redaction failed]`, logged |
| redaction succeeds | redacted | redacted (no change) |

E2E: patched `redact_sensitive_text` to raise → confirmed neither stdout nor stderr secret survived and the fallback marker was present; patched it to a working redactor → confirmed real redaction applied and the fallback did not fire. Sole redaction site in the function (1/1 covered). `py_compile` clean.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa05c0f/W9kb1cppK7qIBhHARn713_PiuztjGN.png)

Nous Research
