### PR TITLE
fix(registry): stop desktop-only tools from hiding terminal in hermes doctor (#54831)

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -544,3 +544,58 @@ class TestThreadSafety:
         toolsets = result_holder["value"]
         assert "gated" in toolsets
         assert toolsets["gated"]["available"] is True
+
+
+class TestToolsetAvailabilityAggregation:
+    def test_mixed_toolset_available_when_general_tool_passes(self):
+        """Desktop-only helpers must not hide general-purpose tools from doctor."""
+        reg = ToolRegistry()
+        reg.register(
+            name="read_terminal",
+            toolset="terminal",
+            schema=_make_schema("read_terminal"),
+            handler=_dummy_handler,
+            check_fn=lambda: False,
+        )
+        reg.register(
+            name="terminal",
+            toolset="terminal",
+            schema=_make_schema("terminal"),
+            handler=_dummy_handler,
+            check_fn=lambda: True,
+        )
+        reg.register(
+            name="process",
+            toolset="terminal",
+            schema=_make_schema("process"),
+            handler=_dummy_handler,
+        )
+
+        available, unavailable = reg.check_tool_availability()
+
+        assert "terminal" in available
+        assert unavailable == []
+        assert reg.is_toolset_available("terminal")
+        assert reg.get_available_toolsets()["terminal"]["available"] is True
+
+    def test_mixed_toolset_unavailable_when_every_tool_is_gated(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="read_terminal",
+            toolset="terminal",
+            schema=_make_schema("read_terminal"),
+            handler=_dummy_handler,
+            check_fn=lambda: False,
+        )
+        reg.register(
+            name="terminal",
+            toolset="terminal",
+            schema=_make_schema("terminal"),
+            handler=_dummy_handler,
+            check_fn=lambda: False,
+        )
+
+        available, unavailable = reg.check_tool_availability()
+
+        assert "terminal" not in available
+        assert any(item["name"] == "terminal" for item in unavailable)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -237,26 +237,10 @@ class ToolRegistry:
         """Return a stable snapshot of registered tool entries."""
         return self._snapshot_state()[0]
 
-    def _snapshot_toolset_checks(self) -> Dict[str, Callable]:
-        """Return a stable snapshot of toolset availability checks."""
-        return self._snapshot_state()[1]
-
-    def _evaluate_toolset_check(self, toolset: str, check: Callable | None) -> bool:
-        """Run a toolset check, treating missing or failing checks as unavailable/available."""
-        if not check:
-            return True
-        try:
-            return bool(check())
-        except Exception:
-            logger.debug("Toolset %s check raised; marking unavailable", toolset)
-            return False
-
     def _toolset_has_exposable_tools(
         self,
         toolset: str,
         entries: List[ToolEntry],
-        *,
-        quiet: bool = False,
     ) -> bool:
         """Return True when at least one tool in *toolset* would be exposed.
 
@@ -265,7 +249,6 @@ class ToolRegistry:
         Mixed toolsets (e.g. ``terminal`` plus desktop-only ``read_terminal``)
         must not be gated solely by the first registered ``check_fn``.
         """
-        del quiet  # reserved for parity with check_tool_availability signature
         check_results: Dict[Callable, bool] = {}
         for entry in entries:
             if entry.toolset != toolset:
@@ -437,6 +420,12 @@ class ToolRegistry:
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
             )
+            # Availability is now derived per-tool (_toolset_has_exposable_tools),
+            # so this map no longer gates a toolset. It is still consumed by
+            # get_toolset_requirements -> TOOLSET_REQUIREMENTS["check_fn"], which
+            # banner.py reads (presence only, never called) to classify an
+            # already-unavailable toolset as lazy-init vs disabled. Keep the
+            # write path for that classification.
             if check_fn and toolset not in self._toolset_checks:
                 self._toolset_checks[toolset] = check_fn
             self._generation += 1
@@ -659,7 +648,7 @@ class ToolRegistry:
         entries, _ = self._snapshot_state()
         for ts in sorted({entry.toolset for entry in entries}):
             ts_entries = [entry for entry in entries if entry.toolset == ts]
