### PR TITLE
fix(gateway): encode path-unsafe chars in session key for DingTalk DMs

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -102,7 +102,7 @@ def _sanitize_key_component(value: str) -> str:
     etc.) are left as-is because they are safe in dict keys and common in
     platform identifiers.
     """
-    return value.replace("/", "%2F").replace("\\", "%5C").replace("..", "%2E%2E")
+    return value.replace("%", "%25").replace("/", "%2F").replace("\\", "%5C").replace("..", "%2E%2E")
 
 
 @dataclass

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -89,6 +89,22 @@ def _is_path_unsafe(value: object) -> bool:
     return len(s) >= 2 and s[0].isalpha() and s[1] == ":"
 
 
+def _sanitize_key_component(value: str) -> str:
+    r"""Encode path-unsafe characters in a session key component.
+
+    Some platforms (DingTalk, WhatsApp) use ``/`` or ``\`` in their chat
+    identifiers.  Session keys are stored in ``sessions.json`` and validated
+    by :func:`_is_path_unsafe` on load, so any ``/`` or ``\`` in a raw
+    chat_id triggers a false-positive "directory traversal" rejection.
+
+    Only the characters that :func:`_is_path_unsafe` rejects (``/``, ``\``,
+    and ``..``) are encoded.  Other special characters (``@``, ``+``, ``=``,
+    etc.) are left as-is because they are safe in dict keys and common in
+    platform identifiers.
+    """
+    return value.replace("/", "%2F").replace("\\", "%5C").replace("..", "%2E%2E")
+
+
 @dataclass
 class SessionSource:
     """
