### PR TITLE
fix(approval): detect encoding-based dangerous command bypass

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -452,6 +452,24 @@ DANGEROUS_PATTERNS = [
     (r'\b(python[23]?|perl|ruby|node)\s+-[ec]\s+', "script execution via -e/-c flag"),
     (r'\b(curl|wget)\b.*\|\s*(?:[/\w]*/)?(?:ba)?sh(?:\s|$|-c)', "pipe remote content to shell"),
     (r'\b(bash|sh|zsh|ksh)\s+<\s*<?\s*\(\s*(curl|wget)\b', "execute remote script via process substitution"),
+    # Decode-and-execute: encoded/transformed content piped to shell. Without
+    # these, `echo <base64> | base64 -d | bash` silently runs `rm -rf /` or
+    # any other command because the raw text contains no dangerous keywords.
+    (r'\b(base64|base32|base16)\s+(?:-[dD]|--decode)\b.*\|\s*\b(bash|sh|zsh|ksh|dash)\b',
+     "pipe decoded content to shell (possible command obfuscation)"),
+    # xxd reverse hex dump to shell (xxd uses -r for decode, not -d).
+    (r'\bxxd\s+-r\b.*\|\s*\b(bash|sh|zsh|ksh|dash)\b',
+     "pipe xxd-decoded content to shell (possible command obfuscation)"),
+
+
+    # Character transformation via tr piped to shell.
+    # `echo 'eq -pe v/' | tr 'eqv' 'rmf' | bash` decodes to `rm -rf /`.
+    (r'\becho\b[^|]*\|\s*\btr\b[^|]*\|\s*\b(bash|sh|zsh|ksh|dash)\b',
+     "pipe tr-transformed output to shell (possible command obfuscation)"),
+    # openssl decode piped to shell.
+    # `echo <base64> | openssl base64 -d | bash` decodes arbitrary commands.
+    (r'\bopenssl\b.*\b(?:base64|enc)\b[^|]*\s+-[dD]\b[^|]*\|\s*\b(bash|sh|zsh|ksh|dash)\b',
+     "pipe openssl-decoded content to shell (possible command obfuscation)"),
     (rf'\btee\b.*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via tee"),
     (rf'>>?\s*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via redirection"),
     (rf'\btee\b.*["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_COMMAND_TAIL}', "overwrite project env/config via tee"),


### PR DESCRIPTION
## Summary

Adds 4 new `DANGEROUS_PATTERNS` in `tools/approval.py` to detect dangerous commands obfuscated through encoding/transformation before being piped to a shell.

## Background

The existing `DANGEROUS_PATTERNS` regex list matches known dangerous keywords (`rm -rf`, `mkfs`, `dd`, etc.) in raw command text. An attacker (or prompt-injected LLM) can bypass these checks by encoding the destructive command and decoding it at runtime before piping to a shell — the raw text never contains the dangerous keywords.

## New Patterns

1. **`base64 | base32 | base16 --decode | bash`** — `echo <payload> | base64 -d | bash` runs arbitrary commands without dangerous keywords appearing in the command string.

2. **`xxd -r | bash`** — Reverse hex dump piped to shell. Uses `-r` flag (unlike `base64`'s `-d`), so it would not be caught even by a hypothetical `base64`-style pattern.

3. **`echo | tr | bash`** — Character substitution transforms a benign string into a dangerous command at runtime. e.g. `echo 'eq -pe v/' | tr 'eqv' 'rmf' | bash` becomes `rm -rf /`.

4. **`openssl base64/enc -d | bash`** — OpenSSL's own base64 decode piped to shell. Uses a different binary name than `base64`, so the `base64`-family pattern would not catch it.

## Verification

All of the following return `Dangerous: False` on `origin/main` and `Dangerous: True` after this change:

```bash
echo 'cm0gLXJmIC8=' | base64 -d | bash
echo 'ONUQ===' | base32 -d | bash
echo '2d2f2f2f' | xxd -r -p | bash
echo 'rm -rf /' | tr 'rmf' 'xyz' | bash
echo 'cm0gLXJmIC8=' | openssl base64 -d | bash
echo 'cm0gLXJmIC8=' | openssl enc -base64 -d | bash