### PR TITLE
fix: prefer local skills in skill_view

### DIFF
--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -154,3 +154,59 @@ class TestExternalSkillView:
             result = json.loads(skill_view("my-external-skill"))
         assert result["success"] is True
         assert "external things" in result["content"]
+
+    def test_skill_view_prefers_local_duplicate_over_external(self, hermes_home, external_skills_dir):
+        """skill_view follows the documented local-over-external precedence."""
+        local_skills = hermes_home / "skills"
+        local_skill = local_skills / "my-external-skill"
+        local_skill.mkdir(parents=True)
+        (local_skill / "SKILL.md").write_text(
+            "---\nname: my-external-skill\ndescription: Local version\n---\n\nLocal content.\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills_dir}\n"
+        )
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from agent import skill_utils
+            from tools.skills_tool import skill_view
+
+            skill_utils._external_dirs_cache_clear()
+            result = json.loads(skill_view("my-external-skill"))
+
+        assert result["success"] is True
+        assert "Local content" in result["content"]
+        assert "external things" not in result["content"]
+
+    def test_skill_view_prefers_local_duplicate_for_categorized_path(self, hermes_home, tmp_path):
+        """A full relative path still uses root precedence before external fallbacks."""
+        local_skills = hermes_home / "skills"
+        local_skill = local_skills / "github" / "hermes-agent"
+        external_skills = tmp_path / "external-skills"
+        external_skill = external_skills / "github" / "hermes-agent"
+        local_skill.mkdir(parents=True)
+        external_skill.mkdir(parents=True)
+        (local_skill / "SKILL.md").write_text(
+            "---\nname: hermes-agent\ndescription: Local Hermes skill\n---\n\nLocal Hermes.\n"
+        )
+        (external_skill / "SKILL.md").write_text(
+            "---\nname: hermes-agent\ndescription: Shared Hermes skill\n---\n\nShared Hermes.\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills}\n"
+        )
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from agent import skill_utils
+            from tools.skills_tool import skill_view
+
+            skill_utils._external_dirs_cache_clear()
+            result = json.loads(skill_view("github/hermes-agent"))
+
+        assert result["success"] is True
+        assert "Local Hermes" in result["content"]
+        assert "Shared Hermes" not in result["content"]

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1127,18 +1127,10 @@ Do the legacy thing.
 class TestSkillViewCollisionDetection:
     """Regression tests for skill_view name collision handling.
 
-    When a skill name resolves to multiple paths across the local skills
-    dir and external_dirs, skill_view must refuse to guess. Silent
-    shadowing — where ``/skills`` shows the local version but
-    ``skill_view`` loads the external one — is the bug class this guards
-    against. Reproduces with `skills.external_dirs` registered in
-    config.yaml and a same-name skill nested under a category locally.
-
-    Adapted from a regression suite originally proposed by @polkn in PR
-    #6136 (which used local-first precedence). The collision-refusal
-    behavior preserves the same protection without silently picking a
-    side, and gives the user an actionable hint (use the categorized
-    path) to recover.
+    Local ``~/.hermes/skills`` entries have documented precedence over
+    ``skills.external_dirs``. That precedence must apply in skill_view too,
+    so the agent loads the same skill that appears in the prompt index and
+    skills_list. Collisions with no unique local winner still fail loudly.
     """
 
     def _patch_dirs(self, local_dir, external_dirs):
@@ -1151,9 +1143,8 @@ class TestSkillViewCollisionDetection:
             ),
         )
 
-    def test_nested_local_collides_with_top_level_external(self, tmp_path):
-        """The original bug scenario: nested local + top-level external,
-        same name. Now refuses with both paths surfaced."""
+    def test_nested_local_takes_precedence_over_top_level_external(self, tmp_path):
+        """Nested local + top-level external with the same name loads local."""
         local_dir = tmp_path / "local"
         external_dir = tmp_path / "external"
         local_dir.mkdir()
@@ -1172,18 +1163,12 @@ class TestSkillViewCollisionDetection:
             raw = skill_view("explore-codebase")
 
         result = json.loads(raw)
-        assert result["success"] is False
-        assert "Ambiguous skill name 'explore-codebase'" in result["error"]
-        assert "matches" in result
-        assert len(result["matches"]) == 2
-        # Both paths surfaced
-        assert any("foundations/runtime" in p for p in result["matches"])
-        assert any("external" in p for p in result["matches"])
-        assert "hint" in result
+        assert result["success"] is True
+        assert "LOCAL VERSION" in result["content"]
+        assert "EXTERNAL VERSION" not in result["content"]
 
-    def test_top_level_local_collides_with_external(self, tmp_path):
-        """Top-level local + top-level external with the same name also
-        refuses — same-name shadowing is ambiguous regardless of nesting."""
+    def test_top_level_local_takes_precedence_over_external(self, tmp_path):
+        """Top-level local + top-level external with the same name loads local."""
         local_dir = tmp_path / "local"
         external_dir = tmp_path / "external"
         local_dir.mkdir()
