### PR TITLE
fix(gateway): stop poisoning the LLM prompt with STT-mode chatter (#25142)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9443,35 +9443,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 logger.debug(
                                     "Transcript echo failed (non-fatal): %s", _echo_exc,
                                 )
-                _stt_fail_markers = (
-                    "No STT provider",
-                    "STT is disabled",
-                    "can't listen",
-                    "VOICE_TOOLS_OPENAI_KEY",
-                )
-                if any(marker in message_text for marker in _stt_fail_markers):
-                    _stt_adapter = self.adapters.get(source.platform)
-                    _stt_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-                    if _stt_adapter:
-                        try:
-                            _stt_msg = (
-                                "🎤 I received your voice message but can't transcribe it — "
-                                "no speech-to-text provider is configured.\n\n"
-                                "To enable voice: install faster-whisper "
-                                "(`uv pip install faster-whisper` in the Hermes venv; "
-                                "`pip install faster-whisper` also works if pip is on PATH) "
-                                "and set `stt.enabled: true` in config.yaml, "
-                                "then /restart the gateway."
-                            )
-                            if self._has_setup_skill():
-                                _stt_msg += "\n\nFor full setup instructions, type: `/skill hermes-agent-setup`"
-                            await _stt_adapter.send(
-                                source.chat_id,
-                                _stt_msg,
-                                metadata=_stt_meta,
-                            )
-                        except Exception:
-                            pass
+                # NOTE: Previously, when transcription failed (e.g. no STT
+                # provider configured), the gateway also emitted a hardcoded
+                # English notice via `_stt_adapter.send()`. That bypassed the
+                # LLM and produced two replies — one pre-canned English clip
+                # (which TTS then spoke aloud, in the wrong language) and one
+                # correct, localized LLM reply from the enriched message text.
+                # The enrichment step now leaves a single neutral marker in the
+                # prompt, so the LLM produces one coherent reply in the user's
+                # language. The hardcoded send has therefore been removed.
 
         if audio_file_paths:
             from tools.credential_files import to_agent_visible_cache_path as _to_agent_path
@@ -13829,41 +13809,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if result["success"]:
                     transcript = result["transcript"]
                     successful_transcripts.append(transcript)
-                    enriched_parts.append(
-                        f'[The user sent a voice message~ '
-                        f'Here\'s what they said: "{transcript}"]'
-                    )
+                    # Pass the transcript through as a plain quoted line. The
+                    # earlier wording ("The user sent a voice message~ Here's
+                    # what they said: ...") read as a meta-instruction and made
+                    # the LLM volunteer commentary about voice mode rather than
+                    # reply to the content.
+                    enriched_parts.append(f'"{transcript}"')
                 else:
                     error = result.get("error", "unknown error")
-                    if (
-                        "No STT provider" in error
-                        or error.startswith("Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set")
-                    ):
-                        _no_stt_note = (
-                            "[The user sent a voice message but I can't listen "
-                            "to it right now — no STT provider is configured. "
-                            "A direct message has already been sent to the user "
-                            "with setup instructions."
-                        )
-                        if self._has_setup_skill():
-                            _no_stt_note += (
-                                " You have a skill called hermes-agent-setup "
-                                "that can help users configure Hermes features "
-                                "including voice, tools, and more."
-                            )
-                        _no_stt_note += "]"
-                        enriched_parts.append(_no_stt_note)
-                    else:
-                        enriched_parts.append(
-                            "[The user sent a voice message but I had trouble "
-                            f"transcribing it~ ({error})]"
-                        )
+                    # All failure branches: a single, minimal, neutral marker.
+                    # Do NOT mention "no STT provider configured", "setup
+                    # instructions", or the "hermes-agent-setup" skill, and do
+                    # NOT claim a direct message was sent — those phrases get
+                    # persisted in conversation history and poison every later
+                    # turn, so the model keeps volunteering STT-setup advice
+                    # even after transcription starts working. The cause is
+                    # logged for operator diagnosis but kept out of the
+                    # LLM-visible prompt.
+                    logger.info("Voice transcription failed for %s: %s", path, error)
+                    enriched_parts.append("[voice message could not be transcribed]")
             except Exception as e:
                 logger.error("Transcription error: %s", e)
