### PR TITLE
fix(desktop): guard voice loop during playback

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -100,13 +100,14 @@ export function useComposerVoice({
 
   const submitVoiceTurn = async (text: string) => {
     if (busy) {
-      return
+      return false
     }
 
     triggerHaptic('submit')
     resetBrowseState(sessionId)
     clearDraft()
-    await onSubmit(text)
+
+    return await onSubmit(text)
   }
 
   const conversation = useVoiceConversation({

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -1,0 +1,213 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as VoicePlayback from '@/lib/voice-playback'
+import { setVoicePlaybackState } from '@/store/voice-playback'
+
+import { type ConversationStatus, useVoiceConversation } from './use-voice-conversation'
+
+const recorder = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn()
+}))
+
+const bargeMonitor = vi.hoisted(() => ({
+  callbacks: null as null | { onSpeech: () => void; onUtterance?: (audio: Blob | null) => void },
+  cleanup: vi.fn()
+}))
+
+const speechStream = vi.hoisted(() => ({
+  resolveDone: (_outcome: 'done' | 'fallback'): void => undefined,
+  start: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          configureSpeechToText: 'Configure speech-to-text',
+          couldNotStartSession: 'Could not start voice session',
+          microphoneFailed: 'Microphone failed',
+          playbackFailed: 'Playback failed',
+          transcriptionFailed: 'Transcription failed',
+          unavailable: 'Voice unavailable'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/lib/voice-barge-in', () => ({
+  monitorSpeechDuringPlayback: vi.fn(
+    (callbacks: { onSpeech: () => void; onUtterance?: (audio: Blob | null) => void }) => {
+      bargeMonitor.callbacks = callbacks
+
+      return bargeMonitor.cleanup
+    }
+  )
+}))
+
+vi.mock('@/lib/voice-playback', async importOriginal => {
+  const actual = await importOriginal<typeof VoicePlayback>()
+
+  return {
+    ...actual,
+    startSpeechStream: speechStream.start
+  }
+})
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({
+    handle: recorder,
+    level: 0
+  })
+}))
+
+function playback(status: 'idle' | 'preparing' | 'speaking') {
+  setVoicePlaybackState({
+    audioElement: null,
+    messageId: null,
+    sequence: 0,
+    source: status === 'idle' ? null : 'voice-conversation',
+    status
+  })
+}
+
+function Harness({
+  busy = false,
+  enabled,
+  onStatus,
+  onSubmit = () => undefined,
+  onTranscribeAudio = async () => 'hello',
+  pendingResponse = () => null
+}: {
+  busy?: boolean
+  enabled: boolean
+  onStatus?: (status: ConversationStatus) => void
+  onSubmit?: (text: string) => boolean | Promise<boolean | void> | void
+  onTranscribeAudio?: (audio: Blob) => Promise<string>
+  pendingResponse?: () => { id: string; pending: boolean; text: string } | null
+}) {
+  const conversation = useVoiceConversation({
+    busy,
+    consumePendingResponse: vi.fn(),
+    enabled,
+    onSubmit,
+    onTranscribeAudio,
+    pendingResponse
+  })
+
+  onStatus?.(conversation.status)
+
+  return <div data-status={conversation.status} data-testid="voice-status" />
+}
+
+describe('useVoiceConversation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    playback('idle')
+    recorder.start.mockResolvedValue(undefined)
+    recorder.stop.mockResolvedValue({
+      audio: new Blob(['voice'], { type: 'audio/webm' }),
+      durationMs: 1200,
+      heardSpeech: true
+    })
+    speechStream.start.mockImplementation(async () => ({
+      append: vi.fn(),
+      finish: vi.fn(),
+      done: new Promise<'done' | 'fallback'>(resolve => {
+        speechStream.resolveDone = resolve
+      })
+    }))
+  })
+
+  afterEach(() => {
+    cleanup()
+    playback('idle')
+  })
+
+  it('waits for active playback before starting the microphone', async () => {
+    playback('speaking')
+
+    const { rerender } = render(<Harness enabled={false} />)
+
+    rerender(<Harness enabled />)
+
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(recorder.start).not.toHaveBeenCalled()
+
+    act(() => playback('idle'))
+
+    await waitFor(() => expect(recorder.start).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not enter the thinking loop when submit rejects the transcript', async () => {
+    let onSilence: (() => void) | undefined
+    recorder.start.mockImplementation(async options => {
+      onSilence = options?.onSilence
+    })
+    const onSubmit = vi.fn(() => false)
+    const statuses: ConversationStatus[] = []
+
+    const { rerender } = render(<Harness enabled={false} onStatus={status => statuses.push(status)} />)
+
+    rerender(<Harness enabled onStatus={status => statuses.push(status)} onSubmit={onSubmit} />)
+
+    await waitFor(() => expect(recorder.start).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      onSilence?.()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('hello'))
+    expect(statuses).not.toContain('thinking')
+  })
+
+  it('leaves the barge-in loop idle when the captured utterance submit is rejected', async () => {
+    let onSilence: (() => void) | undefined
+    recorder.start.mockImplementation(async options => {
+      onSilence = options?.onSilence
+    })
+
+    const onSubmit = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+    const pendingResponse = vi.fn(() => null as { id: string; pending: boolean; text: string } | null)
+
+    const { getByTestId, rerender } = render(
+      <Harness enabled={false} onSubmit={onSubmit} pendingResponse={pendingResponse} />
+    )
+
+    rerender(<Harness enabled onSubmit={onSubmit} pendingResponse={pendingResponse} />)
+    await waitFor(() => expect(recorder.start).toHaveBeenCalledTimes(1))
+
+    rerender(<Harness busy enabled onSubmit={onSubmit} pendingResponse={pendingResponse} />)
+
+    await act(async () => {
+      onSilence?.()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('hello'))
+
+    pendingResponse.mockReturnValue({ id: 'assistant-1', pending: true, text: 'Streaming reply' })
+    rerender(<Harness busy enabled onSubmit={onSubmit} pendingResponse={pendingResponse} />)
+    await waitFor(() => expect(bargeMonitor.callbacks).not.toBeNull())
+
+    await act(async () => {
+      bargeMonitor.callbacks?.onSpeech()
+      bargeMonitor.callbacks?.onUtterance?.(new Blob(['barge'], { type: 'audio/webm' }))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2))
+    expect(getByTestId('voice-status').getAttribute('data-status')).toBe('idle')
+
+    speechStream.resolveDone('done')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -1,8 +1,10 @@
+import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
 import { monitorSpeechDuringPlayback } from '@/lib/voice-barge-in'
 import {
+  isVoicePlaybackActive,
   markVoicePlaybackInterrupted,
   playSpeechText,
   type SpeechStreamSession,
@@ -10,6 +12,7 @@ import {
   stopVoicePlayback
 } from '@/lib/voice-playback'
 import { notify, notifyError } from '@/store/notifications'
+import { $voicePlayback } from '@/store/voice-playback'
 
 import { useMicRecorder } from './use-mic-recorder'
 
@@ -25,7 +28,7 @@ interface VoiceConversationOptions {
   busy: boolean
   enabled: boolean
   onFatalError?: () => void
-  onSubmit: (text: string) => Promise<void> | void
+  onSubmit: (text: string) => Promise<boolean | void> | boolean | void
   onTranscribeAudio?: (audio: Blob) => Promise<string>
   pendingResponse: () => PendingVoiceResponse | null
   consumePendingResponse: () => void
@@ -43,6 +46,7 @@ export function useVoiceConversation({
   const { t } = useI18n()
   const voiceCopy = t.notifications.voice
   const { handle, level } = useMicRecorder(voiceCopy)
+  const voicePlayback = useStore($voicePlayback)
   const [status, setStatus] = useState<ConversationStatus>('idle')
   const [muted, setMuted] = useState(false)
   const turnTimeoutRef = useRef<number | null>(null)
@@ -106,7 +110,13 @@ export function useVoiceConversation({
         const result = await handle.stop()
 
         if (!result || (!result.heardSpeech && !forceTranscribe) || !onTranscribeAudio) {
-          if (enabledRef.current && !mutedRef.current && !busyRef.current && statusRef.current !== 'speaking') {
+          if (
+            enabledRef.current &&
+            !mutedRef.current &&
+            !busyRef.current &&
+            statusRef.current !== 'speaking' &&
+            !isVoicePlaybackActive()
+          ) {
             pendingStartRef.current = true
           }
 
@@ -119,7 +129,7 @@ export function useVoiceConversation({
           const transcript = (await onTranscribeAudio(result.audio)).trim()
 
           if (!transcript) {
-            if (enabledRef.current) {
+            if (enabledRef.current && !mutedRef.current && !busyRef.current && !isVoicePlaybackActive()) {
               pendingStartRef.current = true
             }
 
@@ -130,12 +140,25 @@ export function useVoiceConversation({
 
           awaitingSpokenResponseRef.current = true
           dropSpeechSession()
-          await onSubmit(transcript)
+          const accepted = await onSubmit(transcript)
+
+          if (accepted === false) {
+            awaitingSpokenResponseRef.current = false
+
+            if (enabledRef.current && !mutedRef.current) {
+              pendingStartRef.current = true
+            }
+
+            setStatus('idle')
+
+            return
+          }
+
           setStatus('thinking')
         } catch (error) {
           notifyError(error, voiceCopy.transcriptionFailed)
 
-          if (enabledRef.current && !mutedRef.current && !busyRef.current) {
+          if (enabledRef.current && !mutedRef.current && !busyRef.current && !isVoicePlaybackActive()) {
             pendingStartRef.current = true
           }
 
@@ -149,9 +172,7 @@ export function useVoiceConversation({
   )
 
   const startListening = useCallback(async () => {
-    pendingStartRef.current = false
-
-    if (!enabledRef.current || mutedRef.current || busyRef.current) {
+    if (!enabledRef.current || mutedRef.current || busyRef.current || isVoicePlaybackActive()) {
       return
     }
 
@@ -162,6 +183,8 @@ export function useVoiceConversation({
     if (statusRef.current !== 'idle') {
       return
     }
+
+    pendingStartRef.current = false
 
     try {
       // VAD tuning mirrors `tools.voice_mode` defaults so the browser loop matches the CLI.
@@ -251,7 +274,20 @@ export function useVoiceConversation({
         awaitingSpokenResponseRef.current = true
         dropSpeechSession()
         consumePendingResponse()
-        await onSubmit(transcript)
+        const accepted = await onSubmit(transcript)
+
+        if (accepted === false) {
+          awaitingSpokenResponseRef.current = false
+
+          if (enabledRef.current && !mutedRef.current) {
+            pendingStartRef.current = true
+          }
+
+          setStatus('idle')
+
+          return
+        }
+
         setStatus('thinking')
       } catch (error) {
         notifyError(error, voiceCopy.transcriptionFailed)
@@ -474,7 +510,7 @@ export function useVoiceConversation({
         clearTurnTimeout()
         handle.cancel()
         setStatus('idle')
-      } else if (enabledRef.current && !busyRef.current && statusRef.current === 'idle') {
+      } else if (enabledRef.current && !busyRef.current && statusRef.current === 'idle' && !isVoicePlaybackActive()) {
         pendingStartRef.current = true
       }
 
@@ -537,10 +573,10 @@ export function useVoiceConversation({
       return
     }
 
-    if (pendingStartRef.current) {
+    if (pendingStartRef.current && !isVoicePlaybackActive()) {
       void startListening()
     }
-  }, [busy, enabled, muted, openLiveSpeech, pendingResponse, startListening, status])
+  }, [busy, enabled, muted, openLiveSpeech, pendingResponse, startListening, status, voicePlayback.status])
 
   useEffect(() => {
     if (enabled && !wasEnabledRef.current) {


### PR DESCRIPTION
## Summary

- prevent the ordinary desktop voice recorder from re-arming while shared TTS playback is preparing or speaking, without disabling the dedicated playback barge-in monitor
- propagate rejected voice transcript submits back into both normal and captured-barge voice paths so they do not enter a stale `thinking` state
- preserve the pending microphone restart until the session is idle and playback has ended
- add regression coverage for playback-gated mic start, rejected normal submits, and rejected captured-barge submits

## Root cause

The ordinary voice-conversation recorder only gated microphone re-arm on its local conversation status and session busy state. It did not observe the shared voice playback state, and it cleared `pendingStartRef` before all start guards had passed. A playback overlap could therefore either reopen the normal recorder too early or consume the pending restart without retrying it.

The composer submit contract returns `false` when a prompt is rejected, but `submitVoiceTurn()` discarded that result and the voice loop unconditionally entered `thinking`. Current `main` also has a separate captured-utterance path for streaming TTS barge-in; that sibling path had the same rejected-submit behavior.

This update keeps the new `monitorSpeechDuringPlayback` / streaming speech path intact. The playback guard applies only to the ordinary recorder restart, while the dedicated barge-in monitor continues to own microphone capture during playback.

## Testing

- `npm --workspace apps/desktop run test:ui -- src/app/chat/composer/hooks/use-voice-conversation.test.tsx` (3 passed)
- `npm --workspace apps/desktop run test:ui` (243 files, 2052 passed, 1 skipped)
- `npm --workspace apps/desktop run typecheck`
- targeted ESLint and Prettier checks for the three changed files
- `npm --workspace apps/desktop run build`

## Notes

There is an adjacent open PR (#54067) that improves voice-conversation latency and TTS gaps. This PR remains narrower: it guards the ordinary mic re-arm and keeps rejected voice submits out of the response-waiting loop while preserving the newer streaming/barge-in implementation on `main`.
