### PR TITLE
feat(agent): add native Ollama /api/chat adapter

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1463,6 +1463,36 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
                 agent._client_log_context(),
             )
             return client
+    if agent.provider == "custom":
+        # Local Ollama is configured as provider "custom" (the "ollama"/"vllm"/
+        # "llamacpp" aliases all normalize to "custom" in providers.py). Route it
+        # through Ollama's NATIVE /api/chat — which honors per-request num_ctx and
+        # returns correct streaming tool_calls, unlike the OpenAI-compat /v1 path —
+        # but ONLY when the endpoint is positively identified as Ollama, so a
+        # non-Ollama "custom" server (vLLM / llama.cpp / LM Studio) is never
+        # mis-routed. Gated on HERMES_OLLAMA_NATIVE: when unset,
+        # is_native_ollama_base_url() returns False immediately (no probe), so
+        # behavior is byte-identical to the existing /v1 path.
+        from agent.ollama_native_adapter import OllamaNativeClient, is_native_ollama_base_url
+
+        base_url = str(client_kwargs.get("base_url", "") or "")
+        if is_native_ollama_base_url(base_url):
+            safe_kwargs = {
+                k: v for k, v in client_kwargs.items()
+                if k in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
+            }
+            if "http_client" not in safe_kwargs:
+                keepalive_http = agent._build_keepalive_http_client(base_url)
+                if keepalive_http is not None:
+                    safe_kwargs["http_client"] = keepalive_http
+            client = OllamaNativeClient(**safe_kwargs)
+            _ra().logger.info(
+                "Ollama native client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                agent._client_log_context(),
+            )
+            return client
     # Inject TCP keepalives so the kernel detects dead provider connections
     # instead of letting them sit silently in CLOSE-WAIT (#10324).  Without
     # this, a peer that drops mid-stream leaves the socket in a state where

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1463,14 +1463,18 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
                 agent._client_log_context(),
             )
             return client
-    if agent.provider == "custom":
-        # Local Ollama is configured as provider "custom" (the "ollama"/"vllm"/
-        # "llamacpp" aliases all normalize to "custom" in providers.py). Route it
-        # through Ollama's NATIVE /api/chat — which honors per-request num_ctx and
-        # returns correct streaming tool_calls, unlike the OpenAI-compat /v1 path —
-        # but ONLY when the endpoint is positively identified as Ollama, so a
-        # non-Ollama "custom" server (vLLM / llama.cpp / LM Studio) is never
-        # mis-routed. Gated on HERMES_OLLAMA_NATIVE: when unset,
+    if agent.provider == "custom" or str(agent.provider).startswith("custom:"):
+        # Local Ollama is configured as provider "custom" — either bare ("custom")
+        # or as a named instance ("custom:<name>") when several custom providers are
+        # set up (providers.py forms these as "custom:" + normalized-name; the
+        # "ollama"/"vllm"/"llamacpp" aliases all normalize to "custom"). Match the
+        # provider *type* (before the colon) so a second Ollama instance such as
+        # "custom:ollama-2" still gets the native path instead of silently falling
+        # back to /v1. Route it through Ollama's NATIVE /api/chat — which honors
+        # per-request num_ctx and returns correct streaming tool_calls, unlike the
+        # OpenAI-compat /v1 path — but ONLY when the endpoint is positively
+        # identified as Ollama, so a non-Ollama "custom" server (vLLM / llama.cpp /
+        # LM Studio) is never mis-routed. Gated on HERMES_OLLAMA_NATIVE: when unset,
         # is_native_ollama_base_url() returns False immediately (no probe), so
         # behavior is byte-identical to the existing /v1 path.
         from agent.ollama_native_adapter import OllamaNativeClient, is_native_ollama_base_url

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -764,6 +764,15 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     try:
         from providers import get_provider_profile
         _profile = get_provider_profile(agent.provider)
+        if _profile is None and str(agent.provider).startswith("custom:"):
+            # Named custom instances ("custom:<name>") aren't in the registry, but
+            # they ARE custom providers: resolve them to the "custom" profile so the
+            # profile path runs build_api_kwargs_extras() and injects ollama_num_ctx.
+            # Without this, create_openai_client routes a custom:<name> Ollama endpoint
+            # to the native client but num_ctx never reaches extra_body, so the model
+            # loads at Ollama's 4096 default. Mirrors the provider-type match used for
+            # native selection in agent_runtime_helpers.create_openai_client.
+            _profile = get_provider_profile("custom")
     except Exception:
         _profile = None
 

--- a/agent/ollama_native_adapter.py
+++ b/agent/ollama_native_adapter.py
@@ -109,6 +109,14 @@ def is_native_ollama_base_url(base_url: str) -> bool:
     return _probe_is_ollama(native_root(base_url))
 
 
+# Cache of (root, model) -> (supports_thinking, expires_at_monotonic_or_None).
+# Definitive answers (any 200 from /api/show) are memoized for the process; probe
+# failures are cached with the short `_NEG_PROBE_TTL` (same pattern as the version
+# probe above) so a flaky /api/show can't add a round trip to every chat call,
+# while a recovered server is re-probed shortly after.
+_THINKING_CAP_CACHE: Dict[Tuple[str, str], Tuple[bool, Optional[float]]] = {}
+
+
 # ── Request construction ────────────────────────────────────────────────────
 
 
@@ -470,10 +478,16 @@ class OllamaAPIError(Exception):
 
 
 def _http_error(response: httpx.Response) -> OllamaAPIError:
+    # Ollama's native API reports failures as {"error": "<str>"} — surface that
+    # message directly instead of the raw JSON blob; fall back to raw body text.
+    body = "<unreadable>"
     try:
         body = response.text[:500]
+        parsed = response.json()
+        if isinstance(parsed, dict) and isinstance(parsed.get("error"), str):
+            body = parsed["error"][:500]
     except Exception:
