### PR TITLE
fix(agent): escape dangling backslash before a control char in tool-call JSON repair

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -162,6 +162,14 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
         ch = raw[i]
         if in_string:
             if ch == "\\" and i + 1 < n:
+                if ord(raw[i + 1]) < 0x20:
+                    # A backslash immediately before a literal control char is
+                    # NOT a valid JSON escape. Escape the backslash itself and
+                    # let the control-char branch below escape the following
+                    # char on the next iteration (lossless: both preserved).
+                    out.append("\\\\")
+                    i += 1
+                    continue
                 # Already-escaped char — pass through as-is
                 out.append(ch)
                 out.append(raw[i + 1])

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -140,3 +140,12 @@ class TestRepairToolCallArguments:
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
 
+    def test_backslash_before_literal_control_char(self):
+        """A backslash immediately before a literal newline is not a valid
+        JSON escape; the repair must escape the backslash (and the control
+        char) instead of silently dropping all args."""
+        raw = '{"path": "C:\\\ntmp"}'
+        result = _repair_tool_call_arguments(raw, "write_file")
+        parsed = json.loads(result)  # must parse under strict=True
+        assert parsed["path"] == "C:\\\ntmp"  # backslash + newline preserved
+


### PR DESCRIPTION
## What does this PR do?

`_escape_invalid_chars_in_json_strings` (the control-char repair pass for malformed local-model tool-call JSON, in `agent/message_sanitization.py`) treats a backslash immediately followed by a *literal* control char (e.g. a real newline or tab) as a valid escape sequence and passes both bytes through unescaped. The control char then never reaches the `ord(ch) < 0x20` escape branch, so the repaired string stays invalid JSON, `_repair_tool_call_arguments` exhausts its repair passes, and returns `"{}"` — silently discarding **all** tool-call arguments.

A model on a local/quirky backend (llama.cpp, GLM via Ollama — exactly what this repair pipeline exists for) that emits a backslash right before a line break therefore loses every argument, and the tool runs with none.

The fix: when a backslash precedes a literal control char, escape the backslash (`\\`) and let the existing control-char branch escape the following char on the next iteration. The repaired JSON is then valid **and** lossless — both the backslash and the control char are preserved.

## Related Issue

<!-- No filed issue; author-found regression in the tool-call JSON repair pipeline. -->

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/message_sanitization.py` — in `_escape_invalid_chars_in_json_strings`, detect a backslash immediately before a literal control char (`ord < 0x20`); escape the backslash and advance by one so the control char is escaped by the existing branch on the next iteration.
- `tests/run_agent/test_repair_tool_call_arguments.py` — add `test_backslash_before_literal_control_char` covering the lossless round-trip.

## How to Test

Reproduction (before the fix):

```python
from agent.message_sanitization import _repair_tool_call_arguments
_repair_tool_call_arguments('{"path": "C:\<backslash><newline>tmp"}', "write_file")
# -> "{}"   (all arguments silently dropped)
```

After the fix it repairs to valid JSON that parses (under `strict=True`) back to `C:` + backslash + newline + `tmp`.

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/run_agent/test_repair_tool_call_arguments.py -q`
2. The new `test_backslash_before_literal_control_char` fails on `main` (raises `KeyError: 'path'`, args lost) and passes with this change.
3. All 22 tests in the file pass; no existing control-char test regresses.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A