### PR TITLE
fix(whatsapp): gate opt-in owner-typed forwards on customer chatId allowlist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1691,6 +1691,13 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Free-form per-event metadata.  Adapters may set platform-specific
+    # signals here (e.g. WhatsApp sets ``whatsapp_from_owner=True`` when
+    # the bridge is configured to forward owner-typed messages).  Plugins
+    # consume via ``event.metadata.get(...)`` and must not rely on any
+    # particular key existing.
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -35,6 +35,10 @@ from hermes_constants import (
 
 logger = logging.getLogger(__name__)
 
+# Inbound owner-typed WhatsApp text is prefixed at MessageEvent construction so
+# transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
+_OWNER_REPLY_PREFIX = "[owner reply] "
+
 
 def _listener_pids_on_port(port: int) -> list:
     """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
@@ -1314,12 +1318,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # that look owner-typed (linked-device send, not echoed from our
             # own /send).  Surfaced under a platform-prefixed key so plugins
             # can detect "owner just replied in this customer chat" without
-            # having to peek at raw_message.  Gated by
-            # ``WHATSAPP_FORWARD_OWNER_MESSAGES`` at the bridge layer; the
-            # propagation here is unconditional so a future producer can set
-            # the flag without us having to touch this code path again.
+            # having to peek at raw_message.  We also prefix ``MessageEvent.text``
+            # with ``[owner reply] `` here so the marker survives any downstream
+            # failure (e.g. handover-rule errors that bypass silent_ingest).
+            # Gated by ``WHATSAPP_FORWARD_OWNER_MESSAGES`` at the bridge layer;
+            # metadata + text tagging are unconditional when the flag is present
+            # so a future producer can set it without adapter changes.
             if data.get("fromOwner"):
                 metadata["whatsapp_from_owner"] = True
+                if not body.startswith(_OWNER_REPLY_PREFIX):
+                    body = f"{_OWNER_REPLY_PREFIX}{body}"
 
             return MessageEvent(
                 text=body,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1309,6 +1309,18 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
+            metadata: Dict[str, Any] = {}
+            # The bridge sets ``fromOwner: true`` on inbound fromMe messages
+            # that look owner-typed (linked-device send, not echoed from our
+            # own /send).  Surfaced under a platform-prefixed key so plugins
+            # can detect "owner just replied in this customer chat" without
+            # having to peek at raw_message.  Gated by
+            # ``WHATSAPP_FORWARD_OWNER_MESSAGES`` at the bridge layer; the
+            # propagation here is unconditional so a future producer can set
+            # the flag without us having to touch this code path again.
+            if data.get("fromOwner"):
+                metadata["whatsapp_from_owner"] = True
+
             return MessageEvent(
                 text=body,
                 message_type=msg_type,
@@ -1317,6 +1329,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                metadata=metadata,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -31,6 +31,7 @@ import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
+import { classifyOwnerMessageGate } from './owner_message_gate.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -334,9 +335,31 @@ async function startSocket() {
           //
           // We always drop (a). We drop (b) too unless the operator opts in
           // via WHATSAPP_FORWARD_OWNER_MESSAGES so existing deployments see
-          // no behavior change.
-          if (recentlySentIds.has(msg.key.id)) continue;
-          if (!FORWARD_OWNER_MESSAGES) continue;
+          // no behavior change. When opted in, we still gate on the
+          // customer chatId allowlist — without that gate, any contact
+          // the owner replied to would leak into Hermes and trigger
+          // implicit handover. See `owner_message_gate.js`.
+          const decision = classifyOwnerMessageGate({
+            fromMe: true,
+            fromOwnerEnabled: FORWARD_OWNER_MESSAGES,
+            recentlySent: recentlySentIds,
+            allowlistMatches: (id) => matchesAllowedUser(id, ALLOWED_USERS, SESSION_DIR),
+            messageId: msg.key.id,
+            chatId,
+          });
+          if (decision.action === 'drop_echo') continue;
+          if (decision.action === 'drop_disabled') continue;
+          if (decision.action === 'drop_allowlist') {
+            try {
+              console.log(JSON.stringify({
+                event: 'ignored',
+                reason: 'allowlist_mismatch_owner_chat',
+                chatId,
+                senderId,
+              }));
+            } catch {}
+            continue;
+          }
           fromOwner = true;
         } else {
           // Self-chat mode: only allow messages in the user's own self-chat.

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -30,6 +30,7 @@ import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { createOutboundIdTracker } from './outbound_ids.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -43,6 +44,23 @@ const WHATSAPP_DEBUG =
   process.env &&
   typeof process.env.WHATSAPP_DEBUG === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_DEBUG.toLowerCase());
+
+// Opt-in: when true (and WHATSAPP_MODE === 'bot'), fromMe inbound messages
+// that are NOT echoes of our own /send or /send-media calls are forwarded
+// to the Python adapter with `fromOwner: true`. This lets plugins detect
+// "owner just typed in this customer chat" — needed for handover / sliding
+// TTL flows. Default OFF: existing deployments see no behavior change.
+//
+// Heuristic limitation: we distinguish bot-API-sent from owner-typed by
+// looking up `key.id` in `recentlySentIds` (populated when /send returns).
+// On bridge restart that set is empty, so a few in-flight bot replies may
+// briefly look like owner-typed until they age out. Acceptable; we don't
+// persist the set.
+const FORWARD_OWNER_MESSAGES =
+  typeof process !== 'undefined' &&
+  process.env &&
+  typeof process.env.WHATSAPP_FORWARD_OWNER_MESSAGES === 'string' &&
+  ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_FORWARD_OWNER_MESSAGES.toLowerCase());
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
@@ -146,12 +164,7 @@ function splitLongMessage(message, maxLength = MAX_MESSAGE_LENGTH) {
 }
 
 function trackSentMessageId(sent) {
-  if (sent?.key?.id) {
-    recentlySentIds.add(sent.key.id);
-    if (recentlySentIds.size > MAX_RECENT_IDS) {
-      recentlySentIds.delete(recentlySentIds.values().next().value);
-    }
-  }
+  rememberSentId(sent?.key?.id);
 }
 
 function normalizeWhatsAppId(value) {
@@ -205,9 +218,18 @@ const logger = pino({ level: 'warn' });
 const messageQueue = [];
 const MAX_QUEUE_SIZE = 100;
 
-// Track recently sent message IDs to prevent echo-back loops with media
-const recentlySentIds = new Set();
-const MAX_RECENT_IDS = 50;
+// Track recently sent message IDs.  Two purposes:
+//   1. Prevent echo-back loops with media in self-chat mode.
+//   2. (When WHATSAPP_FORWARD_OWNER_MESSAGES=true) distinguish our own
+//      bot-API outbound messages from owner-typed messages on the linked
+//      device so we can forward only the latter.
+// Capacity bounded (see outbound_ids.js) to keep memory flat under
+// sustained sending.
+const recentlySentIds = createOutboundIdTracker(512);
+
+function rememberSentId(id) {
+  recentlySentIds.remember(id);
+}
 
 let sock = null;
 let connectionState = 'disconnected';
@@ -300,23 +322,33 @@ async function startSocket() {
       const senderNumber = senderId.replace(/@.*/, '');
 
       // Handle fromMe messages based on mode
+      let fromOwner = false;
       if (msg.key.fromMe) {
         if (isGroup || chatId.includes('status')) continue;
 
         if (WHATSAPP_MODE === 'bot') {
-          // Bot mode: separate number. ALL fromMe are echo-backs of our own replies — skip.
-          continue;
+          // Bot mode: separate bot number. fromMe inbound is either
+          //   (a) an echo of our own /send (recentlySentIds will catch it), or
+          //   (b) a message the owner typed from their own phone using the
+          //       linked-device session.
+          //
+          // We always drop (a). We drop (b) too unless the operator opts in
+          // via WHATSAPP_FORWARD_OWNER_MESSAGES so existing deployments see
+          // no behavior change.
+          if (recentlySentIds.has(msg.key.id)) continue;
+          if (!FORWARD_OWNER_MESSAGES) continue;
+          fromOwner = true;
+        } else {
+          // Self-chat mode: only allow messages in the user's own self-chat.
+          // WhatsApp now uses LID (Linked Identity Device) format: 67427329167522@lid
+          // AND classic format: 34652029134@s.whatsapp.net
+          // sock.user has both: { id: "number:10@s.whatsapp.net", lid: "lid_number:10@lid" }
+          const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
+          const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
+          const chatNumber = chatId.replace(/@.*/, '');
+          const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
+          if (!isSelfChat) continue;
         }
-
-        // Self-chat mode: only allow messages in the user's own self-chat
-        // WhatsApp now uses LID (Linked Identity Device) format: 67427329167522@lid
-        // AND classic format: 34652029134@s.whatsapp.net
-        // sock.user has both: { id: "number:10@s.whatsapp.net", lid: "lid_number:10@lid" }
-        const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
-        const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
-        const chatNumber = chatId.replace(/@.*/, '');
-        const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
-        if (!isSelfChat) continue;
       }
 
       // Handle !fromMe messages (from other people) based on mode.
@@ -473,6 +505,7 @@ async function startSocket() {
         hasQuotedMessage,
         botIds,
         timestamp: msg.messageTimestamp,
+        fromOwner,
       };
 
       messageQueue.push(event);
@@ -678,9 +711,7 @@ app.post('/send-media', async (req, res) => {
     }
 
     const sent = await sendWithTimeout(chatId, msgPayload);
-
     trackSentMessageId(sent);
-
     res.json({ success: true, messageId: sent?.key?.id });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -758,6 +789,9 @@ if (PAIR_ONLY) {
       console.log(`🔒 No WHATSAPP_ALLOWED_USERS set — incoming messages are rejected.`);
       console.log(`   Set WHATSAPP_ALLOWED_USERS=<phone> to authorize specific users,`);
       console.log(`   or WHATSAPP_ALLOWED_USERS=* for an explicit open bot.`);
+    }
+    if (WHATSAPP_MODE === 'bot' && FORWARD_OWNER_MESSAGES) {
+      console.log(`👤 WHATSAPP_FORWARD_OWNER_MESSAGES=true — owner-typed messages will be forwarded with fromOwner:true`);
     }
     console.log();
     startSocket();

--- a/scripts/whatsapp-bridge/outbound_ids.js
+++ b/scripts/whatsapp-bridge/outbound_ids.js
@@ -1,0 +1,39 @@
+/**
+ * Bounded LRU set of outbound message IDs.
+ *
+ * Used by the WhatsApp bridge to distinguish "echo of our own /send" from
+ * "owner-typed message on the linked device" when forwarding `fromMe`
+ * inbound events back to the Python adapter.
+ *
+ * Heuristic limitation (intentional, documented for future debugging):
+ * the set is in-memory only.  On bridge restart it is empty, so for the
+ * brief window between restart and the first new outbound, any in-flight
+ * delivery receipts of pre-restart sends would be classified as
+ * owner-typed.  The TTL on owner-driven plugin actions (e.g. handover
+ * sliding TTL) bounds blast radius; persisting would not be worth the
+ * extra complexity / disk churn.
+ */
+
+export function createOutboundIdTracker(maxSize = 512) {
+  const ids = new Set();
+
+  function remember(id) {
+    if (!id) return;
+    ids.add(id);
+    while (ids.size > maxSize) {
+      // Set iteration order is insertion order, so values().next() is the
+      // oldest entry — drop it to keep memory flat under sustained sending.
+      ids.delete(ids.values().next().value);
+    }
+  }
+
+  function has(id) {
+    return Boolean(id) && ids.has(id);
+  }
+
+  function size() {
+    return ids.size;
+  }
+
+  return { remember, has, size };
+}

--- a/scripts/whatsapp-bridge/outbound_ids.js
+++ b/scripts/whatsapp-bridge/outbound_ids.js
@@ -1,9 +1,12 @@
 /**
- * Bounded LRU set of outbound message IDs.
+ * Bounded FIFO set of outbound message IDs.
  *
  * Used by the WhatsApp bridge to distinguish "echo of our own /send" from
  * "owner-typed message on the linked device" when forwarding `fromMe`
  * inbound events back to the Python adapter.
+ *
+ * Eviction drops the oldest insertion-order entry when the cap is exceeded.
+ * Re-remembering an existing id is a no-op for ordering (not LRU refresh).
  *
  * Heuristic limitation (intentional, documented for future debugging):
  * the set is in-memory only.  On bridge restart it is empty, so for the
@@ -15,6 +18,9 @@
  */
 
 export function createOutboundIdTracker(maxSize = 512) {
+  if (!Number.isInteger(maxSize) || maxSize < 1) {
+    throw new RangeError('createOutboundIdTracker: maxSize must be a positive integer');
+  }
   const ids = new Set();
 
   function remember(id) {

--- a/scripts/whatsapp-bridge/outbound_ids.test.mjs
+++ b/scripts/whatsapp-bridge/outbound_ids.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createOutboundIdTracker } from './outbound_ids.js';
+
+test('remembers and recognises an outbound id', () => {
+  const tracker = createOutboundIdTracker();
+  tracker.remember('msg-1');
+  assert.equal(tracker.has('msg-1'), true);
+  assert.equal(tracker.has('msg-2'), false);
+});
+
+test('ignores empty / falsy ids', () => {
+  const tracker = createOutboundIdTracker();
+  tracker.remember(undefined);
+  tracker.remember('');
+  tracker.remember(null);
+  assert.equal(tracker.size(), 0);
+  assert.equal(tracker.has(''), false);
+  assert.equal(tracker.has(undefined), false);
+});
+
+test('evicts oldest entry once the cap is exceeded', () => {
+  const tracker = createOutboundIdTracker(3);
+  tracker.remember('a');
+  tracker.remember('b');
+  tracker.remember('c');
+  tracker.remember('d'); // cap=3 → 'a' should be evicted
+  assert.equal(tracker.has('a'), false);
+  assert.equal(tracker.has('b'), true);
+  assert.equal(tracker.has('c'), true);
+  assert.equal(tracker.has('d'), true);
+  assert.equal(tracker.size(), 3);
+});
+
+test('cap holds across many inserts (bounded memory)', () => {
+  const tracker = createOutboundIdTracker(8);
+  for (let i = 0; i < 100; i += 1) {
+    tracker.remember(`id-${i}`);
+  }
+  assert.equal(tracker.size(), 8);
+  // Oldest (id-0..id-91) should be gone, latest 8 retained.
+  assert.equal(tracker.has('id-0'), false);
+  assert.equal(tracker.has('id-91'), false);
+  assert.equal(tracker.has('id-92'), true);
+  assert.equal(tracker.has('id-99'), true);
+});
+
+test('re-remembering an existing id refreshes its position', () => {
+  // Insertion-order semantics: re-adding doesn't move it forward in
+  // Set iteration order. This is intentional — we don't need recency,
+  // just bounded membership.  Pin the actual behaviour so future
+  // refactors don't accidentally introduce LRU semantics.
+  const tracker = createOutboundIdTracker(2);
+  tracker.remember('a');
+  tracker.remember('b');
+  tracker.remember('a'); // no-op for ordering
+  tracker.remember('c'); // evicts 'a' (oldest by insertion)
+  assert.equal(tracker.has('a'), false);
+  assert.equal(tracker.has('b'), true);
+  assert.equal(tracker.has('c'), true);
+});

--- a/scripts/whatsapp-bridge/outbound_ids.test.mjs
+++ b/scripts/whatsapp-bridge/outbound_ids.test.mjs
@@ -46,11 +46,11 @@ test('cap holds across many inserts (bounded memory)', () => {
   assert.equal(tracker.has('id-99'), true);
 });
 
-test('re-remembering an existing id refreshes its position', () => {
+test('re-remembering an existing id does not promote it (FIFO, not LRU)', () => {
   // Insertion-order semantics: re-adding doesn't move it forward in
   // Set iteration order. This is intentional — we don't need recency,
   // just bounded membership.  Pin the actual behaviour so future
-  // refactors don't accidentally introduce LRU semantics.
+  // refactors don't accidentally introduce LRU refresh semantics.
   const tracker = createOutboundIdTracker(2);
   tracker.remember('a');
   tracker.remember('b');
@@ -59,4 +59,10 @@ test('re-remembering an existing id refreshes its position', () => {
   assert.equal(tracker.has('a'), false);
   assert.equal(tracker.has('b'), true);
   assert.equal(tracker.has('c'), true);
+});
+
+test('rejects non-positive maxSize', () => {
+  assert.throws(() => createOutboundIdTracker(0), RangeError);
+  assert.throws(() => createOutboundIdTracker(-1), RangeError);
+  assert.throws(() => createOutboundIdTracker(1.5), RangeError);
 });

--- a/scripts/whatsapp-bridge/owner_message_gate.js
+++ b/scripts/whatsapp-bridge/owner_message_gate.js
@@ -1,0 +1,56 @@
+/**
+ * Pure classifier for the WhatsApp bridge's bot-mode dispatch loop.
+ *
+ * Centralises the "should this fromMe message be forwarded as fromOwner?"
+ * decision so the gate can be unit-tested without spinning up Baileys or
+ * the Express server.
+ *
+ * Lives next to `outbound_ids.js` rather than inline in `bridge.js`
+ * because the previous implementation accidentally bypassed the
+ * customer-side allowlist when forwarding owner-typed messages — see
+ * the regression test in `owner_message_gate.test.mjs`.
+ *
+ * Caller responsibilities:
+ *   - Only invoke in bot mode. Self-chat mode has its own self-chat
+ *     pinning logic and must not delegate here.
+ *   - Pre-filter group / status JIDs (the gate doesn't know about them).
+ *   - On `drop_allowlist`, log the rejection so operators can audit
+ *     accidental allowlist mismatches.
+ *
+ * Returned actions:
+ *   - 'pass'           : non-fromMe, fall through to existing handling
+ *   - 'drop_echo'      : fromMe and matches a recently-sent /send id
+ *   - 'drop_disabled'  : fromMe but operator hasn't opted into forwarding
+ *   - 'drop_allowlist' : fromMe and the *customer chatId* isn't on the
+ *                        allowlist (owner-typed reply to a stranger)
+ *   - 'forward_owner'  : fromMe, owner-typed, allowlisted — forward with
+ *                        fromOwner: true
+ */
+
+export function classifyOwnerMessageGate({
+  fromMe,
+  fromOwnerEnabled,
+  recentlySent,
+  allowlistMatches,
+  messageId,
+  chatId,
+}) {
+  if (!fromMe) {
+    return { action: 'pass' };
+  }
+  if (recentlySent && recentlySent.has(messageId)) {
+    return { action: 'drop_echo' };
+  }
+  if (!fromOwnerEnabled) {
+    return { action: 'drop_disabled' };
+  }
+  // Allowlist gate: check the *customer* chatId, not the sender. The
+  // sender is the owner's own number/LID and won't be on the allowlist
+  // by construction. Without this check, any contact the owner happens
+  // to reply to leaks into Hermes and triggers implicit handover in the
+  // gateway-policy plugin.
+  if (typeof allowlistMatches === 'function' && !allowlistMatches(chatId)) {
+    return { action: 'drop_allowlist' };
+  }
+  return { action: 'forward_owner' };
+}

--- a/scripts/whatsapp-bridge/owner_message_gate.test.mjs
+++ b/scripts/whatsapp-bridge/owner_message_gate.test.mjs
@@ -1,0 +1,126 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { classifyOwnerMessageGate } from './owner_message_gate.js';
+
+function makeRecentlySent(ids = []) {
+  const set = new Set(ids);
+  return { has: (id) => set.has(id) };
+}
+
+function makeAllowlist(allowedChatIds) {
+  if (allowedChatIds === '*') {
+    return () => true;
+  }
+  const set = new Set(allowedChatIds);
+  return (id) => set.has(id);
+}
+
+test('non-fromMe messages always pass through', () => {
+  const decision = classifyOwnerMessageGate({
+    fromMe: false,
+    fromOwnerEnabled: true,
+    recentlySent: makeRecentlySent(),
+    allowlistMatches: makeAllowlist([]),
+    messageId: 'M1',
+    chatId: '6281234567890@s.whatsapp.net',
+  });
+  assert.deepEqual(decision, { action: 'pass' });
+});
+
+test('fromMe echo of our own /send is dropped', () => {
+  const decision = classifyOwnerMessageGate({
+    fromMe: true,
+    fromOwnerEnabled: true,
+    recentlySent: makeRecentlySent(['M-OWN-1']),
+    allowlistMatches: makeAllowlist('*'),
+    messageId: 'M-OWN-1',
+    chatId: '6281234567890@s.whatsapp.net',
+  });
+  assert.deepEqual(decision, { action: 'drop_echo' });
+});
+
+test('fromMe is dropped when forwarding is disabled', () => {
+  const decision = classifyOwnerMessageGate({
+    fromMe: true,
+    fromOwnerEnabled: false,
+    recentlySent: makeRecentlySent(),
+    allowlistMatches: makeAllowlist('*'),
+    messageId: 'M-OWN-2',
+    chatId: '6281234567890@s.whatsapp.net',
+  });
+  assert.deepEqual(decision, { action: 'drop_disabled' });
+});
+
+test('fromMe is dropped when chatId is not on the allowlist (regression)', () => {
+  // This is the bug. Before the fix, an owner reply in a non-allowlisted
+  // chat was still forwarded with fromOwner: true, which made the
+  // gateway-policy owner-implicit branch create stray handover rows for
+  // the non-allowlisted contact.
+  const decision = classifyOwnerMessageGate({
+    fromMe: true,
+    fromOwnerEnabled: true,
+    recentlySent: makeRecentlySent(),
+    allowlistMatches: makeAllowlist(['6281234567890@s.whatsapp.net']),
+    messageId: 'M-OWN-3',
+    chatId: '111600547700784@lid',
+  });
+  assert.deepEqual(decision, { action: 'drop_allowlist' });
+});
+
+test('fromMe is forwarded as owner when chatId is allowlisted', () => {
+  const decision = classifyOwnerMessageGate({
+    fromMe: true,
+    fromOwnerEnabled: true,
+    recentlySent: makeRecentlySent(),
+    allowlistMatches: makeAllowlist(['6281234567890@s.whatsapp.net']),
+    messageId: 'M-OWN-4',
+    chatId: '6281234567890@s.whatsapp.net',
+  });
+  assert.deepEqual(decision, { action: 'forward_owner' });
+});
+
+test('open-allowlist (matchesAllowedUser short-circuits true) forwards as owner', () => {
+  // matchesAllowedUser returns true on empty allowlist or "*"; the gate
+  // must respect that so deployments without an allowlist are unaffected
+  // by the new check.
+  const decision = classifyOwnerMessageGate({
+    fromMe: true,
+    fromOwnerEnabled: true,
+    recentlySent: makeRecentlySent(),
+    allowlistMatches: () => true,
+    messageId: 'M-OWN-5',
+    chatId: '111600547700784@lid',
+  });
+  assert.deepEqual(decision, { action: 'forward_owner' });
+});
+
+test('echo check fires before allowlist check', () => {
+  // A bot-API echo whose chatId happens to be off-allowlist should still
+  // be dropped as drop_echo, not drop_allowlist, so logging stays
+  // honest about the actual reason.
+  const decision = classifyOwnerMessageGate({
+    fromMe: true,
+    fromOwnerEnabled: true,
+    recentlySent: makeRecentlySent(['M-ECHO-1']),
+    allowlistMatches: makeAllowlist([]),
+    messageId: 'M-ECHO-1',
+    chatId: '111600547700784@lid',
+  });
+  assert.deepEqual(decision, { action: 'drop_echo' });
+});
+
+test('disabled flag fires before allowlist check', () => {
+  // Pre-existing deployments with WHATSAPP_FORWARD_OWNER_MESSAGES unset
+  // must see drop_disabled regardless of allowlist state, otherwise
+  // every fromMe message would log a misleading allowlist_mismatch.
+  const decision = classifyOwnerMessageGate({
+    fromMe: true,
+    fromOwnerEnabled: false,
+    recentlySent: makeRecentlySent(),
+    allowlistMatches: makeAllowlist([]),
+    messageId: 'M-OWN-6',
+    chatId: '111600547700784@lid',
+  });
+  assert.deepEqual(decision, { action: 'drop_disabled' });
+});

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -1,11 +1,12 @@
-"""Tests for WhatsApp owner-message metadata propagation.
+"""Tests for WhatsApp owner-message metadata and source-level text tagging.
 
 The Node bridge sets ``fromOwner: true`` on inbound `fromMe` messages that
 look owner-typed (linked-device send, not echoed from /send) when the
 operator opts into ``WHATSAPP_FORWARD_OWNER_MESSAGES``.  These tests pin
 the adapter's responsibility: lift that flag onto
-``MessageEvent.metadata["whatsapp_from_owner"]`` and otherwise leave it
-absent.  The env-var gate itself lives in the bridge — the adapter just
+``MessageEvent.metadata["whatsapp_from_owner"]``, prefix ``MessageEvent.text``
+with ``[owner reply] ``, and otherwise leave metadata absent and text
+unchanged.  The env-var gate itself lives in the bridge — the adapter just
 trusts the payload.
 """
 
@@ -64,6 +65,36 @@ def test_metadata_flag_set_when_payload_has_from_owner():
 
     assert event is not None
     assert event.metadata.get("whatsapp_from_owner") is True
+    assert event.text.startswith("[owner reply] ")
+    assert event.text == "[owner reply] hi from the linked phone"
+
+
+def test_from_owner_does_not_double_prefix_when_already_tagged():
+    adapter = _make_adapter()
+    payload = _dm_payload(
+        fromOwner=True,
+        body="[owner reply] already tagged",
+    )
+
+    event = asyncio.run(adapter._build_message_event(payload))
+
+    assert event is not None
+    assert event.metadata.get("whatsapp_from_owner") is True
+    assert event.text == "[owner reply] already tagged"
+
+
+def test_from_owner_prefixes_empty_body_for_uniform_media_placeholders():
+    """Owner media with empty caption still gets the marker (bridge may
+    substitute placeholders like ``[image received]`` upstream; empty stays
+    tagged for consistency)."""
+    adapter = _make_adapter()
+    payload = _dm_payload(fromOwner=True, body="")
+
+    event = asyncio.run(adapter._build_message_event(payload))
+
+    assert event is not None
+    assert event.metadata.get("whatsapp_from_owner") is True
+    assert event.text == "[owner reply] "
 
 
 def test_metadata_flag_absent_by_default():

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -1,0 +1,90 @@
+"""Tests for WhatsApp owner-message metadata propagation.
+
+The Node bridge sets ``fromOwner: true`` on inbound `fromMe` messages that
+look owner-typed (linked-device send, not echoed from /send) when the
+operator opts into ``WHATSAPP_FORWARD_OWNER_MESSAGES``.  These tests pin
+the adapter's responsibility: lift that flag onto
+``MessageEvent.metadata["whatsapp_from_owner"]`` and otherwise leave it
+absent.  The env-var gate itself lives in the bridge — the adapter just
+trusts the payload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.whatsapp import WhatsAppAdapter
+
+
+def _make_adapter():
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True)
+    adapter._message_handler = AsyncMock()
+    adapter._dm_policy = "open"
+    adapter._allow_from = set()
+    adapter._group_policy = "open"
+    adapter._group_allow_from = set()
+    adapter._mention_patterns = []
+    adapter._free_response_chats = set()
+    adapter._whatsapp_free_response_chats = lambda: set()
+    return adapter
+
+
+def _dm_payload(**overrides):
+    payload = {
+        "messageId": "M1",
+        "chatId": "6281234567890@s.whatsapp.net",
+        "senderId": "6281234567890@s.whatsapp.net",
+        "senderName": "Customer",
+        "chatName": "Customer",
+        "isGroup": False,
+        "body": "hi from the linked phone",
+        "hasMedia": False,
+        "mediaType": "",
+        "mediaUrls": [],
+        "mentionedIds": [],
+        "quotedParticipant": "",
+        "botIds": [],
+        "timestamp": 0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_metadata_flag_set_when_payload_has_from_owner():
+    adapter = _make_adapter()
+    payload = _dm_payload(fromOwner=True)
+
+    event = asyncio.run(adapter._build_message_event(payload))
+
+    assert event is not None
+    assert event.metadata.get("whatsapp_from_owner") is True
+
+
+def test_metadata_flag_absent_by_default():
+    """Default bridge payload (env flag off → field never present) must not
+    leak the metadata key.  Plugins use ``.get(...)`` and rely on absence."""
+    adapter = _make_adapter()
+    payload = _dm_payload()
+
+    event = asyncio.run(adapter._build_message_event(payload))
+
+    assert event is not None
+    assert "whatsapp_from_owner" not in event.metadata
+
+
+def test_metadata_flag_absent_when_explicitly_false():
+    """Explicit fromOwner=false must not set the metadata key — plugins
+    test for truthiness, but absence is the canonical "not owner" state."""
+    adapter = _make_adapter()
+    payload = _dm_payload(fromOwner=False)
+
+    event = asyncio.run(adapter._build_message_event(payload))
+
+    assert event is not None
+    assert "whatsapp_from_owner" not in event.metadata

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.whatsapp import WhatsAppAdapter
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
 
 def _make_adapter():


### PR DESCRIPTION
## Summary

`WHATSAPP_FORWARD_OWNER_MESSAGES` lets a bot-mode WhatsApp deployment forward owner-typed (`fromMe`) replies into Hermes — and those forwards are now bounded by the same `WHATSAPP_ALLOWED_USERS` allowlist as every other inbound. Default OFF; deployments without the flag see no behavior change.

Salvages #16445 (the feature) and #16485 (the allowlist gate) as one landing so the forward path ships secure-by-default rather than introducing the leak in one PR and patching it in the next.

## Changes

- `scripts/whatsapp-bridge/bridge.js` — opt-in forward of bot-mode `fromMe` inbounds with `fromOwner: true`, gated through the new classifier.
- `scripts/whatsapp-bridge/owner_message_gate.js` (new) — pure `classifyOwnerMessageGate()` returning `drop_echo` / `drop_disabled` / `drop_allowlist` / `forward_owner`. Gates on the **customer chatId** (not the owner's own senderId), and short-circuits to forward on an empty/`*` allowlist so open deployments are unaffected.
- `scripts/whatsapp-bridge/outbound_ids.js` (new) — bounded FIFO of sent message IDs to tell our own `/send` echoes apart from owner-typed sends.
- `plugins/platforms/whatsapp/adapter.py` — lifts `fromOwner` onto `MessageEvent.metadata["whatsapp_from_owner"]` and prefixes text with `[owner reply] ` so the marker survives downstream failures.
- `gateway/platforms/base.py` — adds free-form `MessageEvent.metadata` dict.
- Tests: `owner_message_gate.test.mjs`, `outbound_ids.test.mjs`, `tests/gateway/test_whatsapp_from_owner.py`.

## Root cause (the gap #16485 closes)

The bridge's allowlist gate lives under `if (!msg.key.fromMe)`, so the owner-forward path — which is a `fromMe` branch — never reached it. With the flag on, an owner reply in **any** chat the linked device had open (a friend, a vendor, another tenant's chat) was forwarded regardless of `WHATSAPP_ALLOWED_USERS`, widening the scope the allowlist is meant to bound.

## Validation

| Check | Result |
|---|---|
| `owner_message_gate.test.mjs` + `outbound_ids.test.mjs` (`node --test`) | 20/20 pass |
| `tests/gateway/test_whatsapp_from_owner.py` | 5/5 pass |
| E2E: owner→stranger chat | `drop_allowlist` ✓ |
| E2E: owner→allowlisted customer | `forward_owner` ✓ |
| E2E: bot echo (allowlisted) | `drop_echo` ✓ (echo precedence) |
| E2E: open allowlist `*` → stranger | `forward_owner` ✓ (no change for open deployments) |
| E2E: flag off | `drop_disabled` ✓ (default-off preserved) |

Cherry-picked with authorship preserved — @keiravoss94 (feature + gate), @vKongv (upstream-relocation fixes).

## Infographic

![WhatsApp owner-forward gate](https://v3b.fal.media/files/b/0aa05c30/RoqmI7fU2RvWIxr_0xios_gVHuzZTI.png)

Nous Research