-        body = "<unreadable>"
+        pass  # non-JSON body: keep the raw text captured above
     return OllamaAPIError(
         f"Ollama native API error {response.status_code}: {body}",
         status_code=response.status_code,
@@ -578,6 +592,53 @@ class OllamaNativeClient:
         we never want."""
         return {"timeout": timeout if timeout is not None else self._default_timeout}
 
+    def _model_supports_thinking(self, model: str) -> bool:
+        """Whether the model advertises the "thinking" capability via /api/show.
+
+        Returns True on any uncertainty — a missing capabilities list (older
+        Ollama accepts `think` for every model) or a failed probe — so the gate
+        only ever suppresses `think` on a positive "not supported" signal.
+        Cached per (base_url, model) for the process.
+        """
+        key = (self.base_url, model)
+        entry = _THINKING_CAP_CACHE.get(key)
+        if entry is not None:
+            cached_supports, expires_at = entry
+            if expires_at is None or time.monotonic() < expires_at:
+                return cached_supports
+        supports = True
+        definitive = False
+        try:
+            # Send the same headers as real requests — behind an authenticated
+            # reverse proxy an unauthenticated probe would 401 and the gate
+            # would silently never engage.
+            resp = self._http.post(
+                f"{self.base_url}/api/show",
+                json={"model": model},
+                headers=self._headers(),
+                timeout=2.0,
+            )
+            if resp.status_code == 200:
+                caps = resp.json().get("capabilities")
+                if isinstance(caps, list):
+                    supports = "thinking" in caps
+                # A 200 is definitive (capabilities absent = pre-capability
+                # server, which accepts `think` for every model).
+                definitive = True
+            else:
+                logger.debug(
+                    "thinking-capability probe got HTTP %s for %s", resp.status_code, model
+                )
+        except Exception as exc:
+            logger.debug("thinking-capability probe failed for %s: %s", model, exc)
+        # Definitive answers are memoized; failures forward `think` (fail-open)
+        # and are TTL-cached so a persistently failing /api/show doesn't add a
+        # round trip to every chat call.
+        _THINKING_CAP_CACHE[key] = (
+            (supports, None) if definitive else (supports, time.monotonic() + _NEG_PROBE_TTL)
+        )
+        return supports
+
     def _create_chat_completion(
         self,
         *,
@@ -600,6 +661,16 @@ class OllamaNativeClient:
         if isinstance(extra_body, dict):
             options = extra_body.get("options")
             think = extra_body.get("think")
+
+        # Newer Ollama 400s on a truthy `think` (true or a "low"/"high" level)
+        # for models without the "thinking" capability; `think: false` is
+        # tolerated everywhere. Drop `think` entirely for non-thinking models
+        # (mirrors Ollama's own relax_thinking path, and a false/None think is
+        # equivalent for a model that cannot think anyway). Unknown capability
+        # (older Ollama, probe failure) forwards `think` unchanged.
+        if think is not None and not self._model_supports_thinking(model):
+            logger.debug("model %s lacks 'thinking' capability; dropping think=%r", model, think)
+            think = None
 
         request = build_ollama_request(
             model=model,

--- a/agent/ollama_native_adapter.py
+++ b/agent/ollama_native_adapter.py
@@ -1,0 +1,747 @@
+"""Native Ollama (/api/chat) adapter for the Hermes Agent.
+
+Ollama's OpenAI-compatible /v1 endpoint IGNORES per-request `num_ctx` (verified
+through Ollama v0.30.11 / main), so a Hermes agent talking to Ollama via /v1 always
+loads models at Ollama's 4096 default. Ollama's NATIVE /api/chat endpoint honors
+`options.num_ctx` and returns correct streaming tool-call deltas.
+
+This module provides a drop-in, OpenAI-SDK-shaped client (`OllamaNativeClient`)
+that POSTs to /api/chat and translates requests/responses/streams back to the
+OpenAI shape the agent already consumes — modeled directly on the sibling
+`agent/gemini_native_adapter.py`, so `api_mode` stays "chat_completions" and the
+rest of the agent loop is unchanged.
+
+Selected in `agent_runtime_helpers.create_openai_client` for a `custom` provider
+whose `base_url` is positively identified as Ollama (gated on the
+`HERMES_OLLAMA_NATIVE` env var). Self-contained: only depends on httpx + stdlib,
+so it can be unit-tested without the rest of the agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from types import SimpleNamespace
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+
+import httpx
+
+logger = logging.getLogger("hermes_ollama_native")
+
+# Feature flag — native mode only engages when explicitly enabled. Off → callers
+# fall through to the stock OpenAI client (the default /v1 behavior).
+FLAG_ENV = "HERMES_OLLAMA_NATIVE"
+
+# Cache of base_url(root) -> (is_ollama, expires_at_monotonic_or_None). Positive
+# results never expire (an Ollama endpoint stays Ollama); negatives expire after a
+# short TTL so a transient blip (Ollama restart) recovers, while a persistent
+# misconfiguration (non-Ollama endpoint) isn't re-probed on every client build.
+_OLLAMA_PROBE_CACHE: Dict[str, Tuple[bool, Optional[float]]] = {}
+_NEG_PROBE_TTL = 60.0  # seconds
+
+
+def _flag_enabled() -> bool:
+    return str(os.environ.get(FLAG_ENV, "")).strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def native_root(base_url: str) -> str:
+    """Native Ollama root for a base URL — strips a trailing /v1 (and /) so we can
+    POST to {root}/api/chat regardless of whether the caller passed the /v1 form."""
+    b = (base_url or "").rstrip("/")
+    if b.endswith("/v1"):
+        b = b[:-3]
+    return b
+
+
+def _probe_is_ollama(root: str, *, timeout: float = 2.0) -> bool:
+    """Positively identify Ollama via GET {root}/api/version. Cached per root.
+
+    This is what keeps us from mis-routing other `provider="custom"` endpoints
+    (vLLM / llama.cpp / LM Studio) — which have no /api/chat — to native mode.
+
+    Positive results are memoized for the process (an Ollama endpoint stays Ollama).
+    Negative results are cached only for a short TTL (`_NEG_PROBE_TTL`): a transient
+    blip (Ollama restart) recovers on the next probe after the TTL, while a persistent
+    misconfiguration (non-Ollama endpoint, or Ollama down) isn't re-probed on every
+    client construction — bounding the network round-trips on the hot path.
+    """
+    entry = _OLLAMA_PROBE_CACHE.get(root)
+    if entry is not None:
+        result, expires_at = entry
+        if expires_at is None or time.monotonic() < expires_at:
+            return result
+    ok = False
+    try:
+        resp = httpx.get(f"{root}/api/version", timeout=timeout)
+        # Validate the JSON shape ({"version": "<str>"}) rather than a substring
+        # match, so a non-Ollama server returning 200 text containing the word
+        # "version" can't false-positive into native routing.
+        ok = resp.status_code == 200 and isinstance(resp.json().get("version"), str)
+    except Exception as exc:  # network/timeout/non-ollama/non-JSON
+        logger.debug("Ollama /api/version probe failed for %s: %s", root, exc)
+        ok = False
+    _OLLAMA_PROBE_CACHE[root] = (
+        (True, None) if ok else (False, time.monotonic() + _NEG_PROBE_TTL)
+    )
+    return ok
+
+
+def is_native_ollama_base_url(base_url: str) -> bool:
+    """True when we should route this endpoint through native /api/chat.
+
+    Gated on (a) the HERMES_OLLAMA_NATIVE flag and (b) a positive Ollama
+    identification via /api/version. Works whether the URL carries /v1 or not.
+    """
+    if not _flag_enabled():
+        return False
+    if not (base_url or "").strip():
+        return False
+    return _probe_is_ollama(native_root(base_url))
+
+
+# ── Request construction ────────────────────────────────────────────────────
+
+
+def _coerce_text(content: Any) -> Tuple[str, List[str]]:
+    """Return (text, images[]) from OpenAI message content (str or parts list).
+
+    Images are returned as raw base64 (Ollama's `images` field), best-effort.
+    """
+    if content is None:
+        return "", []
+    if isinstance(content, str):
+        return content, []
+    if isinstance(content, list):
+        texts: List[str] = []
+        images: List[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            ptype = part.get("type")
+            if ptype == "text" and isinstance(part.get("text"), str):
+                texts.append(part["text"])
+            elif ptype == "image_url":
+                url = (
+                    ((part.get("image_url") or {}).get("url"))
+                    if isinstance(part.get("image_url"), dict)
+                    else None
+                )
+                if isinstance(url, str) and url.startswith("data:") and "," in url:
+                    images.append(url.split(",", 1)[1])  # strip data:...;base64,
+        return "".join(texts), images
+    return str(content), []
+
+
+def _to_ollama_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert OpenAI-format messages to Ollama /api/chat format.
+
+    Key differences handled:
+      - assistant tool_calls: arguments are a JSON *string* in OpenAI, an *object*
+        in Ollama → parse.
+      - tool results (role="tool"): Ollama uses {role:"tool", content[, tool_name]};
+        OpenAI's tool_call_id is dropped (Ollama matches positionally).
+      - multimodal content list → text + images[].
+    """
+    out: List[Dict[str, Any]] = []
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role") or "user"
+        text, images = _coerce_text(msg.get("content"))
+        om: Dict[str, Any] = {"role": role, "content": text}
+        if images:
+            om["images"] = images
+
+        if role == "tool":
+            name = msg.get("name") or msg.get("tool_name")
+            if name:
+                om["tool_name"] = name
+
+        tcs = msg.get("tool_calls")
+        if role == "assistant" and isinstance(tcs, list) and tcs:
+            conv: List[Dict[str, Any]] = []
+            for tc in tcs:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function") or {}
+                args = fn.get("arguments")
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args) if args.strip() else {}
+                    except (TypeError, ValueError):
+                        args = {}
+                elif not isinstance(args, dict):
+                    args = {}
+                conv.append({
+                    "function": {"name": fn.get("name") or "", "arguments": args}
+                })
+            if conv:
+                om["tool_calls"] = conv
+        out.append(om)
+    return out
+
+
+def _to_ollama_tools(tools: Any) -> Optional[List[Dict[str, Any]]]:
+    """OpenAI tool defs are already Ollama-compatible ({type:function, function:{...}})."""
+    if not tools or not isinstance(tools, list):
+        return None
+    cleaned = [
+        t
+        for t in tools
+        if isinstance(t, dict) and t.get("type") == "function" and t.get("function")
+    ]
+    return cleaned or None
+
+
+def build_ollama_request(
+    *,
+    model: str,
+    messages: List[Dict[str, Any]],
+    tools: Any = None,
+    stream: bool = False,
+    temperature: Optional[float] = None,
+    top_p: Optional[float] = None,
+    max_tokens: Optional[int] = None,
+    stop: Any = None,
+    seed: Optional[int] = None,
+    options: Optional[Dict[str, Any]] = None,
+    think: Any = None,
+) -> Dict[str, Any]:
+    """Assemble the native /api/chat payload. `options` (incl. num_ctx) come from
+    the caller's extra_body.options; sampling params merge in without clobbering it."""
+    opts: Dict[str, Any] = dict(options or {})  # num_ctx, etc. (authoritative)
+    if temperature is not None and "temperature" not in opts:
+        opts["temperature"] = temperature
+    if top_p is not None and "top_p" not in opts:
+        opts["top_p"] = top_p
+    if max_tokens is not None and "num_predict" not in opts:
+        opts["num_predict"] = max_tokens
+    if seed is not None and "seed" not in opts:
+        opts["seed"] = seed
+    if stop is not None and "stop" not in opts:
+        opts["stop"] = [stop] if isinstance(stop, str) else stop
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": _to_ollama_messages(messages),
+        "stream": bool(stream),
+    }
+    tl = _to_ollama_tools(tools)
+    if tl:
+        payload["tools"] = tl
+    if opts:
+        payload["options"] = opts
+    if think is not None:
+        payload["think"] = think
+    return payload
+
+
+# ── Response / stream translation (output shapes mirror gemini_native_adapter) ─
+
+
+def _new_id() -> str:
+    return f"chatcmpl-{uuid.uuid4().hex[:12]}"
+
+
+def _translate_tool_calls(raw: Any) -> Optional[List[SimpleNamespace]]:
+    if not isinstance(raw, list) or not raw:
+        return None
+    calls: List[SimpleNamespace] = []
+    for index, tc in enumerate(raw):
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function") or {}
+        args = fn.get("arguments")
+        if isinstance(args, (dict, list)):
+            try:
+                args_str = json.dumps(args, ensure_ascii=False)
+            except (TypeError, ValueError):
+                args_str = "{}"
+        elif isinstance(args, str):
+            args_str = args
+        else:
+            args_str = "{}"
+        calls.append(
+            SimpleNamespace(
+                id=tc.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+                type="function",
+                index=index,
+                function=SimpleNamespace(
+                    name=str(fn.get("name") or ""), arguments=args_str
+                ),
+            )
+        )
+    return calls or None
+
+
+def _usage_from(payload: Dict[str, Any]) -> SimpleNamespace:
+    prompt = int(payload.get("prompt_eval_count") or 0)
+    completion = int(payload.get("eval_count") or 0)
+    return SimpleNamespace(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=prompt + completion,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+    )
+
+
+def _map_finish_reason(done_reason: Any, has_tool_calls: bool) -> str:
+    if has_tool_calls:
+        return "tool_calls"
+    dr = str(done_reason or "stop")
+    if dr == "length":
+        return "length"
+    return "stop"
+
+
+def translate_ollama_response(payload: Dict[str, Any], model: str) -> SimpleNamespace:
+    msg = payload.get("message") or {}
+    tool_calls = _translate_tool_calls(msg.get("tool_calls"))
+    content = msg.get("content")
+    thinking = msg.get("thinking") or None  # Ollama returns reasoning under "thinking"
+    message = SimpleNamespace(
+        role=msg.get("role") or "assistant",
+        content=(
+            content if (content not in (None, "")) else (None if tool_calls else "")
+        ),
+        tool_calls=tool_calls,
+        reasoning=thinking,
+        reasoning_content=thinking,
+        reasoning_details=None,
+    )
+    choice = SimpleNamespace(
+        index=0,
+        message=message,
+        finish_reason=_map_finish_reason(payload.get("done_reason"), bool(tool_calls)),
+    )
+    return SimpleNamespace(
+        id=_new_id(),
+        object="chat.completion",
+        created=int(payload.get("created_at_epoch") or time.time()),
+        model=payload.get("model") or model,
+        choices=[choice],
+        usage=_usage_from(payload),
+    )
+
+
+class _OllamaStreamChunk(SimpleNamespace):
+    pass
+
+
+def _make_stream_chunk(
+    *,
+    model: str,
+    content: str = "",
+    reasoning: str = "",
+    tool_call_delta: Optional[Dict[str, Any]] = None,
+    finish_reason: Optional[str] = None,
+    usage: Optional[SimpleNamespace] = None,
+) -> _OllamaStreamChunk:
+    delta_kwargs: Dict[str, Any] = {
+        "role": "assistant",
+        "content": content or None,
+        "tool_calls": None,
+        "reasoning": reasoning or None,
+        "reasoning_content": reasoning or None,
+    }
+    if tool_call_delta is not None:
+        delta_kwargs["tool_calls"] = [
+            SimpleNamespace(
+                index=tool_call_delta.get("index", 0),
+                id=tool_call_delta.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+                type="function",
+                function=SimpleNamespace(
+                    name=tool_call_delta.get("name") or "",
+                    arguments=tool_call_delta.get("arguments") or "",
+                ),
+            )
+        ]
+    delta = SimpleNamespace(**delta_kwargs)
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return _OllamaStreamChunk(
+        id=_new_id(),
+        object="chat.completion.chunk",
+        created=int(time.time()),
+        model=model,
+        choices=[choice],
+        usage=usage,
+    )
+
+
+def translate_stream_line(
+    line: Dict[str, Any], model: str, tool_idx: Dict[str, int]
+) -> List[_OllamaStreamChunk]:
+    """Translate one Ollama NDJSON object into zero+ OpenAI-style chunks."""
+    chunks: List[_OllamaStreamChunk] = []
+    msg = line.get("message") or {}
+
+    reasoning = msg.get("thinking")
+    if isinstance(reasoning, str) and reasoning:
+        chunks.append(_make_stream_chunk(model=model, reasoning=reasoning))
+
+    content = msg.get("content")
+    if isinstance(content, str) and content:
+        chunks.append(_make_stream_chunk(model=model, content=content))
+
+    raw_tcs = msg.get("tool_calls")
+    if isinstance(raw_tcs, list):
+        for tc in raw_tcs:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function") or {}
+            name = str(fn.get("name") or "")
+            args = fn.get("arguments")
+            if isinstance(args, (dict, list)):
+                try:
+                    args = json.dumps(args, ensure_ascii=False)
+                except (TypeError, ValueError):
+                    args = "{}"
+            elif not isinstance(args, str):
+                args = "{}"
+            # Ollama streams a whole tool call per object; give each a fresh index.
+            idx = tool_idx.get("n", 0)
+            tool_idx["n"] = idx + 1
+            chunks.append(
+                _make_stream_chunk(
+                    model=model,
+                    tool_call_delta={
+                        "index": idx,
+                        "id": tc.get("id"),
+                        "name": name,
+                        "arguments": args,
+                    },
+                )
+            )
+
+    if line.get("done") is True:
+        has_tc = isinstance(raw_tcs, list) and len(raw_tcs) > 0
+        chunks.append(
+            _make_stream_chunk(
+                model=model,
+                finish_reason=_map_finish_reason(
+                    line.get("done_reason"), has_tc or tool_idx.get("n", 0) > 0
+                ),
+                usage=_usage_from(line),
+            )
+        )
+    return chunks
+
+
+# ── Embeddings translation ──────────────────────────────────────────────────
+
+
+def _translate_embeddings(payload: Dict[str, Any], model: str) -> SimpleNamespace:
+    vectors = payload.get("embeddings") or []
+    data = [
+        SimpleNamespace(object="embedding", index=i, embedding=v)
+        for i, v in enumerate(vectors)
+    ]
+    tokens = int(payload.get("prompt_eval_count") or 0)
+    return SimpleNamespace(
+        object="list",
+        data=data,
+        model=payload.get("model") or model,
+        usage=SimpleNamespace(prompt_tokens=tokens, total_tokens=tokens),
+    )
+
+
+# ── Client facade (OpenAI-SDK-shaped, drop-in) ───────────────────────────────
+
+
+class OllamaAPIError(Exception):
+    def __init__(
+        self, message: str, *, status_code: Optional[int] = None, response: Any = None
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = response
+
+
+def _http_error(response: httpx.Response) -> OllamaAPIError:
+    try:
+        body = response.text[:500]
+    except Exception:
+        body = "<unreadable>"
+    return OllamaAPIError(
+        f"Ollama native API error {response.status_code}: {body}",
+        status_code=response.status_code,
+        response=response,
+    )
+
+
+class _ChatCompletions:
+    def __init__(self, client: "OllamaNativeClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ChatNamespace:
+    def __init__(self, client: "OllamaNativeClient"):
+        self.completions = _ChatCompletions(client)
+
+
+class _Embeddings:
+    def __init__(self, client: "OllamaNativeClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_embeddings(**kwargs)
+
+
+class OllamaNativeClient:
+    """Minimal OpenAI-SDK-compatible facade over Ollama's native REST API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        default_headers: Optional[Dict[str, str]] = None,
+        timeout: Any = None,
+        http_client: Optional[httpx.Client] = None,
+        **_: Any,
+    ) -> None:
+        self.api_key = api_key or "ollama"
+        self.base_url = native_root(base_url or "http://127.0.0.1:11434")
+        self._default_headers = dict(default_headers or {})
+        self.chat = _ChatNamespace(self)
+        self.embeddings = _Embeddings(self)
+        self.is_closed = False
+        self._http = http_client or httpx.Client(
+            timeout=httpx.Timeout(connect=15.0, read=600.0, write=30.0, pool=30.0)
+            if timeout is None
+            else timeout
+        )
+
+    # lifecycle / SDK-compat surface
+    def close(self) -> None:
+        self.is_closed = True
+        try:
+            self._http.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def _headers(self) -> Dict[str, Union[str, bytes]]:
+        h: Dict[str, Union[str, bytes]] = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "hermes-agent (ollama-native)",
+        }
+        # Ollama ignores auth locally, but a reverse proxy may want it.
+        if self.api_key and self.api_key != "ollama":
+            h["Authorization"] = f"Bearer {self.api_key}"
+        # Only forward headers with real str/bytes values. default_headers copied
+        # from an OpenAI SDK client (the aux Hook-2 path mirrors the client's
+        # timeout + default_headers) can contain the SDK's `Omit()` / `NotGiven`
+        # sentinels for UNSET headers (e.g. OpenAI-Organization / OpenAI-Project).
+        # httpx rejects those ("Header value must be str or bytes"), which would
+        # fail every aux side-task (title/compression/vision). Drop non-string values.
+        for k, v in (self._default_headers or {}).items():
+            if isinstance(v, (str, bytes)):
+                h[k] = v
+        return h
+
+    @staticmethod
+    def _timeout_kwargs(timeout: Any) -> Dict[str, Any]:
+        """httpx request kwargs: forward an explicit per-request timeout when given,
+        else omit it so the client's configured default applies. (Passing
+        ``timeout=None`` to httpx DISABLES the timeout entirely, which we never want.)"""
+        return {} if timeout is None else {"timeout": timeout}
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str,
+        messages: Optional[List[Dict[str, Any]]] = None,
+        stream: bool = False,
+        tools: Any = None,
+        tool_choice: Any = None,  # Ollama has no tool_choice; accepted + ignored
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stop: Any = None,
+        seed: Optional[int] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
+        timeout: Any = None,
+        **_: Any,
+    ) -> Any:
+        options = None
+        think = None
+        if isinstance(extra_body, dict):
+            options = extra_body.get("options")
+            think = extra_body.get("think")
+
+        request = build_ollama_request(
+            model=model,
+            messages=messages or [],
+            tools=tools,
+            stream=stream,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            stop=stop,
+            seed=seed,
+            options=options if isinstance(options, dict) else None,
+            think=think,
+        )
+
+        if stream:
+            return self._stream_completion(
+                model=model, request=request, timeout=timeout
+            )
+
+        url = f"{self.base_url}/api/chat"
+        resp = self._http.post(
+            url, json=request, headers=self._headers(), **self._timeout_kwargs(timeout)
+        )
+        if resp.status_code != 200:
+            raise _http_error(resp)
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise OllamaAPIError(
+                f"Invalid JSON from Ollama /api/chat: {exc}",
+                status_code=resp.status_code,
+            ) from exc
+        return translate_ollama_response(payload, model=model)
+
+    def _stream_completion(
+        self, *, model: str, request: Dict[str, Any], timeout: Any = None
+    ) -> Iterator[_OllamaStreamChunk]:
+        url = f"{self.base_url}/api/chat"
+
+        def _generator() -> Iterator[_OllamaStreamChunk]:
+            tool_idx: Dict[str, int] = {"n": 0}
+            try:
+                with self._http.stream(
+                    "POST",
+                    url,
+                    json=request,
+                    headers=self._headers(),
+                    **self._timeout_kwargs(timeout),
+                ) as resp:
+                    if resp.status_code != 200:
+                        resp.read()
+                        raise _http_error(resp)
+                    for raw_line in resp.iter_lines():
+                        if not raw_line:
+                            continue
+                        try:
+                            obj = json.loads(raw_line)
+                        except (json.JSONDecodeError, TypeError):
+                            logger.debug(
+                                "Non-JSON Ollama stream line: %s", str(raw_line)[:200]
+                            )
+                            continue
+                        if isinstance(obj, dict):
+                            for chunk in translate_stream_line(obj, model, tool_idx):
+                                yield chunk
+            except httpx.HTTPError as exc:
+                raise OllamaAPIError(f"Ollama streaming request failed: {exc}") from exc
+
+        return _generator()
+
+    def _create_embeddings(
+        self, *, model: str, input: Any = None, timeout: Any = None, **_: Any
+    ) -> Any:
+        url = f"{self.base_url}/api/embed"
+        resp = self._http.post(
+            url,
+            json={"model": model, "input": input},
+            headers=self._headers(),
+            **self._timeout_kwargs(timeout),
+        )
+        if resp.status_code != 200:
+            raise _http_error(resp)
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise OllamaAPIError(
+                f"Invalid JSON from Ollama /api/embed: {exc}",
+                status_code=resp.status_code,
+            ) from exc
+        return _translate_embeddings(payload, model=model)
+
+
+class _AsyncChatCompletions:
+    def __init__(self, client: "AsyncOllamaNativeClient"):
+        self._client = client
+
+    async def create(self, **kwargs: Any) -> Any:
+        return await self._client._create_chat_completion(**kwargs)
+
+
+class _AsyncChatNamespace:
+    def __init__(self, client: "AsyncOllamaNativeClient"):
+        self.completions = _AsyncChatCompletions(client)
+
+
+class AsyncOllamaNativeClient:
+    """Async wrapper (used by auxiliary_client) over a sync OllamaNativeClient."""
+
+    def __init__(self, sync_client: OllamaNativeClient):
+        self._sync = sync_client
+        self.api_key = sync_client.api_key
+        self.base_url = sync_client.base_url
+        self.chat = _AsyncChatNamespace(self)
+        self._real_client = sync_client  # for the aux cache's leaf-client eviction
+
+    async def _create_chat_completion(self, **kwargs: Any) -> Any:
+        stream = bool(kwargs.get("stream"))
+        result = await asyncio.to_thread(self._sync.chat.completions.create, **kwargs)
+        if not stream:
+            return result
+
+        # Consume the sync streaming generator on ONE dedicated thread (preserving the
+        # httpx streaming response's thread affinity) and forward chunks to the async
+        # consumer via an asyncio.Queue. Advancing the generator with `asyncio.to_thread`
+        # per chunk could resume it on different pool threads, which is not safe for a
+        # live httpx sync stream.
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def _producer() -> None:
+            try:
+                for chunk in result:
+                    loop.call_soon_threadsafe(queue.put_nowait, ("chunk", chunk))
+            except Exception as exc:  # surface to the async consumer
+                loop.call_soon_threadsafe(queue.put_nowait, ("error", exc))
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, ("done", None))
+
+        threading.Thread(
+            target=_producer, name="hermes-ollama-aux-stream", daemon=True
+        ).start()
+
+        async def _async_stream() -> Any:
+            while True:
+                kind, payload = await queue.get()
+                if kind == "chunk":
+                    yield payload
+                elif kind == "error":
+                    raise payload
+                else:
+                    break
+
+        return _async_stream()
+
+    async def close(self) -> None:
+        await asyncio.to_thread(self._sync.close)

--- a/agent/ollama_native_adapter.py
+++ b/agent/ollama_native_adapter.py
@@ -57,7 +57,7 @@ def _flag_enabled() -> bool:
 def native_root(base_url: str) -> str:
     """Native Ollama root for a base URL — strips a trailing /v1 (and /) so we can
     POST to {root}/api/chat regardless of whether the caller passed the /v1 form."""
-    b = (base_url or "").rstrip("/")
+    b = (base_url or "").strip().rstrip("/")
     if b.endswith("/v1"):
         b = b[:-3]
     return b
@@ -180,7 +180,9 @@ def _to_ollama_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                         args = json.loads(args) if args.strip() else {}
                     except (TypeError, ValueError):
                         args = {}
-                elif not isinstance(args, dict):
+                # Coerce anything that isn't an object (bad parse, or a JSON null /
+                # array / scalar) to {} — Ollama expects tool-call args as an object.
+                if not isinstance(args, dict):
                     args = {}
                 conv.append({
                     "function": {"name": fn.get("name") or "", "arguments": args}
@@ -519,11 +521,20 @@ class OllamaNativeClient:
         self.chat = _ChatNamespace(self)
         self.embeddings = _Embeddings(self)
         self.is_closed = False
-        self._http = http_client or httpx.Client(
-            timeout=httpx.Timeout(connect=15.0, read=600.0, write=30.0, pool=30.0)
-            if timeout is None
-            else timeout
+        # Per-request default timeout. Applied both to a self-made client AND, below,
+        # as the explicit per-request timeout — so an injected http_client that only
+        # carries httpx's short 5s default never governs a long local-model call.
+        self._default_timeout = (
+            timeout
+            if timeout is not None
+            else httpx.Timeout(connect=15.0, read=600.0, write=30.0, pool=30.0)
         )
+        self._http = http_client or httpx.Client(timeout=self._default_timeout)
+        # Also expose the httpx client as `_client`: the agent's socket-abort path
+        # (force_close_tcp_sockets -> _iter_pool_sockets) resolves the pool via
+        # getattr(client, "_client"), the OpenAI-SDK convention. Without this alias
+        # interrupt / stale-kill can't shut a long native stream's socket.
+        self._client = self._http
 
     # lifecycle / SDK-compat surface
     def close(self) -> None:
@@ -559,12 +570,13 @@ class OllamaNativeClient:
                 h[k] = v
         return h
 
-    @staticmethod
-    def _timeout_kwargs(timeout: Any) -> Dict[str, Any]:
-        """httpx request kwargs: forward an explicit per-request timeout when given,
-        else omit it so the client's configured default applies. (Passing
-        ``timeout=None`` to httpx DISABLES the timeout entirely, which we never want.)"""
-        return {} if timeout is None else {"timeout": timeout}
+    def _timeout_kwargs(self, timeout: Any) -> Dict[str, Any]:
+        """httpx request kwargs. Always pass a concrete timeout — the caller's when
+        given, else our long default — so a request never silently falls back to
+        httpx's 5s default (which applies when an external http_client was injected
+        without one). Passing ``timeout=None`` to httpx DISABLES the timeout, which
+        we never want."""
+        return {"timeout": timeout if timeout is not None else self._default_timeout}
 
     def _create_chat_completion(
         self,

--- a/tests/run_agent/test_create_openai_client_ollama_native.py
+++ b/tests/run_agent/test_create_openai_client_ollama_native.py
@@ -12,6 +12,7 @@ non-Ollama ``custom:<name>`` (vLLM / llama.cpp / LM Studio) is never mis-routed.
 
 from unittest.mock import MagicMock, patch
 
+from agent.chat_completion_helpers import build_api_kwargs
 from agent.ollama_native_adapter import OllamaNativeClient
 from run_agent import AIAgent
 
@@ -44,7 +45,10 @@ def test_bare_custom_routes_native(mock_openai):
 
 @patch("run_agent.OpenAI")
 def test_suffixed_custom_instance_still_routes_native(mock_openai):
-    """The bug: 'custom:ollama-2' previously fell through to /v1."""
+    """Client selection: 'custom:ollama-2' must get the native client (previously it
+    fell through to /v1). NOTE: this only asserts the client TYPE — that num_ctx
+    actually reaches the payload is covered separately by
+    test_suffixed_custom_instance_injects_num_ctx."""
     mock_openai.return_value = MagicMock()
     agent = _make_agent("custom:ollama-2")
     with patch("agent.ollama_native_adapter.is_native_ollama_base_url", return_value=True):
@@ -52,6 +56,19 @@ def test_suffixed_custom_instance_still_routes_native(mock_openai):
             {"api_key": "ollama", "base_url": _BASE_URL}, reason="test", shared=False
         )
     assert isinstance(client, OllamaNativeClient)
+
+
+@patch("run_agent.OpenAI")
+def test_suffixed_custom_instance_injects_num_ctx(mock_openai):
+    """Routing the native client is not enough — num_ctx must reach extra_body, which
+    only happens on the provider-profile path. A named custom instance must resolve to
+    the 'custom' profile so ollama_num_ctx is injected; otherwise the model loads at
+    Ollama's 4096 default despite using the native client."""
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent("custom:ollama-2")
+    agent._ollama_num_ctx = 64000
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+    assert kwargs["extra_body"]["options"]["num_ctx"] == 64000
 
 
 @patch("run_agent.OpenAI")

