### PR TITLE
fix(kanban): unknown skill warns instead of crashing the worker

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15359,7 +15359,21 @@ def main(
         )
         if missing_skills:
             missing_display = ", ".join(missing_skills)
-            raise ValueError(f"Unknown skill(s): {missing_display}")
+            # If at least one skill loaded, degrade gracefully: skip the
+            # unknown ones and continue. A typo'd skill name should not crash
+            # the worker (which auto-blocks the Kanban task after retries).
+            # Only when EVERY requested skill is missing do we hard-fail, so a
+            # fully-misconfigured worker fails loudly instead of running blind.
+            if loaded_skills:
+                logger.warning(
+                    "Unknown skill(s) requested, skipping: %s. "
+                    "Continuing with: %s. "
+                    "List available skills with `hermes skills list`.",
+                    missing_display,
+                    ", ".join(loaded_skills),
+                )
+            else:
+                raise ValueError(f"Unknown skill(s): {missing_display}")
         if skills_prompt:
             cli.system_prompt = "\n\n".join(
                 part for part in (cli.system_prompt, skills_prompt) if part

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "193368749+jimmyjohansson84@users.noreply.github.com": "jimmyjohansson84",  # PR #27123 salvage (Kanban unknown-skill warn-instead-of-crash; #27136)
     "phanvanhoa@gmail.com": "theAgenticBuilder",  # PR #14180 salvage (route delegate_task progress lines through _safe_print so ACP stdio JSON-RPC frames stay clean)
     "huangxudong663@gmail.com": "huangxudong663-sys",  # PR #15157 salvage (isinstance(dict) guard on tool-call model_extra; NVIDIA NIM non-dict crash)
     "cypher@augmentl.com": "Nickperillo",  # PR #8008 salvage (Discord channel-name matching + flush pending sends on shutdown)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4212,12 +4212,25 @@ def _make_agent(
     if startup_skills:
         from agent.skill_commands import build_preloaded_skills_prompt
 
-        skills_prompt, _loaded_skills, missing_skills = build_preloaded_skills_prompt(
+        skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
             startup_skills,
             task_id=session_id or key,
         )
         if missing_skills:
-            raise ValueError(f"Unknown skill(s): {', '.join(missing_skills)}")
+            missing_display = ", ".join(missing_skills)
+            # Degrade gracefully when some skills loaded; only hard-fail when
+            # every requested skill is missing. Mirrors cli.py — a typo'd skill
+            # name should not crash the worker and auto-block the Kanban task.
+            if loaded_skills:
+                logger.warning(
+                    "Unknown skill(s) requested, skipping: %s. "
+                    "Continuing with: %s. "
+                    "List available skills with `hermes skills list`.",
+                    missing_display,
+                    ", ".join(loaded_skills),
+                )
+            else:
+                raise ValueError(f"Unknown skill(s): {missing_display}")
         if skills_prompt:
             system_prompt = "\n\n".join(
                 part for part in (system_prompt, skills_prompt) if part


### PR DESCRIPTION
## Summary
A Kanban worker no longer crashes when a task references a skill name that doesn't exist — it skips the unknown one, logs a warning, and continues with the valid skills.

Root cause: both `cli.py` and `tui_gateway/server.py` raised `ValueError` whenever `build_preloaded_skills_prompt` returned any missing skill. A single typo'd skill name in the task DB crashed the worker on startup → the dispatcher retried → after the failure limit the task auto-blocked and could never complete without manual intervention.

## Changes
- `cli.py` / `tui_gateway/server.py`: when some skills load successfully, skip the unknown ones with a `logger.warning(...)` and proceed. **Nuance added during salvage:** when *every* requested skill is missing (nothing loaded), still raise — a fully-misconfigured worker should fail loudly rather than run blind with no skills.
- `scripts/release.py`: AUTHOR_MAP entry for contributor credit.

## Validation
| Case | Before | After |
|---|---|---|
| Some skills valid, one typo'd | `ValueError`, worker crashes | warn + continue with valid skills |
| Every requested skill missing | `ValueError` | `ValueError` (unchanged — fail loud) |

E2E tested against the real `build_preloaded_skills_prompt` loader: partial-missing → warn+continue, all-missing → raise.

Salvaged from #27123 by @jimmyjohansson84. The PR's headline Gemini `systemInstruction` fix was already on `main`, and a bundled auto-assign feature was dropped (main has since added its own auto-assign path). This PR carries only the still-needed skill-warn fix.

Closes #27136

## Infographic
![Kanban unknown-skill warn-not-crash](https://v3b.fal.media/files/b/0aa05c56/qwKi83L_tl5gRV8iJ22UG_pTeyJTrv.png)

Nous Research
