### PR TITLE
feat: add Spectrum iMessage app scaffold

### DIFF
--- a/hermes-agent/.agents/skills/spectrum/SKILL.md
+++ b/hermes-agent/.agents/skills/spectrum/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: spectrum
+description: >
+  Build messaging agents and apps with Spectrum — Photon's unified messaging SDK. Write your handler logic
+  once and ship it across iMessage, WhatsApp Business, the terminal, or a custom platform. Spectrum is
+  multi-platform by design and is becoming multi-language; the current SDK is `spectrum-ts` (TypeScript), with
+  additional language SDKs planned. Use this skill for any Spectrum question — quickstart, multi-platform setup,
+  receiving messages, content builders, spaces and users, reactions and replies, platform narrowing, the
+  built-in providers (iMessage cloud/local/dedicated with message effects, Terminal TUI test harness, WhatsApp
+  Business 1:1), custom event streams, graceful shutdown, building your own provider with `definePlatform`, and
+  the production architecture patterns Photon uses internally to ship agents that live natively inside IM apps
+  (five-stage inbound pipeline with debounce → batch flush → mark as read → generate → send, in-flight
+  cancellation with abort signals, drain-in-handler, carry-forward, idempotent retries via stable client GUIDs
+  and a startIndex resume cursor, per-resource memory scope `resourceId` vs `threadId`, durable job-failure
+  audit log).
+  This is the entry point for the skill; consult the topic files in this directory for full reference.
+  Keywords: spectrum, spectrum-ts, photon, unified messaging, multi-platform, multi-language, im agent,
+  messaging agent, imessage, whatsapp, whatsapp business, terminal, tuichat, definePlatform, custom platform,
+  platform provider, platform narrowing, app.messages, Spectrum(), space, send, reply, react, tapback, typing
+  indicator, responding, startTyping, stopTyping, content builder, text, attachment, voice, contact, richlink,
+  poll, group, custom content, message effects, bubble effect, screen effect, line model, dedicated line,
+  shared pool, custom events, app.stop, lifecycle, SIGINT, graceful shutdown, message queue, debounce, batch,
+  in-flight, cancellation, abort controller, carry forward, idempotent retry, client guid, dedup, deduplication,
+  startIndex, resume cursor, working memory, resourceId, threadId, per-resource memory, job failure, audit log,
+  race condition, worker crash, retry, pg-boss, queue worker, conversational agent, chat agent, native
+  messaging, agent architecture, production agent, spectrum patterns, best practices.
+license: MIT
+metadata:
+  author: photon-hq
+  version: '2.0.0'
+---
+
+# Spectrum
+
+Spectrum is Photon's unified messaging SDK. Write your handler logic once against a single `app.messages` stream and deliver it across every platform — iMessage, WhatsApp Business, your terminal, or a custom platform you build yourself.
+
+The current SDK is **[`spectrum-ts`](https://github.com/photon-hq/spectrum-ts)** (TypeScript). Spectrum is multi-platform by design and **multi-language is on the roadmap** — additional language SDKs (e.g. Python, Go, Swift) will join the family. The architecture, primitives, and patterns described in this skill are intended to be language-neutral; code samples in the topic files are currently TypeScript and are flagged where the API surface is language-specific (imports, syntax, runtime types).
+
+## How this skill is organized
+
+Each topic lives in its own file in this directory. Read the file relevant to the user's question.
+
+| File | When to consult |
+|---|---|
+| [`getting-started.md`](./getting-started.md) | Installation, the `Spectrum()` app instance, multi-platform setup, the four core primitives. |
+| [`messages.md`](./messages.md) | Receiving messages, the `Message` shape, narrowing on `content.type`, filtering own messages. |
+| [`content.md`](./content.md) | Content builders for outgoing messages: `text`, `attachment`, `voice`, `contact`, `richlink`, `poll`, `group`, `custom`. |
+| [`spaces-and-users.md`](./spaces-and-users.md) | The `Space` interface, typing indicators, `responding`, creating DMs and groups. |
+| [`reactions-and-replies.md`](./reactions-and-replies.md) | `message.react(...)`, threaded `message.reply(...)`, when to use which. |
+| [`platform-narrowing.md`](./platform-narrowing.md) | Recovering platform-specific types from generic Spectrum primitives. |
+| [`providers/imessage.md`](./providers/imessage.md) | iMessage provider — cloud, local, dedicated modes, line model, per-phone routing, message effects, tapbacks. |
+| [`providers/terminal.md`](./providers/terminal.md) | Terminal TUI provider — chat sidebar, reactions, replies, attachments, slash commands. |
+| [`providers/whatsapp-business.md`](./providers/whatsapp-business.md) | WhatsApp Business Cloud API. **1:1 only**. |
+| [`custom-events-and-lifecycle.md`](./custom-events-and-lifecycle.md) | Per-provider event streams (`app.typing`, etc.), `app.stop()`, signal handling. |
+| [`custom-platforms.md`](./custom-platforms.md) | Authoring your own provider with `definePlatform` — full field reference. |
+| [`best-practices.md`](./best-practices.md) | Production architecture patterns Photon uses internally — debounce pipeline, in-flight cancellation, carry-forward, idempotent retries, per-resource memory, job-failure audit log. |
+
+## See also
+
+- [Spectrum docs](https://docs.photon.codes/spectrum-ts/getting-started)
+- [`spectrum-ts` on GitHub](https://github.com/photon-hq/spectrum-ts)

--- a/hermes-agent/.agents/skills/spectrum/best-practices.md
+++ b/hermes-agent/.agents/skills/spectrum/best-practices.md
@@ -1,0 +1,248 @@
+# Best practices: production agent patterns
+
+> **Language note.** Code on this page is TypeScript (`spectrum-ts`). The architecture, queue topology, and concurrency rules described here are language-neutral and apply to any Spectrum SDK; only the runtime details (`AbortController`, `pg-boss`, async iterators) are TS-specific. The same patterns work with any equivalent job queue and abort/cancellation primitive in another language.
+
+These are the architecture patterns Photon uses internally to ship agents that **live natively inside IM apps**. They're pulled directly from production — the problems we hit and the solutions we built. If you're building a similar agent, these patterns will save you months of trial and error.
+
+A naive Spectrum agent — read incoming, call the LLM, send the reply — falls apart in ways you don't see until you ship it. The user types "hey" → "wait" → "actually nvm" inside three seconds and gets three independent responses. The agent replies in 200ms when a real person would take five minutes. A worker crashes mid-send and the user receives the same message twice on retry. The patterns below solve those problems.
+
+## The pipeline
+
+Every incoming message flows through five stages backed by a job queue. Each stage is a separately enqueued job, which is what makes any of them cancellable when a follow-up message lands.
+
+```mermaid
+flowchart LR
+  In([Incoming message]) --> BQ[(Batch queue)]
+  BQ -->|debounce window| Flush[Batch flush]
+  Flush --> Read[Mark as read]
+  Read --> Gen[Generate reply]
+  Gen --> Send[Send with pacing]
+  Send --> Done([Done])
+
+  Inflight[(In-flight table)] -.tracks.- Flush
+  Inflight -.tracks.- Read
+  Inflight -.tracks.- Gen
+  Inflight -.tracks.- Send
+```
+
+The `In-flight` table is a per-chat record of whichever job ID currently owns each stage. When a new message arrives, the enqueuer reads it, cancels those jobs, and moves any messages that were already drained into a carry-forward table so the next batch sees them.
+
+### Why split it up
+
+If you do everything in one handler — read, generate, send — you lose the ability to react to a new message that arrives during generation. By the time you notice, you've already sent a reply that ignored what the user just said, or you've raced the LLM against itself.
+
+Splitting into stages costs a few hundred ms of extra hop latency and buys you:
+
+- **Cancellation points.** Each stage can check a flag and abort cleanly.
+- **Resume points.** A worker crash mid-stage retries one stage, not the whole conversation turn.
+- **Idempotency seams.** The send stage carries stable client GUIDs so retries don't double-send.
+- **Distinct timing.** The read stage can sleep for an hour while the send stage runs in 500ms — they're independent jobs.
+
+## Inbound pipeline
+
+People text in bursts. A real conversation looks like this:
+
+```
+hey
+wait
+actually
+do you know if the train runs on holidays
+```
+
+Four messages in eight seconds. If your agent fires a generation on each one, you get four overlapping replies — and the model never sees the actual question. The fix is to debounce: wait a few seconds for the burst to settle, and handle whatever has accumulated as one turn.
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant Q as Batch queue
+  participant H as Batch handler
+
+  U->>Q: "hey"
+  Q->>Q: schedule flush in 5s
+  U->>Q: "wait"
+  Q->>Q: reset flush timer
+  U->>Q: "actually"
+  Q->>Q: reset flush timer
+  U->>Q: "do you know..."
+  Q->>Q: reset flush timer
+  Note over Q: 5s elapse, no new message
+  Q->>H: flush — drain all four messages
+  H->>H: generate one reply
+```
+
+A few seconds of fixed debounce gets you most of the way there. The harder problems are what happens after the flush.
+
+### Drain in the handler, not the enqueuer
+
+The single most important rule: **the messages stay in the queue table until the handler reads them.** Don't pull them into the job payload at enqueue time.
+
+Why: if the batch-flush job gets cancelled before the handler runs, anything in the payload is lost. Anything still in the queue is naturally picked up by the next batch. Keeping the data in the queue table until the last possible moment makes cancellation a non-event for those messages.
+
+```mermaid
+flowchart TD
+  A[New message] --> B[Insert into batch_queue table]
+  B --> C{Batch flush job<br/>already scheduled?}
+  C -->|yes| D[Reset its run_at to now + debounce]
+  C -->|no| E[Schedule new batch flush job]
+  D --> F[Job fires at run_at]
+  E --> F
+  F --> G[Handler reads + deletes rows<br/>from batch_queue]
+  G --> H[Hand drained messages to read stage]
+```
+
+If the flush job is cancelled between F and G, the rows stay in `batch_queue` and the next incoming message picks them up.
+
+### Carry-forward
+
+Sometimes the handler does drain the queue but is then cancelled mid-generation. Those messages are now in memory inside a cancelled job — they'd be lost on the floor.
+
+The fix is a `carried_messages` table. When a job is cancelled after draining, write the drained messages there. The next batch's handler reads from `carried_messages` first and prepends them as `[Earlier message] ...` lines so the model sees them as historical context, not as fresh input.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Queued
+  Queued --> Drained: handler starts
+  Drained --> Generating: pass to LLM
+  Generating --> Sent: reply complete
+  Generating --> Carried: cancelled
+  Carried --> Queued: re-enqueued for next batch
+  Sent --> [*]
+```
+
+### In-flight cancellation
+
+When a new message arrives and you have a job in flight (reading, generating, or sending), you need to stop it. Two pieces:
+
+1. **A cancellation flag** in a per-chat `in_flight` table. The enqueuer sets `cancelled_at` and calls `boss.cancel(jobId)`.
+2. **Polling inside the handler.** The send stage in particular polls `cancelled_at` every 500ms and aborts via an `AbortController`.
+
+The subtle bit: compare `cancelled_at` against the chain's own `chainStartedAt` timestamp, not against "is the flag set." Otherwise a stale flag from a prior cancelled chain orphans the new one. The flag is per-chain, not per-chat.
+
+```ts
+const inflight = await readInflight(chatId);
+if (inflight?.cancelled_at && inflight.cancelled_at > chainStartedAt) {
+  abortController.abort();
+}
+```
+
+### What you give up
+
+This pipeline buys you correctness at the cost of a few hundred milliseconds of hop latency between stages. For a conversational Spectrum agent that's irrelevant — humans don't notice 300ms when a real reply takes 5 seconds anyway. For a low-latency tool integration, you'd consolidate stages.
+
+## Recovery and state
+
+Workers crash. The send job fails halfway through a 4-message reply. The retry runs from the top — and the user gets messages 1 and 2 again, then 3 and 4 for the first time. Now they have a duplicate.
+
+You need three things to make this robust: stable client GUIDs, a resume cursor, and a place to record what failed.
+
+### Stable client GUIDs
+
+Every message you enqueue gets a deterministic identifier — a `clientGuid` — assigned at enqueue time, not at send time. The transport uses it for deduplication: if it sees the same `clientGuid` twice, it discards the second copy.
+
+```ts
+const messages = reply.map((text, index) => ({
+  text,
+  clientGuid: `${jobId}-${index}`, // stable across retries
+}));
+```
+
+Most modern messaging transports support stable client-side IDs for dedup, and Spectrum surfaces them through the provider interface — check what your provider exposes before assuming you need to build dedup yourself.
+
+The reason `clientGuid` must be stable is subtle: a worker that crashes after the transport ack'd but before the worker recorded it will retry the same message. Without a stable GUID, the transport sees a "new" message and delivers a duplicate.
+
+### startIndex resume cursor
+
+GUID-based dedup handles "transport already saw this." But you also want the worker itself to skip messages it knows it already sent — for performance and to avoid the dedup roundtrip.
+
+Persist a `startIndex` on the job. After each successful send, atomically bump it. On retry, resume from there:
+
+```mermaid
+sequenceDiagram
+  participant W as Worker
+  participant Tx as Transport
+
+  W->>W: assign clientGuids [A, B, C, D]
+  W->>Tx: send msg[0] (guid A)
+  Tx-->>W: ack
+  W->>W: startIndex = 1 (persisted)
+  W->>Tx: send msg[1] (guid B)
+  Tx-->>W: ack
+  W->>W: startIndex = 2 (persisted)
+  W-x W: ⚡ crash
+  Note over W,Tx: retry — load startIndex=2
+  W->>Tx: send msg[2] (guid C)
+  W->>Tx: send msg[3] (guid D)
+```
+
+If the crash happens _between_ ack and persist, the retry resends `msg[1]` — but the transport sees the same `clientGuid B` and discards it. Both layers of defense are doing work.
+
+### Per-resource memory scope
+
+A single agent talks to many users. Each one needs their own working memory, conversation history, and observational notes. Mixing them up is catastrophic — the agent telling one user about another user's plans is the kind of bug you see once and never forget.
+
+Scope every memory operation by `resourceId = senderAddress`. The thread ID is per-chat (`chat-${chatId}`), but memory is per-person:
+
+```ts
+await memory.getWorkingMemory({
+  resourceId: senderAddress,
+  threadId: `chat-${chatId}`,
+});
+```
+
+The same person messaging from a group chat versus a 1:1 sees the same working memory (same `resourceId`), but conversation history is per-thread (different `threadId`). That's usually what you want — the agent remembers _who you are_ across all chats but treats each thread as its own conversation.
+
+```mermaid
+flowchart TD
+  Sender[senderAddress: alice@example.com]
+  Sender --> WM[Working memory:<br/>per-resource]
+  Sender --> Notes[Observational notes:<br/>per-resource]
+
+  Chat1[chat-1<br/>1:1 with alice]
+  Chat2[chat-2<br/>group with alice + bob]
+
+  Chat1 --> H1[Message history<br/>per-thread]
+  Chat2 --> H2[Message history<br/>per-thread]
+
+  WM -.shared across.- Chat1
+  WM -.shared across.- Chat2
+```
+
+If you shard memory across databases or tenants, each shard needs to follow the same convention. Test multi-user concurrency hard — race conditions in working-memory updates corrupt state silently and you won't notice until two users compare notes.
+
+### Job failure audit log
+
+When a job fails, you want to know which job, when, with what payload, and why — without grepping through rotating logs.
+
+A `job_failures` table is a small amount of code that pays back disproportionately. Every error path calls `recordJobFailure(queueName, jobId, payload, error)` and inserts a row. Now you can ask:
+
+- "Which jobs failed in the last hour?"
+- "Are all failures coming from one chat?" (a corrupt working-memory state)
+- "Are all failures from one queue stage?" (a transport outage vs. an LLM bug)
+- "What was the payload that triggered this?" (reproducer)
+
+Operational notes:
+
+- **Add a retention policy.** Otherwise the table grows forever. Delete entries older than 30 days.
+- **Make `recordJobFailure` itself fail-safe.** Wrap it in a try/catch with a log fallback — you don't want a failed-failure-record to take down the worker.
+- **Be careful with payload size.** If your jobs carry images or large blobs, the audit table balloons. Either truncate or store a pointer.
+
+### Putting it together
+
+```mermaid
+flowchart TD
+  Job[Job starts] --> Try{Run handler}
+  Try -->|success| Done[Done]
+  Try -->|crash| Retry[Queue retries with same jobId]
+  Try -->|error| Audit[recordJobFailure]
+  Audit --> Retry
+  Retry --> Resume[Load startIndex]
+  Resume --> Send[Send from startIndex onward]
+  Send --> Tx{Transport check}
+  Tx -->|new clientGuid| Deliver[Delivered]
+  Tx -->|seen clientGuid| Skip[Discarded as dup]
+  Deliver --> Bump[Persist startIndex]
+  Skip --> Bump
+  Bump --> Done
+```
+
+Three independent layers — queue retry, resume cursor, transport dedup — and any one is enough to prevent a duplicate in most failure modes. Together they survive almost everything short of the database itself going down.

--- a/hermes-agent/.agents/skills/spectrum/content.md
+++ b/hermes-agent/.agents/skills/spectrum/content.md
@@ -1,0 +1,108 @@
+# Content builders
+
+> TypeScript samples below — builder names and content shapes are language-neutral.
+
+Every `send`/`reply` accepts a plain string or a content builder: `text`, `attachment`, `voice`, `contact`, `richlink`, `poll`, `option`, `group`, `custom`.
+
+## Text
+
+```ts
+import { text } from "spectrum-ts";
+
+await space.send(text("Hello, world."));
+await space.send("Hello, world."); // strings are equivalent
+```
+
+## Attachments
+
+Pass a file path or a `Buffer`. MIME types are inferred from the file extension; override with `options.mimeType` when you have raw bytes. If MIME can't be inferred and `options.mimeType` is omitted, the builder throws at build time.
+
+```ts
+import { attachment } from "spectrum-ts";
+
+await space.send(attachment("/path/to/photo.jpg"));
+await space.send(attachment(buffer, { name: "report.pdf", mimeType: "application/pdf" }));
+```
+
+## Voice
+
+Same input shape as `attachment`, plus optional `duration` for waveform UIs. Platforms without voice support downgrade to a regular audio attachment.
+
+```ts
+import { voice } from "spectrum-ts";
+
+await space.send(voice("/path/to/note.m4a"));
+await space.send(voice(buffer, { name: "note.m4a", mimeType: "audio/mp4", duration: 12 }));
+```
+
+## Contacts
+
+Accepts a structured `ContactInput`, a vCard string, a `vcf` instance, or a `User` plus optional details.
+
+```ts
+import { contact, fromVCard } from "spectrum-ts";
+
+await space.send(contact({
+  name: { first: "Ada", last: "Lovelace" },
+  phones: [{ value: "+15551234567", type: "mobile" }],
+}));
+
+await space.send(contact(alice, { org: { name: "Acme", title: "Engineer" } }));
+
+const vcf = await readFile("/path/to/ada.vcf", "utf8");
+await space.send(contact(vcf));
+```
+
+`fromVCard` parses; `toVCard` serializes a resolved `Contact` back. `ContactInput` fields: `name`, `phones`, `emails`, `addresses`, `org`, `urls`, `birthday`, `note`, `photo`, `raw`.
+
+## Rich links
+
+Spectrum scrapes Open Graph metadata at send time. `title()`, `summary()`, `cover()` are lazy — fetched only if the receiving platform needs them. Platforms without rich-link support fall back to plain text.
+
+```ts
+import { richlink } from "spectrum-ts";
+
+await space.send(richlink("https://example.com/article"));
+```
+
+## Polls
+
+```ts
+import { poll, option } from "spectrum-ts";
+
+await space.send(poll("Lunch?", "Pizza", "Sushi", "Tacos"));
+await space.send(poll("Lunch?", [option("Pizza"), option("Sushi")]));
+```
+
+Poll responses arrive as `poll_option` content.
+
+## Groups
+
+`group()` bundles multiple messages into one logical unit (album, multi-attachment reply). Each item is delivered as its own `Message` but ships together. Groups don't nest, and reactions can't be group members — both enforced at construction. Platforms without grouping fall back to sending each item sequentially.
+
+```ts
+import { group, attachment } from "spectrum-ts";
+
+await space.send(group(
+  attachment("/path/to/photo-1.jpg"),
+  attachment("/path/to/photo-2.jpg"),
+));
+```
+
+## Custom
+
+Send platform-specific structured payloads. The provider's `actions.send` interprets `raw`.
+
+```ts
+import { custom } from "spectrum-ts";
+
+await space.send(custom({ type: "card", title: "Order Confirmed" }));
+```
+
+## Composing multiple items
+
+```ts
+await space.send("Here's the file:", attachment("/path/to/document.pdf"));
+```
+
+Items send as separate messages (one `send()` per item). Use `group(...)` for a single bundled unit.

--- a/hermes-agent/.agents/skills/spectrum/custom-events-and-lifecycle.md
+++ b/hermes-agent/.agents/skills/spectrum/custom-events-and-lifecycle.md
@@ -1,0 +1,32 @@
+# Custom events and lifecycle
+
+> TypeScript samples below — the per-provider event model and idempotent `stop()` are language-neutral.
+
+## Custom events
+
+Providers can emit events beyond messages — typing, read receipts, delivery status, anything. Each is exposed as a flat async iterable on the app instance:
+
+```ts
+for await (const event of app.typing) {
+  console.log(`${event.platform}: typing event received`);
+}
+```
+
+The property name matches the event name the provider declared. Streams are created lazily on first access; subsequent iterations share the same source. Per-platform access is also available on a narrowed instance:
+
+```ts
+const im = imessage(app);
+for await (const event of im.typing) { /* iMessage-only typing events */ }
+```
+
+## Graceful shutdown
+
+```ts
+await app.stop();
+```
+
+Closes the merged message stream, drains and disposes every custom event stream, and tears down every platform client via its `lifecycle.destroyClient` hook (if defined). Idempotent.
+
+Spectrum registers `SIGINT` and `SIGTERM` handlers on startup. When a signal fires, `stop()` is invoked with a 3-second timeout — exit 0 if cleanup completes, exit 1 if not. You don't need to wire this up yourself.
+
+Call `stop()` manually when embedding Spectrum in a longer-running process, in tests that create and dispose an app per case, or when re-initializing with a different provider set.

--- a/hermes-agent/.agents/skills/spectrum/custom-platforms.md
+++ b/hermes-agent/.agents/skills/spectrum/custom-platforms.md
@@ -1,0 +1,106 @@
+# Building a custom platform
+
+> TypeScript samples below — the authoring contract (config, user/space resolvers, lifecycle, events, actions) is language-neutral; the TS SDK validates with Zod.
+
+`definePlatform` takes a name and a definition object and returns a callable that exposes `.config()` for registration and accepts a Spectrum instance, space, or message for [narrowing](./platform-narrowing.md).
+
+```ts
+import { definePlatform } from "spectrum-ts";
+import z from "zod";
+
+export const myPlatform = definePlatform("my-platform", {
+  config: z.object({ apiKey: z.string() }),
+
+  user: {
+    resolve: async ({ input, client }) => ({
+      id: input.userID,
+      displayName: await client.lookupUser(input.userID),
+    }),
+  },
+
+  space: {
+    resolve: async ({ input, client }) => ({
+      id: await client.findOrCreateConversation(input.users.map(u => u.id)),
+    }),
+  },
+
+  lifecycle: {
+    createClient: async ({ config, store }) => new MyPlatformClient(config.apiKey),
+    destroyClient: async ({ client }) => { await client.disconnect(); },
+  },
+
+  events: {
+    async *messages({ client }) {
+      for await (const msg of client.onMessage()) {
+        yield {
+          id: msg.id,
+          content: { type: "text", text: msg.body },
+          sender: { id: msg.authorId },
+          space: { id: msg.channelId },
+          timestamp: new Date(msg.ts),
+        };
+      }
+    },
+  },
+
+  actions: {
+    send: async ({ space, content, client }) => {
+      if (content.type === "text") await client.send(space.id, content.text);
+    },
+    // Optional: startTyping, stopTyping, reactToMessage, replyToMessage, editMessage, getMessage
+  },
+
+  static: {
+    reactions: { thumbsUp: "+1", thumbsDown: "-1" } as const,
+  },
+});
+```
+
+## Field reference
+
+| Field | Required | Description |
+|---|---|---|
+| `config` | Yes | Zod schema validating `platform.config()` argument. If every field is optional, `.config()` can be called with no arguments. |
+| `user.resolve` | Yes | Resolves a user from a string ID. Returns at minimum `{ id }`. |
+| `user.schema` | No | Optional Zod schema for extra user properties. |
+| `space.resolve` | Yes | Resolves or creates a conversation. Receives users + optional params. |
+| `space.schema` / `space.params` | No | Schemas for the resolved space and for extra creation params. |
+| `lifecycle.createClient` | Yes | Creates the platform client. Receives `config`, `projectId`, `projectSecret` (both may be `undefined`), and `store`. |
+| `lifecycle.destroyClient` | No | Tears down the client on shutdown. |
+| `events.messages` | Yes | Async generator yielding incoming messages. |
+| `events.[custom]` | No | Additional generators — exposed on `app.[eventName]`. |
+| `actions.send` | Yes | Sends a single content item. Invoked once per item when multiple are passed. |
+| `actions.startTyping` / `stopTyping` | No | Typing indicator. |
+| `actions.reactToMessage` / `replyToMessage` | No | Missing → corresponding `message.*` becomes a no-op. |
+| `actions.editMessage` / `getMessage` | No | Edit and lookup. |
+| `message.schema` | No | Zod schema for extra typed fields on incoming messages — surfaced through narrowing. |
+| `static` | No | Constants attached to the platform object (e.g. tapback names). |
+
+## Event producers
+
+Every event generator receives `{ client, config, store }` and returns an `AsyncIterable`:
+
+```ts
+events: {
+  async *messages({ client }) { /* ... */ },
+  async *typing({ client }) {
+    for await (const ev of client.typing()) {
+      yield { spaceId: ev.chatId, userId: ev.user };
+    }
+  },
+},
+```
+
+Non-`messages` events are auto-wired as flat properties on both `app` and the narrowed platform instance.
+
+## Registering
+
+```ts
+const app = await Spectrum({
+  providers: [myPlatform.config({ apiKey: process.env.MY_KEY! })],
+});
+
+const mine = myPlatform(app);
+const space = await mine.space(await mine.user("user-123"));
+await space.send("Hello from my custom platform.");
+```

--- a/hermes-agent/.agents/skills/spectrum/getting-started.md
+++ b/hermes-agent/.agents/skills/spectrum/getting-started.md
@@ -1,0 +1,102 @@
+# Getting started
+
+> TypeScript samples below — primitives and the app instance are language-neutral.
+
+## Installation
+
+```bash
+npm install spectrum-ts        # or pnpm / yarn / bun add
+```
+
+Requires TypeScript 5 or later.
+
+## Core concepts
+
+| Primitive | What it represents |
+|---|---|
+| **Message** | An incoming piece of content — text, attachments, or structured data — from any platform. |
+| **Space** | A conversation context. A DM, a group chat, a terminal session. You send messages *into* a space. |
+| **User** | A participant on a platform, identified by a platform-specific ID. |
+| **Platform provider** | A platform adapter (iMessage, terminal, WhatsApp, or your own) that translates platform-specific protocols into Spectrum's unified interface. |
+
+Every message arrives as a `[Space, Message]` pair.
+
+## Quickstart
+
+Find `PROJECT_ID` and `SECRET_KEY` in your project **Settings** on the [dashboard](https://app.photon.codes/).
+
+```ts
+import { Spectrum } from "spectrum-ts";
+import { imessage } from "spectrum-ts/providers/imessage";
+
+const app = await Spectrum({
+  projectId: "your-project-id",
+  projectSecret: "your-project-secret",
+  providers: [imessage.config()],
+});
+
+for await (const [space, message] of app.messages) {
+  if (message.content.type !== "text") continue;
+
+  // Use the platform's native vocabulary, not a bare send:
+  await message.react("like");                 // tapback to acknowledge instantly
+  await space.responding(async () => {         // show a typing indicator while you work
+    await message.reply(`echo: ${message.content.text}`);  // threaded reply, not a loose message
+  });
+}
+```
+
+> **Building an agent? Be rich, not robotic.** A bare `space.send(...)` works, but on iMessage (and other rich platforms) it reads like a webhook, not a person. Reach for the native features whenever they fit the moment:
+> - **`message.react("love" | "like" | "laugh" | …)`** — acknowledge a message instantly with a tapback before you've composed a full answer.
+> - **`message.reply(...)`** — answer *the specific message* in-thread, so the conversation stays legible in a busy chat.
+> - **`space.responding(async () => { … })`** — wrap slow work (an LLM call, a fetch) so the recipient sees a typing indicator instead of dead air.
+>
+> These **no-op silently** on platforms that don't support them, so there's no downside to reaching for the richer call — write the expressive version once and it degrades gracefully everywhere. See [`reactions-and-replies.md`](./reactions-and-replies.md), [`spaces-and-users.md`](./spaces-and-users.md), and the iMessage-only flourishes (message effects, the full tapback set) in [`providers/imessage.md`](./providers/imessage.md).
+
+Projectless providers like `terminal` work without credentials:
+
+```ts
+const app = await Spectrum({ providers: [terminal.config()] });
+```
+
+## The app instance
+
+```ts
+app.messages                       // AsyncIterable<[Space, Message]>
+await app.send(space, ...)         // send into a space
+await app.responding(space, fn)    // run fn with a typing indicator
+await app.stop()                   // graceful shutdown
+```
+
+See [`custom-events-and-lifecycle.md`](./custom-events-and-lifecycle.md) for custom event streams and shutdown.
+
+## Multi-platform
+
+Combine providers — `app.messages` merges every source. The `message.platform` field identifies the origin.
+
+```ts
+import { Spectrum } from "spectrum-ts";
+import { imessage } from "spectrum-ts/providers/imessage";
+import { terminal } from "spectrum-ts/providers/terminal";
+import { whatsappBusiness } from "spectrum-ts/providers/whatsapp-business";
+
+const app = await Spectrum({
+  projectId: process.env.PROJECT_ID!,
+  projectSecret: process.env.PROJECT_SECRET!,
+  providers: [
+    imessage.config(),
+    whatsappBusiness.config({
+      accessToken: process.env.WA_TOKEN!,
+      phoneNumberId: process.env.WA_NUMBER_ID!,
+      appSecret: process.env.WA_SECRET!,
+    }),
+    terminal.config(),
+  ],
+});
+
+for await (const [space, message] of app.messages) {
+  await space.responding(async () => {
+    await message.reply("Hello from Spectrum.");
+  });
+}
+```

--- a/hermes-agent/.agents/skills/spectrum/messages.md
+++ b/hermes-agent/.agents/skills/spectrum/messages.md
@@ -1,0 +1,84 @@
+# Messages
+
+> TypeScript samples below — the `Message` shape and content variants are language-neutral.
+
+Every incoming message arrives through `app.messages` as a `[Space, Message]` pair. The space is already bound to the originating conversation — you don't need to resolve it yourself to reply.
+
+## The Message shape
+
+| Field | Description |
+|---|---|
+| `id` | Platform-assigned message identifier. |
+| `content` | Discriminated union on `type` — see [Narrowing content](#narrowing-content). |
+| `sender` | The `User` who sent the message (`{ id, __platform }`). |
+| `space` | The `Space` the message was sent into. |
+| `platform` | Name of the provider that delivered the message (e.g. `"iMessage"`, `"terminal"`). |
+| `timestamp` | `Date` of when the message was sent. |
+| `react(reaction)` | React to this message. No-op on platforms without reactions. |
+| `reply(...content)` | Reply threaded to this message. No-op on platforms without thread support. |
+
+## Narrowing content
+
+`Content` is a discriminated union. Always narrow on `message.content.type` before accessing fields.
+
+```ts
+for await (const [space, message] of app.messages) {
+  switch (message.content.type) {
+    case "text":
+      console.log(message.content.text);
+      break;
+    case "attachment":
+      console.log(`${message.content.name} (${message.content.mimeType})`, await message.content.read());
+      break;
+    case "voice":
+      console.log(`voice note (${message.content.duration}s)`);
+      break;
+    case "contact":
+      console.log(message.content.name?.formatted, message.content.phones);
+      break;
+    case "richlink":
+      console.log(message.content.url, await message.content.title());
+      break;
+    case "reaction":
+      console.log(`${message.content.emoji} on ${message.content.target.id}`);
+      break;
+    case "poll":
+      console.log(message.content.title, message.content.options);
+      break;
+    case "poll_option":
+      console.log(`vote ${message.content.selected ? "+" : "-"}`, message.content.title);
+      break;
+    case "group":
+      console.log(`group of ${message.content.items.length} items`);
+      break;
+    case "custom":
+      console.log(message.content.raw);
+      break;
+  }
+}
+```
+
+| Type | Fields |
+|---|---|
+| `"text"` | `text` |
+| `"attachment"` | `name`, `mimeType`, `size?`, `read()`, `stream()` |
+| `"voice"` | `name?`, `mimeType`, `duration?`, `size?`, `read()`, `stream()` |
+| `"contact"` | `name?`, `phones?`, `emails?`, `addresses?`, `org?`, `urls?`, `birthday?`, `note?`, `photo?`, `user?` |
+| `"richlink"` | `url`, `title()`, `summary()`, `cover()` |
+| `"reaction"` | `emoji`, `target: Message` |
+| `"poll"` | `title`, `options: { title }[]` |
+| `"poll_option"` | `option`, `poll`, `selected`, `title` — sent as a vote |
+| `"group"` | `items: Message[]` |
+| `"custom"` | `raw: unknown` |
+
+Outgoing-only variants like `"effect"` (an iMessage screen effect wrapping inner content) appear on echoed sends — see [`providers/imessage.md`](./providers/imessage.md).
+
+## Filtering out your own messages
+
+Some platforms echo your own sends. Compare the sender to a known identity:
+
+```ts
+if (message.sender.id === myAccountId) continue;
+```
+
+iMessage exposes an `isFromMe` flag on the raw message extra (via [platform narrowing](./platform-narrowing.md)).

--- a/hermes-agent/.agents/skills/spectrum/platform-narrowing.md
+++ b/hermes-agent/.agents/skills/spectrum/platform-narrowing.md
@@ -1,0 +1,28 @@
+# Platform narrowing
+
+> TypeScript samples below — narrowing is the conceptual pattern across SDKs; the TS implementation uses callable provider objects with TS type narrowing.
+
+Every provider exports a callable — `imessage`, `terminal`, `whatsappBusiness` — that **narrows** generic Spectrum types into platform-specific ones. The same function handles three inputs:
+
+```ts
+import { imessage } from "spectrum-ts/providers/imessage";
+
+// 1. Narrow the app — get user/space resolvers and custom events
+const im = imessage(app);
+const user = await im.user("+15551234567");
+const space = await im.space(user);
+
+// 2. Narrow a space — access platform-specific fields
+for await (const [space, message] of app.messages) {
+  if (message.platform !== "iMessage") continue;
+  const imSpace = imessage(space);
+  if (imSpace.type === "group") { /* ... */ }
+}
+
+// 3. Narrow a message — exposes provider's `message.schema` extras
+const imMessage = imessage(message);
+```
+
+If the platform isn't registered in `providers`, `imessage(app)` resolves to `never` (compile-time error in TS). Narrowing a space/message from the wrong platform throws at runtime — gate on `message.platform` first.
+
+The generic `Space` and `Message` interfaces are deliberately small — just enough to send, react, and reply across every platform. Narrowing is the escape hatch for everything else: typed access to iMessage chat types, WhatsApp phone numbers, or any extra field your [custom platform](./custom-platforms.md) exposes.

--- a/hermes-agent/.agents/skills/spectrum/providers/imessage.md
+++ b/hermes-agent/.agents/skills/spectrum/providers/imessage.md
@@ -1,0 +1,94 @@
+# iMessage provider
+
+> TypeScript samples below — connection modes, line model, effects, and tapbacks are platform features that apply across all Spectrum SDKs.
+
+```ts
+import { imessage } from "spectrum-ts/providers/imessage";
+```
+
+Three connection modes — local, cloud, and dedicated. iMessage-specific features (tapbacks, DM vs group spaces, per-phone routing) come through [platform narrowing](../platform-narrowing.md).
+
+## Connection modes
+
+```ts
+// Cloud (default) — managed by Spectrum, full feature set.
+// Tokens auto-renew at 80% of TTL. Requires projectId/projectSecret on Spectrum().
+imessage.config();
+
+// Local — reads macOS Messages SQLite directly. No network.
+// Only supports text + attachments. No reactions, typing, replies, or group creation.
+imessage.config({ local: true });
+
+// Dedicated — connect to your own iMessage gRPC endpoints with your own tokens.
+// Each entry must include the phone number it serves so Spectrum can route correctly.
+imessage.config({
+  clients: [
+    { address: "instance-1.example.com:443", token: "your-token", phone: "+15551111111" },
+    { address: "instance-2.example.com:443", token: "your-token", phone: "+15552222222" },
+  ],
+});
+```
+
+## Line model (cloud mode)
+
+| Plan | Line allocation | What end users see |
+|---|---|---|
+| **Free / Pro** | Shared pool — each end user routed through a different number from a shared pool | Normal iMessage from a number that may differ across recipients |
+| **Business** | Dedicated — all end users text the same number, which belongs to your project | Normal iMessage, always from the same number |
+
+**Auto-scale** is an opt-in Business feature: when traffic to a dedicated line nears its per-line capacity, Spectrum provisions an additional line. Open-source paths (`local: true` or your own dedicated relay) provide their own iCloud account; managed-line concepts don't apply.
+
+## Space types and per-phone routing
+
+iMessage spaces carry `type: "dm" | "group"` and a `phone` field. With multiple dedicated lines, pin a conversation to a specific line:
+
+```ts
+const dm = await im.space(alice, { phone: "+15559999999" });
+```
+
+When omitted, Spectrum picks at random from available dedicated lines. Per-phone routing applies to **dedicated lines (Business plan) only**; on shared-pool plans the parameter is ignored. Space creation requires cloud or dedicated mode — local mode throws.
+
+## Message effects
+
+Wrap any content with `effect()`. Wrapped content can be a string or `attachment(...)`. Effects only apply on iMessage; other platforms see the inner content unchanged.
+
+```ts
+import { effect, imessage } from "spectrum-ts/providers/imessage";
+
+await space.send(effect("Happy birthday!", imessage.effect.message.celebration));
+await space.send(effect(attachment("/path/to/photo.jpg"), imessage.effect.message.confetti));
+```
+
+| Bubble effects | |
+|---|---|
+| `imessage.effect.message.slam` | `"com.apple.MobileSMS.expressivesend.impact"` |
+| `imessage.effect.message.loud` | `"com.apple.MobileSMS.expressivesend.loud"` |
+| `imessage.effect.message.gentle` | `"com.apple.MobileSMS.expressivesend.gentle"` |
+| `imessage.effect.message.invisible` | `"com.apple.MobileSMS.expressivesend.invisibleink"` |
+
+| Screen effects | |
+|---|---|
+| `imessage.effect.message.confetti` | `"com.apple.messages.effect.CKConfettiEffect"` |
+| `imessage.effect.message.fireworks` | `"com.apple.messages.effect.CKFireworksEffect"` |
+| `imessage.effect.message.balloons` | `"com.apple.messages.effect.CKBalloonEffect"` |
+| `imessage.effect.message.heart` | `"com.apple.messages.effect.CKHeartEffect"` |
+| `imessage.effect.message.lasers` | `"com.apple.messages.effect.CKLasersEffect"` |
+| `imessage.effect.message.celebration` | `"com.apple.messages.effect.CKHappyBirthdayEffect"` |
+| `imessage.effect.message.sparkles` | `"com.apple.messages.effect.CKSparklesEffect"` |
+| `imessage.effect.message.spotlight` | `"com.apple.messages.effect.CKSpotlightEffect"` |
+| `imessage.effect.message.echo` | `"com.apple.messages.effect.CKEchoEffect"` |
+
+## Tapbacks
+
+| Constant | Value |
+|---|---|
+| `imessage.tapbacks.love` | `"love"` |
+| `imessage.tapbacks.like` | `"like"` |
+| `imessage.tapbacks.dislike` | `"dislike"` |
+| `imessage.tapbacks.laugh` | `"laugh"` |
+| `imessage.tapbacks.emphasize` | `"emphasize"` |
+| `imessage.tapbacks.question` | `"question"` |
+
+```ts
+await message.react(imessage.tapbacks.laugh);
+```

--- a/hermes-agent/.agents/skills/spectrum/providers/terminal.md
+++ b/hermes-agent/.agents/skills/spectrum/providers/terminal.md
@@ -1,0 +1,48 @@
+# Terminal provider
+
+> TypeScript samples below — the TUI behavior is the same regardless of agent language.
+
+```ts
+import { terminal } from "spectrum-ts/providers/terminal";
+```
+
+A full chat TUI for developing and testing agents locally. `terminal.config()` spawns the standalone [tuichat](https://github.com/photon-hq/tuichat) binary as a subprocess and drives it over JSON-RPC. The binary auto-downloads from GitHub Releases on first run. In a TTY it boots the rich UI; in a non-TTY context (CI, piped input) it falls back to a synchronous readline loop — same agent code works for scripted tests.
+
+```ts
+const app = await Spectrum({ providers: [terminal.config()] });
+```
+
+No credentials, no config — just import and run.
+
+| Feature | How |
+|---|---|
+| Multiple chats | `Ctrl+N` opens a new chat, `Ctrl+J` / `Ctrl+K` switch. Each chat is its own space. |
+| Reactions | Press `r` on a message — arrives as a `reaction` content message. |
+| Replies | Press `e` — arrives with a `replyTo: { messageId }` extra. |
+| File attachments | Drag-and-drop into the terminal. |
+| Inline images | Kitty graphics protocol when supported, half-block fallback. |
+| Typing indicators | `space.startTyping()` / `space.stopTyping()`. |
+| Console capture | `console.log` / `info` / `warn` / `error` / `debug` are forwarded into a pinned `__system__` chat instead of garbling the UI. |
+
+## Slash commands
+
+```ts
+terminal.config({
+  commands: [
+    { name: "/clear", description: "Clear conversation memory" },
+    { name: "/whoami", description: "Print sender details" },
+  ],
+});
+```
+
+Names must match `/^\/[A-Za-z0-9_-]+$/`. Slash commands arrive as regular text messages with the command string as the content.
+
+## Programmatic spaces
+
+Default is `chat-1`; new chats opened with `Ctrl+N` get `chat-2`, `chat-3`, ... To open a named space programmatically:
+
+```ts
+const t = terminal(app);
+const debug = await t.space({ id: "debug" });
+await debug.send("agent online");
+```

--- a/hermes-agent/.agents/skills/spectrum/providers/whatsapp-business.md
+++ b/hermes-agent/.agents/skills/spectrum/providers/whatsapp-business.md
@@ -1,0 +1,33 @@
+# WhatsApp Business provider
+
+> TypeScript samples below — the 1:1-only constraint is a platform feature.
+
+```ts
+import { whatsappBusiness } from "spectrum-ts/providers/whatsapp-business";
+```
+
+Wraps the official WhatsApp Business Cloud API. Reactions and threaded replies map to native WhatsApp features. **1:1 only** — `space(userA, userB)` throws.
+
+## Config
+
+```ts
+whatsappBusiness.config({
+  accessToken: "...",       // permanent or system-user token from Meta for Developers
+  phoneNumberId: "...",     // sender phone number ID
+  appSecret: "...",         // verifies webhook payload signatures
+});
+```
+
+Find these values in your WhatsApp Business app settings on [Meta for Developers](https://developers.facebook.com/).
+
+## Starting a conversation
+
+Resolve a user by their WhatsApp phone number (international format, digits only):
+
+```ts
+const wa = whatsappBusiness(app);
+const customer = await wa.user("15551234567");
+const space = await wa.space(customer);
+
+await space.send("Thanks for reaching out.");
+```

--- a/hermes-agent/.agents/skills/spectrum/reactions-and-replies.md
+++ b/hermes-agent/.agents/skills/spectrum/reactions-and-replies.md
@@ -1,0 +1,21 @@
+# Reactions and replies
+
+> TypeScript samples below — silent no-op on unsupported platforms is part of the model, not a TS detail.
+
+Both `react` and `reply` live directly on an incoming message. Both no-op silently on platforms that don't support them — no `try/catch` needed.
+
+```ts
+await message.react("love");
+await message.reply("Replying to your message.");
+await message.reply("Here's the file:", attachment("/path/to/file.pdf"));
+```
+
+On platforms with thread support (iMessage, WhatsApp Business), `reply` sends threaded. **It is not downgraded to a regular send** — if you need guaranteed delivery, use `space.send(...)`.
+
+For iMessage tapback constants (`imessage.tapbacks.love`, `like`, `dislike`, `laugh`, `emphasize`, `question`), see [`providers/imessage.md`](./providers/imessage.md).
+
+| Want to | Use |
+|---|---|
+| Send fresh content into a conversation | `space.send(...)` |
+| Reply in-thread to a specific message | `message.reply(...)` |
+| React to a specific message | `message.react(reaction)` |

--- a/hermes-agent/.agents/skills/spectrum/spaces-and-users.md
+++ b/hermes-agent/.agents/skills/spectrum/spaces-and-users.md
@@ -1,0 +1,47 @@
+# Spaces and users
+
+> TypeScript samples below — the space/user model is language-neutral.
+
+A **space** is a conversation. A **user** is a participant. Both carry a `__platform` tag.
+
+## Space interface
+
+| Method | Description |
+|---|---|
+| `send(...content)` | Send one or more content items. |
+| `startTyping()` / `stopTyping()` | Show / hide typing indicator. No-op without support. |
+| `responding(fn)` | Run `fn` wrapped in typing — guarantees indicator is cleared even on throw. |
+| `edit(message, newContent)` | Edit a previously sent message. |
+| `getMessage(id)` | Look up a message by ID. |
+
+## Typing indicators
+
+`responding` is the recommended pattern:
+
+```ts
+await space.responding(async () => {
+  const result = await generateResponse(message);
+  await space.send(result);
+});
+```
+
+Or via the app helper: `await app.responding(space, async () => { ... })`.
+
+## Creating a space
+
+Use [platform narrowing](./platform-narrowing.md) for the platform instance, then pass users:
+
+```ts
+import { imessage } from "spectrum-ts/providers/imessage";
+
+const im = imessage(app);
+const alice = await im.user("+15551111111");
+const bob = await im.user("+15552222222");
+
+const dm = await im.space(alice);
+const group = await im.space(alice, bob);
+
+await group.send("Welcome to the group.");
+```
+
+The returned space satisfies the generic `Space` interface and carries platform-specific fields (e.g. `type: "dm" | "group"` on iMessage).

--- a/hermes-agent/.claude/skills/spectrum
+++ b/hermes-agent/.claude/skills/spectrum
@@ -1,0 +1,1 @@
+../../.agents/skills/spectrum

--- a/hermes-agent/.env.example
+++ b/hermes-agent/.env.example
@@ -1,0 +1,3 @@
+# Top-level Spectrum credentials (from your Photon dashboard).
+PROJECT_ID=
+PROJECT_SECRET=

--- a/hermes-agent/.gitignore
+++ b/hermes-agent/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.env
+.env.local
+dist
+*.log
+.DS_Store

--- a/hermes-agent/AGENTS.md
+++ b/hermes-agent/AGENTS.md
@@ -1,0 +1,30 @@
+# hermes-agent — agent instructions
+
+This is a [Spectrum](https://photon.codes/docs/spectrum-ts) app, pinned to `spectrum-ts@^5.1.0`. The entry point is `src/index.ts`, which configures the iMessage provider(s) and runs the echo loop.
+
+## Working in this project
+
+- Run the app with `npm run start`.
+- Add providers by importing them in `src/index.ts` and listing them in the `Spectrum({ providers: [...] })` config.
+- Outgoing message content uses the builders documented in the skill (text, attachment, voice, contact, richlink, poll, group, custom).
+
+## Environment
+
+This project reads secrets from `.env` (gitignored). **Do not read, write, or echo `.env`** — it contains credentials.
+
+If startup fails with an authentication error, tell the user to verify their `PROJECT_ID` / `PROJECT_SECRET` at the [Photon dashboard](https://app.photon.codes).
+
+## Spectrum SDK reference
+
+This project includes the `spectrum` skill from [`photon-hq/skills`](https://github.com/photon-hq/skills). Your agent should auto-discover it. If it doesn't, or if you switch agents, install for your agent with:
+
+```sh
+npx skills add photon-hq/skills --skill spectrum --agent <your-agent>
+```
+
+(Use `--agent '*'` to install for all supported agents.)
+
+## See also
+
+- [Spectrum docs](https://photon.codes/docs/spectrum-ts)
+- [`spectrum-ts` on GitHub](https://github.com/photon-hq/spectrum-ts)

--- a/hermes-agent/CLAUDE.md
+++ b/hermes-agent/CLAUDE.md
@@ -1,0 +1,3 @@
+# Agent instructions
+
+@AGENTS.md

--- a/hermes-agent/README.md
+++ b/hermes-agent/README.md
@@ -1,0 +1,25 @@
+# hermes-agent
+
+A [Spectrum](https://photon.codes/docs/spectrum-ts) project. Wired with: iMessage.
+
+## Environment
+
+Before running, open `.env` and fill in the values:
+
+From your project Settings on the [Photon dashboard](https://app.photon.codes):
+
+- `PROJECT_ID`
+- `PROJECT_SECRET`
+
+## Run
+
+```sh
+npm install
+npm run start
+```
+
+## Where to go next
+
+- [Spectrum docs](https://photon.codes/docs/spectrum-ts)
+- Edit `src/index.ts` to replace the echo loop with real agent logic.
+- Add more providers from `spectrum-ts/providers/*`.

--- a/hermes-agent/agent/skills/spectrum/SKILL.md
+++ b/hermes-agent/agent/skills/spectrum/SKILL.md
@@ -1,0 +1,34 @@
+---
+description: "Build messaging agents and apps with Spectrum — Photon's unified messaging SDK. Write your handler logic once and ship it across iMessage, WhatsApp Business, the terminal, or a custom platform. Spectrum is multi-platform by design and is becoming multi-language; the current SDK is `spectrum-ts` (TypeScript), with additional language SDKs planned. Use this skill for any Spectrum question — quickstart, multi-platform setup, receiving messages, content builders, spaces and users, reactions and replies, platform narrowing, the built-in providers (iMessage cloud/local/dedicated with message effects, Terminal TUI test harness, WhatsApp Business 1:1), custom event streams, graceful shutdown, building your own provider with `definePlatform`, and the production architecture patterns Photon uses internally to ship agents that live natively inside IM apps (five-stage inbound pipeline with debounce → batch flush → mark as read → generate → send, in-flight cancellation with abort signals, drain-in-handler, carry-forward, idempotent retries via stable client GUIDs and a startIndex resume cursor, per-resource memory scope `resourceId` vs `threadId`, durable job-failure audit log). This is the entry point for the skill; consult the topic files in this directory for full reference. Keywords: spectrum, spectrum-ts, photon, unified messaging, multi-platform, multi-language, im agent, messaging agent, imessage, whatsapp, whatsapp business, terminal, tuichat, definePlatform, custom platform, platform provider, platform narrowing, app.messages, Spectrum(), space, send, reply, react, tapback, typing indicator, responding, startTyping, stopTyping, content builder, text, attachment, voice, contact, richlink, poll, group, custom content, message effects, bubble effect, screen effect, line model, dedicated line, shared pool, custom events, app.stop, lifecycle, SIGINT, graceful shutdown, message queue, debounce, batch, in-flight, cancellation, abort controller, carry forward, idempotent retry, client guid, dedup, deduplication, startIndex, resume cursor, working memory, resourceId, threadId, per-resource memory, job failure, audit log, race condition, worker crash, retry, pg-boss, queue worker, conversational agent, chat agent, native messaging, agent architecture, production agent, spectrum patterns, best practices.\n"
+license: "MIT"
+metadata: {"author":"photon-hq","version":"2.0.0"}
+---
+# Spectrum
+
+Spectrum is Photon's unified messaging SDK. Write your handler logic once against a single `app.messages` stream and deliver it across every platform — iMessage, WhatsApp Business, your terminal, or a custom platform you build yourself.
+
+The current SDK is **[`spectrum-ts`](https://github.com/photon-hq/spectrum-ts)** (TypeScript). Spectrum is multi-platform by design and **multi-language is on the roadmap** — additional language SDKs (e.g. Python, Go, Swift) will join the family. The architecture, primitives, and patterns described in this skill are intended to be language-neutral; code samples in the topic files are currently TypeScript and are flagged where the API surface is language-specific (imports, syntax, runtime types).
+
+## How this skill is organized
+
+Each topic lives in its own file in this directory. Read the file relevant to the user's question.
+
+| File | When to consult |
+|---|---|
+| [`getting-started.md`](./getting-started.md) | Installation, the `Spectrum()` app instance, multi-platform setup, the four core primitives. |
+| [`messages.md`](./messages.md) | Receiving messages, the `Message` shape, narrowing on `content.type`, filtering own messages. |
+| [`content.md`](./content.md) | Content builders for outgoing messages: `text`, `attachment`, `voice`, `contact`, `richlink`, `poll`, `group`, `custom`. |
+| [`spaces-and-users.md`](./spaces-and-users.md) | The `Space` interface, typing indicators, `responding`, creating DMs and groups. |
+| [`reactions-and-replies.md`](./reactions-and-replies.md) | `message.react(...)`, threaded `message.reply(...)`, when to use which. |
+| [`platform-narrowing.md`](./platform-narrowing.md) | Recovering platform-specific types from generic Spectrum primitives. |
+| [`providers/imessage.md`](./providers/imessage.md) | iMessage provider — cloud, local, dedicated modes, line model, per-phone routing, message effects, tapbacks. |
+| [`providers/terminal.md`](./providers/terminal.md) | Terminal TUI provider — chat sidebar, reactions, replies, attachments, slash commands. |
+| [`providers/whatsapp-business.md`](./providers/whatsapp-business.md) | WhatsApp Business Cloud API. **1:1 only**. |
+| [`custom-events-and-lifecycle.md`](./custom-events-and-lifecycle.md) | Per-provider event streams (`app.typing`, etc.), `app.stop()`, signal handling. |
+| [`custom-platforms.md`](./custom-platforms.md) | Authoring your own provider with `definePlatform` — full field reference. |
+| [`best-practices.md`](./best-practices.md) | Production architecture patterns Photon uses internally — debounce pipeline, in-flight cancellation, carry-forward, idempotent retries, per-resource memory, job-failure audit log. |
+
+## See also
+
+- [Spectrum docs](https://docs.photon.codes/spectrum-ts/getting-started)
+- [`spectrum-ts` on GitHub](https://github.com/photon-hq/spectrum-ts)

--- a/hermes-agent/agent/skills/spectrum/best-practices.md
+++ b/hermes-agent/agent/skills/spectrum/best-practices.md
@@ -1,0 +1,248 @@
+# Best practices: production agent patterns
+
+> **Language note.** Code on this page is TypeScript (`spectrum-ts`). The architecture, queue topology, and concurrency rules described here are language-neutral and apply to any Spectrum SDK; only the runtime details (`AbortController`, `pg-boss`, async iterators) are TS-specific. The same patterns work with any equivalent job queue and abort/cancellation primitive in another language.
+
+These are the architecture patterns Photon uses internally to ship agents that **live natively inside IM apps**. They're pulled directly from production — the problems we hit and the solutions we built. If you're building a similar agent, these patterns will save you months of trial and error.
+
+A naive Spectrum agent — read incoming, call the LLM, send the reply — falls apart in ways you don't see until you ship it. The user types "hey" → "wait" → "actually nvm" inside three seconds and gets three independent responses. The agent replies in 200ms when a real person would take five minutes. A worker crashes mid-send and the user receives the same message twice on retry. The patterns below solve those problems.
+
+## The pipeline
+
+Every incoming message flows through five stages backed by a job queue. Each stage is a separately enqueued job, which is what makes any of them cancellable when a follow-up message lands.
+
+```mermaid
+flowchart LR
+  In([Incoming message]) --> BQ[(Batch queue)]
+  BQ -->|debounce window| Flush[Batch flush]
+  Flush --> Read[Mark as read]
+  Read --> Gen[Generate reply]
+  Gen --> Send[Send with pacing]
+  Send --> Done([Done])
+
+  Inflight[(In-flight table)] -.tracks.- Flush
+  Inflight -.tracks.- Read
+  Inflight -.tracks.- Gen
+  Inflight -.tracks.- Send
+```
+
+The `In-flight` table is a per-chat record of whichever job ID currently owns each stage. When a new message arrives, the enqueuer reads it, cancels those jobs, and moves any messages that were already drained into a carry-forward table so the next batch sees them.
+
+### Why split it up
+
+If you do everything in one handler — read, generate, send — you lose the ability to react to a new message that arrives during generation. By the time you notice, you've already sent a reply that ignored what the user just said, or you've raced the LLM against itself.
+
+Splitting into stages costs a few hundred ms of extra hop latency and buys you:
+
+- **Cancellation points.** Each stage can check a flag and abort cleanly.
+- **Resume points.** A worker crash mid-stage retries one stage, not the whole conversation turn.
+- **Idempotency seams.** The send stage carries stable client GUIDs so retries don't double-send.
+- **Distinct timing.** The read stage can sleep for an hour while the send stage runs in 500ms — they're independent jobs.
+
+## Inbound pipeline
+
+People text in bursts. A real conversation looks like this:
+
+```
+hey
+wait
+actually
+do you know if the train runs on holidays
+```
+
+Four messages in eight seconds. If your agent fires a generation on each one, you get four overlapping replies — and the model never sees the actual question. The fix is to debounce: wait a few seconds for the burst to settle, and handle whatever has accumulated as one turn.
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant Q as Batch queue
+  participant H as Batch handler
+
+  U->>Q: "hey"
+  Q->>Q: schedule flush in 5s
+  U->>Q: "wait"
+  Q->>Q: reset flush timer
+  U->>Q: "actually"
+  Q->>Q: reset flush timer
+  U->>Q: "do you know..."
+  Q->>Q: reset flush timer
+  Note over Q: 5s elapse, no new message
+  Q->>H: flush — drain all four messages
+  H->>H: generate one reply
+```
+
+A few seconds of fixed debounce gets you most of the way there. The harder problems are what happens after the flush.
+
+### Drain in the handler, not the enqueuer
+
+The single most important rule: **the messages stay in the queue table until the handler reads them.** Don't pull them into the job payload at enqueue time.
+
+Why: if the batch-flush job gets cancelled before the handler runs, anything in the payload is lost. Anything still in the queue is naturally picked up by the next batch. Keeping the data in the queue table until the last possible moment makes cancellation a non-event for those messages.
+
+```mermaid
+flowchart TD
+  A[New message] --> B[Insert into batch_queue table]
+  B --> C{Batch flush job<br/>already scheduled?}
+  C -->|yes| D[Reset its run_at to now + debounce]
+  C -->|no| E[Schedule new batch flush job]
+  D --> F[Job fires at run_at]
+  E --> F
+  F --> G[Handler reads + deletes rows<br/>from batch_queue]
+  G --> H[Hand drained messages to read stage]
+```
+
+If the flush job is cancelled between F and G, the rows stay in `batch_queue` and the next incoming message picks them up.
+
+### Carry-forward
+
+Sometimes the handler does drain the queue but is then cancelled mid-generation. Those messages are now in memory inside a cancelled job — they'd be lost on the floor.
+
+The fix is a `carried_messages` table. When a job is cancelled after draining, write the drained messages there. The next batch's handler reads from `carried_messages` first and prepends them as `[Earlier message] ...` lines so the model sees them as historical context, not as fresh input.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Queued
+  Queued --> Drained: handler starts
+  Drained --> Generating: pass to LLM
+  Generating --> Sent: reply complete
+  Generating --> Carried: cancelled
+  Carried --> Queued: re-enqueued for next batch
+  Sent --> [*]
+```
+
+### In-flight cancellation
+
+When a new message arrives and you have a job in flight (reading, generating, or sending), you need to stop it. Two pieces:
+
+1. **A cancellation flag** in a per-chat `in_flight` table. The enqueuer sets `cancelled_at` and calls `boss.cancel(jobId)`.
+2. **Polling inside the handler.** The send stage in particular polls `cancelled_at` every 500ms and aborts via an `AbortController`.
+
+The subtle bit: compare `cancelled_at` against the chain's own `chainStartedAt` timestamp, not against "is the flag set." Otherwise a stale flag from a prior cancelled chain orphans the new one. The flag is per-chain, not per-chat.
+
+```ts
+const inflight = await readInflight(chatId);
+if (inflight?.cancelled_at && inflight.cancelled_at > chainStartedAt) {
+  abortController.abort();
+}
+```
+
+### What you give up
+
+This pipeline buys you correctness at the cost of a few hundred milliseconds of hop latency between stages. For a conversational Spectrum agent that's irrelevant — humans don't notice 300ms when a real reply takes 5 seconds anyway. For a low-latency tool integration, you'd consolidate stages.
+
+## Recovery and state
+
+Workers crash. The send job fails halfway through a 4-message reply. The retry runs from the top — and the user gets messages 1 and 2 again, then 3 and 4 for the first time. Now they have a duplicate.
+
+You need three things to make this robust: stable client GUIDs, a resume cursor, and a place to record what failed.
+
+### Stable client GUIDs
+
+Every message you enqueue gets a deterministic identifier — a `clientGuid` — assigned at enqueue time, not at send time. The transport uses it for deduplication: if it sees the same `clientGuid` twice, it discards the second copy.
+
+```ts
+const messages = reply.map((text, index) => ({
+  text,
+  clientGuid: `${jobId}-${index}`, // stable across retries
+}));
+```
+
+Most modern messaging transports support stable client-side IDs for dedup, and Spectrum surfaces them through the provider interface — check what your provider exposes before assuming you need to build dedup yourself.
+
+The reason `clientGuid` must be stable is subtle: a worker that crashes after the transport ack'd but before the worker recorded it will retry the same message. Without a stable GUID, the transport sees a "new" message and delivers a duplicate.
+
+### startIndex resume cursor
+
+GUID-based dedup handles "transport already saw this." But you also want the worker itself to skip messages it knows it already sent — for performance and to avoid the dedup roundtrip.
+
+Persist a `startIndex` on the job. After each successful send, atomically bump it. On retry, resume from there:
+
+```mermaid
+sequenceDiagram
+  participant W as Worker
+  participant Tx as Transport
+
+  W->>W: assign clientGuids [A, B, C, D]
+  W->>Tx: send msg[0] (guid A)
+  Tx-->>W: ack
+  W->>W: startIndex = 1 (persisted)
+  W->>Tx: send msg[1] (guid B)
+  Tx-->>W: ack
+  W->>W: startIndex = 2 (persisted)
+  W-x W: ⚡ crash
+  Note over W,Tx: retry — load startIndex=2
+  W->>Tx: send msg[2] (guid C)
+  W->>Tx: send msg[3] (guid D)
+```
+
+If the crash happens _between_ ack and persist, the retry resends `msg[1]` — but the transport sees the same `clientGuid B` and discards it. Both layers of defense are doing work.
+
+### Per-resource memory scope
+
+A single agent talks to many users. Each one needs their own working memory, conversation history, and observational notes. Mixing them up is catastrophic — the agent telling one user about another user's plans is the kind of bug you see once and never forget.
+
+Scope every memory operation by `resourceId = senderAddress`. The thread ID is per-chat (`chat-${chatId}`), but memory is per-person:
+
+```ts
+await memory.getWorkingMemory({
+  resourceId: senderAddress,
+  threadId: `chat-${chatId}`,
+});
+```
+
+The same person messaging from a group chat versus a 1:1 sees the same working memory (same `resourceId`), but conversation history is per-thread (different `threadId`). That's usually what you want — the agent remembers _who you are_ across all chats but treats each thread as its own conversation.
+
+```mermaid
+flowchart TD
+  Sender[senderAddress: alice@example.com]
+  Sender --> WM[Working memory:<br/>per-resource]
+  Sender --> Notes[Observational notes:<br/>per-resource]
+
+  Chat1[chat-1<br/>1:1 with alice]
+  Chat2[chat-2<br/>group with alice + bob]
+
+  Chat1 --> H1[Message history<br/>per-thread]
+  Chat2 --> H2[Message history<br/>per-thread]
+
+  WM -.shared across.- Chat1
+  WM -.shared across.- Chat2
+```
+
+If you shard memory across databases or tenants, each shard needs to follow the same convention. Test multi-user concurrency hard — race conditions in working-memory updates corrupt state silently and you won't notice until two users compare notes.
+
+### Job failure audit log
+
+When a job fails, you want to know which job, when, with what payload, and why — without grepping through rotating logs.
+
+A `job_failures` table is a small amount of code that pays back disproportionately. Every error path calls `recordJobFailure(queueName, jobId, payload, error)` and inserts a row. Now you can ask:
+
+- "Which jobs failed in the last hour?"
+- "Are all failures coming from one chat?" (a corrupt working-memory state)
+- "Are all failures from one queue stage?" (a transport outage vs. an LLM bug)
+- "What was the payload that triggered this?" (reproducer)
+
+Operational notes:
+
+- **Add a retention policy.** Otherwise the table grows forever. Delete entries older than 30 days.
+- **Make `recordJobFailure` itself fail-safe.** Wrap it in a try/catch with a log fallback — you don't want a failed-failure-record to take down the worker.
+- **Be careful with payload size.** If your jobs carry images or large blobs, the audit table balloons. Either truncate or store a pointer.
+
+### Putting it together
+
+```mermaid
+flowchart TD
+  Job[Job starts] --> Try{Run handler}
+  Try -->|success| Done[Done]
+  Try -->|crash| Retry[Queue retries with same jobId]
+  Try -->|error| Audit[recordJobFailure]
+  Audit --> Retry
+  Retry --> Resume[Load startIndex]
+  Resume --> Send[Send from startIndex onward]
+  Send --> Tx{Transport check}
+  Tx -->|new clientGuid| Deliver[Delivered]
+  Tx -->|seen clientGuid| Skip[Discarded as dup]
+  Deliver --> Bump[Persist startIndex]
+  Skip --> Bump
+  Bump --> Done
+```
+
+Three independent layers — queue retry, resume cursor, transport dedup — and any one is enough to prevent a duplicate in most failure modes. Together they survive almost everything short of the database itself going down.

--- a/hermes-agent/agent/skills/spectrum/content.md
+++ b/hermes-agent/agent/skills/spectrum/content.md
@@ -1,0 +1,108 @@
+# Content builders
+
+> TypeScript samples below — builder names and content shapes are language-neutral.
+
+Every `send`/`reply` accepts a plain string or a content builder: `text`, `attachment`, `voice`, `contact`, `richlink`, `poll`, `option`, `group`, `custom`.
+
+## Text
+
+```ts
+import { text } from "spectrum-ts";
+
+await space.send(text("Hello, world."));
+await space.send("Hello, world."); // strings are equivalent
+```
+
+## Attachments
+
+Pass a file path or a `Buffer`. MIME types are inferred from the file extension; override with `options.mimeType` when you have raw bytes. If MIME can't be inferred and `options.mimeType` is omitted, the builder throws at build time.
+
+```ts
+import { attachment } from "spectrum-ts";
+
+await space.send(attachment("/path/to/photo.jpg"));
+await space.send(attachment(buffer, { name: "report.pdf", mimeType: "application/pdf" }));
+```
+
+## Voice
+
+Same input shape as `attachment`, plus optional `duration` for waveform UIs. Platforms without voice support downgrade to a regular audio attachment.
+
+```ts
+import { voice } from "spectrum-ts";
+
+await space.send(voice("/path/to/note.m4a"));
+await space.send(voice(buffer, { name: "note.m4a", mimeType: "audio/mp4", duration: 12 }));
+```
+
+## Contacts
+
+Accepts a structured `ContactInput`, a vCard string, a `vcf` instance, or a `User` plus optional details.
+
+```ts
+import { contact, fromVCard } from "spectrum-ts";
+
+await space.send(contact({
+  name: { first: "Ada", last: "Lovelace" },
+  phones: [{ value: "+15551234567", type: "mobile" }],
+}));
+
+await space.send(contact(alice, { org: { name: "Acme", title: "Engineer" } }));
+
+const vcf = await readFile("/path/to/ada.vcf", "utf8");
+await space.send(contact(vcf));
+```
+
+`fromVCard` parses; `toVCard` serializes a resolved `Contact` back. `ContactInput` fields: `name`, `phones`, `emails`, `addresses`, `org`, `urls`, `birthday`, `note`, `photo`, `raw`.
+
+## Rich links
+
+Spectrum scrapes Open Graph metadata at send time. `title()`, `summary()`, `cover()` are lazy — fetched only if the receiving platform needs them. Platforms without rich-link support fall back to plain text.
+
+```ts
+import { richlink } from "spectrum-ts";
+
+await space.send(richlink("https://example.com/article"));
+```
+
+## Polls
+
+```ts
+import { poll, option } from "spectrum-ts";
+
+await space.send(poll("Lunch?", "Pizza", "Sushi", "Tacos"));
+await space.send(poll("Lunch?", [option("Pizza"), option("Sushi")]));
+```
+
+Poll responses arrive as `poll_option` content.
+
+## Groups
+
+`group()` bundles multiple messages into one logical unit (album, multi-attachment reply). Each item is delivered as its own `Message` but ships together. Groups don't nest, and reactions can't be group members — both enforced at construction. Platforms without grouping fall back to sending each item sequentially.
+
+```ts
+import { group, attachment } from "spectrum-ts";
+
+await space.send(group(
+  attachment("/path/to/photo-1.jpg"),
+  attachment("/path/to/photo-2.jpg"),
+));
+```
+
+## Custom
+
+Send platform-specific structured payloads. The provider's `actions.send` interprets `raw`.
+
+```ts
+import { custom } from "spectrum-ts";
+
+await space.send(custom({ type: "card", title: "Order Confirmed" }));
+```
+
+## Composing multiple items
+
+```ts
+await space.send("Here's the file:", attachment("/path/to/document.pdf"));
+```
+
+Items send as separate messages (one `send()` per item). Use `group(...)` for a single bundled unit.

--- a/hermes-agent/agent/skills/spectrum/custom-events-and-lifecycle.md
+++ b/hermes-agent/agent/skills/spectrum/custom-events-and-lifecycle.md
@@ -1,0 +1,32 @@
+# Custom events and lifecycle
+
+> TypeScript samples below — the per-provider event model and idempotent `stop()` are language-neutral.
+
+## Custom events
+
+Providers can emit events beyond messages — typing, read receipts, delivery status, anything. Each is exposed as a flat async iterable on the app instance:
+
+```ts
+for await (const event of app.typing) {
+  console.log(`${event.platform}: typing event received`);
+}
+```
+
+The property name matches the event name the provider declared. Streams are created lazily on first access; subsequent iterations share the same source. Per-platform access is also available on a narrowed instance:
+
+```ts
+const im = imessage(app);
+for await (const event of im.typing) { /* iMessage-only typing events */ }
+```
+
+## Graceful shutdown
+
+```ts
+await app.stop();
+```
+
+Closes the merged message stream, drains and disposes every custom event stream, and tears down every platform client via its `lifecycle.destroyClient` hook (if defined). Idempotent.
+
+Spectrum registers `SIGINT` and `SIGTERM` handlers on startup. When a signal fires, `stop()` is invoked with a 3-second timeout — exit 0 if cleanup completes, exit 1 if not. You don't need to wire this up yourself.
+
+Call `stop()` manually when embedding Spectrum in a longer-running process, in tests that create and dispose an app per case, or when re-initializing with a different provider set.

--- a/hermes-agent/agent/skills/spectrum/custom-platforms.md
+++ b/hermes-agent/agent/skills/spectrum/custom-platforms.md
@@ -1,0 +1,106 @@
+# Building a custom platform
+
+> TypeScript samples below — the authoring contract (config, user/space resolvers, lifecycle, events, actions) is language-neutral; the TS SDK validates with Zod.
+
+`definePlatform` takes a name and a definition object and returns a callable that exposes `.config()` for registration and accepts a Spectrum instance, space, or message for [narrowing](./platform-narrowing.md).
+
+```ts
+import { definePlatform } from "spectrum-ts";
+import z from "zod";
+
+export const myPlatform = definePlatform("my-platform", {
+  config: z.object({ apiKey: z.string() }),
+
+  user: {
+    resolve: async ({ input, client }) => ({
+      id: input.userID,
+      displayName: await client.lookupUser(input.userID),
+    }),
+  },
+
+  space: {
+    resolve: async ({ input, client }) => ({
+      id: await client.findOrCreateConversation(input.users.map(u => u.id)),
+    }),
+  },
+
+  lifecycle: {
+    createClient: async ({ config, store }) => new MyPlatformClient(config.apiKey),
+    destroyClient: async ({ client }) => { await client.disconnect(); },
+  },
+
+  events: {
+    async *messages({ client }) {
+      for await (const msg of client.onMessage()) {
+        yield {
+          id: msg.id,
+          content: { type: "text", text: msg.body },
+          sender: { id: msg.authorId },
+          space: { id: msg.channelId },
+          timestamp: new Date(msg.ts),
+        };
+      }
+    },
+  },
+
+  actions: {
+    send: async ({ space, content, client }) => {
+      if (content.type === "text") await client.send(space.id, content.text);
+    },
+    // Optional: startTyping, stopTyping, reactToMessage, replyToMessage, editMessage, getMessage
+  },
+
+  static: {
+    reactions: { thumbsUp: "+1", thumbsDown: "-1" } as const,
+  },
+});
+```
+
+## Field reference
+
+| Field | Required | Description |
+|---|---|---|
+| `config` | Yes | Zod schema validating `platform.config()` argument. If every field is optional, `.config()` can be called with no arguments. |
+| `user.resolve` | Yes | Resolves a user from a string ID. Returns at minimum `{ id }`. |
+| `user.schema` | No | Optional Zod schema for extra user properties. |
+| `space.resolve` | Yes | Resolves or creates a conversation. Receives users + optional params. |
+| `space.schema` / `space.params` | No | Schemas for the resolved space and for extra creation params. |
+| `lifecycle.createClient` | Yes | Creates the platform client. Receives `config`, `projectId`, `projectSecret` (both may be `undefined`), and `store`. |
+| `lifecycle.destroyClient` | No | Tears down the client on shutdown. |
+| `events.messages` | Yes | Async generator yielding incoming messages. |
+| `events.[custom]` | No | Additional generators — exposed on `app.[eventName]`. |
+| `actions.send` | Yes | Sends a single content item. Invoked once per item when multiple are passed. |
+| `actions.startTyping` / `stopTyping` | No | Typing indicator. |
+| `actions.reactToMessage` / `replyToMessage` | No | Missing → corresponding `message.*` becomes a no-op. |
+| `actions.editMessage` / `getMessage` | No | Edit and lookup. |
+| `message.schema` | No | Zod schema for extra typed fields on incoming messages — surfaced through narrowing. |
+| `static` | No | Constants attached to the platform object (e.g. tapback names). |
+
+## Event producers
+
+Every event generator receives `{ client, config, store }` and returns an `AsyncIterable`:
+
+```ts
+events: {
+  async *messages({ client }) { /* ... */ },
+  async *typing({ client }) {
+    for await (const ev of client.typing()) {
+      yield { spaceId: ev.chatId, userId: ev.user };
+    }
+  },
+},
+```
+
+Non-`messages` events are auto-wired as flat properties on both `app` and the narrowed platform instance.
+
+## Registering
+
+```ts
+const app = await Spectrum({
+  providers: [myPlatform.config({ apiKey: process.env.MY_KEY! })],
+});
+
+const mine = myPlatform(app);
+const space = await mine.space(await mine.user("user-123"));
+await space.send("Hello from my custom platform.");
+```

--- a/hermes-agent/agent/skills/spectrum/getting-started.md
+++ b/hermes-agent/agent/skills/spectrum/getting-started.md
@@ -1,0 +1,102 @@
+# Getting started
+
+> TypeScript samples below — primitives and the app instance are language-neutral.
+
+## Installation
+
+```bash
+npm install spectrum-ts        # or pnpm / yarn / bun add
+```
+
+Requires TypeScript 5 or later.
+
+## Core concepts
+
+| Primitive | What it represents |
+|---|---|
+| **Message** | An incoming piece of content — text, attachments, or structured data — from any platform. |
+| **Space** | A conversation context. A DM, a group chat, a terminal session. You send messages *into* a space. |
+| **User** | A participant on a platform, identified by a platform-specific ID. |
+| **Platform provider** | A platform adapter (iMessage, terminal, WhatsApp, or your own) that translates platform-specific protocols into Spectrum's unified interface. |
+
+Every message arrives as a `[Space, Message]` pair.
+
+## Quickstart
+
+Find `PROJECT_ID` and `SECRET_KEY` in your project **Settings** on the [dashboard](https://app.photon.codes/).
+
+```ts
+import { Spectrum } from "spectrum-ts";
+import { imessage } from "spectrum-ts/providers/imessage";
+
+const app = await Spectrum({
+  projectId: "your-project-id",
+  projectSecret: "your-project-secret",
+  providers: [imessage.config()],
+});
+
+for await (const [space, message] of app.messages) {
+  if (message.content.type !== "text") continue;
+
+  // Use the platform's native vocabulary, not a bare send:
+  await message.react("like");                 // tapback to acknowledge instantly
+  await space.responding(async () => {         // show a typing indicator while you work
+    await message.reply(`echo: ${message.content.text}`);  // threaded reply, not a loose message
+  });
+}
+```
+
+> **Building an agent? Be rich, not robotic.** A bare `space.send(...)` works, but on iMessage (and other rich platforms) it reads like a webhook, not a person. Reach for the native features whenever they fit the moment:
+> - **`message.react("love" | "like" | "laugh" | …)`** — acknowledge a message instantly with a tapback before you've composed a full answer.
+> - **`message.reply(...)`** — answer *the specific message* in-thread, so the conversation stays legible in a busy chat.
+> - **`space.responding(async () => { … })`** — wrap slow work (an LLM call, a fetch) so the recipient sees a typing indicator instead of dead air.
+>
+> These **no-op silently** on platforms that don't support them, so there's no downside to reaching for the richer call — write the expressive version once and it degrades gracefully everywhere. See [`reactions-and-replies.md`](./reactions-and-replies.md), [`spaces-and-users.md`](./spaces-and-users.md), and the iMessage-only flourishes (message effects, the full tapback set) in [`providers/imessage.md`](./providers/imessage.md).
+
+Projectless providers like `terminal` work without credentials:
+
+```ts
+const app = await Spectrum({ providers: [terminal.config()] });
+```
+
+## The app instance
+
+```ts
+app.messages                       // AsyncIterable<[Space, Message]>
+await app.send(space, ...)         // send into a space
+await app.responding(space, fn)    // run fn with a typing indicator
+await app.stop()                   // graceful shutdown
+```
+
+See [`custom-events-and-lifecycle.md`](./custom-events-and-lifecycle.md) for custom event streams and shutdown.
+
+## Multi-platform
+
+Combine providers — `app.messages` merges every source. The `message.platform` field identifies the origin.
+
+```ts
+import { Spectrum } from "spectrum-ts";
+import { imessage } from "spectrum-ts/providers/imessage";
+import { terminal } from "spectrum-ts/providers/terminal";
+import { whatsappBusiness } from "spectrum-ts/providers/whatsapp-business";
+
+const app = await Spectrum({
+  projectId: process.env.PROJECT_ID!,
+  projectSecret: process.env.PROJECT_SECRET!,
+  providers: [
+    imessage.config(),
+    whatsappBusiness.config({
+      accessToken: process.env.WA_TOKEN!,
+      phoneNumberId: process.env.WA_NUMBER_ID!,
+      appSecret: process.env.WA_SECRET!,
+    }),
+    terminal.config(),
+  ],
+});
+
+for await (const [space, message] of app.messages) {
+  await space.responding(async () => {
+    await message.reply("Hello from Spectrum.");
+  });
+}
+```

--- a/hermes-agent/agent/skills/spectrum/messages.md
+++ b/hermes-agent/agent/skills/spectrum/messages.md
@@ -1,0 +1,84 @@
+# Messages
+
+> TypeScript samples below — the `Message` shape and content variants are language-neutral.
+
+Every incoming message arrives through `app.messages` as a `[Space, Message]` pair. The space is already bound to the originating conversation — you don't need to resolve it yourself to reply.
+
+## The Message shape
+
+| Field | Description |
+|---|---|
+| `id` | Platform-assigned message identifier. |
+| `content` | Discriminated union on `type` — see [Narrowing content](#narrowing-content). |
+| `sender` | The `User` who sent the message (`{ id, __platform }`). |
+| `space` | The `Space` the message was sent into. |
+| `platform` | Name of the provider that delivered the message (e.g. `"iMessage"`, `"terminal"`). |
+| `timestamp` | `Date` of when the message was sent. |
+| `react(reaction)` | React to this message. No-op on platforms without reactions. |
+| `reply(...content)` | Reply threaded to this message. No-op on platforms without thread support. |
+
+## Narrowing content
+
+`Content` is a discriminated union. Always narrow on `message.content.type` before accessing fields.
+
+```ts
+for await (const [space, message] of app.messages) {
+  switch (message.content.type) {
+    case "text":
+      console.log(message.content.text);
+      break;
+    case "attachment":
+      console.log(`${message.content.name} (${message.content.mimeType})`, await message.content.read());
+      break;
+    case "voice":
+      console.log(`voice note (${message.content.duration}s)`);
+      break;
+    case "contact":
+      console.log(message.content.name?.formatted, message.content.phones);
+      break;
+    case "richlink":
+      console.log(message.content.url, await message.content.title());
+      break;
+    case "reaction":
+      console.log(`${message.content.emoji} on ${message.content.target.id}`);
+      break;
+    case "poll":
+      console.log(message.content.title, message.content.options);
+      break;
+    case "poll_option":
+      console.log(`vote ${message.content.selected ? "+" : "-"}`, message.content.title);
+      break;
+    case "group":
+      console.log(`group of ${message.content.items.length} items`);
+      break;
+    case "custom":
+      console.log(message.content.raw);
+      break;
+  }
+}
+```
+
+| Type | Fields |
+|---|---|
+| `"text"` | `text` |
+| `"attachment"` | `name`, `mimeType`, `size?`, `read()`, `stream()` |
+| `"voice"` | `name?`, `mimeType`, `duration?`, `size?`, `read()`, `stream()` |
+| `"contact"` | `name?`, `phones?`, `emails?`, `addresses?`, `org?`, `urls?`, `birthday?`, `note?`, `photo?`, `user?` |
+| `"richlink"` | `url`, `title()`, `summary()`, `cover()` |
+| `"reaction"` | `emoji`, `target: Message` |
+| `"poll"` | `title`, `options: { title }[]` |
+| `"poll_option"` | `option`, `poll`, `selected`, `title` — sent as a vote |
+| `"group"` | `items: Message[]` |
+| `"custom"` | `raw: unknown` |
+
+Outgoing-only variants like `"effect"` (an iMessage screen effect wrapping inner content) appear on echoed sends — see [`providers/imessage.md`](./providers/imessage.md).
+
+## Filtering out your own messages
+
+Some platforms echo your own sends. Compare the sender to a known identity:
+
+```ts
+if (message.sender.id === myAccountId) continue;
+```
+
+iMessage exposes an `isFromMe` flag on the raw message extra (via [platform narrowing](./platform-narrowing.md)).

--- a/hermes-agent/agent/skills/spectrum/platform-narrowing.md
+++ b/hermes-agent/agent/skills/spectrum/platform-narrowing.md
@@ -1,0 +1,28 @@
+# Platform narrowing
+
+> TypeScript samples below — narrowing is the conceptual pattern across SDKs; the TS implementation uses callable provider objects with TS type narrowing.
+
+Every provider exports a callable — `imessage`, `terminal`, `whatsappBusiness` — that **narrows** generic Spectrum types into platform-specific ones. The same function handles three inputs:
+
+```ts
+import { imessage } from "spectrum-ts/providers/imessage";
+
+// 1. Narrow the app — get user/space resolvers and custom events
+const im = imessage(app);
+const user = await im.user("+15551234567");
+const space = await im.space(user);
+
+// 2. Narrow a space — access platform-specific fields
+for await (const [space, message] of app.messages) {
+  if (message.platform !== "iMessage") continue;
+  const imSpace = imessage(space);
+  if (imSpace.type === "group") { /* ... */ }
+}
+
+// 3. Narrow a message — exposes provider's `message.schema` extras
+const imMessage = imessage(message);
+```
+
+If the platform isn't registered in `providers`, `imessage(app)` resolves to `never` (compile-time error in TS). Narrowing a space/message from the wrong platform throws at runtime — gate on `message.platform` first.
+
+The generic `Space` and `Message` interfaces are deliberately small — just enough to send, react, and reply across every platform. Narrowing is the escape hatch for everything else: typed access to iMessage chat types, WhatsApp phone numbers, or any extra field your [custom platform](./custom-platforms.md) exposes.

--- a/hermes-agent/agent/skills/spectrum/providers/imessage.md
+++ b/hermes-agent/agent/skills/spectrum/providers/imessage.md
@@ -1,0 +1,94 @@
+# iMessage provider
+
+> TypeScript samples below — connection modes, line model, effects, and tapbacks are platform features that apply across all Spectrum SDKs.
+
+```ts
+import { imessage } from "spectrum-ts/providers/imessage";
+```
+
+Three connection modes — local, cloud, and dedicated. iMessage-specific features (tapbacks, DM vs group spaces, per-phone routing) come through [platform narrowing](../platform-narrowing.md).
+
+## Connection modes
+
+```ts
+// Cloud (default) — managed by Spectrum, full feature set.
+// Tokens auto-renew at 80% of TTL. Requires projectId/projectSecret on Spectrum().
+imessage.config();
+
+// Local — reads macOS Messages SQLite directly. No network.
+// Only supports text + attachments. No reactions, typing, replies, or group creation.
+imessage.config({ local: true });
+
+// Dedicated — connect to your own iMessage gRPC endpoints with your own tokens.
+// Each entry must include the phone number it serves so Spectrum can route correctly.
+imessage.config({
+  clients: [
+    { address: "instance-1.example.com:443", token: "your-token", phone: "+15551111111" },
+    { address: "instance-2.example.com:443", token: "your-token", phone: "+15552222222" },
+  ],
+});
+```
+
+## Line model (cloud mode)
+
+| Plan | Line allocation | What end users see |
+|---|---|---|
+| **Free / Pro** | Shared pool — each end user routed through a different number from a shared pool | Normal iMessage from a number that may differ across recipients |
+| **Business** | Dedicated — all end users text the same number, which belongs to your project | Normal iMessage, always from the same number |
+
+**Auto-scale** is an opt-in Business feature: when traffic to a dedicated line nears its per-line capacity, Spectrum provisions an additional line. Open-source paths (`local: true` or your own dedicated relay) provide their own iCloud account; managed-line concepts don't apply.
+
+## Space types and per-phone routing
+
+iMessage spaces carry `type: "dm" | "group"` and a `phone` field. With multiple dedicated lines, pin a conversation to a specific line:
+
+```ts
+const dm = await im.space(alice, { phone: "+15559999999" });
+```
+
+When omitted, Spectrum picks at random from available dedicated lines. Per-phone routing applies to **dedicated lines (Business plan) only**; on shared-pool plans the parameter is ignored. Space creation requires cloud or dedicated mode — local mode throws.
+
+## Message effects
+
+Wrap any content with `effect()`. Wrapped content can be a string or `attachment(...)`. Effects only apply on iMessage; other platforms see the inner content unchanged.
+
+```ts
+import { effect, imessage } from "spectrum-ts/providers/imessage";
+
+await space.send(effect("Happy birthday!", imessage.effect.message.celebration));
+await space.send(effect(attachment("/path/to/photo.jpg"), imessage.effect.message.confetti));
+```
+
+| Bubble effects | |
+|---|---|
+| `imessage.effect.message.slam` | `"com.apple.MobileSMS.expressivesend.impact"` |
+| `imessage.effect.message.loud` | `"com.apple.MobileSMS.expressivesend.loud"` |
+| `imessage.effect.message.gentle` | `"com.apple.MobileSMS.expressivesend.gentle"` |
+| `imessage.effect.message.invisible` | `"com.apple.MobileSMS.expressivesend.invisibleink"` |
+
+| Screen effects | |
+|---|---|
+| `imessage.effect.message.confetti` | `"com.apple.messages.effect.CKConfettiEffect"` |
+| `imessage.effect.message.fireworks` | `"com.apple.messages.effect.CKFireworksEffect"` |
+| `imessage.effect.message.balloons` | `"com.apple.messages.effect.CKBalloonEffect"` |
+| `imessage.effect.message.heart` | `"com.apple.messages.effect.CKHeartEffect"` |
+| `imessage.effect.message.lasers` | `"com.apple.messages.effect.CKLasersEffect"` |
+| `imessage.effect.message.celebration` | `"com.apple.messages.effect.CKHappyBirthdayEffect"` |
+| `imessage.effect.message.sparkles` | `"com.apple.messages.effect.CKSparklesEffect"` |
+| `imessage.effect.message.spotlight` | `"com.apple.messages.effect.CKSpotlightEffect"` |
+| `imessage.effect.message.echo` | `"com.apple.messages.effect.CKEchoEffect"` |
+
+## Tapbacks
+
+| Constant | Value |
+|---|---|
+| `imessage.tapbacks.love` | `"love"` |
+| `imessage.tapbacks.like` | `"like"` |
+| `imessage.tapbacks.dislike` | `"dislike"` |
+| `imessage.tapbacks.laugh` | `"laugh"` |
+| `imessage.tapbacks.emphasize` | `"emphasize"` |
+| `imessage.tapbacks.question` | `"question"` |
+
+```ts
+await message.react(imessage.tapbacks.laugh);
+```

--- a/hermes-agent/agent/skills/spectrum/providers/terminal.md
+++ b/hermes-agent/agent/skills/spectrum/providers/terminal.md
@@ -1,0 +1,48 @@
+# Terminal provider
+
+> TypeScript samples below — the TUI behavior is the same regardless of agent language.
+
+```ts
+import { terminal } from "spectrum-ts/providers/terminal";
+```
+
+A full chat TUI for developing and testing agents locally. `terminal.config()` spawns the standalone [tuichat](https://github.com/photon-hq/tuichat) binary as a subprocess and drives it over JSON-RPC. The binary auto-downloads from GitHub Releases on first run. In a TTY it boots the rich UI; in a non-TTY context (CI, piped input) it falls back to a synchronous readline loop — same agent code works for scripted tests.
+
+```ts
+const app = await Spectrum({ providers: [terminal.config()] });
+```
+
+No credentials, no config — just import and run.
+
+| Feature | How |
+|---|---|
+| Multiple chats | `Ctrl+N` opens a new chat, `Ctrl+J` / `Ctrl+K` switch. Each chat is its own space. |
+| Reactions | Press `r` on a message — arrives as a `reaction` content message. |
+| Replies | Press `e` — arrives with a `replyTo: { messageId }` extra. |
+| File attachments | Drag-and-drop into the terminal. |
+| Inline images | Kitty graphics protocol when supported, half-block fallback. |
+| Typing indicators | `space.startTyping()` / `space.stopTyping()`. |
+| Console capture | `console.log` / `info` / `warn` / `error` / `debug` are forwarded into a pinned `__system__` chat instead of garbling the UI. |
+
+## Slash commands
+
+```ts
+terminal.config({
+  commands: [
+    { name: "/clear", description: "Clear conversation memory" },
+    { name: "/whoami", description: "Print sender details" },
+  ],
+});
+```
+
+Names must match `/^\/[A-Za-z0-9_-]+$/`. Slash commands arrive as regular text messages with the command string as the content.
+
+## Programmatic spaces
+
+Default is `chat-1`; new chats opened with `Ctrl+N` get `chat-2`, `chat-3`, ... To open a named space programmatically:
+
+```ts
+const t = terminal(app);
+const debug = await t.space({ id: "debug" });
+await debug.send("agent online");
+```

--- a/hermes-agent/agent/skills/spectrum/providers/whatsapp-business.md
+++ b/hermes-agent/agent/skills/spectrum/providers/whatsapp-business.md
@@ -1,0 +1,33 @@
+# WhatsApp Business provider
+
+> TypeScript samples below — the 1:1-only constraint is a platform feature.
+
+```ts
+import { whatsappBusiness } from "spectrum-ts/providers/whatsapp-business";
+```
+
+Wraps the official WhatsApp Business Cloud API. Reactions and threaded replies map to native WhatsApp features. **1:1 only** — `space(userA, userB)` throws.
+
+## Config
+
+```ts
+whatsappBusiness.config({
+  accessToken: "...",       // permanent or system-user token from Meta for Developers
+  phoneNumberId: "...",     // sender phone number ID
+  appSecret: "...",         // verifies webhook payload signatures
+});
+```
+
+Find these values in your WhatsApp Business app settings on [Meta for Developers](https://developers.facebook.com/).
+
+## Starting a conversation
+
+Resolve a user by their WhatsApp phone number (international format, digits only):
+
+```ts
+const wa = whatsappBusiness(app);
+const customer = await wa.user("15551234567");
+const space = await wa.space(customer);
+
+await space.send("Thanks for reaching out.");
+```

--- a/hermes-agent/agent/skills/spectrum/reactions-and-replies.md
+++ b/hermes-agent/agent/skills/spectrum/reactions-and-replies.md
@@ -1,0 +1,21 @@
+# Reactions and replies
+
+> TypeScript samples below — silent no-op on unsupported platforms is part of the model, not a TS detail.
+
+Both `react` and `reply` live directly on an incoming message. Both no-op silently on platforms that don't support them — no `try/catch` needed.
+
+```ts
+await message.react("love");
+await message.reply("Replying to your message.");
+await message.reply("Here's the file:", attachment("/path/to/file.pdf"));
+```
+
+On platforms with thread support (iMessage, WhatsApp Business), `reply` sends threaded. **It is not downgraded to a regular send** — if you need guaranteed delivery, use `space.send(...)`.
+
+For iMessage tapback constants (`imessage.tapbacks.love`, `like`, `dislike`, `laugh`, `emphasize`, `question`), see [`providers/imessage.md`](./providers/imessage.md).
+
+| Want to | Use |
+|---|---|
+| Send fresh content into a conversation | `space.send(...)` |
+| Reply in-thread to a specific message | `message.reply(...)` |
+| React to a specific message | `message.react(reaction)` |

--- a/hermes-agent/agent/skills/spectrum/spaces-and-users.md
+++ b/hermes-agent/agent/skills/spectrum/spaces-and-users.md
@@ -1,0 +1,47 @@
+# Spaces and users
+
+> TypeScript samples below — the space/user model is language-neutral.
+
+A **space** is a conversation. A **user** is a participant. Both carry a `__platform` tag.
+
+## Space interface
+
+| Method | Description |
+|---|---|
+| `send(...content)` | Send one or more content items. |
+| `startTyping()` / `stopTyping()` | Show / hide typing indicator. No-op without support. |
+| `responding(fn)` | Run `fn` wrapped in typing — guarantees indicator is cleared even on throw. |
+| `edit(message, newContent)` | Edit a previously sent message. |
+| `getMessage(id)` | Look up a message by ID. |
+
+## Typing indicators
+
+`responding` is the recommended pattern:
+
+```ts
+await space.responding(async () => {
+  const result = await generateResponse(message);
+  await space.send(result);
+});
+```
+
+Or via the app helper: `await app.responding(space, async () => { ... })`.
+
+## Creating a space
+
+Use [platform narrowing](./platform-narrowing.md) for the platform instance, then pass users:
+
+```ts
+import { imessage } from "spectrum-ts/providers/imessage";
+
+const im = imessage(app);
+const alice = await im.user("+15551111111");
+const bob = await im.user("+15552222222");
+
+const dm = await im.space(alice);
+const group = await im.space(alice, bob);
+
+await group.send("Welcome to the group.");
+```
+
+The returned space satisfies the generic `Space` interface and carries platform-specific fields (e.g. `type: "dm" | "group"` on iMessage).

--- a/hermes-agent/package-lock.json
+++ b/hermes-agent/package-lock.json
@@ -1,0 +1,2421 @@
+{
+  "name": "hermes-agent",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hermes-agent",
+      "version": "0.0.1",
+      "dependencies": {
+        "spectrum-ts": "^5.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22",
+        "tsx": "^4",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/sdk-logs": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@parseaple/bplist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@parseaple/bplist/-/bplist-1.0.1.tgz",
+      "integrity": "sha512-HHZKfvCaY8r5lwc6YCiAIhpAwH56YR29JPQa/9ZW0UqzjqdzFidGgoWVIhIF8tPXCwivIt93vbyT0O5bpC1Twg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@parseaple/typedstream": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@parseaple/typedstream/-/typedstream-2.0.2.tgz",
+      "integrity": "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@parseaple/bplist": "1.0.1"
+      }
+    },
+    "node_modules/@photon-ai/advanced-imessage": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@photon-ai/advanced-imessage/-/advanced-imessage-0.11.2.tgz",
+      "integrity": "sha512-3mjzy1IIBtsCQK6kAB8dbFCK0np7hS256wwW+nqNL8vKz0W5nRhu1iKAwyZxP8Z470dtNX5RjNgcl9I4wZeuTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.11.0",
+        "@grpc/grpc-js": "^1.12.6",
+        "nice-grpc": "^2.1.11",
+        "nice-grpc-common": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@photon-ai/imessage-kit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/imessage-kit/-/imessage-kit-3.0.0.tgz",
+      "integrity": "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@parseaple/typedstream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "^12.5.0"
+      }
+    },
+    "node_modules/@photon-ai/otel": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-1.0.0.tgz",
+      "integrity": "sha512-5fACVHN7BtGS+phglVAxun5QLckNUSS4p750oCxR//m9JNVzFQMoLFWfC6DnWBP/W0/+B2yP75+3NMVLodEJEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/api-logs": "^0.218.0",
+        "@opentelemetry/context-async-hooks": "^2.7.1",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+        "@opentelemetry/resources": "^2.7.1",
+        "@opentelemetry/sdk-logs": "^0.218.0",
+        "@opentelemetry/sdk-trace-base": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@photon-ai/proto": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@photon-ai/proto/-/proto-0.2.4.tgz",
+      "integrity": "sha512-DQANEp0gHvtwqpMGEF0ufa0hs1nniRdsSuo0Q/TG6GoL1WjC5tp59tHFSLUeIm6fvnAuRjREsGzURz3+/69g7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "nice-grpc-common": "^2.0.3"
+      }
+    },
+    "node_modules/@photon-ai/slack": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/slack/-/slack-0.2.0.tgz",
+      "integrity": "sha512-k3XzGKIVS1EsjrPz9pbWvrvScmiy/iqKdA2npS5xu1CtCoycBkdFsqJKyB6iIyDR02Q3/38kQh7MvKsCzUyo3Q==",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@grpc/grpc-js": "^1.14.3",
+        "nice-grpc": "^2.1.15",
+        "nice-grpc-common": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@photon-ai/telegram-ts": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/telegram-ts/-/telegram-ts-10.0.0.tgz",
+      "integrity": "sha512-kYGj/ieKOCG+OxoD1R69xHoT7zHl9dboF52LMPUl4FnorbwA8b2pid0uFoDYF55WIfoeo+VSqwlmY84GgpSedg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@photon-ai/whatsapp-business": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@photon-ai/whatsapp-business/-/whatsapp-business-0.1.1.tgz",
+      "integrity": "sha512-JAf/gHh92+H6h/7AMOQ6l+WFYBWdeRH5fZ+tvOUYJJnX1C4aJPDFa23VTH4ndhKPgA5bK/h++cxUZx2lMubvYQ==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "long": "^5.3.2",
+        "nice-grpc": "^2.1.15",
+        "nice-grpc-common": "^2.0.3",
+        "protobufjs": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@photon-ai/whatsapp-business/node_modules/protobufjs": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.4.tgz",
+      "integrity": "sha512-/+XMv9JalknuncEJSwsyEVlwcxVLKx2iaoSUXFZA86MJkdqyOdfrlB1sB7S6aKyUk9tl20YY+SgQe5J2sJHTcg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@repeaterjs/repeater": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.1.0.tgz",
+      "integrity": "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@spectrum-ts/core": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-5.1.0.tgz",
+      "integrity": "sha512-07ynd5YILbhxTLk5iGA3MJpMSt0rsl0ed5sSi4SRw65jXgzaRqY4aBIz2f6V+dGSyPKl8KTamMiw89jxgi2rSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/otel": "^1.0.0",
+        "@photon-ai/proto": "^0.2.4",
+        "@repeaterjs/repeater": "^3.0.6",
+        "marked": "^18.0.5",
+        "mime-types": "^3.0.1",
+        "open-graph-scraper": "^6.11.0",
+        "vcf": "^2.1.2",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "elysia": "^1",
+        "express": "^4 || ^5",
+        "ffmpeg-static": "^5",
+        "hono": "^4",
+        "typescript": "^5 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "elysia": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@spectrum-ts/imessage": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-5.1.0.tgz",
+      "integrity": "sha512-dsXVEjxqEHCffRK63gZKinoLebwrC0MawHfeVCOnuENrge6eJmm5+i3uv2B8G0RxlGImiQRUamk+kGOpK5v3NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/advanced-imessage": "^0.11.0",
+        "@photon-ai/imessage-kit": "^3.0.0",
+        "@photon-ai/otel": "^1.0.0",
+        "lru-cache": "^11.0.0",
+        "marked": "^18.0.5",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/slack": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-5.1.0.tgz",
+      "integrity": "sha512-uOLqeJssAthGwNTqhfre8Z5SBCoQK4DSiEylzPc3WiNAvIOV47RzuE5PYfQy4UWU461sL/CmESFXrrGZ7Efl1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/slack": "^0.2.0",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/telegram": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-5.1.0.tgz",
+      "integrity": "sha512-+Y0xZt/6EYFSOGlEBMppUZY7QbhVrDzW8XUbss0zJzDtjcAO9M10nViwTaLWwfFR2OqviKRO9HoB3jKp2X40gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/telegram-ts": "10.0.0",
+        "marked": "^18.0.5",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/terminal": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-5.1.0.tgz",
+      "integrity": "sha512-x3HsH2qAlU56cWYn/h9ALoGEDogHLYG9d5Xfc6lsNG1IE9A0rrsoz8ujjDlwNqwzJTMqYHrvbzIXEwzE2vyLiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@spectrum-ts/whatsapp-business": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-5.1.0.tgz",
+      "integrity": "sha512-EwUiCLuesGtL8o6I5iDeWNiKewNOHbNQy6zQngINfE7lCmTn9Yu7it/E0n5jIcui+8HUJrB+/dVnnNFkc5uQuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/whatsapp-business": "^0.1.1",
+        "mime-types": "^3.0.1",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^5.0.0",
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/abort-controller-x": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
+      "integrity": "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "license": "MIT"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/foldline": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/foldline/-/foldline-1.1.0.tgz",
+      "integrity": "sha512-9SheyADS50hjvFYjFJ3OB/GlDz2mD1T2CHd7auIk4Uto5YYWPBcw8iYo3F+gENJ+/SOeH9tT0loHZSqlUlumTA==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nice-grpc": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.16.tgz",
+      "integrity": "sha512-Cl3Pn00212Hl8/U6bpgMxmhZj5lyv3nWoJov4cd3FjWarktrMHP4DNvSjCnDwkMWYx4W1tyscEia4JX6Y4GVCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.0",
+        "abort-controller-x": "^0.5.0",
+        "nice-grpc-common": "^2.0.3"
+      }
+    },
+    "node_modules/nice-grpc-common": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-2.0.3.tgz",
+      "integrity": "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-error": "^1.0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open-graph-scraper": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/open-graph-scraper/-/open-graph-scraper-6.11.0.tgz",
+      "integrity": "sha512-KkO3qMMzJj9KYGtCl19dRtncb+RuBiG/P9BgukcAG4p2w9wSAWTE90vL6/xqth1K9ThkYF/+xfTGrVvU79TJtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "cheerio": "^1.1.2",
+        "iconv-lite": "^0.7.0",
+        "undici": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/spectrum-ts": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-5.1.0.tgz",
+      "integrity": "sha512-rgRemlXhCZLgGce+zO7/OE+pF5omv2Jx9hL+YU8kdFGBEhTq0FkAhJD6W8H2eSqYuF3Xk4q5hBPh+XqmyY3mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@spectrum-ts/core": "5.1.0",
+        "@spectrum-ts/imessage": "5.1.0",
+        "@spectrum-ts/slack": "5.1.0",
+        "@spectrum-ts/telegram": "5.1.0",
+        "@spectrum-ts/terminal": "5.1.0",
+        "@spectrum-ts/whatsapp-business": "5.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ts-error": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ts-error/-/ts-error-1.0.6.tgz",
+      "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/vcf": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vcf/-/vcf-2.1.2.tgz",
+      "integrity": "sha512-oLYtZ+GJPjpKS950fw70+HavdP7ZO2Q+xMCMeCyiUKuXkJJJG1/wUjCKTagPryS1gApYjZOWW/khmdLsch8jxg==",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "foldline": "^1.1.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/hermes-agent/package.json
+++ b/hermes-agent/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hermes-agent",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "spectrum-ts": "^5.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/node": "^22",
+    "tsx": "^4"
+  }
+}

--- a/hermes-agent/skills-lock.json
+++ b/hermes-agent/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "spectrum": {
+      "source": "photon-hq/skills",
+      "sourceType": "github",
+      "skillPath": "skills/spectrum/SKILL.md",
+      "computedHash": "1aea89f15a5bdf127691c679303a6edd7ec147ba7b366ca8ebdcc1705a3dd01d"
+    }
+  }
+}

--- a/hermes-agent/src/index.ts
+++ b/hermes-agent/src/index.ts
@@ -1,0 +1,21 @@
+import { Spectrum } from "spectrum-ts";
+import { imessage } from "@spectrum-ts/imessage";
+// Spectrum bridges a single agent loop to many messaging interfaces.
+// Each provider in `providers` adds an interface (terminal TUI, iMessage, …).
+// Docs: https://photon.codes/docs/spectrum-ts
+const app = await Spectrum({
+  projectId: process.env.PROJECT_ID!,
+  projectSecret: process.env.PROJECT_SECRET!,
+  providers: [
+    // iMessage
+    imessage.config(),
+  ],
+});
+
+// `app.messages` is an async iterable. Each tick yields a `space` (the
+// conversation) and an inbound `message`. Reply by awaiting `space.send(...)`.
+for await (const [space, message] of app.messages) {
+  if (message.content.type === "text") {
+    await space.send(`echo: ${message.content.text}`);
+  }
+}

--- a/hermes-agent/tsconfig.json
+++ b/hermes-agent/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "types": ["node"],
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Add a flattened Spectrum TypeScript app scaffold under `hermes-agent/`
- Wire the app to the Spectrum iMessage provider with an echo loop
- Include `.env.example`, local ignore rules, README/agent instructions, lockfile, and Spectrum skill references

## Review notes
- Flattened the previously embedded git repo; `.git`, `.env`, and `node_modules` were not committed
- Static scan found no hardcoded quoted secrets, shell injection, eval/exec, unsafe pickle, or SQL string-formatting patterns

## Test Plan
- `npm exec tsc -- --noEmit` from `hermes-agent/`
- `git diff --cached --check` before commit