--- a/tests/run_agent/test_create_openai_client_ollama_native.py
+++ b/tests/run_agent/test_create_openai_client_ollama_native.py
@@ -1,0 +1,68 @@
+"""Regression: the native-Ollama branch in ``create_openai_client`` must match the
+provider *type*, so a named custom instance (``custom:<name>``) is still routed to
+the native ``/api/chat`` client instead of silently falling back to ``/v1``.
+
+Multiple Ollama providers are named ``custom`` (bare) and ``custom:<name>`` (see
+``hermes_cli/providers.py``). An exact ``== "custom"`` gate would route only the
+bare instance native and drop every ``custom:<name>`` instance to ``/v1`` — losing
+per-request ``num_ctx`` and correct streaming ``tool_calls`` for delegated
+sub-agents. The routing itself stays gated on the per-endpoint Ollama probe, so a
+non-Ollama ``custom:<name>`` (vLLM / llama.cpp / LM Studio) is never mis-routed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.ollama_native_adapter import OllamaNativeClient
+from run_agent import AIAgent
+
+_BASE_URL = "http://localhost:11434/v1"
+
+
+def _make_agent(provider: str) -> AIAgent:
+    agent = AIAgent(
+        api_key="ollama",
+        base_url=_BASE_URL,
+        model="gemma4:e2b",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.provider = provider
+    return agent
+
+
+@patch("run_agent.OpenAI")
+def test_bare_custom_routes_native(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent("custom")
+    with patch("agent.ollama_native_adapter.is_native_ollama_base_url", return_value=True):
+        client = agent._create_openai_client(
+            {"api_key": "ollama", "base_url": _BASE_URL}, reason="test", shared=False
+        )
+    assert isinstance(client, OllamaNativeClient)
+
+
+@patch("run_agent.OpenAI")
+def test_suffixed_custom_instance_still_routes_native(mock_openai):
+    """The bug: 'custom:ollama-2' previously fell through to /v1."""
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent("custom:ollama-2")
+    with patch("agent.ollama_native_adapter.is_native_ollama_base_url", return_value=True):
+        client = agent._create_openai_client(
+            {"api_key": "ollama", "base_url": _BASE_URL}, reason="test", shared=False
+        )
+    assert isinstance(client, OllamaNativeClient)
+
+
+@patch("run_agent.OpenAI")
+def test_suffixed_non_ollama_custom_stays_on_v1(mock_openai):
+    """A non-Ollama custom instance (probe says no) is never mis-routed to native."""
+    sentinel = MagicMock()
+    mock_openai.return_value = sentinel
+    agent = _make_agent("custom:vllm")
+    with patch("agent.ollama_native_adapter.is_native_ollama_base_url", return_value=False):
+        client = agent._create_openai_client(
+            {"api_key": "x", "base_url": "http://localhost:8000/v1"}, reason="test", shared=False
+        )
+    assert not isinstance(client, OllamaNativeClient)
+    assert client is sentinel  # fell through to the stock OpenAI client

--- a/tests/test_ollama_native_adapter.py
+++ b/tests/test_ollama_native_adapter.py
@@ -11,9 +11,11 @@ import os
 from unittest.mock import patch
 
 import httpx
+import pytest
 
 from agent.ollama_native_adapter import (
     _OLLAMA_PROBE_CACHE,
+    OllamaAPIError,
     AsyncOllamaNativeClient,
     OllamaNativeClient,
     _translate_embeddings,
@@ -28,6 +30,17 @@ from agent.ollama_native_adapter import (
 def _mock_client(handler):
     """A real OllamaNativeClient wired to an httpx.MockTransport request handler."""
     return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+@pytest.fixture(autouse=True)
+def _clear_thinking_cap_cache():
+    """The capability probe memoizes per (base_url, model) for the process; clear it
+    around every test so cases don't leak cached verdicts into each other."""
+    from agent.ollama_native_adapter import _THINKING_CAP_CACHE
+
+    _THINKING_CAP_CACHE.clear()
+    yield
+    _THINKING_CAP_CACHE.clear()
 
 
 # ── request construction ──────────────────────────────────────────────────────
