### PR TITLE
fix(auth): add config.yaml model.api_key fallback for API-key providers

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -599,6 +599,28 @@ def _resolve_api_key_provider_secret(
     except Exception:
         pass
 
+    # Fallback: read api_key from config.yaml model section when env vars
+    # and credential pool come up empty — but ONLY when model.provider
+    # matches this provider_id.  This honours the credential-isolation
+    # contract (config.py clear_model_endpoint_credentials): model.api_key
+    # is valid only for the explicitly configured provider; a stale key
+    # left behind after switching providers must not leak to an unrelated
+    # one.  Fixes #55539 — Kanban worker subprocess sends Bearer None
+    # because _default_spawn doesn't pass --api-key on the command line.
+    try:
+        from hermes_cli.config import load_config
+        _cfg = load_config()
+        _model_cfg = (_cfg or {}).get("model") if isinstance(_cfg, dict) else None
+        if isinstance(_model_cfg, dict):
+            _cfg_provider = str(_model_cfg.get("provider") or "").strip().lower()
+            if _cfg_provider == provider_id:
+                for _k in ("api_key", "api"):
+                    _v = _model_cfg.get(_k)
+                    if isinstance(_v, str) and _v.strip():
+                        return _v.strip(), "config:model.api_key"
+    except Exception:
+        pass
+
     return "", ""
 
 
@@ -6342,24 +6364,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     key_source = ""
     api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
 
-    # Fallback: read api_key from config.yaml model section when env vars
-    # and credential pool come up empty.  Mirrors the cfg_api_key logic in
-    # _resolve_openrouter_runtime and _resolve_azure_foundry_runtime.
-    # Fixes #55539 — Kanban worker subprocess sends Bearer None because
-    # _default_spawn doesn't pass --api-key, so the secret resolver can
-    # only check env vars / credential pool.  Reading config.yaml ensures
-    # the profile's model.api_key is still picked up.
-    if not api_key:
-        from hermes_cli.config import load_config
-        _model_cfg = (load_config() or {}).get("model")
-        if isinstance(_model_cfg, dict):
-            for _k in ("api_key", "api"):
-                _v = _model_cfg.get(_k)
-                if isinstance(_v, str) and _v.strip():
-                    api_key = _v.strip()
-                    key_source = "config:model.api_key"
-                    break
-
+    # No-auth LM Studio
     # No-auth LM Studio: substitute a placeholder so runtime / auxiliary_client
     # see the local server as configured. doctor still reports unconfigured
     # because get_api_key_provider_status uses the raw secret resolver.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6342,6 +6342,24 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     key_source = ""
     api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
 
+    # Fallback: read api_key from config.yaml model section when env vars
+    # and credential pool come up empty.  Mirrors the cfg_api_key logic in
+    # _resolve_openrouter_runtime and _resolve_azure_foundry_runtime.
+    # Fixes #55539 — Kanban worker subprocess sends Bearer None because
+    # _default_spawn doesn't pass --api-key, so the secret resolver can
+    # only check env vars / credential pool.  Reading config.yaml ensures
+    # the profile's model.api_key is still picked up.
+    if not api_key:
+        from hermes_cli.config import load_config
+        _model_cfg = (load_config() or {}).get("model")
+        if isinstance(_model_cfg, dict):
+            for _k in ("api_key", "api"):
+                _v = _model_cfg.get(_k)
+                if isinstance(_v, str) and _v.strip():
+                    api_key = _v.strip()
+                    key_source = "config:model.api_key"
+                    break
+
     # No-auth LM Studio: substitute a placeholder so runtime / auxiliary_client
     # see the local server as configured. doctor still reports unconfigured
     # because get_api_key_provider_status uses the raw secret resolver.

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1305,3 +1305,104 @@ class TestMinimaxOAuthProvider:
             "doesn't fire the 'No auxiliary LLM provider configured' warning "
             "for every minimax-oauth session."
         )
