### PR TITLE
fix(desktop): use profile model for plain new chats

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -3,7 +3,15 @@ import { cleanup, render, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getGlobalModelInfo } from '@/hermes'
-import { $activeSessionId, $currentModel, $currentProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
+import {
+  $activeSessionId,
+  $currentModel,
+  $currentProvider,
+  $draftModelOverridePending,
+  setCurrentModel,
+  setCurrentProvider,
+  setDraftModelOverridePending
+} from '@/store/session'
 
 import { useModelControls } from './use-model-controls'
 
@@ -56,6 +64,7 @@ describe('useModelControls', () => {
     $activeSessionId.set(null)
     setCurrentModel('')
     setCurrentProvider('')
+    setDraftModelOverridePending(false)
   })
 
   afterEach(() => {
@@ -64,6 +73,7 @@ describe('useModelControls', () => {
     $activeSessionId.set(null)
     setCurrentModel('')
     setCurrentProvider('')
+    setDraftModelOverridePending(false)
   })
 
   it('applies the global model when there is no active runtime session', async () => {
@@ -149,6 +159,7 @@ describe('useModelControls', () => {
     // the gateway or the profile default here.
     expect($currentModel.get()).toBe('claude-sonnet-4.6')
     expect($currentProvider.get()).toBe('anthropic')
+    expect($draftModelOverridePending.get()).toBe(true)
     expect(requestGateway).not.toHaveBeenCalled()
     expect(setGlobalModel).not.toHaveBeenCalled()
   })
@@ -168,15 +179,16 @@ describe('useModelControls', () => {
     await result.current.refreshCurrentModel()
     expect($currentModel.get()).toBe('openai/gpt-5.5')
 
-    // A user pick must survive the lifecycle refreshes that fire on boot / fresh
-    // draft / session events.
-    setCurrentModel('anthropic/claude-sonnet-4.6')
-    setCurrentProvider('anthropic')
+    // A deliberate draft pick must survive the lifecycle refreshes that fire on
+    // boot / fresh draft / session events.
+    await result.current.selectModel({ model: 'anthropic/claude-sonnet-4.6', provider: 'anthropic' })
     await result.current.refreshCurrentModel()
     expect($currentModel.get()).toBe('anthropic/claude-sonnet-4.6')
 
     // A profile swap forces a reseed to the new profile's default.
+    setDraftModelOverridePending(true)
     await result.current.refreshCurrentModel(true)
     expect($currentModel.get()).toBe('openai/gpt-5.5')
+    expect($draftModelOverridePending.get()).toBe(false)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -4,7 +4,15 @@ import { useCallback } from 'react'
 import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
-import { $activeSessionId, $currentModel, $currentProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
+import {
+  $activeSessionId,
+  $currentModel,
+  $currentProvider,
+  $draftModelOverridePending,
+  setCurrentModel,
+  setCurrentProvider,
+  setDraftModelOverridePending
+} from '@/store/session'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelSelection {
@@ -46,13 +54,13 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
         return
       }
 
-      if (!force && $currentModel.get()) {
+      if (!force && $currentModel.get() && $draftModelOverridePending.get()) {
         return
       }
 
       const result = await getGlobalModelInfo()
 
-      if ($activeSessionId.get() || (!force && $currentModel.get())) {
+      if ($activeSessionId.get() || (!force && $currentModel.get() && $draftModelOverridePending.get())) {
         return
       }
 
@@ -63,6 +71,8 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
       if (typeof result.provider === 'string') {
         setCurrentProvider(result.provider)
       }
+
+      setDraftModelOverridePending(false)
     } catch {
       // The delayed session.info event still updates this once the agent is ready.
     }
@@ -89,6 +99,8 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
       // No live session yet: the pick is pure UI state. session.create reads
       // $currentModel/$currentProvider and applies it as that session's override.
       if (!activeSessionId) {
+        setDraftModelOverridePending(true)
+
         return true
       }
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -9,9 +9,13 @@ import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
 import {
   $activeSessionId,
   $currentCwd,
+  $draftModelOverridePending,
   $messages,
   $resumeFailedSessionId,
   setActiveSessionId,
+  setCurrentModel,
+  setCurrentProvider,
+  setDraftModelOverridePending,
   setMessages,
   setResumeFailedSessionId,
   setSessions
@@ -114,6 +118,9 @@ describe('createBackendSessionForSend profile routing', () => {
     $newChatProfile.set(null)
     $activeGatewayProfile.set('default')
     $currentCwd.set('')
+    setCurrentModel('')
+    setCurrentProvider('')
+    setDraftModelOverridePending(false)
     vi.restoreAllMocks()
   })
 
@@ -154,6 +161,28 @@ describe('createBackendSessionForSend profile routing', () => {
     })
 
     expect(params).toMatchObject({ cwd: '/remote/worktree' })
+  })
+
+  it('does not carry the previous session model into a plain new chat', async () => {
+    const params = await createWith(() => {
+      setCurrentModel('stepfun/step-3.7-flash:free')
+      setCurrentProvider('nous')
+      setDraftModelOverridePending(false)
+    })
+
+    expect(params).not.toHaveProperty('model')
+    expect(params).not.toHaveProperty('provider')
+  })
+
+  it('ships an explicit no-session picker choice as a one-shot draft model override', async () => {
+    const params = await createWith(() => {
+      setCurrentModel('claude-sonnet-4.6')
+      setCurrentProvider('anthropic')
+      setDraftModelOverridePending(true)
+    })
+
+    expect(params).toMatchObject({ model: 'claude-sonnet-4.6', provider: 'anthropic' })
+    expect($draftModelOverridePending.get()).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -22,6 +22,7 @@ import {
   $currentModel,
   $currentProvider,
   $currentReasoningEffort,
+  $draftModelOverridePending,
   $messages,
   $sessions,
   $yoloActive,
@@ -33,6 +34,7 @@ import {
   setCurrentCwd,
   setCurrentServiceTier,
   setCurrentUsage,
+  setDraftModelOverridePending,
   setFreshDraftReady,
   setIntroSeed,
   setMessages,
@@ -134,12 +136,6 @@ export function useSessionActions({
       })
       setSessionStartedAt(null)
       setTurnStartedAt(null)
-      // The composer's model/effort/fast is sticky UI state (persisted in
-      // localStorage) — a new chat FOLLOWS your last pick instead of snapping
-      // back to the profile default, so we deliberately don't reset it here. The
-      // profile default still owns first-run seeding and profile switches (see
-      // refreshCurrentModel). Only $currentServiceTier (a live-session mirror)
-      // is cleared.
       setCurrentServiceTier('')
       setYoloActive(false)
       // In a project → the repo's default-branch (main worktree) checkout; not in
@@ -173,15 +169,12 @@ export function useSessionActions({
         const newChatProfile = $newChatProfile.get() ?? normalizeProfileKey($activeGatewayProfile.get())
         await ensureGatewayProfile(newChatProfile)
         const cwd = $currentCwd.get().trim() || workspaceCwdForNewSession()
-        // The composer's model/effort/fast is sticky UI state ($currentModel,
-        // $currentProvider, $currentReasoningEffort, $currentFastMode). Ship it
-        // with every session.create so the new chat opens on whatever the picker
-        // shows — applied as per-session overrides, never written to the profile
-        // default (that lives in Settings → Model).
-        const uiModel = $currentModel.get().trim()
-        const uiProvider = $currentProvider.get().trim()
+        const useDraftModelOverride = $draftModelOverridePending.get()
+        const uiModel = useDraftModelOverride ? $currentModel.get().trim() : ''
+        const uiProvider = useDraftModelOverride ? $currentProvider.get().trim() : ''
         const uiEffort = $currentReasoningEffort.get().trim()
         const uiFast = $currentFastMode.get()
+        setDraftModelOverridePending(false)
 
         const created = await requestGateway<SessionCreateResponse>('session.create', {
           cols: 96,

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -11,11 +11,6 @@ type Updater<T> = T | ((current: T) => T)
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 
-// The composer's model/effort/fast is sticky UI state, NOT the profile default
-// (that lives in Settings → Model). Persisting it in localStorage makes a pick
-// follow across Cmd+N and app restarts instead of snapping back to the default.
-// It's deliberately global (not per-profile): a profile switch force-reseeds to
-// that profile's default, while within a profile new chats keep your last pick.
 const COMPOSER_MODEL_KEY = 'hermes.desktop.composer.model'
 const COMPOSER_PROVIDER_KEY = 'hermes.desktop.composer.provider'
 const COMPOSER_EFFORT_KEY = 'hermes.desktop.composer.reasoning-effort'
@@ -196,6 +191,7 @@ export function mergeSessionPage(
 
 export const $connection = atom<HermesConnection | null>(null)
 export const $gatewayState = atom('idle')
+export const $draftModelOverridePending = atom(false)
 export const $sessions = atom<SessionInfo[]>([])
 export const $sessionsTotal = atom<number>(0)
 // Cron-job sessions (source === 'cron') are fetched as their own list so the
@@ -301,6 +297,7 @@ export const setSessionProfileTotals = (next: Updater<Record<string, number>>) =
 export const setSessionsLoading = (next: Updater<boolean>) => updateAtom($sessionsLoading, next)
 export const setWorkingSessionIds = (next: Updater<string[]>) => updateAtom($workingSessionIds, next)
 export const setActiveSessionId = (next: Updater<string | null>) => updateAtom($activeSessionId, next)
+export const setDraftModelOverridePending = (next: Updater<boolean>) => updateAtom($draftModelOverridePending, next)
 export const setSelectedStoredSessionId = (next: Updater<string | null>) => updateAtom($selectedStoredSessionId, next)
 export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($messages, next)
 export const setFreshDraftReady = (next: Updater<boolean>) => updateAtom($freshDraftReady, next)


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop/TUI new-chat model inheritance so a plain new conversation uses the active profile's `model.default` instead of accidentally carrying over the previous session's runtime model.

The desktop footer can mirror the active session's model. Before this change, `session.create` always sent that mirrored model as a per-session override, so a brand-new chat could ignore the selected profile's configured default. This change only sends a model override when the user explicitly picked a model while no runtime session was active; that draft override is consumed once.

## Related Issue

Fixes #54906

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/session.ts`
  - Adds a transient `$draftModelOverridePending` flag for explicit no-session model picks.
- `apps/desktop/src/app/session/hooks/use-model-controls.ts`
  - Marks no-session picker choices as pending draft model overrides.
  - Clears the pending flag when the composer is reseeded from profile/global model info.
- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`
  - Sends `model` / `provider` on `session.create` only when a pending draft model override exists.
  - Consumes the draft override after session creation starts.
- `apps/desktop/src/app/session/hooks/use-model-controls.test.tsx`
  - Covers draft-override flag behavior and profile-default reseeding.
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`
  - Covers that a previous session model is not sent to plain new chats.
  - Covers that an explicit no-session picker choice is still sent once.

## How to Test

1. Run targeted UI tests:
   ```bash
   cd apps/desktop
   npm run test:ui -- src/app/session/hooks/use-model-controls.test.tsx src/app/session/hooks/use-session-actions.test.tsx
   ```
2. Run targeted lint:
   ```bash
   cd apps/desktop
   npx eslint src/store/session.ts src/app/session/hooks/use-model-controls.ts src/app/session/hooks/use-session-actions/index.ts src/app/session/hooks/use-model-controls.test.tsx src/app/session/hooks/use-session-actions.test.tsx
   ```
3. Run desktop typecheck:
   ```bash
   cd apps/desktop
   npm run typecheck
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / desktop unit test environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

```text
> hermes@0.17.0 test:ui
> vitest run --environment jsdom src/app/session/hooks/use-model-controls.test.tsx src/app/session/hooks/use-session-actions.test.tsx

✓ src/app/session/hooks/use-session-actions.test.tsx (15 tests)
✓ src/app/session/hooks/use-model-controls.test.tsx (5 tests)

Test Files  2 passed (2)
Tests       20 passed (20)
```

```text
> hermes@0.17.0 typecheck
> tsc -p . --noEmit
```