### PR TITLE
fix: redact status --all API keys, harden compression message handling (salvage #15795)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1768,7 +1768,15 @@ This compaction should PRIORITISE preserving all information related to the focu
             # retry (_generate_summary recursion) re-enters harmlessly.
             with aux_interrupt_protection():
                 response = call_llm(**call_kwargs)
-            content = response.choices[0].message.content
+            # ``_validate_llm_response`` only guarantees ``choices[0].message``
+            # exists, not that it's an object with ``.content``. Some
+            # OpenAI-compatible proxies / local backends return a dict- or
+            # str-shaped message; coerce defensively instead of crashing.
+            message = response.choices[0].message
+            if isinstance(message, dict):
+                content = message.get("content")
+            else:
+                content = getattr(message, "content", message)
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):
                 content = str(content) if content else ""

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -354,8 +354,14 @@ def _extract_text(response: Any) -> str:
     except Exception:
         pass
     try:
-        content = response.choices[0].message.content
-        return (content or "").strip()
+        message = response.choices[0].message
+        if isinstance(message, dict):
+            content = message.get("content")
+        else:
+            content = getattr(message, "content", message)
+        if not isinstance(content, str):
+            content = str(content) if content else ""
+        return content.strip()
     except Exception:
         return ""
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -91,7 +91,6 @@ from hermes_constants import is_termux as _is_termux
 
 def show_status(args):
     """Show status of all Hermes Agent components."""
-    show_all = getattr(args, 'all', False)
     deep = getattr(args, 'deep', False)
 
     print()
@@ -165,12 +164,12 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -53,6 +53,7 @@ AUTHOR_MAP = {
     "39369769+jasonQin6@users.noreply.github.com": "jasonQin6",  # PR #15093 salvage (session staleness guard on stream consumer run() loop; #11016 follow-up)
     "znding04@gmail.com": "znding04",  # PR #15487 salvage (distinguish OpenRouter upstream 429 from account 429; upstream_rate_limit failover reason)
     "zkowkmdx@sharklasers.com": "nnnet",  # PR #25142 salvage (stop STT-failure chatter poisoning the LLM prompt; drop hardcoded English notice)
+    "vladimsmirnoff33@gmail.com": "londo161",  # PR #15795 salvage (redact status --all API keys; tolerate dict/str compression message shape)
     "cypher@augmentl.com": "Nickperillo",  # PR #8008 salvage (Discord channel-name matching + flush pending sends on shutdown)
     "tenoryang@outlook.com": "MarioYounger",  # PR #9028 salvage (bash/sh heredoc approval, NFKC homograph fold, execute_code CREDS/BEARER/APIKEY env filter)
     "peet.wannasarnmetha@gmail.com": "peetwan",  # PR #51841 salvage (loopback ws-ping tuning + token-frame coalescing + loop heartbeat; #48445/#50005)

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -510,6 +510,24 @@ class TestNonStringContent:
         assert summary is None
         assert c._summary_failure_cooldown_until > 0
 
+    def test_string_message_coerced_to_summary_content(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message = "plain summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            summary = c._generate_summary(messages)
+
+        assert summary == f"{SUMMARY_PREFIX}\nplain summary text"
+
     def test_summary_call_does_not_force_temperature(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -3,15 +3,16 @@ from types import SimpleNamespace
 from hermes_cli.status import show_status
 
 
-def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
+def test_show_status_all_does_not_print_tavily_key_value(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    sentinel = "NONSECRET_SENTINEL_VALUE_DO_NOT_PRINT_123456"
+    monkeypatch.setenv("TAVILY_API_KEY", sentinel)
 
-    show_status(SimpleNamespace(all=False, deep=False))
+    show_status(SimpleNamespace(all=True, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
-    assert "tvly...cdef" in output
+    assert sentinel not in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary
`hermes status --all` now redacts API keys (the flag's own help text already promised "redacted for sharing"), and context-compression summary handling tolerates a `dict`/`str`-shaped `message` instead of crashing.

Salvage of #15795 by @londo161, cherry-picked onto current `main` with authorship preserved. Adds a sibling fix in `agent/moa_loop.py` for the same response-shape access pattern.

## Changes
- `hermes_cli/status.py`: drop the `show_all` redaction bypass — API keys are always masked, matching the `--all` help text "Show all details (redacted for sharing)".
- `agent/context_compressor.py`: `_validate_llm_response` only guarantees `choices[0].message` exists, not that it's an object with `.content`. Coerce a dict/str-shaped message defensively (preserves the `aux_interrupt_protection()` wrapper).
- `agent/moa_loop.py`: same `response.choices[0].message.content` access in `_extract_text` — already in a try/except so it didn't crash, but silently returned empty on a dict/str message. Now extracts the content.
- Regression tests for the status redaction and the string-shaped compression message.

## Validation
| | Before | After |
|---|---|---|
| `status --all` with `TAVILY_API_KEY` set | raw key printed | redacted (E2E confirmed) |
| compression w/ str-shaped message | `AttributeError` crash | content extracted |
| moa `_extract_text` w/ dict/str message | silently empty | content extracted |
| targeted suite | — | 142/142 pass |

E2E verified with real imports against a temp `HERMES_HOME`: `status --all` no longer leaks the raw key, and `moa_loop._extract_text` returns content for str/dict/object messages.

## Infographic
![PR #15795 infographic](https://v3b.fal.media/files/b/0aa05c07/urk7PzK08aeqTglwsEJCe_IUCqe7O4.png)

Nous Research