-                enriched_parts.append(
-                    "[The user sent a voice message but something went wrong "
-                    "when I tried to listen to it~ Let them know!]"
-                )
+                enriched_parts.append("[voice message could not be transcribed]")
 
         if enriched_parts:
             prefix = "\n\n".join(enriched_parts)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -51,6 +51,7 @@ AUTHOR_MAP = {
     "huangxudong663@gmail.com": "huangxudong663-sys",  # PR #15157 salvage (isinstance(dict) guard on tool-call model_extra; NVIDIA NIM non-dict crash)
     "39369769+jasonQin6@users.noreply.github.com": "jasonQin6",  # PR #15093 salvage (session staleness guard on stream consumer run() loop; #11016 follow-up)
     "znding04@gmail.com": "znding04",  # PR #15487 salvage (distinguish OpenRouter upstream 429 from account 429; upstream_rate_limit failover reason)
+    "zkowkmdx@sharklasers.com": "nnnet",  # PR #25142 salvage (stop STT-failure chatter poisoning the LLM prompt; drop hardcoded English notice)
     "cypher@augmentl.com": "Nickperillo",  # PR #8008 salvage (Discord channel-name matching + flush pending sends on shutdown)
     "tenoryang@outlook.com": "MarioYounger",  # PR #9028 salvage (bash/sh heredoc approval, NFKC homograph fold, execute_code CREDS/BEARER/APIKEY env filter)
     "peet.wannasarnmetha@gmail.com": "peetwan",  # PR #51841 salvage (loopback ws-ping tuning + token-frame coalescing + loop heartbeat; #48445/#50005)

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -354,9 +354,11 @@ class TestCliApprovalUi:
             chat_console.return_value.print = MagicMock()
             cli._handle_background_command("/btw check weather")
 
-            deadline = time.time() + 2
-            while cli._background_tasks and time.time() < deadline:
-                time.sleep(0.01)
+            # Join the worker thread deterministically rather than polling a
+            # wall-clock deadline — under load the thread's finally-block pop
+            # of _background_tasks can lag a fixed timeout, which flaked CI.
+            for _thread in list(cli._background_tasks.values()):
+                _thread.join(timeout=10)
 
         assert seen["approval"].__self__ is cli
         assert seen["approval"].__func__ is HermesCLI._approval_callback

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -97,7 +97,9 @@ async def test_enrich_message_with_transcription_avoids_bogus_no_provider_messag
         )
 
     assert "No STT provider is configured" not in result
-    assert "trouble transcribing" in result
+    assert "[voice message could not be transcribed]" in result
+    # The opaque backend cause must NOT leak into the LLM-visible prompt.
+    assert "VOICE_TOOLS_OPENAI_KEY" not in result
     assert "caption" in result
     assert transcripts == []
 
@@ -180,5 +182,6 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
         )
 
     assert result is not None
+    # Success path: the transcript passes through as a plain quoted line, with
+    # no "voice message" meta-commentary that the LLM would echo back.
     assert "queued voice transcript" in result
-    assert "voice message" in result.lower()

--- a/tests/gateway/test_telegram_audio_vs_voice.py
+++ b/tests/gateway/test_telegram_audio_vs_voice.py
@@ -75,8 +75,9 @@ async def test_voice_message_still_transcribed():
         )
 
     mock_transcribe.assert_called_once_with("/tmp/voice.ogg")
+    # The transcript passes through as a plain quoted line — no "voice message"
+    # meta-commentary in the LLM-visible prompt.
     assert "hello world" in result
-    assert "voice message" in result.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Voice messages no longer make the assistant volunteer STT-setup advice or reply in the wrong language. The gateway's transcription-failure handling stops leaking pre-canned setup chatter into the LLM-visible prompt, and the hardcoded English notice that double-replied (and got read aloud by TTS) is removed.

Salvage of #25142 by @nnnet, re-applied onto current `main` with authorship preserved. The PR's original line numbers were stale and `_enrich_message_with_transcription` had since grown a `(text, transcripts)` signature plus a transcript-echo feature at four call sites — so the change was re-applied by hand on top of current `main` rather than cherry-picked.

## Root cause

The STT-failure enrichment templates injected `"no STT provider is configured"`, `"a direct message has already been sent"`, and a `hermes-agent-setup` skill mention into the prompt. That text persists in conversation history, so after a single STT failure the model kept replying about configuring Whisper/Vosk on every later voice turn — even once transcription started succeeding (observed in prod on `gpt-5-nano`). Separately, the gateway fired a hardcoded English `_stt_adapter.send()` notice that produced a second, wrong-language reply spoken aloud by TTS.

## Changes

- `gateway/run.py`: neutralize all enrichment templates — success passes the transcript through as a plain quoted line; every failure branch emits a single `[voice message could not be transcribed]` marker. Cause moved to `logger.info` (diagnosable in container logs, kept out of the prompt). Removed the hardcoded English `_stt_adapter.send()` notice. The transcript-echo feature already on `main` is left intact.
- `tests/gateway/`: updated the STT/voice tests to assert the neutral contract (no poison phrases; transcript present).
- `scripts/release.py`: AUTHOR_MAP entry for @nnnet.

## Validation

| | Before | After |
|---|---|---|
| STT failure note in prompt history | setup instructions persist | single neutral marker |
| Later voice turns after a failure | model keeps pushing Whisper/Vosk setup | replies on topic |
| Failed transcription replies | 2 (English pre-canned + localized LLM) | 1 (LLM, user's language) |
| Backend error cause | leaked into prompt | `logger.info` only |

E2E: ran `_enrich_message_with_transcription` with real imports across all three branches (success / no-STT-provider / exception) against a temp `HERMES_HOME` — Russian transcript passes through as `"<transcript>"`, both failure paths emit only the neutral marker, caption preserved, cause logged not prompted. Targeted gateway tests green.

## Infographic

![STT prompt poisoning fix](https://v3b.fal.media/files/b/0aa05c05/aGVRN_bt7OAiESBdkYWJ5_7l83iwX6.png)

---

Nous Research
