### PR TITLE
fix(sms): use shared strip_markdown helper instead of broken duplicate

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -391,20 +391,6 @@ class SmsAdapter(BasePlatformAdapter):
 # ──────────────────────────────────────────────────────────────────────────
 
 
-def _strip_markdown_for_sms(message: str) -> str:
-    """Strip markdown — SMS renders it as literal characters."""
-    message = re.sub(r"\*\*(.+?)\*\*", r"\1", message, flags=re.DOTALL)
-    message = re.sub(r"\*(.+?)\*", r"\1", message, flags=re.DOTALL)
-    message = re.sub(r"__(.+?)__", r"\1", message, flags=re.DOTALL)
-    message = re.sub(r"_(.+?)_", r"\1", message, flags=re.DOTALL)
-    message = re.sub(r"```[a-z]*\n?", "", message)
-    message = re.sub(r"`(.+?)`", r"\1", message)
-    message = re.sub(r"^#{1,6}\s+", "", message, flags=re.MULTILINE)
-    message = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", message)
-    message = re.sub(r"\n{3,}", "\n\n", message)
-    return message.strip()
-
-
 async def _standalone_send(
     pconfig,
     chat_id,
@@ -428,7 +414,7 @@ async def _standalone_send(
     if not account_sid or not auth_token or not from_number:
         return {"error": "SMS not configured (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER required)"}
 
-    message = _strip_markdown_for_sms(message)
+    message = strip_markdown(message)
 
     def _redacted_error(text):
         try:


### PR DESCRIPTION
## Summary

The SMS (Twilio) adapter's `_standalone_send` function was calling a duplicate `_strip_markdown_for_sms` function that was missing the required `re` import, causing a `NameError: name 're' is not defined` at runtime.

## Root Cause

When the SMS adapter was migrated from `gateway/platforms/sms.py` to the plugins directory (`plugins/platforms/sms/adapter.py`), a local copy of the markdown stripping function was created (`_strip_markdown_for_sms`). However, this copy was missing the `import re` statement that the original function relied on from the module scope.

Meanwhile, a shared `strip_markdown` helper already existed in `gateway.platforms.helpers` and was **already imported** at the top of the adapter file (line 37):
```python
from gateway.platforms.helpers import redact_phone, strip_markdown
```

## Solution

Removed the broken duplicate function and replaced its usage with the shared `strip_markdown` helper from `gateway.platforms.helpers`. This:
1. Fixes the `NameError` bug
2. Eliminates code duplication 
3. Ensures consistent markdown stripping across all platforms (SMS, iMessage/BlueBubbles, Feishu, etc.)

## Testing

- All 39 existing SMS adapter tests pass
- All 149 send_message_tool tests pass  
- Linter passes
- Manual verification confirms the function no longer crashes and correctly strips markdown

## Related Issue

Fixes #55379