### PR TITLE
feat(telegram): add thread_profiles config for per-topic Hermes profile routing

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -460,6 +460,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self._dm_topic_chat_ids: Set[str] = {
             str(e["chat_id"]) for e in self._dm_topics_config if "chat_id" in e
         }
+        # Thread-to-profile routing for forum topics / DM topics.
+        # Format: {"chat_id:thread_id": "profile_name", ...}
+        self._thread_profiles: Dict[str, str] = self.config.extra.get("thread_profiles", {})
         # Document size cap. Telegram's public Bot API caps getFile at 20MB; a
         # locally-hosted telegram-bot-api server (configured via extra.base_url)
         # raises that to 2GB, so the presence of base_url is the opt-in.
@@ -610,6 +613,14 @@ class TelegramAdapter(BasePlatformAdapter):
             elif chat_type == "dm" and is_topic_message:
                 thread_id = str(thread_id_raw)
 
+        profile: Optional[str] = None
+        if thread_id and chat_id:
+            key = f"{chat_id}:{thread_id}"
+            profile = self._thread_profiles.get(key)
+            if not profile:
+                # Also try partial match: thread_id alone
+                profile = self._thread_profiles.get(thread_id)
+
         return SessionSource(
             platform=Platform.TELEGRAM,
             chat_id=chat_id or "",
@@ -617,6 +628,7 @@ class TelegramAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_id,
+            profile=profile,
         )
 
     def _telegram_auth_env_configured(self) -> bool:


### PR DESCRIPTION
## Summary

Adds support for routing Telegram forum topics to specific Hermes profiles via a `thread_profiles` mapping in the Telegram adapter extra config.

## Motivation (Cima20Nest)

This enables running a single Telegram bot that routes different forum topics to different Hermes profiles, each with its own SOUL, skills, and memories. Use case: a project management group where #jornada routes to a development profile, #business routes to a strategy profile, #security routes to a whitehat profile, etc.

## Config example

```yaml
telegram:
  extra:
    thread_profiles:
      "-1003528109556:12345": "business"
      "-1003528109556:67890": "jornada-dev"
```

## How it works

When a message arrives in a forum topic (supergroup with `is_forum=True`), the adapter checks the `(chat_id:thread_id)` composite key first, then falls back to `thread_id` alone. If a match is found, `SessionSource.profile` is populated, and the gateway routes the session to that profile.

## Changes

- **1 file changed, 12 insertions**
- `plugins/platforms/telegram/adapter.py`: parse `thread_profiles` from config.extra, resolve profile in `_source_from_message_for_auth`

No new dependencies. No breaking changes. `SessionSource.profile` already exists and is used by the webhook adapter.