### PR TITLE
fix(tui): update streaming with full text on message.complete to prevent scroll flash

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -380,7 +380,7 @@ describe('createGatewayEventHandler', () => {
     }
   })
 
-  it('ignores late thinking.delta after the turn has already completed', () => {
+  it('ignores late thinking.delta after the turn has already completed', async () => {
     vi.useFakeTimers()
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))
@@ -388,6 +388,10 @@ describe('createGatewayEventHandler', () => {
     try {
       onEvent({ payload: {}, type: 'message.start' } as any)
       onEvent({ payload: { text: 'final answer' }, type: 'message.complete' } as any)
+      // recordMessageComplete defers idle()/busy=false to the next microtask
+      // so the streaming block stays rendered for the commit that appends the
+      // committed message (#55425). Flush that microtask before asserting.
+      await Promise.resolve()
       expect(getUiState().busy).toBe(false)
       expect(getUiState().status).toBe('ready')
 
@@ -1581,7 +1585,7 @@ describe('createGatewayEventHandler', () => {
       })
     })
 
-    it('holds a notice arriving mid-turn (busy) and flushes it at message.complete', () => {
+    it('holds a notice arriving mid-turn (busy) and flushes it at message.complete', async () => {
       const onEvent = createGatewayEventHandler(buildCtx([]))
 
       onEvent({ payload: {}, type: 'message.start' } as any)
@@ -1596,6 +1600,11 @@ describe('createGatewayEventHandler', () => {
       expect(getUiState().notice).toBeNull()
 
       onEvent({ payload: { text: 'done' }, type: 'message.complete' } as any)
+
+      // recordMessageComplete defers idle()/flushPendingNotice() to the next
+      // microtask so the streaming block stays rendered for the commit that
+      // appends the committed message (#55425). Flush it before asserting.
+      await Promise.resolve()
 
       // Turn end flushes the held notice.
       expect(getUiState().notice).toMatchObject({ key: 'credits.90', text: '⚠ 90% used' })
@@ -1646,7 +1655,7 @@ describe('createGatewayEventHandler', () => {
       expect(getUiState().notice).toMatchObject({ key: 'credits.90', text: '⚠ 90% used' })
     })
 
-    it('latest-wins: a second mid-turn notice replaces the first held one', () => {
+    it('latest-wins: a second mid-turn notice replaces the first held one', async () => {
       const onEvent = createGatewayEventHandler(buildCtx([]))
 
       onEvent({ payload: {}, type: 'message.start' } as any)
@@ -1660,6 +1669,11 @@ describe('createGatewayEventHandler', () => {
       } as any)
 
       onEvent({ payload: { text: 'done' }, type: 'message.complete' } as any)
+
+      // recordMessageComplete defers idle()/flushPendingNotice() to the next
+      // microtask so the streaming block stays rendered for the commit that
+      // appends the committed message (#55425). Flush it before asserting.
+      await Promise.resolve()
 
       // Only the latest held notice surfaces.
       expect(getUiState().notice).toMatchObject({ key: 'credits.depleted', text: '✕ exhausted' })
@@ -1760,7 +1774,7 @@ describe('createGatewayEventHandler', () => {
       }
     })
 
-    it('starts the ttl clock when the notice becomes VISIBLE (at turn end), not on arrival', () => {
+    it('starts the ttl clock when the notice becomes VISIBLE (at turn end), not on arrival', async () => {
       vi.useFakeTimers()
 
       try {
@@ -1777,6 +1791,10 @@ describe('createGatewayEventHandler', () => {
         expect(getUiState().notice).toBeNull()
 
         onEvent({ payload: { text: 'done' }, type: 'message.complete' } as any)
+        // recordMessageComplete defers idle()/flushPendingNotice() to the next
+        // microtask so the streaming block stays rendered for the commit that
+        // appends the committed message (#55425). Flush it before asserting.
+        await Promise.resolve()
         expect(getUiState().notice).toMatchObject({ key: 'credits.restored' })
 
         // Full 8s starts now (on apply), so it survives nearly that long.

--- a/ui-tui/src/__tests__/turnControllerStreamingComplete.test.ts
+++ b/ui-tui/src/__tests__/turnControllerStreamingComplete.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { turnController } from '../app/turnController.js'
+import { getTurnState, resetTurnState } from '../app/turnStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
+
+// Regression for issue #55425 — "TUI: Long responses flash — earlier content
+// disappears, only tail visible".  When a long streaming response lands,
+// `message.complete` must defer clearing the live streaming state until AFTER
+// the committed messages are appended to the transcript.  Synchronously
+// calling `idle()` first produced a frame where the live area was empty AND
+// the committed message had not yet mounted, so the ScrollBox snapped to a
+// smaller scrollHeight and yanked the viewport off the content the user was
+// reading.  See turnController.recordMessageComplete for the full reasoning.
+describe('turnController.recordMessageComplete — streaming state cleared after the append', () => {
+  beforeEach(() => {
+    resetUiState()
+    resetTurnState()
+    turnController.fullReset()
+  })
+
+  afterEach(() => {
+    turnController.fullReset()
+  })
+
+  it('keeps streaming state set synchronously, then clears on the next microtask', async () => {
+    turnController.startMessage()
+    patchUiState({ busy: true })
+    turnController.hydrateStreamingText('Hello, world. Another chunk.')
+    expect(getTurnState().streaming).toBe('Hello, world. Another chunk.')
+    expect(getUiState().busy).toBe(true)
+
+    const result = turnController.recordMessageComplete({ text: 'Hello, world. Another chunk.' })
+
+    // finalMessages is still returned synchronously so the caller can append.
+    expect(result.finalText).toBe('Hello, world. Another chunk.')
+    expect(result.wasInterrupted).toBe(false)
+
+    // The streaming-clear is DEFERRED — the live area should still be
+    // populated for the React commit that adds the committed message, so the
+    // ScrollBox's scrollHeight stays stable across the transition.
+    expect(getTurnState().streaming).toBe('Hello, world. Another chunk.')
+    expect(getUiState().busy).toBe(true)
+
+    // After yielding the microtask queue, idle() has run and the live state
+    // is back to the baseline.
+    await Promise.resolve()
+    expect(getTurnState().streaming).toBe('')
+    expect(getTurnState().streamSegments).toEqual([])
+    expect(getUiState().busy).toBe(false)
+  })
+
+  it('updates streaming to full payload text when boundedLiveRenderText truncated it', async () => {
+    turnController.startMessage()
+    patchUiState({ busy: true })
+    // Simulate boundedLiveRenderText having truncated the streaming text
+    // (e.g. LIVE_RENDER_MAX_CHARS = 16_000) by setting a truncated value.
+    turnController.hydrateStreamingText('[showing live tail; omitted 1K lines / 12K chars]\n...final tail only')
+    expect(getTurnState().streaming).toBe('[showing live tail; omitted 1K lines / 12K chars]\n...final tail only')
+
+    // The payload text is the full, untruncated response.
+    // Note: repeat(500) means the last phrase has no trailing space, so splitReasoning's
+    // text.trim() produces a string equal to the original (no trailing space to strip).
+    const phrase = 'The full response text that was originally long enough to be truncated.'
+    const fullLongText = phrase.repeat(500)
+    const result = turnController.recordMessageComplete({ text: fullLongText })
+
+    // Synchronously, streaming is updated to the FULL payload text (not the
+    // truncated version) so the streaming area height matches the committed
+    // message during the transition frame. Note: splitReasoning trims the
+    // result, so the stored text is fullLongText trimmed (no trailing space).
+    expect(getTurnState().streaming).toBe(fullLongText.trim())
+    expect(result.wasInterrupted).toBe(false)
+
+    // Microtask still clears as usual.
+    await Promise.resolve()
+    expect(getTurnState().streaming).toBe('')
+    expect(getTurnState().streamSegments).toEqual([])
+    expect(getUiState().busy).toBe(false)
+  })
+
+  it('skips streaming update when final text is empty (reasoning-only response)', async () => {
+    turnController.startMessage()
+    patchUiState({ busy: true })
+    turnController.hydrateStreamingText('Some previous streaming text')
+    expect(getTurnState().streaming).toBe('Some previous streaming text')
+
+    // A reasoning-only payload with no visible text.
+    const result = turnController.recordMessageComplete({
+      text: '',
+      reasoning: 'Just thinking, no visible output'
+    })
+
+    // The streaming text should remain unchanged (no empty override).
+    // The existing streaming text stays visible until the microtask clears it.
+    expect(getTurnState().streaming).toBe('Some previous streaming text')
+    expect(result.wasInterrupted).toBe(false)
+
+    await Promise.resolve()
+    expect(getTurnState().streaming).toBe('')
+  })
+
+  it('still cleans up synchronously when the turn was interrupted', () => {
+    turnController.startMessage()
+    patchUiState({ busy: true })
+    turnController.hydrateStreamingText('partial response…')
+    turnController.interruptTurn({
+      appendMessage: () => {},
+      gw: { request: () => Promise.resolve({} as never) },
+      sid: 'test',
+      sys: () => {}
+    })
+
+    // After interrupt, streaming is already cleared — recordMessageComplete
+    // (if it even fires) should not re-trigger the microtask deferral since
+    // wasInterrupted is true.
+    expect(getTurnState().streaming).toBe('')
+    expect(getUiState().busy).toBe(false)
+  })
+})

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -580,6 +580,22 @@ class TurnController {
     // review: duplicate-message blocker)
     const dedupeStart = payload.response_previewed ? 0 : (this.interimBoundaryIndex ?? 0)
     const finalText = finalTail(split.text, this.segmentMessages.slice(dedupeStart))
+
+    // Patch streaming with the full (non-truncated, non-deduped) payload
+    // text so the streaming area matches the committed message's height
+    // during the transition frame.  Without this, boundedLiveRenderText
+    // (called by scheduleStreaming) may have truncated the streaming text
+    // to LIVE_RENDER_MAX_CHARS/LIVE_RENDER_MAX_LINES, producing a
+    // streaming area that is shorter than the committed history message.
+    // When queueMicrotask(idle) clears the streaming area one frame later,
+    // the height mismatch causes the ScrollBox to snap, yanking the
+    // viewport and making earlier content appear to vanish (#55425).
+    //
+    // Only patch when the turn wasn't interrupted — during interrupt the
+    // streaming state is already being torn down by interruptTurn().
+    if (!this.interrupted && split.text) {
+      patchTurnState({ streaming: split.text, streamingIsFull: true })
+    }
     const existingReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
     const savedReasoning = [existingReasoning, existingReasoning ? '' : split.reasoning].filter(Boolean).join('\n\n')
     const savedToolTokens = this.toolTokenAcc
@@ -651,17 +667,44 @@ class TurnController {
       void this.persistSpawnTree?.(finishedSubagents, sessionId)
     }
 
-    this.idle()
-    this.clearReasoning()
-    this.turnTools = []
-    this.persistedToolLabels.clear()
-    this.bufRef = ''
-    this.interrupted = false
-    patchTurnState({ activity: [], outcome: '' })
-
-    // Real turn end: surface any notice held back while busy. Done after
-    // idle() flips busy=false so applyNotice() reaches the visible slot.
-    this.flushPendingNotice()
+    // Defer clearing the live streaming state until AFTER the caller has
+    // appended the committed messages to history.  This was the root cause
+    // of the "long response flash" (#55425): the streaming block unmounted
+    // in one React commit while the committed message landed in a separate
+    // commit, producing a frame where the live area was empty and the
+    // ScrollBox snapped to a smaller scrollHeight — yanking the viewport
+    // off the content the user was reading.  Keeping `streaming`,
+    // `streamSegments`, etc. set until the next microtask lets
+    // `appendMessage`'s `setHistoryItems` and the streaming-clear
+    // `patchTurnState` settle in the same React batch via concurrent-mode
+    // automatic batching of the gateway event handler.
+    //
+    // The streaming block will keep rendering its (now-frozen) final text
+    // for one extra commit — visually identical to the committed message
+    // and only on screen for a single frame.
+    if (!wasInterrupted) {
+      queueMicrotask(() => {
+        this.idle()
+        this.clearReasoning()
+        this.turnTools = []
+        this.persistedToolLabels.clear()
+        this.bufRef = ''
+        this.interrupted = false
+        patchTurnState({ activity: [], outcome: '' })
+        // Real turn end: surface any notice held back while busy. Done after
+        // idle() flips busy=false so applyNotice() reaches the visible slot.
+        this.flushPendingNotice()
+      })
+    } else {
+      this.idle()
+      this.clearReasoning()
+      this.turnTools = []
+      this.persistedToolLabels.clear()
+      this.bufRef = ''
+      this.interrupted = false
+      patchTurnState({ activity: [], outcome: '' })
+      this.flushPendingNotice()
+    }
 
     return { finalMessages, finalText, wasInterrupted }
   }

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -281,6 +281,7 @@ class TurnController {
       streamPendingTools: [],
       streamSegments: [],
       streaming: '',
+      streamingIsFull: false,
       subagents: [],
       tools: [],
       turnTrail: []
@@ -596,6 +597,7 @@ class TurnController {
     if (!this.interrupted && split.text) {
       patchTurnState({ streaming: split.text, streamingIsFull: true })
     }
+
     const existingReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
     const savedReasoning = [existingReasoning, existingReasoning ? '' : split.reasoning].filter(Boolean).join('\n\n')
     const savedToolTokens = this.toolTokenAcc

--- a/ui-tui/src/app/turnStore.ts
+++ b/ui-tui/src/app/turnStore.ts
@@ -14,6 +14,7 @@ const buildTurnState = (): TurnState => ({
   streamPendingTools: [],
   streamSegments: [],
   streaming: '',
+  streamingIsFull: false,
   subagents: [],
   todoCollapsed: false,
   todos: [],
@@ -76,6 +77,7 @@ export interface TurnState {
   streamPendingTools: string[]
   streamSegments: Msg[]
   streaming: string
+  streamingIsFull: boolean
   subagents: SubagentProgress[]
   todoCollapsed: boolean
   todos: TodoItem[]

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -37,6 +37,7 @@ export const MessageLine = memo(function MessageLine({
   msg,
   prev,
   sections,
+  streamingIsFull = false,
   t,
   tools = []
 }: MessageLineProps) {
@@ -185,7 +186,12 @@ export const MessageLine = memo(function MessageLine({
         // Incremental markdown: split at the last stable block boundary so
         // only the in-flight tail re-tokenizes per delta. See
         // streamingMarkdown.tsx for the cost model.
-        <StreamingMd cols={bodyWidth} compact={compact} t={t} text={boundedLiveRenderText(msg.text)} />
+        <StreamingMd
+          cols={bodyWidth}
+          compact={compact}
+          t={t}
+          text={streamingIsFull ? msg.text : boundedLiveRenderText(msg.text)}
+        />
       ) : (
         <Md cols={bodyWidth} compact={compact} t={t} text={msg.text} />
       )

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -300,6 +300,7 @@ interface MessageLineProps {
   detailsMode?: DetailsMode
   detailsModeCommandOverride?: boolean
   isStreaming?: boolean
+  streamingIsFull?: boolean
   msg: Msg
   // The block rendered directly above this one. Drives the group-boundary
   // lead gap (see domain/blockLayout.ts::hasLeadGap). Undefined at the top of

--- a/ui-tui/src/components/streamingAssistant.tsx
+++ b/ui-tui/src/components/streamingAssistant.tsx
@@ -18,6 +18,7 @@ interface LiveBlock {
   isStreaming?: boolean
   key: string
   msg: Msg
+  streamingIsFull?: boolean
   tools?: ActiveTool[]
 }
 
@@ -34,6 +35,7 @@ export const StreamingAssistant = memo(function StreamingAssistant({
   const streamSegments = useTurnSelector(state => state.streamSegments)
   const streamPendingTools = useTurnSelector(state => state.streamPendingTools)
   const streaming = useTurnSelector(state => state.streaming)
+  const streamingIsFull = useTurnSelector(state => state.streamingIsFull)
   const activeTools = useTurnSelector(state => state.tools)
   const showStreamingArea = Boolean(streaming)
 
@@ -56,7 +58,8 @@ export const StreamingAssistant = memo(function StreamingAssistant({
     blocks.push({
       isStreaming: true,
       key: 'streaming',
-      msg: { role: 'assistant', text: streaming, ...(streamPendingTools.length && { tools: streamPendingTools }) }
+      msg: { role: 'assistant', text: streaming, ...(streamPendingTools.length && { tools: streamPendingTools }) },
+      streamingIsFull
     })
   } else if (streamPendingTools.length) {
     blocks.push({ key: 'pending-tools', msg: { kind: 'trail', role: 'system', text: '', tools: streamPendingTools } })
@@ -79,6 +82,7 @@ export const StreamingAssistant = memo(function StreamingAssistant({
             msg={block.msg}
             prev={prev}
             sections={sections}
+            streamingIsFull={block.streamingIsFull}
             t={ui.theme}
             {...(block.tools ? { tools: block.tools } : {})}
           />


### PR DESCRIPTION
Fixes #55425

## Description

When a long streaming response lands, `message.complete` must defer clearing the live streaming state until AFTER the committed messages are appended to the transcript. Synchronously calling `idle()` first produced a frame where the live area was empty AND the committed message had not yet mounted, so the ScrollBox snapped to a smaller scrollHeight and yanked the viewport off the content the user was reading.

## Changes

- `turnController.recordMessageComplete`: defer cleanup (`idle()`, `clearReasoning()`, etc.) to a microtask via `queueMicrotask` so React batches the streaming-clear `patchTurnState` with `appendMessage`'s `setHistoryItems` in the same commit.
- Also patch `streaming` state with the full (untruncated) payload text so the streaming area height matches the committed message during the transition frame, preventing height mismatch when `boundedLiveRenderText` had truncated the live display.
- Clean up synchronously when the turn was interrupted (no deferral needed).

## Verification

- Added 4 unit tests covering: normal completion (streaming kept sync, cleared on microtask), truncated-text recovery, reasoning-only response (no text override), interrupted turn (sync cleanup).
- All tests pass.