### PR TITLE
fix(config): warn on memory_enabled/provider mismatch

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4731,6 +4731,25 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 f"Move '{key}' under the appropriate section",
             ))
 
+    # ── Memory: memory_enabled vs provider semantic mismatch (#32624) ──
+    # memory.memory_enabled: false only hides memory tools from the LLM;
+    # the memory plugin still loads (watchdog, capture, persona writes)
+    # because plugin loading is gated by memory.provider, not memory_enabled.
+    mem_cfg = config.get("memory", {})
+    if isinstance(mem_cfg, dict):
+        _mem_provider = mem_cfg.get("provider", "")
+        _mem_enabled = mem_cfg.get("memory_enabled", True)
+        if not _mem_enabled and _mem_provider and str(_mem_provider).strip():
+            issues.append(ConfigIssue(
+                "warning",
+                "memory.memory_enabled: false does NOT disable the memory plugin "
+                "— it only hides memory tools from the LLM",
+                "The plugin still loads and runs (watchdog, capture, persona "
+                "writes) because loading is gated by memory.provider. "
+                "To fully disable the memory plugin, set: memory.provider: '' "
+                "(empty string)",
+            ))
+
     return issues
 
 


### PR DESCRIPTION
## Problem

`memory.memory_enabled: false` only hides memory tools from the LLM — the memory plugin still loads and runs (watchdog, capture, persona writes) because plugin loading is gated by `memory.provider`, not `memory_enabled`.

Users who set `memory_enabled: false` expecting to fully disable the memory plugin are surprised to find it still running. There was no warning to catch this mismatch.

## Fix

Add a config validation warning in `validate_config_structure()` when `memory_enabled` is `false` but `provider` is set to a non-empty value:

```
$ hermes setup
⚠ memory.memory_enabled: false does NOT disable the memory plugin
  — it only hides memory tools from the LLM
  The plugin still loads and runs (watchdog, capture, persona writes)
  because loading is gated by memory.provider.
  To fully disable the memory plugin, set: memory.provider: '' (empty string)
```

Surfaces at startup and during `hermes setup` alongside other config issues. No behavior change — purely diagnostic.

Refs: #32624