@@ -791,10 +807,13 @@ def build_session_key(
         dm_chat_id = source.chat_id
         if source.platform == Platform.WHATSAPP:
             dm_chat_id = canonical_whatsapp_identifier(source.chat_id)
+        if dm_chat_id:
+            dm_chat_id = _sanitize_key_component(dm_chat_id)
 
         if dm_chat_id:
             if source.thread_id:
-                return f"{ns}:{platform}:dm:{dm_chat_id}:{source.thread_id}"
+                safe_thread = _sanitize_key_component(source.thread_id)
+                return f"{ns}:{platform}:dm:{dm_chat_id}:{safe_thread}"
             return f"{ns}:{platform}:dm:{dm_chat_id}"
         # No chat_id — fall back to the sender's own identifier before the
         # bare per-platform sink.  Without this, every DM from every user that
@@ -809,11 +828,14 @@ def build_session_key(
                 or dm_participant_id
             )
         if dm_participant_id:
+            dm_participant_id = _sanitize_key_component(str(dm_participant_id))
             if source.thread_id:
-                return f"{ns}:{platform}:dm:{dm_participant_id}:{source.thread_id}"
+                safe_thread = _sanitize_key_component(source.thread_id)
+                return f"{ns}:{platform}:dm:{dm_participant_id}:{safe_thread}"
             return f"{ns}:{platform}:dm:{dm_participant_id}"
         if source.thread_id:
-            return f"{ns}:{platform}:dm:{source.thread_id}"
+            safe_thread = _sanitize_key_component(source.thread_id)
+            return f"{ns}:{platform}:dm:{safe_thread}"
         return f"{ns}:{platform}:dm"
 
     participant_id = source.user_id_alt or source.user_id
@@ -825,9 +847,9 @@ def build_session_key(
     key_parts = [ns, platform, source.chat_type]
 
     if source.chat_id:
-        key_parts.append(source.chat_id)
+        key_parts.append(_sanitize_key_component(source.chat_id))
     if source.thread_id:
-        key_parts.append(source.thread_id)
+        key_parts.append(_sanitize_key_component(source.thread_id))
 
     # In threads, default to shared sessions (all participants see the same
     # conversation).  Per-user isolation only applies when explicitly enabled
@@ -837,7 +859,7 @@ def build_session_key(
         isolate_user = False
 
     if isolate_user and participant_id:
-        key_parts.append(str(participant_id))
+        key_parts.append(_sanitize_key_component(str(participant_id)))
 
     return ":".join(key_parts)
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1104,7 +1104,7 @@ class TestWhatsAppIdentifierPublicHelpers:
         assert normalize_whatsapp_identifier("60123456789:47@s.whatsapp.net") == "60123456789"
 
     def test_normalize_strips_leading_plus(self):
-        assert normalize_whatsapp_identifier("+601****6789") == "60123456789"
+        assert normalize_whatsapp_identifier("+60123456789") == "60123456789"
 
     def test_normalize_handles_bare_numeric(self):
         assert normalize_whatsapp_identifier("60123456789") == "60123456789"
@@ -1635,3 +1635,14 @@ class TestDingTalkSessionKeySlash:
         }
         entry = SessionEntry.from_dict(data)
         assert entry.session_key == "agent:main:dingtalk:dm:cidNcWXuYmxUGBIug3mN5iy%2F9w"
+
+    def test_percent_encoded_before_slash(self):
+        """Literal '%' must be encoded first to prevent collision with %2F."""
+        from gateway.session import _sanitize_key_component
+
+        # room/a -> room%2F  (slash encoded)
+        assert _sanitize_key_component("room/a") == "room%2Fa"
+        # room%2Fa -> room%252Fa  (literal % encoded to %25, then / untouched)
+        assert _sanitize_key_component("room%2Fa") == "room%252Fa"
+        # These must NOT collide
+        assert _sanitize_key_component("room/a") != _sanitize_key_component("room%2Fa")

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import (
+    SessionEntry,
     SessionSource,
     SessionStore,
     build_session_context,
@@ -1103,7 +1104,7 @@ class TestWhatsAppIdentifierPublicHelpers:
         assert normalize_whatsapp_identifier("60123456789:47@s.whatsapp.net") == "60123456789"
 
     def test_normalize_strips_leading_plus(self):
-        assert normalize_whatsapp_identifier("+60123456789") == "60123456789"
+        assert normalize_whatsapp_identifier("+601****6789") == "60123456789"
 
     def test_normalize_handles_bare_numeric(self):
         assert normalize_whatsapp_identifier("60123456789") == "60123456789"
@@ -1580,3 +1581,57 @@ class TestGatewaySessionDbRecovery:
         assert reset.session_id != entry.session_id
         assert reset.was_auto_reset is True
         assert reset.auto_reset_reason == "idle"
+
+class TestDingTalkSessionKeySlash:
+    """Regression: DingTalk DM chat_id contains '/' which triggered
+    _is_path_unsafe() false positive (#55617)."""
+
+    def test_dingtalk_dm_chat_id_with_slash_produces_safe_key(self):
+        from gateway.session import build_session_key, _is_path_unsafe
+
+        source = SessionSource(
+            platform=Platform.DINGTALK,
+            chat_id="cidNcWXuYmxUGBIug3mN5iy/9w/Ez8547TrWG+V8QP0w/E=",
+            chat_type="dm",
+        )
+        key = build_session_key(source)
+        assert "/" not in key
+        assert "\\" not in key
+        assert not _is_path_unsafe(key)
+        assert "%2F" in key  # slash is percent-encoded
+
+    def test_dingtalk_dm_chat_id_with_slash_preserves_determinism(self):
+        """Same chat_id must always produce the same key."""
+        source1 = SessionSource(
+            platform=Platform.DINGTALK,
+            chat_id="cidNcWXuYmxUGBIug3mN5iy/9w/Ez8547TrWG+V8QP0w/E=",
+            chat_type="dm",
+        )
+        source2 = SessionSource(
+            platform=Platform.DINGTALK,
+            chat_id="cidNcWXuYmxUGBIug3mN5iy/9w/Ez8547TrWG+V8QP0w/E=",
+            chat_type="dm",
+        )
+        assert build_session_key(source1) == build_session_key(source2)
+
+    def test_session_entry_from_dict_with_slash_key_raises(self):
+        """Old unencoded keys with '/' still fail _is_path_unsafe."""
+        data = {
+            "session_key": "agent:main:dingtalk:dm:cidNcWXuYmxUGBIug3mN5iy/9w",
+            "session_id": "test-id",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+        with pytest.raises(ValueError, match="directory traversal"):
+            SessionEntry.from_dict(data)
+
+    def test_session_entry_from_dict_with_encoded_key_succeeds(self):
+        """New encoded keys (no '/') pass _is_path_unsafe."""
+        data = {
+            "session_key": "agent:main:dingtalk:dm:cidNcWXuYmxUGBIug3mN5iy%2F9w",
+            "session_id": "test-id",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+        entry = SessionEntry.from_dict(data)
+        assert entry.session_key == "agent:main:dingtalk:dm:cidNcWXuYmxUGBIug3mN5iy%2F9w"


### PR DESCRIPTION
## What does this PR do?

DingTalk DM `chat_id` values contain `/` and `+` (they are base64-like identifiers such as `cidNcWXuYmxUGBIug3mN5iy/9w/Ez8547TrWG+V8QP0w/E=`).  When `build_session_key()` embeds the raw `chat_id` into the session key, the resulting key contains `/`, which `_is_path_unsafe()` rejects as a potential directory traversal on gateway restart.  The session entry is silently skipped, causing DingTalk DM historical context to be lost on every restart.

This PR adds `_sanitize_key_component()` that percent-encodes only the characters `_is_path_unsafe()` rejects (`/`, `\`, `..`) while preserving platform-native identifiers (`@`, `+`, `=`) that are safe in dict keys.  The function is applied to all variable components in `build_session_key()`: `chat_id`, `thread_id`, and `participant_id` across DM, group, and thread session paths.

## Related Issue

Fixes #55617

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py`: Added `_sanitize_key_component()` helper that encodes `/` → `%2F`, `\` → `%5C`, `..` → `%2E%2E`.  Applied it to `dm_chat_id`, `dm_participant_id`, `thread_id`, `chat_id`, and `participant_id` in `build_session_key()`.  Existing key format (`agent:main:platform:dm:...`) is preserved; only the variable components are encoded.
- `tests/gateway/test_session.py`: Added `TestDingTalkSessionKeySlash` — 4 tests covering safe key output, determinism, old unencoded key rejection, and new encoded key acceptance.

## How to Test

1. `python -m pytest tests/gateway/test_session.py::TestDingTalkSessionKeySlash -xvs` — 4 new tests should pass.
2. `python -m pytest tests/gateway/test_dingtalk.py -x -q` — existing DingTalk tests should pass (68 tests).
3. `python -m pytest tests/gateway/test_session.py -x -q` — all 99 session tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_session.py tests/gateway/test_dingtalk.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
