### PR TITLE
fix(cli): add CREATE_BREAKAWAY_FROM_JOB to windows_hide_flags()

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -195,10 +195,16 @@ def windows_hide_flags() -> int:
     ``DETACHED_PROCESS`` — the child still inherits stdio handles so
     ``capture_output=True`` works.  ``DETACHED_PROCESS`` would sever
     stdio and break stdout capture.
+
+    ``CREATE_BREAKAWAY_FROM_JOB`` is included so that child processes
+    spawned inside an Electron / Tauri Windows Job Object are not
+    forcibly re-parented into the job — without this flag,
+    ``CREATE_NO_WINDOW`` is silently ignored and a visible ``cmd.exe``
+    window flashes for every subprocess.
     """
     if not IS_WINDOWS:
         return 0
-    return _CREATE_NO_WINDOW
+    return _CREATE_NO_WINDOW | _CREATE_BREAKAWAY_FROM_JOB
 
 
 def windows_detach_popen_kwargs() -> dict:

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -601,6 +601,29 @@ class TestSubprocessCompatHelpers:
             "can respawn the gateway after Electron exits."
         )
 
+    def test_windows_hide_flags_includes_breakaway_from_job(self, monkeypatch):
+        """CREATE_BREAKAWAY_FROM_JOB is load-bearing for ``windows_hide_flags()``.
+
+        Without it, ``CREATE_NO_WINDOW`` alone is silently ignored when the
+        parent process lives inside a Windows Job Object (Electron, Tauri,
+        etc.).  Every subprocess spawn produces a visible ``cmd.exe`` flash
+        instead of running headless.
+
+        Regression guard for issue #55604.
+        """
+        from hermes_cli import _subprocess_compat as sc
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        flags = sc.windows_hide_flags()
+        assert flags & 0x08000000, "missing CREATE_NO_WINDOW"
+        assert flags & 0x01000000, (
+            "CREATE_BREAKAWAY_FROM_JOB (0x01000000) must be present in "
+            "windows_hide_flags() so child processes inside Electron / Tauri "
+            "job objects are not forcibly re-parented."
+        )
+        # Must NOT include DETACHED_PROCESS — that severs stdio and breaks
+        # capture_output=True, which is the whole point of hide vs detach.
+        assert not (flags & 0x00000008), "DETACHED_PROCESS must not be in hide flags"
+
     def test_windows_detach_flags_without_breakaway_drops_only_that_bit(
         self, monkeypatch
     ):


### PR DESCRIPTION
## What does this PR do?

Adds `CREATE_BREAKAWAY_FROM_JOB` to `windows_hide_flags()` so that subprocess calls made from inside an Electron / Tauri Windows Job Object remain hidden. Without this flag, `CREATE_NO_WINDOW` alone is silently ignored by the OS and every subprocess spawn produces a visible `cmd.exe` window flash.

The constant (`_CREATE_BREAKAWAY_FROM_JOB = 0x01000000`) already exists in the file and is already used by `windows_detach_flags()` for the same reason — it was simply missing from the hide-only variant.

## Related Issue

Fixes #55604

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/_subprocess_compat.py`: Added `| _CREATE_BREAKAWAY_FROM_JOB` to `windows_hide_flags()` return value; updated docstring to explain why the flag is needed.
- `tests/tools/test_windows_native_support.py`: Added `test_windows_hide_flags_includes_breakaway_from_job` — regression guard that verifies the breakaway bit is set and `DETACHED_PROCESS` is absent (which would break `capture_output`).

## How to Test

1. Run `python -m pytest tests/tools/test_windows_native_support.py::TestSubprocessCompatHelpers::test_windows_hide_flags_includes_breakaway_from_job -xvs` — should pass.
2. Run `python -m pytest tests/test_windows_subprocess_no_window_flags.py -q` — all 15 existing tests should still pass (they mock `windows_hide_flags` so are unaffected by the implementation change).
3. On a Windows machine with Electron Desktop (Hermes One): navigate to the "About" page — no `cmd.exe` windows should flash.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 — POSIX path returns 0 (correct no-op); Windows path verified via monkeypatched IS_WINDOWS in tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated in `windows_hide_flags()`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — POSIX path unchanged (returns 0); only Windows path affected
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
