### PR TITLE
fix(tools): defense-in-depth guard against hallucinated acp_command crashing the gateway (#27426)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -73,6 +73,7 @@ AUTHOR_MAP = {
     "267614622+agt-user@users.noreply.github.com": "agt-user",  # PR #48496 salvage (telegram CLOSE-WAIT polling heartbeat, #48495)
     "80915+DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # PR #52272 salvage (route reasoning-model thinking-timeouts to timeout not context_overflow + reasoning-specific guidance; #52271)
     "66773372+Tranquil-Flow@users.noreply.github.com": "Tranquil-Flow",  # PR #52623 salvage (auxiliary Anthropic base_url host validation; #52608)
+    "nikshepsvn@gmail.com": "nikshepsvn",  # PR #27426 salvage (two-layer guard against hallucinated acp_command crashing the gateway on hosts with no ACP CLI)
     "65363919+coygeek@users.noreply.github.com": "coygeek",  # PR #37735 salvage (redact provider error text at api-server HTTP boundary; #37733)
     "moonsong@nousresearch.local": "Tranquil-Flow",  # PR #52623 salvage (auxiliary Anthropic base_url host validation; #52608)
     "140971685+Dr1985@users.noreply.github.com": "Dr1985",  # PR #42567 salvage (launchd supervision detection + status reporting; #42524)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -602,6 +602,69 @@ class TestToolNamePreservation(unittest.TestCase):
         self.assertEqual(captured["provider"], "copilot-acp")
         self.assertEqual(captured["acp_command"], "copilot")
 
+    def test_schema_prunes_acp_command_when_no_acp_binary(self):
+        """Schema-level defense: delegate_task tool schema must NOT advertise
+        acp_command / acp_args to the model when no ACP binary is installed.
+
+        Headless deploys (Railway / Fly / Docker / fresh VPS) typically have
+        none of copilot / claude / codex. Without the schema prune, models
+        occasionally hallucinate ``acp_command="copilot"`` from the field's
+        description and crash subagent runs.
+        """
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        with patch("tools.delegate_tool._acp_binary_available", return_value=False):
+            overrides = _build_dynamic_schema_overrides()
+
+        props = overrides["parameters"]["properties"]
+        self.assertNotIn("acp_command", props, "top-level acp_command must be pruned")
+        self.assertNotIn("acp_args", props, "top-level acp_args must be pruned")
+
+        task_item_props = props["tasks"]["items"]["properties"]
+        self.assertNotIn(
+            "acp_command", task_item_props, "per-task acp_command must be pruned"
+        )
+        self.assertNotIn(
+            "acp_args", task_item_props, "per-task acp_args must be pruned"
+        )
+
+    def test_schema_keeps_acp_command_when_binary_available(self):
+        """Backward compat: when an ACP CLI IS on PATH, schema is unchanged.
+        Users with working ACP setups must still be able to invoke it.
+        """
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        with patch("tools.delegate_tool._acp_binary_available", return_value=True):
+            overrides = _build_dynamic_schema_overrides()
+
+        props = overrides["parameters"]["properties"]
+        self.assertIn("acp_command", props)
+        self.assertIn("acp_args", props)
+
+        task_item_props = props["tasks"]["items"]["properties"]
+        self.assertIn("acp_command", task_item_props)
+        self.assertIn("acp_args", task_item_props)
+
+    def test_acp_binary_available_checks_known_clis(self):
+        """_acp_binary_available must check the known ACP CLI names via
+        shutil.which — guards against typos or accidental list trimming.
+        """
+        from tools.delegate_tool import _KNOWN_ACP_BINARIES, _acp_binary_available
+
+        self.assertIn("copilot", _KNOWN_ACP_BINARIES)
+
+        calls = []
+
+        def fake_which(name):
+            calls.append(name)
+            return None
+
+        with patch("shutil.which", side_effect=fake_which):
+            self.assertFalse(_acp_binary_available())
+
+        for name in _KNOWN_ACP_BINARIES:
+            self.assertIn(name, calls)
+
     def test_saved_tool_names_set_on_child_before_run(self):
         """_run_single_child must set _delegate_saved_tool_names on the child
         from model_tools._last_resolved_tool_names before run_conversation."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -517,6 +517,91 @@ class TestToolNamePreservation(unittest.TestCase):
                     f"_saved_tool_names leaked back into wrong scope: {exc}"
                 )
 
+    def test_build_child_agent_ignores_acp_command_when_binary_missing(self):
+        """Regression: _build_child_agent must not force provider='copilot-acp'
+        when the override_acp_command binary is not on PATH.
+
+        Without this guard, a model that hallucinates
+        ``delegate_task(acp_command="copilot")`` on a host without the Copilot
+        CLI installed (Railway / headless containers / fresh VPS) would route
+        the subagent through CopilotACPClient, which spawns the binary via
+        subprocess and raises RuntimeError. After 3 retries the asyncio loop
+        teardown can take the entire gateway down.
+        """
+        parent = _make_mock_parent(depth=0)
+        # The crash scenario is a TG/cron agent on a host with no ACP CLI —
+        # parent itself has no acp_command, so clearing the override must NOT
+        # fall through to a stray parent value.
+        parent.acp_command = None
+        parent.acp_args = []
+        captured = {}
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("shutil.which", return_value=None) as mock_which:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="search X for crypto twitter",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_acp_command="copilot",
+                override_acp_args=["--foo"],
+            )
+
+            _, kwargs = MockAgent.call_args
+            captured["provider"] = kwargs.get("provider")
+            captured["acp_command"] = kwargs.get("acp_command")
+            captured["acp_args"] = kwargs.get("acp_args")
+
+        mock_which.assert_called_with("copilot")
+        self.assertNotEqual(
+            captured["provider"],
+            "copilot-acp",
+            "missing acp_command binary must NOT force copilot-acp provider",
+        )
+        self.assertIsNone(captured["acp_command"])
+        self.assertEqual(captured["acp_args"], [])
+
+    def test_build_child_agent_honors_acp_command_when_binary_present(self):
+        """When the acp_command binary exists on PATH, behavior is unchanged:
+        provider is forced to copilot-acp and command/args propagate to the
+        child agent. Guards against the missing-binary check accidentally
+        breaking working ACP delegation setups.
+        """
+        parent = _make_mock_parent(depth=0)
+        captured = {}
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("shutil.which", return_value="/usr/local/bin/copilot"):
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="copilot path",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_acp_command="copilot",
+                override_acp_args=["--foo"],
+            )
+
+            _, kwargs = MockAgent.call_args
+            captured["provider"] = kwargs.get("provider")
+            captured["acp_command"] = kwargs.get("acp_command")
+
+        self.assertEqual(captured["provider"], "copilot-acp")
+        self.assertEqual(captured["acp_command"], "copilot")
+
     def test_saved_tool_names_set_on_child_before_run(self):
         """_run_single_child must set _delegate_saved_tool_names on the child
         from model_tools._last_resolved_tool_names before run_conversation."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3271,6 +3271,30 @@ def _build_role_param_description() -> str:
     )
 
 