-            if self._toolset_has_exposable_tools(ts, entries, quiet=quiet):
+            if self._toolset_has_exposable_tools(ts, entries):
                 available.append(ts)
             else:
                 unavailable.append({

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -251,6 +251,33 @@ class ToolRegistry:
             logger.debug("Toolset %s check raised; marking unavailable", toolset)
             return False
 
+    def _toolset_has_exposable_tools(
+        self,
+        toolset: str,
+        entries: List[ToolEntry],
+        *,
+        quiet: bool = False,
+    ) -> bool:
+        """Return True when at least one tool in *toolset* would be exposed.
+
+        Mirrors :meth:`get_tool_definitions` per-tool filtering so doctor,
+        banners, and other toolset-level surfaces agree with runtime exposure.
+        Mixed toolsets (e.g. ``terminal`` plus desktop-only ``read_terminal``)
+        must not be gated solely by the first registered ``check_fn``.
+        """
+        del quiet  # reserved for parity with check_tool_availability signature
+        check_results: Dict[Callable, bool] = {}
+        for entry in entries:
+            if entry.toolset != toolset:
+                continue
+            if not entry.check_fn:
+                return True
+            if entry.check_fn not in check_results:
+                check_results[entry.check_fn] = _check_fn_cached(entry.check_fn)
+            if check_results[entry.check_fn]:
+                return True
+        return False
+
     def get_entry(self, name: str) -> Optional[ToolEntry]:
         """Return a registered tool entry by name, or None."""
         with self._lock:
@@ -567,35 +594,32 @@ class ToolRegistry:
         return {entry.name: entry.toolset for entry in self._snapshot_entries()}
 
     def is_toolset_available(self, toolset: str) -> bool:
-        """Check if a toolset's requirements are met.
+        """Check if a toolset has at least one exposable tool.
 
-        Returns False (rather than crashing) when the check function raises
+        Returns False (rather than crashing) when a per-tool check raises
         an unexpected exception (e.g. network error, missing import, bad config).
         """
-        with self._lock:
-            check = self._toolset_checks.get(toolset)
-        return self._evaluate_toolset_check(toolset, check)
+        entries, _ = self._snapshot_state()
+        return self._toolset_has_exposable_tools(toolset, entries)
 
     def check_toolset_requirements(self) -> Dict[str, bool]:
         """Return ``{toolset: available_bool}`` for every toolset."""
-        entries, toolset_checks = self._snapshot_state()
+        entries, _ = self._snapshot_state()
         toolsets = sorted({entry.toolset for entry in entries})
         return {
-            toolset: self._evaluate_toolset_check(toolset, toolset_checks.get(toolset))
+            toolset: self._toolset_has_exposable_tools(toolset, entries)
             for toolset in toolsets
         }
 
     def get_available_toolsets(self) -> Dict[str, dict]:
         """Return toolset metadata for UI display."""
         toolsets: Dict[str, dict] = {}
-        entries, toolset_checks = self._snapshot_state()
+        entries, _ = self._snapshot_state()
         for entry in entries:
             ts = entry.toolset
             if ts not in toolsets:
                 toolsets[ts] = {
-                    "available": self._evaluate_toolset_check(
-                        ts, toolset_checks.get(ts)
-                    ),
+                    "available": self._toolset_has_exposable_tools(ts, entries),
                     "tools": [],
                     "description": "",
                     "requirements": [],
@@ -632,20 +656,16 @@ class ToolRegistry:
         """Return (available_toolsets, unavailable_info) like the old function."""
         available = []
         unavailable = []
-        seen = set()
-        entries, toolset_checks = self._snapshot_state()
-        for entry in entries:
-            ts = entry.toolset
-            if ts in seen:
-                continue
-            seen.add(ts)
-            if self._evaluate_toolset_check(ts, toolset_checks.get(ts)):
+        entries, _ = self._snapshot_state()
+        for ts in sorted({entry.toolset for entry in entries}):
+            ts_entries = [entry for entry in entries if entry.toolset == ts]
+            if self._toolset_has_exposable_tools(ts, entries, quiet=quiet):
                 available.append(ts)
             else:
                 unavailable.append({
                     "name": ts,
-                    "env_vars": entry.requires_env,
-                    "tools": [e.name for e in entries if e.toolset == ts],
+                    "env_vars": ts_entries[0].requires_env if ts_entries else [],
+                    "tools": [entry.name for entry in ts_entries],
                 })
         return available, unavailable
 


### PR DESCRIPTION
## Summary
`hermes doctor` and the banner now derive a toolset's availability from "does **any** tool in it pass its `check_fn`" (mirroring runtime `get_tool_definitions`), instead of "does the **first-registered** tool's check pass."

Fixes the false `⚠ terminal (system dependency not met)` warning: `read_terminal` (gated on `HERMES_DESKTOP`) registers before `terminal` alphabetically, so its failed gate poisoned the entire `terminal` toolset even though `terminal`/`process` were exposable. Same bug class as the browser_cdp split (#14234), now fixed generically at the registry layer.

## Changes
- `tools/registry.py`: new `_toolset_has_exposable_tools()` (ANY tool passes) replaces the single-`check_fn`-per-toolset model across `is_toolset_available`, `check_toolset_requirements`, `get_available_toolsets`, `check_tool_availability`.
- Follow-up cleanup: removed the now-orphaned `_snapshot_toolset_checks` and `_evaluate_toolset_check` helpers, dropped a no-op `quiet` param, and documented why `_toolset_checks` is still written (`banner.py` reads it via `TOOLSET_REQUIREMENTS["check_fn"]` — presence only, never called — to classify an unavailable toolset as lazy-init vs disabled).

## Validation
| | Before | After |
|---|---|---|
| `is_toolset_available("terminal")` with `read_terminal` gate failing | `False` (false negative) | `True` |
| doctor / banner `terminal` status | `⚠ system dependency not met` | available |
| all-gated toolset | unavailable | unavailable (unchanged) |

- `tests/tools/test_registry.py` — 33 passed (incl. two new cases: mixed-available + all-gated).
- E2E against the live production registry (HERMES_DESKTOP unset): `terminal` available despite the failed `read_terminal`/`close_terminal` desktop gates; ANY-passes confirmed both directions; `get_tool_definitions` exposes `terminal`+`process`; `TOOLSET_REQUIREMENTS` classification dict intact.
- No prompt-cache impact (these surfaces feed doctor/banner/UI, not the model-facing schema); `_check_fn_cached` reuse means no extra probe cost.

## Credit
Salvage of #54831 by @xxxigm — their fix + test commits cherry-picked with authorship preserved; the dead-code cleanup is a follow-up commit on top. Rebased onto current `main`.

Closes #54831.