@@ -1197,13 +1182,33 @@ class TestSkillViewCollisionDetection:
             raw = skill_view("shared-name")
 
         result = json.loads(raw)
+        assert result["success"] is True
+        assert "LOCAL VERSION" in result["content"]
+        assert "EXTERNAL VERSION" not in result["content"]
+
+    def test_external_duplicate_without_local_winner_is_ambiguous(self, tmp_path):
+        """Two external matches with no local shadow remain ambiguous."""
+        local_dir = tmp_path / "local"
+        external_one = tmp_path / "external-one"
+        external_two = tmp_path / "external-two"
+        local_dir.mkdir()
+        external_one.mkdir()
+        external_two.mkdir()
+
+        _make_skill(external_one, "shared-name", body="EXTERNAL ONE")
+        _make_skill(external_two, "shared-name", body="EXTERNAL TWO")
+
+        p1, p2 = self._patch_dirs(local_dir, [external_one, external_two])
+        with p1, p2:
+            raw = skill_view("shared-name")
+
+        result = json.loads(raw)
         assert result["success"] is False
         assert "Ambiguous" in result["error"]
         assert len(result["matches"]) == 2
 
-    def test_collision_resolvable_via_categorized_path(self, tmp_path):
-        """User can recover from a collision by passing the full
-        categorized path — the bare name is ambiguous, the path is not."""
+    def test_categorized_path_still_loads_local_shadow(self, tmp_path):
+        """The full categorized path also resolves to the local shadow."""
         local_dir = tmp_path / "local"
         external_dir = tmp_path / "external"
         local_dir.mkdir()

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1082,30 +1082,54 @@ def skill_view(
                     _record(None, found_md)
 
         if len(candidates) > 1:
-            paths = [str(smd) for _, smd in candidates]
-            logging.getLogger(__name__).warning(
-                "Skill name collision for '%s': %d candidates — %s",
-                name, len(candidates), "; ".join(paths),
-            )
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": (
-                        f"Ambiguous skill name '{name}': {len(candidates)} skills "
-                        "match across your local skills dir and external_dirs. "
-                        "Refusing to guess — load one explicitly by its categorized path."
-                    ),
-                    "matches": paths,
-                    "hint": (
-                        "Pass the full relative path instead of the bare name "
-                        "(e.g., 'category/skill-name'), or rename one of the "
-                        "colliding skills so each name is unique."
-                    ),
-                },
-                ensure_ascii=False,
-            )
+            local_candidates: List[Tuple[Optional[Path], Path]] = []
+            try:
+                local_root = SKILLS_DIR.resolve()
+            except Exception:
+                local_root = SKILLS_DIR
 
-        if candidates:
+            for candidate in candidates:
+                _, candidate_md = candidate
+                try:
+                    candidate_md.resolve().relative_to(local_root)
+                    local_candidates.append(candidate)
+                except ValueError:
+                    continue
+                except Exception:
+                    try:
+                        candidate_md.relative_to(SKILLS_DIR)
+                        local_candidates.append(candidate)
+                    except Exception:
+                        continue
+
+            if len(local_candidates) == 1:
+                # Documented precedence: ~/.hermes/skills shadows any
+                # skills.external_dirs match with the same name/path.
+                skill_dir, skill_md = local_candidates[0]
+            else:
+                paths = [str(smd) for _, smd in candidates]
+                logging.getLogger(__name__).warning(
+                    "Skill name collision for '%s': %d candidates — %s",
+                    name, len(candidates), "; ".join(paths),
+                )
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"Ambiguous skill name '{name}': {len(candidates)} skills "
+                            "match across your local skills dir and external_dirs. "
+                            "Refusing to guess because no unique local skill takes precedence."
+                        ),
+                        "matches": paths,
+                        "hint": (
+                            "Rename one of the colliding skills, or create a "
+                            "single local ~/.hermes/skills copy to shadow external duplicates."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
+
+        if candidates and not skill_md:
             skill_dir, skill_md = candidates[0]
 
         if not skill_md or not skill_md.exists():


### PR DESCRIPTION
## Summary
- restore documented local-over-external precedence in skill_view
- keep ambiguity errors when multiple external matches exist and no unique local skill shadows them
- add regression coverage for bare-name and categorized-path local shadows

## Test Plan
- pytest tests/agent/test_external_skills.py -q
- pytest tests/tools/test_skills_tool.py tests/agent/test_external_skills.py -q
- python -m py_compile tools/skills_tool.py tests/agent/test_external_skills.py tests/tools/test_skills_tool.py
- ruff check tools/skills_tool.py tests/agent/test_external_skills.py tests/tools/test_skills_tool.py