### PR TITLE
fix(qqbot): raise on silent loop exit to keep _listen_loop consistent

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -702,6 +702,19 @@ class QQAdapter(BasePlatformAdapter):
             elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
                 raise RuntimeError("WebSocket closed")
 
+        # while loop exited without raising — ws closed externally between
+        # the loop condition check and `receive()` (e.g. during handshake).
+        # Without this guard, `_listen_loop` sees a normal return, resets
+        # `backoff_idx` to 0 on the next line, and re-enters `_read_events`
+        # which exits again immediately — wasting an iteration and erasing
+        # any backoff the reconnect path had earned. See issue #55492 for
+        # the diagnostic; mirrors the WeCom post-loop guard in PR #55486
+        # so all websocket adapters handle silent loop exits uniformly.
+        if self._running:
+            raise RuntimeError(
+                "QQBot WebSocket closed (loop exit without error frame)"
+            )
+
     async def _heartbeat_loop(self) -> None:
         """Send periodic heartbeats (QQ Gateway expects op 1 heartbeat with latest seq).
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2220,3 +2220,45 @@ class TestReadEventsClosedWsGuard:
         adapter._ws = None
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
+
+    def test_read_events_raises_after_silent_loop_exit(self):
+        """Regression: ws closing mid-loop (between condition and receive) must
+        surface as a RuntimeError, not a silent return that erases backoff.
+
+        Issue #55492: `_listen_loop` resets `backoff_idx = 0` immediately
+        after `await self._read_events()` returns. If the receive loop exits
+        without raising, the next iteration would re-enter and exit again
+        — burning accumulated backoff without sleeping.
+
+        Mirrors the WeCom post-loop guard in PR #55486 for consistency
+        across websocket adapters (gateway/platforms/wecom/adapter.py).
+        """
+        # `aiohttp` is a real runtime dep of the adapter, but tests in this
+        # repo may run in environments where the import isn't resolved by
+        # the Pyright/pytest stub. Fall back to a sentinel int that the
+        # adapter's elif-chain simply ignores (PING branch is `pass`, the
+        # only one that doesn't need any extra attribute on the message).
+        try:
+            import aiohttp as _aio
+            ping_type = _aio.WSMsgType.PING
+        except ImportError:  # pragma: no cover - safety net for local envs
+            ping_type = 0x09  # aiohttp.WSMsgType.PING
+
+        adapter = self._make_adapter()
+
+        class _FakeWs:
+            # Mutable `closed` so the first iteration enters the loop
+            # (`closed=False`), the second sees it flipped to True after
+            # `receive()` returns — exactly the race issue #55492 describes.
+            def __init__(self):
+                self.closed = False
+
+            async def receive(self):
+                self.closed = True  # external close between checks
+                # PING is the most inert branch — no parsing, no raise.
+                return SimpleNamespace(type=ping_type)
+
+        adapter._running = True
+        adapter._ws = _FakeWs()
+        with pytest.raises(RuntimeError, match="loop exit without error frame"):
+            asyncio.run(adapter._read_events())


### PR DESCRIPTION
## Summary

Adds a post-loop `if self._running: raise` guard to `QQAdapter._read_events()` in `gateway/platforms/qqbot/adapter.py`, mirroring the WeCom fix in PR #55486 so all websocket adapters handle silent loop exits uniformly.

---

## Why This Is Needed

QQBot's pre-existing pre-entry guard correctly raises when `self._ws.closed` is `True` at function entry. But if the websocket transitions to `closed=True` between the `while`-condition check and `await self._ws.receive()` (a mid-loop race), the loop exits without raising. `_listen_loop` interprets this as a normal return and immediately resets `backoff_idx = 0`, erasing any reconnect backoff the loop had earned before re-entering `_read_events`.

This is the same silent-loop-exit race diagnosed for WeCom in #55487, just with a pre-entry guard already present — so the busy-loop symptom is mitigated, but the backoff-burning iteration remains. Adding the missing post-loop guard makes the QQBot and WeCom websocket adapters handle the race identically.

---

## Changes

**File:** `gateway/platforms/qqbot/adapter.py`
- `_read_events` adds a post-loop `raise` guard identical in shape to the WeCom fix in PR #55486.

**File:** `tests/gateway/test_qqbot.py`
- New `TestReadEventsClosedWsGuard::test_read_events_raises_after_silent_loop_exit` — drives a fake ws into a mid-loop close via a PING frame that doesn't trigger the elif chain; asserts `RuntimeError` is raised.

---

## How to Test

```bash
PYTHONPATH=. pytest -q tests/gateway/test_qqbot.py -o 'addopts='
```

✅ 162 passed, 0 failed (the two existing `TestReadEventsClosedWsGuard` tests + this one + the rest of the qqbot suite)

---

## Checklist

- [x] Tested on Ubuntu 24.04 (Linux/WSL), Python 3.11
- [x] Follows Conventional Commits
- [x] No unrelated changes — only `gateway/platforms/qqbot/adapter.py` and `tests/gateway/test_qqbot.py` touched

---

## Risk & Impact

**Low.** The added guard fires only on the previously-unhandled mid-loop race; the existing pre-entry guard and normal loop exit paths are unchanged. Brings QQBot in line with the already-merged WeCom fix (#55486), eliminating the backoff-burning iteration on reconnect.

**Type:** 🐛 Bug fix
**Fixes:** #55492