### PR TITLE
fix(dashboard): skip auto-sso for password providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,13 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers (for example BasicAuthProvider) do not implement
+    # the OAuth start_login() redirect flow. Let /login render so the password
+    # form can POST to /auth/password-login instead of auto-bouncing into
+    # /auth/login?provider=basic and raising NotImplementedError.
+    if getattr(provider, "supports_password", False):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -406,6 +406,32 @@ class TestAutoSsoRedirect:
         assert r.headers["location"].startswith("/login")
         assert "/auth/login" not in r.headers["location"]
 
+    def test_single_password_provider_renders_login_page_not_oauth_redirect(self, gated_app):
+        """Password-only providers do not implement OAuth start_login().
+
+        When BasicAuthProvider is the only session provider, the dashboard must
+        render /login so the password form can POST to /auth/password-login,
+        not auto-redirect to /auth/login?provider=basic and raise
+        NotImplementedError.
+        """
+        clear_providers()
+
+        class _PasswordOnlyProvider(StubAuthProvider):
+            name = "basic"
+            display_name = "Password"
+            supports_password = True
+
+            def start_login(  # pragma: no cover - must not be called
+                self, *, redirect_uri: str
+            ):
+                raise AssertionError("password providers must not auto-start OAuth")
+
+        register_provider(_PasswordOnlyProvider())
+        r = gated_app.get("/", follow_redirects=False)
+        assert r.status_code == 302
+        assert r.headers["location"].startswith("/login")
+        assert "/auth/login" not in r.headers["location"]
+
 
 # ---------------------------------------------------------------------------
 # Gate middleware: same-origin next= validation


### PR DESCRIPTION
## Summary

Fixes #55130.

When the bundled `basic` username/password provider is the only interactive dashboard auth provider, unauthenticated HTML navigations should render `/login` so the password form can POST to `/auth/password-login`.

Before this change, the auto-SSO shortcut treated any single session provider as OAuth-capable and redirected to `/auth/login?provider=basic`. `BasicAuthProvider.start_login()` intentionally raises `NotImplementedError`, so the dashboard returned HTTP 500 instead of the login page.

This PR skips the auto-SSO OAuth redirect for providers with `supports_password = True`, preserving the existing OAuth-only shortcut for redirect-capable providers.

## Test

RED first, on current `origin/main` with only the new test added:

```text
FAILED tests/hermes_cli/test_dashboard_auth_401_reauth.py::TestAutoSsoRedirect::test_single_password_provider_renders_login_page_not_oauth_redirect
E assert '/auth/login?provider=basic&next=%2F'.startswith('/login')
```

GREEN after fix:

```text
scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_401_reauth.py -q
45 tests passed, 0 failed
```