+
+
+# =============================================================================
+# Regression tests for #55539 — config.yaml model.api_key fallback
+# =============================================================================
+
+
+class TestConfigApiKeyFallback:
+    """Verify that config.yaml model.api_key is used as a last-resort
+    fallback when env vars and credential pool are empty, but ONLY when
+    model.provider matches the requested provider (credential-isolation).
+    """
+
+    def test_config_api_key_used_when_provider_matches(self, monkeypatch):
+        """model.api_key from config.yaml must be picked up when
+        model.provider matches the requested provider — this is the
+        profile-scoped Kanban-worker scenario (#55539)."""
+        # Clear env vars so the fallback path is hit
+        for ev in ("MINIMAX_CN_API_KEY", "MINIMAX_API_KEY"):
+            monkeypatch.delenv(ev, raising=False)
+        # Mock credential pool to return empty
+        monkeypatch.setattr(
+            "agent.credential_pool.load_pool", lambda _pid: None,
+        )
+        # Mock load_config to return a minimax-cn profile config
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "provider": "minimax-cn",
+                    "api_key": "cfg-minimax-cn-key",
+                },
+            },
+        )
+        creds = resolve_api_key_provider_credentials("minimax-cn")
+        assert creds["api_key"] == "cfg-minimax-cn-key"
+        assert creds["source"] == "config:model.api_key"
+
+    def test_config_api_key_ignored_when_provider_mismatch(self, monkeypatch):
+        """model.api_key from config.yaml must NOT leak when model.provider
+        differs from the requested provider — cross-provider credential
+        isolation contract.  If config has provider: openrouter but we're
+        resolving minimax-cn, the openrouter key must not be used."""
+        # Clear env vars
+        for ev in ("MINIMAX_CN_API_KEY", "MINIMAX_API_KEY"):
+            monkeypatch.delenv(ev, raising=False)
+        # Mock credential pool to return empty
+        monkeypatch.setattr(
+            "agent.credential_pool.load_pool", lambda _pid: None,
+        )
+        # Mock load_config: provider is openrouter, but we're resolving minimax-cn
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "provider": "openrouter",
+                    "api_key": "openrouter-secret-key",
+                },
+            },
+        )
+        creds = resolve_api_key_provider_credentials("minimax-cn")
+        assert creds["api_key"] == "", (
+            "model.api_key from a different provider must not leak through"
+        )
+        assert creds["source"] == "default"
+
+    def test_config_api_key_env_var_takes_precedence(self, monkeypatch):
+        """Env var must still take precedence over config.yaml fallback."""
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "env-minimax-cn-key")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "provider": "minimax-cn",
+                    "api_key": "cfg-minimax-cn-key",
+                },
+            },
+        )
+        creds = resolve_api_key_provider_credentials("minimax-cn")
+        assert creds["api_key"] == "env-minimax-cn-key"
+
+    def test_config_api_key_alias_field(self, monkeypatch):
+        """model.api (alias for model.api_key) must also be picked up
+        when provider matches."""
+        for ev in ("DEEPSEEK_API_KEY",):
+            monkeypatch.delenv(ev, raising=False)
+        monkeypatch.setattr(
+            "agent.credential_pool.load_pool", lambda _pid: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "provider": "deepseek",
+                    "api": "cfg-deepseek-key-via-alias",
+                },
+            },
+        )
+        creds = resolve_api_key_provider_credentials("deepseek")
+        assert creds["api_key"] == "cfg-deepseek-key-via-alias"
+        assert creds["source"] == "config:model.api_key"


### PR DESCRIPTION
Fixes #55539

## Problem
Kanban worker subprocess sends Bearer None because _default_spawn does not pass --api-key, and _resolve_api_key_provider_secret only checks env vars and credential pool, never reading config.yaml model.api_key.

## Fix
Added config.yaml model.api_key fallback in resolve_api_key_provider_credentials, mirroring the existing cfg_api_key pattern in _resolve_openrouter_runtime and _resolve_azure_foundry_runtime.