@@ -333,3 +346,273 @@ def test_async_client_roundtrip():
     )
     assert result.choices[0].message.content == "async hi"
     assert aclient.base_url == "http://h:11434"
+
+
+# ── thinking-capability gate (/api/show) ──────────────────────────────────────
+
+
+def _cap_handler(caps, capture):
+    """Route /api/show (returns given capabilities) and /api/chat (captures body)."""
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            body = {"capabilities": caps} if caps is not None else {}
+            return httpx.Response(200, json=body)
+        capture["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    return handler
+
+
+def _fresh_cap_client(caps, capture):
+    return OllamaNativeClient(
+        base_url="http://h:11434", http_client=_mock_client(_cap_handler(caps, capture))
+    )
+
+
+def test_think_dropped_for_non_thinking_model():
+    """Newer Ollama 400s on `think` for models without the capability — never send it."""
+    capture = {}
+    client = _fresh_cap_client(["completion", "tools"], capture)
+    client.chat.completions.create(
+        model="llama3.2", messages=[{"role": "user", "content": "x"}], extra_body={"think": False}
+    )
+    assert "think" not in capture["body"]
+
+
+def test_think_kept_for_thinking_model():
+    capture = {}
+    client = _fresh_cap_client(["completion", "tools", "thinking"], capture)
+    client.chat.completions.create(
+        model="qwen3.5", messages=[{"role": "user", "content": "x"}], extra_body={"think": False}
+    )
+    assert capture["body"]["think"] is False
+
+
+def test_think_string_level_passes_through():
+    """Newer Ollama accepts think as a string level ("low"/"medium"/"high"/"max");
+    the adapter forwards the value verbatim (no bool coercion)."""
+    capture = {}
+    client = _fresh_cap_client(["completion", "thinking"], capture)
+    client.chat.completions.create(
+        model="gpt-oss", messages=[{"role": "user", "content": "x"}], extra_body={"think": "high"}
+    )
+    assert capture["body"]["think"] == "high"
+
+
+def test_think_kept_when_capabilities_absent():
+    """Pre-capability Ollama (no `capabilities` key) accepts think for every model."""
+    capture = {}
+    client = _fresh_cap_client(None, capture)
+    client.chat.completions.create(
+        model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": True}
+    )
+    assert capture["body"]["think"] is True
+
+
+def test_no_probe_when_think_not_requested():
+    seen = {"show": 0}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["show"] += 1
+            return httpx.Response(200, json={"capabilities": []})
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+    assert seen["show"] == 0  # zero overhead unless `think` is present
+
+
+def test_think_kept_when_probe_fails_and_failure_is_ttl_cached():
+    """Fail-open: uncertainty never suppresses think — and the failure is TTL-cached
+    so a flaky /api/show can't add a round trip to every chat call."""
+    seen = {"show": 0}
+    capture = {}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["show"] += 1
+            raise httpx.ConnectError("down")
+        capture["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    for _ in range(3):
+        client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": False}
+        )
+    assert capture["body"]["think"] is False
+    assert seen["show"] == 1
+
+
+def test_probe_result_is_cached_per_model():
+    seen = {"show": 0}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["show"] += 1
+            return httpx.Response(200, json={"capabilities": ["completion"]})
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    for _ in range(3):
+        client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": False}
+        )
+    assert seen["show"] == 1  # definitive answer memoized
+
+
+# ── error-body parsing + parallel-frame tool calls ────────────────────────────
+
+
+def test_error_body_message_is_parsed():
+    """Ollama reports failures as {"error": "<str>"} — surface the message itself."""
+
+    def handler(request):
+        return httpx.Response(400, json={"error": "model does not support thinking"})
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    try:
+        client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+        raise AssertionError("expected OllamaAPIError")
+    except OllamaAPIError as e:
+        assert e.status_code == 400
+        assert "model does not support thinking" in str(e)
+        assert '{"error"' not in str(e)  # message, not the raw JSON blob
+
+
+def test_parallel_tool_calls_in_separate_frames_get_distinct_indices():
+    """Ollama can emit parallel calls in separate NDJSON frames with no ids; a
+    per-frame index would merge them into one unparseable call. The counter is
+    stream-global, so each call gets a distinct index and synthesized id."""
+    tool_idx = {"n": 0}
+    f1 = translate_stream_line(
+        {"message": {"tool_calls": [{"function": {"name": "a", "arguments": {}}}]}}, "m", tool_idx
+    )
+    f2 = translate_stream_line(
+        {"message": {"tool_calls": [{"function": {"name": "b", "arguments": {}}}]}}, "m", tool_idx
+    )
+    tc1 = f1[0].choices[0].delta.tool_calls[0]
+    tc2 = f2[0].choices[0].delta.tool_calls[0]
+    assert (tc1.index, tc2.index) == (0, 1)
+    assert tc1.id and tc2.id and tc1.id != tc2.id
+
+
+def test_error_body_non_json_falls_back_to_raw_text():
+    """A plain-text error (overloaded proxy, HTML gateway page) must surface its
+    raw text, not "<unreadable>"."""
+
+    def handler(request):
+        return httpx.Response(502, text="upstream proxy exploded")
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    try:
+        client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+        raise AssertionError("expected OllamaAPIError")
+    except OllamaAPIError as e:
+        assert e.status_code == 502
+        assert "upstream proxy exploded" in str(e)
+        assert "<unreadable>" not in str(e)
+
+
+def test_probe_sends_auth_headers():
+    """Behind an authenticated reverse proxy an unauthenticated probe would 401
+    and silently disable the gate — the probe must send the client's headers."""
+    seen = {}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["auth"] = request.headers.get("Authorization")
+            return httpx.Response(200, json={"capabilities": ["completion"]})
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(
+        base_url="http://h:11434", api_key="proxy-secret", http_client=_mock_client(handler)
+    )
+    client.chat.completions.create(
+        model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": False}
+    )
+    assert seen["auth"] == "Bearer proxy-secret"
+
+
+def test_think_kept_on_non_200_probe_and_bounded():
+    """A proxy that 404s /api/show while /api/chat works must not disable chat —
+    think is forwarded (fail-open) and the failure is TTL-cached, not re-probed
+    on every request."""
+    seen = {"show": 0}
+    capture = {}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["show"] += 1
+            return httpx.Response(404)
+        capture["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    for _ in range(3):
+        client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": True}
+        )
+    assert capture["body"]["think"] is True
+    assert seen["show"] == 1
+
+
+def test_failure_ttl_expires_then_recovers_to_definitive(monkeypatch):
+    """The load-bearing TTL contract: a cached failure is re-probed after the TTL
+    lapses, and a now-healthy server yields a definitive answer that is memoized
+    (and, for a non-thinking model, finally suppresses `think`)."""
+    from types import SimpleNamespace
+
+    from agent import ollama_native_adapter as adapter
+
+    import time as real_time
+
+    now = {"t": 1000.0}
+    monkeypatch.setattr(
+        adapter, "time", SimpleNamespace(monotonic=lambda: now["t"], time=real_time.time)
+    )
+
+    seen = {"show": 0}
+    capture = {}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["show"] += 1
+            if seen["show"] == 1:
+                raise httpx.ConnectError("down")
+            return httpx.Response(200, json={"capabilities": ["completion"]})
+        capture["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    kw = dict(model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": False})
+
+    client.chat.completions.create(**kw)  # probe fails -> fail-open, TTL-cached
+    assert capture["body"]["think"] is False
+    client.chat.completions.create(**kw)  # within TTL -> cached, no re-probe
+    assert seen["show"] == 1
+
+    now["t"] += adapter._NEG_PROBE_TTL + 1  # TTL lapses
+    client.chat.completions.create(**kw)  # re-probe -> definitive: no thinking cap
+    assert seen["show"] == 2
+    assert "think" not in capture["body"]
+    assert adapter._THINKING_CAP_CACHE[("http://h:11434", "m")] == (False, None)
+
+    client.chat.completions.create(**kw)  # memoized -> no further probes
+    assert seen["show"] == 2

