### PR TITLE
fix(state): surface live compression tip when root is archived (#55588)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2679,9 +2679,20 @@ class SessionDB:
         if min_message_count > 0:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
+        # When projecting compression tips, defer the archive filter to
+        # post-projection so archived compression roots can still seed the
+        # chain walk.  Without this, an archived root is filtered out at
+        # SQL level, its live (non-archived) tip never gets projected, and
+        # the entire conversation disappears from the listing.  (Issue #55588)
+        _defer_archive = (
+            project_compression_tips
+            and not include_children
+            and not include_archived
+            and not archived_only
+        )
         if archived_only:
             where_clauses.append("s.archived = 1")
-        elif not include_archived:
+        elif not include_archived and not _defer_archive:
             where_clauses.append("s.archived = 0")
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
@@ -2840,12 +2851,22 @@ class SessionDB:
                     "id", "ended_at", "end_reason", "message_count",
                     "tool_call_count", "title", "last_active", "preview",
                     "model", "system_prompt", "cwd", "git_branch", "git_repo_root",
+                    "archived",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]
+                # Ensure archived is always set (tip_row may lack it for
+                # very old sessions without the column default).
+                merged.setdefault("archived", s.get("archived", 0))
                 merged["_lineage_root_id"] = s["id"]
                 projected.append(merged)
             sessions = projected
+
+        # Post-projection archive filter: when the archive filter was deferred
+        # to let archived roots seed the compression chain walk, remove
+        # sessions whose projected tip is archived.  (Issue #55588)
+        if _defer_archive:
+            sessions = [s for s in sessions if not s.get("archived")]
 
         return sessions
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3565,6 +3565,80 @@ class TestCompressionChainProjection:
         assert row["end_reason"] == "compression"
 
 
+    def test_list_surfaces_tip_when_root_archived(self, db):
+        """When only the compression root is archived, the live (non-archived)
+        tip must still appear in the default session list.
+
+        Regression test for #55588: the archive filter at SQL level removed
+        the archived root before the projection logic could walk the chain,
+        hiding the entire conversation.
+        """
+        import time as _time
+        t0 = _time.time() - 3600
+        root_id, _, _, tip_id = self._build_compression_chain(db, t0)
+
+        # Archive only the root (not the tip) to simulate the issue state.
+        db._conn.execute(
+            "UPDATE sessions SET archived = 1 WHERE id = ?", (root_id,)
+        )
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        ids = [s["id"] for s in sessions]
+
+        # The tip (projected from the archived root) must be visible.
+        assert tip_id in ids
+        # The archived root must NOT appear raw.
+        assert root_id not in ids
+
+        tip_row = next(s for s in sessions if s["id"] == tip_id)
+        assert tip_row["_lineage_root_id"] == root_id
+        # The projected row carries the tip's archived status (0), not the
+        # root's (1).
+        assert tip_row["archived"] == 0
+
+    def test_list_hides_chain_when_tip_archived(self, db):
+        """When the tip is archived (and root via cascade), the entire chain
+        must be hidden from the default list.
+        """
+        import time as _time
+        t0 = _time.time() - 3600
+        root_id, _, _, tip_id = self._build_compression_chain(db, t0)
+
+        # Archive the tip — set_session_archived cascades to the root.
+        db.set_session_archived(tip_id, True)
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        ids = [s["id"] for s in sessions]
+
+        assert tip_id not in ids
+        assert root_id not in ids
+
+    def test_list_shows_archived_chain_with_include_archived(self, db):
+        """With include_archived=True, archived compression chains are
+        visible and projected correctly.
+        """
+        import time as _time
+        t0 = _time.time() - 3600
+        root_id, _, _, tip_id = self._build_compression_chain(db, t0)
+
+        db._conn.execute(
+            "UPDATE sessions SET archived = 1 WHERE id = ?", (root_id,)
+        )
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(
+            source="cli", limit=20, include_archived=True
+        )
+        ids = [s["id"] for s in sessions]
+
+        assert tip_id in ids
+        assert root_id not in ids
+
+        tip_row = next(s for s in sessions if s["id"] == tip_id)
+        assert tip_row["_lineage_root_id"] == root_id
+
+
 # =========================================================================
 # Session source exclusion (--source flag for third-party isolation)
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where compression chain sessions disappear from the session list (sidebar, `hermes sessions list`, API) when the root session is archived but the live tip is not.

When a conversation undergoes 2+ context compressions, the compression chain's root session can have `archived=1` while the live tip has `archived=0`. The SQL `archived=0` filter in `list_sessions_rich()` removed the archived root before the projection logic could walk the chain, so the live tip was never projected and the entire conversation vanished from the listing.

## Related Issue

Fixes #55588

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_state.py`**: Defer the `archived=0` SQL filter to post-projection when `project_compression_tips=True` and `not include_children`. This lets archived compression roots seed the chain walk so their live tips get projected. Added `"archived"` to the projection merge keys so the tip's archive status replaces the root's. Added a post-projection filter to remove sessions whose projected tip is archived.
- **`tests/test_hermes_state.py`**: Added 3 regression tests in `TestCompressionChainProjection`:
  - `test_list_surfaces_tip_when_root_archived`: verifies the live tip appears when only the root is archived
  - `test_list_hides_chain_when_tip_archived`: verifies the entire chain is hidden when the tip is archived (via cascade)
  - `test_list_shows_archived_chain_with_include_archived`: verifies `include_archived=True` shows the projected chain correctly

## How to Test

1. Run `pytest tests/test_hermes_state.py::TestCompressionChainProjection -x -q` — all 14 tests should pass (11 existing + 3 new).
2. Run `pytest tests/hermes_state/test_session_archiving.py -x -q` — both existing archiving tests should pass.
3. Run `pytest tests/test_hermes_state.py -x -q` — all 301 tests should pass.
4. Manual verification: create a compression chain, archive only the root via direct SQL (`UPDATE sessions SET archived=1 WHERE id='root_session_id'`), then call `list_sessions_rich()` — the live tip should appear with `archived=0`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (SQLite-level change, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix:
```
$ hermes sessions list | grep "自由探索"
# (no output — entire compression chain hidden)
```

After fix:
```
$ hermes sessions list | grep "自由探索 #2"
自由探索 #2  |  我现在就是在用0.17.0跟你对话... | 14m ago | 20260630_134304_d28011
```
