### PR TITLE
fix(stt): pass language parameter to Groq Whisper API

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -311,6 +311,73 @@ class TestTranscribeGroq:
         assert result["success"] is False
         assert "Permission denied" in result["error"]
 
+    def test_language_from_groq_config(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hello world"
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client), \
+             patch("tools.transcription_tools._load_stt_config",
+                   return_value={"groq": {"language": "he"}}):
+            from tools.transcription_tools import _transcribe_groq
+            result = _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
+
+        assert result["success"] is True
+        call_kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+        assert call_kwargs["language"] == "he"
+
+    def test_language_falls_back_to_local_config(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hello world"
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client), \
+             patch("tools.transcription_tools._load_stt_config",
+                   return_value={"local": {"language": "ja"}}):
+            from tools.transcription_tools import _transcribe_groq
+            result = _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
+
+        assert result["success"] is True
+        call_kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+        assert call_kwargs["language"] == "ja"
+
+    def test_groq_language_takes_precedence_over_local(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hello world"
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client), \
+             patch("tools.transcription_tools._load_stt_config",
+                   return_value={"groq": {"language": "he"}, "local": {"language": "ja"}}):
+            from tools.transcription_tools import _transcribe_groq
+            result = _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
+
+        assert result["success"] is True
+        call_kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+        assert call_kwargs["language"] == "he"
+
+    def test_no_language_when_unconfigured(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hello world"
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client), \
+             patch("tools.transcription_tools._load_stt_config", return_value={}):
+            from tools.transcription_tools import _transcribe_groq
+            result = _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
+
+        assert result["success"] is True
+        call_kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+        assert "language" not in call_kwargs
+
 
 # ============================================================================
 # _transcribe_openai — additional tests

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1289,20 +1289,34 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
         logger.info("Model %s not available on Groq, using %s", model_name, DEFAULT_GROQ_STT_MODEL)
         model_name = DEFAULT_GROQ_STT_MODEL
 
+    # Language: config.yaml (stt.groq.language) > stt.local.language > auto-detect.
+    stt_cfg = _load_stt_config()
+    _forced_lang = (
+        stt_cfg.get("groq", {}).get("language")
+        or stt_cfg.get("local", {}).get("language")
+        or None
+    )
+
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
         client = OpenAI(api_key=api_key, base_url=GROQ_BASE_URL, timeout=30, max_retries=0)
         try:
+            transcribe_kwargs: dict = {}
+            if _forced_lang:
+                transcribe_kwargs["language"] = _forced_lang
+
             with open(file_path, "rb") as audio_file:
                 transcription = client.audio.transcriptions.create(
                     model=model_name,
                     file=audio_file,
                     response_format="text",
+                    **transcribe_kwargs,
                 )
 
             transcript_text = str(transcription).strip()
-            logger.info("Transcribed %s via Groq API (%s, %d chars)",
-                         Path(file_path).name, model_name, len(transcript_text))
+            logger.info("Transcribed %s via Groq API (%s, lang=%s, %d chars)",
+                         Path(file_path).name, model_name,
+                         _forced_lang or "auto", len(transcript_text))
 
             return {"success": True, "transcript": transcript_text, "provider": "groq"}
         finally:


### PR DESCRIPTION
## What does this PR do?

Passes the configured `language` parameter to the Groq Whisper API in `_transcribe_groq()`. Without this, Groq relies on auto-detection, which incorrectly identifies non-English audio (e.g., Hebrew) as English, producing garbled transcriptions.

The fix reads language from `stt.groq.language` with fallback to `stt.local.language`, matching the existing pattern in `_transcribe_local()` and `_transcribe_local_command()`.

## Related Issue

Fixes #55551

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/transcription_tools.py`: Add language parameter resolution in `_transcribe_groq()` — reads `stt.groq.language` → `stt.local.language` → auto-detect. Passes `language=` to `client.audio.transcriptions.create()` when configured. Updates log line to include language.
- `tests/tools/test_transcription_tools.py`: Add 4 regression tests — groq-specific config, local config fallback, precedence when both set, no language when unconfigured.

## How to Test

1. Run `pytest tests/tools/test_transcription_tools.py::TestTranscribeGroq -q` — all 11 tests should pass (7 existing + 4 new).
2. Configure `stt.groq.language: he` in config.yaml, send a Hebrew voice message via Telegram with Groq STT provider — transcription should produce Hebrew output instead of garbled English.
3. Verify gateway log shows `lang=he` instead of `lang=auto` in the Groq transcription line.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (config-reading change, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
