### PR TITLE
fix(whatsapp): resolve outbound LID targets via reverse mapping

### DIFF
--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -69,8 +69,10 @@ def normalize_whatsapp_identifier(value: str) -> str:
 
 # A target that is "just a phone number" — optional leading ``+`` then digits
 # and the usual human separators (spaces, dots, dashes, parens). Anything that
-# already carries an ``@`` is a fully-qualified JID and must pass through
-# untouched (group ``@g.us``, LID ``@lid``, ``status@broadcast`` etc.).
+# already carries an ``@`` is a fully-qualified JID and normally passes through
+# untouched (group ``@g.us``, ``status@broadcast`` etc.). LID DMs are the one
+# exception: when Baileys has recorded a reverse phone mapping, outbound sends
+# should use that visible phone-number chat instead.
 _BARE_PHONE_RE = re.compile(r"^\+?[\d\s().\-]+$")
 
 
@@ -87,7 +89,8 @@ def to_whatsapp_jid(value: str) -> str:
 
     - ``"+50766715226"`` / ``"50766715226"`` → ``"50766715226@s.whatsapp.net"``
     - ``"50766715226@s.whatsapp.net"`` → unchanged
-    - ``"group-id@g.us"`` / ``"130631430344750@lid"`` → unchanged
+    - ``"group-id@g.us"`` → unchanged
+    - ``"130631430344750@lid"`` → mapped phone JID when the bridge knows it
     - ``"user:device@s.whatsapp.net"`` style colon-before-``@`` → ``@`` form
     - anything that isn't a recognizable bare phone → returned unchanged so
       the bridge can surface a meaningful error rather than us mangling it.
@@ -105,6 +108,29 @@ def to_whatsapp_jid(value: str) -> str:
     if ":" in normalized and "@" in normalized:
         prefix, _, domain = normalized.partition("@")
         normalized = f"{prefix.split(':', 1)[0]}@{domain}"
+
+    # Baileys can accept a LID as an outbound target without placing the
+    # message in the contact's visible phone-number chat. Prefer the bridge's
+    # reverse mapping when one exists, while preserving LIDs that are not yet
+    # mapped. get_hermes_dir supports both current and legacy session layouts.
+    if normalized.endswith("@lid"):
+        lid = normalize_whatsapp_identifier(normalized)
+        if _SAFE_IDENTIFIER_RE.match(lid):
+            session_dir = get_hermes_dir(
+                "platforms/whatsapp/session", "whatsapp/session"
+            )
+            mapping_path = session_dir / f"lid-mapping-{lid}_reverse.json"
+            try:
+                if mapping_path.exists():
+                    mapped = normalize_whatsapp_identifier(
+                        json.loads(mapping_path.read_text(encoding="utf-8"))
+                    )
+                    if mapped:
+                        return f"{mapped}@s.whatsapp.net"
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.debug(
+                    "whatsapp_identity: failed to read %s: %s", mapping_path, exc
+                )
 
     # Already a fully-qualified JID — leave it alone.
     if "@" in normalized:

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -137,6 +137,28 @@ class TestSendChunking:
     """WhatsApp send() splits long messages into chunks."""
 
     @pytest.mark.asyncio
+    async def test_lid_send_uses_mapped_phone_jid_at_bridge_boundary(self, tmp_path, monkeypatch):
+        """A known LID must target the visible phone chat, not the raw LID."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        session_dir = tmp_path / "platforms" / "whatsapp" / "session"
+        session_dir.mkdir(parents=True)
+        (session_dir / "lid-mapping-130631430344750_reverse.json").write_text(
+            '"50766715226"', encoding="utf-8"
+        )
+
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send("130631430344750@lid", "hello")
+
+        assert result.success
+        assert adapter._http_session.post.call_args.kwargs["json"]["chatId"] == (
+            "50766715226@s.whatsapp.net"
+        )
+
+    @pytest.mark.asyncio
     async def test_short_message_single_send(self):
         adapter = _make_adapter()
         resp = MagicMock(status=200)

--- a/tests/gateway/test_whatsapp_to_jid.py
+++ b/tests/gateway/test_whatsapp_to_jid.py
@@ -32,7 +32,6 @@ class TestToWhatsappJid:
         [
             "50766715226@s.whatsapp.net",  # already a user JID
             "123456789-987654321@g.us",    # group JID
-            "130631430344750@lid",         # linked identity
             "status@broadcast",            # broadcast pseudo-chat
             "123@newsletter",              # channel/newsletter
         ],
@@ -40,4 +39,38 @@ class TestToWhatsappJid:
     def test_fully_qualified_jid_passes_through(self, jid):
         assert to_whatsapp_jid(jid) == jid
 
+    def test_device_suffixed_colon_form_collapses_to_at(self):
+        # ``user:device@domain`` (legacy) → ``user@domain``
+        assert to_whatsapp_jid("60123456789:47@s.whatsapp.net") == (
+            "60123456789@s.whatsapp.net"
+        )
 
+    def test_lid_with_reverse_mapping_becomes_phone_jid(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "gateway.whatsapp_identity.get_hermes_dir",
+            lambda *_args: tmp_path,
+        )
+        (tmp_path / "lid-mapping-130631430344750_reverse.json").write_text(
+            '"50766715226"', encoding="utf-8"
+        )
+
+        assert to_whatsapp_jid("130631430344750@lid") == (
+            "50766715226@s.whatsapp.net"
+        )
+
+    def test_unmapped_lid_passes_through(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "gateway.whatsapp_identity.get_hermes_dir",
+            lambda *_args: tmp_path,
+        )
+
+        assert to_whatsapp_jid("130631430344750@lid") == "130631430344750@lid"
+
+    @pytest.mark.parametrize("empty", ["", "   ", None])
+    def test_empty_input_returns_empty(self, empty):
+        assert to_whatsapp_jid(empty) == ""
+
+    def test_unrecognized_target_passes_through_unchanged(self):
+        # Not a phone, no ``@`` — leave it for the bridge to reject with a
+        # meaningful error rather than mangling it into a bogus JID.
+        assert to_whatsapp_jid("not-a-number") == "not-a-number"


### PR DESCRIPTION
## Summary

Fix outbound WhatsApp DMs that arrive as `@lid` identities by resolving the bridge's reverse LID mapping before sending.

When a WhatsApp DM arrives as `<id>@lid`, Hermes may later use that same value as the outbound target. The WhatsApp bridge already stores reverse mapping files (`lid-mapping-<lid>_reverse.json`) that identify the corresponding phone number. This change teaches `to_whatsapp_jid()` to use that mapping and send to `<phone>@s.whatsapp.net` when available.

If no reverse mapping exists, the LID target is left unchanged.

## Why

This preserves existing behavior for groups, broadcasts, newsletters, already-normalized JIDs, and unmapped LIDs, while fixing a real delivery failure mode for WhatsApp DMs where inbound identity and reliable outbound identity differ.

## Tests

```bash
uv run --with pytest python -m pytest tests/gateway/test_whatsapp_to_jid.py tests/gateway/test_whatsapp_identity.py -q -o 'addopts='
# 17 passed
```
