### PR TITLE
fix(file-safety): distinguish safe-root denials from credential-path blocks

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -26,7 +26,7 @@ from openai.types.chat.chat_completion_message_tool_call import (
     Function,
 )
 
-from agent.file_safety import get_read_block_error, is_write_denied
+from agent.file_safety import get_read_block_error, get_write_denial_reason, is_write_denied
 from agent.redact import redact_sensitive_text
 from tools.environments.local import hermes_subprocess_env
 
@@ -727,10 +727,9 @@ class CopilotACPClient:
         elif method == "fs/write_text_file":
             try:
                 path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
-                if is_write_denied(str(path)):
-                    raise PermissionError(
-                        f"Write denied: '{path}' is a protected system/credential file."
-                    )
+                reason = get_write_denial_reason(str(path))
+                if reason:
+                    raise PermissionError(reason)
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_text(str(params.get("content") or ""))
                 response = {

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -144,6 +144,73 @@ def is_write_denied(path: str) -> bool:
     return False
 
 
+def get_write_denial_reason(path: str) -> str | None:
+    """Return a human-readable reason why *path* is write-denied, or ``None``.
+
+    Unlike :func:`is_write_denied` (which returns a plain ``bool``), this
+    function distinguishes between:
+
+    * **Protected credential / system path** — the path is in the static
+      deny-list or matches a sensitive prefix (``/etc/shadow``, ``~/.ssh/…``,
+      mcp-tokens, pairing files).
+    * **Outside configured safe roots** — ``HERMES_WRITE_SAFE_ROOT`` is set
+      and the path falls outside every allowed root.
+
+    Returns ``None`` when the path is writable.
+    """
+    home = os.path.realpath(os.path.expanduser("~"))
+    resolved = os.path.realpath(os.path.expanduser(str(path)))
+
+    # --- Static deny-list (credential / system paths) ---
+    if resolved in build_write_denied_paths(home):
+        return f"Write denied: '{path}' is a protected system/credential file."
+    for prefix in build_write_denied_prefixes(home):
+        if resolved.startswith(prefix):
+            return f"Write denied: '{path}' is a protected system/credential file."
+
+    mcp_tokens_dir_name = "mcp-tokens"
+
+    hermes_dirs: list[str] = []
+    for base in (_hermes_home_path(), _hermes_root_path()):
+        try:
+            real = os.path.realpath(base)
+            if real not in hermes_dirs:
+                hermes_dirs.append(real)
+        except Exception:
+            continue
+
+    for base_real in hermes_dirs:
+        try:
+            mcp_real = os.path.realpath(os.path.join(base_real, mcp_tokens_dir_name))
+            if resolved == mcp_real or resolved.startswith(mcp_real + os.sep):
+                return f"Write denied: '{path}' is a protected system/credential file."
+        except Exception:
+            pass
+        try:
+            pairing_real = os.path.realpath(os.path.join(base_real, "pairing"))
+            if resolved == pairing_real or resolved.startswith(pairing_real + os.sep):
+                return f"Write denied: '{path}' is a protected system/credential file."
+        except Exception:
+            pass
+
+    # --- Safe-root check ---
+    safe_roots = get_safe_write_roots()
+    if safe_roots:
+        allowed = False
+        for safe_root in safe_roots:
+            if resolved == safe_root or resolved.startswith(safe_root + os.sep):
+                allowed = True
+                break
+        if not allowed:
+            roots_display = ", ".join(sorted(safe_roots))
+            return (
+                f"Write denied: '{path}' is outside the configured "
+                f"HERMES_WRITE_SAFE_ROOT ({roots_display})."
+            )
+
+    return None
+
+
 # Common secret-bearing project-local environment file basenames.
 # These are blocked because .env files routinely contain API keys,
 # database passwords, and other credentials.

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -249,6 +249,11 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
 
         self.assertIn("error", response)
         self.assertFalse(outside.exists())
+        # Verify the error message distinguishes safe-root from credential denial
+        error_msg = response["error"].get("message", "") if isinstance(response["error"], dict) else str(response["error"])
+        assert "outside" in error_msg
+        assert "HERMES_WRITE_SAFE_ROOT" in error_msg
+        assert "credential" not in error_msg
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -209,7 +209,7 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
             target = home / ".ssh" / "id_rsa"
             target.parent.mkdir(parents=True, exist_ok=True)
 
-            with patch("agent.copilot_acp_client.is_write_denied", return_value=True, create=True):
+            with patch("agent.copilot_acp_client.get_write_denial_reason", return_value="Write denied: protected path", create=True):
                 response = self._dispatch(
                     {
                         "jsonrpc": "2.0",

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -419,5 +419,77 @@ class TestGetWriteDenialReason:
         assert "protected system/credential file" in reason
 
 
+
+class TestSafeRootDenialMessageIntegration:
+    """Regression tests verifying that file-tools surface the correct denial
+    message when HERMES_WRITE_SAFE_ROOT blocks a path.
+
+    Prior to this fix, ALL write denials returned the same "protected
+    system/credential file" message regardless of root cause.  These tests
+    exercise the actual write_file / patch_replace code path, not just
+    the get_write_denial_reason() helper in isolation.
+    """
+
+    @pytest.fixture
+    def ops(self, tmp_path: Path):
+        from tools.environments.local import LocalEnvironment
+        from tools.file_operations import ShellFileOperations
+        env = LocalEnvironment(cwd=str(tmp_path))
+        return ShellFileOperations(env, cwd=str(tmp_path))
+
+    def test_write_file_safe_root_outside_shows_safe_root_message(
+        self, ops, tmp_path: Path, monkeypatch
+    ):
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        outside = tmp_path / "other" / "file.txt"
+        outside.parent.mkdir()
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        res = ops.write_file(str(outside), "content")
+        assert res.error is not None
+        assert "outside" in res.error
+        assert "HERMES_WRITE_SAFE_ROOT" in res.error
+        assert str(safe_root) in res.error
+        assert "credential" not in res.error
+        assert not outside.exists()
+
+    def test_patch_replace_safe_root_outside_shows_safe_root_message(
+        self, ops, tmp_path: Path, monkeypatch
+    ):
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        outside = tmp_path / "other" / "file.txt"
+        outside.parent.mkdir()
+        outside.write_text("old content")
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        res = ops.patch_replace(str(outside), "old", "new")
+        assert res.error is not None
+        assert "outside" in res.error
+        assert "HERMES_WRITE_SAFE_ROOT" in res.error
+        assert "credential" not in res.error
+
+    def test_write_file_credential_path_shows_credential_message(
+        self, ops, tmp_path: Path
+    ):
+        res = ops.write_file("/etc/shadow", "content")
+        assert res.error is not None
+        assert "protected system/credential file" in res.error
+        assert "outside" not in res.error
+
+    def test_write_file_allowed_path_returns_no_error(
+        self, ops, tmp_path: Path, monkeypatch
+    ):
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        inside = safe_root / "file.txt"
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        res = ops.write_file(str(inside), "content")
+        assert res.error is None
+        assert inside.read_text() == "content"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -368,5 +368,56 @@ class TestBomHandling:
         assert raw == self.BOM.encode("utf-8") + b"import os, json\nimport sys\n"
 
 
+class TestGetWriteDenialReason:
+    """Tests for get_write_denial_reason() — specific denial messages."""
+
+    def test_credential_path_returns_credential_message(self, tmp_path: Path):
+        from agent.file_safety import get_write_denial_reason
+
+        reason = get_write_denial_reason("/etc/shadow")
+        assert reason is not None
+        assert "protected system/credential file" in reason
+        assert "outside" not in reason
+
+    def test_safe_root_outside_returns_safe_root_message(self, tmp_path: Path, monkeypatch):
+        from agent.file_safety import get_write_denial_reason
+
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        outside = tmp_path / "other" / "file.txt"
+        outside.parent.mkdir()
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        reason = get_write_denial_reason(str(outside))
+        assert reason is not None
+        assert "outside" in reason
+        assert "HERMES_WRITE_SAFE_ROOT" in reason
+        assert str(safe_root) in reason
+        assert "credential" not in reason
+
+    def test_allowed_path_returns_none(self, tmp_path: Path, monkeypatch):
+        from agent.file_safety import get_write_denial_reason
+
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        inside = safe_root / "file.txt"
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        assert get_write_denial_reason(str(inside)) is None
+
+    def test_credential_path_takes_precedence_over_safe_root(self, tmp_path: Path, monkeypatch):
+        from agent.file_safety import get_write_denial_reason
+
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        # /etc/shadow is a credential path — should get credential message,
+        # not safe-root message, even though it's also outside the safe root.
+        reason = get_write_denial_reason("/etc/shadow")
+        assert reason is not None
+        assert "protected system/credential file" in reason
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -38,6 +38,7 @@ from agent.file_safety import (
     build_write_denied_paths,
     build_write_denied_prefixes,
     is_write_denied as _shared_is_write_denied,
+    get_write_denial_reason,
 )
 
 
@@ -1250,7 +1251,8 @@ class ShellFileOperations(FileOperations):
     def _python_delete(self, path: str, recursive: bool) -> WriteResult:
         path = self._expand_path(path)
         if _is_write_denied(path):
-            return WriteResult(error=f"Delete denied: {path} is a protected path")
+            reason = get_write_denial_reason(path) or "Write denied"
+            return WriteResult(error=reason)
 
         # We can't shell out to ``rm`` here — it doesn't exist on Windows
         # ``cmd.exe`` or PowerShell, so this code path is what's left when
@@ -1295,8 +1297,9 @@ class ShellFileOperations(FileOperations):
         src = self._expand_path(src)
         dst = self._expand_path(dst)
         for p in (src, dst):
-            if _is_write_denied(p):
-                return WriteResult(error=f"Move denied: {p} is a protected path")
+            reason = get_write_denial_reason(p)
+            if reason:
+                return WriteResult(error=reason)
         result = self._exec(
             f"mv {self._escape_shell_arg(src)} {self._escape_shell_arg(dst)}"
         )
@@ -1334,8 +1337,9 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
 
         # Block writes to sensitive paths
-        if _is_write_denied(path):
-            return WriteResult(error=f"Write denied: '{path}' is a protected system/credential file.")
+        reason = get_write_denial_reason(path)
+        if reason:
+            return WriteResult(error=reason)
 
         # Capture pre-write content.  Two consumers want it:
         #
@@ -1480,8 +1484,9 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
 
         # Block writes to sensitive paths
-        if _is_write_denied(path):
-            return PatchResult(error=f"Write denied: '{path}' is a protected system/credential file.")
+        reason = get_write_denial_reason(path)
+        if reason:
+            return PatchResult(error=reason)
 
         # Read current content
         read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"


### PR DESCRIPTION
## What does this PR do?

When `HERMES_WRITE_SAFE_ROOT` is set and a write target falls outside the allowed root, the old code returned the same `"protected system/credential file"` message as actual credential-path denials. This pushed users toward the wrong diagnosis — in containerized deployments, writing to `/tmp/test.txt` is obviously not a credential-file issue, but the error message said it was.

This PR adds `get_write_denial_reason()` in `agent/file_safety.py` that returns a specific message for each denial class:

- **Credential / system path**: `"Write denied: '...' is a protected system/credential file."`
- **Outside safe root**: `"Write denied: '...' is outside the configured HERMES_WRITE_SAFE_ROOT (/opt/data)."`

All 5 callers are updated to use the new function.

## Related Issue

Fixes #55607

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/file_safety.py`: Added `get_write_denial_reason(path) -> str | None` — returns a specific reason string for credential-path vs safe-root denials, or `None` if the path is writable. `is_write_denied()` is preserved unchanged for backward compatibility.
- `tools/file_operations.py`: Updated 4 callers (`_python_delete`, `move_file`, `write_file`, `apply_patch`) to use `get_write_denial_reason()` instead of hardcoded messages.
- `agent/copilot_acp_client.py`: Updated `fs/write_text_file` handler to use `get_write_denial_reason()`.
- `tests/tools/test_file_write_safety.py`: Added `TestGetWriteDenialReason` — 4 tests covering credential message, safe-root message, allowed path (None), and precedence (credential check runs before safe-root).
- `tests/agent/test_copilot_acp_client.py`: Updated mock from `is_write_denied` to `get_write_denial_reason` to match the new call site.

## How to Test

1. `python -m pytest tests/tools/test_file_write_safety.py::TestGetWriteDenialReason -xvs` — 4 new tests should pass.
2. `python -m pytest tests/tools/test_file_write_safety.py tests/tools/test_file_operations.py tests/tools/test_write_deny.py -q` — all existing safety tests should still pass (152 tests).
3. `python -m pytest tests/agent/test_copilot_acp_client.py::CopilotACPClientSafetyTests -q` — 9 safety tests should pass.
4. Reproduce: set `HERMES_WRITE_SAFE_ROOT=/opt/data`, try to write `/tmp/test.txt` — error should say "outside the configured HERMES_WRITE_SAFE_ROOT" instead of "protected system/credential file".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (pre-existing failure in `test_run_prompt_preserves_real_home_when_profile_home_available` is unrelated)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstring added to `get_write_denial_reason()`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (path resolution is platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
