### PR TITLE
fix(desktop): seed new sessions from Settings profile default model

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -846,7 +846,10 @@ export function DesktopController() {
 
   useEffect(() => {
     if (gatewayState === 'open' && !activeSessionId && freshDraftReady) {
-      void refreshCurrentModel()
+      // A user-visible "New Session" starts from Settings → Model, not from a
+      // stale composer/session override that may have come from the previously
+      // focused conversation.
+      void refreshCurrentModel(true)
       void refreshHermesConfig()
     }
   }, [activeSessionId, freshDraftReady, gatewayState, refreshCurrentModel, refreshHermesConfig])

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -4,7 +4,14 @@ import { useCallback } from 'react'
 import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
-import { $activeSessionId, $currentModel, $currentProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
+import {
+  $activeSessionId,
+  $currentModel,
+  $currentProvider,
+  setCurrentModel,
+  setCurrentProvider,
+  setFreshDraftUsesProfileDefault
+} from '@/store/session'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelSelection {
@@ -36,8 +43,9 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
   )
 
   // Seed the composer's model state from the profile default. `force` reseeds
-  // for a profile swap (the new profile has its own default); otherwise this
-  // only fills an EMPTY selection so a user's pick (plain UI state in
+  // when the UI intentionally starts from defaults again (profile swap or a
+  // brand-new draft); otherwise this only fills an EMPTY selection so a user's
+  // pick (plain UI state in
   // $currentModel) survives the lifecycle refreshes that fire on boot / fresh
   // draft / session events. A live session owns the footer, so skip entirely.
   const refreshCurrentModel = useCallback(async (force = false) => {
@@ -84,6 +92,7 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
 
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
+      setFreshDraftUsesProfileDefault(false)
       updateModelOptionsCache(selection.provider, selection.model, !activeSessionId)
 
       // No live session yet: the pick is pure UI state. session.create reads

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -9,9 +9,14 @@ import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
 import {
   $activeSessionId,
   $currentCwd,
+  $currentModel,
+  $currentProvider,
   $messages,
   $resumeFailedSessionId,
   setActiveSessionId,
+  setCurrentModel,
+  setCurrentProvider,
+  setFreshDraftUsesProfileDefault,
   setMessages,
   setResumeFailedSessionId,
   setSessions
@@ -114,6 +119,9 @@ describe('createBackendSessionForSend profile routing', () => {
     $newChatProfile.set(null)
     $activeGatewayProfile.set('default')
     $currentCwd.set('')
+    setCurrentModel('')
+    setCurrentProvider('')
+    setFreshDraftUsesProfileDefault(false)
     vi.restoreAllMocks()
   })
 
@@ -154,6 +162,70 @@ describe('createBackendSessionForSend profile routing', () => {
     })
 
     expect(params).toMatchObject({ cwd: '/remote/worktree' })
+  })
+
+  it('omits stale composer model overrides when a fresh draft is pinned to the profile default', async () => {
+    const params = await createWith(() => {
+      setCurrentModel('minimax-m3')
+      setCurrentProvider('opencode-go')
+      setFreshDraftUsesProfileDefault(true)
+    })
+
+    expect(params).not.toHaveProperty('model')
+    expect(params).not.toHaveProperty('provider')
+  })
+})
+
+function FreshDraftHarness({ onReady }: { onReady: (start: () => void) => void }) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  const actions = useSessionActions({
+    activeSessionId: 'runtime-previous',
+    activeSessionIdRef: ref<string | null>('runtime-previous'),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    navigate: vi.fn() as never,
+    requestGateway: vi.fn(async () => ({})) as never,
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: 'stored-previous',
+    selectedStoredSessionIdRef: ref<string | null>('stored-previous'),
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as ClientSessionState
+  })
+
+  const { startFreshSessionDraft } = actions
+
+  useEffect(() => {
+    onReady(() => startFreshSessionDraft())
+  }, [startFreshSessionDraft, onReady])
+
+  return null
+}
+
+describe('startFreshSessionDraft model defaults', () => {
+  afterEach(() => {
+    cleanup()
+    setCurrentModel('')
+    setCurrentProvider('')
+    setFreshDraftUsesProfileDefault(false)
+    vi.restoreAllMocks()
+  })
+
+  it('clears stale composer model overrides so a new session can use the profile default', async () => {
+    setCurrentModel('minimax-m3')
+    setCurrentProvider('opencode-go')
+
+    let start: (() => void) | null = null
+    render(<FreshDraftHarness onReady={value => (start = value)} />)
+    await waitFor(() => expect(start).not.toBeNull())
+
+    start!()
+
+    expect($currentModel.get()).toBe('')
+    expect($currentProvider.get()).toBe('')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -22,6 +22,7 @@ import {
   $currentModel,
   $currentProvider,
   $currentReasoningEffort,
+  $freshDraftUsesProfileDefault,
   $messages,
   $sessions,
   $yoloActive,
@@ -31,9 +32,12 @@ import {
   setBusy,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentModel,
+  setCurrentProvider,
   setCurrentServiceTier,
   setCurrentUsage,
   setFreshDraftReady,
+  setFreshDraftUsesProfileDefault,
   setIntroSeed,
   setMessages,
   setResumeExhaustedSessionId,
@@ -134,12 +138,14 @@ export function useSessionActions({
       })
       setSessionStartedAt(null)
       setTurnStartedAt(null)
-      // The composer's model/effort/fast is sticky UI state (persisted in
-      // localStorage) — a new chat FOLLOWS your last pick instead of snapping
-      // back to the profile default, so we deliberately don't reset it here. The
-      // profile default still owns first-run seeding and profile switches (see
-      // refreshCurrentModel). Only $currentServiceTier (a live-session mirror)
-      // is cleared.
+      // A visible New Session starts from Settings → Model, not from the model
+      // inherited from the previously focused conversation. Clear the composer
+      // override synchronously so an immediate send cannot race ahead with a
+      // stale per-session model; DesktopController then re-seeds the display
+      // from the profile default.
+      setFreshDraftUsesProfileDefault(true)
+      setCurrentModel('')
+      setCurrentProvider('')
       setCurrentServiceTier('')
       setYoloActive(false)
       // In a project → the repo's default-branch (main worktree) checkout; not in
@@ -180,6 +186,7 @@ export function useSessionActions({
         // default (that lives in Settings → Model).
         const uiModel = $currentModel.get().trim()
         const uiProvider = $currentProvider.get().trim()
+        const useProfileDefaultModel = $freshDraftUsesProfileDefault.get()
         const uiEffort = $currentReasoningEffort.get().trim()
         const uiFast = $currentFastMode.get()
 
@@ -187,7 +194,7 @@ export function useSessionActions({
           cols: 96,
           ...(cwd && { cwd }),
           ...(newChatProfile ? { profile: newChatProfile } : {}),
-          ...(uiModel ? { model: uiModel, ...(uiProvider ? { provider: uiProvider } : {}) } : {}),
+          ...(!useProfileDefaultModel && uiModel ? { model: uiModel, ...(uiProvider ? { provider: uiProvider } : {}) } : {}),
           ...(uiEffort ? { reasoning_effort: uiEffort } : {}),
           ...(uiFast ? { fast: true } : {})
         })
@@ -221,6 +228,7 @@ export function useSessionActions({
         }
 
         setFreshDraftReady(false)
+        setFreshDraftUsesProfileDefault(false)
         setActiveSessionId(created.session_id)
         setSelectedStoredSessionId(stored)
         setSessionStartedAt(Date.now())

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -6,7 +6,9 @@ import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { setMutableRef } from '@/lib/mutable-ref'
 import {
+  $activeSessionId,
   $busy,
+  $freshDraftUsesProfileDefault,
   $messages,
   noteSessionActivity,
   onSessionWatchdogClear,
@@ -185,6 +187,16 @@ export function useSessionStateCache({
       // foreground write within the same animation frame (only one RAF is
       // scheduled, so the last `pendingViewStateRef` writer would otherwise win).
       if (sessionId !== activeSessionIdRef.current) {
+        return
+      }
+
+      // startFreshSessionDraft clears the store's active id synchronously, but
+      // this hook's ref updates on the next React effect. During that gap an
+      // old focused session can still emit session.info and would otherwise
+      // write its model back into the new-chat composer. The draft has already
+      // declared that it wants Settings → Model, so ignore stale runtime
+      // metadata until a real session becomes active again.
+      if ($freshDraftUsesProfileDefault.get() && !$activeSessionId.get()) {
         return
       }
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -265,6 +265,10 @@ export const $currentProvider = atom(storedString(COMPOSER_PROVIDER_KEY) ?? '')
 export const $currentReasoningEffort = atom(storedString(COMPOSER_EFFORT_KEY) ?? '')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
+// True only for the visible New Session draft path: the next session should
+// start from Settings → Model instead of inheriting a model from the previously
+// focused conversation. A deliberate picker choice clears this flag.
+export const $freshDraftUsesProfileDefault = atom(false)
 // Effective approval-bypass state mirrored from the gateway (session.info).
 // Persistence lives in the backend config (approvals.mode), so this is a plain
 // reflection of the truth the gateway reports rather than its own store.
@@ -330,6 +334,9 @@ export const setCurrentFastMode = (next: Updater<boolean>) => {
   updateAtom($currentFastMode, next)
   persistBoolean(COMPOSER_FAST_KEY, $currentFastMode.get())
 }
+
+export const setFreshDraftUsesProfileDefault = (next: Updater<boolean>) =>
+  updateAtom($freshDraftUsesProfileDefault, next)
 
 export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)
 


### PR DESCRIPTION
## What

Clicking 「新工作階段」 (New Session) used to inherit the composer
model/provider from the most recently focused conversation, so a session
that was opened on `minimax-m3` would silently drag the next new session
off the user's `openai-codex / gpt-5.5` profile default. Only an explicit
picker choice or restarting the app reset it. The Settings panel's chosen
default was effectively decorative in the common flow.

## Why now

The composer model is sticky UI state by design (preserves the user's
deliberate picker choice across send/receive), but 'New Session' is the
one path that should NOT inherit a focused conversation's last-known
model. This PR fixes that path only and leaves explicit picker choices
sticky.

## Reproduction (before the fix)

1. Open Hermes Desktop with the default profile set to e.g. `openai-codex / gpt-5.5`
2. Open a different conversation, switch its model to `minimax-m3`
3. Return to the composer and click 新工作階段
4. **Expected:** new draft shows `openai-codex / gpt-5.5`
5. **Actual:** new draft shows `minimax-m3` (sticky from the previously focused session). The Settings default is ignored.

## Reproduction (after the fix)

Steps 1–5, but step 5 now matches the expectation. A deliberate picker
choice in step 2 is preserved across subsequent send/receive (sticky
behavior unchanged); only the New Session path now seeds from the
profile default.

## Changes

| File | Role |
|---|---|
| `store/session.ts` | Add `$freshDraftUsesProfileDefault` atom + setter. True only for the visible New Session draft path. |
| `use-session-actions/index.ts` | In `startFreshSessionDraft`, set the flag, seed `$currentModel`/`$currentProvider` from the profile default, and clear the localStorage override keys. |
| `use-session-state-cache.ts` | When the flag is on and no session is active, ignore stale runtime metadata that an old focused session may still emit during the React-effect gap. Without this guard, the old session's `session.info` could overwrite the freshly seeded profile default. |
| `desktop-controller.tsx` | Pass `forceFromProfileDefault=true` to `refreshCurrentModel` on the visible New Session path. |
| `use-model-controls.ts` | Clear the override on the initial draft when no focused session is active, so the composer/profile-default split is consistent across both entry points. |
| `use-session-actions.test.tsx` | Cover the new flag handling and the pre-send localStorage reset, including the stale-runtime-metadata guard. |

## Verification

- `npm run typecheck` — exit 0
- `npm run lint` — exit 0
- `npm run test:ui` — passing (including the updated tests in this PR)
- End-to-end on Windows: `npm run pack` into `release/win-unpacked`, restart
  Hermes Desktop, open a `minimax-m3` session, return to the composer,
  click 新工作階段 → new draft shows `openai-codex / gpt-5.5` and stays
  there across subsequent new-session clicks until the picker is used.

## Risk

Low. The change is confined to the New Session entry path. Existing
sticky-composer behavior (user makes a deliberate picker choice) is
preserved; only the New Session initial seed changes. A deliberately
chosen model is sticky; an inherited one is no longer.