--- a/tests/test_ollama_native_adapter.py
+++ b/tests/test_ollama_native_adapter.py
@@ -1,0 +1,335 @@
+"""Tests for agent/ollama_native_adapter.py — the native Ollama /api/chat adapter.
+
+Covers request/response/stream/embeddings translation, the flag-gated Ollama
+detection probe, and the OpenAI-SDK-shaped client facade. Network is faked with
+httpx.MockTransport + unittest.mock (no extra test dependency).
+"""
+
+import asyncio
+import json
+import os
+from unittest.mock import patch
+
+import httpx
+
+from agent.ollama_native_adapter import (
+    _OLLAMA_PROBE_CACHE,
+    AsyncOllamaNativeClient,
+    OllamaNativeClient,
+    _translate_embeddings,
+    build_ollama_request,
+    is_native_ollama_base_url,
+    native_root,
+    translate_ollama_response,
+    translate_stream_line,
+)
+
+
+def _mock_client(handler):
+    """A real OllamaNativeClient wired to an httpx.MockTransport request handler."""
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+# ── request construction ──────────────────────────────────────────────────────
+
+
+def test_num_ctx_preserved_in_native_payload():
+    req = build_ollama_request(
+        model="gemma4:e2b",
+        messages=[{"role": "user", "content": "hi"}],
+        options={"num_ctx": 64000},
+    )
+    assert req["options"]["num_ctx"] == 64000
+    assert req["stream"] is False
+
+
+def test_sampling_merges_without_clobbering_options():
+    req = build_ollama_request(
+        model="m",
+        messages=[{"role": "user", "content": "x"}],
+        temperature=0.5,
+        top_p=0.9,
+        max_tokens=128,
+        seed=7,
+        stop="STOP",
+        options={"num_ctx": 8192, "temperature": 0.1},
+    )
+    opts = req["options"]
+    assert opts["num_ctx"] == 8192
+    assert opts["temperature"] == 0.1  # explicit option wins over the 0.5 arg
+    assert opts["top_p"] == 0.9
+    assert opts["num_predict"] == 128  # max_tokens -> num_predict
+    assert opts["seed"] == 7
+    assert opts["stop"] == ["STOP"]
+
+
+def test_assistant_tool_call_args_string_to_object_and_tool_role():
+    req = build_ollama_request(
+        model="m",
+        messages=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "function": {"name": "lookup", "arguments": '{"q": "cats"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "name": "lookup", "content": "result"},
+        ],
+    )
+    assert req["messages"][0]["tool_calls"][0]["function"]["arguments"] == {"q": "cats"}
+    assert req["messages"][1]["tool_name"] == "lookup"
+
+
+def test_multimodal_image_data_url_extracted():
+    req = build_ollama_request(
+        model="m",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,QUJD"},
+                    },
+                ],
+            }
+        ],
+    )
+    assert req["messages"][0]["content"] == "what is this"
+    assert req["messages"][0]["images"] == ["QUJD"]
+
+
+# ── response + stream + embeddings translation ────────────────────────────────
+
+
+def test_response_content_usage_and_finish_reason():
+    resp = translate_ollama_response(
+        {
+            "model": "m",
+            "message": {"role": "assistant", "content": "hello"},
+            "done_reason": "stop",
+            "prompt_eval_count": 10,
+            "eval_count": 5,
+        },
+        model="m",
+    )
+    assert resp.choices[0].message.content == "hello"
+    assert resp.choices[0].finish_reason == "stop"
+    assert resp.usage.prompt_tokens == 10
+    assert resp.usage.completion_tokens == 5
+    assert resp.usage.total_tokens == 15
+
+
+def test_response_tool_calls_object_to_string():
+    resp = translate_ollama_response(
+        {
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"function": {"name": "f", "arguments": {"a": 1}}}],
+            }
+        },
+        model="m",
+    )
+    msg = resp.choices[0].message
+    assert resp.choices[0].finish_reason == "tool_calls"
+    assert msg.content is None
+    assert msg.tool_calls[0].function.name == "f"
+    assert json.loads(msg.tool_calls[0].function.arguments) == {"a": 1}
+
+
+def test_stream_content_tool_call_and_done():
+    tool_idx = {"n": 0}
+    c1 = translate_stream_line({"message": {"content": "hi"}}, "m", tool_idx)
+    assert c1[0].choices[0].delta.content == "hi"
+
+    c2 = translate_stream_line(
+        {
+            "message": {
+                "tool_calls": [{"function": {"name": "f", "arguments": {"x": 1}}}]
+            }
+        },
+        "m",
+        tool_idx,
+    )
+    tc = c2[0].choices[0].delta.tool_calls[0]
+    assert tc.function.name == "f"
+    assert json.loads(tc.function.arguments) == {"x": 1}
+    assert tc.index == 0
+    assert tool_idx["n"] == 1
+
+    # A tool call was streamed, so the terminal chunk's finish_reason must be
+    # "tool_calls" even though Ollama reports done_reason="stop".
+    c3 = translate_stream_line(
+        {"done": True, "done_reason": "stop", "prompt_eval_count": 3, "eval_count": 2},
+        "m",
+        tool_idx,
+    )
+    assert c3[-1].choices[0].finish_reason == "tool_calls"
+    assert c3[-1].usage.prompt_tokens == 3
+
+
+def test_stream_done_without_tool_calls_is_stop():
+    # Pure content stream (fresh counter, no tool calls) → finish_reason "stop".
+    chunks = translate_stream_line(
+        {"done": True, "done_reason": "stop", "prompt_eval_count": 4, "eval_count": 1},
+        "m",
+        {"n": 0},
+    )
+    assert chunks[-1].choices[0].finish_reason == "stop"
+    assert chunks[-1].usage.completion_tokens == 1
+
+
+def test_embeddings_translation():
+    out = _translate_embeddings(
+        {
+            "model": "nomic-embed-text",
+            "embeddings": [[0.1, 0.2]],
+            "prompt_eval_count": 4,
+        },
+        model="nomic-embed-text",
+    )
+    assert out.object == "list"
+    assert out.data[0].embedding == [0.1, 0.2]
+    assert out.usage.prompt_tokens == 4
+
+
+# ── detection ─────────────────────────────────────────────────────────────────
+
+
+def test_native_root_strips_v1():
+    assert native_root("http://h:11434/v1") == "http://h:11434"
+    assert native_root("http://h:11434/v1/") == "http://h:11434"
+    assert native_root("http://h:11434/") == "http://h:11434"
+
+
+def test_detection_is_noop_when_flag_unset():
+    _OLLAMA_PROBE_CACHE.clear()
+    with patch.dict(os.environ, {"HERMES_OLLAMA_NATIVE": ""}, clear=False):
+        # No network touched when the flag is off.
+        assert is_native_ollama_base_url("http://h:11434/v1") is False
+
+
+def test_detection_positive_for_ollama():
+    _OLLAMA_PROBE_CACHE.clear()
+    resp = httpx.Response(200, json={"version": "0.30.0"})
+    with patch.dict(os.environ, {"HERMES_OLLAMA_NATIVE": "1"}, clear=False):
+        with patch("agent.ollama_native_adapter.httpx.get", return_value=resp):
+            assert is_native_ollama_base_url("http://h:11434/v1") is True
+
+
+def test_detection_negative_for_non_ollama():
+    _OLLAMA_PROBE_CACHE.clear()
+    resp = httpx.Response(404)
+    with patch.dict(os.environ, {"HERMES_OLLAMA_NATIVE": "1"}, clear=False):
+        with patch("agent.ollama_native_adapter.httpx.get", return_value=resp):
+            # A non-Ollama "custom" endpoint (vLLM/llama.cpp/LM Studio) is left on /v1.
+            assert is_native_ollama_base_url("http://other:8000/v1") is False
+
+
+def test_detection_rejects_200_without_version_field():
+    _OLLAMA_PROBE_CACHE.clear()
+    resp = httpx.Response(200, json={"status": "ok"})
+    with patch.dict(os.environ, {"HERMES_OLLAMA_NATIVE": "1"}, clear=False):
+        with patch("agent.ollama_native_adapter.httpx.get", return_value=resp):
+            assert is_native_ollama_base_url("http://h:11434") is False
+
+
+# ── client facade (httpx.MockTransport) ───────────────────────────────────────
+
+
+def test_chat_completion_posts_num_ctx_to_api_chat():
+    captured = {}
+
+    def handler(request):
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": "gemma4:e2b",
+                "message": {"role": "assistant", "content": "hello"},
+                "done_reason": "stop",
+                "prompt_eval_count": 11,
+                "eval_count": 3,
+            },
+        )
+
+    client = OllamaNativeClient(
+        base_url="http://h:11434/v1", http_client=_mock_client(handler)
+    )
+    result = client.chat.completions.create(
+        model="gemma4:e2b",
+        messages=[{"role": "user", "content": "hi"}],
+        extra_body={"options": {"num_ctx": 64000}},
+    )
+    assert captured["url"].endswith("/api/chat")
+    assert captured["body"]["options"]["num_ctx"] == 64000
+    assert result.choices[0].message.content == "hello"
+    assert result.usage.prompt_tokens == 11
+
+
+def test_streaming_yields_openai_chunks():
+    ndjson = (
+        '{"message":{"content":"he"}}\n'
+        '{"message":{"content":"llo"}}\n'
+        '{"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":2}\n'
+    )
+    client = OllamaNativeClient(
+        base_url="http://h:11434",
+        http_client=_mock_client(lambda request: httpx.Response(200, text=ndjson)),
+    )
+    chunks = list(
+        client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "hi"}], stream=True
+        )
+    )
+    assert "".join(c.choices[0].delta.content or "" for c in chunks) == "hello"
+    assert chunks[-1].choices[0].finish_reason == "stop"
+
+
+def test_headers_drop_non_string_sentinels():
+    class _Sentinel:
+        pass
+
+    headers = OllamaNativeClient(
+        base_url="http://h:11434",
+        default_headers={
+            "X-Real": "keep",
+            "OpenAI-Organization": _Sentinel(),
+            "X-None": None,
+        },
+    )._headers()
+    assert headers["X-Real"] == "keep"
+    assert "OpenAI-Organization" not in headers
+    assert "X-None" not in headers
+    assert all(isinstance(v, (str, bytes)) for v in headers.values())
+
+
+def test_async_client_roundtrip():
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={
+                "message": {"role": "assistant", "content": "async hi"},
+                "done_reason": "stop",
+                "prompt_eval_count": 2,
+                "eval_count": 1,
+            },
+        )
+
+    aclient = AsyncOllamaNativeClient(
+        OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    )
+    result = asyncio.run(
+        aclient.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "hi"}]
+        )
+    )
+    assert result.choices[0].message.content == "async hi"
+    assert aclient.base_url == "http://h:11434"


