### PR TITLE
fix(skills): keep lock hashes stable for prefix paths

### DIFF
--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -249,6 +249,96 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
     assert "Updated 1 skill" in output
 
 
+def test_do_update_refreshes_stale_lock_content_hash(monkeypatch, tmp_path, hub_env):
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+
+    identifier = "owner/repo/demo-skill"
+    latest_bundle = hub.SkillBundle(
+        name="demo-skill",
+        files={
+            "SKILL.md": "# Demo\n\nlatest content\n",
+            "references/styles.md": "flat style notes\n",
+            "references/styles/blueprint.md": "nested blueprint\n",
+        },
+        source="github",
+        identifier=identifier,
+        trust_level="community",
+        metadata={"preserve": "me"},
+    )
+    expected_hash = hub.bundle_content_hash(latest_bundle)
+
+    lock = hub.HubLockFile(path=hub_env / "lock.json")
+    lock.save({
+        "version": 1,
+        "installed": {
+            "demo-skill": {
+                "source": "github",
+                "identifier": identifier,
+                "trust_level": "community",
+                "scan_verdict": "safe",
+                "content_hash": "sha256:stalehash",
+                "install_path": "demo-skill",
+                "files": ["SKILL.md"],
+                "metadata": {"preserve": "me"},
+                "installed_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            },
+        },
+    })
+
+    installed_dir = hub.SKILLS_DIR / "demo-skill"
+    installed_dir.mkdir(parents=True)
+    (installed_dir / "SKILL.md").write_text("# Demo\n\nold content\n", encoding="utf-8")
+
+    class _Source:
+        def source_id(self):
+            return "github"
+
+        def inspect(self, _identifier):
+            return hub.SkillMeta(
+                name="demo-skill",
+                description="Demo skill",
+                source="github",
+                identifier=identifier,
+                trust_level="community",
+            )
+
+        def fetch(self, _identifier):
+            return latest_bundle
+
+    monkeypatch.setattr(hub, "HubLockFile", lambda: lock)
+    monkeypatch.setattr(hub, "create_source_router", lambda auth=None: [_Source()])
+    monkeypatch.setattr(
+        guard,
+        "scan_skill",
+        lambda skill_path, source="community": guard.ScanResult(
+            skill_name="demo-skill",
+            source=source,
+            trust_level="community",
+            verdict="safe",
+        ),
+    )
+    monkeypatch.setattr(guard, "format_scan_report", lambda result: "scan ok")
+    monkeypatch.setattr(guard, "should_allow_install", lambda result, force=False: (True, "ok"))
+
+    before = hub.check_for_skill_updates(lock=lock, sources=[_Source()])
+    assert before[0]["status"] == "update_available"
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_update(name="demo-skill", console=console)
+
+    assert (hub.SKILLS_DIR / "demo-skill" / "SKILL.md").read_text(encoding="utf-8") == latest_bundle.files["SKILL.md"]
+
+    refreshed = lock.get_installed("demo-skill")
+    assert refreshed["content_hash"] == expected_hash
+    assert refreshed["metadata"] == {"preserve": "me"}
+
+    after = hub.check_for_skill_updates(lock=lock, sources=[_Source()])
+    assert after[0]["status"] == "up_to_date"
+
+
 def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():
     results = [type("R", (), {
         "name": "kubernetes",

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1168,6 +1168,28 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_matches_installed_content_hash_with_shared_prefix_paths(self, tmp_path):
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "# Demo\n",
+                "references/styles.md": "flat style notes\n",
+                "references/styles/blueprint.md": "nested blueprint\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        (skill_dir / "references" / "styles").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Demo\n")
+        (skill_dir / "references" / "styles.md").write_text("flat style notes\n")
+        (skill_dir / "references" / "styles" / "blueprint.md").write_text("nested blueprint\n")
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
     def test_bundle_content_hash_accepts_binary_files(self):
         bundle = SkillBundle(
             name="demo-binary-skill",

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -776,15 +776,17 @@ def content_hash(skill_path: Path) -> str:
     """
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for f in sorted(skill_path.rglob("*")):
+        files = []
+        for f in skill_path.rglob("*"):
             if f.is_file():
-                try:
-                    rel = f.relative_to(skill_path).as_posix()
-                    h.update(rel.encode("utf-8"))
-                    h.update(b"\x00")
-                    h.update(f.read_bytes())
-                except OSError:
-                    continue
+                files.append((f.relative_to(skill_path).as_posix(), f))
+        for rel, f in sorted(files):
+            try:
+                h.update(rel.encode("utf-8"))
+                h.update(b"\x00")
+                h.update(f.read_bytes())
+            except OSError:
+                continue
     elif skill_path.is_file():
         h.update(skill_path.read_bytes())
     return f"sha256:{h.hexdigest()[:16]}"


### PR DESCRIPTION
## Summary
- make `content_hash()` sort files by the same relative POSIX path string it hashes
- add a regression test for shared-prefix paths such as `references/styles.md` and `references/styles/blueprint.md`
- add an update-flow regression test showing `skills update` refreshes the lock hash and a following check reports `up_to_date`

Fixes #41176.

## Verification
- `pytest tests/hermes_cli/test_skills_hub.py -k stale_lock_content_hash -q`
- `pytest tests/tools/test_skills_hub.py -k 'shared_prefix_paths or bundle_content_hash_matches_installed_content_hash' -q`
- `pytest tests/hermes_cli/test_skills_hub.py tests/tools/test_skills_hub.py -q`
- `pytest tests/tools/test_skills_guard.py tests/tools/test_pr_6656_regressions.py -q`
- `python3 -m ruff check tools/skills_guard.py tests/hermes_cli/test_skills_hub.py tests/tools/test_skills_hub.py`

Note: `scripts/run_tests.sh tests/hermes_cli/test_skills_hub.py tests/tools/test_skills_hub.py -q` was not run because this worktree does not have a repo-local `.venv`/`venv`; the script exits before pytest starts.
