### PR TITLE
fix(tui): raise virtual history MAX_MOUNTED default to keep long responses reachable

### DIFF
--- a/ui-tui/src/__tests__/useVirtualHistoryHeights.test.ts
+++ b/ui-tui/src/__tests__/useVirtualHistoryHeights.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { ensureVirtualItemHeight } from '../hooks/useVirtualHistory.js'
+import { ensureVirtualItemHeight, MAX_MOUNTED } from '../hooks/useVirtualHistory.js'
 
 describe('ensureVirtualItemHeight', () => {
   it('reuses cached heights without invoking the estimator', () => {
@@ -35,5 +35,16 @@ describe('ensureVirtualItemHeight', () => {
 
     expect(ensureVirtualItemHeight(heights, 'd', 0, 0, estimateHeight)).toBe(1)
     expect(heights.get('d')).toBe(1)
+  })
+})
+
+// Issue #55594: long assistant responses scroll out of the mounted range
+// and the clamp holds the viewport at the edge of mounted content while
+// the user catches up.  Raising the default cap from 120 → 300 keeps
+// longer responses reachable.  The constant is exported so callers can
+// override per-instance via the `maxMounted` option.
+describe('MAX_MOUNTED default', () => {
+  it('is at least 300 to keep long responses reachable', () => {
+    expect(MAX_MOUNTED).toBeGreaterThanOrEqual(300)
   })
 })

--- a/ui-tui/src/__tests__/useVirtualHistoryHeights.test.ts
+++ b/ui-tui/src/__tests__/useVirtualHistoryHeights.test.ts
@@ -1,6 +1,10 @@
+import { PassThrough } from 'stream'
+
+import { Box, renderSync, ScrollBox, type ScrollBoxHandle, Text } from '@hermes/ink'
+import React, { useLayoutEffect, useRef } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
-import { ensureVirtualItemHeight, MAX_MOUNTED } from '../hooks/useVirtualHistory.js'
+import { ensureVirtualItemHeight, useVirtualHistory } from '../hooks/useVirtualHistory.js'
 
 describe('ensureVirtualItemHeight', () => {
   it('reuses cached heights without invoking the estimator', () => {
@@ -40,11 +44,131 @@ describe('ensureVirtualItemHeight', () => {
 
 // Issue #55594: long assistant responses scroll out of the mounted range
 // and the clamp holds the viewport at the edge of mounted content while
-// the user catches up.  Raising the default cap from 120 → 300 keeps
-// longer responses reachable.  The constant is exported so callers can
-// override per-instance via the `maxMounted` option.
-describe('MAX_MOUNTED default', () => {
-  it('is at least 300 to keep long responses reachable', () => {
-    expect(MAX_MOUNTED).toBeGreaterThanOrEqual(300)
+// the user catches up.  The default `maxMounted` cap (raised 120 → 300)
+// exists so longer responses stay reachable.  Rather than freezing the
+// constant, assert the behavioural contract under the hook's DEFAULT
+// options across a range of transcript sizes: the tail of a long response
+// must remain mounted (reachable) and the viewport must stay covered so
+// nothing "disappears" while the user scrolls up.
+interface Item {
+  height: number
+  key: string
+}
+
+interface Exposed {
+  scroll: ScrollBoxHandle | null
+  virtualHistory: ReturnType<typeof useVirtualHistory>
+}
+
+const makeStreams = () => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', () => {})
+
+  return { stderr, stdin, stdout }
+}
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+function DefaultOptionsHarness({
+  expose,
+  items
+}: {
+  expose: React.MutableRefObject<Exposed | null>
+  items: readonly Item[]
+}) {
+  const scrollRef = useRef<ScrollBoxHandle | null>(null)
+
+  // No options: exercise the hook's DEFAULT estimate, overscan and
+  // maxMounted behaviour (the maxMounted default is what #55594 raised).
+  const virtualHistory = useVirtualHistory(scrollRef, items, 80)
+
+  useLayoutEffect(() => {
+    expose.current = { scroll: scrollRef.current, virtualHistory }
+  })
+
+  return React.createElement(
+    ScrollBox,
+    { flexDirection: 'column', height: 10, ref: scrollRef, stickyScroll: true },
+    React.createElement(
+      Box,
+      { flexDirection: 'column', width: '100%' },
+      virtualHistory.topSpacer > 0 ? React.createElement(Box, { height: virtualHistory.topSpacer }) : null,
+      ...items.slice(virtualHistory.start, virtualHistory.end).map(item =>
+        React.createElement(
+          Box,
+          { height: item.height, key: item.key, ref: virtualHistory.measureRef(item.key) },
+          React.createElement(Text, null, item.key)
+        )
+      ),
+      virtualHistory.bottomSpacer > 0 ? React.createElement(Box, { height: virtualHistory.bottomSpacer }) : null
+    )
+  )
+}
+
+// Height of the rows actually mounted between topSpacer and bottomSpacer.
+const mountedContentBottom = (
+  items: readonly Item[],
+  virtualHistory: ReturnType<typeof useVirtualHistory>
+) => {
+  let height = 0
+
+  for (let index = virtualHistory.start; index < virtualHistory.end; index++) {
+    height += items[index]?.height ?? 0
+  }
+
+  return virtualHistory.topSpacer + height
+}
+
+describe('useVirtualHistory default options', () => {
+  it('keeps long responses reachable when scrolling up (default maxMounted)', async () => {
+    // Issue #55594: a long assistant response scrolls out of the mounted
+    // range and the clamp pins the viewport at the edge of mounted content,
+    // so the response appears to "disappear" with no way back. The default
+    // maxMounted cap exists so the mounted range still spans the response a
+    // user is catching up through. Sweep a range of response sizes so the
+    // test asserts behaviour under varying input, not a frozen snapshot.
+    for (const rows of [200, 320, 500, 1000]) {
+      const longResponse = Array.from({ length: rows }, (_, index) => ({ height: 2, key: `resp-${index}` }))
+      const tail = { height: 4, key: 'tail' }
+      const items = [...longResponse, tail]
+      const expose = { current: null as Exposed | null }
+      const streams = makeStreams()
+
+      const instance = renderSync(React.createElement(DefaultOptionsHarness, { expose, items }), {
+        patchConsole: false,
+        stderr: streams.stderr as NodeJS.WriteStream,
+        stdin: streams.stdin as NodeJS.ReadStream,
+        stdout: streams.stdout as NodeJS.WriteStream
+      })
+
+      try {
+        await delay(20)
+        const scroll = expose.current!.scroll!
+
+        // Start pinned to the bottom (sticky) and scroll up into the long
+        // response — the scenario from #55594.
+        scroll.scrollBy(-(rows * 2) + 4)
+        await delay(80)
+
+        const scrollTop = scroll.getScrollTop()
+        const viewportBottom = scrollTop + scroll.getViewportHeight()
+        const mountedBottom = mountedContentBottom(items, expose.current!.virtualHistory)
+
+        // The viewport must land on real mounted response rows, not blank
+        // spacer — otherwise the response has "disappeared" behind an
+        // unmountable gap. Allow a little slack for the clamp edge.
+        expect(viewportBottom).toBeLessThanOrEqual(mountedBottom + 2)
+        expect(scrollTop).toBeLessThan(mountedBottom)
+      } finally {
+        instance.unmount()
+        instance.cleanup()
+      }
+    }
   })
 })

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -22,7 +22,14 @@ const OVERSCAN = 20
 // viewport+2*overscan = 80 rows of needed coverage = ~25 items at avg 3
 // rows/item, so 120 leaves >4× headroom and never blanks the viewport
 // even when items are tiny.
-const MAX_MOUNTED = 120
+// Bumped 120 → 300: issue #55594 — long assistant responses scroll out
+// of the mounted range and the clamp (setClampBounds) holds the viewport
+// at the edge of mounted content while the user catches up, so the
+// response is perceived as having "disappeared" with no way back.  300
+// is 2.5× the old cap and still well under the ~23k live Yoga node budget
+// (300 items × ~75 nodes/item = ~22.5k, similar to the old 260 ceiling
+// that was tolerable).  Override per-instance via the `maxMounted` option.
+export const MAX_MOUNTED = 300
 const COLD_START = 30
 // Floor on unmeasured row height used when computing coverage — guarantees
 // the mounted span physically reaches the viewport bottom regardless of how


### PR DESCRIPTION
Partially addresses #55594 (root cause #1 only — sticky-scroll cooldown and history cap are follow-ups)

## Description

Long assistant responses (multi-screen, tables, code blocks) scroll out of the virtualized ScrollBox mount window and become unreachable. The user perceives the response as having "disappeared" with no way back.

Root cause: `MAX_MOUNTED = 120` is the default upper bound on items mounted inside the virtual history. The `setClampBounds()` clamp (in `render-node-to-output.ts`) holds the viewport at the edge of mounted content while the user is mid-scroll. Once the user's scroll position passes the 120-item boundary, the user sees blank spacer instead of real content.

Fix: bump `MAX_MOUNTED` from 120 → 300. The new cap is 2.5× the old one and stays well under the ~23k live Yoga node ceiling (300 items × ~75 nodes/item ≈ 22.5k, comparable to the 260-item ceiling that was tolerable before profiling). Export the constant so callers can override per-instance via the existing `maxMounted` hook option.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — passes
- `npx vitest run src/__tests__/useVirtualHistoryHeights.test.ts src/__tests__/virtualHistoryClamp.test.ts src/__tests__/virtualHistoryOffsetCache.test.ts` — 14/14 pass
- `npx vitest run` — 1088 pass, 4 pre-existing failures in `cursorDriftRegression.test.ts`, `statusRule.test.ts`, `virtualHeights.test.ts` (confirmed on `main` before my change, unrelated to this fix)
- The 4 pre-existing failures don't touch `useVirtualHistory` or the virtual scroll mount cap

## Files Changed

- `ui-tui/src/hooks/useVirtualHistory.ts` — `MAX_MOUNTED` 120 → 300, exported
- `ui-tui/src/__tests__/useVirtualHistoryHeights.test.ts` — invariant test on the new default