### PR TITLE
fix(aux): preserve provider identity for resolved endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5238,9 +5238,10 @@ def _resolve_task_provider_model(
       3. "auto" (full auto-detection chain)
 
     Returns (provider, model, base_url, api_key, api_mode) where model may
-    be None (use provider default). When base_url is set, provider is forced
-    to "custom" and the task uses that direct endpoint. api_mode is one of
-    "chat_completions", "codex_responses", or None (auto-detect).
+    be None (use provider default). A bare base_url is treated as custom, but
+    a first-class provider plus base_url keeps the provider identity so its
+    auth, transport, and request-shaping behavior still apply. api_mode is one
+    of "chat_completions", "codex_responses", or None (auto-detect).
     """
     cfg_provider = None
     cfg_model = None
@@ -5273,11 +5274,35 @@ def _resolve_task_provider_model(
             return prov, existing_base
         return "custom", existing_base or target_base
 
+    def _preserve_provider_with_base_url(prov: Optional[str]) -> bool:
+        normalized = str(prov or "").strip().lower()
+        if normalized in {"", "auto", "custom"} or normalized.startswith("custom:"):
+            return False
+        try:
+            from hermes_cli.providers import get_provider
+
+            return get_provider(normalized) is not None
+        except Exception:
+            # Keep the high-risk provider-backed routes safe even if provider
+            # catalog loading is unavailable during early import/test paths.
+            return normalized in {
+                "anthropic",
+                "copilot",
+                "copilot-acp",
+                "minimax-oauth",
+                "nous",
+                "openai-codex",
+                "qwen-oauth",
+                "xai-oauth",
+            }
+
     if provider:
         provider, base_url = _expand_direct_api_alias(provider, base_url)
     if cfg_provider:
         cfg_provider, cfg_base_url = _expand_direct_api_alias(cfg_provider, cfg_base_url)
 
+    if base_url and _preserve_provider_with_base_url(provider):
+        return provider, resolved_model, base_url, api_key, resolved_api_mode
     if base_url:
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -31,6 +31,7 @@ from agent.auxiliary_client import (
     _OPENROUTER_MODEL,
     OPENROUTER_BASE_URL,
     _resolve_auto,
+    _resolve_task_provider_model,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
 )
@@ -106,6 +107,65 @@ class TestAuxiliaryMaxTokensParam:
         with patch("agent.auxiliary_client._resolve_custom_runtime", return_value=("https://api.githubcopilot.com/chat/completions", "key", None)), \
              patch("agent.auxiliary_client._read_nous_auth", return_value=None):
             assert auxiliary_max_tokens_param(2048) == {"max_completion_tokens": 2048}
+
+
+class TestResolveTaskProviderModel:
+    @pytest.mark.parametrize(
+        "provider",
+        [
+            "anthropic",
+            "minimax-oauth",
+            "nous",
+            "openai-codex",
+            "qwen-oauth",
+            "xai-oauth",
+        ],
+    )
+    def test_explicit_base_url_preserves_first_class_provider_identity(self, provider):
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="moa_reference",
+            provider=provider,
+            model="test-model",
+            base_url="https://provider.example/v1",
+            api_key="resolved-token",
+        )
+
+        assert resolved_provider == provider
+        assert model == "test-model"
+        assert base_url == "https://provider.example/v1"
+        assert api_key == "resolved-token"
+        assert api_mode is None
+
+    @pytest.mark.parametrize("provider", ["", "auto", "custom", "custom:local", "unknown-provider"])
+    def test_explicit_base_url_without_first_class_provider_routes_as_custom(self, provider):
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="moa_reference",
+            provider=provider,
+            model="test-model",
+            base_url="https://provider.example/v1",
+            api_key="resolved-token",
+        )
+
+        assert resolved_provider == "custom"
+        assert model == "test-model"
+        assert base_url == "https://provider.example/v1"
+        assert api_key == "resolved-token"
+        assert api_mode is None
+
+    def test_direct_openai_alias_with_base_url_still_routes_as_custom(self):
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="vision",
+            provider="openai",
+            model="gpt-4o-mini",
+            base_url="https://proxy.example/v1",
+            api_key="sk-test",
+        )
+
+        assert resolved_provider == "custom"
+        assert model == "gpt-4o-mini"
+        assert base_url == "https://proxy.example/v1"
+        assert api_key == "sk-test"
+        assert api_mode is None
 
 
 class TestBuildCallKwargsMaxTokens:

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from run_agent import AIAgent
 
 
@@ -196,6 +198,47 @@ def test_moa_codex_slot_preserves_provider_identity(monkeypatch):
     rt = moa_loop._slot_runtime({"provider": "openai-codex", "model": "gpt-5.5"})
 
     assert rt == {"provider": "openai-codex", "model": "gpt-5.5"}
+
+
+@pytest.mark.parametrize("provider", ["anthropic", "minimax-oauth", "qwen-oauth"])
+def test_moa_provider_backed_slot_survives_aux_resolution(monkeypatch, provider):
+    """MoA can pass resolved endpoints for provider-backed slots without
+    call_llm flattening them to generic custom endpoints.
+
+    ``_slot_runtime`` resolves a provider-backed slot to ``provider`` plus a
+    concrete ``base_url``/``api_key``/``api_mode``; ``_run_reference`` then
+    forwards that dict to ``call_llm``. ``call_llm`` resolves the routing tuple
+    via ``_resolve_task_provider_model`` (which takes everything except
+    ``api_mode``, handled separately). The provider identity must survive that
+    resolution rather than being flattened to ``custom``.
+    """
+    from agent import moa_loop
+    from agent.auxiliary_client import _resolve_task_provider_model
+
+    def fake_resolve(*, requested, target_model=None):
+        return {
+            "provider": requested,
+            "api_mode": "anthropic_messages",
+            "base_url": f"https://{requested}.example/v1",
+            "api_key": f"token-for-{requested}",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve
+    )
+
+    rt = moa_loop._slot_runtime({"provider": provider, "model": "test-model"})
+    # api_mode is forwarded to call_llm directly, not to _resolve_task_provider_model.
+    resolver_kwargs = {k: v for k, v in rt.items() if k != "api_mode"}
+    resolved_provider, model, base_url, api_key, _mode = _resolve_task_provider_model(
+        task="moa_reference",
+        **resolver_kwargs,
+    )
+
+    assert resolved_provider == provider
+    assert model == "test-model"
+    assert base_url == f"https://{provider}.example/v1"
+    assert api_key == f"token-for-{provider}"
 
 
 def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):


### PR DESCRIPTION
## Summary
MoA reference slots and auxiliary tasks keep their first-class provider identity when runtime resolution hands back both a provider and a concrete `base_url`, instead of being flattened to `custom`.

Root cause: `_resolve_task_provider_model()` forced `provider="custom"` whenever any `base_url` was present. Correct for bare/custom endpoints, but wrong for provider-backed routes (anthropic, qwen-oauth, minimax-oauth, openai-codex, xai-oauth, nous, copilot) whose provider branch adds OAuth refresh, transport, and request-shaping. A MoA Codex reference therefore hit `chatgpt.com/backend-api/codex` as a plain custom endpoint — no Cloudflare headers — got HTML back, and surfaced as a spurious "rate-limited" on the first turn (the support thread that prompted this).

## Changes
- `agent/auxiliary_client.py`: add `_preserve_provider_with_base_url()`; first-class providers paired with a resolved `base_url` keep their identity. Bare `base_url`, `custom`/`custom:*`, `auto`, unknown providers, and the direct `openai` alias still route through `custom`. Primary check is the provider catalog (`get_provider`), with a static high-risk allow-list as the import-safe fallback.
- `tests/agent/test_auxiliary_client.py`: `TestResolveTaskProviderModel` — identity preserved for first-class providers, custom routing for bare/custom/unknown and the openai alias.
- `tests/run_agent/test_moa_loop_mode.py`: provider-backed slot survives `_slot_runtime()` + aux resolution (`api_mode` is handled separately by `call_llm`, so it's not passed to the resolver).

## Validation
| | Before | After |
|---|---|---|
| `openai-codex` ref slot (with base_url) | `custom` → Cloudflare HTML → false 429 | `openai-codex` → correct transport |
| `anthropic`/`qwen-oauth`/`minimax-oauth` ref | flattened to `custom` | identity preserved |
| bare base_url / `openai` alias | `custom` | `custom` (unchanged) |

`scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/run_agent/test_moa_loop_mode.py` → 278 passed, 0 failed. E2E resolution chain verified with real imports.

Salvaged from #54425 by @helix4u onto current `main` (the original branch was 332 commits stale and its diff reverted unrelated recent fixes). His authorship is preserved on the commit; the resolver logic and tests are his, reconciled with main's current `api_mode` propagation contract.

## Infographic

![provider-identity-preserved](https://v3b.fal.media/files/b/0aa05cdc/u7U9Jon8aWeDhyUAQ-j1C_usONQrHY.png)