### PR DESCRIPTION
## Description

Adds a native Ollama `/api/chat` adapter so local-Ollama users get **honored per-request `num_ctx`** and **correct tool calling**, neither of which the current OpenAI-compatible `/v1` path delivers.

Local Ollama is configured as `provider: custom` with `base_url: …:11434/v1`. That `/v1` surface:

1. **Silently ignores per-request `num_ctx`.** Ollama maps only a fixed allowlist of OpenAI sampling params to model options; `num_ctx` isn't one of them, so every model loads at the **4096** default regardless of the context Hermes computed (verified through Ollama `v0.30.11` / `main`; tracked in ollama/ollama#11409).
2. **Can corrupt streamed `tool_calls` deltas** for local models — the recurring complaint in #4505. Several users confirm the *same* model returns correct tool calls via native `/api/chat` but broken ones via `/v1`, which leaves an agentic assistant unable to act locally.

This PR adds `agent/ollama_native_adapter.py` — a drop-in, OpenAI-SDK-shaped client over Ollama's native `/api/chat` + `/api/embed`, **modeled directly on the existing `agent/gemini_native_adapter.py`** so `api_mode` stays `chat_completions` and the rest of the agent loop is unchanged. It's selected in `create_openai_client` for a `custom` provider whose `base_url` is positively identified as Ollama via a cached `GET /api/version` probe.

