### PR TITLE
fix(desktop): preserve named custom provider identity

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -115,6 +115,40 @@ describe('ModelSettings', () => {
     expect(screen.queryByText(/DeepSeek/)).toBeNull()
   })
 
+  it('selects the saved custom provider identity returned by the backend', async () => {
+    getGlobalModelInfo.mockResolvedValueOnce({
+      provider: 'custom:api.aixyzs.com',
+      model: 'gpt-5.3-codex-spark'
+    })
+    getGlobalModelOptions.mockResolvedValueOnce({
+      providers: [
+        {
+          name: 'Custom endpoint',
+          slug: 'custom',
+          models: [],
+          authenticated: false,
+          auth_type: 'api_key'
+        },
+        {
+          name: 'API.AIXYZS.COM',
+          slug: 'custom:api.aixyzs.com',
+          api_url: 'https://api.aixyzs.com/v1',
+          models: ['gpt-5.3-codex-spark'],
+          authenticated: true,
+          is_user_defined: true
+        }
+      ]
+    })
+
+    await renderModelSettings()
+
+    const providerSelect = (await screen.findAllByRole('combobox'))[0]
+
+    expect(providerSelect.textContent).toContain('API.AIXYZS.COM')
+    expect(screen.queryByText(/needs an API key/)).toBeNull()
+    expect(screen.queryByRole('button', { name: /Set up Custom endpoint/ })).toBeNull()
+  })
+
   it.each(['custom', 'local', 'custom:lab'])(
     'opens local endpoint setup when %s has no inventory row',
     async provider => {

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 
 import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
 import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
-import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
+import { $activeSessionId, $currentModel, $currentProvider, $currentReasoningEffort } from '@/store/session'
 
 import { ModelMenuPanel } from './model-menu-panel'
 
@@ -39,12 +39,20 @@ const GOOGLE_PROVIDER = {
   slug: 'google'
 }
 
+const CUSTOM_PROVIDER = {
+  capabilities: { 'gpt-5.3-codex-spark': { fast: false, reasoning: true } },
+  models: ['gpt-5.3-codex-spark'],
+  name: 'API.AIXYZS.COM',
+  slug: 'custom:api.aixyzs.com'
+}
+
 const MOCK_PROVIDERS = [DEEPSEEK_PROVIDER, GOOGLE_PROVIDER, MOA_PROVIDER]
 
 beforeEach(() => {
   $activeSessionId.set('runtime-1')
   $currentModel.set('')
   $currentProvider.set('')
+  $currentReasoningEffort.set('')
   $collapsedProviders.set([])
   getGlobalModelOptions.mockResolvedValue({ providers: MOCK_PROVIDERS })
 })
@@ -54,20 +62,20 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-function renderPanel(onSelectModel = vi.fn()) {
+function renderPanel(onSelectModel = vi.fn(), requestGateway = vi.fn(async () => ({}) as never)) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
   const content = render(
     <QueryClientProvider client={client}>
       <DropdownMenu open>
         <DropdownMenuContent>
-          <ModelMenuPanel onSelectModel={onSelectModel} requestGateway={vi.fn() as never} />
+          <ModelMenuPanel onSelectModel={onSelectModel} requestGateway={requestGateway as never} />
         </DropdownMenuContent>
       </DropdownMenu>
     </QueryClientProvider>
   )
 
-  return { onSelectModel, content }
+  return { onSelectModel, requestGateway, content }
 }
 
 describe('ModelMenuPanel MoA presets', () => {
@@ -141,6 +149,29 @@ describe('ModelMenuPanel current selection', () => {
 
     expect(currentRow?.querySelector('.codicon-check')).not.toBeNull()
     expect(staleRow?.querySelector('.codicon-check')).toBeNull()
+  })
+
+  it('writes reasoning changes for the active named custom provider row', async () => {
+    $currentProvider.set('custom:api.aixyzs.com')
+    $currentModel.set('gpt-5.3-codex-spark')
+    $currentReasoningEffort.set('max')
+    getGlobalModelOptions.mockResolvedValue({ providers: [CUSTOM_PROVIDER] })
+    const requestGateway = vi.fn(async () => ({}) as never)
+    const { content } = renderPanel(vi.fn(), requestGateway)
+
+    const row = (await content.findByText('GPT-5.3-codex-spark')).closest('[role="menuitem"]')
+
+    expect(row?.querySelector('.codicon-check')).not.toBeNull()
+    fireEvent.keyDown(row!, { key: 'ArrowRight' })
+    fireEvent.click(await screen.findByText('Extra High'))
+
+    await vi.waitFor(() => {
+      expect(requestGateway).toHaveBeenCalledWith('config.set', {
+        key: 'reasoning',
+        session_id: 'runtime-1',
+        value: 'xhigh'
+      })
+    })
   })
 })
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6177,22 +6177,40 @@ def get_model_info(profile: Optional[str] = None):
     try:
         with _profile_scope(profile):
             cfg = load_config()
-        model_cfg = cfg.get("model", "")
+            model_cfg = cfg.get("model", "")
 
-        # Extract model name and provider from the config
-        if isinstance(model_cfg, dict):
-            model_name = model_cfg.get("default", model_cfg.get("name", ""))
-            provider = model_cfg.get("provider", "")
-            base_url = model_cfg.get("base_url", "")
-            config_ctx = model_cfg.get("context_length")
-        else:
-            model_name = str(model_cfg) if model_cfg else ""
-            provider = ""
-            base_url = ""
-            config_ctx = None
+            # Extract model name and provider from the config
+            if isinstance(model_cfg, dict):
+                model_name = model_cfg.get("default", model_cfg.get("name", ""))
+                provider = model_cfg.get("provider", "")
+                base_url = model_cfg.get("base_url", "")
+                config_ctx = model_cfg.get("context_length")
+            else:
+                model_name = str(model_cfg) if model_cfg else ""
+                provider = ""
+                base_url = ""
+                config_ctx = None
+
+            display_provider = provider
+            if str(provider or "").strip().lower() == "custom":
+                try:
+                    from hermes_cli.runtime_provider import canonical_custom_identity
+
+                    display_provider = (
+                        canonical_custom_identity(
+                            base_url=base_url or None,
+                            model=model_name or None,
+                        )
+                        or provider
+                    )
+                except Exception:
+                    _log.debug(
+                        "Failed to resolve custom provider identity for model info",
+                        exc_info=True,
+                    )
 
         if not model_name:
-            return dict(_EMPTY_MODEL_INFO, provider=provider)
+            return dict(_EMPTY_MODEL_INFO, provider=display_provider)
 
         # Resolve auto-detected context length (pass config_ctx=None to get
         # purely auto-detected value, then separately report the override)
@@ -6233,7 +6251,7 @@ def get_model_info(profile: Optional[str] = None):
 
         return {
             "model": model_name,
-            "provider": provider,
+            "provider": display_provider,
             "auto_context_length": auto_ctx,
             "config_context_length": config_ctx_int,
             "effective_context_length": effective_ctx,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2647,6 +2647,33 @@ class TestModelInfoEndpoint:
         assert data["config_context_length"] == 100000
         assert data["effective_context_length"] == 100000  # override wins
 
+    def test_model_info_returns_named_custom_provider_identity(self):
+        from hermes_cli.config import save_config
+
+        save_config(
+            {
+                "model": {
+                    "default": "gpt-5.3-codex-spark",
+                    "provider": "custom",
+                    "base_url": "https://api.aixyzs.com/v1",
+                },
+                "providers": {
+                    "api.aixyzs.com": {
+                        "api": "https://api.aixyzs.com/v1/",
+                        "models": ["gpt-5.3-codex-spark"],
+                    }
+                },
+            }
+        )
+
+        with (
+            patch("agent.model_metadata.get_model_context_length", return_value=0),
+            patch("agent.models_dev.get_model_capabilities", return_value=None),
+        ):
+            resp = self.client.get("/api/model/info")
+
+        assert resp.status_code == 200
+        assert resp.json()["provider"] == "custom:api.aixyzs.com"
 
     def test_model_info_graceful_on_metadata_error(self, monkeypatch):
         """Endpoint should return zeros on import/resolution errors, not 500."""

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -57,10 +57,13 @@ def _custom_agent(base_url=MIMO_URL):
     return types.SimpleNamespace(
         model="mimo-v2.5-pro",
         provider="custom",
+        requested_provider="custom:mimo-v2.5-pro",
         base_url=base_url,
         api_mode="chat_completions",
         reasoning_config=None,
         service_tier=None,
+        session_id="",
+        tools=[],
     )
 
 
@@ -152,6 +155,7 @@ class TestResumeRoundTrip:
         )
 
         assert kwargs["provider"] == "custom"
+        assert kwargs["requested_provider"] == "custom:mimo-v2.5-pro"
         assert kwargs["base_url"] == MIMO_URL
         assert kwargs["api_key"] == MIMO_KEY
 
@@ -261,6 +265,7 @@ class TestBareCustomNoBaseUrlHealsFromConfig:
 
         assert kwargs["base_url"] == MIMO_URL
         assert kwargs["api_key"] == MIMO_KEY
+        assert kwargs["requested_provider"] == "custom:mimo-v2.5-pro"
         assert "openrouter.ai" not in (kwargs.get("base_url") or "")
 
     def test_first_db_row_persists_entry_identity_not_bare_custom(self, monkeypatch):
@@ -342,4 +347,32 @@ class TestModelNameRecoversEntryIdentity:
             == "custom:hermes-ultra"
         )
 
+
+class TestLiveSessionProviderIdentity:
+    def test_session_info_reports_requested_custom_catalog_identity(self, monkeypatch):
+        from tui_gateway import server
+
+        monkeypatch.setattr(server, "_load_cfg", lambda: {})
+        agent = _custom_agent()
+
+        info = server._session_info(agent, {"history": [], "session_key": ""})
+
+        assert info["provider"] == "custom:mimo-v2.5-pro"
+
+    def test_session_info_uses_override_for_pre_identity_agents(self, monkeypatch):
+        from tui_gateway import server
+
+        monkeypatch.setattr(server, "_load_cfg", lambda: {})
+        agent = _custom_agent()
+        agent.requested_provider = "custom"
+        session = {
+            "history": [],
+            "session_key": "",
+            "model_override": {
+                "model": "mimo-v2.5-pro",
+                "provider": "custom:mimo-v2.5-pro",
+            },
+        }
+
+        assert server._session_info(agent, session)["provider"] == "custom:mimo-v2.5-pro"
 

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -55,6 +55,7 @@ def test_make_agent_passes_resolved_provider():
 
         call_kwargs = mock_agent.call_args
         assert call_kwargs.kwargs["provider"] == "anthropic"
+        assert call_kwargs.kwargs["requested_provider"] is None
         assert call_kwargs.kwargs["base_url"] == "https://api.anthropic.com"
         assert call_kwargs.kwargs["api_key"] == "sk-test-key"
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5104,6 +5104,31 @@ def _project_info_for_cwd(cwd: str) -> dict | None:
         return None
 
 
+def _session_provider_identity(agent, session: dict | None, mirror: dict) -> str:
+    """Return the catalog identity for a live session's resolved provider."""
+    provider = str(
+        mirror.get("provider") or getattr(agent, "provider", "") or ""
+    ).strip()
+    if provider.lower() != "custom":
+        return provider
+
+    override = (session or {}).get("model_override")
+    override_provider = (
+        override.get("provider") if isinstance(override, dict) else ""
+    )
+    # ``agent.provider`` is the runtime/billing class (bare ``custom``), while
+    # the requested provider and session override retain the routable catalog
+    # identity. Prefer the live agent because a successful in-place model switch
+    # updates it before the session override is committed.
+    for candidate in (getattr(agent, "requested_provider", ""), override_provider):
+        normalized = str(candidate or "").strip().lower()
+        if normalized.startswith("custom:"):
+            return normalized
+
+    # A genuine ad-hoc custom endpoint has no named catalog row.
+    return provider
+
+
 def _session_info(agent, session: dict | None = None) -> dict:
     if session is None:
         for candidate in _sessions.values():
@@ -5155,10 +5180,10 @@ def _session_info(agent, session: dict | None = None) -> dict:
     pending_switch = (session or {}).get("pending_model_switch") or {}
     pending_model = str(pending_switch.get("display_model") or "").strip()
     pending_provider = str(pending_switch.get("display_provider") or "").strip()
+    session_provider = _session_provider_identity(agent, session, mirror)
     info: dict = {
         "model": pending_model or mirror.get("model", getattr(agent, "model", "")),
-        "provider": pending_provider
-        or mirror.get("provider", getattr(agent, "provider", "")),
+        "provider": pending_provider or session_provider,
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
@@ -6531,11 +6556,34 @@ def _make_agent(
             if not resolution.selected_model:
                 raise RuntimeError("Auth fallback resolved without a model")
             model = resolution.selected_model
+    agent_requested_provider = None
+    if str(runtime.get("provider") or "").strip().lower() == "custom":
+        agent_requested_provider = str(
+            runtime.get("requested_provider") or requested_provider or ""
+        ).strip()
+        try:
+            from hermes_cli.runtime_provider import canonical_custom_identity
+
+            agent_requested_provider = (
+                canonical_custom_identity(
+                    base_url=runtime.get("base_url") or None,
+                    config_provider=agent_requested_provider or None,
+                    model=model or None,
+                )
+                or agent_requested_provider
+            )
+        except Exception:
+            logger.debug(
+                "custom provider identity recovery failed (agent build)",
+                exc_info=True,
+            )
+
     _pr = _load_provider_routing()
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
+        requested_provider=agent_requested_provider or None,
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),


### PR DESCRIPTION
## What does this PR do?

Preserves the routable `custom:<name>` identity across the Desktop/TUI model-state path.

Current `main` already heals persisted session rows and model-picker inventory, but initial live agents and `/api/model/info` could still expose the resolved runtime/billing class `custom`. Desktop catalog rows are keyed by `custom:<name>`, so the named row appeared inactive. The model menu intentionally treats an inactive row as a preset-only edit; as a result, changing reasoning from `max` to `xhigh` did not send the live session's `config.set`, and the next request still used `max`.

The fix makes the backend authoritative for the canonical provider identity instead of adding another renderer-side config lookup.

## Related Issue

N/A - reproduced directly on current `main` with a named custom endpoint.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor

## Changes Made

- Preserve the canonical custom provider requested identity when `tui_gateway` constructs an `AIAgent`, without changing built-in-provider fallback semantics.
- Emit that canonical identity from `session.info`, with a session-override fallback for agents created before the identity was retained.
- Canonicalize the provider returned by `/api/model/info` inside the requested profile scope.
- Cover Settings selection, active-session reasoning writes, agent construction, session info, REST model info, and the non-custom guard.
- Replace the prior supplemental Desktop config-fetch approach, so a failed extra fetch can no longer blank Model Settings.

## How to Test

1. Configure a named custom provider and select one of its models.
2. Start a Desktop session and verify the named provider/model row remains active.
3. Change reasoning from `Max` to `Extra High`; verify `config.set` receives `xhigh` for the live session.
4. Open Settings -> Model and verify the saved named provider is selected rather than the generic unconfigured Custom endpoint row.

Focused automated validation:

- `scripts/run_tests.sh -j 3 tests/tui_gateway/test_custom_provider_session_persistence.py tests/tui_gateway/test_make_agent_provider.py tests/hermes_cli/test_web_server.py -q` (158 passed)
- `scripts/run_tests.sh tests/tui_gateway/test_reasoning_session_scope.py -q` (8 passed)
- `npm --workspace apps/desktop run test:ui -- src/app/settings/model-settings.test.tsx src/app/shell/model-menu-panel.test.tsx` (41 passed)
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run lint` (0 errors; existing warnings only)
- `.venv/bin/ruff check` on changed Python files

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Conventional Commit message
- [x] Checked current main and related custom-provider fixes before implementing
- [x] PR contains only related changes
- [ ] Full `pytest tests/ -q` suite run (focused suites above passed)
- [x] Added regression tests
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered; no platform-specific behavior added
- [x] Tool descriptions/schemas update: N/A