+# Known ACP-compatible CLIs that delegate_task can shell out to. Kept
+# narrow on purpose: only the ones agent/copilot_acp_client.py and friends
+# actually understand. Add new entries here when a new ACP CLI ships.
+_KNOWN_ACP_BINARIES: tuple[str, ...] = ("copilot", "claude", "codex")
+
+
+def _acp_binary_available() -> bool:
+    """True iff at least one known ACP CLI is on PATH.
+
+    Used to gate inclusion of ``acp_command`` / ``acp_args`` in the
+    delegate_task schema. On headless hosts (Railway / Fly / Docker /
+    fresh VPS) without any of these binaries, exposing the fields invites
+    the model to hallucinate ``acp_command="copilot"`` from the schema's
+    description, which used to crash subagent runs and take the gateway
+    down. Pruning the fields from the schema removes the temptation.
+
+    Not cached: ``shutil.which`` is cheap and we want the schema to react
+    to mid-session installs without forcing a process restart.
+    """
+    import shutil as _shutil
+
+    return any(_shutil.which(name) for name in _KNOWN_ACP_BINARIES)
+
+
 def _build_dynamic_schema_overrides() -> dict:
     """Return per-call schema overrides reflecting current config.
 
@@ -3287,6 +3311,25 @@ def _build_dynamic_schema_overrides() -> dict:
     }
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
     overrides_params["properties"]["role"]["description"] = _build_role_param_description()
+
+    # Prune ACP overrides from the schema when no known ACP CLI is on PATH.
+    # The runtime guard in _build_child_agent remains as defense-in-depth for
+    # internal callers / tests / future code paths that skip the schema layer.
+    if not _acp_binary_available():
+        overrides_params["properties"].pop("acp_command", None)
+        overrides_params["properties"].pop("acp_args", None)
+        tasks_schema = dict(overrides_params["properties"].get("tasks", {}))
+        if "items" in tasks_schema:
+            items = dict(tasks_schema["items"])
+            if "properties" in items:
+                items["properties"] = {
+                    k: v
+                    for k, v in items["properties"].items()
+                    if k not in ("acp_command", "acp_args")
+                }
+            tasks_schema["items"] = items
+            overrides_params["properties"]["tasks"] = tasks_schema
+
     return {
         "description": _build_top_level_description(),
         "parameters": overrides_params,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1229,6 +1229,22 @@ def _build_child_agent(
         effective_api_mode = None  # force re-derivation from provider's defaults
     else:
         effective_api_mode = getattr(parent_agent, "api_mode", None)
+    # Defensive: validate override_acp_command exists on PATH before honoring
+    # it. Models occasionally pass acp_command="copilot" / "claude" / etc. in
+    # delegate_task tool calls despite the schema saying not to, which forces
+    # the subagent onto the copilot-acp transport below and crashes the
+    # gateway when the binary is missing (e.g. headless container deploys).
+    if override_acp_command:
+        import shutil as _shutil
+
+        if not _shutil.which(override_acp_command):
+            logger.warning(
+                "Ignoring acp_command=%r: binary not found on PATH; "
+                "falling back to default transport.",
+                override_acp_command,
+            )
+            override_acp_command = None
+            override_acp_args = None
     effective_acp_command = override_acp_command or getattr(
         parent_agent, "acp_command", None
     )


### PR DESCRIPTION
## Summary
A model passing `acp_command="copilot"` (or `claude`/`codex`) in a `delegate_task` call can no longer crash the gateway on a host where that CLI isn't installed.

Root cause: `_build_child_agent` unconditionally set `effective_provider = "copilot-acp"` whenever `override_acp_command` was truthy — with no check that the binary actually exists. On headless deploys (Railway/Fly/Docker/fresh VPS) the subagent then tried to spawn a missing binary, failed, and after 3 retries the asyncio teardown took the whole gateway down (`cannot schedule new futures after interpreter shutdown`).

Salvage of #27426 by @nikshepsvn, cherry-picked onto current `main` with authorship preserved.

## Changes
- `tools/delegate_tool.py` — **Layer 1 (schema):** prune `acp_command`/`acp_args` from the `delegate_task` schema when no known ACP CLI (`copilot`/`claude`/`codex`) is on PATH, so the model can't pass a field it never sees. Reuses the existing per-call `_build_dynamic_schema_overrides()` pattern.
- `tools/delegate_tool.py` — **Layer 2 (runtime):** `shutil.which()` guard in `_build_child_agent` that drops `override_acp_command` (and falls back to the default transport) when the binary is missing — defense-in-depth for internal callers / tests / future code paths.
- `tests/tools/test_delegate.py` — 5 new tests (runtime fallback, runtime backward-compat, schema prune fires, schema unchanged when a CLI is present, known-binary list sanity).
- `scripts/release.py` — AUTHOR_MAP entry for `nikshepsvn`.

## Why it's safe
The PATH check is host-stable within a session — the schema stays byte-identical for the life of a conversation, so prompt caching is preserved. It's the same "only advertise a field when its prerequisite is configured" approach already used two lines above for opt-in per-task model selection.

## Validation
| | Result |
|---|---|
| `tests/tools/test_delegate.py` | 149/149 pass |
| Behavior change for hosts WITH an ACP CLI on PATH | none (schema + runtime both unchanged) |
| Behavior change for hosts WITHOUT | field pruned from schema; runtime falls back instead of crashing |

## Infographic
![PR #27426 infographic](https://v3b.fal.media/files/b/0aa05c2a/AhgSx-OWGLZisFfmm7Hvx_uiIXGFne.png)