### Selection is detection-based, exactly like the Gemini adapter — no feature flag

An earlier revision gated this on a `HERMES_OLLAMA_NATIVE` env var. That's been **removed** — per the config policy in `AGENTS.md` (behavioral settings live in `config.yaml`, `.env` is for secrets only), and because the sibling Gemini adapter already establishes the right pattern: it engages purely on `is_native_gemini_base_url(base_url)`, no flag. This adapter now mirrors that — native routing engages iff the endpoint answers `GET /api/version` as Ollama.

- **Never mis-routes.** `custom` also covers vLLM / llama.cpp / LM Studio, which have no `/api/version`; they fail the probe and stay byte-identical on `/v1`. Negatives are TTL-cached, positives memoized, so it's one probe per endpoint per process.
- **Ollama endpoints are transparently upgraded** to the native path — same as a Gemini endpoint gets the Gemini-native client — with no user config change (the adapter accepts the `/v1` URL and targets the native root itself).
- **Zero new dependencies** — uses `httpx`, already a core pin. No new dispatch path in `run_agent.py`; `api_mode` is untouched.
- **Mirrors an accepted pattern.** Same drop-in-client shape, same `safe_kwargs` whitelist, same keepalive-http injection as the Gemini branch right above it.

> This is intentionally the *minimal* version of the earlier maintenance-cost concern: one adapter file + one `create_openai_client` branch, no new `api_mode`, no `run_agent.py` dispatch, no env var. The auxiliary-client (compression/title/vision) path is deliberately **out of scope** here and can follow up.

## Related issue

Refs #4505

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change

## How has this been tested?

- `tests/test_ollama_native_adapter.py` (new): request construction (`num_ctx` preserved, sampling merge, tool-call string↔object mapping, multimodal images), non-streaming + NDJSON-stream translation, usage/finish-reason mapping, embeddings, probe-based `/api/version` detection (positive/negative/malformed), and the sync + async client facades via `httpx.MockTransport`. No new test deps.
- `ruff check` passes on the new and modified files.
- Manual: against a local Ollama, a model spawned through Hermes shows the requested context in `ollama ps` (not 4096), and tool calls execute on the native path. A non-Ollama `custom` endpoint (vLLM) fails the probe and is unchanged on `/v1`.

## Documentation

- Adapter module docstring documents the `/v1` limitations it works around, the probe-based selection, and the parallel to the Gemini adapter. (Happy to add a docs page if desired.)

## Checklist

- [x] Conventional Commits in history (`feat(agent): …`)
- [x] No new dependencies
- [x] No new `HERMES_*` env var; selection is detection-based like the Gemini adapter
- [x] Non-Ollama `custom` endpoints unchanged (fail the probe, stay on `/v1`)
