### PR TITLE
fix(kanban): strip parent credentials from worker env

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7686,17 +7686,22 @@ def _default_spawn(
     profile_arg = normalize_profile_name(task.assignee)
 
     prompt = f"work kanban task {task.id}"
-    env = dict(os.environ)
+    from tools.environments.local import hermes_subprocess_env
+    env = hermes_subprocess_env(inherit_credentials=False)
+    for key in list(env):
+        if key == "GATEWAY_RELAY_SECRET" or key.startswith("GATEWAY_RELAY_"):
+            env.pop(key, None)
+            continue
+        if key.startswith("AUXILIARY_") and (
+            key.endswith("_API_KEY") or key.endswith("_BASE_URL")
+        ):
+            env.pop(key, None)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root
-    # config.  Without this, `env = dict(os.environ)` copies only the parent's
-    # env, and when the child process starts `hermes -p <name>` the
-    # _apply_profile_override() runs *before* hermes_constants is imported.
-    # If HERMES_HOME is absent from the child's env, get_hermes_home() falls
-    # back to Path.home() / ".hermes" (the DEFAULT profile root), ignoring the
-    # profile-specific config entirely.  Fixes profile-scoped fallback_providers
-    # being invisible to kanban workers.
+    # config.  Build from the centralized sanitized subprocess env first so the
+    # worker does not inherit provider/gateway credentials from the dispatching
+    # profile, then pin only the target profile and kanban routing variables.
     from hermes_cli.profiles import resolve_profile_env
     try:
         env["HERMES_HOME"] = resolve_profile_env(profile_arg)

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -429,6 +429,54 @@ class TestWorkerSpawnEnv:
         expected_ws = fresh_home / "kanban" / "boards" / "spawntest" / "workspaces"
         assert env["HERMES_KANBAN_WORKSPACES_ROOT"] == str(expected_ws)
 
+    def test_default_spawn_strips_parent_profile_credentials(self, fresh_home, monkeypatch):
+        captured = {}
+
+        class FakeProc:
+            pid = 12345
+
+        def fake_popen(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env", {})
+            return FakeProc()
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+        monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", lambda _home: None)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-parent-profile")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-parent-profile")
+        monkeypatch.setenv("AUXILIARY_VISION_API_KEY", "sk-aux-parent-profile")
+        monkeypatch.setenv("GATEWAY_RELAY_SECRET", "relay-parent-profile")
+        kb.create_board("spawntest")
+
+        task = kb.Task(
+            id="t_secret",
+            title="worker test",
+            body=None,
+            assignee="teknium",
+            status="ready",
+            priority=0,
+            created_by="user",
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+        )
+
+        kb._default_spawn(task, str(fresh_home / "ws"), board="spawntest")
+
+        env = captured["env"]
+        assert env["HERMES_PROFILE"] == "teknium"
+        assert env["HERMES_KANBAN_TASK"] == "t_secret"
+        assert "OPENAI_API_KEY" not in env
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "AUXILIARY_VISION_API_KEY" not in env
+        assert "GATEWAY_RELAY_SECRET" not in env
+
     def test_default_board_spawn_keeps_legacy_paths(self, fresh_home, monkeypatch):
         captured = {}
 


### PR DESCRIPTION
## Summary

This prevents Kanban worker subprocesses from inheriting provider and gateway credentials from the dispatching process environment.

`_default_spawn()` launches workers for the assignee profile by setting `HERMES_HOME` / `HERMES_PROFILE`, but it previously started from `dict(os.environ)`. Because Hermes credential resolution checks process env before the profile `.env`, a worker intended to run under one profile could still see provider keys and internal gateway secrets from the dispatcher/default profile.

## Why

Kanban workers are profile-scoped subprocesses. Their config, auth state, and `.env` should come from the assignee profile, not from whichever gateway/CLI process happened to dispatch the task.

Before this change, a dispatcher process containing values such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `AUXILIARY_*_API_KEY`, or `GATEWAY_RELAY_SECRET` passed those values straight into the worker env. That can cause wrong-profile credential use and leaks internal gateway routing secrets into an unrelated worker process.

## Changes

- Build Kanban worker env from `hermes_subprocess_env(inherit_credentials=False)` instead of raw `os.environ`.
- Keep the existing worker-specific pins for `HERMES_HOME`, `HERMES_PROFILE`, `HERMES_KANBAN_*`, workspace, branch, and runtime settings.
- Strip dynamic Hermes internal secrets (`AUXILIARY_*_API_KEY`, `AUXILIARY_*_BASE_URL`, `GATEWAY_RELAY_*`) from the worker env.
- Add regression coverage proving parent profile credentials do not reach `_default_spawn()` workers.

## Tests

```text
python -m pytest tests/hermes_cli/test_kanban_boards.py -k "default_spawn" -q --timeout-method=thread
2 passed, 55 deselected

python -m pytest tests/hermes_cli/test_kanban_db.py -k "dispatcher_spawn_injects_kanban_db_and_workspaces_root" -q --timeout-method=thread
1 passed, 222 deselected

python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -k "default_spawn" -q --timeout-method=thread
6 passed, 163 deselected

python -m pytest tests/hermes_cli/test_kanban_worker_spawn_toolsets.py -q --timeout-method=thread
2 passed