### PR TITLE
fix(desktop): preserve pinned sessions key on empty array to prevent permanent loss

### DIFF
--- a/apps/desktop/src/lib/persisted.test.ts
+++ b/apps/desktop/src/lib/persisted.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { Codecs } from './persisted'
+
+describe('Codecs.stringArray', () => {
+  it('decodes a JSON array of strings', () => {
+    expect(Codecs.stringArray.decode('["a","b","c"]')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('filters out non-strings and empty strings on decode', () => {
+    expect(Codecs.stringArray.decode('["a","",123,null,"b"]')).toEqual(['a', 'b'])
+  })
+
+  it('returns empty array for non-array JSON', () => {
+    expect(Codecs.stringArray.decode('"oops"')).toEqual([])
+    expect(Codecs.stringArray.decode('{}')).toEqual([])
+  })
+
+  it('encodes a non-empty array to JSON', () => {
+    expect(Codecs.stringArray.encode(['a', 'b'])).toBe('["a","b"]')
+  })
+
+  it('encodes an empty array to null (removes key)', () => {
+    expect(Codecs.stringArray.encode([])).toBeNull()
+  })
+})
+
+describe('Codecs.stringArrayPreserved', () => {
+  it('decodes identically to stringArray', () => {
+    expect(Codecs.stringArrayPreserved.decode('["a","b"]')).toEqual(['a', 'b'])
+    expect(Codecs.stringArrayPreserved.decode('[]')).toEqual([])
+    expect(Codecs.stringArrayPreserved.decode('"oops"')).toEqual([])
+  })
+
+  it('encodes a non-empty array to JSON', () => {
+    expect(Codecs.stringArrayPreserved.encode(['a', 'b'])).toBe('["a","b"]')
+  })
+
+  it('encodes an empty array to "[]" (preserves key)', () => {
+    expect(Codecs.stringArrayPreserved.encode([])).toBe('[]')
+  })
+
+  it('round-trips an empty array through encode → decode', () => {
+    const encoded = Codecs.stringArrayPreserved.encode([])
+    expect(encoded).toBe('[]')
+    // Simulating what persistentAtom does: readKey returns "[]", decode returns []
+    expect(Codecs.stringArrayPreserved.decode(encoded!)).toEqual([])
+  })
+})

--- a/apps/desktop/src/lib/persisted.ts
+++ b/apps/desktop/src/lib/persisted.ts
@@ -30,6 +30,19 @@ export const Codecs = {
     },
     encode: value => (value.length === 0 ? null : JSON.stringify(value))
   } as Codec<string[]>,
+  // Like stringArray but never removes the key on empty — writes "[]" instead.
+  // Use for user-curated lists (e.g. pinned sessions) where an absent key is
+  // indistinguishable from "lost all data" and recovery is impossible.
+  stringArrayPreserved: {
+    decode: raw => {
+      const parsed = JSON.parse(raw) as unknown
+
+      return Array.isArray(parsed)
+        ? parsed.filter((item): item is string => typeof item === 'string' && item.length > 0)
+        : []
+    },
+    encode: value => JSON.stringify(value)
+  } as Codec<string[]>,
   // Mirrors storedStringRecord/persistStringRecord: keeps only string values.
   stringRecord: {
     decode: raw => {

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -66,7 +66,7 @@ export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states 
   return typeof override === 'number' ? override : SIDEBAR_DEFAULT_WIDTH
 })
 
-export const $pinnedSessionIds = persistentAtom(SIDEBAR_PINNED_STORAGE_KEY, [] as string[], Codecs.stringArray)
+export const $pinnedSessionIds = persistentAtom(SIDEBAR_PINNED_STORAGE_KEY, [] as string[], Codecs.stringArrayPreserved)
 export const $sidebarSessionOrderIds = persistentAtom(
   SIDEBAR_SESSION_ORDER_STORAGE_KEY,
   [] as string[],


### PR DESCRIPTION
## What does this PR do?

Prevents permanent loss of the Desktop pinned sessions key in localStorage. When the pinned sessions list becomes empty (e.g., all sessions deleted/archived), `Codecs.stringArray.encode([])` returns `null`, which causes `writeKey` to call `localStorage.removeItem()` — permanently deleting the key. On next load, the key is absent and the atom initializes with `[]`, making it impossible to distinguish "user never pinned anything" from "all pins were irreversibly lost."

Adds `Codecs.stringArrayPreserved` — a codec variant that writes `"[]"` instead of `null` on empty arrays, keeping the localStorage key alive. Uses it for `$pinnedSessionIds` so pin metadata survives even if the list transiently empties.

## Related Issue

Fixes #55616

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/persisted.ts` — Add `Codecs.stringArrayPreserved` codec variant that encodes empty arrays as `"[]"` instead of `null`, preventing key deletion
- `apps/desktop/src/store/layout.ts` — Switch `$pinnedSessionIds` from `Codecs.stringArray` to `Codecs.stringArrayPreserved`
- `apps/desktop/src/lib/persisted.test.ts` — Add 9 tests covering both `stringArray` (null on empty) and `stringArrayPreserved` (`"[]"` on empty) codecs, including round-trip behavior

## How to Test

1. Run `cd apps/desktop && npx vitest run src/lib/persisted.test.ts --environment jsdom` — all 9 tests should pass
2. Run `cd apps/desktop && npx vitest run src/store/session.test.ts --environment jsdom` — existing 19 session tests should pass (no regression)
3. Manual verification: In Desktop, pin a session, then unpin it. Check `localStorage.getItem('hermes.desktop.pinnedSessions')` in DevTools — it should return `"[]"` (not `null`), confirming the key persists
4. Pin another session — it should appear correctly, proving the preserved key doesn't break re-pinning

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npx vitest run --environment jsdom` and all related tests pass
- [x] I've added tests for my changes (9 tests for the new codec behavior)
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (Electron localStorage is cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
