### PR TITLE
fix(security): redact Fireworks AI API keys in logs

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -106,6 +106,7 @@ _PREFIX_PATTERNS = [
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
     r"ntn_[A-Za-z0-9]{10,}",            # Notion internal integration token
+    r"fw_[A-Za-z0-9]{30,}",             # Fireworks AI API key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name.

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -886,3 +886,25 @@ class TestFileReadNonReusableRedaction:
         out = redact_sensitive_text(f"key: {self.SK}", force=True, file_read=True)
         assert "«redacted:sk-…»" in out
         assert self.SK not in out
+
+
+class TestFireworksToken:
+    KEY = "fw_" + "A" * 40
+
+    def test_bare_token_masked(self):
+        result = redact_sensitive_text(f"fireworks error: key {self.KEY}", force=True)
+        assert self.KEY not in result
+        assert "fw_AA" in result
+
+    def test_env_assignment_masked(self):
+        result = redact_sensitive_text(f"FIREWORKS_API_KEY={self.KEY}", force=True)
+        assert self.KEY not in result
+
+    def test_too_short_not_masked(self):
+        short = "fw_tooshort"
+        result = redact_sensitive_text(f"text {short} here", force=True)
+        assert short in result
+
+    def test_prefix_visible_in_masked_output(self):
+        result = redact_sensitive_text(self.KEY, force=True)
+        assert result.startswith("fw_AA")


### PR DESCRIPTION
## Summary
Raw Fireworks AI API keys now get masked in logs, stack traces, and tool output. Fireworks is a registered provider (`FIREWORKS_API_KEY` is passed to the agent environment in `tools/environments/local.py` and listed in `hermes_cli/models.py`), but its `fw_<40 alnum>` key format was missing from `_PREFIX_PATTERNS` in `agent/redact.py` — only the `FIREWORKS_API_KEY=...` env-assignment form was caught, so a bare key in a traceback or debug print leaked verbatim.

## Changes
- `agent/redact.py`: add `r"fw_[A-Za-z0-9]{30,}"` to `_PREFIX_PATTERNS`. The 30-char minimum matches the real 40-char keys while guarding short false positives like `fw_version`. `fw_` extracts cleanly as a literal prefix-substring, so the `_PREFIX_SUBSTRINGS` pre-screen stays correct.
- `tests/agent/test_redact.py`: `TestFireworksToken` — bare token masking, env-assignment masking, short-prefix false-positive guard, visible-prefix-in-output.

## Validation
| | Before | After |
|---|---|---|
| `fw_…` in a stack trace | leaked verbatim | masked (`fw_AA…`) |
| `fw_version` short string | n/a | left untouched |
| redact suite | — | 126/126 pass |

Salvaged from #27500 by @flamiinngo via cherry-pick (authorship preserved). E2E-verified with real imports against the live redactor.

## Infographic
![Redact Fireworks AI keys](https://v3b.fal.media/files/b/0aa05c32/hBJiFG24Qs26b2FDVm2wv_p4G3oFs1.png)

— Nous Research
