### PR TITLE
Fix concurrent tool execution middleware wrapping

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2024,6 +2024,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             pass
         return result
 
+    wrap_tool_execution = True
+
     if function_name == "todo":
         def _execute(next_args: dict) -> Any:
             from tools.todo_tool import todo_tool as _todo_tool
@@ -2111,6 +2113,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
     else:
+        wrap_tool_execution = False
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(
                 function_name, next_args, effective_task_id,
@@ -2125,6 +2128,12 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
+
+    if not wrap_tool_execution:
+        # Registry-backed tools are dispatched through model_tools.handle_function_call,
+        # which already owns the tool_execution middleware boundary around
+        # registry.dispatch(). Wrapping here would run adaptive middleware twice.
+        return _execute(function_args)
 
     from hermes_cli.middleware import run_tool_execution_middleware
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2931,6 +2931,70 @@ class TestConcurrentToolExecution:
         assert post_call[1]["args"] == {"todos": [], "request_rewritten": True, "merge": True}
         assert post_call[1]["middleware_trace"] == [{"source": "request-test"}]
 
+    def test_concurrent_agent_level_tool_execution_middleware_wraps_inline_dispatch(self, agent, monkeypatch):
+        """Concurrent built-in tool paths should expose the adaptive execution boundary."""
+        tool_call = _mock_tool_call(name="todo", arguments='{"todos":[]}', call_id="todo-1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+        seen = {}
+
+        def execution_middleware(**kwargs):
+            seen["middleware_args"] = dict(kwargs["args"])
+            seen["tool_name"] = kwargs["tool_name"]
+            downstream = kwargs["next_call"]({**kwargs["args"], "merge": True})
+            return f"mw::{downstream}"
+
+        manager = SimpleNamespace(_middleware={"tool_request": [], "tool_execution": [execution_middleware]})
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_middleware", lambda kind, **kwargs: [])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda hook_name, **kwargs: [])
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: False)
+
+        with patch("tools.todo_tool.todo_tool", return_value='{"ok":true}') as mock_todo:
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert seen["tool_name"] == "todo"
+        assert seen["middleware_args"] == {"todos": []}
+        mock_todo.assert_called_once_with(todos=[], merge=True, store=agent._todo_store)
+        assert len(messages) == 1
+        assert messages[0]["tool_call_id"] == "todo-1"
+        assert messages[0]["content"] == 'mw::{"ok":true}'
+
+    def test_concurrent_registry_tool_execution_middleware_wraps_dispatch(self, agent, monkeypatch):
+        """Concurrent registry-tool paths should run through tool_execution middleware."""
+        tool_call = _mock_tool_call(name="web_search", arguments='{"q":"alpha"}', call_id="search-1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+        seen = {}
+
+        def execution_middleware(**kwargs):
+            seen["middleware_args"] = dict(kwargs["args"])
+            seen["tool_name"] = kwargs["tool_name"]
+            downstream = kwargs["next_call"]({**kwargs["args"], "q": "rewritten"})
+            return f"mw::{downstream}"
+
+        manager = SimpleNamespace(_middleware={"tool_request": [], "tool_execution": [execution_middleware]})
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_middleware", lambda kind, **kwargs: [])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: None,
+        )
+
+        with patch("model_tools.registry.dispatch", return_value="search-result") as mock_dispatch:
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert seen["tool_name"] == "web_search"
+        assert seen["middleware_args"] == {"q": "alpha"}
+        assert mock_dispatch.call_args.args[:2] == ("web_search", {"q": "rewritten"})
+        assert len(messages) == 1
+        assert messages[0]["tool_call_id"] == "search-1"
+        assert messages[0]["content"] == "mw::search-result"
+
     def test_concurrent_agent_level_tool_preserves_request_middleware_trace(self, agent, monkeypatch):
         tool_call = _mock_tool_call(name="todo", arguments='{"todos":[]}', call_id="todo-1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])


### PR DESCRIPTION
## Summary

Fixes the concurrent tool execution path so agent-level `tool_execution` middleware wraps agent-owned inline dispatch exactly once while registry-backed tool execution continues to use the existing `model_tools.handle_function_call()` middleware boundary.

## Why

The concurrent path had a boundary mismatch: applying middleware at the wrong layer can either bypass agent-owned inline dispatch middleware or double-wrap registry-backed tools. This PR keeps the registry path unchanged and wraps only the agent-owned inline dispatch boundary.

## Verification

```bash
uv run --extra dev pytest \
  tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_concurrent_agent_level_tool_execution_middleware_wraps_inline_dispatch \
  tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_concurrent_registry_tool_execution_middleware_wraps_dispatch \
  -q -o 'addopts='
# 2 passed

uv run --extra dev pytest tests/run_agent/test_run_agent.py::TestConcurrentToolExecution tests/hermes_cli/test_plugins.py::TestPluginDiscovery -q -o 'addopts='
# 57 passed

python -m py_compile agent/agent_runtime_helpers.py tests/run_agent/test_run_agent.py
# PASS
```

## Notes

- Minimal patch: implementation boundary + focused regression coverage.
- No new core tools, provider routing, config keys, or plugin-specific special cases.
