### PR TITLE
feat(plugin): voice call

### DIFF
--- a/plugins/platforms/voice_call/README.md
+++ b/plugins/platforms/voice_call/README.md
@@ -1,0 +1,79 @@
+# voice_call — phone calls for Hermes
+
+Gateway platform plugin that lets Hermes make and receive real phone calls
+through carrier APIs: **Telnyx (default)**, Twilio, Plivo, or a
+credential-free **mock** provider for development. Ported from OpenClaw's
+voice-call extension.
+
+The plugin registers a gateway platform (so the carrier webhook server
+starts and stops with `hermes gateway run` — inbound calls need an
+always-on listener), the `voice_call` model tool, the `hermes voicecall`
+CLI, and the `/voicecall` slash command.
+
+User documentation: `website/docs/user-guide/features/voice-call.md`.
+
+## Dev quickstart (mock provider, no credentials)
+
+```yaml
+# ~/.hermes/config.yaml
+gateway:
+  platforms:
+    voice_call:
+      enabled: true
+      extra:
+        provider: mock
+        from_number: "+15555550000"
+        inbound_policy: allowlist
+        allow_from: ["+15555550001"]
+```
+
+```bash
+hermes gateway run                 # starts the webhook server on 127.0.0.1:3334
+hermes voicecall status --json
+hermes voicecall call --to +15555550001 --message "Hello from Hermes"
+hermes voicecall status
+```
+
+Simulate an inbound call + caller speech (mock provider accepts
+pre-normalized events):
+
+```bash
+curl -X POST http://127.0.0.1:3334/voice/webhook \
+  -H 'content-type: application/json' \
+  -d '{"event":{"type":"call.initiated","direction":"inbound","provider_call_id":"c1","from":"+15555550001","to":"+15555550000"}}'
+curl -X POST http://127.0.0.1:3334/voice/webhook \
+  -H 'content-type: application/json' \
+  -d '{"event":{"type":"call.answered","provider_call_id":"c1"}}'
+curl -X POST http://127.0.0.1:3334/voice/webhook \
+  -H 'content-type: application/json' \
+  -d '{"event":{"type":"call.speech","provider_call_id":"c1","text":"what time is it?"}}'
+```
+
+The transcript becomes a normal gateway agent turn; the reply is "spoken"
+back through the provider (visible in `hermes voicecall tail`).
+
+## Telnyx live smoke checklist
+
+1. `~/.hermes/.env`: `TELNYX_API_KEY`, `TELNYX_CONNECTION_ID`,
+   `TELNYX_PUBLIC_KEY` (from the Telnyx portal's webhook signing section).
+2. Config: `provider: telnyx`, your `from_number`, and either `public_url`
+   (your reverse proxy) or `tunnel: {provider: ngrok}` + `NGROK_AUTHTOKEN`.
+3. `hermes voicecall doctor` — everything should read `present` / `ok`.
+4. `hermes gateway run`, then
+   `hermes voicecall call --to +1... --message "Hello from Hermes" --mode notify`.
+
+## Architecture
+
+```
+adapter.py    thin BasePlatformAdapter shell (connect/disconnect/send)
+runtime.py    singleton owning provider + store + manager + webhook server
+manager.py    call state machine, timers, transcript waiters
+store.py      JSONL persistence + boot restore-and-verify
+webhook.py    aiohttp server: signature verify → replay cache → policy → manager
+responder.py  caller speech → MessageEvent → gateway agent → spoken reply
+providers/    base ABC, mock, telnyx, twilio, plivo
+realtime/     speech-to-speech bridge (OpenAI Realtime / Gemini Live)
+```
+
+Tests: `scripts/run_tests.sh tests/plugins/platforms/voice_call
+tests/gateway/test_voice_call_platform.py -q`

--- a/plugins/platforms/voice_call/SKILL.md
+++ b/plugins/platforms/voice_call/SKILL.md
@@ -1,0 +1,46 @@
+# Voice calls
+
+You can place and manage real phone calls with the `voice_call` tool.
+
+## When to call someone
+
+Only place calls the user explicitly asked for (or pre-authorized, e.g.
+"call me when the build finishes"). Calls ring a real phone and cost real
+money. Never call numbers the user hasn't given you.
+
+## Modes
+
+- **notify** — deliver one spoken message and hang up. Best for alerts and
+  reminders: `{"action": "initiate_call", "to_number": "+1...", "message":
+  "Your deployment finished successfully.", "mode": "notify"}`
+- **conversation** — stay on the line. Use `continue_call` to say something
+  and wait for the reply, `speak_to_user` to talk without waiting, and
+  `end_call` when the conversation is done. Always end with a polite
+  goodbye before hanging up.
+
+## Speaking style
+
+Everything in `message` is read aloud by a TTS voice:
+
+- 1–3 short sentences; natural spoken phrasing.
+- No markdown, URLs, code, emoji, or lists — say "I sent the link to your
+  chat" instead of reading a URL.
+- Spell out anything ambiguous ("three thirty PM", not "15:30").
+- Never speak secrets, tokens, codes, or credentials aloud unless the user
+  explicitly asked you to relay one.
+
+## Phone menus
+
+Use `send_dtmf` with the digits to press (e.g. `{"digits": "1"}` to choose
+option 1, `w` adds a half-second pause: `"1w1w0"`).
+
+## Incoming calls
+
+When someone calls in, their speech arrives as regular chat messages from
+their phone number. Reply normally — your reply is spoken to them on the
+call. Keep replies short; long monologues are painful on the phone.
+
+## Checking state
+
+`{"action": "get_status"}` lists active calls;
+add `call_id` for one call's state and transcript length.

--- a/plugins/platforms/voice_call/__init__.py
+++ b/plugins/platforms/voice_call/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/voice_call/adapter.py
+++ b/plugins/platforms/voice_call/adapter.py
@@ -1,0 +1,262 @@
+"""Voice-call platform adapter (Hermes plugin).
+
+Makes and receives real phone calls through carrier APIs — Telnyx
+(default), Twilio, Plivo, or a credential-free mock provider. Unlike thin
+messaging adapters, this adapter owns gateway-lifetime infrastructure: an
+aiohttp webhook server for carrier callbacks, an optional tunnel for public
+exposure, a call state machine with JSONL persistence, and (optionally) a
+realtime media-stream bridge to speech-to-speech models.
+
+The adapter itself stays thin: ``connect()``/``disconnect()`` delegate to
+the runtime singleton in ``runtime.py``, and ``send()`` maps gateway replies
+onto live calls. All heavy lifting lives in the runtime's components so the
+``voice_call`` tool, CLI, and slash command can drive calls without an
+adapter reference.
+
+Configuration in config.yaml::
+
+    gateway:
+      platforms:
+        voice_call:
+          enabled: true
+          extra:
+            provider: telnyx          # mock | telnyx | twilio | plivo
+            from_number: "+15555550000"
+            inbound_policy: allowlist # disabled | allowlist | open
+            allow_from: ["+15555550001"]
+            serve: { bind: "127.0.0.1", port: 3334, path: "/voice/webhook" }
+            tunnel: { provider: ngrok }   # or public_url: https://...
+
+Carrier credentials live in ``~/.hermes/.env`` (TELNYX_API_KEY,
+TELNYX_CONNECTION_ID, TELNYX_PUBLIC_KEY, TWILIO_*, PLIVO_*). See
+``config.py`` for the full schema and validation rules.
+"""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+from .config import VoiceCallConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _aiohttp_available(lazy_install: bool = False) -> bool:
+    """Check for aiohttp, optionally lazy-installing it (discord pattern)."""
+    try:
+        import aiohttp  # noqa: F401
+        return True
+    except ImportError:
+        pass
+    if not lazy_install:
+        return False
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+        _lazy_ensure("platform.voice_call", prompt=False)
+        import aiohttp  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def check_requirements() -> bool:
+    """Plugin gate: the webhook server needs aiohttp (lazy-installable)."""
+    return _aiohttp_available(lazy_install=False)
+
+
+def validate_config(config) -> bool:
+    """Is the platform fully configured for its selected provider?"""
+    try:
+        cfg = VoiceCallConfig.from_platform_config(config)
+        return not cfg.validate()
+    except Exception:
+        logger.debug("voice_call validate_config failed", exc_info=True)
+        return False
+
+
+def is_connected(config) -> bool:
+    """Surface in ``hermes status`` before the adapter is instantiated."""
+    return validate_config(config)
+
+
+def _env_enablement() -> Optional[Dict[str, Any]]:
+    """Seed ``PlatformConfig.extra`` from env vars during gateway config load.
+
+    Unlike pure-messaging platforms, voice_call binds a local port and may
+    spawn a tunnel at startup, so mere credential presence must not
+    auto-enable it. Users opt in explicitly with ``VOICE_CALL_ENABLED=true``.
+    """
+    if os.getenv("VOICE_CALL_ENABLED", "").strip().lower() not in ("1", "true", "yes"):
+        return None
+    seed: Dict[str, Any] = {}
+    provider = os.getenv("VOICE_CALL_PROVIDER", "").strip().lower()
+    if provider:
+        seed["provider"] = provider
+    from_number = os.getenv("VOICE_CALL_FROM_NUMBER", "").strip()
+    if from_number:
+        seed["from_number"] = from_number
+    allowed = os.getenv("VOICE_CALL_ALLOWED_NUMBERS", "").strip()
+    if allowed:
+        seed["allow_from"] = [n.strip() for n in allowed.split(",") if n.strip()]
+    public_url = os.getenv("VOICE_CALL_PUBLIC_URL", "").strip()
+    if public_url:
+        seed["public_url"] = public_url
+    home = os.getenv("VOICE_CALL_HOME_NUMBER", "").strip()
+    if home:
+        seed["home_channel"] = {"chat_id": home, "name": "Voice home"}
+    return seed
+
+
+class VoiceCallAdapter(BasePlatformAdapter):
+    """Gateway-lifetime shell around the voice-call runtime singleton."""
+
+    def __init__(self, config: PlatformConfig):
+        platform = Platform("voice_call")
+        super().__init__(config=config, platform=platform)
+        # Parsed lazily in connect(): __init__ must stay side-effect-free
+        # and tolerate synthetic configs (platform interface tests construct
+        # adapters with MagicMock configs).
+        self._vc_config: Optional[VoiceCallConfig] = None
+
+    @property
+    def enforces_own_access_policy(self) -> bool:
+        """Inbound access is gated by the webhook's inbound_policy/allowlist.
+
+        Without this, the gateway's env-allowlist default-deny would
+        silently drop callers that the configured allowlist already accepted.
+        """
+        return True
+
+    # -- Connection lifecycle -------------------------------------------------
+
+    async def connect(self) -> bool:
+        """Validate config and boot the voice-call runtime."""
+        if not _aiohttp_available(lazy_install=True):
+            logger.warning(
+                "[%s] aiohttp not installed and lazy install failed. "
+                "Run: pip install aiohttp",
+                self.name,
+            )
+            return False
+
+        try:
+            cfg = VoiceCallConfig.from_platform_config(self.config)
+        except Exception as e:
+            logger.error("[%s] Failed to parse config: %s", self.name, e)
+            return False
+
+        errors = cfg.validate()
+        if errors:
+            for err in errors:
+                logger.warning("[%s] Config error: %s", self.name, err)
+            self._set_fatal_error(
+                "voice_call_config",
+                "voice_call config invalid: " + "; ".join(errors),
+                retryable=False,
+            )
+            return False
+
+        self._vc_config = cfg
+        try:
+            from .runtime import ensure_runtime
+
+            await ensure_runtime(cfg, adapter=self)
+        except OSError as e:
+            # Port bind / tunnel network failures are environmental and may
+            # clear up — let the gateway's reconnect watcher retry.
+            logger.error("[%s] Runtime start failed: %s", self.name, e)
+            self._set_fatal_error(
+                "voice_call_bind",
+                f"voice_call runtime failed to start: {e}",
+                retryable=True,
+            )
+            return False
+        except Exception as e:
+            logger.error("[%s] Runtime start failed: %s", self.name, e, exc_info=True)
+            return False
+
+        self._mark_connected()
+        logger.info(
+            "[%s] Connected — provider=%s, webhook %s:%s%s",
+            self.name, cfg.provider, cfg.serve.bind, cfg.serve.port, cfg.serve.path,
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        """Stop the runtime (idempotent; tolerates partial initialization)."""
+        self._running = False
+        self._mark_disconnected()
+        try:
+            from .runtime import stop_runtime
+
+            await stop_runtime()
+        except Exception as e:
+            logger.warning("[%s] Error stopping runtime: %s", self.name, e)
+        logger.info("[%s] Disconnected", self.name)
+
+    # -- Outbound (gateway → caller) -------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Speak an agent reply on the live call associated with ``chat_id``.
+
+        ``chat_id`` is the remote party's E.164 number; with per-call session
+        scope the call id travels as the source ``thread_id`` and arrives in
+        ``metadata``.
+        """
+        from .runtime import get_runtime
+
+        runtime = get_runtime()
+        if runtime is None:
+            return SendResult(success=False, error="voice_call runtime not running")
+        thread_id = (metadata or {}).get("thread_id")
+        ok, detail = await runtime.speak_for_chat(chat_id, content, thread_id=thread_id)
+        if ok:
+            return SendResult(success=True, message_id=detail)
+        return SendResult(success=False, error=detail)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """No typing indicator on a phone call."""
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """A chat is one remote phone number; calls are always 1:1."""
+        return {"name": chat_id, "type": "dm"}
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system at startup."""
+    ctx.register_platform(
+        name="voice_call",
+        label="Voice Calls",
+        adapter_factory=lambda cfg: VoiceCallAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=[],
+        install_hint="pip install aiohttp",
+        env_enablement_fn=_env_enablement,
+        # Cron delivery: `deliver=voice_call` jobs call VOICE_CALL_HOME_NUMBER.
+        cron_deliver_env_var="VOICE_CALL_HOME_NUMBER",
+        # The gateway-side allowlist seed; the webhook's inbound_policy is the
+        # actual enforcement point (enforces_own_access_policy = True).
+        allowed_users_env="VOICE_CALL_ALLOWED_NUMBERS",
+        allow_all_env="VOICE_CALL_ALLOW_ALL",
+        max_message_length=1000,
+        emoji="📞",
+        # Phone numbers are PII — keep them out of session descriptions.
+        pii_safe=True,
+        platform_hint=(
+            "You are speaking on a live phone call. Reply in one to three "
+            "short, natural, spoken-style sentences of plain text — no "
+            "markdown, URLs, code, emoji, or lists. Never read secrets, "
+            "tokens, or credentials aloud."
+        ),
+    )

--- a/plugins/platforms/voice_call/adapter.py
+++ b/plugins/platforms/voice_call/adapter.py
@@ -232,7 +232,48 @@ class VoiceCallAdapter(BasePlatformAdapter):
 
 
 def register(ctx) -> None:
-    """Plugin entry point — called by the Hermes plugin system at startup."""
+    """Plugin entry point — called by the Hermes plugin system at startup.
+
+    Non-platform registrations are hasattr-guarded: minimal plugin contexts
+    (e.g. the platform interface test suite) only implement
+    ``register_platform``.
+    """
+    _register_platform(ctx)
+    if hasattr(ctx, "register_tool"):
+        from .tool import VOICE_CALL_SCHEMA, tool_check, voice_call_handler
+
+        ctx.register_tool(
+            name="voice_call",
+            toolset="voice_call",
+            schema=VOICE_CALL_SCHEMA,
+            handler=voice_call_handler,
+            check_fn=tool_check,
+            is_async=True,
+            emoji="📞",
+            description="Make and manage real phone calls",
+        )
+    if hasattr(ctx, "register_cli_command"):
+        from . import cli
+
+        ctx.register_cli_command(
+            name="voicecall",
+            help="Voice calls (status, call, speak, end, doctor)",
+            setup_fn=cli.register_cli,
+            handler_fn=cli.dispatch,
+            description="Manage Hermes voice calls via the running gateway",
+        )
+    if hasattr(ctx, "register_command"):
+        from .tool import slash_handler
+
+        ctx.register_command(
+            name="voicecall",
+            handler=slash_handler,
+            description="Voice call status/control",
+            args_hint="status | call --to +1555... --message \"...\" | end --call-id ID",
+        )
+
+
+def _register_platform(ctx) -> None:
     ctx.register_platform(
         name="voice_call",
         label="Voice Calls",

--- a/plugins/platforms/voice_call/adapter.py
+++ b/plugins/platforms/voice_call/adapter.py
@@ -307,6 +307,11 @@ def _register_platform(ctx) -> None:
             "You are speaking on a live phone call. Reply in one to three "
             "short, natural, spoken-style sentences of plain text — no "
             "markdown, URLs, code, emoji, or lists. Never read secrets, "
-            "tokens, or credentials aloud."
+            "tokens, or credentials aloud. The caller is waiting on the "
+            "line, so speed beats thoroughness: answer from a single quick "
+            "web_search when you need fresh information, and avoid slow "
+            "deep research (web_extract, browsing, multi-step "
+            "investigation) unless the caller explicitly asks you to dig "
+            "deeper."
         ),
     )

--- a/plugins/platforms/voice_call/adapter.py
+++ b/plugins/platforms/voice_call/adapter.py
@@ -218,7 +218,9 @@ class VoiceCallAdapter(BasePlatformAdapter):
         if runtime is None:
             return SendResult(success=False, error="voice_call runtime not running")
         thread_id = (metadata or {}).get("thread_id")
-        ok, detail = await runtime.speak_for_chat(chat_id, content, thread_id=thread_id)
+        ok, detail = await runtime.speak_for_chat(
+            chat_id, content, thread_id=thread_id, metadata=metadata
+        )
         if ok:
             return SendResult(success=True, message_id=detail)
         return SendResult(success=False, error=detail)

--- a/plugins/platforms/voice_call/adapter.py
+++ b/plugins/platforms/voice_call/adapter.py
@@ -239,6 +239,13 @@ def register(ctx) -> None:
     ``register_platform``.
     """
     _register_platform(ctx)
+    # The realtime bridge's agent_consult tool runs host-owned completions
+    # through the plugin LLM facade. Resolved lazily at consult time so
+    # registration never instantiates the facade (and minimal test contexts
+    # without .llm simply yield None).
+    from .realtime.bridge import set_plugin_llm_factory
+
+    set_plugin_llm_factory(lambda: getattr(ctx, "llm", None))
     if hasattr(ctx, "register_tool"):
         from .tool import VOICE_CALL_SCHEMA, tool_check, voice_call_handler
 

--- a/plugins/platforms/voice_call/audio.py
+++ b/plugins/platforms/voice_call/audio.py
@@ -1,0 +1,98 @@
+"""Telephony audio primitives: G.711 µ-law codec, PCM16 resampling, framing.
+
+Vendored pure-Python implementations — stdlib ``audioop`` was removed in
+Python 3.13 and Hermes supports 3.13, so we carry the ~60 lines ourselves.
+Carrier media streams speak µ-law at 8 kHz in 160-byte (20 ms) frames;
+realtime voice models speak PCM16 at 16/24 kHz.
+"""
+
+from array import array
+
+ULAW_SILENCE_BYTE = 0xFF  # µ-law encoding of 0
+FRAME_BYTES = 160          # 20 ms of µ-law @ 8 kHz
+FRAME_SECONDS = 0.02
+
+_BIAS = 0x84
+_CLIP = 32635
+
+
+def _decode_sample(byte: int) -> int:
+    byte = ~byte & 0xFF
+    sign = byte & 0x80
+    exponent = (byte >> 4) & 0x07
+    sample = ((((byte & 0x0F) << 3) + _BIAS) << exponent) - _BIAS
+    return -sample if sign else sample
+
+
+_DECODE_TABLE = array("h", (_decode_sample(b) for b in range(256)))
+
+
+def _encode_sample(sample: int) -> int:
+    sign = 0x80 if sample < 0 else 0
+    if sample < 0:
+        sample = -sample
+    if sample > _CLIP:
+        sample = _CLIP
+    sample += _BIAS
+    exponent = sample.bit_length() - 8  # sample >= 0x84 → bit_length >= 8
+    if exponent < 0:
+        exponent = 0
+    mantissa = (sample >> (exponent + 3)) & 0x0F
+    return ~(sign | (exponent << 4) | mantissa) & 0xFF
+
+
+_ENCODE_TABLE = bytes(
+    _encode_sample(s - 32768) for s in range(65536)
+)  # index by (sample & 0xFFFF) via offset below
+
+
+def ulaw_to_pcm16(data: bytes) -> bytes:
+    """Decode µ-law bytes to little-endian PCM16."""
+    out = array("h", bytes(2 * len(data)))
+    for i, byte in enumerate(data):
+        out[i] = _DECODE_TABLE[byte]
+    return out.tobytes()
+
+
+def pcm16_to_ulaw(data: bytes) -> bytes:
+    """Encode little-endian PCM16 to µ-law bytes."""
+    samples = array("h")
+    samples.frombytes(data[: len(data) - (len(data) % 2)])
+    return bytes(_ENCODE_TABLE[(s + 32768) & 0xFFFF] for s in samples)
+
+
+def resample_pcm16(data: bytes, src_rate: int, dst_rate: int) -> bytes:
+    """Linear-interpolation resampling of mono PCM16."""
+    if src_rate == dst_rate or not data:
+        return data
+    src = array("h")
+    src.frombytes(data[: len(data) - (len(data) % 2)])
+    n_src = len(src)
+    if n_src == 0:
+        return b""
+    n_dst = max(1, int(n_src * dst_rate / src_rate))
+    out = array("h", bytes(2 * n_dst))
+    step = (n_src - 1) / n_dst if n_dst > 1 else 0.0
+    pos = 0.0
+    for i in range(n_dst):
+        idx = int(pos)
+        frac = pos - idx
+        nxt = src[idx + 1] if idx + 1 < n_src else src[idx]
+        out[i] = int(src[idx] * (1.0 - frac) + nxt * frac)
+        pos += step
+    return out.tobytes()
+
+
+def chunk_frames(data: bytes, frame_bytes: int = FRAME_BYTES) -> list:
+    """Split µ-law bytes into fixed frames, padding the tail with silence."""
+    frames = []
+    for offset in range(0, len(data), frame_bytes):
+        frame = data[offset:offset + frame_bytes]
+        if len(frame) < frame_bytes:
+            frame = frame + bytes([ULAW_SILENCE_BYTE]) * (frame_bytes - len(frame))
+        frames.append(frame)
+    return frames
+
+
+def silence_frame(frame_bytes: int = FRAME_BYTES) -> bytes:
+    return bytes([ULAW_SILENCE_BYTE]) * frame_bytes

--- a/plugins/platforms/voice_call/cli.py
+++ b/plugins/platforms/voice_call/cli.py
@@ -39,11 +39,11 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
 
     speak_p = subs.add_parser("speak", help="Say something on a live call")
     speak_p.add_argument("--call-id", required=True)
-    speak_p.add_argument("--message", required=True)
+    speak_p.add_argument("-m", "--message", required=True)
 
     cont_p = subs.add_parser("continue", help="Say something and wait for the reply")
     cont_p.add_argument("--call-id", required=True)
-    cont_p.add_argument("--message", required=True)
+    cont_p.add_argument("-m", "--message", required=True)
 
     dtmf_p = subs.add_parser("dtmf", help="Send keypad digits")
     dtmf_p.add_argument("--call-id", required=True)

--- a/plugins/platforms/voice_call/cli.py
+++ b/plugins/platforms/voice_call/cli.py
@@ -40,6 +40,11 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
         "--instructions",
         help="per-call brief for the realtime voice (script/persona/questions)",
     )
+    call_p.add_argument(
+        "--might-continue", action="store_true", dest="might_continue",
+        help="notify mode: hold the line open after the message so a "
+             "follow-up 'continue' can turn it into a conversation",
+    )
 
     speak_p = subs.add_parser("speak", help="Say something on a live call")
     speak_p.add_argument("--call-id", required=True)
@@ -197,7 +202,8 @@ def _cmd_status(args: argparse.Namespace) -> int:
 def _cmd_call(args: argparse.Namespace) -> int:
     result = _admin_request(
         {"command": "call", "to": args.to, "message": args.message,
-         "mode": args.mode, "instructions": getattr(args, "instructions", None)}
+         "mode": args.mode, "instructions": getattr(args, "instructions", None),
+         "might_continue": getattr(args, "might_continue", False)}
     )
     if result.get("success"):
         print(

--- a/plugins/platforms/voice_call/cli.py
+++ b/plugins/platforms/voice_call/cli.py
@@ -1,0 +1,272 @@
+"""``hermes voicecall ...`` CLI.
+
+The CLI runs in its own process; action commands drive the *running*
+gateway through the webhook server's localhost admin endpoint,
+authenticated with the pre-shared token at
+``$HERMES_HOME/voice-calls/admin.token``. Read-only commands (``tail``,
+parts of ``doctor``) work straight off the on-disk state.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_home
+
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    subs = subparser.add_subparsers(dest="voicecall_command")
+
+    status_p = subs.add_parser("status", help="Show active calls")
+    status_p.add_argument("--json", action="store_true", dest="as_json")
+
+    call_p = subs.add_parser("call", help="Place an outbound call")
+    call_p.add_argument("--to", required=True, help="E.164 destination (+1555...)")
+    call_p.add_argument("--message", help="What to say when answered")
+    call_p.add_argument("--mode", choices=("notify", "conversation"))
+
+    speak_p = subs.add_parser("speak", help="Say something on a live call")
+    speak_p.add_argument("--call-id", required=True)
+    speak_p.add_argument("--message", required=True)
+
+    cont_p = subs.add_parser("continue", help="Say something and wait for the reply")
+    cont_p.add_argument("--call-id", required=True)
+    cont_p.add_argument("--message", required=True)
+
+    dtmf_p = subs.add_parser("dtmf", help="Send keypad digits")
+    dtmf_p.add_argument("--call-id", required=True)
+    dtmf_p.add_argument("--digits", required=True)
+
+    end_p = subs.add_parser("end", help="Hang up a call")
+    end_p.add_argument("--call-id", required=True)
+
+    subs.add_parser("doctor", help="Diagnose voice_call configuration")
+
+    tail_p = subs.add_parser("tail", help="Show recent call log entries")
+    tail_p.add_argument("--lines", type=int, default=20)
+
+
+def dispatch(args: argparse.Namespace) -> int:
+    command = getattr(args, "voicecall_command", None)
+    if not command:
+        print("usage: hermes voicecall "
+              "{status,call,speak,continue,dtmf,end,doctor,tail} ...")
+        return 1
+    handler = {
+        "status": _cmd_status,
+        "call": _cmd_call,
+        "speak": _cmd_speak,
+        "continue": _cmd_continue,
+        "dtmf": _cmd_dtmf,
+        "end": _cmd_end,
+        "doctor": _cmd_doctor,
+        "tail": _cmd_tail,
+    }[command]
+    return handler(args)
+
+
+# -- admin endpoint plumbing -----------------------------------------------------
+
+
+def _voice_dir() -> Path:
+    return get_hermes_home() / "voice-calls"
+
+
+def _load_extra() -> Dict[str, Any]:
+    """voice_call platform ``extra`` from config.yaml (best effort)."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly() or {}
+        return (
+            (config.get("gateway") or {}).get("platforms", {}).get("voice_call", {})
+        ).get("extra") or {}
+    except Exception:
+        return {}
+
+
+def _admin_address(extra: Dict[str, Any]) -> str:
+    serve = extra.get("serve") or {}
+    bind = str(serve.get("bind", "127.0.0.1"))
+    if bind in ("0.0.0.0", "::"):
+        bind = "127.0.0.1"
+    port = int(serve.get("port", 3334))
+    return f"http://{bind}:{port}"
+
+
+def _admin_token() -> Optional[str]:
+    try:
+        token = (_voice_dir() / "admin.token").read_text(encoding="utf-8").strip()
+        return token or None
+    except OSError:
+        return None
+
+
+def _admin_request(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """POST a command to the running gateway's admin endpoint."""
+    token = _admin_token()
+    if token is None:
+        return {
+            "success": False,
+            "error": (
+                "no admin token found — is the gateway running with the "
+                "voice_call platform enabled? (hermes gateway run)"
+            ),
+        }
+
+    async def _post():
+        import httpx
+
+        url = _admin_address(_load_extra()) + "/voice/admin"
+        async with httpx.AsyncClient(timeout=70.0) as client:
+            resp = await client.post(
+                url, json=payload, headers={"x-voice-call-admin-token": token}
+            )
+            return resp.json()
+
+    try:
+        return asyncio.run(_post())
+    except Exception as e:  # noqa: BLE001 — connection refused etc.
+        return {
+            "success": False,
+            "error": f"could not reach the voice_call gateway endpoint: {e}",
+        }
+
+
+def _print_result(result: Dict[str, Any], as_json: bool = False) -> int:
+    if as_json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0 if result.get("success") else 1
+    if not result.get("success"):
+        print(f"error: {result.get('error')}", file=sys.stderr)
+        return 1
+    return 0
+
+
+# -- commands -----------------------------------------------------------------
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    result = _admin_request({"command": "status"})
+    if args.as_json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0 if result.get("success") else 1
+    if not result.get("success"):
+        print(f"error: {result.get('error')}", file=sys.stderr)
+        return 1
+    calls = result.get("active_calls", [])
+    print(f"provider: {result.get('provider')}")
+    if result.get("public_url"):
+        print(f"public url: {result['public_url']}")
+    if not calls:
+        print("no active calls")
+        return 0
+    for call in calls:
+        peer = call.get("to_number") if call.get("direction") == "outbound" else call.get("from_number")
+        print(
+            f"  {call['call_id']}  {call['state']:<10} {call['direction']:<8} "
+            f"{peer or '?'}  mode={call.get('mode')}"
+        )
+    return 0
+
+
+def _cmd_call(args: argparse.Namespace) -> int:
+    result = _admin_request(
+        {"command": "call", "to": args.to, "message": args.message, "mode": args.mode}
+    )
+    if result.get("success"):
+        print(f"dialing {args.to} — call_id {result.get('call_id')}")
+    return _print_result(result)
+
+
+def _cmd_speak(args: argparse.Namespace) -> int:
+    result = _admin_request(
+        {"command": "speak", "call_id": args.call_id, "message": args.message}
+    )
+    if result.get("success"):
+        print("ok")
+    return _print_result(result)
+
+
+def _cmd_continue(args: argparse.Namespace) -> int:
+    result = _admin_request(
+        {"command": "continue", "call_id": args.call_id, "message": args.message}
+    )
+    if result.get("success"):
+        print(f"reply: {result.get('reply')}")
+    return _print_result(result)
+
+
+def _cmd_dtmf(args: argparse.Namespace) -> int:
+    result = _admin_request(
+        {"command": "dtmf", "call_id": args.call_id, "digits": args.digits}
+    )
+    if result.get("success"):
+        print("ok")
+    return _print_result(result)
+
+
+def _cmd_end(args: argparse.Namespace) -> int:
+    result = _admin_request({"command": "end", "call_id": args.call_id})
+    if result.get("success"):
+        print("call ended")
+    return _print_result(result)
+
+
+def _cmd_doctor(args: argparse.Namespace) -> int:
+    """Report config validity and env presence — never secret values."""
+    from .config import PROVIDER_REQUIRED_ENV, VoiceCallConfig
+
+    extra = _load_extra()
+    cfg = VoiceCallConfig.from_extra(extra)
+    print(f"provider: {cfg.provider}")
+    print(f"serve: {cfg.serve.bind}:{cfg.serve.port}{cfg.serve.path}")
+    print(f"public exposure: "
+          f"{cfg.public_url or cfg.tunnel.provider}")
+
+    for env in PROVIDER_REQUIRED_ENV.get(cfg.provider, []):
+        present = "present" if os.getenv(env, "").strip() else "MISSING"
+        print(f"env {env}: {present}")
+    if cfg.provider == "telnyx":
+        present = "present" if os.getenv("TELNYX_PUBLIC_KEY", "").strip() else "MISSING"
+        print(f"env TELNYX_PUBLIC_KEY: {present}")
+
+    errors = cfg.validate()
+    if errors:
+        print("\nconfig errors:")
+        for error in errors:
+            print(f"  ✗ {error}")
+    else:
+        print("\nconfig: ok")
+
+    result = _admin_request({"command": "status"})
+    if result.get("success"):
+        print(f"gateway runtime: reachable ({len(result.get('active_calls', []))} "
+              "active calls)")
+    else:
+        print(f"gateway runtime: not reachable — {result.get('error')}")
+    return 1 if errors else 0
+
+
+def _cmd_tail(args: argparse.Namespace) -> int:
+    calls_path = _voice_dir() / "calls.jsonl"
+    if not calls_path.exists():
+        print("no call log yet")
+        return 0
+    with open(calls_path, encoding="utf-8") as f:
+        lines = [line.strip() for line in f if line.strip()]
+    for line in lines[-max(1, args.lines):]:
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        print(
+            f"{data.get('call_id')}  {data.get('state'):<12} "
+            f"{data.get('direction'):<8} from={data.get('from_number')} "
+            f"to={data.get('to_number')} reason={data.get('end_reason')}"
+        )
+    return 0

--- a/plugins/platforms/voice_call/cli.py
+++ b/plugins/platforms/voice_call/cli.py
@@ -25,9 +25,17 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
     status_p.add_argument("--json", action="store_true", dest="as_json")
 
     call_p = subs.add_parser("call", help="Place an outbound call")
-    call_p.add_argument("--to", required=True, help="E.164 destination (+1555...)")
-    call_p.add_argument("--message", help="What to say when answered")
-    call_p.add_argument("--mode", choices=("notify", "conversation"))
+    call_p.add_argument(
+        "-t", "--to",
+        help="E.164 destination (+1555...); falls back to config to_number",
+    )
+    call_p.add_argument("-m", "--message", help="What to say when answered")
+    # CLI default is conversation (matches OpenClaw's voicecall CLI); the
+    # model tool and cron delivery still follow outbound.default_mode.
+    call_p.add_argument(
+        "--mode", choices=("notify", "conversation"), default="conversation",
+        help="notify: speak and hang up; conversation: stay open (default)",
+    )
 
     speak_p = subs.add_parser("speak", help="Say something on a live call")
     speak_p.add_argument("--call-id", required=True)
@@ -48,6 +56,14 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
 
     tail_p = subs.add_parser("tail", help="Show recent call log entries")
     tail_p.add_argument("--lines", type=int, default=20)
+    tail_p.add_argument(
+        "-f", "--follow", action="store_true",
+        help="Keep printing new entries as they are written",
+    )
+    tail_p.add_argument(
+        "--poll", type=float, default=0.25,
+        help="Follow-mode poll interval in seconds (default 0.25)",
+    )
 
 
 def dispatch(args: argparse.Namespace) -> int:
@@ -179,7 +195,10 @@ def _cmd_call(args: argparse.Namespace) -> int:
         {"command": "call", "to": args.to, "message": args.message, "mode": args.mode}
     )
     if result.get("success"):
-        print(f"dialing {args.to} — call_id {result.get('call_id')}")
+        print(
+            f"dialing {args.to or 'configured to_number'} "
+            f"({args.mode}) — call_id {result.get('call_id')}"
+        )
     return _print_result(result)
 
 
@@ -252,21 +271,50 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     return 1 if errors else 0
 
 
+def _print_call_line(line: str) -> None:
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        return
+    print(
+        f"{data.get('call_id')}  {data.get('state'):<12} "
+        f"{data.get('direction'):<8} from={data.get('from_number')} "
+        f"to={data.get('to_number')} reason={data.get('end_reason')}"
+    )
+
+
 def _cmd_tail(args: argparse.Namespace) -> int:
+    import time
+
     calls_path = _voice_dir() / "calls.jsonl"
-    if not calls_path.exists():
+    if not calls_path.exists() and not args.follow:
         print("no call log yet")
         return 0
-    with open(calls_path, encoding="utf-8") as f:
-        lines = [line.strip() for line in f if line.strip()]
-    for line in lines[-max(1, args.lines):]:
-        try:
-            data = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        print(
-            f"{data.get('call_id')}  {data.get('state'):<12} "
-            f"{data.get('direction'):<8} from={data.get('from_number')} "
-            f"to={data.get('to_number')} reason={data.get('end_reason')}"
-        )
-    return 0
+    position = 0
+    if calls_path.exists():
+        with open(calls_path, encoding="utf-8") as f:
+            lines = [line.strip() for line in f if line.strip()]
+        for line in lines[-max(1, args.lines):]:
+            _print_call_line(line)
+        position = calls_path.stat().st_size
+    if not args.follow:
+        return 0
+    try:
+        while True:
+            time.sleep(max(0.05, args.poll))
+            if not calls_path.exists():
+                continue
+            size = calls_path.stat().st_size
+            if size < position:
+                position = 0  # log was compacted/rotated — start over
+            if size == position:
+                continue
+            with open(calls_path, encoding="utf-8") as f:
+                f.seek(position)
+                chunk = f.read()
+                position = f.tell()
+            for line in chunk.splitlines():
+                if line.strip():
+                    _print_call_line(line.strip())
+    except KeyboardInterrupt:
+        return 0

--- a/plugins/platforms/voice_call/cli.py
+++ b/plugins/platforms/voice_call/cli.py
@@ -36,6 +36,10 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
         "--mode", choices=("notify", "conversation"), default="conversation",
         help="notify: speak and hang up; conversation: stay open (default)",
     )
+    call_p.add_argument(
+        "--instructions",
+        help="per-call brief for the realtime voice (script/persona/questions)",
+    )
 
     speak_p = subs.add_parser("speak", help="Say something on a live call")
     speak_p.add_argument("--call-id", required=True)
@@ -192,7 +196,8 @@ def _cmd_status(args: argparse.Namespace) -> int:
 
 def _cmd_call(args: argparse.Namespace) -> int:
     result = _admin_request(
-        {"command": "call", "to": args.to, "message": args.message, "mode": args.mode}
+        {"command": "call", "to": args.to, "message": args.message,
+         "mode": args.mode, "instructions": getattr(args, "instructions", None)}
     )
     if result.get("success"):
         print(

--- a/plugins/platforms/voice_call/config.py
+++ b/plugins/platforms/voice_call/config.py
@@ -131,6 +131,9 @@ class RealtimeConfig:
 class VoiceCallConfig:
     provider: str = DEFAULT_PROVIDER
     from_number: Optional[str] = None
+    # Default destination for outbound calls when no --to/to_number is given
+    # (OpenClaw's `toNumber`). Useful for "call me" setups.
+    to_number: Optional[str] = None
     session_scope: str = "per-phone"
     inbound_policy: str = "allowlist"
     allow_from: List[str] = field(default_factory=list)
@@ -179,6 +182,11 @@ class VoiceCallConfig:
             from_number=(
                 extra.get("from_number")
                 or os.getenv("VOICE_CALL_FROM_NUMBER")
+                or None
+            ),
+            to_number=(
+                extra.get("to_number")
+                or os.getenv("VOICE_CALL_TO_NUMBER")
                 or None
             ),
             session_scope=str(extra.get("session_scope", "per-phone")).strip().lower(),
@@ -284,6 +292,8 @@ class VoiceCallConfig:
 
         if self.from_number and not is_e164(self.from_number):
             errors.append("from_number must be E.164 (+15555550000 style)")
+        if self.to_number and not is_e164(self.to_number):
+            errors.append("to_number must be E.164 (+15555550000 style)")
         for number in self.allow_from:
             if not is_e164(number):
                 errors.append(f"allow_from entry {number!r} is not E.164")

--- a/plugins/platforms/voice_call/config.py
+++ b/plugins/platforms/voice_call/config.py
@@ -87,7 +87,14 @@ class TunnelConfig:
 @dataclass
 class OutboundConfig:
     default_mode: str = "notify"
+    # Plain notify: how long to wait after the message before hanging up
+    # (just deliver-and-drop).
     notify_hangup_delay_s: int = 3
+    # might_continue notify: how long to hold the line open after the
+    # message so the agent has time to issue a continue_call and turn it
+    # into a conversation. Longer than the plain delay because the agent's
+    # follow-up is a separate, latency-bearing tool call.
+    notify_continue_window_s: int = 15
 
 
 @dataclass
@@ -209,6 +216,9 @@ class VoiceCallConfig:
             outbound=OutboundConfig(
                 default_mode=str(outbound_raw.get("default_mode", "notify")).strip().lower(),
                 notify_hangup_delay_s=_as_int(outbound_raw.get("notify_hangup_delay_s"), 3),
+                notify_continue_window_s=_as_int(
+                    outbound_raw.get("notify_continue_window_s"), 15
+                ),
             ),
             timeouts=TimeoutsConfig(
                 max_call_s=_as_int(timeouts_raw.get("max_call_s"), 600),

--- a/plugins/platforms/voice_call/config.py
+++ b/plugins/platforms/voice_call/config.py
@@ -288,8 +288,8 @@ class VoiceCallConfig:
             if not is_e164(number):
                 errors.append(f"allow_from entry {number!r} is not E.164")
 
-        if not (1 <= self.serve.port <= 65535):
-            errors.append("serve.port must be 1-65535")
+        if not (0 <= self.serve.port <= 65535):  # 0 = ephemeral (bind any free port)
+            errors.append("serve.port must be 0-65535")
         if not self.serve.path.startswith("/"):
             errors.append("serve.path must start with /")
         # Note: inbound_policy "allowlist" with an empty allow_from is valid

--- a/plugins/platforms/voice_call/config.py
+++ b/plugins/platforms/voice_call/config.py
@@ -100,7 +100,7 @@ class TimeoutsConfig:
 
 @dataclass
 class ResponderConfig:
-    thinking_phrase: str = "One moment."
+    thinking_phrase: str = "Let me check that for you — one moment."
     response_timeout_s: int = 60
 
 
@@ -217,7 +217,7 @@ class VoiceCallConfig:
                 transcript_wait_s=_as_int(timeouts_raw.get("transcript_wait_s"), 60),
             ),
             responder=ResponderConfig(
-                thinking_phrase=str(responder_raw.get("thinking_phrase", "One moment.")),
+                thinking_phrase=str(responder_raw.get("thinking_phrase", "Let me check that for you — one moment.")),
                 response_timeout_s=_as_int(responder_raw.get("response_timeout_s"), 60),
             ),
             security=SecurityConfig(

--- a/plugins/platforms/voice_call/config.py
+++ b/plugins/platforms/voice_call/config.py
@@ -1,0 +1,344 @@
+"""Configuration for the voice_call platform.
+
+Parsed from ``gateway.platforms.voice_call.extra`` in config.yaml with
+environment-variable fallbacks. Secrets (carrier credentials) live only in
+``~/.hermes/.env`` — validation checks their *presence*, never logs values.
+"""
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+E164_RE = re.compile(r"^\+[1-9]\d{1,14}$")
+
+PROVIDERS = ("mock", "telnyx", "twilio", "plivo")
+DEFAULT_PROVIDER = "telnyx"
+
+SESSION_SCOPES = ("per-phone", "per-call")
+INBOUND_POLICIES = ("disabled", "allowlist", "open")
+OUTBOUND_MODES = ("notify", "conversation")
+TUNNEL_PROVIDERS = ("none", "ngrok", "tailscale-serve", "tailscale-funnel")
+REALTIME_PROVIDERS = ("openai", "gemini")
+# Carriers whose media streams the realtime bridge supports.
+REALTIME_CALL_PROVIDERS = ("telnyx", "twilio")
+
+DEFAULT_SERVE_BIND = "127.0.0.1"
+DEFAULT_SERVE_PORT = 3334
+DEFAULT_SERVE_PATH = "/voice/webhook"
+DEFAULT_STREAM_PATH = "/voice/stream"
+
+# Env vars whose presence is required per provider (checked at validation
+# time only when that provider is selected).
+PROVIDER_REQUIRED_ENV = {
+    "mock": [],
+    "telnyx": ["TELNYX_API_KEY", "TELNYX_CONNECTION_ID"],
+    "twilio": ["TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN"],
+    "plivo": ["PLIVO_AUTH_ID", "PLIVO_AUTH_TOKEN"],
+}
+
+
+def normalize_e164(number: str) -> str:
+    """Normalize a phone number for comparison: strip separators, keep +digits."""
+    cleaned = re.sub(r"[\s\-().]", "", str(number or ""))
+    if cleaned and not cleaned.startswith("+") and cleaned.isdigit():
+        cleaned = f"+{cleaned}"
+    return cleaned
+
+
+def is_e164(number: str) -> bool:
+    return bool(E164_RE.match(normalize_e164(number)))
+
+
+def _env_list(name: str) -> List[str]:
+    raw = os.getenv(name, "")
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass
+class ServeConfig:
+    bind: str = DEFAULT_SERVE_BIND
+    port: int = DEFAULT_SERVE_PORT
+    path: str = DEFAULT_SERVE_PATH
+    stream_path: str = DEFAULT_STREAM_PATH
+
+
+@dataclass
+class TunnelConfig:
+    provider: str = "none"
+    ngrok_domain: Optional[str] = None
+
+
+@dataclass
+class OutboundConfig:
+    default_mode: str = "notify"
+    notify_hangup_delay_s: int = 3
+
+
+@dataclass
+class TimeoutsConfig:
+    max_call_s: int = 600
+    ring_s: int = 45
+    silence_s: int = 30
+    transcript_wait_s: int = 60
+
+
+@dataclass
+class ResponderConfig:
+    thinking_phrase: str = "One moment."
+    response_timeout_s: int = 60
+
+
+@dataclass
+class SecurityConfig:
+    skip_signature_verification: bool = False
+    max_body_bytes: int = 1_000_000
+    body_read_timeout_s: int = 30
+    max_inflight_per_ip: int = 8
+    replay_ttl_s: int = 600
+
+
+@dataclass
+class StreamingConfig:
+    enabled: bool = False
+
+
+@dataclass
+class RealtimeConfig:
+    enabled: bool = False
+    provider: str = "openai"
+    model: Optional[str] = None
+    voice: Optional[str] = None
+    instructions: Optional[str] = None
+
+
+@dataclass
+class VoiceCallConfig:
+    provider: str = DEFAULT_PROVIDER
+    from_number: Optional[str] = None
+    session_scope: str = "per-phone"
+    inbound_policy: str = "allowlist"
+    allow_from: List[str] = field(default_factory=list)
+    inbound_greeting: str = "Hello, this is Hermes. How can I help?"
+    serve: ServeConfig = field(default_factory=ServeConfig)
+    public_url: Optional[str] = None
+    tunnel: TunnelConfig = field(default_factory=TunnelConfig)
+    outbound: OutboundConfig = field(default_factory=OutboundConfig)
+    timeouts: TimeoutsConfig = field(default_factory=TimeoutsConfig)
+    responder: ResponderConfig = field(default_factory=ResponderConfig)
+    security: SecurityConfig = field(default_factory=SecurityConfig)
+    streaming: StreamingConfig = field(default_factory=StreamingConfig)
+    realtime: RealtimeConfig = field(default_factory=RealtimeConfig)
+    # Raw provider-specific sub-dicts from extra (e.g. extra["telnyx"]).
+    # Providers read credentials env-first, then from here.
+    provider_extra: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    # -- parsing --------------------------------------------------------------
+
+    @classmethod
+    def from_extra(cls, extra: Optional[Dict[str, Any]]) -> "VoiceCallConfig":
+        """Build config from ``PlatformConfig.extra`` with env fallbacks."""
+        extra = dict(extra or {})
+
+        serve_raw = extra.get("serve") or {}
+        tunnel_raw = extra.get("tunnel") or {}
+        outbound_raw = extra.get("outbound") or {}
+        timeouts_raw = extra.get("timeouts") or {}
+        responder_raw = extra.get("responder") or {}
+        security_raw = extra.get("security") or {}
+        streaming_raw = extra.get("streaming") or {}
+        realtime_raw = extra.get("realtime") or {}
+
+        allow_from = extra.get("allow_from")
+        if allow_from is None:
+            allow_from = _env_list("VOICE_CALL_ALLOWED_NUMBERS")
+        if isinstance(allow_from, str):
+            allow_from = [n.strip() for n in allow_from.split(",") if n.strip()]
+
+        provider = str(
+            extra.get("provider") or os.getenv("VOICE_CALL_PROVIDER") or DEFAULT_PROVIDER
+        ).strip().lower()
+
+        return cls(
+            provider=provider,
+            from_number=(
+                extra.get("from_number")
+                or os.getenv("VOICE_CALL_FROM_NUMBER")
+                or None
+            ),
+            session_scope=str(extra.get("session_scope", "per-phone")).strip().lower(),
+            inbound_policy=str(extra.get("inbound_policy", "allowlist")).strip().lower(),
+            allow_from=[normalize_e164(n) for n in allow_from],
+            inbound_greeting=str(
+                extra.get("inbound_greeting", cls.inbound_greeting)
+            ),
+            serve=ServeConfig(
+                bind=str(serve_raw.get("bind", DEFAULT_SERVE_BIND)),
+                port=_as_int(serve_raw.get("port"), DEFAULT_SERVE_PORT),
+                path=str(serve_raw.get("path", DEFAULT_SERVE_PATH)),
+                stream_path=str(serve_raw.get("stream_path", DEFAULT_STREAM_PATH)),
+            ),
+            public_url=(extra.get("public_url") or os.getenv("VOICE_CALL_PUBLIC_URL") or None),
+            tunnel=TunnelConfig(
+                provider=str(tunnel_raw.get("provider", "none")).strip().lower(),
+                ngrok_domain=tunnel_raw.get("ngrok_domain") or os.getenv("NGROK_DOMAIN") or None,
+            ),
+            outbound=OutboundConfig(
+                default_mode=str(outbound_raw.get("default_mode", "notify")).strip().lower(),
+                notify_hangup_delay_s=_as_int(outbound_raw.get("notify_hangup_delay_s"), 3),
+            ),
+            timeouts=TimeoutsConfig(
+                max_call_s=_as_int(timeouts_raw.get("max_call_s"), 600),
+                ring_s=_as_int(timeouts_raw.get("ring_s"), 45),
+                silence_s=_as_int(timeouts_raw.get("silence_s"), 30),
+                transcript_wait_s=_as_int(timeouts_raw.get("transcript_wait_s"), 60),
+            ),
+            responder=ResponderConfig(
+                thinking_phrase=str(responder_raw.get("thinking_phrase", "One moment.")),
+                response_timeout_s=_as_int(responder_raw.get("response_timeout_s"), 60),
+            ),
+            security=SecurityConfig(
+                skip_signature_verification=_as_bool(
+                    security_raw.get("skip_signature_verification"), False
+                ),
+                max_body_bytes=_as_int(security_raw.get("max_body_bytes"), 1_000_000),
+                body_read_timeout_s=_as_int(security_raw.get("body_read_timeout_s"), 30),
+                max_inflight_per_ip=_as_int(security_raw.get("max_inflight_per_ip"), 8),
+                replay_ttl_s=_as_int(security_raw.get("replay_ttl_s"), 600),
+            ),
+            streaming=StreamingConfig(enabled=_as_bool(streaming_raw.get("enabled"), False)),
+            realtime=RealtimeConfig(
+                enabled=_as_bool(realtime_raw.get("enabled"), False),
+                provider=str(realtime_raw.get("provider", "openai")).strip().lower(),
+                model=realtime_raw.get("model") or None,
+                voice=realtime_raw.get("voice") or None,
+                instructions=realtime_raw.get("instructions") or None,
+            ),
+            provider_extra={
+                name: dict(extra.get(name) or {})
+                for name in PROVIDERS
+                if isinstance(extra.get(name), dict)
+            },
+        )
+
+    @classmethod
+    def from_platform_config(cls, config: Any) -> "VoiceCallConfig":
+        return cls.from_extra(getattr(config, "extra", None) or {})
+
+    # -- validation -----------------------------------------------------------
+
+    @property
+    def requires_public_webhook(self) -> bool:
+        return self.provider != "mock"
+
+    def provider_credential(self, key: str, env_var: str) -> Optional[str]:
+        """Resolve a provider credential env-first, then from provider_extra."""
+        value = os.getenv(env_var, "").strip()
+        if value:
+            return value
+        sub = self.provider_extra.get(self.provider, {})
+        value = str(sub.get(key, "") or "").strip()
+        return value or None
+
+    def validate(self) -> List[str]:
+        """Return a list of human-readable config errors (empty = valid)."""
+        errors: List[str] = []
+
+        if self.provider not in PROVIDERS:
+            errors.append(
+                f"provider must be one of {', '.join(PROVIDERS)} (got {self.provider!r})"
+            )
+            return errors  # everything else is provider-relative
+
+        if self.session_scope not in SESSION_SCOPES:
+            errors.append(
+                f"session_scope must be one of {', '.join(SESSION_SCOPES)}"
+            )
+        if self.inbound_policy not in INBOUND_POLICIES:
+            errors.append(
+                f"inbound_policy must be one of {', '.join(INBOUND_POLICIES)}"
+            )
+        if self.outbound.default_mode not in OUTBOUND_MODES:
+            errors.append(
+                f"outbound.default_mode must be one of {', '.join(OUTBOUND_MODES)}"
+            )
+        if self.tunnel.provider not in TUNNEL_PROVIDERS:
+            errors.append(
+                f"tunnel.provider must be one of {', '.join(TUNNEL_PROVIDERS)}"
+            )
+
+        if self.from_number and not is_e164(self.from_number):
+            errors.append("from_number must be E.164 (+15555550000 style)")
+        for number in self.allow_from:
+            if not is_e164(number):
+                errors.append(f"allow_from entry {number!r} is not E.164")
+
+        if not (1 <= self.serve.port <= 65535):
+            errors.append("serve.port must be 1-65535")
+        if not self.serve.path.startswith("/"):
+            errors.append("serve.path must start with /")
+        # Note: inbound_policy "allowlist" with an empty allow_from is valid
+        # config for outbound-only setups — it simply rejects all inbound
+        # calls (the webhook logs a warning when that happens).
+
+        # Provider credentials (presence only — values are never logged).
+        missing = [
+            env
+            for env in PROVIDER_REQUIRED_ENV[self.provider]
+            if not self.provider_credential(env.split("_", 1)[1].lower(), env)
+        ]
+        if missing:
+            errors.append(
+                f"provider '{self.provider}' requires env vars: {', '.join(missing)}"
+            )
+
+        if (
+            self.provider == "telnyx"
+            and not self.security.skip_signature_verification
+            and not self.provider_credential("public_key", "TELNYX_PUBLIC_KEY")
+        ):
+            errors.append(
+                "telnyx requires TELNYX_PUBLIC_KEY for webhook signature "
+                "verification (or security.skip_signature_verification: true — "
+                "not recommended)"
+            )
+
+        if (
+            self.requires_public_webhook
+            and not self.public_url
+            and self.tunnel.provider == "none"
+        ):
+            errors.append(
+                f"provider '{self.provider}' needs a publicly reachable webhook: "
+                "set public_url or tunnel.provider (ngrok / tailscale-serve / "
+                "tailscale-funnel)"
+            )
+
+        if self.realtime.enabled:
+            if self.realtime.provider not in REALTIME_PROVIDERS:
+                errors.append(
+                    f"realtime.provider must be one of {', '.join(REALTIME_PROVIDERS)}"
+                )
+            if self.provider not in REALTIME_CALL_PROVIDERS:
+                errors.append(
+                    "realtime.enabled requires provider telnyx or twilio "
+                    "(media streams are not supported on "
+                    f"{self.provider!r})"
+                )
+
+        return errors

--- a/plugins/platforms/voice_call/events.py
+++ b/plugins/platforms/voice_call/events.py
@@ -94,8 +94,9 @@ class EventType(str, Enum):
     CALL_RINGING = "call.ringing"
     CALL_ANSWERED = "call.answered"
     CALL_ACTIVE = "call.active"
-    CALL_SPEAKING = "call.speaking"  # outbound TTS started/finished
-    CALL_SPEECH = "call.speech"      # inbound transcript (text, is_final)
+    CALL_SPEAKING = "call.speaking"      # outbound TTS started
+    CALL_SPEAK_ENDED = "call.speak.ended"  # outbound TTS finished playing
+    CALL_SPEECH = "call.speech"          # inbound transcript (text, is_final)
     CALL_SILENCE = "call.silence"
     CALL_DTMF = "call.dtmf"
     CALL_ENDED = "call.ended"

--- a/plugins/platforms/voice_call/events.py
+++ b/plugins/platforms/voice_call/events.py
@@ -1,0 +1,251 @@
+"""Core domain types for the voice_call platform.
+
+Every carrier webhook payload — regardless of provider — is parsed into the
+``NormalizedEvent`` shape so the call manager never sees provider-specific
+wire formats. Call lifecycle state lives in ``CallRecord``, persisted as
+JSONL by ``store.py``.
+"""
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+
+class CallState(str, Enum):
+    """Lifecycle states for a call.
+
+    Non-terminal flow: initiated → ringing → answered → active, with
+    speaking ⇄ listening oscillation during a conversation. Terminal states
+    are absorbing.
+    """
+
+    INITIATED = "initiated"
+    RINGING = "ringing"
+    ANSWERED = "answered"
+    ACTIVE = "active"
+    SPEAKING = "speaking"
+    LISTENING = "listening"
+    # Terminal
+    COMPLETED = "completed"
+    HANGUP_USER = "hangup-user"
+    HANGUP_BOT = "hangup-bot"
+    TIMEOUT = "timeout"
+    ERROR = "error"
+    FAILED = "failed"
+    NO_ANSWER = "no-answer"
+    BUSY = "busy"
+    VOICEMAIL = "voicemail"
+
+
+TERMINAL_STATES = frozenset(
+    {
+        CallState.COMPLETED,
+        CallState.HANGUP_USER,
+        CallState.HANGUP_BOT,
+        CallState.TIMEOUT,
+        CallState.ERROR,
+        CallState.FAILED,
+        CallState.NO_ANSWER,
+        CallState.BUSY,
+        CallState.VOICEMAIL,
+    }
+)
+
+# Forward progression order for non-terminal states. Backwards transitions
+# are rejected except for the speaking ⇄ listening oscillation.
+_STATE_ORDER = {
+    CallState.INITIATED: 0,
+    CallState.RINGING: 1,
+    CallState.ANSWERED: 2,
+    CallState.ACTIVE: 3,
+    CallState.SPEAKING: 4,
+    CallState.LISTENING: 4,
+}
+
+
+def is_terminal(state: CallState) -> bool:
+    return state in TERMINAL_STATES
+
+
+def is_valid_transition(current: CallState, new: CallState) -> bool:
+    """Return True when ``current → new`` is a legal state transition.
+
+    Carrier webhooks can arrive out of order, so illegal transitions are a
+    normal occurrence — callers log and drop them rather than raising.
+    """
+    if current == new:
+        return False
+    if current in TERMINAL_STATES:
+        return False
+    if new in TERMINAL_STATES:
+        return True
+    # speaking ⇄ listening may oscillate
+    if {current, new} == {CallState.SPEAKING, CallState.LISTENING}:
+        return True
+    return _STATE_ORDER[new] > _STATE_ORDER[current]
+
+
+class EventType(str, Enum):
+    """Provider-agnostic webhook event types (the normalization target)."""
+
+    CALL_INITIATED = "call.initiated"
+    CALL_RINGING = "call.ringing"
+    CALL_ANSWERED = "call.answered"
+    CALL_ACTIVE = "call.active"
+    CALL_SPEAKING = "call.speaking"  # outbound TTS started/finished
+    CALL_SPEECH = "call.speech"      # inbound transcript (text, is_final)
+    CALL_SILENCE = "call.silence"
+    CALL_DTMF = "call.dtmf"
+    CALL_ENDED = "call.ended"
+    CALL_ERROR = "call.error"
+
+
+# EventType → the CallState it implies (when it implies one at all).
+EVENT_STATE_MAP = {
+    EventType.CALL_INITIATED: CallState.INITIATED,
+    EventType.CALL_RINGING: CallState.RINGING,
+    EventType.CALL_ANSWERED: CallState.ANSWERED,
+    EventType.CALL_ACTIVE: CallState.ACTIVE,
+}
+
+
+@dataclass
+class NormalizedEvent:
+    """A single provider webhook event, normalized.
+
+    ``provider_call_id`` is the carrier's call identifier; ``call_id`` is
+    ours (recovered from ``client_state``/metadata when the provider echoes
+    it back). ``dedupe_key`` feeds replay/duplicate suppression.
+    """
+
+    type: EventType
+    provider: str = ""
+    provider_call_id: Optional[str] = None
+    call_id: Optional[str] = None
+    from_number: Optional[str] = None
+    to_number: Optional[str] = None
+    direction: Optional[Literal["inbound", "outbound"]] = None
+    # call.speech
+    text: Optional[str] = None
+    is_final: bool = True
+    # call.dtmf
+    digits: Optional[str] = None
+    # call.ended / call.error
+    reason: Optional[str] = None
+    retryable: bool = False
+    # call.silence
+    duration_ms: Optional[int] = None
+    dedupe_key: Optional[str] = None
+    timestamp: float = field(default_factory=time.time)
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TranscriptEntry:
+    timestamp: float
+    speaker: Literal["bot", "user"]
+    text: str
+    is_final: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "speaker": self.speaker,
+            "text": self.text,
+            "is_final": self.is_final,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TranscriptEntry":
+        return cls(
+            timestamp=float(data.get("timestamp", 0.0)),
+            speaker="bot" if data.get("speaker") == "bot" else "user",
+            text=str(data.get("text", "")),
+            is_final=bool(data.get("is_final", True)),
+        )
+
+
+def new_call_id() -> str:
+    return f"vc-{uuid.uuid4().hex[:20]}"
+
+
+@dataclass
+class CallRecord:
+    """Full state of one call. Persisted as one JSONL line per change."""
+
+    call_id: str
+    provider: str
+    direction: Literal["inbound", "outbound"]
+    state: CallState = CallState.INITIATED
+    provider_call_id: Optional[str] = None
+    from_number: Optional[str] = None
+    to_number: Optional[str] = None
+    session_key: Optional[str] = None
+    mode: Literal["notify", "conversation"] = "conversation"
+    started_at: float = field(default_factory=time.time)
+    answered_at: Optional[float] = None
+    ended_at: Optional[float] = None
+    end_reason: Optional[str] = None
+    transcript: List[TranscriptEntry] = field(default_factory=list)
+    processed_event_ids: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.state in TERMINAL_STATES
+
+    @property
+    def peer_number(self) -> Optional[str]:
+        """The remote party's number (the caller for inbound, callee for outbound)."""
+        return self.from_number if self.direction == "inbound" else self.to_number
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "call_id": self.call_id,
+            "provider": self.provider,
+            "direction": self.direction,
+            "state": self.state.value,
+            "provider_call_id": self.provider_call_id,
+            "from_number": self.from_number,
+            "to_number": self.to_number,
+            "session_key": self.session_key,
+            "mode": self.mode,
+            "started_at": self.started_at,
+            "answered_at": self.answered_at,
+            "ended_at": self.ended_at,
+            "end_reason": self.end_reason,
+            "transcript": [t.to_dict() for t in self.transcript],
+            "processed_event_ids": list(self.processed_event_ids),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CallRecord":
+        try:
+            state = CallState(data.get("state", "initiated"))
+        except ValueError:
+            state = CallState.ERROR
+        return cls(
+            call_id=str(data.get("call_id", "")) or new_call_id(),
+            provider=str(data.get("provider", "")),
+            direction="inbound" if data.get("direction") == "inbound" else "outbound",
+            state=state,
+            provider_call_id=data.get("provider_call_id"),
+            from_number=data.get("from_number"),
+            to_number=data.get("to_number"),
+            session_key=data.get("session_key"),
+            mode="notify" if data.get("mode") == "notify" else "conversation",
+            started_at=float(data.get("started_at", 0.0)),
+            answered_at=data.get("answered_at"),
+            ended_at=data.get("ended_at"),
+            end_reason=data.get("end_reason"),
+            transcript=[
+                TranscriptEntry.from_dict(t)
+                for t in data.get("transcript", [])
+                if isinstance(t, dict)
+            ],
+            processed_event_ids=[str(e) for e in data.get("processed_event_ids", [])],
+            metadata=dict(data.get("metadata") or {}),
+        )

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -64,6 +64,12 @@ class CallManager:
         self.realtime_speaker: Optional[
             Callable[[CallRecord, str], Awaitable[bool]]
         ] = None
+        # Optional hook to attach a media stream to a LIVE call (Telnyx
+        # streaming_start) — lets a notify-born call upgrade all the way to
+        # the realtime voice instead of carrier TTS. Returns True on success.
+        self.upgrade_realtime: Optional[
+            Callable[[CallRecord], Awaitable[bool]]
+        ] = None
 
         self.active: Dict[str, CallRecord] = {}
         self._by_provider_id: Dict[str, str] = {}
@@ -705,14 +711,25 @@ class CallManager:
             self._cancel_timer(call_id, "notify")
             record.mode = "conversation"
             self._persist(record)
+            # Prefer the full realtime upgrade (mid-call media stream →
+            # speech-to-speech voice); fall back to carrier transcription.
             if not self._realtime_owns_audio(record):
-                try:
-                    await self.provider.start_listening(record)
-                except Exception as e:  # noqa: BLE001
-                    logger.warning(
-                        "voice_call: start_listening failed during notify "
-                        "upgrade of %s: %s", call_id, e,
-                    )
+                upgraded = False
+                if self.upgrade_realtime is not None:
+                    try:
+                        upgraded = await self.upgrade_realtime(record)
+                    except Exception:  # noqa: BLE001
+                        logger.exception(
+                            "voice_call: realtime upgrade hook failed"
+                        )
+                if not upgraded:
+                    try:
+                        await self.provider.start_listening(record)
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning(
+                            "voice_call: start_listening failed during notify "
+                            "upgrade of %s: %s", call_id, e,
+                        )
 
         realtime = self._realtime_owns_audio(record)
         spoke_at = time.time()

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -199,6 +199,14 @@ class CallManager:
         self._persist(record)
         return True
 
+    def _notify_window(self, record: CallRecord) -> int:
+        """Seconds to hold a notify call open after a message before
+        auto-hangup. might_continue calls get the longer window so a
+        follow-up continue_call has time to arrive."""
+        if record.metadata.get("might_continue"):
+            return max(0, self.config.outbound.notify_continue_window_s)
+        return max(0, self.config.outbound.notify_hangup_delay_s)
+
     def _realtime_owns_audio(self, record: CallRecord) -> bool:
         """True when a realtime bridge handles this call's audio — carrier
         TTS/transcription would talk over the model."""
@@ -554,8 +562,10 @@ class CallManager:
             if initial:
                 await self.speak(record.call_id, str(initial))
             if record.mode == "notify":
-                delay = max(0, self.config.outbound.notify_hangup_delay_s)
-                self._arm_timer(record.call_id, "notify", delay, self._on_notify_hangup)
+                self._arm_timer(
+                    record.call_id, "notify", self._notify_window(record),
+                    self._on_notify_hangup,
+                )
             else:
                 await self._start_listening(record)
         else:
@@ -628,6 +638,7 @@ class CallManager:
         mode: Optional[str] = None,
         from_number: Optional[str] = None,
         instructions: Optional[str] = None,
+        might_continue: bool = False,
     ) -> CallRecord:
         to_number = normalize_e164(to_number or self.config.to_number or "")
         if not to_number:
@@ -662,6 +673,10 @@ class CallManager:
             # questions) — merged into the session instructions by the
             # bridge so the model conducts the whole call itself.
             record.metadata["realtime_instructions"] = str(instructions)
+        if might_continue:
+            # Hold a notify call open longer after the message so a
+            # follow-up continue_call can turn it into a conversation.
+            record.metadata["might_continue"] = True
         self._register(record)
         if self.prepare_call is not None:
             try:
@@ -722,8 +737,7 @@ class CallManager:
             self._arm_silence_timer(record)
         elif is_notify and record.answered_at:
             self._arm_timer(
-                call_id, "notify",
-                max(0, self.config.outbound.notify_hangup_delay_s),
+                call_id, "notify", self._notify_window(record),
                 self._on_notify_hangup,
             )
 

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -182,6 +182,23 @@ class CallManager:
             if waiter is not None and not waiter.done():
                 waiter.set_result(text)
 
+    def queue_initial_message(self, call_id: str, text: str) -> bool:
+        """Queue ``text`` to be spoken when a still-ringing outbound call is
+        answered. Returns False when the call already has an opening message
+        (or isn't in a queueable state)."""
+        record = self.active.get(call_id)
+        if (
+            record is None
+            or record.is_terminal
+            or record.answered_at is not None
+            or record.direction != "outbound"
+            or record.metadata.get("initial_message")
+        ):
+            return False
+        record.metadata["initial_message"] = text
+        self._persist(record)
+        return True
+
     def _realtime_owns_audio(self, record: CallRecord) -> bool:
         """True when a realtime bridge handles this call's audio — carrier
         TTS/transcription would talk over the model."""

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -1,0 +1,587 @@
+"""Call state manager for the voice_call platform.
+
+Owns every active :class:`CallRecord`: state transitions, transcript
+accumulation, timers (ring / max-duration / silence / notify hangup),
+transcript waiters for ``continue_call``-style turns, and persistence
+through :class:`CallStore`. Consumes only ``NormalizedEvent``s — never
+provider wire formats.
+"""
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple
+
+from .config import VoiceCallConfig, is_e164, normalize_e164
+from .events import (
+    CallRecord,
+    CallState,
+    EventType,
+    NormalizedEvent,
+    TranscriptEntry,
+    is_valid_transition,
+    new_call_id,
+)
+from .providers.base import VoiceCallProvider
+from .store import CallStore
+
+logger = logging.getLogger(__name__)
+
+# A transcript callback receives the call and the final user utterance.
+TranscriptCallback = Callable[[CallRecord, str], Awaitable[None]]
+CallEndedCallback = Callable[[CallRecord], Awaitable[None]]
+
+_DEDUPE_CAP = 2048
+_ORPHAN_CAP = 256
+_ORPHAN_TTL_S = 300.0
+
+
+class CallNotFoundError(KeyError):
+    pass
+
+
+class CallManager:
+    def __init__(
+        self,
+        config: VoiceCallConfig,
+        provider: VoiceCallProvider,
+        store: CallStore,
+        on_final_transcript: Optional[TranscriptCallback] = None,
+        on_call_ended: Optional[CallEndedCallback] = None,
+    ):
+        self.config = config
+        self.provider = provider
+        self.store = store
+        self.on_final_transcript = on_final_transcript
+        self.on_call_ended = on_call_ended
+
+        self.active: Dict[str, CallRecord] = {}
+        self._by_provider_id: Dict[str, str] = {}
+        self._by_chat: Dict[str, str] = {}  # peer E.164 → most recent call_id
+        self._processed: "OrderedDict[str, float]" = OrderedDict()
+        self._waiters: Dict[str, asyncio.Future] = {}
+        self._timers: Dict[Tuple[str, str], asyncio.Task] = {}
+        # Events that arrived for an outbound call before initiate_call()
+        # returned the provider call id (webhook/initiate race).
+        self._orphans: "OrderedDict[str, List[NormalizedEvent]]" = OrderedDict()
+        self._orphan_seen: Dict[str, float] = {}
+
+    # -- lifecycle ----------------------------------------------------------
+
+    async def initialize(self, restore: bool = True) -> None:
+        """Restore persisted non-terminal calls, verifying each with the
+        provider: terminal → finalize, expired → hang up, unknown → keep."""
+        if not restore:
+            return
+        for record in self.store.load_active().values():
+            try:
+                status = await self.provider.get_call_status(record)
+            except Exception as e:  # noqa: BLE001 — transient carrier errors
+                logger.warning(
+                    "voice_call restore: status check failed for %s: %s",
+                    record.call_id, e,
+                )
+                status = None
+            if status is not None and status.is_terminal:
+                record.state = CallState.COMPLETED
+                record.ended_at = record.ended_at or time.time()
+                record.end_reason = record.end_reason or "completed-while-down"
+                self.store.append(record)
+                continue
+            elapsed = time.time() - record.started_at
+            if elapsed > self.config.timeouts.max_call_s:
+                try:
+                    await self.provider.hangup_call(record)
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "voice_call restore: hangup failed for %s", record.call_id,
+                        exc_info=True,
+                    )
+                record.state = CallState.TIMEOUT
+                record.ended_at = time.time()
+                record.end_reason = "max-duration"
+                self.store.append(record)
+                continue
+            self._register(record)
+            remaining = max(1.0, self.config.timeouts.max_call_s - elapsed)
+            self._arm_timer(record.call_id, "max", remaining, self._on_max_duration)
+            logger.info("voice_call restore: resumed call %s (%s)",
+                        record.call_id, record.state.value)
+
+    async def shutdown(self) -> None:
+        """Cancel timers and waiters. Calls stay alive at the carrier and are
+        re-verified by the next boot's restore pass."""
+        for task in list(self._timers.values()):
+            task.cancel()
+        self._timers.clear()
+        for fut in list(self._waiters.values()):
+            if not fut.done():
+                fut.cancel()
+        self._waiters.clear()
+
+    # -- lookups ------------------------------------------------------------
+
+    def get_call(self, call_id: str) -> Optional[CallRecord]:
+        return self.active.get(call_id)
+
+    def get_active_calls(self) -> List[CallRecord]:
+        return list(self.active.values())
+
+    def call_for_chat(self, chat_id: str) -> Optional[CallRecord]:
+        call_id = self._by_chat.get(normalize_e164(chat_id))
+        return self.active.get(call_id) if call_id else None
+
+    def _register(self, record: CallRecord) -> None:
+        self.active[record.call_id] = record
+        if record.provider_call_id:
+            self._by_provider_id[record.provider_call_id] = record.call_id
+        peer = record.peer_number
+        if peer:
+            self._by_chat[normalize_e164(peer)] = record.call_id
+
+    def _unregister(self, record: CallRecord) -> None:
+        self.active.pop(record.call_id, None)
+        if record.provider_call_id:
+            self._by_provider_id.pop(record.provider_call_id, None)
+        peer = normalize_e164(record.peer_number or "")
+        if peer and self._by_chat.get(peer) == record.call_id:
+            self._by_chat.pop(peer, None)
+
+    # -- persistence / transitions -------------------------------------------
+
+    def _persist(self, record: CallRecord) -> None:
+        try:
+            self.store.append(record)
+        except OSError:
+            logger.warning("voice_call: failed to persist call %s",
+                           record.call_id, exc_info=True)
+
+    def _transition(self, record: CallRecord, new_state: CallState) -> bool:
+        if not is_valid_transition(record.state, new_state):
+            logger.debug(
+                "voice_call: dropping invalid transition %s → %s for %s",
+                record.state.value, new_state.value, record.call_id,
+            )
+            return False
+        record.state = new_state
+        self._persist(record)
+        return True
+
+    def _session_key(self, record: CallRecord) -> str:
+        peer = normalize_e164(record.peer_number or "unknown")
+        if self.config.session_scope == "per-call":
+            return f"{peer}:{record.call_id}"
+        return peer
+
+    # -- timers ---------------------------------------------------------------
+
+    def _arm_timer(
+        self,
+        call_id: str,
+        kind: str,
+        delay: float,
+        callback: Callable[[str], Awaitable[None]],
+    ) -> None:
+        self._cancel_timer(call_id, kind)
+
+        async def _fire():
+            try:
+                await asyncio.sleep(delay)
+                self._timers.pop((call_id, kind), None)
+                await callback(call_id)
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # noqa: BLE001 — timers must never kill the loop
+                logger.exception("voice_call: %s timer failed for %s", kind, call_id)
+
+        self._timers[(call_id, kind)] = asyncio.get_running_loop().create_task(_fire())
+
+    def _cancel_timer(self, call_id: str, kind: str) -> None:
+        task = self._timers.pop((call_id, kind), None)
+        if task:
+            task.cancel()
+
+    def _cancel_all_timers(self, call_id: str) -> None:
+        for key in [k for k in self._timers if k[0] == call_id]:
+            self._timers.pop(key).cancel()
+
+    async def _on_ring_timeout(self, call_id: str) -> None:
+        record = self.active.get(call_id)
+        if record is None or record.state not in (CallState.INITIATED, CallState.RINGING):
+            return
+        logger.info("voice_call: ring timeout for %s", call_id)
+        try:
+            await self.provider.hangup_call(record)
+        except Exception:  # noqa: BLE001
+            logger.debug("voice_call: hangup after ring timeout failed", exc_info=True)
+        await self._finalize(record, CallState.NO_ANSWER, "ring-timeout")
+
+    async def _on_max_duration(self, call_id: str) -> None:
+        record = self.active.get(call_id)
+        if record is None:
+            return
+        logger.info("voice_call: max duration reached for %s", call_id)
+        try:
+            await self.provider.hangup_call(record)
+        except Exception:  # noqa: BLE001
+            logger.debug("voice_call: hangup at max duration failed", exc_info=True)
+        await self._finalize(record, CallState.TIMEOUT, "max-duration")
+
+    async def _on_silence_timeout(self, call_id: str) -> None:
+        record = self.active.get(call_id)
+        if record is None or record.is_terminal:
+            return
+        logger.info("voice_call: silence timeout for %s", call_id)
+        try:
+            await self.provider.hangup_call(record)
+        except Exception:  # noqa: BLE001
+            logger.debug("voice_call: hangup after silence failed", exc_info=True)
+        await self._finalize(record, CallState.TIMEOUT, "silence-timeout")
+
+    async def _on_notify_hangup(self, call_id: str) -> None:
+        record = self.active.get(call_id)
+        if record is None or record.is_terminal:
+            return
+        try:
+            await self.provider.hangup_call(record)
+        except Exception:  # noqa: BLE001
+            logger.debug("voice_call: notify hangup failed", exc_info=True)
+        await self._finalize(record, CallState.HANGUP_BOT, "notify-complete")
+
+    def _arm_silence_timer(self, record: CallRecord) -> None:
+        silence_s = self.config.timeouts.silence_s
+        if silence_s and record.mode == "conversation":
+            self._arm_timer(record.call_id, "silence", silence_s, self._on_silence_timeout)
+
+    # -- finalization ----------------------------------------------------------
+
+    async def _finalize(
+        self, record: CallRecord, state: CallState, reason: Optional[str]
+    ) -> None:
+        if record.is_terminal:
+            return
+        self._cancel_all_timers(record.call_id)
+        record.ended_at = time.time()
+        record.end_reason = reason
+        record.state = state
+        self._persist(record)
+        self._unregister(record)
+        waiter = self._waiters.pop(record.call_id, None)
+        if waiter and not waiter.done():
+            waiter.set_exception(
+                RuntimeError(f"call ended ({state.value}) while waiting for transcript")
+            )
+        if self.on_call_ended is not None:
+            try:
+                await self.on_call_ended(record)
+            except Exception:  # noqa: BLE001 — callbacks must not break teardown
+                logger.exception("voice_call: on_call_ended callback failed")
+
+    @staticmethod
+    def _terminal_state_for_reason(
+        reason: Optional[str], record: CallRecord
+    ) -> CallState:
+        lowered = (reason or "").lower()
+        answered = record.answered_at is not None
+        if "busy" in lowered:
+            return CallState.BUSY
+        if "voicemail" in lowered or "machine" in lowered:
+            return CallState.VOICEMAIL
+        if "no-answer" in lowered or "noanswer" in lowered:
+            return CallState.NO_ANSWER
+        if "timeout" in lowered:
+            return CallState.TIMEOUT if answered else CallState.NO_ANSWER
+        if "error" in lowered or "fail" in lowered:
+            return CallState.FAILED
+        if "hangup-bot" in lowered or "bot" in lowered:
+            return CallState.HANGUP_BOT
+        if "hangup" in lowered or "user" in lowered or "normal_clearing" in lowered:
+            return CallState.HANGUP_USER if answered else CallState.NO_ANSWER
+        return CallState.COMPLETED if answered else CallState.NO_ANSWER
+
+    # -- event processing -------------------------------------------------------
+
+    def _is_duplicate(self, event: NormalizedEvent) -> bool:
+        key = event.dedupe_key
+        if not key:
+            return False
+        now = time.time()
+        # Evict expired / overflow entries.
+        while self._processed and (
+            len(self._processed) > _DEDUPE_CAP
+            or next(iter(self._processed.values())) < now - 600
+        ):
+            self._processed.popitem(last=False)
+        if key in self._processed:
+            return True
+        self._processed[key] = now
+        return False
+
+    def _find_call(self, event: NormalizedEvent) -> Optional[CallRecord]:
+        if event.call_id and event.call_id in self.active:
+            return self.active[event.call_id]
+        if event.provider_call_id:
+            call_id = self._by_provider_id.get(event.provider_call_id)
+            if call_id:
+                return self.active.get(call_id)
+        return None
+
+    def _stash_orphan(self, event: NormalizedEvent) -> None:
+        pid = event.provider_call_id
+        if not pid:
+            return
+        now = time.time()
+        for key in [k for k, ts in self._orphan_seen.items() if ts < now - _ORPHAN_TTL_S]:
+            self._orphans.pop(key, None)
+            self._orphan_seen.pop(key, None)
+        while len(self._orphans) > _ORPHAN_CAP:
+            evicted, _ = self._orphans.popitem(last=False)
+            self._orphan_seen.pop(evicted, None)
+        self._orphans.setdefault(pid, []).append(event)
+        self._orphan_seen[pid] = now
+
+    async def _drain_orphans(self, provider_call_id: str) -> None:
+        events = self._orphans.pop(provider_call_id, None)
+        self._orphan_seen.pop(provider_call_id, None)
+        for event in events or []:
+            await self.process_event(event)
+
+    async def process_event(self, event: NormalizedEvent) -> None:
+        """Apply one normalized provider event to call state."""
+        if self._is_duplicate(event):
+            logger.debug("voice_call: duplicate event %s dropped", event.dedupe_key)
+            return
+
+        record = self._find_call(event)
+        if record is None:
+            if event.type == EventType.CALL_INITIATED and event.direction == "inbound":
+                record = await self._create_inbound(event)
+            else:
+                # Probably an outbound webhook racing initiate_call().
+                self._stash_orphan(event)
+                return
+        if record is None or record.is_terminal:
+            return
+
+        if event.type == EventType.CALL_INITIATED:
+            pass  # creation handled above; outbound initiated in initiate_call()
+        elif event.type == EventType.CALL_RINGING:
+            self._transition(record, CallState.RINGING)
+        elif event.type == EventType.CALL_ANSWERED:
+            await self._on_answered(record)
+        elif event.type == EventType.CALL_ACTIVE:
+            self._transition(record, CallState.ACTIVE)
+        elif event.type == EventType.CALL_SPEECH:
+            await self._on_speech(record, event)
+        elif event.type == EventType.CALL_DTMF:
+            if event.digits:
+                record.metadata.setdefault("dtmf_received", []).append(event.digits)
+                self._persist(record)
+        elif event.type == EventType.CALL_SILENCE:
+            pass  # the silence timer is authoritative
+        elif event.type == EventType.CALL_SPEAKING:
+            self._transition(record, CallState.SPEAKING)
+        elif event.type == EventType.CALL_ENDED:
+            await self._finalize(
+                record,
+                self._terminal_state_for_reason(event.reason, record),
+                event.reason or "ended",
+            )
+        elif event.type == EventType.CALL_ERROR:
+            if event.retryable:
+                logger.warning(
+                    "voice_call: retryable provider error on %s: %s",
+                    record.call_id, event.reason,
+                )
+            else:
+                await self._finalize(record, CallState.ERROR, event.reason or "error")
+
+    async def _create_inbound(self, event: NormalizedEvent) -> Optional[CallRecord]:
+        record = CallRecord(
+            call_id=event.call_id or new_call_id(),
+            provider=self.provider.name,
+            direction="inbound",
+            provider_call_id=event.provider_call_id,
+            from_number=event.from_number,
+            to_number=event.to_number,
+            mode="conversation",
+        )
+        record.session_key = self._session_key(record)
+        self._register(record)
+        self._persist(record)
+        self._arm_timer(
+            record.call_id, "max", self.config.timeouts.max_call_s, self._on_max_duration
+        )
+        try:
+            await self.provider.answer_call(record)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("voice_call: answer failed for inbound %s: %s",
+                           record.call_id, e)
+            await self._finalize(record, CallState.FAILED, "answer-failed")
+            return None
+        logger.info(
+            "voice_call: inbound call %s from %s", record.call_id, record.from_number
+        )
+        return record
+
+    async def _on_answered(self, record: CallRecord) -> None:
+        self._cancel_timer(record.call_id, "ring")
+        record.answered_at = record.answered_at or time.time()
+        if not self._transition(record, CallState.ANSWERED):
+            return
+        self._arm_timer(
+            record.call_id, "max", self.config.timeouts.max_call_s, self._on_max_duration
+        )
+
+        if record.direction == "outbound":
+            initial = record.metadata.pop("initial_message", None)
+            if initial:
+                await self.speak(record.call_id, str(initial))
+            if record.mode == "notify":
+                delay = max(0, self.config.outbound.notify_hangup_delay_s)
+                self._arm_timer(record.call_id, "notify", delay, self._on_notify_hangup)
+            else:
+                await self._start_listening(record)
+        else:
+            if self.config.inbound_greeting:
+                await self.speak(record.call_id, self.config.inbound_greeting)
+            await self._start_listening(record)
+
+    async def _start_listening(self, record: CallRecord) -> None:
+        try:
+            await self.provider.start_listening(record)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("voice_call: start_listening failed for %s: %s",
+                           record.call_id, e)
+        self._transition(record, CallState.LISTENING)
+        self._arm_silence_timer(record)
+
+    async def _on_speech(self, record: CallRecord, event: NormalizedEvent) -> None:
+        text = (event.text or "").strip()
+        if not text:
+            return
+        if not event.is_final:
+            return  # partial transcripts are realtime-phase territory
+        record.transcript.append(
+            TranscriptEntry(timestamp=event.timestamp, speaker="user", text=text)
+        )
+        self._persist(record)
+        self._arm_silence_timer(record)
+
+        waiter = self._waiters.pop(record.call_id, None)
+        if waiter is not None and not waiter.done():
+            waiter.set_result(text)
+            return
+        if self.on_final_transcript is not None and record.mode == "conversation":
+            asyncio.get_running_loop().create_task(
+                self._dispatch_transcript(record, text)
+            )
+
+    async def _dispatch_transcript(self, record: CallRecord, text: str) -> None:
+        try:
+            await self.on_final_transcript(record, text)
+        except Exception:  # noqa: BLE001 — agent failures must not kill the call
+            logger.exception("voice_call: transcript callback failed for %s",
+                             record.call_id)
+
+    # -- actions ------------------------------------------------------------------
+
+    async def initiate_call(
+        self,
+        to_number: str,
+        message: Optional[str] = None,
+        mode: Optional[str] = None,
+        from_number: Optional[str] = None,
+    ) -> CallRecord:
+        to_number = normalize_e164(to_number)
+        if not is_e164(to_number):
+            raise ValueError(f"to_number must be E.164, got {to_number!r}")
+        from_number = normalize_e164(from_number or self.config.from_number or "")
+        if not is_e164(from_number):
+            raise ValueError(
+                "no valid from_number (set from_number or VOICE_CALL_FROM_NUMBER)"
+            )
+        mode = mode or self.config.outbound.default_mode
+        if mode not in ("notify", "conversation"):
+            raise ValueError(f"mode must be notify|conversation, got {mode!r}")
+
+        record = CallRecord(
+            call_id=new_call_id(),
+            provider=self.provider.name,
+            direction="outbound",
+            from_number=from_number,
+            to_number=to_number,
+            mode=mode,  # type: ignore[arg-type]
+        )
+        record.session_key = self._session_key(record)
+        if message:
+            record.metadata["initial_message"] = message
+        self._register(record)
+        self._persist(record)
+        self._arm_timer(
+            record.call_id, "ring", self.config.timeouts.ring_s, self._on_ring_timeout
+        )
+        try:
+            provider_call_id = await self.provider.initiate_call(record)
+        except Exception as e:
+            logger.warning("voice_call: initiate failed: %s", e)
+            await self._finalize(record, CallState.FAILED, f"initiate-failed: {e}")
+            raise
+        record.provider_call_id = provider_call_id
+        self._by_provider_id[provider_call_id] = record.call_id
+        self._persist(record)
+        await self._drain_orphans(provider_call_id)
+        return record
+
+    def _require_call(self, call_id: str) -> CallRecord:
+        record = self.active.get(call_id)
+        if record is None:
+            raise CallNotFoundError(call_id)
+        return record
+
+    async def speak(self, call_id: str, text: str) -> None:
+        record = self._require_call(call_id)
+        was_listening = record.state == CallState.LISTENING
+        self._transition(record, CallState.SPEAKING)
+        await self.provider.speak(record, text)
+        record.transcript.append(
+            TranscriptEntry(timestamp=time.time(), speaker="bot", text=text)
+        )
+        self._persist(record)
+        if was_listening or record.mode == "conversation":
+            self._transition(record, CallState.LISTENING)
+            self._arm_silence_timer(record)
+
+    async def continue_call(self, call_id: str, text: str) -> str:
+        """Speak ``text`` and wait for the caller's next final utterance."""
+        record = self._require_call(call_id)
+        existing = self._waiters.get(call_id)
+        if existing is not None and not existing.done():
+            raise RuntimeError(f"already waiting for a reply on {call_id}")
+        await self.speak(call_id, text)
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._waiters[call_id] = fut
+        try:
+            return await asyncio.wait_for(
+                fut, timeout=self.config.timeouts.transcript_wait_s
+            )
+        finally:
+            if self._waiters.get(call_id) is fut:
+                self._waiters.pop(call_id, None)
+
+    async def send_dtmf(self, call_id: str, digits: str) -> None:
+        record = self._require_call(call_id)
+        await self.provider.send_dtmf(record, digits)
+        record.metadata.setdefault("dtmf_sent", []).append(digits)
+        self._persist(record)
+
+    async def end_call(self, call_id: str, reason: str = "hangup-bot") -> None:
+        record = self._require_call(call_id)
+        try:
+            await self.provider.hangup_call(record)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("voice_call: provider hangup failed for %s: %s", call_id, e)
+        await self._finalize(
+            record, self._terminal_state_for_reason(reason, record), reason
+        )

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -58,6 +58,12 @@ class CallManager:
         # Optional hook invoked before the provider dials/answers — the
         # realtime bridge uses it to attach stream metadata to the record.
         self.prepare_call: Optional[Callable[[CallRecord], None]] = None
+        # Optional hook for speaking on realtime-bridged calls: the model
+        # owns the audio there, so carrier TTS would talk over the stream.
+        # Set by the runtime; returns True when the bridge delivered it.
+        self.realtime_speaker: Optional[
+            Callable[[CallRecord, str], Awaitable[bool]]
+        ] = None
 
         self.active: Dict[str, CallRecord] = {}
         self._by_provider_id: Dict[str, str] = {}
@@ -148,6 +154,13 @@ class CallManager:
             )
         )
         self._persist(record)
+        # On realtime calls the carrier transcription is off, so this is the
+        # only place caller utterances surface — resolve continue_call
+        # waiters here just like _on_speech does for carrier transcripts.
+        if speaker != "bot":
+            waiter = self._waiters.pop(call_id, None)
+            if waiter is not None and not waiter.done():
+                waiter.set_result(text)
 
     def _realtime_owns_audio(self, record: CallRecord) -> bool:
         """True when a realtime bridge handles this call's audio — carrier
@@ -607,6 +620,16 @@ class CallManager:
 
     async def speak(self, call_id: str, text: str) -> None:
         record = self._require_call(call_id)
+        # Realtime calls: route through the bridge (the model speaks it);
+        # carrier TTS would talk over the media stream. The bridge mirrors
+        # the model's actual words into the transcript, so skip the append.
+        if self._realtime_owns_audio(record) and self.realtime_speaker is not None:
+            if await self.realtime_speaker(record, text):
+                return
+            logger.warning(
+                "voice_call: realtime delivery failed for %s; falling back "
+                "to carrier TTS", call_id,
+            )
         was_listening = record.state == CallState.LISTENING
         self._transition(record, CallState.SPEAKING)
         await self.provider.speak(record, text)

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -630,6 +630,12 @@ class CallManager:
                 "voice_call: realtime delivery failed for %s; falling back "
                 "to carrier TTS", call_id,
             )
+        # Speaking again on a notify call: hold the auto-hangup while the
+        # new message plays, then re-arm it (notify semantics: hang up a
+        # few seconds after the LAST message).
+        is_notify = record.mode == "notify"
+        if is_notify:
+            self._cancel_timer(call_id, "notify")
         was_listening = record.state == CallState.LISTENING
         self._transition(record, CallState.SPEAKING)
         await self.provider.speak(record, text)
@@ -640,13 +646,40 @@ class CallManager:
         if was_listening or record.mode == "conversation":
             self._transition(record, CallState.LISTENING)
             self._arm_silence_timer(record)
+        elif is_notify and record.answered_at:
+            self._arm_timer(
+                call_id, "notify",
+                max(0, self.config.outbound.notify_hangup_delay_s),
+                self._on_notify_hangup,
+            )
 
     async def continue_call(self, call_id: str, text: str) -> str:
-        """Speak ``text`` and wait for the caller's next final utterance."""
-        self._require_call(call_id)
+        """Speak ``text`` and wait for the caller's next final utterance.
+
+        On a notify call this upgrades the call to a conversation: the
+        auto-hangup is cancelled and carrier transcription starts, so the
+        caller's reply can come back.
+        """
+        record = self._require_call(call_id)
         existing = self._waiters.get(call_id)
         if existing is not None and not existing.done():
             raise RuntimeError(f"already waiting for a reply on {call_id}")
+        if record.mode == "notify":
+            logger.info(
+                "voice_call: continue_call upgrades notify call %s to "
+                "conversation", call_id,
+            )
+            self._cancel_timer(call_id, "notify")
+            record.mode = "conversation"
+            self._persist(record)
+            if not self._realtime_owns_audio(record):
+                try:
+                    await self.provider.start_listening(record)
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        "voice_call: start_listening failed during notify "
+                        "upgrade of %s: %s", call_id, e,
+                    )
         await self.speak(call_id, text)
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._waiters[call_id] = fut

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -587,6 +587,16 @@ class CallManager:
                 "playback on %s: %.80r", record.call_id, text,
             )
             return
+        if self._realtime_owns_audio(record):
+            # The realtime model converses directly; its bridge mirrors
+            # transcripts via append_transcript. A stray carrier transcript
+            # here (transcription left running across an upgrade) must not
+            # spawn a SECOND responder — that's two voices answering.
+            logger.info(
+                "voice_call: ignoring carrier transcript on realtime call "
+                "%s: %.80r", record.call_id, text,
+            )
+            return
         record.transcript.append(
             TranscriptEntry(timestamp=event.timestamp, speaker="user", text=text)
         )
@@ -676,15 +686,17 @@ class CallManager:
 
     async def speak(self, call_id: str, text: str) -> None:
         record = self._require_call(call_id)
-        # Realtime calls: route through the bridge (the model speaks it);
-        # carrier TTS would talk over the media stream. The bridge mirrors
-        # the model's actual words into the transcript, so skip the append.
-        if self._realtime_owns_audio(record) and self.realtime_speaker is not None:
-            if await self.realtime_speaker(record, text):
+        # INVARIANT: once the realtime model owns a call's audio, carrier
+        # TTS must NEVER fire on it — two voices talking over each other is
+        # worse than a dropped message. No fallback.
+        if self._realtime_owns_audio(record):
+            if self.realtime_speaker is not None and await self.realtime_speaker(
+                record, text
+            ):
                 return
-            logger.warning(
-                "voice_call: realtime delivery failed for %s; falling back "
-                "to carrier TTS", call_id,
+            raise RuntimeError(
+                f"realtime bridge could not deliver to {call_id} — "
+                "not falling back to carrier TTS over the media stream"
             )
         # Speaking again on a notify call: hold the auto-hangup while the
         # new message plays, then re-arm it (notify semantics: hang up a
@@ -739,7 +751,18 @@ class CallManager:
                         logger.exception(
                             "voice_call: realtime upgrade hook failed"
                         )
-                if not upgraded:
+                if upgraded:
+                    # Make sure carrier transcription is OFF — the bridge's
+                    # transcripts are authoritative now, and a second
+                    # transcript source means a second responder.
+                    try:
+                        await self.provider.stop_listening(record)
+                    except Exception:  # noqa: BLE001
+                        logger.debug(
+                            "voice_call: stop_listening after realtime "
+                            "upgrade failed", exc_info=True,
+                        )
+                else:
                     try:
                         await self.provider.start_listening(record)
                     except Exception as e:  # noqa: BLE001

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -355,7 +355,14 @@ class CallManager:
 
         record = self._find_call(event)
         if record is None:
-            if event.type == EventType.CALL_INITIATED and event.direction == "inbound":
+            # Carriers differ in the first inbound webhook they send
+            # (Telnyx: call.initiated, Twilio: ringing, Plivo: answered via
+            # StartApp) — auto-register on any of them.
+            if event.direction == "inbound" and event.type in (
+                EventType.CALL_INITIATED,
+                EventType.CALL_RINGING,
+                EventType.CALL_ANSWERED,
+            ):
                 record = await self._create_inbound(event)
             else:
                 # Probably an outbound webhook racing initiate_call().
@@ -363,6 +370,20 @@ class CallManager:
                 return
         if record is None or record.is_terminal:
             return
+
+        # Some carriers swap identifiers mid-call (Plivo: dial returns a
+        # request_uuid, webhooks then carry the real CallUUID). When the
+        # event matched via our call_id, adopt the newer carrier id so call
+        # control (speak/hangup) targets the right resource.
+        if (
+            event.provider_call_id
+            and event.provider_call_id != record.provider_call_id
+        ):
+            if record.provider_call_id:
+                self._by_provider_id.pop(record.provider_call_id, None)
+            record.provider_call_id = event.provider_call_id
+            self._by_provider_id[event.provider_call_id] = record.call_id
+            self._persist(record)
 
         if event.type == EventType.CALL_INITIATED:
             pass  # creation handled above; outbound initiated in initiate_call()

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -627,6 +627,7 @@ class CallManager:
         message: Optional[str] = None,
         mode: Optional[str] = None,
         from_number: Optional[str] = None,
+        instructions: Optional[str] = None,
     ) -> CallRecord:
         to_number = normalize_e164(to_number or self.config.to_number or "")
         if not to_number:
@@ -656,6 +657,11 @@ class CallManager:
         record.session_key = self._session_key(record)
         if message:
             record.metadata["initial_message"] = message
+        if instructions:
+            # Per-call brief for the realtime voice (script, persona,
+            # questions) — merged into the session instructions by the
+            # bridge so the model conducts the whole call itself.
+            record.metadata["realtime_instructions"] = str(instructions)
         self._register(record)
         if self.prepare_call is not None:
             try:

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -70,6 +70,15 @@ class CallManager:
         self._by_chat: Dict[str, str] = {}  # peer E.164 → most recent call_id
         self._processed: "OrderedDict[str, float]" = OrderedDict()
         self._waiters: Dict[str, asyncio.Future] = {}
+        # Speak-playback tracking (carrier call.speak.ended events): lets
+        # continue_call wait until its question finished playing before
+        # listening for the reply.
+        self._speak_ended_at: Dict[str, float] = {}
+        self._speak_done_waiters: Dict[str, asyncio.Future] = {}
+        # Calls whose caller speech should be discarded right now (e.g. the
+        # caller reacting to the previous message while the continue_call
+        # question is still playing — that's not the answer).
+        self._drop_speech: set = set()
         self._timers: Dict[Tuple[str, str], asyncio.Task] = {}
         # Events that arrived for an outbound call before initiate_call()
         # returned the provider call id (webhook/initiate race).
@@ -128,6 +137,11 @@ class CallManager:
             if not fut.done():
                 fut.cancel()
         self._waiters.clear()
+        for fut in list(self._speak_done_waiters.values()):
+            if not fut.done():
+                fut.cancel()
+        self._speak_done_waiters.clear()
+        self._drop_speech.clear()
 
     # -- lookups ------------------------------------------------------------
 
@@ -307,6 +321,11 @@ class CallManager:
             waiter.set_exception(
                 RuntimeError(f"call ended ({state.value}) while waiting for transcript")
             )
+        self._drop_speech.discard(record.call_id)
+        self._speak_ended_at.pop(record.call_id, None)
+        speak_waiter = self._speak_done_waiters.pop(record.call_id, None)
+        if speak_waiter is not None and not speak_waiter.done():
+            speak_waiter.cancel()
         if self.on_call_ended is not None:
             try:
                 await self.on_call_ended(record)
@@ -438,6 +457,11 @@ class CallManager:
             pass  # the silence timer is authoritative
         elif event.type == EventType.CALL_SPEAKING:
             self._transition(record, CallState.SPEAKING)
+        elif event.type == EventType.CALL_SPEAK_ENDED:
+            self._speak_ended_at[record.call_id] = time.time()
+            waiter = self._speak_done_waiters.pop(record.call_id, None)
+            if waiter is not None and not waiter.done():
+                waiter.set_result(True)
         elif event.type == EventType.CALL_ENDED:
             await self._finalize(
                 record,
@@ -531,6 +555,15 @@ class CallManager:
             return
         if not event.is_final:
             return  # partial transcripts are realtime-phase territory
+        if record.call_id in self._drop_speech:
+            # continue_call's question is still playing — the caller is
+            # reacting to the PREVIOUS message ("thanks", "okay"), not
+            # answering the question that hasn't finished yet.
+            logger.info(
+                "voice_call: discarding caller speech during question "
+                "playback on %s: %.80r", record.call_id, text,
+            )
+            return
         record.transcript.append(
             TranscriptEntry(timestamp=event.timestamp, speaker="user", text=text)
         )
@@ -680,7 +713,21 @@ class CallManager:
                         "voice_call: start_listening failed during notify "
                         "upgrade of %s: %s", call_id, e,
                     )
-        await self.speak(call_id, text)
+
+        realtime = self._realtime_owns_audio(record)
+        spoke_at = time.time()
+        if not realtime:
+            # Anything the caller says while our question is still playing
+            # is a reaction to the PREVIOUS message, not the answer —
+            # discard it until playback completes.
+            self._drop_speech.add(call_id)
+        try:
+            await self.speak(call_id, text)
+            if not realtime:
+                await self._wait_speak_done(call_id, spoke_at, text)
+        finally:
+            self._drop_speech.discard(call_id)
+
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._waiters[call_id] = fut
         try:
@@ -690,6 +737,28 @@ class CallManager:
         finally:
             if self._waiters.get(call_id) is fut:
                 self._waiters.pop(call_id, None)
+
+    async def _wait_speak_done(
+        self, call_id: str, spoke_at: float, text: str
+    ) -> None:
+        """Block until the carrier reports our TTS finished playing
+        (call.speak.ended), or a duration estimate elapses for carriers
+        that don't send one."""
+        if self._speak_ended_at.get(call_id, 0.0) >= spoke_at:
+            return  # already finished (short text / fast event)
+        estimate = min(30.0, 2.0 + 0.08 * len(text))
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._speak_done_waiters[call_id] = fut
+        try:
+            await asyncio.wait_for(fut, timeout=estimate)
+        except asyncio.TimeoutError:
+            logger.debug(
+                "voice_call: no speak.ended within %.1fs for %s — proceeding",
+                estimate, call_id,
+            )
+        finally:
+            if self._speak_done_waiters.get(call_id) is fut:
+                self._speak_done_waiters.pop(call_id, None)
 
     async def send_dtmf(self, call_id: str, digits: str) -> None:
         record = self._require_call(call_id)

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -544,12 +544,17 @@ class CallManager:
 
     async def initiate_call(
         self,
-        to_number: str,
+        to_number: Optional[str] = None,
         message: Optional[str] = None,
         mode: Optional[str] = None,
         from_number: Optional[str] = None,
     ) -> CallRecord:
-        to_number = normalize_e164(to_number)
+        to_number = normalize_e164(to_number or self.config.to_number or "")
+        if not to_number:
+            raise ValueError(
+                "no destination number (pass to_number or set to_number / "
+                "VOICE_CALL_TO_NUMBER in config)"
+            )
         if not is_e164(to_number):
             raise ValueError(f"to_number must be E.164, got {to_number!r}")
         from_number = normalize_e164(from_number or self.config.from_number or "")

--- a/plugins/platforms/voice_call/manager.py
+++ b/plugins/platforms/voice_call/manager.py
@@ -55,6 +55,9 @@ class CallManager:
         self.store = store
         self.on_final_transcript = on_final_transcript
         self.on_call_ended = on_call_ended
+        # Optional hook invoked before the provider dials/answers — the
+        # realtime bridge uses it to attach stream metadata to the record.
+        self.prepare_call: Optional[Callable[[CallRecord], None]] = None
 
         self.active: Dict[str, CallRecord] = {}
         self._by_provider_id: Dict[str, str] = {}
@@ -131,6 +134,25 @@ class CallManager:
     def call_for_chat(self, chat_id: str) -> Optional[CallRecord]:
         call_id = self._by_chat.get(normalize_e164(chat_id))
         return self.active.get(call_id) if call_id else None
+
+    def append_transcript(self, call_id: str, speaker: str, text: str) -> None:
+        """Record a transcript line from an external source (realtime bridge)."""
+        record = self.active.get(call_id)
+        if record is None:
+            return
+        record.transcript.append(
+            TranscriptEntry(
+                timestamp=time.time(),
+                speaker="bot" if speaker == "bot" else "user",
+                text=text,
+            )
+        )
+        self._persist(record)
+
+    def _realtime_owns_audio(self, record: CallRecord) -> bool:
+        """True when a realtime bridge handles this call's audio — carrier
+        TTS/transcription would talk over the model."""
+        return bool(record.metadata.get("realtime"))
 
     def _register(self, record: CallRecord) -> None:
         self.active[record.call_id] = record
@@ -430,6 +452,11 @@ class CallManager:
         )
         record.session_key = self._session_key(record)
         self._register(record)
+        if self.prepare_call is not None:
+            try:
+                self.prepare_call(record)
+            except Exception:  # noqa: BLE001
+                logger.exception("voice_call: prepare_call hook failed")
         self._persist(record)
         self._arm_timer(
             record.call_id, "max", self.config.timeouts.max_call_s, self._on_max_duration
@@ -454,6 +481,13 @@ class CallManager:
         self._arm_timer(
             record.call_id, "max", self.config.timeouts.max_call_s, self._on_max_duration
         )
+
+        if self._realtime_owns_audio(record):
+            # The realtime bridge speaks the greeting/initial message and
+            # consumes the caller's audio directly; carrier TTS or
+            # transcription here would talk over the model.
+            self._transition(record, CallState.LISTENING)
+            return
 
         if record.direction == "outbound":
             initial = record.metadata.pop("initial_message", None)
@@ -539,6 +573,11 @@ class CallManager:
         if message:
             record.metadata["initial_message"] = message
         self._register(record)
+        if self.prepare_call is not None:
+            try:
+                self.prepare_call(record)
+            except Exception:  # noqa: BLE001
+                logger.exception("voice_call: prepare_call hook failed")
         self._persist(record)
         self._arm_timer(
             record.call_id, "ring", self.config.timeouts.ring_s, self._on_ring_timeout
@@ -576,7 +615,7 @@ class CallManager:
 
     async def continue_call(self, call_id: str, text: str) -> str:
         """Speak ``text`` and wait for the caller's next final utterance."""
-        record = self._require_call(call_id)
+        self._require_call(call_id)
         existing = self._waiters.get(call_id)
         if existing is not None and not existing.done():
             raise RuntimeError(f"already waiting for a reply on {call_id}")

--- a/plugins/platforms/voice_call/plugin.yaml
+++ b/plugins/platforms/voice_call/plugin.yaml
@@ -1,0 +1,65 @@
+name: voice_call
+label: Voice Calls
+kind: platform
+version: 0.1.0
+description: >
+  Phone voice-call gateway platform for Hermes Agent. Makes and receives
+  real PSTN calls through carrier APIs — Telnyx (default), Twilio, Plivo,
+  or a credential-free mock provider for development. Runs an always-on
+  webhook server for the gateway's lifetime so inbound calls can arrive
+  any time, with per-provider webhook signature verification, an inbound
+  caller allowlist, and optional ngrok/Tailscale exposure. Ported from
+  OpenClaw's voice-call extension.
+author: rudra-telnyx
+platforms: [linux, macos]
+provides_tools:
+  - voice_call
+# ``requires_env`` / ``optional_env`` are surfaced in the ``hermes config``
+# UI. Credentials are provider-dependent, so nothing is globally required;
+# validate_config enforces the right set for the selected provider.
+requires_env: []
+optional_env:
+  - name: TELNYX_API_KEY
+    description: "Telnyx API key (default provider)"
+    prompt: "Telnyx API key"
+    password: true
+  - name: TELNYX_CONNECTION_ID
+    description: "Telnyx Call Control connection ID"
+    prompt: "Telnyx connection ID"
+    password: false
+  - name: TELNYX_PUBLIC_KEY
+    description: "Telnyx Ed25519 public key for webhook signature verification"
+    prompt: "Telnyx public key"
+    password: false
+  - name: TWILIO_ACCOUNT_SID
+    description: "Twilio account SID"
+    prompt: "Twilio account SID"
+    password: false
+  - name: TWILIO_AUTH_TOKEN
+    description: "Twilio auth token"
+    prompt: "Twilio auth token"
+    password: true
+  - name: PLIVO_AUTH_ID
+    description: "Plivo auth ID"
+    prompt: "Plivo auth ID"
+    password: false
+  - name: PLIVO_AUTH_TOKEN
+    description: "Plivo auth token"
+    prompt: "Plivo auth token"
+    password: true
+  - name: VOICE_CALL_FROM_NUMBER
+    description: "E.164 caller ID for outbound calls (e.g. +15555550000)"
+    prompt: "Outbound from number"
+    password: false
+  - name: VOICE_CALL_ALLOWED_NUMBERS
+    description: "Comma-separated E.164 numbers allowed to call in (allowlist)"
+    prompt: "Allowed inbound numbers (comma-separated)"
+    password: false
+  - name: VOICE_CALL_HOME_NUMBER
+    description: "Default number for cron / notification call delivery"
+    prompt: "Home number (or empty)"
+    password: false
+  - name: NGROK_AUTHTOKEN
+    description: "ngrok auth token (only with tunnel.provider: ngrok)"
+    prompt: "ngrok auth token (or empty)"
+    password: true

--- a/plugins/platforms/voice_call/providers/__init__.py
+++ b/plugins/platforms/voice_call/providers/__init__.py
@@ -1,0 +1,63 @@
+"""Provider registry/factory for the voice_call platform."""
+
+from typing import Callable, Dict
+
+from ..config import VoiceCallConfig
+from .base import (
+    CallStatusResult,
+    VoiceCallProvider,
+    WebhookContext,
+    WebhookParseResult,
+    WebhookVerificationResult,
+)
+
+
+def _mock_factory(config: VoiceCallConfig) -> VoiceCallProvider:
+    from .mock import MockProvider
+
+    return MockProvider(config)
+
+
+def _telnyx_factory(config: VoiceCallConfig) -> VoiceCallProvider:
+    from .telnyx import TelnyxProvider
+
+    return TelnyxProvider(config)
+
+
+def _twilio_factory(config: VoiceCallConfig) -> VoiceCallProvider:
+    from .twilio import TwilioProvider
+
+    return TwilioProvider(config)
+
+
+def _plivo_factory(config: VoiceCallConfig) -> VoiceCallProvider:
+    from .plivo import PlivoProvider
+
+    return PlivoProvider(config)
+
+
+PROVIDER_FACTORIES: Dict[str, Callable[[VoiceCallConfig], VoiceCallProvider]] = {
+    "mock": _mock_factory,
+    "telnyx": _telnyx_factory,
+    "twilio": _twilio_factory,
+    "plivo": _plivo_factory,
+}
+
+
+def create_provider(config: VoiceCallConfig) -> VoiceCallProvider:
+    """Instantiate the configured provider (imports lazily per provider)."""
+    factory = PROVIDER_FACTORIES.get(config.provider)
+    if factory is None:
+        raise ValueError(f"unknown voice_call provider: {config.provider!r}")
+    return factory(config)
+
+
+__all__ = [
+    "CallStatusResult",
+    "PROVIDER_FACTORIES",
+    "VoiceCallProvider",
+    "WebhookContext",
+    "WebhookParseResult",
+    "WebhookVerificationResult",
+    "create_provider",
+]

--- a/plugins/platforms/voice_call/providers/_http.py
+++ b/plugins/platforms/voice_call/providers/_http.py
@@ -1,0 +1,85 @@
+"""Guarded JSON HTTP client shared by the real call providers.
+
+Port of OpenClaw's guarded-json-api: every request is pinned to the
+provider's fixed API hostname (no config-driven base URLs that could
+exfiltrate credentials), bounded in time and size, and errors never echo
+credentials back into logs.
+"""
+
+import json
+import logging
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_S = 15.0
+_MAX_RESPONSE_BYTES = 1_000_000
+
+
+class ProviderApiError(RuntimeError):
+    def __init__(self, message: str, status: Optional[int] = None):
+        super().__init__(message)
+        self.status = status
+
+
+async def guarded_json_request(
+    method: str,
+    url: str,
+    *,
+    allowed_host: str,
+    headers: Optional[Dict[str, str]] = None,
+    json_body: Optional[Dict[str, Any]] = None,
+    auth: Optional[tuple] = None,
+    form_body: Optional[Dict[str, Any]] = None,
+    allow_not_found: bool = False,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    error_prefix: str = "provider API error",
+) -> Optional[Dict[str, Any]]:
+    """POST/GET JSON to a pinned provider host.
+
+    Returns the parsed JSON object ({} for empty bodies), or ``None`` for a
+    404 when ``allow_not_found`` is set. Raises :class:`ProviderApiError`
+    otherwise.
+    """
+    host = urlparse(url).hostname or ""
+    if host.lower() != allowed_host.lower():
+        raise ProviderApiError(
+            f"{error_prefix}: refusing request to host {host!r} "
+            f"(allowed: {allowed_host})"
+        )
+
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout_s) as client:
+            response = await client.request(
+                method,
+                url,
+                headers=headers,
+                json=json_body,
+                data=form_body,
+                auth=auth,
+            )
+    except httpx.HTTPError as e:
+        raise ProviderApiError(f"{error_prefix}: {type(e).__name__}: {e}") from e
+
+    if response.status_code == 404 and allow_not_found:
+        return None
+    if response.status_code >= 400:
+        # Bounded body excerpt; carrier error payloads are not secret but
+        # keep them short to avoid log spam.
+        excerpt = response.text[:300]
+        raise ProviderApiError(
+            f"{error_prefix}: HTTP {response.status_code}: {excerpt}",
+            status=response.status_code,
+        )
+
+    content = response.content[:_MAX_RESPONSE_BYTES]
+    if not content.strip():
+        return {}
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as e:
+        raise ProviderApiError(f"{error_prefix}: invalid JSON response") from e
+    return data if isinstance(data, dict) else {"data": data}

--- a/plugins/platforms/voice_call/providers/base.py
+++ b/plugins/platforms/voice_call/providers/base.py
@@ -144,6 +144,18 @@ class VoiceCallProvider(abc.ABC):
         """
         return {}
 
+    # True when the carrier can attach a media stream to an ALREADY LIVE
+    # call (Telnyx streaming_start) — enables notify → realtime upgrades.
+    supports_midcall_streaming: bool = False
+
+    async def start_media_stream(
+        self, call: CallRecord, stream_url: str, auth_token: str
+    ) -> None:
+        """Attach a media stream to a live call (mid-call realtime upgrade)."""
+        raise NotImplementedError(
+            f"{self.name} cannot attach a media stream mid-call"
+        )
+
     def finalize_response(
         self, ctx: WebhookContext, result: WebhookParseResult
     ) -> WebhookParseResult:

--- a/plugins/platforms/voice_call/providers/base.py
+++ b/plugins/platforms/voice_call/providers/base.py
@@ -1,0 +1,145 @@
+"""Provider abstraction for the voice_call platform.
+
+Everything carrier-specific lives behind :class:`VoiceCallProvider`:
+API clients, webhook signature verification, wire-format parsing into
+``NormalizedEvent``, speak/TTS, transcription control, and (for carriers
+that support media streams) realtime streaming field construction.
+
+The call manager and webhook server consume only this interface.
+"""
+
+import abc
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from ..config import VoiceCallConfig
+from ..events import CallRecord, NormalizedEvent
+
+
+@dataclass
+class WebhookContext:
+    """One inbound HTTP request to the webhook server, provider-agnostic."""
+
+    method: str
+    path: str
+    body: bytes
+    headers: Dict[str, str] = field(default_factory=dict)
+    query: Dict[str, str] = field(default_factory=dict)
+    remote_ip: str = ""
+    # Full external URL as the carrier signed it (public URL + path),
+    # needed by HMAC schemes that sign the URL (Twilio).
+    url: str = ""
+
+    def header(self, name: str) -> Optional[str]:
+        """Case-insensitive header lookup."""
+        lowered = name.lower()
+        for key, value in self.headers.items():
+            if key.lower() == lowered:
+                return value
+        return None
+
+
+@dataclass
+class WebhookVerificationResult:
+    ok: bool
+    error: Optional[str] = None
+    # Provider-derived replay/dedupe key (e.g. Plivo nonce, Telnyx
+    # signature+timestamp). Falls back to a body hash in the server.
+    dedupe_key: Optional[str] = None
+
+
+@dataclass
+class WebhookParseResult:
+    """Normalized events plus the HTTP response the carrier expects."""
+
+    events: List[NormalizedEvent] = field(default_factory=list)
+    response_status: int = 200
+    response_body: str = ""
+    response_content_type: str = "application/json"
+
+
+@dataclass
+class CallStatusResult:
+    """Result of asking the carrier about a call (used by boot restore)."""
+
+    is_active: bool = False
+    is_terminal: bool = False
+    # True when the carrier could not answer (transient error) — keep the
+    # call and rely on timers rather than guessing.
+    is_unknown: bool = False
+    raw_status: Optional[str] = None
+
+
+class VoiceCallProvider(abc.ABC):
+    """Base interface every call provider implements.
+
+    Methods that not all carriers support (``send_dtmf``,
+    ``start_listening``/``stop_listening``, ``answer_call``) have safe
+    default implementations.
+    """
+
+    name: str = ""
+    requires_public_webhook: bool = True
+
+    def __init__(self, config: VoiceCallConfig):
+        self.config = config
+        self.public_url: Optional[str] = None
+
+    def set_public_url(self, url: str) -> None:
+        self.public_url = url.rstrip("/")
+
+    @property
+    def webhook_url(self) -> Optional[str]:
+        if not self.public_url:
+            return None
+        return f"{self.public_url}{self.config.serve.path}"
+
+    # -- webhook ----------------------------------------------------------
+
+    @abc.abstractmethod
+    def verify_webhook(self, ctx: WebhookContext) -> WebhookVerificationResult:
+        """Verify the request really came from the carrier."""
+
+    @abc.abstractmethod
+    def parse_webhook(self, ctx: WebhookContext) -> WebhookParseResult:
+        """Parse a verified request into normalized events + HTTP response."""
+
+    # -- call control ------------------------------------------------------
+
+    @abc.abstractmethod
+    async def initiate_call(self, call: CallRecord) -> str:
+        """Start an outbound call; return the carrier's call id."""
+
+    async def answer_call(self, call: CallRecord) -> None:
+        """Answer an inbound call (carriers like Telnyx require an explicit
+        answer command; webhook-response carriers answer implicitly)."""
+
+    @abc.abstractmethod
+    async def hangup_call(self, call: CallRecord) -> None:
+        """Terminate the call at the carrier."""
+
+    @abc.abstractmethod
+    async def speak(self, call: CallRecord, text: str) -> None:
+        """Speak ``text`` to the remote party using carrier-native TTS."""
+
+    async def send_dtmf(self, call: CallRecord, digits: str) -> None:
+        raise NotImplementedError(f"{self.name} does not support DTMF")
+
+    async def start_listening(self, call: CallRecord) -> None:
+        """Start carrier-native transcription of the remote party."""
+
+    async def stop_listening(self, call: CallRecord) -> None:
+        """Stop carrier-native transcription."""
+
+    @abc.abstractmethod
+    async def get_call_status(self, call: CallRecord) -> CallStatusResult:
+        """Ask the carrier whether a call is still alive (boot restore)."""
+
+    # -- realtime media streams (P7) ----------------------------------------
+
+    def streaming_fields(self, stream_url: str, auth_token: str) -> Dict[str, Any]:
+        """Provider-specific dial/answer fields that attach a media stream.
+
+        Returns ``{}`` for carriers without media-stream support.
+        """
+        return {}

--- a/plugins/platforms/voice_call/providers/base.py
+++ b/plugins/platforms/voice_call/providers/base.py
@@ -143,3 +143,12 @@ class VoiceCallProvider(abc.ABC):
         Returns ``{}`` for carriers without media-stream support.
         """
         return {}
+
+    def finalize_response(
+        self, ctx: WebhookContext, result: WebhookParseResult
+    ) -> WebhookParseResult:
+        """Hook called after the webhook's events were processed, letting a
+        provider rewrite the HTTP response based on state created during
+        processing (Twilio uses this to serve ``<Connect><Stream>`` TwiML
+        for freshly-registered realtime calls). Default: unchanged."""
+        return result

--- a/plugins/platforms/voice_call/providers/mock.py
+++ b/plugins/platforms/voice_call/providers/mock.py
@@ -160,6 +160,17 @@ class MockProvider(VoiceCallProvider):
 
     async def speak(self, call: CallRecord, text: str) -> None:
         self.spoken.append((call.provider_call_id, text))
+        # Like a real carrier, report playback completion asynchronously.
+        if self.event_sink is not None:
+            async def _speak_ended(pid=call.provider_call_id, cid=call.call_id):
+                await asyncio.sleep(0.02)
+                sink = self.event_sink
+                if sink is not None and pid not in self._terminal:
+                    await sink(NormalizedEvent(
+                        type=EventType.CALL_SPEAK_ENDED, provider=self.name,
+                        provider_call_id=pid, call_id=cid,
+                    ))
+            asyncio.get_running_loop().create_task(_speak_ended())
 
     async def send_dtmf(self, call: CallRecord, digits: str) -> None:
         self.dtmf_sent.append((call.provider_call_id, digits))

--- a/plugins/platforms/voice_call/providers/mock.py
+++ b/plugins/platforms/voice_call/providers/mock.py
@@ -1,0 +1,178 @@
+"""Credential-free mock provider for development and tests.
+
+Behaves like a well-behaved carrier without any network access:
+
+- ``initiate_call`` returns a synthetic provider call id and (by default)
+  pushes ``call.ringing`` → ``call.answered`` → ``call.active`` events
+  through the runtime's event sink, like a real carrier webhook would.
+- The webhook endpoint accepts pre-normalized JSON events —
+  ``{"event": {...}}`` or ``{"events": [...]}`` — so inbound calls and
+  caller speech can be simulated with curl.
+- ``speak`` records what the bot said for assertions.
+
+No signature verification (there is no carrier to verify against) and no
+public webhook requirement.
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import Awaitable, Callable, List, Optional
+
+from ..config import VoiceCallConfig
+from ..events import CallRecord, EventType, NormalizedEvent
+from .base import (
+    CallStatusResult,
+    VoiceCallProvider,
+    WebhookContext,
+    WebhookParseResult,
+    WebhookVerificationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+EventSink = Callable[[NormalizedEvent], Awaitable[None]]
+
+
+def _parse_event_dict(data: dict) -> Optional[NormalizedEvent]:
+    """Build a NormalizedEvent from a JSON dict; None when type is unknown."""
+    try:
+        event_type = EventType(str(data.get("type", "")))
+    except ValueError:
+        return None
+    direction = data.get("direction")
+    if direction not in ("inbound", "outbound"):
+        direction = None
+    return NormalizedEvent(
+        type=event_type,
+        provider="mock",
+        provider_call_id=data.get("provider_call_id"),
+        call_id=data.get("call_id"),
+        from_number=data.get("from") or data.get("from_number"),
+        to_number=data.get("to") or data.get("to_number"),
+        direction=direction,
+        text=data.get("text"),
+        is_final=bool(data.get("is_final", True)),
+        digits=data.get("digits"),
+        reason=data.get("reason"),
+        retryable=bool(data.get("retryable", False)),
+        dedupe_key=data.get("dedupe_key") or data.get("event_id"),
+        raw=data,
+    )
+
+
+class MockProvider(VoiceCallProvider):
+    name = "mock"
+    requires_public_webhook = False
+
+    def __init__(self, config: VoiceCallConfig):
+        super().__init__(config)
+        extra = config.provider_extra.get("mock", {})
+        # Auto-advance outbound calls to answered unless disabled (tests
+        # that exercise ring timeouts turn this off).
+        self.auto_answer: bool = bool(extra.get("auto_answer", True))
+        self.fail_initiate: bool = bool(extra.get("fail_initiate", False))
+        self.event_sink: Optional[EventSink] = None
+        # Observability for tests.
+        self.spoken: List[tuple] = []          # (provider_call_id, text)
+        self.hangups: List[str] = []           # provider_call_id
+        self.dtmf_sent: List[tuple] = []       # (provider_call_id, digits)
+        self.listening: List[str] = []         # provider_call_id currently listening
+        self.answered: List[str] = []          # provider_call_id
+        self._terminal: set = set()
+
+    # -- webhook ----------------------------------------------------------
+
+    def verify_webhook(self, ctx: WebhookContext) -> WebhookVerificationResult:
+        return WebhookVerificationResult(ok=True)
+
+    def parse_webhook(self, ctx: WebhookContext) -> WebhookParseResult:
+        try:
+            data = json.loads(ctx.body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return WebhookParseResult(
+                response_status=400, response_body='{"error": "invalid json"}'
+            )
+        raw_events = data.get("events") if isinstance(data, dict) else None
+        if raw_events is None:
+            raw_events = [data.get("event")] if isinstance(data, dict) and data.get("event") else []
+        events = []
+        for raw in raw_events:
+            if not isinstance(raw, dict):
+                continue
+            event = _parse_event_dict(raw)
+            if event is None:
+                return WebhookParseResult(
+                    response_status=400,
+                    response_body=json.dumps(
+                        {"error": f"unknown event type {raw.get('type')!r}"}
+                    ),
+                )
+            events.append(event)
+        return WebhookParseResult(events=events, response_body='{"ok": true}')
+
+    # -- call control ------------------------------------------------------
+
+    async def initiate_call(self, call: CallRecord) -> str:
+        if self.fail_initiate:
+            raise RuntimeError("mock provider: initiate_call forced failure")
+        provider_call_id = f"mock-{uuid.uuid4().hex[:12]}"
+        if self.auto_answer and self.event_sink is not None:
+            asyncio.get_running_loop().create_task(
+                self._auto_answer(provider_call_id, call)
+            )
+        return provider_call_id
+
+    async def _auto_answer(self, provider_call_id: str, call: CallRecord) -> None:
+        # Yield first so the manager finishes registering the call id mapping.
+        await asyncio.sleep(0)
+        sink = self.event_sink
+        if sink is None:
+            return
+        for event_type in (
+            EventType.CALL_RINGING,
+            EventType.CALL_ANSWERED,
+            EventType.CALL_ACTIVE,
+        ):
+            if provider_call_id in self._terminal:
+                return
+            await sink(
+                NormalizedEvent(
+                    type=event_type,
+                    provider=self.name,
+                    provider_call_id=provider_call_id,
+                    call_id=call.call_id,
+                    direction="outbound",
+                    from_number=call.from_number,
+                    to_number=call.to_number,
+                )
+            )
+
+    async def answer_call(self, call: CallRecord) -> None:
+        if call.provider_call_id:
+            self.answered.append(call.provider_call_id)
+
+    async def hangup_call(self, call: CallRecord) -> None:
+        if call.provider_call_id:
+            self.hangups.append(call.provider_call_id)
+            self._terminal.add(call.provider_call_id)
+
+    async def speak(self, call: CallRecord, text: str) -> None:
+        self.spoken.append((call.provider_call_id, text))
+
+    async def send_dtmf(self, call: CallRecord, digits: str) -> None:
+        self.dtmf_sent.append((call.provider_call_id, digits))
+
+    async def start_listening(self, call: CallRecord) -> None:
+        if call.provider_call_id and call.provider_call_id not in self.listening:
+            self.listening.append(call.provider_call_id)
+
+    async def stop_listening(self, call: CallRecord) -> None:
+        if call.provider_call_id in self.listening:
+            self.listening.remove(call.provider_call_id)
+
+    async def get_call_status(self, call: CallRecord) -> CallStatusResult:
+        if call.provider_call_id in self._terminal:
+            return CallStatusResult(is_terminal=True, raw_status="completed")
+        return CallStatusResult(is_active=True, raw_status="active")

--- a/plugins/platforms/voice_call/providers/plivo.py
+++ b/plugins/platforms/voice_call/providers/plivo.py
@@ -1,0 +1,345 @@
+"""Plivo call provider (Voice API + Plivo XML).
+
+Port of OpenClaw's ``src/providers/plivo.ts`` (turn-based subset):
+
+- outbound dials via ``POST /v1/Account/{auth_id}/Call/`` with
+  ``answer_url`` carrying ``?callId=<ours>``; the response's
+  ``request_uuid`` is replaced by the real ``CallUUID`` when the first
+  webhook arrives (the manager refreshes the mapping)
+- webhook events are form-encoded: ``CallStatus`` lifecycle, ``Digits``
+  DTMF, speech recognition results from ``<GetInput inputType="speech">``
+- TTS uses the same transfer trick as OpenClaw: store the pending text,
+  transfer the A-leg to ``?flow=xml-speak``, and answer that request with
+  ``<Speak>`` + ``<GetInput>`` XML (Plivo has no reliable live-TTS +
+  speech-capture combination outside XML)
+- webhook signature: V3 (HMAC-SHA256 over the canonical URL+params + "." +
+  nonce, ``X-Plivo-Signature-V3``/``-Nonce``) with V2 fallback
+"""
+
+import base64
+import binascii
+import hashlib
+import hmac
+import logging
+from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit
+from xml.sax.saxutils import escape as xml_escape
+
+from ..config import VoiceCallConfig
+from ..events import CallRecord, EventType, NormalizedEvent
+from ._http import guarded_json_request
+from .base import (
+    CallStatusResult,
+    VoiceCallProvider,
+    WebhookContext,
+    WebhookParseResult,
+    WebhookVerificationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+API_HOST = "api.plivo.com"
+
+XML_EMPTY = '<?xml version="1.0" encoding="UTF-8"?><Response></Response>'
+XML_KEEPALIVE = (
+    '<?xml version="1.0" encoding="UTF-8"?><Response><Wait length="300"/></Response>'
+)
+
+_TERMINAL_STATUSES = {"completed", "busy", "no-answer", "failed", "cancelled"}
+
+_ENDED_REASON_MAP = {
+    "completed": "completed",
+    "busy": "busy",
+    "no-answer": "no-answer",
+    "failed": "failed",
+    "cancelled": "hangup-bot",
+}
+
+# Form keys Plivo uses for speech-recognition results (GetInput).
+_SPEECH_KEYS = ("Speech", "SpeechResult", "Transcription", "UnstableSpeech")
+
+
+def _normalize_b64(value: str) -> Optional[str]:
+    """Canonicalize base64 (decode → re-encode) the way the Plivo SDK does."""
+    try:
+        return base64.b64encode(base64.b64decode(value)).decode()
+    except (binascii.Error, ValueError):
+        return None
+
+
+def _sorted_query_string(pairs: List[tuple]) -> str:
+    return "&".join(f"{k}={v}" for k, v in sorted(pairs))
+
+
+def _sorted_params_string(pairs: List[tuple]) -> str:
+    return "".join(f"{k}{v}" for k, v in sorted(pairs))
+
+
+def construct_plivo_v3_base(method: str, url: str, post_params: List[tuple]) -> str:
+    """Plivo V3 canonical string: url?sorted-query[.]sorted-post-params."""
+    parts = urlsplit(url)
+    base = f"{parts.scheme}://{parts.netloc}{parts.path}"
+    query_pairs = parse_qsl(parts.query, keep_blank_values=True)
+    query_string = _sorted_query_string(query_pairs)
+    has_post = bool(post_params)
+    if query_string or has_post:
+        base = f"{base}?{query_string}"
+    if query_string and has_post:
+        base += "."
+    if method == "GET":
+        return base
+    return base + _sorted_params_string(post_params)
+
+
+def compute_plivo_v3_signature(
+    auth_token: str, method: str, url: str, post_params: List[tuple], nonce: str
+) -> str:
+    payload = construct_plivo_v3_base(method, url, post_params) + "." + nonce
+    digest = hmac.new(
+        auth_token.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256
+    ).digest()
+    return base64.b64encode(digest).decode()
+
+
+def compute_plivo_v2_signature(auth_token: str, url: str, nonce: str) -> str:
+    parts = urlsplit(url)
+    base = f"{parts.scheme}://{parts.netloc}{parts.path}"
+    digest = hmac.new(
+        auth_token.encode("utf-8"), (base + nonce).encode("utf-8"), hashlib.sha256
+    ).digest()
+    return base64.b64encode(digest).decode()
+
+
+class PlivoProvider(VoiceCallProvider):
+    name = "plivo"
+    requires_public_webhook = True
+
+    def __init__(self, config: VoiceCallConfig):
+        super().__init__(config)
+        self.auth_id = config.provider_credential("auth_id", "PLIVO_AUTH_ID")
+        self.auth_token = config.provider_credential("auth_token", "PLIVO_AUTH_TOKEN")
+        if not self.auth_id:
+            raise ValueError("Plivo auth ID is required (PLIVO_AUTH_ID)")
+        if not self.auth_token:
+            raise ValueError("Plivo auth token is required (PLIVO_AUTH_TOKEN)")
+        self.base_url = f"https://{API_HOST}/v1/Account/{self.auth_id}"
+        # Pending TTS texts served when the transferred leg fetches xml-speak.
+        self._pending_speak: Dict[str, str] = {}
+
+    # -- HTTP -----------------------------------------------------------------
+
+    async def _api(
+        self,
+        endpoint: str,
+        body: Optional[Dict[str, Any]] = None,
+        *,
+        method: str = "POST",
+        allow_not_found: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        return await guarded_json_request(
+            method,
+            f"{self.base_url}{endpoint}",
+            allowed_host=API_HOST,
+            auth=(self.auth_id, self.auth_token),
+            json_body=body,
+            allow_not_found=allow_not_found,
+            error_prefix="Plivo API error",
+        )
+
+    # -- webhook ------------------------------------------------------------------
+
+    def verify_webhook(self, ctx: WebhookContext) -> WebhookVerificationResult:
+        signature_v3 = ctx.header("x-plivo-signature-v3")
+        nonce_v3 = ctx.header("x-plivo-signature-v3-nonce")
+        if signature_v3 and nonce_v3:
+            try:
+                post_params = parse_qsl(
+                    ctx.body.decode("utf-8"), keep_blank_values=True
+                )
+            except UnicodeDecodeError:
+                return WebhookVerificationResult(ok=False, error="undecodable body")
+            expected = _normalize_b64(
+                compute_plivo_v3_signature(
+                    self.auth_token, ctx.method, ctx.url, post_params, nonce_v3
+                )
+            )
+            # The header may carry several comma-separated signatures.
+            for candidate in signature_v3.split(","):
+                normalized = _normalize_b64(candidate.strip())
+                if normalized and expected and hmac.compare_digest(expected, normalized):
+                    digest = hashlib.sha256(
+                        (ctx.url + "\n" + nonce_v3).encode()
+                    ).hexdigest()
+                    return WebhookVerificationResult(
+                        ok=True, dedupe_key=f"plivo:v3:{digest}"
+                    )
+            return WebhookVerificationResult(ok=False, error="invalid Plivo V3 signature")
+
+        signature_v2 = ctx.header("x-plivo-signature-v2")
+        nonce_v2 = ctx.header("x-plivo-signature-v2-nonce")
+        if signature_v2 and nonce_v2:
+            expected = _normalize_b64(
+                compute_plivo_v2_signature(self.auth_token, ctx.url, nonce_v2)
+            )
+            provided = _normalize_b64(signature_v2)
+            if expected and provided and hmac.compare_digest(expected, provided):
+                digest = hashlib.sha256(
+                    (ctx.url + "\n" + nonce_v2).encode()
+                ).hexdigest()
+                return WebhookVerificationResult(
+                    ok=True, dedupe_key=f"plivo:v2:{digest}"
+                )
+            return WebhookVerificationResult(ok=False, error="invalid Plivo V2 signature")
+
+        return WebhookVerificationResult(
+            ok=False, error="missing Plivo signature headers"
+        )
+
+    def parse_webhook(self, ctx: WebhookContext) -> WebhookParseResult:
+        try:
+            params = dict(parse_qsl(ctx.body.decode("utf-8"), keep_blank_values=True))
+        except UnicodeDecodeError:
+            return WebhookParseResult(
+                response_status=400, response_body=XML_EMPTY,
+                response_content_type="text/xml",
+            )
+        flow = ctx.query.get("flow", "")
+        call_id = ctx.query.get("callId")
+
+        # Transferred-leg XML flows return Plivo XML and produce no events.
+        if flow == "xml-speak":
+            text = self._pending_speak.pop(call_id or "", None)
+            xml = self._speak_xml(call_id, text) if text else XML_KEEPALIVE
+            return WebhookParseResult(
+                response_body=xml, response_content_type="text/xml"
+            )
+
+        event = self._normalize_event(params, call_id)
+        body = XML_KEEPALIVE if flow in ("answer", "getinput") else XML_EMPTY
+        return WebhookParseResult(
+            events=[event] if event else [],
+            response_body=body,
+            response_content_type="text/xml",
+        )
+
+    def _normalize_event(
+        self, params: Dict[str, str], call_id_override: Optional[str]
+    ) -> Optional[NormalizedEvent]:
+        call_uuid = params.get("CallUUID", "")
+        request_uuid = params.get("RequestUUID", "")
+        direction = params.get("Direction")
+        base = dict(
+            provider=self.name,
+            provider_call_id=call_uuid or request_uuid or None,
+            call_id=call_id_override or None,
+            from_number=params.get("From") or None,
+            to_number=params.get("To") or None,
+            direction=direction if direction in ("inbound", "outbound") else None,
+            raw=dict(params),
+        )
+
+        digits = params.get("Digits")
+        if digits:
+            return NormalizedEvent(type=EventType.CALL_DTMF, digits=digits, **base)
+        for key in _SPEECH_KEYS:
+            speech = params.get(key)
+            if speech:
+                return NormalizedEvent(
+                    type=EventType.CALL_SPEECH, text=speech, is_final=True, **base
+                )
+
+        status = params.get("CallStatus", "")
+        if status == "ringing":
+            return NormalizedEvent(type=EventType.CALL_RINGING, **base)
+        if status == "in-progress":
+            return NormalizedEvent(type=EventType.CALL_ANSWERED, **base)
+        reason = _ENDED_REASON_MAP.get(status)
+        if reason:
+            return NormalizedEvent(type=EventType.CALL_ENDED, reason=reason, **base)
+        # Plivo posts the answer_url with Event=StartApp when the call
+        # connects; treat it as answered so the call can proceed.
+        if params.get("Event") == "StartApp" and call_uuid:
+            return NormalizedEvent(type=EventType.CALL_ANSWERED, **base)
+        return None
+
+    # -- XML builders ------------------------------------------------------------------
+
+    def _webhook_url_with(self, call_id: Optional[str], **query) -> str:
+        base = self.webhook_url or ""
+        merged = {"provider": "plivo", **({"callId": call_id} if call_id else {}), **query}
+        return f"{base}?{urlencode(merged)}"
+
+    def _speak_xml(self, call_id: Optional[str], text: str) -> str:
+        extra = self.config.provider_extra.get("plivo", {})
+        language = xml_escape(str(extra.get("language", "en-US")))
+        action = xml_escape(self._webhook_url_with(call_id, flow="getinput"))
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?><Response>'
+            f'<Speak language="{language}">{xml_escape(text)}</Speak>'
+            f'<GetInput inputType="speech" method="POST" action="{action}" '
+            f'language="{language}" executionTimeout="30" speechEndTimeout="1" '
+            'redirect="false"></GetInput>'
+            '<Wait length="300"/></Response>'
+        )
+
+    # -- call control -------------------------------------------------------------------
+
+    async def initiate_call(self, call: CallRecord) -> str:
+        result = await self._api(
+            "/Call/",
+            {
+                "to": call.to_number,
+                "from": call.from_number,
+                "answer_url": self._webhook_url_with(call.call_id, flow="answer"),
+                "answer_method": "POST",
+                "hangup_url": self._webhook_url_with(call.call_id, flow="hangup"),
+                "hangup_method": "POST",
+                "ring_timeout": 30,
+            },
+        )
+        request_uuid = (result or {}).get("request_uuid")
+        if isinstance(request_uuid, list):
+            request_uuid = request_uuid[0] if request_uuid else ""
+        return str(request_uuid or "")
+
+    async def hangup_call(self, call: CallRecord) -> None:
+        await self._api(
+            f"/Call/{call.provider_call_id}/", method="DELETE", allow_not_found=True
+        )
+
+    async def speak(self, call: CallRecord, text: str) -> None:
+        # Transfer the A-leg to our xml-speak flow; the transferred leg
+        # fetches <Speak> + <GetInput> XML carrying this pending text.
+        self._pending_speak[call.call_id] = text
+        await self._api(
+            f"/Call/{call.provider_call_id}/",
+            {
+                "legs": "aleg",
+                "aleg_url": self._webhook_url_with(call.call_id, flow="xml-speak"),
+                "aleg_method": "POST",
+            },
+        )
+
+    async def send_dtmf(self, call: CallRecord, digits: str) -> None:
+        safe = "".join(c for c in digits if c in "0123456789*#w")
+        await self._api(f"/Call/{call.provider_call_id}/DTMF/", {"digits": safe})
+
+    async def start_listening(self, call: CallRecord) -> None:
+        """No-op: conversation-mode ``speak`` XML embeds ``<GetInput>``, and
+        transferring the leg here would cut the greeting off mid-word."""
+
+    async def get_call_status(self, call: CallRecord) -> CallStatusResult:
+        try:
+            result = await self._api(
+                f"/Call/{call.provider_call_id}/", method="GET", allow_not_found=True
+            )
+        except Exception:  # noqa: BLE001 — transient errors must not kill restore
+            return CallStatusResult(is_unknown=True, raw_status="error")
+        if result is None:
+            return CallStatusResult(is_terminal=True, raw_status="not-found")
+        status = str(result.get("call_status", "unknown"))
+        return CallStatusResult(
+            is_active=status not in _TERMINAL_STATUSES,
+            is_terminal=status in _TERMINAL_STATUSES,
+            raw_status=status,
+        )

--- a/plugins/platforms/voice_call/providers/telnyx.py
+++ b/plugins/platforms/voice_call/providers/telnyx.py
@@ -67,6 +67,7 @@ _EVENT_TYPE_MAP = {
     "call.answered": EventType.CALL_ANSWERED,
     "call.bridged": EventType.CALL_ACTIVE,
     "call.speak.started": EventType.CALL_SPEAKING,
+    "call.speak.ended": EventType.CALL_SPEAK_ENDED,
     "call.transcription": EventType.CALL_SPEECH,
     "call.hangup": EventType.CALL_ENDED,
     "call.dtmf.received": EventType.CALL_DTMF,

--- a/plugins/platforms/voice_call/providers/telnyx.py
+++ b/plugins/platforms/voice_call/providers/telnyx.py
@@ -1,0 +1,358 @@
+"""Telnyx call provider (Call Control API v2) — the default provider.
+
+Port of OpenClaw's ``src/providers/telnyx.ts``:
+
+- outbound calls via ``POST /v2/calls`` with ``client_state`` carrying our
+  call id (base64) so every webhook event binds back to the right call
+- explicit ``answer`` for inbound calls (a Telnyx quirk — webhook-response
+  carriers answer implicitly)
+- carrier-native TTS (``actions/speak``) and transcription
+  (``actions/transcription_start/stop``)
+- Ed25519 webhook signature verification (``telnyx-signature-ed25519`` +
+  ``telnyx-timestamp``, 5-minute skew window) via the already-pinned
+  ``cryptography`` package
+- bidirectional PCMU/RTP media-stream fields on dial/answer for the
+  realtime phase
+
+All HTTP is pinned to ``api.telnyx.com``.
+"""
+
+import base64
+import binascii
+import hashlib
+import json
+import logging
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+from ..config import VoiceCallConfig
+from ..events import CallRecord, EventType, NormalizedEvent
+from ._http import guarded_json_request
+from .base import (
+    CallStatusResult,
+    VoiceCallProvider,
+    WebhookContext,
+    WebhookParseResult,
+    WebhookVerificationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+API_HOST = "api.telnyx.com"
+BASE_URL = f"https://{API_HOST}/v2"
+SIGNATURE_MAX_SKEW_S = 300
+
+_HANGUP_CAUSE_MAP = {
+    "normal_clearing": "completed",
+    "normal_unspecified": "completed",
+    "originator_cancel": "hangup-bot",
+    "call_rejected": "busy",
+    "user_busy": "busy",
+    "no_answer": "no-answer",
+    "no_user_response": "no-answer",
+    "destination_out_of_order": "failed",
+    "network_out_of_order": "failed",
+    "service_unavailable": "failed",
+    "recovery_on_timer_expire": "failed",
+    "machine_detected": "voicemail",
+    "fax_detected": "voicemail",
+    "user_hangup": "hangup-user",
+    "subscriber_absent": "hangup-user",
+}
+
+_EVENT_TYPE_MAP = {
+    "call.initiated": EventType.CALL_INITIATED,
+    "call.ringing": EventType.CALL_RINGING,
+    "call.answered": EventType.CALL_ANSWERED,
+    "call.bridged": EventType.CALL_ACTIVE,
+    "call.speak.started": EventType.CALL_SPEAKING,
+    "call.transcription": EventType.CALL_SPEECH,
+    "call.hangup": EventType.CALL_ENDED,
+    "call.dtmf.received": EventType.CALL_DTMF,
+}
+
+
+def _normalize_direction(direction: Optional[str]) -> Optional[str]:
+    if direction in ("incoming", "inbound"):
+        return "inbound"
+    if direction in ("outgoing", "outbound"):
+        return "outbound"
+    return None
+
+
+def _decode_client_state(value: str) -> Optional[str]:
+    """Base64-decode ``client_state`` if it round-trips cleanly."""
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    try:
+        return decoded.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def build_streaming_fields(
+    stream_url: str, auth_token: Optional[str] = None
+) -> Dict[str, Any]:
+    """Bidirectional PCMU/RTP media-stream fields for dial/answer requests."""
+    fields: Dict[str, Any] = {
+        "stream_url": stream_url,
+        "stream_track": "inbound_track",
+        "stream_codec": "PCMU",
+        "stream_bidirectional_mode": "rtp",
+        "stream_bidirectional_codec": "PCMU",
+        "stream_bidirectional_sampling_rate": 8000,
+        "stream_bidirectional_target_legs": "self",
+    }
+    if auth_token:
+        fields["stream_auth_token"] = auth_token
+    return fields
+
+
+class TelnyxProvider(VoiceCallProvider):
+    name = "telnyx"
+    requires_public_webhook = True
+
+    def __init__(self, config: VoiceCallConfig):
+        super().__init__(config)
+        self.api_key = config.provider_credential("api_key", "TELNYX_API_KEY")
+        self.connection_id = config.provider_credential(
+            "connection_id", "TELNYX_CONNECTION_ID"
+        )
+        self.public_key = config.provider_credential("public_key", "TELNYX_PUBLIC_KEY")
+        if not self.api_key:
+            raise ValueError("Telnyx API key is required (TELNYX_API_KEY)")
+        if not self.connection_id:
+            raise ValueError(
+                "Telnyx connection ID is required (TELNYX_CONNECTION_ID)"
+            )
+
+    # -- HTTP -----------------------------------------------------------------
+
+    async def _api(
+        self,
+        endpoint: str,
+        body: Optional[Dict[str, Any]] = None,
+        *,
+        method: str = "POST",
+        allow_not_found: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        return await guarded_json_request(
+            method,
+            f"{BASE_URL}{endpoint}",
+            allowed_host=API_HOST,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            json_body=body,
+            allow_not_found=allow_not_found,
+            error_prefix="Telnyx API error",
+        )
+
+    # -- webhook ----------------------------------------------------------------
+
+    def verify_webhook(self, ctx: WebhookContext) -> WebhookVerificationResult:
+        if not self.public_key:
+            return WebhookVerificationResult(
+                ok=False, error="missing TELNYX_PUBLIC_KEY"
+            )
+        signature_b64 = ctx.header("telnyx-signature-ed25519")
+        timestamp = ctx.header("telnyx-timestamp")
+        if not signature_b64 or not timestamp:
+            return WebhookVerificationResult(
+                ok=False, error="missing signature or timestamp header"
+            )
+        try:
+            event_time = int(timestamp)
+        except ValueError:
+            return WebhookVerificationResult(ok=False, error="invalid timestamp header")
+
+        try:
+            from cryptography.exceptions import InvalidSignature
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+                Ed25519PublicKey,
+            )
+
+            # Accept base64url variants the way OpenClaw does.
+            normalized = signature_b64.replace("-", "+").replace("_", "/")
+            normalized += "=" * (-len(normalized) % 4)
+            signature = base64.b64decode(normalized)
+            key = Ed25519PublicKey.from_public_bytes(
+                base64.b64decode(self.public_key)
+            )
+            signed_payload = timestamp.encode("utf-8") + b"|" + ctx.body
+            try:
+                key.verify(signature, signed_payload)
+            except InvalidSignature:
+                return WebhookVerificationResult(ok=False, error="invalid signature")
+        except (ValueError, binascii.Error) as e:
+            return WebhookVerificationResult(
+                ok=False, error=f"verification error: {type(e).__name__}"
+            )
+
+        if abs(time.time() - event_time) > SIGNATURE_MAX_SKEW_S:
+            return WebhookVerificationResult(ok=False, error="timestamp too old")
+
+        digest = hashlib.sha256(
+            timestamp.encode() + b"\n" + signature + b"\n" + ctx.body
+        ).hexdigest()
+        return WebhookVerificationResult(ok=True, dedupe_key=f"telnyx:{digest}")
+
+    def parse_webhook(self, ctx: WebhookContext) -> WebhookParseResult:
+        try:
+            payload = json.loads(ctx.body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return WebhookParseResult(response_status=400, response_body="{}")
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(data, dict) or not data.get("event_type"):
+            return WebhookParseResult(response_body="{}")
+        event = self._normalize_event(data)
+        return WebhookParseResult(
+            events=[event] if event else [], response_body="{}"
+        )
+
+    def _normalize_event(self, data: Dict[str, Any]) -> Optional[NormalizedEvent]:
+        event_type = _EVENT_TYPE_MAP.get(str(data.get("event_type", "")))
+        if event_type is None:
+            return None  # streaming.* and other events are not call events
+        body = data.get("payload") or {}
+
+        call_id = None
+        client_state = body.get("client_state")
+        if client_state:
+            call_id = _decode_client_state(str(client_state)) or str(client_state)
+
+        text = None
+        is_final = True
+        if event_type == EventType.CALL_SPEECH:
+            tdata = body.get("transcription_data") or {}
+            text = tdata.get("transcript") or body.get("transcription") or ""
+            is_final = bool(tdata.get("is_final", body.get("is_final", True)))
+        elif event_type == EventType.CALL_SPEAKING:
+            text = body.get("text") or ""
+
+        reason = None
+        if event_type == EventType.CALL_ENDED:
+            cause = str(body.get("hangup_cause") or "")
+            reason = _HANGUP_CAUSE_MAP.get(cause)
+            if reason is None:
+                if cause:
+                    logger.warning("telnyx: unknown hangup cause %r", cause)
+                reason = "completed"
+
+        return NormalizedEvent(
+            type=event_type,
+            provider=self.name,
+            provider_call_id=body.get("call_control_id"),
+            call_id=call_id,
+            from_number=body.get("from"),
+            to_number=body.get("to"),
+            direction=_normalize_direction(body.get("direction")),
+            text=text,
+            is_final=is_final,
+            digits=body.get("digit") if event_type == EventType.CALL_DTMF else None,
+            reason=reason,
+            dedupe_key=str(data.get("id")) if data.get("id") else None,
+            raw=data,
+        )
+
+    # -- call control ----------------------------------------------------------------
+
+    def _streaming_kwargs(self, call: CallRecord) -> Dict[str, Any]:
+        stream_url = call.metadata.get("stream_url")
+        if not stream_url:
+            return {}
+        return build_streaming_fields(
+            stream_url, call.metadata.get("stream_auth_token")
+        )
+
+    async def initiate_call(self, call: CallRecord) -> str:
+        body: Dict[str, Any] = {
+            "connection_id": self.connection_id,
+            "to": call.to_number,
+            "from": call.from_number,
+            "webhook_url": self.webhook_url,
+            "webhook_url_method": "POST",
+            "client_state": base64.b64encode(call.call_id.encode()).decode(),
+            "timeout_secs": 30,
+            **self._streaming_kwargs(call),
+        }
+        result = await self._api("/calls", body)
+        return str((result or {}).get("data", {}).get("call_control_id", ""))
+
+    async def answer_call(self, call: CallRecord) -> None:
+        body: Dict[str, Any] = {
+            "command_id": f"hermes-answer-{call.call_id}",
+            "client_state": base64.b64encode(call.call_id.encode()).decode(),
+            **self._streaming_kwargs(call),
+        }
+        await self._api(f"/calls/{call.provider_call_id}/actions/answer", body)
+
+    async def hangup_call(self, call: CallRecord) -> None:
+        await self._api(
+            f"/calls/{call.provider_call_id}/actions/hangup",
+            {"command_id": str(uuid.uuid4())},
+            allow_not_found=True,
+        )
+
+    async def speak(self, call: CallRecord, text: str) -> None:
+        extra = self.config.provider_extra.get("telnyx", {})
+        await self._api(
+            f"/calls/{call.provider_call_id}/actions/speak",
+            {
+                "command_id": str(uuid.uuid4()),
+                "payload": text,
+                "voice": str(extra.get("voice", "female")),
+                "language": str(extra.get("language", "en-US")),
+            },
+        )
+
+    async def send_dtmf(self, call: CallRecord, digits: str) -> None:
+        await self._api(
+            f"/calls/{call.provider_call_id}/actions/send_dtmf",
+            {"command_id": str(uuid.uuid4()), "digits": digits},
+        )
+
+    async def start_listening(self, call: CallRecord) -> None:
+        extra = self.config.provider_extra.get("telnyx", {})
+        await self._api(
+            f"/calls/{call.provider_call_id}/actions/transcription_start",
+            {
+                "command_id": str(uuid.uuid4()),
+                "language": str(extra.get("transcription_language", "en")),
+            },
+        )
+
+    async def stop_listening(self, call: CallRecord) -> None:
+        await self._api(
+            f"/calls/{call.provider_call_id}/actions/transcription_stop",
+            {"command_id": str(uuid.uuid4())},
+            allow_not_found=True,
+        )
+
+    async def get_call_status(self, call: CallRecord) -> CallStatusResult:
+        try:
+            result = await self._api(
+                f"/calls/{call.provider_call_id}", method="GET", allow_not_found=True
+            )
+        except Exception:  # noqa: BLE001 — transient errors must not kill restore
+            return CallStatusResult(is_unknown=True, raw_status="error")
+        if result is None:
+            return CallStatusResult(is_terminal=True, raw_status="not-found")
+        data = result.get("data") or {}
+        is_alive = data.get("is_alive")
+        if is_alive is None:
+            return CallStatusResult(is_unknown=True, raw_status=data.get("state"))
+        return CallStatusResult(
+            is_active=bool(is_alive),
+            is_terminal=not is_alive,
+            raw_status=data.get("state"),
+        )
+
+    # -- realtime ----------------------------------------------------------------------
+
+    def streaming_fields(self, stream_url: str, auth_token: str) -> Dict[str, Any]:
+        return build_streaming_fields(stream_url, auth_token)

--- a/plugins/platforms/voice_call/providers/telnyx.py
+++ b/plugins/platforms/voice_call/providers/telnyx.py
@@ -357,3 +357,18 @@ class TelnyxProvider(VoiceCallProvider):
 
     def streaming_fields(self, stream_url: str, auth_token: str) -> Dict[str, Any]:
         return build_streaming_fields(stream_url, auth_token)
+
+    supports_midcall_streaming = True
+
+    async def start_media_stream(
+        self, call: CallRecord, stream_url: str, auth_token: str
+    ) -> None:
+        """Attach a bidirectional media stream to a live call — Telnyx's
+        streaming_start action makes notify → realtime upgrades possible."""
+        await self._api(
+            f"/calls/{call.provider_call_id}/actions/streaming_start",
+            {
+                "command_id": str(uuid.uuid4()),
+                **build_streaming_fields(stream_url, auth_token),
+            },
+        )

--- a/plugins/platforms/voice_call/providers/twilio.py
+++ b/plugins/platforms/voice_call/providers/twilio.py
@@ -1,0 +1,288 @@
+"""Twilio call provider (Programmable Voice REST API + TwiML).
+
+Port of OpenClaw's ``src/providers/twilio.ts`` (turn-based subset):
+
+- outbound dials via ``POST /2010-04-01/Accounts/{sid}/Calls.json`` with the
+  webhook URL carrying ``?callId=<ours>`` and a separate status callback
+  (``&type=status``) for lifecycle events
+- webhook events are form-encoded; ``CallStatus`` maps to lifecycle events,
+  ``SpeechResult`` (from ``<Gather input="speech">``) to ``call.speech``,
+  ``Digits`` to ``call.dtmf``
+- TTS via call update with inline TwiML: ``<Say>`` followed by an embedded
+  ``<Gather>`` so the next caller utterance posts back — Twilio has no
+  "speak on live call" API, so each speak replaces the call's TwiML
+- webhook signature: HMAC-SHA1 over ``url + sorted(key+value)`` form params
+  (``X-Twilio-Signature``), retried without the port (Twilio signs both
+  variants in the wild)
+
+Media streams (``<Connect><Stream>``) land with the realtime phase.
+"""
+
+import base64
+import hashlib
+import hmac
+import logging
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from xml.sax.saxutils import escape as xml_escape
+
+from ..config import VoiceCallConfig
+from ..events import CallRecord, EventType, NormalizedEvent
+from ._http import guarded_json_request
+from .base import (
+    CallStatusResult,
+    VoiceCallProvider,
+    WebhookContext,
+    WebhookParseResult,
+    WebhookVerificationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+API_HOST = "api.twilio.com"
+
+EMPTY_TWIML = '<?xml version="1.0" encoding="UTF-8"?><Response></Response>'
+KEEPALIVE_TWIML = (
+    '<?xml version="1.0" encoding="UTF-8"?><Response><Pause length="30"/></Response>'
+)
+
+_TERMINAL_STATUSES = {"completed", "busy", "failed", "no-answer", "canceled"}
+
+_ENDED_REASON_MAP = {
+    "completed": "completed",
+    "busy": "busy",
+    "failed": "failed",
+    "no-answer": "no-answer",
+    "canceled": "hangup-bot",
+}
+
+
+def compute_twilio_signature(auth_token: str, url: str, params: Dict[str, str]) -> str:
+    """Twilio's documented scheme: HMAC-SHA1 over url + sorted key+value."""
+    payload = url + "".join(k + params[k] for k in sorted(params))
+    digest = hmac.new(
+        auth_token.encode("utf-8"), payload.encode("utf-8"), hashlib.sha1
+    ).digest()
+    return base64.b64encode(digest).decode()
+
+
+def _strip_port(url: str) -> str:
+    parts = urlsplit(url)
+    if parts.port is None:
+        return url
+    host = parts.hostname or ""
+    if ":" in host:  # IPv6
+        host = f"[{host}]"
+    return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
+
+
+def _normalize_direction(direction: Optional[str]) -> Optional[str]:
+    if not direction:
+        return None
+    if direction.startswith("outbound"):
+        return "outbound"
+    if direction == "inbound":
+        return "inbound"
+    return None
+
+
+class TwilioProvider(VoiceCallProvider):
+    name = "twilio"
+    requires_public_webhook = True
+
+    def __init__(self, config: VoiceCallConfig):
+        super().__init__(config)
+        self.account_sid = config.provider_credential("account_sid", "TWILIO_ACCOUNT_SID")
+        self.auth_token = config.provider_credential("auth_token", "TWILIO_AUTH_TOKEN")
+        if not self.account_sid:
+            raise ValueError("Twilio account SID is required (TWILIO_ACCOUNT_SID)")
+        if not self.auth_token:
+            raise ValueError("Twilio auth token is required (TWILIO_AUTH_TOKEN)")
+        self.base_url = f"https://{API_HOST}/2010-04-01/Accounts/{self.account_sid}"
+
+    # -- HTTP ---------------------------------------------------------------
+
+    async def _api(
+        self,
+        endpoint: str,
+        form: Optional[Dict[str, Any]] = None,
+        *,
+        method: str = "POST",
+        allow_not_found: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        return await guarded_json_request(
+            method,
+            f"{self.base_url}{endpoint}",
+            allowed_host=API_HOST,
+            auth=(self.account_sid, self.auth_token),
+            form_body=form,
+            allow_not_found=allow_not_found,
+            error_prefix="Twilio API error",
+        )
+
+    # -- webhook ---------------------------------------------------------------
+
+    def verify_webhook(self, ctx: WebhookContext) -> WebhookVerificationResult:
+        signature = ctx.header("x-twilio-signature")
+        if not signature:
+            return WebhookVerificationResult(
+                ok=False, error="missing X-Twilio-Signature header"
+            )
+        try:
+            params = dict(parse_qsl(ctx.body.decode("utf-8"), keep_blank_values=True))
+        except UnicodeDecodeError:
+            return WebhookVerificationResult(ok=False, error="undecodable body")
+
+        # Twilio signs the exact public URL; port inclusion varies, so try a
+        # small deterministic set of variants before failing closed.
+        candidates = [ctx.url, _strip_port(ctx.url)]
+        for url in dict.fromkeys(candidates):
+            expected = compute_twilio_signature(self.auth_token, url, params)
+            if hmac.compare_digest(expected, signature):
+                digest = hashlib.sha256(
+                    signature.encode() + b"\n" + url.encode() + b"\n" + ctx.body
+                ).hexdigest()
+                return WebhookVerificationResult(
+                    ok=True, dedupe_key=f"twilio:{digest}"
+                )
+        return WebhookVerificationResult(
+            ok=False, error=f"invalid signature for URL {ctx.url}"
+        )
+
+    def parse_webhook(self, ctx: WebhookContext) -> WebhookParseResult:
+        try:
+            params = dict(parse_qsl(ctx.body.decode("utf-8"), keep_blank_values=True))
+        except UnicodeDecodeError:
+            return WebhookParseResult(response_status=400, response_body=EMPTY_TWIML,
+                                      response_content_type="text/xml")
+        event = self._normalize_event(params, ctx.query.get("callId"))
+        # Status callbacks get an empty ack; voice-flow requests (initial
+        # answer webhook, Gather actions) get a keep-alive <Pause> so the
+        # call stays up while the manager speaks via call update.
+        is_status = ctx.query.get("type") == "status"
+        body = EMPTY_TWIML if is_status else KEEPALIVE_TWIML
+        return WebhookParseResult(
+            events=[event] if event else [],
+            response_body=body,
+            response_content_type="text/xml",
+        )
+
+    def _normalize_event(
+        self, params: Dict[str, str], call_id_override: Optional[str]
+    ) -> Optional[NormalizedEvent]:
+        call_sid = params.get("CallSid", "")
+        base = dict(
+            provider=self.name,
+            provider_call_id=call_sid or None,
+            call_id=call_id_override or None,
+            from_number=params.get("From") or None,
+            to_number=params.get("To") or None,
+            direction=_normalize_direction(params.get("Direction")),
+            dedupe_key=None,  # the webhook layer dedupes on the signature
+            raw=dict(params),
+        )
+
+        speech = params.get("SpeechResult")
+        if speech:
+            return NormalizedEvent(
+                type=EventType.CALL_SPEECH, text=speech, is_final=True, **base
+            )
+        digits = params.get("Digits")
+        if digits:
+            return NormalizedEvent(type=EventType.CALL_DTMF, digits=digits, **base)
+
+        status = params.get("CallStatus", "")
+        if status in ("queued", "initiated"):
+            return NormalizedEvent(type=EventType.CALL_INITIATED, **base)
+        if status == "ringing":
+            return NormalizedEvent(type=EventType.CALL_RINGING, **base)
+        if status == "in-progress":
+            return NormalizedEvent(type=EventType.CALL_ANSWERED, **base)
+        reason = _ENDED_REASON_MAP.get(status)
+        if reason:
+            return NormalizedEvent(type=EventType.CALL_ENDED, reason=reason, **base)
+        return None
+
+    # -- call control --------------------------------------------------------------
+
+    def _webhook_url_with(self, call: CallRecord, **query) -> str:
+        base = self.webhook_url or ""
+        return f"{base}?{urlencode({'callId': call.call_id, **query})}"
+
+    async def initiate_call(self, call: CallRecord) -> str:
+        form: Dict[str, Any] = {
+            "To": call.to_number,
+            "From": call.from_number,
+            "Url": self._webhook_url_with(call),
+            "StatusCallback": self._webhook_url_with(call, type="status"),
+            "StatusCallbackEvent": ["initiated", "ringing", "answered", "completed"],
+            "Timeout": "30",
+        }
+        result = await self._api("/Calls.json", form)
+        return str((result or {}).get("sid", ""))
+
+    async def hangup_call(self, call: CallRecord) -> None:
+        await self._api(
+            f"/Calls/{call.provider_call_id}.json",
+            {"Status": "completed"},
+            allow_not_found=True,
+        )
+
+    def _speak_twiml(self, call: CallRecord, text: str) -> str:
+        extra = self.config.provider_extra.get("twilio", {})
+        voice = xml_escape(str(extra.get("voice", "alice")))
+        language = xml_escape(str(extra.get("language", "en-US")))
+        gather = ""
+        if call.mode == "conversation":
+            action = xml_escape(self._webhook_url_with(call))
+            gather = (
+                f'<Gather input="speech" speechTimeout="auto" '
+                f'language="{language}" action="{action}" method="POST"/>'
+            )
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?><Response>'
+            f'<Say voice="{voice}" language="{language}">{xml_escape(text)}</Say>'
+            f'{gather}<Pause length="60"/></Response>'
+        )
+
+    async def speak(self, call: CallRecord, text: str) -> None:
+        # No live-TTS API: replace the call's TwiML with Say + embedded
+        # Gather so the caller's next utterance posts back to us.
+        await self._api(
+            f"/Calls/{call.provider_call_id}.json",
+            {"Twiml": self._speak_twiml(call, text)},
+        )
+
+    async def send_dtmf(self, call: CallRecord, digits: str) -> None:
+        safe = "".join(c for c in digits if c in "0123456789*#w")
+        await self._api(
+            f"/Calls/{call.provider_call_id}.json",
+            {
+                "Twiml": (
+                    '<?xml version="1.0" encoding="UTF-8"?><Response>'
+                    f'<Play digits="{safe}"/><Pause length="60"/></Response>'
+                )
+            },
+        )
+
+    async def start_listening(self, call: CallRecord) -> None:
+        """No-op: every conversation-mode ``speak`` embeds a ``<Gather>``,
+        and updating the call here would cut the greeting off mid-word."""
+
+    async def get_call_status(self, call: CallRecord) -> CallStatusResult:
+        try:
+            result = await self._api(
+                f"/Calls/{call.provider_call_id}.json",
+                method="GET",
+                allow_not_found=True,
+            )
+        except Exception:  # noqa: BLE001 — transient errors must not kill restore
+            return CallStatusResult(is_unknown=True, raw_status="error")
+        if result is None:
+            return CallStatusResult(is_terminal=True, raw_status="not-found")
+        status = str(result.get("status", ""))
+        return CallStatusResult(
+            is_active=status not in _TERMINAL_STATUSES,
+            is_terminal=status in _TERMINAL_STATUSES,
+            raw_status=status,
+        )

--- a/plugins/platforms/voice_call/providers/twilio.py
+++ b/plugins/platforms/voice_call/providers/twilio.py
@@ -99,6 +99,10 @@ class TwilioProvider(VoiceCallProvider):
         if not self.auth_token:
             raise ValueError("Twilio auth token is required (TWILIO_AUTH_TOKEN)")
         self.base_url = f"https://{API_HOST}/2010-04-01/Accounts/{self.account_sid}"
+        # Realtime: the bridge stashes a wss stream URL per call id; the next
+        # voice-flow webhook for that call answers with <Connect><Stream>
+        # instead of the keep-alive <Pause>.
+        self.pending_streams: Dict[str, str] = {}
 
     # -- HTTP ---------------------------------------------------------------
 
@@ -159,6 +163,9 @@ class TwilioProvider(VoiceCallProvider):
         # Status callbacks get an empty ack; voice-flow requests (initial
         # answer webhook, Gather actions) get a keep-alive <Pause> so the
         # call stays up while the manager speaks via call update.
+        # finalize_response() upgrades voice-flow responses to
+        # <Connect><Stream> when a realtime stream was registered while the
+        # events were being processed.
         is_status = ctx.query.get("type") == "status"
         body = EMPTY_TWIML if is_status else KEEPALIVE_TWIML
         return WebhookParseResult(
@@ -166,6 +173,41 @@ class TwilioProvider(VoiceCallProvider):
             response_body=body,
             response_content_type="text/xml",
         )
+
+    def register_pending_stream(self, record: CallRecord, stream_url: str) -> None:
+        """Realtime bridge hook: the next voice-flow webhook for this call
+        answers with ``<Connect><Stream>`` instead of the keep-alive."""
+        self.pending_streams[record.call_id] = stream_url
+        if record.provider_call_id:
+            self.pending_streams[record.provider_call_id] = stream_url
+
+    def finalize_response(
+        self, ctx: WebhookContext, result: WebhookParseResult
+    ) -> WebhookParseResult:
+        """Called by the webhook server after events are processed — by then
+        an inbound call's record (and its pending stream) exists."""
+        if ctx.query.get("type") == "status":
+            return result
+        keys = [ctx.query.get("callId")]
+        try:
+            params = dict(parse_qsl(ctx.body.decode("utf-8"), keep_blank_values=True))
+            keys.append(params.get("CallSid"))
+        except UnicodeDecodeError:
+            pass
+        for key in keys:
+            stream_url = self.pending_streams.pop(key, None) if key else None
+            if stream_url:
+                # Drop the twin entry (call_id + CallSid both map to it).
+                for other, url in list(self.pending_streams.items()):
+                    if url == stream_url:
+                        self.pending_streams.pop(other, None)
+                result.response_body = (
+                    '<?xml version="1.0" encoding="UTF-8"?><Response>'
+                    f'<Connect><Stream url="{xml_escape(stream_url)}"/></Connect>'
+                    "</Response>"
+                )
+                break
+        return result
 
     def _normalize_event(
         self, params: Dict[str, str], call_id_override: Optional[str]

--- a/plugins/platforms/voice_call/realtime/__init__.py
+++ b/plugins/platforms/voice_call/realtime/__init__.py
@@ -1,0 +1,7 @@
+"""Realtime voice for the voice_call platform.
+
+Plugin-local speech-to-speech support (Hermes has no realtime provider
+registry): carrier media-stream frame adapters, OpenAI Realtime / Gemini
+Live websocket clients, and the bridge that splices a phone call's µ-law
+audio into a realtime model session.
+"""

--- a/plugins/platforms/voice_call/realtime/base.py
+++ b/plugins/platforms/voice_call/realtime/base.py
@@ -38,6 +38,20 @@ DEFAULT_INSTRUCTIONS = (
     "Never read secrets, tokens, or credentials aloud."
 )
 
+# Always appended to the session instructions (even user-configured ones):
+# how to sound while a consult is running. Without this the model
+# improvises negatively ("I don't have the result yet").
+WAITING_ETIQUETTE = (
+    " While a lookup is in progress and the caller says something, respond "
+    "briefly, warmly, and positively — for example 'Still checking, just a "
+    "couple more seconds' or 'Almost there'. Never say you don't have the "
+    "result, never say it failed or is unavailable while it is still "
+    "running, and never offer to get back to them later — the answer "
+    "arrives in this call. Vary the phrasing; don't repeat the same filler "
+    "twice in a row. When the result arrives, deliver it directly without "
+    "re-announcing that you were checking."
+)
+
 
 @dataclass
 class RealtimeEvent:

--- a/plugins/platforms/voice_call/realtime/base.py
+++ b/plugins/platforms/voice_call/realtime/base.py
@@ -1,0 +1,89 @@
+"""Realtime voice session abstraction.
+
+Hermes has no first-class realtime voice provider registry, so the
+voice_call plugin carries its own (modeled on ``plugins/google_meet/
+realtime`` but asyncio-native): a :class:`RealtimeVoiceSession` is one live
+speech-to-speech connection — caller PCM in, model PCM out, plus
+transcripts, barge-in signals, and tool calls.
+"""
+
+import abc
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Dict
+
+AGENT_CONSULT_TOOL = {
+    "name": "agent_consult",
+    "description": (
+        "Ask the Hermes agent a question you cannot answer from the "
+        "conversation alone — anything needing the user's data, memory, "
+        "files, or up-to-date information. Tell the caller you are "
+        "checking, then call this."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": "The question, with any context the agent needs.",
+            }
+        },
+        "required": ["question"],
+    },
+}
+
+DEFAULT_INSTRUCTIONS = (
+    "You are Hermes, a helpful assistant speaking on a live phone call. "
+    "Reply briefly and naturally, in a conversational spoken style. Use the "
+    "agent_consult tool when you need the user's data or fresh information. "
+    "Never read secrets, tokens, or credentials aloud."
+)
+
+
+@dataclass
+class RealtimeEvent:
+    """One event from a realtime session."""
+
+    type: str          # audio | transcript | speech_started | response_done
+                       # | tool_call | error | closed
+    audio: bytes = b""             # PCM16 at output_sample_rate (audio)
+    text: str = ""                 # transcript text / error detail
+    role: str = ""                 # transcript speaker: "user" | "assistant"
+    is_final: bool = True
+    tool_call_id: str = ""
+    tool_name: str = ""
+    tool_args: Dict[str, Any] = field(default_factory=dict)
+
+
+class RealtimeVoiceSession(abc.ABC):
+    """One live speech-to-speech connection to a realtime voice model."""
+
+    name: str = ""
+    input_sample_rate: int = 24000   # PCM16 rate the model expects in
+    output_sample_rate: int = 24000  # PCM16 rate the model produces
+
+    @abc.abstractmethod
+    async def connect(self) -> None:
+        """Open the websocket and configure the session."""
+
+    @abc.abstractmethod
+    async def send_audio(self, pcm16: bytes) -> None:
+        """Stream caller audio (PCM16 @ input_sample_rate) to the model."""
+
+    @abc.abstractmethod
+    def events(self) -> AsyncIterator[RealtimeEvent]:
+        """Yield model events until the session closes."""
+
+    @abc.abstractmethod
+    async def send_tool_result(self, tool_call_id: str, result: str) -> None:
+        """Return a tool result so the model can speak the answer."""
+
+    @abc.abstractmethod
+    async def inject_text(self, text: str) -> None:
+        """Ask the model to say something (e.g. the inbound greeting)."""
+
+    @abc.abstractmethod
+    async def cancel_response(self) -> None:
+        """Stop the in-flight model response (barge-in)."""
+
+    @abc.abstractmethod
+    async def close(self) -> None: ...

--- a/plugins/platforms/voice_call/realtime/base.py
+++ b/plugins/platforms/voice_call/realtime/base.py
@@ -31,6 +31,25 @@ AGENT_CONSULT_TOOL = {
     },
 }
 
+END_CALL_TOOL = {
+    "name": "end_call",
+    "description": (
+        "Hang up the phone call. Use when the caller says goodbye, asks you "
+        "to hang up, or the conversation is clearly finished. Say a brief "
+        "goodbye FIRST, then call this — the line closes a moment after."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "reason": {
+                "type": "string",
+                "description": "Short reason (e.g. 'caller said goodbye').",
+            }
+        },
+        "required": [],
+    },
+}
+
 DEFAULT_INSTRUCTIONS = (
     "You are Hermes, a helpful assistant speaking on a live phone call. "
     "Reply briefly and naturally, in a conversational spoken style. Use the "
@@ -49,7 +68,10 @@ WAITING_ETIQUETTE = (
     "running, and never offer to get back to them later — the answer "
     "arrives in this call. Vary the phrasing; don't repeat the same filler "
     "twice in a row. When the result arrives, deliver it directly without "
-    "re-announcing that you were checking."
+    "re-announcing that you were checking. When the caller says goodbye, "
+    "asks you to hang up, or the conversation has clearly ended, say a "
+    "brief goodbye and then call the end_call tool — do not leave the line "
+    "open."
 )
 
 

--- a/plugins/platforms/voice_call/realtime/base.py
+++ b/plugins/platforms/voice_call/realtime/base.py
@@ -64,6 +64,11 @@ class RealtimeVoiceSession(abc.ABC):
     # "ulaw": the model speaks G.711 µ-law @ 8 kHz natively (OpenAI
     # audio/pcmu) and the bridge passes carrier frames straight through.
     audio_wire_format: str = "pcm16"
+    # True while the model has a response in flight (set from
+    # response.created/turn events). The bridge uses this to decide whether
+    # caller speech is barge-in (interrupt) or just a normal turn, and to
+    # defer tool results until the current utterance finishes.
+    response_active: bool = False
 
     @abc.abstractmethod
     async def connect(self) -> None:

--- a/plugins/platforms/voice_call/realtime/base.py
+++ b/plugins/platforms/voice_call/realtime/base.py
@@ -60,6 +60,10 @@ class RealtimeVoiceSession(abc.ABC):
     name: str = ""
     input_sample_rate: int = 24000   # PCM16 rate the model expects in
     output_sample_rate: int = 24000  # PCM16 rate the model produces
+    # "pcm16": bridge transcodes carrier µ-law ⇄ PCM16 at the rates above.
+    # "ulaw": the model speaks G.711 µ-law @ 8 kHz natively (OpenAI
+    # audio/pcmu) and the bridge passes carrier frames straight through.
+    audio_wire_format: str = "pcm16"
 
     @abc.abstractmethod
     async def connect(self) -> None:

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -207,6 +207,10 @@ class RealtimeCallBridge:
         # would collide with the active response, so they flush on
         # response_done instead.
         self._deferred_tool_results: list = []
+        # While an agent_consult routes through the gateway, the agent's
+        # reply arrives via adapter.send() → runtime.speak_for_chat() →
+        # deliver_agent_text(); this future hands it back to the consult.
+        self._consult_future: Optional[asyncio.Future] = None
 
     async def run(self, ws) -> None:
         self._ws = ws
@@ -307,13 +311,22 @@ class RealtimeCallBridge:
             elif event.type == "transcript":
                 self._record_transcript(event.role, event.text)
             elif event.type == "tool_call":
+                logger.info(
+                    "voice_call realtime: tool call %s id=%s call=%s args=%.200s",
+                    event.tool_name, event.tool_call_id,
+                    self.record.call_id, event.tool_args,
+                )
                 asyncio.get_running_loop().create_task(
                     self._handle_tool_call(event)
                 )
             elif event.type == "response_done":
                 await self._flush_deferred_tool_results()
             elif event.type == "error":
-                logger.warning("voice_call realtime: model error: %s", event.text)
+                # A cancel racing a just-finished response is benign noise.
+                if "no active response" in (event.text or "").lower():
+                    logger.debug("voice_call realtime: %s", event.text)
+                else:
+                    logger.warning("voice_call realtime: model error: %s", event.text)
             elif event.type == "closed":
                 return
 
@@ -359,7 +372,8 @@ class RealtimeCallBridge:
 
     async def _handle_tool_call(self, event) -> None:
         question = str(event.tool_args.get("question", "")).strip()
-        # Consults take seconds (full agent model) — speak a filler so the
+        started_at = time.time()
+        # Consults take seconds (full agent run) — speak a filler so the
         # caller isn't sitting in silence wondering if the call dropped
         # (silence provokes "hello?", which used to barge-in the answer).
         phrase = self.runtime.config.responder.thinking_phrase
@@ -369,16 +383,44 @@ class RealtimeCallBridge:
             except Exception:  # noqa: BLE001
                 logger.debug("voice_call realtime: filler inject failed",
                              exc_info=True)
+        timeout = max(15.0, float(self.runtime.config.responder.response_timeout_s))
         try:
             answer = await asyncio.wait_for(
-                self._consult_agent(question), timeout=CONSULT_TIMEOUT_S
+                self._consult_agent(question), timeout=timeout
             )
+            status = "ok"
         except asyncio.TimeoutError:
             answer = "Sorry, looking that up took too long."
+            status = "timeout"
         except Exception as e:  # noqa: BLE001
             logger.exception("voice_call realtime: agent_consult failed")
             answer = f"Sorry, I could not check that: {e}"
+            status = "error"
+        logger.info(
+            "voice_call realtime: consult completed call=%s status=%s "
+            "elapsed=%.1fs answer_chars=%d",
+            self.record.call_id, status, time.time() - started_at, len(answer),
+        )
         await self._deliver_tool_result(event.tool_call_id, answer)
+
+    async def deliver_agent_text(self, text: str) -> bool:
+        """Agent output routed to a realtime call (via adapter.send()).
+
+        A pending consult consumes it as the tool result; otherwise the
+        realtime model is asked to speak it (e.g. cron/agent-initiated
+        messages while a realtime call is live — carrier TTS would talk
+        over the media stream)."""
+        fut = self._consult_future
+        if fut is not None and not fut.done():
+            fut.set_result(text)
+            return True
+        try:
+            await self.session.inject_text(text)
+            return True
+        except Exception:  # noqa: BLE001
+            logger.warning("voice_call realtime: inject of agent text failed",
+                           exc_info=True)
+            return False
 
     async def _deliver_tool_result(self, tool_call_id: str, answer: str) -> None:
         """Send now, or defer until the in-flight utterance (filler) ends —
@@ -410,6 +452,39 @@ class RealtimeCallBridge:
     async def _consult_agent(self, question: str) -> str:
         if not question:
             return "No question was provided."
+        # Preferred: route through the gateway as a normal message so the
+        # full Hermes agent answers — with its real tools (web search,
+        # weather, memory, ...) and the same per-phone session as
+        # turn-based calls. This mirrors OpenClaw, whose consult runs the
+        # embedded agent with the tool catalog rather than a bare LLM.
+        if self.runtime.adapter is not None:
+            logger.info(
+                "voice_call realtime: consulting gateway agent call=%s "
+                "question=%.200s", self.record.call_id, question,
+            )
+            return await self._consult_via_gateway(question)
+        # Headless fallback: tool-less host completion (can only answer
+        # from model knowledge).
+        logger.info(
+            "voice_call realtime: consulting plugin LLM (no gateway adapter) "
+            "call=%s question=%.200s", self.record.call_id, question,
+        )
+        return await self._consult_via_completion(question)
+
+    async def _consult_via_gateway(self, question: str) -> str:
+        from ..responder import dispatch_transcript
+
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._consult_future = fut
+        try:
+            await dispatch_transcript(self.runtime, self.record, question)
+            answer = (await fut).strip()
+            return answer[:CONSULT_MAX_CHARS] or "I could not find an answer."
+        finally:
+            if self._consult_future is fut:
+                self._consult_future = None
+
+    async def _consult_via_completion(self, question: str) -> str:
         llm = _plugin_llm_factory() if _plugin_llm_factory is not None else None
         if llm is None:
             return "The agent is not available right now."

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -182,15 +182,20 @@ class RealtimeBridgeManager:
             )
             record.metadata.pop("realtime", None)
             return False
-        # The carrier now dials our /voice/stream/{token} endpoint.
+        # The carrier now dials our /voice/stream/{token} endpoint. Wait for
+        # the bridge to exist AND its model session to be connected —
+        # injecting before that is a silent drop.
         deadline = time.time() + timeout
         while time.time() < deadline:
-            if self.active_bridges.get(record.call_id) is not None:
-                logger.info(
-                    "voice_call realtime: mid-call upgrade complete call=%s",
-                    record.call_id,
-                )
-                return True
+            bridge = self.active_bridges.get(record.call_id)
+            if bridge is not None:
+                ready = getattr(bridge, "ready", None)
+                if ready is None or ready.is_set():
+                    logger.info(
+                        "voice_call realtime: mid-call upgrade complete call=%s",
+                        record.call_id,
+                    )
+                    return True
             await asyncio.sleep(0.1)
         logger.warning(
             "voice_call realtime: carrier never opened the stream for %s — "
@@ -254,6 +259,9 @@ class RealtimeCallBridge:
         self._ws = None
         self._greeting_until = 0.0
         self._pacer: Optional[AudioPacer] = None
+        # Set once the model session is connected — anything injected before
+        # this would be silently dropped by the unconnected websocket.
+        self.ready: asyncio.Event = asyncio.Event()
         # Tool results that arrived while the model was mid-utterance (e.g.
         # speaking the "let me check" filler) — sending response.create then
         # would collide with the active response, so they flush on
@@ -286,6 +294,7 @@ class RealtimeCallBridge:
             if initial:
                 await self.session.inject_text(str(initial))
                 self._greeting_until = time.time() + 3.0
+        self.ready.set()
 
         pacer = AudioPacer(self._send_media_frame)
         self._pacer = pacer
@@ -582,6 +591,17 @@ class RealtimeCallBridge:
             )
             fut.set_result(text)
             return True
+        # Injecting into a not-yet-connected session is a silent drop —
+        # wait for the model websocket (mid-call upgrades race this).
+        if not self.ready.is_set():
+            try:
+                await asyncio.wait_for(self.ready.wait(), timeout=10.0)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "voice_call realtime: session never became ready for %s",
+                    self.record.call_id,
+                )
+                return False
         logger.info(
             "voice_call realtime: speaking agent message call=%s chars=%d",
             self.record.call_id, len(text),

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -211,6 +211,10 @@ class RealtimeCallBridge:
         # reply arrives via adapter.send() → runtime.speak_for_chat() →
         # deliver_agent_text(); this future hands it back to the consult.
         self._consult_future: Optional[asyncio.Future] = None
+        # The "let me check" filler can't play at tool_call time (the
+        # function-call response is still active) — it plays on the next
+        # response_done while the consult is still pending.
+        self._consult_filler_pending = False
 
     async def run(self, ws) -> None:
         self._ws = ws
@@ -321,6 +325,7 @@ class RealtimeCallBridge:
                 )
             elif event.type == "response_done":
                 await self._flush_deferred_tool_results()
+                await self._maybe_speak_filler()
             elif event.type == "error":
                 # A cancel racing a just-finished response is benign noise.
                 if "no active response" in (event.text or "").lower():
@@ -370,32 +375,86 @@ class RealtimeCallBridge:
 
     # -- agent_consult ---------------------------------------------------------------
 
+    async def _maybe_speak_filler(self) -> None:
+        """Speak the "let me check" filler once a consult is running and the
+        model's function-call response has finished (it can't play earlier —
+        the response is still active at tool_call time; the flag is cleared
+        when the consult completes)."""
+        if not self._consult_filler_pending or self.session.response_active:
+            return
+        self._consult_filler_pending = False
+        phrase = self.runtime.config.responder.thinking_phrase
+        if not phrase:
+            return
+        try:
+            await self.session.inject_text(phrase)
+            logger.info(
+                "voice_call realtime: spoke consult filler call=%s",
+                self.record.call_id,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("voice_call realtime: filler inject failed", exc_info=True)
+
     async def _handle_tool_call(self, event) -> None:
         question = str(event.tool_args.get("question", "")).strip()
         started_at = time.time()
-        # Consults take seconds (full agent run) — speak a filler so the
-        # caller isn't sitting in silence wondering if the call dropped
-        # (silence provokes "hello?", which used to barge-in the answer).
-        phrase = self.runtime.config.responder.thinking_phrase
-        if phrase and not self.session.response_active:
-            try:
-                await self.session.inject_text(phrase)
-            except Exception:  # noqa: BLE001
-                logger.debug("voice_call realtime: filler inject failed",
-                             exc_info=True)
         timeout = max(15.0, float(self.runtime.config.responder.response_timeout_s))
+
+        # Empty-args consults happen when the model flails (e.g. retrying
+        # after a timeout). OpenClaw's fallback: join an in-flight consult
+        # if one exists, else use the caller's last utterance as the question.
+        if not question:
+            pending = self._consult_future
+            if pending is not None and not pending.done():
+                logger.info(
+                    "voice_call realtime: empty consult joins the in-flight "
+                    "one call=%s", self.record.call_id,
+                )
+                try:
+                    answer = await asyncio.wait_for(
+                        asyncio.shield(pending), timeout=timeout
+                    )
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    answer = (
+                        "Still looking that up — the answer will arrive "
+                        "shortly; do not call this tool again for the same "
+                        "question."
+                    )
+                await self._deliver_tool_result(event.tool_call_id, answer)
+                return
+            question = next(
+                (t.text for t in reversed(self.record.transcript)
+                 if t.speaker == "user"),
+                "",
+            )
+
+        # Queue the spoken "let me check" filler — usually the function-call
+        # response is still active here, so it plays on the next
+        # response_done; if the session is already idle it plays now.
+        if self.runtime.config.responder.thinking_phrase:
+            self._consult_filler_pending = True
+            await self._maybe_speak_filler()
         try:
             answer = await asyncio.wait_for(
                 self._consult_agent(question), timeout=timeout
             )
             status = "ok"
         except asyncio.TimeoutError:
-            answer = "Sorry, looking that up took too long."
+            # The gateway turn is usually still running; its answer will be
+            # spoken when it lands (deliver_agent_text → inject). Keep the
+            # model from re-asking in the meantime.
+            answer = (
+                "This is taking longer than expected. Tell the caller you are "
+                "still checking; the answer will be spoken as soon as it is "
+                "ready. Do not call this tool again for the same question."
+            )
             status = "timeout"
         except Exception as e:  # noqa: BLE001
             logger.exception("voice_call realtime: agent_consult failed")
             answer = f"Sorry, I could not check that: {e}"
             status = "error"
+        finally:
+            self._consult_filler_pending = False
         logger.info(
             "voice_call realtime: consult completed call=%s status=%s "
             "elapsed=%.1fs answer_chars=%d",

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -403,17 +403,33 @@ class RealtimeCallBridge:
         )
         await self._deliver_tool_result(event.tool_call_id, answer)
 
-    async def deliver_agent_text(self, text: str) -> bool:
+    async def deliver_agent_text(self, text: str, final: bool = True) -> bool:
         """Agent output routed to a realtime call (via adapter.send()).
 
-        A pending consult consumes it as the tool result; otherwise the
-        realtime model is asked to speak it (e.g. cron/agent-initiated
-        messages while a realtime call is live — carrier TTS would talk
-        over the media stream)."""
+        Only the turn's FINAL response counts: a pending consult consumes
+        it as the tool result; otherwise the realtime model is asked to
+        speak it (e.g. cron/agent-initiated messages while a realtime call
+        is live — carrier TTS would talk over the media stream). Interim
+        sends (tool-progress chrome, status notices) are acknowledged but
+        dropped — they must not resolve a consult or be read aloud."""
+        if not final:
+            logger.debug(
+                "voice_call realtime: suppressed interim agent send "
+                "call=%s text=%.120s", self.record.call_id, text,
+            )
+            return True
         fut = self._consult_future
         if fut is not None and not fut.done():
+            logger.info(
+                "voice_call realtime: consult answer received call=%s chars=%d",
+                self.record.call_id, len(text),
+            )
             fut.set_result(text)
             return True
+        logger.info(
+            "voice_call realtime: speaking agent message call=%s chars=%d",
+            self.record.call_id, len(text),
+        )
         try:
             await self.session.inject_text(text)
             return True
@@ -474,6 +490,20 @@ class RealtimeCallBridge:
     async def _consult_via_gateway(self, question: str) -> str:
         from ..responder import dispatch_transcript
 
+        # A newer question supersedes an in-flight consult: resolve the old
+        # future benignly (its tool result completes immediately) — the new
+        # dispatch interrupts the old gateway turn, which is the same
+        # semantics as a user changing their mind mid-message.
+        previous = self._consult_future
+        if previous is not None and not previous.done():
+            logger.info(
+                "voice_call realtime: consult superseded by newer question "
+                "call=%s", self.record.call_id,
+            )
+            previous.set_result(
+                "Superseded by a newer question from the caller; answer that "
+                "instead."
+            )
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._consult_future = fut
         try:

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -267,9 +267,15 @@ class RealtimeCallBridge:
             elif frame.type == "media":
                 if frame.track and "outbound" in frame.track:
                     continue  # never echo our own audio into the model
-                pcm = audio.ulaw_to_pcm16(frame.payload)
-                pcm = audio.resample_pcm16(pcm, 8000, self.session.input_sample_rate)
-                await self.session.send_audio(pcm)
+                if self.session.audio_wire_format == "ulaw":
+                    # Model speaks the phone line's codec — pass through.
+                    await self.session.send_audio(frame.payload)
+                else:
+                    pcm = audio.ulaw_to_pcm16(frame.payload)
+                    pcm = audio.resample_pcm16(
+                        pcm, 8000, self.session.input_sample_rate
+                    )
+                    await self.session.send_audio(pcm)
             elif frame.type == "stop":
                 return
             elif frame.type == "error":
@@ -282,10 +288,13 @@ class RealtimeCallBridge:
     async def _outbound_pump(self, pacer: AudioPacer) -> None:
         async for event in self.session.events():
             if event.type == "audio":
-                pcm = audio.resample_pcm16(
-                    event.audio, self.session.output_sample_rate, 8000
-                )
-                pacer.push(audio.pcm16_to_ulaw(pcm))
+                if self.session.audio_wire_format == "ulaw":
+                    pacer.push(event.audio)  # already µ-law @ 8 kHz
+                else:
+                    pcm = audio.resample_pcm16(
+                        event.audio, self.session.output_sample_rate, 8000
+                    )
+                    pacer.push(audio.pcm16_to_ulaw(pcm))
             elif event.type == "speech_started":
                 await self._handle_barge_in(pacer)
             elif event.type == "transcript":

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -201,6 +201,12 @@ class RealtimeCallBridge:
         self.session = session
         self._ws = None
         self._greeting_until = 0.0
+        self._pacer: Optional[AudioPacer] = None
+        # Tool results that arrived while the model was mid-utterance (e.g.
+        # speaking the "let me check" filler) — sending response.create then
+        # would collide with the active response, so they flush on
+        # response_done instead.
+        self._deferred_tool_results: list = []
 
     async def run(self, ws) -> None:
         self._ws = ws
@@ -222,6 +228,7 @@ class RealtimeCallBridge:
                 self._greeting_until = time.time() + 3.0
 
         pacer = AudioPacer(self._send_media_frame)
+        self._pacer = pacer
         tasks = [
             asyncio.create_task(self._inbound_pump(ws), name="vc-rt-inbound"),
             asyncio.create_task(self._outbound_pump(pacer), name="vc-rt-outbound"),
@@ -303,6 +310,8 @@ class RealtimeCallBridge:
                 asyncio.get_running_loop().create_task(
                     self._handle_tool_call(event)
                 )
+            elif event.type == "response_done":
+                await self._flush_deferred_tool_results()
             elif event.type == "error":
                 logger.warning("voice_call realtime: model error: %s", event.text)
             elif event.type == "closed":
@@ -311,13 +320,24 @@ class RealtimeCallBridge:
     async def _handle_barge_in(self, pacer: AudioPacer) -> None:
         if time.time() < self._greeting_until:
             return  # don't let line noise cut off the greeting
+        # Caller speech is only an interruption when the bot is actually
+        # talking (response in flight or audio still queued). Otherwise it's
+        # a normal conversational turn — clearing the pacer here would dump
+        # answers the model already finished generating (it produces audio
+        # faster than realtime), and cancelling would just spam
+        # "no active response found" errors.
+        if not (self.session.response_active or pacer.pending):
+            return
         dropped = pacer.clear()
         if self._ws is not None and not self._ws.closed:
             await self._ws.send_str(self.adapter.serialize_clear())
-        try:
-            await self.session.cancel_response()
-        except Exception:  # noqa: BLE001
-            logger.debug("voice_call realtime: cancel_response failed", exc_info=True)
+        if self.session.response_active:
+            try:
+                await self.session.cancel_response()
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "voice_call realtime: cancel_response failed", exc_info=True
+                )
         if dropped:
             logger.debug(
                 "voice_call realtime: barge-in dropped %d queued frames", dropped
@@ -339,6 +359,16 @@ class RealtimeCallBridge:
 
     async def _handle_tool_call(self, event) -> None:
         question = str(event.tool_args.get("question", "")).strip()
+        # Consults take seconds (full agent model) — speak a filler so the
+        # caller isn't sitting in silence wondering if the call dropped
+        # (silence provokes "hello?", which used to barge-in the answer).
+        phrase = self.runtime.config.responder.thinking_phrase
+        if phrase and not self.session.response_active:
+            try:
+                await self.session.inject_text(phrase)
+            except Exception:  # noqa: BLE001
+                logger.debug("voice_call realtime: filler inject failed",
+                             exc_info=True)
         try:
             answer = await asyncio.wait_for(
                 self._consult_agent(question), timeout=CONSULT_TIMEOUT_S
@@ -348,11 +378,34 @@ class RealtimeCallBridge:
         except Exception as e:  # noqa: BLE001
             logger.exception("voice_call realtime: agent_consult failed")
             answer = f"Sorry, I could not check that: {e}"
+        await self._deliver_tool_result(event.tool_call_id, answer)
+
+    async def _deliver_tool_result(self, tool_call_id: str, answer: str) -> None:
+        """Send now, or defer until the in-flight utterance (filler) ends —
+        response.create during an active response is rejected by the API."""
+        if self.session.response_active:
+            self._deferred_tool_results.append((tool_call_id, answer))
+            # Re-check: the response may have ended between the check and
+            # the append (its response_done already processed).
+            if not self.session.response_active:
+                await self._flush_deferred_tool_results()
+            return
         try:
-            await self.session.send_tool_result(event.tool_call_id, answer)
+            await self.session.send_tool_result(tool_call_id, answer)
         except Exception:  # noqa: BLE001
             logger.warning("voice_call realtime: tool result delivery failed",
                            exc_info=True)
+
+    async def _flush_deferred_tool_results(self) -> None:
+        while self._deferred_tool_results and not self.session.response_active:
+            tool_call_id, answer = self._deferred_tool_results.pop(0)
+            try:
+                await self.session.send_tool_result(tool_call_id, answer)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "voice_call realtime: deferred tool result delivery failed",
+                    exc_info=True,
+                )
 
     async def _consult_agent(self, question: str) -> str:
         if not question:

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -150,6 +150,30 @@ class RealtimeBridgeManager:
         if provider is not None and hasattr(provider, "register_pending_stream"):
             provider.register_pending_stream(record, stream_url)
 
+    def _session_config_for(self, record: CallRecord):
+        """The realtime config for one call: the configured instructions
+        plus any per-call brief carried on the record (a call script the
+        agent attached at dial time)."""
+        from ..config import RealtimeConfig
+        from .base import DEFAULT_INSTRUCTIONS
+
+        base = self.runtime.config.realtime
+        extra = str(record.metadata.get("realtime_instructions") or "").strip()
+        if not extra:
+            return base
+        merged = (
+            (base.instructions or DEFAULT_INSTRUCTIONS)
+            + "\n\nThis call's specific brief — follow it exactly:\n"
+            + extra
+        )
+        return RealtimeConfig(
+            enabled=base.enabled,
+            provider=base.provider,
+            model=base.model,
+            voice=base.voice,
+            instructions=merged,
+        )
+
     async def upgrade_to_realtime(self, record: CallRecord, timeout: float = 10.0) -> bool:
         """Attach a media stream to an already-live call (notify-born calls
         have none) and wait for the carrier to open the WebSocket. Telnyx
@@ -224,7 +248,9 @@ class RealtimeBridgeManager:
         await ws.prepare(request)
 
         try:
-            session = create_realtime_session(self.runtime.config.realtime)
+            session = create_realtime_session(
+                self._session_config_for(record)
+            )
         except Exception as e:  # noqa: BLE001 — config/key errors
             logger.error("voice_call realtime: session create failed: %s", e)
             await ws.close()

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -563,10 +563,22 @@ class RealtimeCallBridge:
                 "Superseded by a newer question from the caller; answer that "
                 "instead."
             )
+        # The speed contract rides WITH the question — a distant system-
+        # prompt hint loses to session history full of thorough-research
+        # precedent; an instruction adjacent to the request does not.
+        framed = (
+            "[Voice consult — I am on a live phone call and waiting. Answer "
+            "in 1-3 short spoken sentences as fast as possible: answer "
+            "directly from what you know or at most ONE quick web_search. "
+            "Do not use web_extract, browser, or multi-step research. If a "
+            "thorough answer would take longer, give your best short answer "
+            "now and note what you'd verify later.] "
+            f"{question}"
+        )
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._consult_future = fut
         try:
-            await dispatch_transcript(self.runtime, self.record, question)
+            await dispatch_transcript(self.runtime, self.record, framed)
             answer = (await fut).strip()
             return answer[:CONSULT_MAX_CHARS] or "I could not find an answer."
         finally:

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -150,6 +150,55 @@ class RealtimeBridgeManager:
         if provider is not None and hasattr(provider, "register_pending_stream"):
             provider.register_pending_stream(record, stream_url)
 
+    async def upgrade_to_realtime(self, record: CallRecord, timeout: float = 10.0) -> bool:
+        """Attach a media stream to an already-live call (notify-born calls
+        have none) and wait for the carrier to open the WebSocket. Telnyx
+        supports this via streaming_start; carriers that can't attach
+        mid-call return False and stay on carrier TTS."""
+        if self.active_bridges.get(record.call_id) is not None:
+            return True  # already realtime
+        provider = self.runtime.provider
+        if provider is None or not getattr(provider, "supports_midcall_streaming", False):
+            return False
+        public = (self.runtime.public_url or "").rstrip("/")
+        if not public:
+            return False
+        wss_base = public.replace("https://", "wss://").replace("http://", "ws://")
+        token = self.mint_token(record.call_id)
+        stream_url = f"{wss_base}{self.runtime.config.serve.stream_path}/{token}"
+        record.metadata["stream_url"] = stream_url
+        record.metadata["stream_auth_token"] = token
+        record.metadata["realtime"] = True
+        logger.info(
+            "voice_call realtime: mid-call upgrade requested call=%s",
+            record.call_id,
+        )
+        try:
+            await provider.start_media_stream(record, stream_url, token)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "voice_call realtime: streaming_start failed for %s: %s",
+                record.call_id, e,
+            )
+            record.metadata.pop("realtime", None)
+            return False
+        # The carrier now dials our /voice/stream/{token} endpoint.
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.active_bridges.get(record.call_id) is not None:
+                logger.info(
+                    "voice_call realtime: mid-call upgrade complete call=%s",
+                    record.call_id,
+                )
+                return True
+            await asyncio.sleep(0.1)
+        logger.warning(
+            "voice_call realtime: carrier never opened the stream for %s — "
+            "falling back to carrier TTS", record.call_id,
+        )
+        record.metadata.pop("realtime", None)
+        return False
+
     # -- WS upgrade (installed as webhook_server.stream_handler) -----------------
 
     async def handle_stream_request(self, request):

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -99,7 +99,8 @@ class RealtimeBridgeManager:
 
     def __init__(self, runtime: "VoiceCallRuntime"):
         self.runtime = runtime
-        self._tokens: Dict[str, Tuple[str, float]] = {}  # token → (call_id, ts)
+        # token → (call_id, ts)
+        self._tokens: Dict[str, Tuple[str, float]] = {}
         self.active_bridges: Dict[str, "RealtimeCallBridge"] = {}
 
     # -- token lifecycle ------------------------------------------------------
@@ -137,7 +138,8 @@ class RealtimeBridgeManager:
                 record.call_id,
             )
             return
-        wss_base = public.replace("https://", "wss://").replace("http://", "ws://")
+        wss_base = public.replace(
+            "https://", "wss://").replace("http://", "ws://")
         token = self.mint_token(record.call_id)
         stream_url = f"{wss_base}{config.serve.stream_path}/{token}"
         record.metadata["stream_url"] = stream_url
@@ -156,7 +158,8 @@ class RealtimeBridgeManager:
         token = request.match_info.get("token", "")
         call_id = self.consume_token(token)
         if call_id is None:
-            logger.warning("voice_call realtime: rejected stream with bad token")
+            logger.warning(
+                "voice_call realtime: rejected stream with bad token")
             return web.json_response({"error": "invalid token"}, status=403)
         manager = self.runtime.manager
         record = manager.get_call(call_id) if manager else None
@@ -239,7 +242,8 @@ class RealtimeCallBridge:
         self._pacer = pacer
         tasks = [
             asyncio.create_task(self._inbound_pump(ws), name="vc-rt-inbound"),
-            asyncio.create_task(self._outbound_pump(pacer), name="vc-rt-outbound"),
+            asyncio.create_task(self._outbound_pump(pacer),
+                                name="vc-rt-outbound"),
             asyncio.create_task(pacer.run(), name="vc-rt-pacer"),
         ]
         try:
@@ -259,7 +263,8 @@ class RealtimeCallBridge:
             await self.session.close()
             if not ws.closed:
                 await ws.close()
-        logger.info("voice_call realtime: bridge for %s ended", self.record.call_id)
+        logger.info("voice_call realtime: bridge for %s ended",
+                    self.record.call_id)
 
     async def _send_media_frame(self, frame: bytes) -> None:
         if self._ws is not None and not self._ws.closed:
@@ -331,7 +336,8 @@ class RealtimeCallBridge:
                 if "no active response" in (event.text or "").lower():
                     logger.debug("voice_call realtime: %s", event.text)
                 else:
-                    logger.warning("voice_call realtime: model error: %s", event.text)
+                    logger.warning(
+                        "voice_call realtime: model error: %s", event.text)
             elif event.type == "closed":
                 return
 
@@ -393,12 +399,14 @@ class RealtimeCallBridge:
                 self.record.call_id,
             )
         except Exception:  # noqa: BLE001
-            logger.debug("voice_call realtime: filler inject failed", exc_info=True)
+            logger.debug(
+                "voice_call realtime: filler inject failed", exc_info=True)
 
     async def _handle_tool_call(self, event) -> None:
         question = str(event.tool_args.get("question", "")).strip()
         started_at = time.time()
-        timeout = max(15.0, float(self.runtime.config.responder.response_timeout_s))
+        timeout = max(15.0, float(
+            self.runtime.config.responder.response_timeout_s))
 
         # Empty-args consults happen when the model flails (e.g. retrying
         # after a timeout). OpenClaw's fallback: join an in-flight consult

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -1,0 +1,376 @@
+"""The realtime bridge: carrier media stream ⇄ realtime voice model.
+
+One :class:`RealtimeCallBridge` per live realtime call:
+
+- the carrier opens a WebSocket to ``/voice/stream/{token}`` (the one-shot
+  token was minted when the call was dialed/answered and embedded in the
+  ``stream_url`` the carrier received)
+- inbound pump: carrier frame → µ-law decode → resample → model
+- outbound pump: model audio → resample to 8 kHz → µ-law → 20 ms pacer →
+  carrier; barge-in (caller starts speaking) clears the carrier's queued
+  audio and cancels the in-flight model response
+- ``agent_consult`` tool calls run a host-owned completion through the
+  plugin LLM facade (``ctx.llm``) so the realtime model can answer with
+  the user's data without leaving the audio loop
+- transcripts mirror into the CallRecord for history/persistence
+"""
+
+import asyncio
+import logging
+import secrets
+import time
+from collections import deque
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
+
+from .. import audio
+from ..events import CallRecord
+from .base import RealtimeVoiceSession
+from .frames import StreamFrameAdapter, adapter_for_provider
+from .gemini_live import create_realtime_session
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..runtime import VoiceCallRuntime
+
+logger = logging.getLogger(__name__)
+
+TOKEN_TTL_S = 300.0
+CONSULT_TIMEOUT_S = 45.0
+CONSULT_MAX_CHARS = 2000
+
+# Set by the plugin's register() so the bridge can reach ctx.llm without
+# holding a PluginContext reference through every layer.
+_plugin_llm_factory: Optional[Callable[[], Any]] = None
+
+
+def set_plugin_llm_factory(factory: Callable[[], Any]) -> None:
+    global _plugin_llm_factory
+    _plugin_llm_factory = factory
+
+
+class AudioPacer:
+    """Sends one 160-byte µ-law frame every 20 ms on an absolute schedule
+    (drift-corrected — no cumulative delay), like OpenClaw's audio pacer."""
+
+    def __init__(self, send_frame: Callable[[bytes], Any]):
+        self._send = send_frame
+        self._frames: deque = deque()
+        self._running = False
+
+    def push(self, ulaw: bytes) -> None:
+        self._frames.extend(audio.chunk_frames(ulaw))
+
+    def clear(self) -> int:
+        dropped = len(self._frames)
+        self._frames.clear()
+        return dropped
+
+    @property
+    def pending(self) -> int:
+        return len(self._frames)
+
+    async def run(self) -> None:
+        self._running = True
+        loop = asyncio.get_running_loop()
+        next_at = loop.time()
+        try:
+            while self._running:
+                if self._frames:
+                    frame = self._frames.popleft()
+                    await self._send(frame)
+                    next_at += audio.FRAME_SECONDS
+                    delay = next_at - loop.time()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
+                    elif delay < -1.0:
+                        next_at = loop.time()  # fell badly behind; resync
+                else:
+                    next_at = loop.time()
+                    await asyncio.sleep(0.005)
+        except asyncio.CancelledError:
+            pass
+
+    def stop(self) -> None:
+        self._running = False
+
+
+class RealtimeBridgeManager:
+    """Owned by the runtime when ``realtime.enabled``: mints one-shot stream
+    tokens at dial/answer time and turns carrier WS upgrades into bridges."""
+
+    def __init__(self, runtime: "VoiceCallRuntime"):
+        self.runtime = runtime
+        self._tokens: Dict[str, Tuple[str, float]] = {}  # token → (call_id, ts)
+        self.active_bridges: Dict[str, "RealtimeCallBridge"] = {}
+
+    # -- token lifecycle ------------------------------------------------------
+
+    def mint_token(self, call_id: str) -> str:
+        now = time.time()
+        for token in [t for t, (_, ts) in self._tokens.items()
+                      if ts < now - TOKEN_TTL_S]:
+            self._tokens.pop(token, None)
+        token = secrets.token_urlsafe(24)
+        self._tokens[token] = (call_id, now)
+        return token
+
+    def consume_token(self, token: str) -> Optional[str]:
+        """One-shot: a second use of the same token fails."""
+        entry = self._tokens.pop(token, None)
+        if entry is None:
+            return None
+        call_id, minted_at = entry
+        if minted_at < time.time() - TOKEN_TTL_S:
+            return None
+        return call_id
+
+    # -- dial/answer hook -------------------------------------------------------
+
+    def prepare_call(self, record: CallRecord) -> None:
+        """Attach stream metadata before the provider dials/answers."""
+        if record.mode != "conversation":
+            return  # notify calls keep plain carrier TTS
+        config = self.runtime.config
+        public = (self.runtime.public_url or "").rstrip("/")
+        if not public:
+            logger.warning(
+                "voice_call realtime: no public URL — cannot attach stream to %s",
+                record.call_id,
+            )
+            return
+        wss_base = public.replace("https://", "wss://").replace("http://", "ws://")
+        token = self.mint_token(record.call_id)
+        stream_url = f"{wss_base}{config.serve.stream_path}/{token}"
+        record.metadata["stream_url"] = stream_url
+        record.metadata["stream_auth_token"] = token
+        record.metadata["realtime"] = True
+        # Twilio attaches streams via TwiML, not dial fields.
+        provider = self.runtime.provider
+        if provider is not None and hasattr(provider, "register_pending_stream"):
+            provider.register_pending_stream(record, stream_url)
+
+    # -- WS upgrade (installed as webhook_server.stream_handler) -----------------
+
+    async def handle_stream_request(self, request):
+        from aiohttp import web
+
+        token = request.match_info.get("token", "")
+        call_id = self.consume_token(token)
+        if call_id is None:
+            logger.warning("voice_call realtime: rejected stream with bad token")
+            return web.json_response({"error": "invalid token"}, status=403)
+        manager = self.runtime.manager
+        record = manager.get_call(call_id) if manager else None
+        if record is None:
+            return web.json_response({"error": "no such call"}, status=404)
+
+        ws = web.WebSocketResponse(heartbeat=30)
+        await ws.prepare(request)
+
+        try:
+            session = create_realtime_session(self.runtime.config.realtime)
+        except Exception as e:  # noqa: BLE001 — config/key errors
+            logger.error("voice_call realtime: session create failed: %s", e)
+            await ws.close()
+            return ws
+
+        bridge = RealtimeCallBridge(
+            runtime=self.runtime,
+            record=record,
+            frame_adapter=adapter_for_provider(record.provider),
+            session=session,
+        )
+        self.active_bridges[call_id] = bridge
+        try:
+            await bridge.run(ws)
+        finally:
+            self.active_bridges.pop(call_id, None)
+        return ws
+
+
+class RealtimeCallBridge:
+    def __init__(
+        self,
+        runtime: "VoiceCallRuntime",
+        record: CallRecord,
+        frame_adapter: StreamFrameAdapter,
+        session: RealtimeVoiceSession,
+    ):
+        self.runtime = runtime
+        self.record = record
+        self.adapter = frame_adapter
+        self.session = session
+        self._ws = None
+        self._greeting_until = 0.0
+
+    async def run(self, ws) -> None:
+        self._ws = ws
+        try:
+            await self.session.connect()
+        except Exception as e:  # noqa: BLE001
+            logger.error("voice_call realtime: model connect failed: %s", e)
+            await ws.close()
+            return
+
+        if self.record.direction == "inbound" and self.runtime.config.inbound_greeting:
+            await self.session.inject_text(self.runtime.config.inbound_greeting)
+            # Suppress barge-in while the greeting plays (OpenClaw behavior).
+            self._greeting_until = time.time() + 3.0
+        elif self.record.direction == "outbound":
+            initial = self.record.metadata.pop("initial_message", None)
+            if initial:
+                await self.session.inject_text(str(initial))
+                self._greeting_until = time.time() + 3.0
+
+        pacer = AudioPacer(self._send_media_frame)
+        tasks = [
+            asyncio.create_task(self._inbound_pump(ws), name="vc-rt-inbound"),
+            asyncio.create_task(self._outbound_pump(pacer), name="vc-rt-outbound"),
+            asyncio.create_task(pacer.run(), name="vc-rt-pacer"),
+        ]
+        try:
+            done, pending = await asyncio.wait(
+                tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in done:
+                exc = task.exception()
+                if exc is not None:
+                    logger.warning("voice_call realtime: %s failed: %s",
+                                   task.get_name(), exc)
+        finally:
+            pacer.stop()
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await self.session.close()
+            if not ws.closed:
+                await ws.close()
+        logger.info("voice_call realtime: bridge for %s ended", self.record.call_id)
+
+    async def _send_media_frame(self, frame: bytes) -> None:
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.send_str(self.adapter.serialize_media(frame))
+
+    # -- carrier → model ---------------------------------------------------------
+
+    async def _inbound_pump(self, ws) -> None:
+        from aiohttp import WSMsgType
+
+        async for msg in ws:
+            if msg.type != WSMsgType.TEXT:
+                if msg.type in (WSMsgType.CLOSE, WSMsgType.ERROR):
+                    return
+                continue
+            frame = self.adapter.parse(msg.data)
+            if frame.type == "start":
+                if frame.stream_id:
+                    self.adapter.set_stream_id(frame.stream_id)
+            elif frame.type == "media":
+                if frame.track and "outbound" in frame.track:
+                    continue  # never echo our own audio into the model
+                pcm = audio.ulaw_to_pcm16(frame.payload)
+                pcm = audio.resample_pcm16(pcm, 8000, self.session.input_sample_rate)
+                await self.session.send_audio(pcm)
+            elif frame.type == "stop":
+                return
+            elif frame.type == "error":
+                logger.warning(
+                    "voice_call realtime: carrier stream error: %s", frame.error
+                )
+
+    # -- model → carrier ----------------------------------------------------------
+
+    async def _outbound_pump(self, pacer: AudioPacer) -> None:
+        async for event in self.session.events():
+            if event.type == "audio":
+                pcm = audio.resample_pcm16(
+                    event.audio, self.session.output_sample_rate, 8000
+                )
+                pacer.push(audio.pcm16_to_ulaw(pcm))
+            elif event.type == "speech_started":
+                await self._handle_barge_in(pacer)
+            elif event.type == "transcript":
+                self._record_transcript(event.role, event.text)
+            elif event.type == "tool_call":
+                asyncio.get_running_loop().create_task(
+                    self._handle_tool_call(event)
+                )
+            elif event.type == "error":
+                logger.warning("voice_call realtime: model error: %s", event.text)
+            elif event.type == "closed":
+                return
+
+    async def _handle_barge_in(self, pacer: AudioPacer) -> None:
+        if time.time() < self._greeting_until:
+            return  # don't let line noise cut off the greeting
+        dropped = pacer.clear()
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.send_str(self.adapter.serialize_clear())
+        try:
+            await self.session.cancel_response()
+        except Exception:  # noqa: BLE001
+            logger.debug("voice_call realtime: cancel_response failed", exc_info=True)
+        if dropped:
+            logger.debug(
+                "voice_call realtime: barge-in dropped %d queued frames", dropped
+            )
+
+    def _record_transcript(self, role: str, text: str) -> None:
+        text = (text or "").strip()
+        if not text:
+            return
+        manager = self.runtime.manager
+        if manager is not None:
+            manager.append_transcript(
+                self.record.call_id,
+                "bot" if role == "assistant" else "user",
+                text,
+            )
+
+    # -- agent_consult ---------------------------------------------------------------
+
+    async def _handle_tool_call(self, event) -> None:
+        question = str(event.tool_args.get("question", "")).strip()
+        try:
+            answer = await asyncio.wait_for(
+                self._consult_agent(question), timeout=CONSULT_TIMEOUT_S
+            )
+        except asyncio.TimeoutError:
+            answer = "Sorry, looking that up took too long."
+        except Exception as e:  # noqa: BLE001
+            logger.exception("voice_call realtime: agent_consult failed")
+            answer = f"Sorry, I could not check that: {e}"
+        try:
+            await self.session.send_tool_result(event.tool_call_id, answer)
+        except Exception:  # noqa: BLE001
+            logger.warning("voice_call realtime: tool result delivery failed",
+                           exc_info=True)
+
+    async def _consult_agent(self, question: str) -> str:
+        if not question:
+            return "No question was provided."
+        llm = _plugin_llm_factory() if _plugin_llm_factory is not None else None
+        if llm is None:
+            return "The agent is not available right now."
+        peer = self.record.peer_number or "unknown"
+
+        def _run() -> str:
+            result = llm.complete(
+                [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are the Hermes agent assisting a live phone "
+                            f"call with {peer}. Answer in 1-3 short spoken-"
+                            "style sentences of plain text. No markdown, "
+                            "URLs, or lists. Never reveal secrets."
+                        ),
+                    },
+                    {"role": "user", "content": question},
+                ],
+                purpose="voice_call.agent_consult",
+                timeout=CONSULT_TIMEOUT_S - 5,
+            )
+            return (result.text or "").strip()
+
+        answer = await asyncio.get_running_loop().run_in_executor(None, _run)
+        return answer[:CONSULT_MAX_CHARS] or "I could not find an answer."

--- a/plugins/platforms/voice_call/realtime/bridge.py
+++ b/plugins/platforms/voice_call/realtime/bridge.py
@@ -403,6 +403,21 @@ class RealtimeCallBridge:
                 "voice_call realtime: filler inject failed", exc_info=True)
 
     async def _handle_tool_call(self, event) -> None:
+        if event.tool_name == "end_call":
+            await self._handle_end_call(event)
+            return
+        if event.tool_name != "agent_consult":
+            logger.warning(
+                "voice_call realtime: unknown tool %r requested", event.tool_name
+            )
+            try:
+                await self.session.send_tool_result(
+                    event.tool_call_id, f"Unknown tool {event.tool_name!r}."
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug("voice_call realtime: tool error reply failed",
+                             exc_info=True)
+            return
         question = str(event.tool_args.get("question", "")).strip()
         started_at = time.time()
         timeout = max(15.0, float(
@@ -469,6 +484,31 @@ class RealtimeCallBridge:
             self.record.call_id, status, time.time() - started_at, len(answer),
         )
         await self._deliver_tool_result(event.tool_call_id, answer)
+
+    async def _handle_end_call(self, event) -> None:
+        """The model asked to hang up (caller said goodbye). Let any
+        in-flight goodbye finish playing, then end the call at the carrier —
+        works for every provider via manager.end_call → provider.hangup_call."""
+        reason = str(event.tool_args.get("reason", "") or "model requested hangup")
+        logger.info(
+            "voice_call realtime: model requested hangup call=%s reason=%s",
+            self.record.call_id, reason,
+        )
+        # Grace: drain the goodbye (active response + queued frames), max 8s.
+        deadline = time.time() + 8.0
+        while time.time() < deadline and (
+            self.session.response_active
+            or (self._pacer is not None and self._pacer.pending)
+        ):
+            await asyncio.sleep(0.1)
+        await asyncio.sleep(0.3)  # let the carrier flush the last frames
+        manager = self.runtime.manager
+        if manager is None or manager.get_call(self.record.call_id) is None:
+            return  # already ended (caller hung up first)
+        try:
+            await manager.end_call(self.record.call_id, reason="hangup-bot")
+        except Exception:  # noqa: BLE001
+            logger.exception("voice_call realtime: model-requested hangup failed")
 
     async def deliver_agent_text(self, text: str, final: bool = True) -> bool:
         """Agent output routed to a realtime call (via adapter.send()).

--- a/plugins/platforms/voice_call/realtime/frames.py
+++ b/plugins/platforms/voice_call/realtime/frames.py
@@ -1,0 +1,205 @@
+"""Carrier media-stream wire-format adapters.
+
+Port of OpenClaw's ``src/webhook/stream-frame-adapter.ts``: each carrier
+speaks a slightly different JSON envelope over the media WebSocket. The
+bridge consumes only :class:`StreamFrame`.
+
+Telnyx frames (bidirectional RTP streaming):
+  start: {event, stream_id, start: {call_control_id, media_format}}
+  media: {event, stream_id, media: {payload: b64, track, timestamp}}
+  outbound media: {event: "media", media: {payload}}; clear: {event: "clear"}
+
+Twilio Media Streams:
+  start: {event, streamSid, start: {callSid, mediaFormat}}
+  media: {event, streamSid, media: {payload: b64, track}}
+  outbound media adds streamSid; mark/clear also carry streamSid.
+"""
+
+import abc
+import base64
+import binascii
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class StreamFrame:
+    type: str                      # "connected" | "start" | "media" | "mark" | "stop" | "error" | "unknown"
+    stream_id: Optional[str] = None
+    provider_call_id: Optional[str] = None  # carrier call id from the start frame
+    payload: bytes = b""           # decoded audio (media frames)
+    track: Optional[str] = None
+    mark_name: Optional[str] = None
+    error: Optional[str] = None
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+class StreamFrameAdapter(abc.ABC):
+    """Parse inbound carrier WS messages / serialize outbound ones."""
+
+    name: str = ""
+
+    @abc.abstractmethod
+    def parse(self, message: str) -> StreamFrame: ...
+
+    @abc.abstractmethod
+    def serialize_media(self, payload: bytes) -> str: ...
+
+    @abc.abstractmethod
+    def serialize_clear(self) -> str: ...
+
+    @abc.abstractmethod
+    def serialize_mark(self, name: str) -> str: ...
+
+    def set_stream_id(self, stream_id: str) -> None:
+        """Carriers that envelope outbound frames with a stream id override."""
+
+
+def _decode_payload(media: Dict[str, Any]) -> bytes:
+    payload = media.get("payload")
+    if not payload:
+        return b""
+    try:
+        return base64.b64decode(payload)
+    except (binascii.Error, ValueError):
+        return b""
+
+
+def _parse_json(message: str) -> Optional[Dict[str, Any]]:
+    try:
+        data = json.loads(message)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+class TelnyxStreamFrameAdapter(StreamFrameAdapter):
+    name = "telnyx"
+
+    def parse(self, message: str) -> StreamFrame:
+        data = _parse_json(message)
+        if data is None:
+            return StreamFrame(type="unknown")
+        event = str(data.get("event", ""))
+        stream_id = data.get("stream_id")
+        if event == "connected":
+            return StreamFrame(type="connected", stream_id=stream_id, raw=data)
+        if event == "start":
+            start = data.get("start") or {}
+            return StreamFrame(
+                type="start",
+                stream_id=stream_id,
+                provider_call_id=start.get("call_control_id"),
+                raw=data,
+            )
+        if event == "media":
+            media = data.get("media") or {}
+            return StreamFrame(
+                type="media",
+                stream_id=stream_id,
+                payload=_decode_payload(media),
+                track=media.get("track"),
+                raw=data,
+            )
+        if event == "mark":
+            return StreamFrame(
+                type="mark", stream_id=stream_id,
+                mark_name=(data.get("mark") or {}).get("name"), raw=data,
+            )
+        if event == "stop":
+            return StreamFrame(type="stop", stream_id=stream_id, raw=data)
+        if event == "error":
+            payload = data.get("payload") or {}
+            detail = " ".join(
+                str(payload.get(k)) for k in ("code", "title", "detail")
+                if payload.get(k)
+            )
+            return StreamFrame(
+                type="error", stream_id=stream_id,
+                error=detail or "unknown stream error", raw=data,
+            )
+        return StreamFrame(type="unknown", stream_id=stream_id, raw=data)
+
+    def serialize_media(self, payload: bytes) -> str:
+        return json.dumps(
+            {"event": "media",
+             "media": {"payload": base64.b64encode(payload).decode()}}
+        )
+
+    def serialize_clear(self) -> str:
+        return json.dumps({"event": "clear"})
+
+    def serialize_mark(self, name: str) -> str:
+        return json.dumps({"event": "mark", "mark": {"name": name}})
+
+
+class TwilioStreamFrameAdapter(StreamFrameAdapter):
+    name = "twilio"
+
+    def __init__(self):
+        self._stream_sid: Optional[str] = None
+
+    def set_stream_id(self, stream_id: str) -> None:
+        self._stream_sid = stream_id
+
+    def parse(self, message: str) -> StreamFrame:
+        data = _parse_json(message)
+        if data is None:
+            return StreamFrame(type="unknown")
+        event = str(data.get("event", ""))
+        stream_sid = data.get("streamSid")
+        if event == "connected":
+            return StreamFrame(type="connected", raw=data)
+        if event == "start":
+            start = data.get("start") or {}
+            if stream_sid:
+                self._stream_sid = stream_sid
+            return StreamFrame(
+                type="start",
+                stream_id=stream_sid,
+                provider_call_id=start.get("callSid"),
+                raw=data,
+            )
+        if event == "media":
+            media = data.get("media") or {}
+            return StreamFrame(
+                type="media",
+                stream_id=stream_sid,
+                payload=_decode_payload(media),
+                track=media.get("track"),
+                raw=data,
+            )
+        if event == "mark":
+            return StreamFrame(
+                type="mark", stream_id=stream_sid,
+                mark_name=(data.get("mark") or {}).get("name"), raw=data,
+            )
+        if event == "stop":
+            return StreamFrame(type="stop", stream_id=stream_sid, raw=data)
+        return StreamFrame(type="unknown", stream_id=stream_sid, raw=data)
+
+    def _envelope(self, body: Dict[str, Any]) -> str:
+        if self._stream_sid:
+            body["streamSid"] = self._stream_sid
+        return json.dumps(body)
+
+    def serialize_media(self, payload: bytes) -> str:
+        return self._envelope(
+            {"event": "media",
+             "media": {"payload": base64.b64encode(payload).decode()}}
+        )
+
+    def serialize_clear(self) -> str:
+        return self._envelope({"event": "clear"})
+
+    def serialize_mark(self, name: str) -> str:
+        return self._envelope({"event": "mark", "mark": {"name": name}})
+
+
+def adapter_for_provider(provider_name: str) -> StreamFrameAdapter:
+    if provider_name == "telnyx":
+        return TelnyxStreamFrameAdapter()
+    if provider_name == "twilio":
+        return TwilioStreamFrameAdapter()
+    raise ValueError(f"no stream frame adapter for provider {provider_name!r}")

--- a/plugins/platforms/voice_call/realtime/gemini_live.py
+++ b/plugins/platforms/voice_call/realtime/gemini_live.py
@@ -16,6 +16,7 @@ from ..config import RealtimeConfig
 from .base import (
     AGENT_CONSULT_TOOL,
     DEFAULT_INSTRUCTIONS,
+    WAITING_ETIQUETTE,
     RealtimeEvent,
     RealtimeVoiceSession,
 )
@@ -42,7 +43,9 @@ class GeminiLiveSession(RealtimeVoiceSession):
             raise ValueError("Gemini Live requires GEMINI_API_KEY")
         self.model = config.model or DEFAULT_MODEL
         self.voice = config.voice or DEFAULT_VOICE
-        self.instructions = config.instructions or DEFAULT_INSTRUCTIONS
+        self.instructions = (
+            config.instructions or DEFAULT_INSTRUCTIONS
+        ) + WAITING_ETIQUETTE
         self._ws = None
         self._closed = False
 

--- a/plugins/platforms/voice_call/realtime/gemini_live.py
+++ b/plugins/platforms/voice_call/realtime/gemini_live.py
@@ -134,8 +134,11 @@ class GeminiLiveSession(RealtimeVoiceSession):
         events = []
         content = frame.get("serverContent") or frame.get("server_content") or {}
         if content.get("interrupted"):
+            self.response_active = False
             events.append(RealtimeEvent(type="speech_started"))
         model_turn = content.get("modelTurn") or content.get("model_turn") or {}
+        if model_turn.get("parts"):
+            self.response_active = True
         for part in model_turn.get("parts", []):
             inline = part.get("inlineData") or part.get("inline_data") or {}
             data = inline.get("data")
@@ -153,6 +156,7 @@ class GeminiLiveSession(RealtimeVoiceSession):
                     )
                 )
         if content.get("turnComplete") or content.get("turn_complete"):
+            self.response_active = False
             events.append(RealtimeEvent(type="response_done"))
 
         tool_call = frame.get("toolCall") or frame.get("tool_call") or {}

--- a/plugins/platforms/voice_call/realtime/gemini_live.py
+++ b/plugins/platforms/voice_call/realtime/gemini_live.py
@@ -16,6 +16,7 @@ from ..config import RealtimeConfig
 from .base import (
     AGENT_CONSULT_TOOL,
     DEFAULT_INSTRUCTIONS,
+    END_CALL_TOOL,
     WAITING_ETIQUETTE,
     RealtimeEvent,
     RealtimeVoiceSession,
@@ -71,7 +72,9 @@ class GeminiLiveSession(RealtimeVoiceSession):
                 "system_instruction": {
                     "parts": [{"text": self.instructions}]
                 },
-                "tools": [{"function_declarations": [AGENT_CONSULT_TOOL]}],
+                "tools": [
+                    {"function_declarations": [AGENT_CONSULT_TOOL, END_CALL_TOOL]}
+                ],
             }
         })
 

--- a/plugins/platforms/voice_call/realtime/gemini_live.py
+++ b/plugins/platforms/voice_call/realtime/gemini_live.py
@@ -1,0 +1,202 @@
+"""Gemini Live API session (speech-to-speech over websockets).
+
+Same surface as the OpenAI session, different wire protocol: a ``setup``
+message configures the model, caller audio streams as ``realtime_input``
+media chunks (PCM16 @ 16 kHz), model audio arrives as inline data parts
+(PCM16 @ 24 kHz), and ``interrupted`` server content signals barge-in.
+"""
+
+import base64
+import json
+import logging
+import os
+from typing import Any, AsyncIterator, Dict, Optional
+
+from ..config import RealtimeConfig
+from .base import (
+    AGENT_CONSULT_TOOL,
+    DEFAULT_INSTRUCTIONS,
+    RealtimeEvent,
+    RealtimeVoiceSession,
+)
+
+logger = logging.getLogger(__name__)
+
+LIVE_URL = (
+    "wss://generativelanguage.googleapis.com/ws/"
+    "google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+)
+DEFAULT_MODEL = "gemini-2.5-flash-native-audio-preview"
+DEFAULT_VOICE = "Puck"
+
+
+class GeminiLiveSession(RealtimeVoiceSession):
+    name = "gemini"
+    input_sample_rate = 16000
+    output_sample_rate = 24000
+
+    def __init__(self, config: RealtimeConfig, api_key: Optional[str] = None):
+        self.config = config
+        self.api_key = api_key or os.getenv("GEMINI_API_KEY", "")
+        if not self.api_key:
+            raise ValueError("Gemini Live requires GEMINI_API_KEY")
+        self.model = config.model or DEFAULT_MODEL
+        self.voice = config.voice or DEFAULT_VOICE
+        self.instructions = config.instructions or DEFAULT_INSTRUCTIONS
+        self._ws = None
+        self._closed = False
+
+    async def connect(self) -> None:
+        import websockets
+
+        self._ws = await websockets.connect(
+            f"{LIVE_URL}?key={self.api_key}",
+            max_size=16 * 1024 * 1024,
+        )
+        model = self.model if self.model.startswith("models/") else f"models/{self.model}"
+        await self._send({
+            "setup": {
+                "model": model,
+                "generation_config": {
+                    "response_modalities": ["AUDIO"],
+                    "speech_config": {
+                        "voice_config": {
+                            "prebuilt_voice_config": {"voice_name": self.voice}
+                        }
+                    },
+                },
+                "system_instruction": {
+                    "parts": [{"text": self.instructions}]
+                },
+                "tools": [{"function_declarations": [AGENT_CONSULT_TOOL]}],
+            }
+        })
+
+    async def _send(self, message: Dict[str, Any]) -> None:
+        if self._ws is None or self._closed:
+            return
+        await self._ws.send(json.dumps(message))
+
+    async def send_audio(self, pcm16: bytes) -> None:
+        if not pcm16:
+            return
+        await self._send({
+            "realtime_input": {
+                "media_chunks": [
+                    {
+                        "mime_type": f"audio/pcm;rate={self.input_sample_rate}",
+                        "data": base64.b64encode(pcm16).decode(),
+                    }
+                ]
+            }
+        })
+
+    async def inject_text(self, text: str) -> None:
+        await self._send({
+            "client_content": {
+                "turns": [
+                    {
+                        "role": "user",
+                        "parts": [{"text": f"Say this to the caller now: {text}"}],
+                    }
+                ],
+                "turn_complete": True,
+            }
+        })
+
+    async def cancel_response(self) -> None:
+        """Gemini Live cancels generation automatically on caller speech
+        (server-side VAD); there is no explicit cancel message."""
+
+    async def send_tool_result(self, tool_call_id: str, result: str) -> None:
+        await self._send({
+            "tool_response": {
+                "function_responses": [
+                    {
+                        "id": tool_call_id,
+                        "name": AGENT_CONSULT_TOOL["name"],
+                        "response": {"result": result},
+                    }
+                ]
+            }
+        })
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:  # noqa: BLE001
+                logger.debug("gemini live close failed", exc_info=True)
+            self._ws = None
+
+    def _translate(self, frame: Dict[str, Any]) -> list:
+        events = []
+        content = frame.get("serverContent") or frame.get("server_content") or {}
+        if content.get("interrupted"):
+            events.append(RealtimeEvent(type="speech_started"))
+        model_turn = content.get("modelTurn") or content.get("model_turn") or {}
+        for part in model_turn.get("parts", []):
+            inline = part.get("inlineData") or part.get("inline_data") or {}
+            data = inline.get("data")
+            if data:
+                try:
+                    events.append(
+                        RealtimeEvent(type="audio", audio=base64.b64decode(data))
+                    )
+                except Exception:  # noqa: BLE001
+                    continue
+            elif part.get("text"):
+                events.append(
+                    RealtimeEvent(
+                        type="transcript", role="assistant", text=str(part["text"])
+                    )
+                )
+        if content.get("turnComplete") or content.get("turn_complete"):
+            events.append(RealtimeEvent(type="response_done"))
+
+        tool_call = frame.get("toolCall") or frame.get("tool_call") or {}
+        for fc in tool_call.get("functionCalls", tool_call.get("function_calls", [])):
+            args = fc.get("args") or {}
+            events.append(
+                RealtimeEvent(
+                    type="tool_call",
+                    tool_call_id=str(fc.get("id", "")),
+                    tool_name=str(fc.get("name", "")),
+                    tool_args=args if isinstance(args, dict) else {},
+                )
+            )
+        return events
+
+    async def events(self) -> AsyncIterator[RealtimeEvent]:
+        import websockets
+
+        if self._ws is None:
+            return
+        try:
+            async for raw in self._ws:
+                if isinstance(raw, bytes):
+                    raw = raw.decode("utf-8", "replace")
+                try:
+                    frame = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                for event in self._translate(frame):
+                    yield event
+        except websockets.ConnectionClosed:
+            pass
+        except Exception as e:  # noqa: BLE001
+            if not self._closed:
+                yield RealtimeEvent(type="error", text=str(e))
+        yield RealtimeEvent(type="closed")
+
+
+def create_realtime_session(config: RealtimeConfig) -> RealtimeVoiceSession:
+    """Factory used by the bridge: realtime.provider → session."""
+    if config.provider == "openai":
+        from .openai_realtime import OpenAIRealtimeSession
+
+        return OpenAIRealtimeSession(config)
+    if config.provider == "gemini":
+        return GeminiLiveSession(config)
+    raise ValueError(f"unknown realtime provider {config.provider!r}")

--- a/plugins/platforms/voice_call/realtime/openai_realtime.py
+++ b/plugins/platforms/voice_call/realtime/openai_realtime.py
@@ -17,6 +17,7 @@ from ..config import RealtimeConfig
 from .base import (
     AGENT_CONSULT_TOOL,
     DEFAULT_INSTRUCTIONS,
+    WAITING_ETIQUETTE,
     RealtimeEvent,
     RealtimeVoiceSession,
 )
@@ -44,7 +45,9 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
             raise ValueError("OpenAI Realtime requires OPENAI_API_KEY")
         self.model = config.model or DEFAULT_MODEL
         self.voice = config.voice or DEFAULT_VOICE
-        self.instructions = config.instructions or DEFAULT_INSTRUCTIONS
+        self.instructions = (
+            config.instructions or DEFAULT_INSTRUCTIONS
+        ) + WAITING_ETIQUETTE
         self._ws = None
         self._closed = False
         # call_ids already surfaced as tool_call events — GA can deliver a

--- a/plugins/platforms/voice_call/realtime/openai_realtime.py
+++ b/plugins/platforms/voice_call/realtime/openai_realtime.py
@@ -107,6 +107,10 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
             "type": "response.create",
             "response": {"instructions": f"Say this to the caller now: {text}"},
         })
+        # Optimistic: the server's response.created event lags our create;
+        # without this, a tool result landing in that window would issue a
+        # colliding response.create ("already has an active response").
+        self.response_active = True
 
     async def cancel_response(self) -> None:
         await self._send({"type": "response.cancel"})
@@ -121,6 +125,7 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
             },
         })
         await self._send({"type": "response.create"})
+        self.response_active = True  # optimistic — see inject_text
 
     async def close(self) -> None:
         self._closed = True

--- a/plugins/platforms/voice_call/realtime/openai_realtime.py
+++ b/plugins/platforms/voice_call/realtime/openai_realtime.py
@@ -17,6 +17,7 @@ from ..config import RealtimeConfig
 from .base import (
     AGENT_CONSULT_TOOL,
     DEFAULT_INSTRUCTIONS,
+    END_CALL_TOOL,
     WAITING_ETIQUETTE,
     RealtimeEvent,
     RealtimeVoiceSession,
@@ -77,7 +78,10 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
                         "voice": self.voice,
                     },
                 },
-                "tools": [{"type": "function", **AGENT_CONSULT_TOOL}],
+                "tools": [
+                    {"type": "function", **AGENT_CONSULT_TOOL},
+                    {"type": "function", **END_CALL_TOOL},
+                ],
                 "tool_choice": "auto",
             },
         }

--- a/plugins/platforms/voice_call/realtime/openai_realtime.py
+++ b/plugins/platforms/voice_call/realtime/openai_realtime.py
@@ -46,31 +46,44 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
         # Tool-call argument accumulation: call_id → {"name", "args"}
         self._pending_tools: Dict[str, Dict[str, str]] = {}
 
+    def _session_update(self) -> Dict[str, Any]:
+        """GA realtime session shape (no OpenAI-Beta header, nested audio
+        config). Accounts on the GA API reject the 2024 beta shape with
+        ``beta_api_shape_disabled``."""
+        return {
+            "type": "session.update",
+            "session": {
+                "type": "realtime",
+                "model": self.model,
+                "output_modalities": ["audio"],
+                "instructions": self.instructions,
+                "audio": {
+                    "input": {
+                        "format": {"type": "audio/pcm", "rate": self.input_sample_rate},
+                        "turn_detection": {"type": "server_vad"},
+                        "transcription": {"model": "whisper-1"},
+                    },
+                    "output": {
+                        "format": {
+                            "type": "audio/pcm", "rate": self.output_sample_rate,
+                        },
+                        "voice": self.voice,
+                    },
+                },
+                "tools": [{"type": "function", **AGENT_CONSULT_TOOL}],
+                "tool_choice": "auto",
+            },
+        }
+
     async def connect(self) -> None:
         import websockets
 
         self._ws = await websockets.connect(
             f"{REALTIME_URL}?model={self.model}",
-            additional_headers={
-                "Authorization": f"Bearer {self.api_key}",
-                "OpenAI-Beta": "realtime=v1",
-            },
+            additional_headers={"Authorization": f"Bearer {self.api_key}"},
             max_size=16 * 1024 * 1024,
         )
-        await self._send({
-            "type": "session.update",
-            "session": {
-                "modalities": ["audio", "text"],
-                "voice": self.voice,
-                "instructions": self.instructions,
-                "input_audio_format": "pcm16",
-                "output_audio_format": "pcm16",
-                "input_audio_transcription": {"model": "whisper-1"},
-                "turn_detection": {"type": "server_vad"},
-                "tools": [{"type": "function", **AGENT_CONSULT_TOOL}],
-                "tool_choice": "auto",
-            },
-        })
+        await self._send(self._session_update())
 
     async def _send(self, message: Dict[str, Any]) -> None:
         if self._ws is None or self._closed:

--- a/plugins/platforms/voice_call/realtime/openai_realtime.py
+++ b/plugins/platforms/voice_call/realtime/openai_realtime.py
@@ -1,0 +1,178 @@
+"""OpenAI Realtime API session (speech-to-speech over websockets).
+
+Async sibling of ``plugins/google_meet/realtime/openai_client.py`` —
+duplex instead of text-to-speech-only: caller PCM16 streams in through
+``input_audio_buffer.append``, server VAD detects turns, audio deltas
+stream back out, and ``agent_consult`` tool calls round-trip to the full
+Hermes agent. PCM16 @ 24 kHz both directions.
+"""
+
+import base64
+import json
+import logging
+import os
+from typing import Any, AsyncIterator, Dict, Optional
+
+from ..config import RealtimeConfig
+from .base import (
+    AGENT_CONSULT_TOOL,
+    DEFAULT_INSTRUCTIONS,
+    RealtimeEvent,
+    RealtimeVoiceSession,
+)
+
+logger = logging.getLogger(__name__)
+
+REALTIME_URL = "wss://api.openai.com/v1/realtime"
+DEFAULT_MODEL = "gpt-realtime"
+DEFAULT_VOICE = "marin"
+
+
+class OpenAIRealtimeSession(RealtimeVoiceSession):
+    name = "openai"
+    input_sample_rate = 24000
+    output_sample_rate = 24000
+
+    def __init__(self, config: RealtimeConfig, api_key: Optional[str] = None):
+        self.config = config
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY", "")
+        if not self.api_key:
+            raise ValueError("OpenAI Realtime requires OPENAI_API_KEY")
+        self.model = config.model or DEFAULT_MODEL
+        self.voice = config.voice or DEFAULT_VOICE
+        self.instructions = config.instructions or DEFAULT_INSTRUCTIONS
+        self._ws = None
+        self._closed = False
+        # Tool-call argument accumulation: call_id → {"name", "args"}
+        self._pending_tools: Dict[str, Dict[str, str]] = {}
+
+    async def connect(self) -> None:
+        import websockets
+
+        self._ws = await websockets.connect(
+            f"{REALTIME_URL}?model={self.model}",
+            additional_headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "OpenAI-Beta": "realtime=v1",
+            },
+            max_size=16 * 1024 * 1024,
+        )
+        await self._send({
+            "type": "session.update",
+            "session": {
+                "modalities": ["audio", "text"],
+                "voice": self.voice,
+                "instructions": self.instructions,
+                "input_audio_format": "pcm16",
+                "output_audio_format": "pcm16",
+                "input_audio_transcription": {"model": "whisper-1"},
+                "turn_detection": {"type": "server_vad"},
+                "tools": [{"type": "function", **AGENT_CONSULT_TOOL}],
+                "tool_choice": "auto",
+            },
+        })
+
+    async def _send(self, message: Dict[str, Any]) -> None:
+        if self._ws is None or self._closed:
+            return
+        await self._ws.send(json.dumps(message))
+
+    async def send_audio(self, pcm16: bytes) -> None:
+        if not pcm16:
+            return
+        await self._send({
+            "type": "input_audio_buffer.append",
+            "audio": base64.b64encode(pcm16).decode(),
+        })
+
+    async def inject_text(self, text: str) -> None:
+        await self._send({
+            "type": "response.create",
+            "response": {"instructions": f"Say this to the caller now: {text}"},
+        })
+
+    async def cancel_response(self) -> None:
+        await self._send({"type": "response.cancel"})
+
+    async def send_tool_result(self, tool_call_id: str, result: str) -> None:
+        await self._send({
+            "type": "conversation.item.create",
+            "item": {
+                "type": "function_call_output",
+                "call_id": tool_call_id,
+                "output": result,
+            },
+        })
+        await self._send({"type": "response.create"})
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:  # noqa: BLE001
+                logger.debug("openai realtime close failed", exc_info=True)
+            self._ws = None
+
+    def _translate(self, frame: Dict[str, Any]) -> Optional[RealtimeEvent]:
+        ftype = str(frame.get("type", ""))
+        # Audio deltas (the API renamed response.audio.* → response.output_audio.*).
+        if ftype in ("response.audio.delta", "response.output_audio.delta"):
+            try:
+                audio = base64.b64decode(frame.get("delta") or "")
+            except Exception:  # noqa: BLE001
+                return None
+            return RealtimeEvent(type="audio", audio=audio)
+        if ftype == "input_audio_buffer.speech_started":
+            return RealtimeEvent(type="speech_started")
+        if ftype == "conversation.item.input_audio_transcription.completed":
+            return RealtimeEvent(
+                type="transcript", role="user", text=str(frame.get("transcript", ""))
+            )
+        if ftype in (
+            "response.audio_transcript.done",
+            "response.output_audio_transcript.done",
+        ):
+            return RealtimeEvent(
+                type="transcript", role="assistant",
+                text=str(frame.get("transcript", "")),
+            )
+        if ftype == "response.function_call_arguments.done":
+            call_id = str(frame.get("call_id", ""))
+            try:
+                args = json.loads(frame.get("arguments") or "{}")
+            except json.JSONDecodeError:
+                args = {}
+            return RealtimeEvent(
+                type="tool_call",
+                tool_call_id=call_id,
+                tool_name=str(frame.get("name") or "agent_consult"),
+                tool_args=args if isinstance(args, dict) else {},
+            )
+        if ftype in ("response.done", "response.completed", "response.cancelled"):
+            return RealtimeEvent(type="response_done")
+        if ftype == "error":
+            detail = (frame.get("error") or {}).get("message", "unknown error")
+            return RealtimeEvent(type="error", text=str(detail))
+        return None
+
+    async def events(self) -> AsyncIterator[RealtimeEvent]:
+        import websockets
+
+        if self._ws is None:
+            return
+        try:
+            async for raw in self._ws:
+                try:
+                    frame = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                event = self._translate(frame)
+                if event is not None:
+                    yield event
+        except websockets.ConnectionClosed:
+            pass
+        except Exception as e:  # noqa: BLE001
+            if not self._closed:
+                yield RealtimeEvent(type="error", text=str(e))
+        yield RealtimeEvent(type="closed")

--- a/plugins/platforms/voice_call/realtime/openai_realtime.py
+++ b/plugins/platforms/voice_call/realtime/openai_realtime.py
@@ -30,8 +30,12 @@ DEFAULT_VOICE = "marin"
 
 class OpenAIRealtimeSession(RealtimeVoiceSession):
     name = "openai"
-    input_sample_rate = 24000
-    output_sample_rate = 24000
+    input_sample_rate = 8000
+    output_sample_rate = 8000
+    # The GA realtime API speaks G.711 µ-law natively (audio/pcmu @ 8 kHz)
+    # — the phone line's own codec — so the bridge passes carrier frames
+    # straight through with no transcoding.
+    audio_wire_format = "ulaw"
 
     def __init__(self, config: RealtimeConfig, api_key: Optional[str] = None):
         self.config = config
@@ -43,8 +47,10 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
         self.instructions = config.instructions or DEFAULT_INSTRUCTIONS
         self._ws = None
         self._closed = False
-        # Tool-call argument accumulation: call_id → {"name", "args"}
-        self._pending_tools: Dict[str, Dict[str, str]] = {}
+        # call_ids already surfaced as tool_call events — GA can deliver a
+        # function call both as function_call_arguments.done and inside
+        # response.done output items.
+        self._seen_tool_calls: set = set()
 
     def _session_update(self) -> Dict[str, Any]:
         """GA realtime session shape (no OpenAI-Beta header, nested audio
@@ -59,14 +65,12 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
                 "instructions": self.instructions,
                 "audio": {
                     "input": {
-                        "format": {"type": "audio/pcm", "rate": self.input_sample_rate},
+                        "format": {"type": "audio/pcmu"},
                         "turn_detection": {"type": "server_vad"},
                         "transcription": {"model": "whisper-1"},
                     },
                     "output": {
-                        "format": {
-                            "type": "audio/pcm", "rate": self.output_sample_rate,
-                        },
+                        "format": {"type": "audio/pcmu"},
                         "voice": self.voice,
                     },
                 },
@@ -127,47 +131,75 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
                 logger.debug("openai realtime close failed", exc_info=True)
             self._ws = None
 
-    def _translate(self, frame: Dict[str, Any]) -> Optional[RealtimeEvent]:
+    def _tool_call_event(
+        self, call_id: str, name: str, arguments: Any
+    ) -> Optional[RealtimeEvent]:
+        if not call_id or call_id in self._seen_tool_calls:
+            return None
+        self._seen_tool_calls.add(call_id)
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments or "{}")
+            except json.JSONDecodeError:
+                arguments = {}
+        return RealtimeEvent(
+            type="tool_call",
+            tool_call_id=call_id,
+            tool_name=name or "agent_consult",
+            tool_args=arguments if isinstance(arguments, dict) else {},
+        )
+
+    def _translate(self, frame: Dict[str, Any]) -> list:
         ftype = str(frame.get("type", ""))
         # Audio deltas (the API renamed response.audio.* → response.output_audio.*).
         if ftype in ("response.audio.delta", "response.output_audio.delta"):
             try:
                 audio = base64.b64decode(frame.get("delta") or "")
             except Exception:  # noqa: BLE001
-                return None
-            return RealtimeEvent(type="audio", audio=audio)
+                return []
+            return [RealtimeEvent(type="audio", audio=audio)]
         if ftype == "input_audio_buffer.speech_started":
-            return RealtimeEvent(type="speech_started")
+            return [RealtimeEvent(type="speech_started")]
         if ftype == "conversation.item.input_audio_transcription.completed":
-            return RealtimeEvent(
+            return [RealtimeEvent(
                 type="transcript", role="user", text=str(frame.get("transcript", ""))
-            )
+            )]
         if ftype in (
             "response.audio_transcript.done",
             "response.output_audio_transcript.done",
         ):
-            return RealtimeEvent(
+            return [RealtimeEvent(
                 type="transcript", role="assistant",
                 text=str(frame.get("transcript", "")),
-            )
+            )]
         if ftype == "response.function_call_arguments.done":
-            call_id = str(frame.get("call_id", ""))
-            try:
-                args = json.loads(frame.get("arguments") or "{}")
-            except json.JSONDecodeError:
-                args = {}
-            return RealtimeEvent(
-                type="tool_call",
-                tool_call_id=call_id,
-                tool_name=str(frame.get("name") or "agent_consult"),
-                tool_args=args if isinstance(args, dict) else {},
+            event = self._tool_call_event(
+                str(frame.get("call_id", "")),
+                str(frame.get("name") or ""),
+                frame.get("arguments"),
             )
+            return [event] if event else []
         if ftype in ("response.done", "response.completed", "response.cancelled"):
-            return RealtimeEvent(type="response_done")
+            # GA delivers function calls as response.done output items (the
+            # standalone arguments.done event is not guaranteed) — scan and
+            # dedupe against ones already surfaced.
+            events = []
+            output = (frame.get("response") or {}).get("output") or []
+            for item in output:
+                if isinstance(item, dict) and item.get("type") == "function_call":
+                    event = self._tool_call_event(
+                        str(item.get("call_id", "")),
+                        str(item.get("name") or ""),
+                        item.get("arguments"),
+                    )
+                    if event:
+                        events.append(event)
+            events.append(RealtimeEvent(type="response_done"))
+            return events
         if ftype == "error":
             detail = (frame.get("error") or {}).get("message", "unknown error")
-            return RealtimeEvent(type="error", text=str(detail))
-        return None
+            return [RealtimeEvent(type="error", text=str(detail))]
+        return []
 
     async def events(self) -> AsyncIterator[RealtimeEvent]:
         import websockets
@@ -180,8 +212,7 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
                     frame = json.loads(raw)
                 except (json.JSONDecodeError, TypeError):
                     continue
-                event = self._translate(frame)
-                if event is not None:
+                for event in self._translate(frame):
                     yield event
         except websockets.ConnectionClosed:
             pass

--- a/plugins/platforms/voice_call/realtime/openai_realtime.py
+++ b/plugins/platforms/voice_call/realtime/openai_realtime.py
@@ -151,8 +151,12 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
 
     def _translate(self, frame: Dict[str, Any]) -> list:
         ftype = str(frame.get("type", ""))
+        if ftype == "response.created":
+            self.response_active = True
+            return []
         # Audio deltas (the API renamed response.audio.* → response.output_audio.*).
         if ftype in ("response.audio.delta", "response.output_audio.delta"):
+            self.response_active = True
             try:
                 audio = base64.b64decode(frame.get("delta") or "")
             except Exception:  # noqa: BLE001
@@ -180,6 +184,7 @@ class OpenAIRealtimeSession(RealtimeVoiceSession):
             )
             return [event] if event else []
         if ftype in ("response.done", "response.completed", "response.cancelled"):
+            self.response_active = False
             # GA delivers function calls as response.done output items (the
             # standalone arguments.done event is not guaranteed) — scan and
             # dedupe against ones already surfaced.

--- a/plugins/platforms/voice_call/responder.py
+++ b/plugins/platforms/voice_call/responder.py
@@ -1,0 +1,85 @@
+"""Turn-loop glue: caller speech → gateway agent turn → spoken reply.
+
+A final inbound transcript becomes a normal gateway ``MessageEvent`` (so
+voice gets sessions, history, tools, and memory like every other platform);
+the agent's reply comes back through ``adapter.send()`` →
+``runtime.speak_for_chat()`` → carrier TTS. The platform_hint registered by
+the adapter asks for short spoken-style plain text; :func:`strip_for_speech`
+removes whatever markup slips through before it reaches the caller's ear.
+"""
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from .events import CallRecord
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .runtime import VoiceCallRuntime
+
+logger = logging.getLogger(__name__)
+
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`([^`]*)`")
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_BARE_URL_RE = re.compile(r"https?://\S+")
+_MD_EMPHASIS_RE = re.compile(r"(\*{1,3}|_{1,3}|~~)(\S(?:.*?\S)?)\1")
+_MD_HEADING_RE = re.compile(r"^#{1,6}\s+", re.MULTILINE)
+_MD_BULLET_RE = re.compile(r"^\s*[-*+]\s+", re.MULTILINE)
+
+
+def strip_for_speech(text: str, max_chars: int = 1000) -> str:
+    """Reduce agent output to something a TTS voice can say naturally."""
+    out = _CODE_FENCE_RE.sub(" code omitted. ", text or "")
+    out = _INLINE_CODE_RE.sub(r"\1", out)
+    out = _MD_LINK_RE.sub(r"\1", out)
+    out = _BARE_URL_RE.sub("a link", out)
+    out = _MD_EMPHASIS_RE.sub(r"\2", out)
+    out = _MD_HEADING_RE.sub("", out)
+    out = _MD_BULLET_RE.sub("", out)
+    out = re.sub(r"\s+", " ", out).strip()
+    if len(out) > max_chars:
+        cut = out[:max_chars]
+        # Prefer ending on a sentence boundary.
+        for stop in (". ", "! ", "? "):
+            idx = cut.rfind(stop)
+            if idx > max_chars // 2:
+                return cut[: idx + 1].strip()
+        out = cut.rstrip() + "…"
+    return out
+
+
+async def dispatch_transcript(
+    runtime: "VoiceCallRuntime", record: CallRecord, text: str
+) -> None:
+    """Route a final caller utterance into the gateway as a MessageEvent."""
+    adapter = runtime.adapter
+    if adapter is None:
+        logger.warning(
+            "voice_call: transcript on %s but no gateway adapter is attached "
+            "(headless runtime?) — dropping", record.call_id,
+        )
+        return
+
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    peer = record.peer_number or "unknown"
+    thread_id = (
+        record.call_id if runtime.config.session_scope == "per-call" else None
+    )
+    source = adapter.build_source(
+        chat_id=peer,
+        chat_name=f"Call with {peer}",
+        chat_type="dm",
+        user_id=peer,
+        user_name=peer,
+        thread_id=thread_id,
+    )
+    event = MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id=f"{record.call_id}:{len(record.transcript)}",
+        raw_message={"call_id": record.call_id, "provider": record.provider},
+    )
+    await adapter.handle_message(event)

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -5,15 +5,20 @@ One runtime per process, owned by the gateway through the platform adapter:
 :func:`stop_runtime`. The tool, CLI, and slash handlers reach the runtime
 through :func:`get_runtime` without holding an adapter reference.
 
-P1 note: this is the lifecycle skeleton only — the provider, call manager,
-store, and webhook server are wired in by later phases.
+Boot order (mirrors OpenClaw's runtime.ts pipeline):
+provider → store → manager (+ restore) → webhook server → tunnel/public URL.
+Teardown is the reverse and tolerates partial initialization.
 """
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import Any, Optional, Tuple
 
-from .config import VoiceCallConfig
+from .config import VoiceCallConfig, normalize_e164
+from .events import CallRecord
+from .manager import CallManager
+from .store import CallStore
 
 logger = logging.getLogger(__name__)
 
@@ -32,17 +37,47 @@ def _get_lock() -> asyncio.Lock:
 class VoiceCallRuntime:
     """Owns everything that must live for the gateway's lifetime."""
 
-    def __init__(self, config: VoiceCallConfig, adapter: Any = None):
+    def __init__(
+        self,
+        config: VoiceCallConfig,
+        adapter: Any = None,
+        store_dir: Optional[Path] = None,
+    ):
         self.config = config
         self.adapter = adapter
+        self.provider = None
+        self.store: Optional[CallStore] = None
+        self.manager: Optional[CallManager] = None
+        self.webhook_server = None  # P3
+        self.tunnel = None          # P5
+        self.public_url: Optional[str] = config.public_url
+        self._store_dir = store_dir
         self._started = False
 
     async def start(self) -> None:
         """Boot the runtime. Idempotent; raises on unrecoverable setup errors."""
         if self._started:
             return
-        # Later phases: resolve provider → start webhook server → resolve
-        # public URL/tunnel → create manager → restore persisted calls.
+        from .providers import create_provider
+
+        self.provider = create_provider(self.config)
+        if self.public_url:
+            self.provider.set_public_url(self.public_url)
+        # The mock provider pushes carrier-style events (ringing/answered)
+        # back into the manager the way real webhooks would.
+        if hasattr(self.provider, "event_sink"):
+            self.provider.event_sink = self._provider_event_sink
+
+        self.store = CallStore(base_dir=self._store_dir)
+        self.manager = CallManager(
+            self.config,
+            self.provider,
+            self.store,
+            on_final_transcript=self._on_final_transcript,
+            on_call_ended=self._on_call_ended,
+        )
+        await self.manager.initialize()
+
         self._started = True
         logger.info(
             "voice_call runtime started (provider=%s, serve=%s:%s%s)",
@@ -54,24 +89,64 @@ class VoiceCallRuntime:
 
     async def stop(self) -> None:
         """Tear everything down. Idempotent; tolerates partial initialization."""
-        if not self._started:
-            return
         self._started = False
+        if self.manager is not None:
+            try:
+                await self.manager.shutdown()
+            except Exception:  # noqa: BLE001
+                logger.exception("voice_call: manager shutdown failed")
+            self.manager = None
+        self.provider = None
         logger.info("voice_call runtime stopped")
+
+    # -- event plumbing -----------------------------------------------------
+
+    async def _provider_event_sink(self, event) -> None:
+        if self.manager is not None:
+            await self.manager.process_event(event)
+
+    async def _on_final_transcript(self, record: CallRecord, text: str) -> None:
+        """Final caller utterance → gateway agent turn (wired in P4)."""
+        logger.debug(
+            "voice_call: final transcript on %s: %r", record.call_id, text[:80]
+        )
+
+    async def _on_call_ended(self, record: CallRecord) -> None:
+        logger.info(
+            "voice_call: call %s ended (%s: %s)",
+            record.call_id, record.state.value, record.end_reason,
+        )
+
+    # -- adapter send() support ----------------------------------------------
 
     async def speak_for_chat(
         self, chat_id: str, content: str, thread_id: Optional[str] = None
     ) -> Tuple[bool, str]:
         """Speak ``content`` on the live call mapped to ``chat_id``.
 
-        Returns ``(success, detail)``. Wired to the call manager in a later
-        phase; until then there is never an active call.
+        Returns ``(success, call_id_or_error)``. With per-call session scope
+        the call id travels as the session thread_id and takes precedence.
         """
-        return False, f"no active voice call for {chat_id}"
+        if self.manager is None:
+            return False, "voice_call runtime not started"
+        record = None
+        if thread_id:
+            record = self.manager.get_call(str(thread_id))
+        if record is None:
+            record = self.manager.call_for_chat(normalize_e164(chat_id))
+        if record is None or record.is_terminal:
+            return False, f"no active voice call for {chat_id}"
+        try:
+            await self.manager.speak(record.call_id, content)
+        except Exception as e:  # noqa: BLE001 — surface as failed SendResult
+            return False, f"speak failed: {e}"
+        return True, record.call_id
 
 
 async def ensure_runtime(
-    config: VoiceCallConfig, adapter: Any = None
+    config: VoiceCallConfig,
+    adapter: Any = None,
+    store_dir: Optional[Path] = None,
 ) -> VoiceCallRuntime:
     """Return the running runtime, starting it on first use.
 
@@ -84,7 +159,7 @@ async def ensure_runtime(
             if adapter is not None:
                 _runtime.adapter = adapter
             return _runtime
-        runtime = VoiceCallRuntime(config, adapter=adapter)
+        runtime = VoiceCallRuntime(config, adapter=adapter, store_dir=store_dir)
         try:
             await runtime.start()
         except Exception:

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -48,8 +48,9 @@ class VoiceCallRuntime:
         self.provider = None
         self.store: Optional[CallStore] = None
         self.manager: Optional[CallManager] = None
-        self.webhook_server = None  # P3
-        self.tunnel = None          # P5
+        self.webhook_server = None
+        self.tunnel = None
+        self.bridge_manager = None  # realtime only
         self.public_url: Optional[str] = config.public_url
         self._store_dir = store_dir
         self._started = False
@@ -97,6 +98,19 @@ class VoiceCallRuntime:
         except Exception:
             await self.webhook_server.stop()
             raise
+
+        if self.config.realtime.enabled:
+            from .realtime.bridge import RealtimeBridgeManager
+
+            self.bridge_manager = RealtimeBridgeManager(self)
+            self.webhook_server.stream_handler = (
+                self.bridge_manager.handle_stream_request
+            )
+            self.manager.prepare_call = self.bridge_manager.prepare_call
+            logger.info(
+                "voice_call realtime enabled (model provider=%s)",
+                self.config.realtime.provider,
+            )
 
         self._started = True
         logger.info(

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -241,7 +241,11 @@ class VoiceCallRuntime:
     # -- adapter send() support ----------------------------------------------
 
     async def speak_for_chat(
-        self, chat_id: str, content: str, thread_id: Optional[str] = None
+        self,
+        chat_id: str,
+        content: str,
+        thread_id: Optional[str] = None,
+        metadata: Optional[dict] = None,
     ) -> Tuple[bool, str]:
         """Speak ``content`` on the live call mapped to ``chat_id``.
 
@@ -272,7 +276,12 @@ class VoiceCallRuntime:
             else None
         )
         if bridge is not None:
-            if await bridge.deliver_agent_text(spoken):
+            # The gateway marks only the turn's final response with
+            # metadata["notify"]; everything else (tool-progress chrome,
+            # interim status lines, notices) must not reach the caller's
+            # ear or resolve a pending consult.
+            is_final = bool((metadata or {}).get("notify"))
+            if await bridge.deliver_agent_text(spoken, final=is_final):
                 return True, record.call_id
             return False, "realtime bridge could not deliver the message"
         try:

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -108,6 +108,7 @@ class VoiceCallRuntime:
             )
             self.manager.prepare_call = self.bridge_manager.prepare_call
             self.manager.realtime_speaker = self._bridge_speak
+            self.manager.upgrade_realtime = self.bridge_manager.upgrade_to_realtime
             logger.info(
                 "voice_call realtime enabled (model provider=%s)",
                 self.config.realtime.provider,

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -107,6 +107,7 @@ class VoiceCallRuntime:
                 self.bridge_manager.handle_stream_request
             )
             self.manager.prepare_call = self.bridge_manager.prepare_call
+            self.manager.realtime_speaker = self._bridge_speak
             logger.info(
                 "voice_call realtime enabled (model provider=%s)",
                 self.config.realtime.provider,
@@ -222,6 +223,17 @@ class VoiceCallRuntime:
     async def _provider_event_sink(self, event) -> None:
         if self.manager is not None:
             await self.manager.process_event(event)
+
+    async def _bridge_speak(self, record: CallRecord, text: str) -> bool:
+        """manager.speak() hook: deliver via the call's realtime bridge."""
+        bridge = (
+            self.bridge_manager.active_bridges.get(record.call_id)
+            if self.bridge_manager is not None
+            else None
+        )
+        if bridge is None:
+            return False
+        return await bridge.deliver_agent_text(text)
 
     async def _on_final_transcript(self, record: CallRecord, text: str) -> None:
         """Final caller utterance → gateway agent turn."""

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -55,10 +55,16 @@ class VoiceCallRuntime:
         self._started = False
 
     async def start(self) -> None:
-        """Boot the runtime. Idempotent; raises on unrecoverable setup errors."""
+        """Boot the runtime. Idempotent; raises on unrecoverable setup errors.
+
+        Order mirrors OpenClaw: provider → store/manager (+restore) →
+        webhook server → tunnel. A failure after the server binds stops the
+        server again so the port is never leaked.
+        """
         if self._started:
             return
         from .providers import create_provider
+        from .webhook import VoiceCallWebhookServer
 
         self.provider = create_provider(self.config)
         if self.public_url:
@@ -78,6 +84,20 @@ class VoiceCallRuntime:
         )
         await self.manager.initialize()
 
+        self.webhook_server = VoiceCallWebhookServer(
+            self.config,
+            self.provider,
+            process_event=self.manager.process_event,
+            admin_handler=self._handle_admin_command,
+            admin_token=self._load_or_create_admin_token(),
+        )
+        await self.webhook_server.start()
+        try:
+            await self._resolve_public_url()
+        except Exception:
+            await self.webhook_server.stop()
+            raise
+
         self._started = True
         logger.info(
             "voice_call runtime started (provider=%s, serve=%s:%s%s)",
@@ -90,6 +110,18 @@ class VoiceCallRuntime:
     async def stop(self) -> None:
         """Tear everything down. Idempotent; tolerates partial initialization."""
         self._started = False
+        if self.webhook_server is not None:
+            try:
+                await self.webhook_server.stop()
+            except Exception:  # noqa: BLE001
+                logger.exception("voice_call: webhook server stop failed")
+            self.webhook_server = None
+        if self.tunnel is not None:
+            try:
+                await self.tunnel.stop()
+            except Exception:  # noqa: BLE001
+                logger.exception("voice_call: tunnel stop failed")
+            self.tunnel = None
         if self.manager is not None:
             try:
                 await self.manager.shutdown()
@@ -98,6 +130,77 @@ class VoiceCallRuntime:
             self.manager = None
         self.provider = None
         logger.info("voice_call runtime stopped")
+
+    async def _resolve_public_url(self) -> None:
+        """Resolve the externally reachable URL (explicit > tunnel)."""
+        if self.public_url or self.config.tunnel.provider == "none":
+            return
+        # Tunnel providers (ngrok / tailscale) are wired in the Telnyx phase.
+        from .tunnel import start_tunnel  # noqa: PLC0415
+
+        self.tunnel = await start_tunnel(self.config)
+        self.public_url = self.tunnel.public_url
+        self.provider.set_public_url(self.public_url)
+
+    def _load_or_create_admin_token(self) -> str:
+        """Pre-shared token the CLI uses against the local admin endpoint."""
+        import secrets
+
+        token_path = self.store.base_dir / "admin.token"
+        try:
+            existing = token_path.read_text(encoding="utf-8").strip()
+            if existing:
+                return existing
+        except OSError:
+            pass
+        token = secrets.token_urlsafe(32)
+        try:
+            self.store.base_dir.mkdir(parents=True, exist_ok=True)
+            token_path.write_text(token, encoding="utf-8")
+            token_path.chmod(0o600)
+        except OSError:
+            logger.warning("voice_call: could not persist admin token", exc_info=True)
+        return token
+
+    async def _handle_admin_command(self, payload: dict) -> dict:
+        """CLI → runtime command dispatch (served on the admin endpoint)."""
+        command = str(payload.get("command", ""))
+        if self.manager is None:
+            return {"success": False, "error": "runtime not started"}
+        if command == "status":
+            calls = [r.to_dict() for r in self.manager.get_active_calls()]
+            return {
+                "success": True,
+                "provider": self.config.provider,
+                "public_url": self.public_url,
+                "active_calls": calls,
+            }
+        if command == "call":
+            record = await self.manager.initiate_call(
+                str(payload.get("to", "")),
+                message=payload.get("message"),
+                mode=payload.get("mode"),
+            )
+            return {"success": True, "call_id": record.call_id}
+        if command == "speak":
+            await self.manager.speak(
+                str(payload.get("call_id", "")), str(payload.get("message", ""))
+            )
+            return {"success": True}
+        if command == "continue":
+            reply = await self.manager.continue_call(
+                str(payload.get("call_id", "")), str(payload.get("message", ""))
+            )
+            return {"success": True, "reply": reply}
+        if command == "dtmf":
+            await self.manager.send_dtmf(
+                str(payload.get("call_id", "")), str(payload.get("digits", ""))
+            )
+            return {"success": True}
+        if command == "end":
+            await self.manager.end_call(str(payload.get("call_id", "")))
+            return {"success": True}
+        return {"success": False, "error": f"unknown command {command!r}"}
 
     # -- event plumbing -----------------------------------------------------
 

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -180,6 +180,26 @@ class VoiceCallRuntime:
 
     async def _handle_admin_command(self, payload: dict) -> dict:
         """CLI → runtime command dispatch (served on the admin endpoint)."""
+        from .manager import CallNotFoundError
+
+        try:
+            return await self._dispatch_admin_command(payload)
+        except CallNotFoundError as e:
+            # Normal race: the call ended (caller or model hung up) before
+            # this command arrived. A clean error, not a stack trace.
+            call_id = str(e).strip("'\"")
+            logger.info(
+                "voice_call admin: %s on already-ended call %s",
+                payload.get("command"), call_id,
+            )
+            return {
+                "success": False,
+                "error": f"no active call {call_id!r} — it already ended",
+            }
+        except (ValueError, RuntimeError, asyncio.TimeoutError) as e:
+            return {"success": False, "error": str(e)}
+
+    async def _dispatch_admin_command(self, payload: dict) -> dict:
         command = str(payload.get("command", ""))
         if self.manager is None:
             return {"success": False, "error": "runtime not started"}

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -1,0 +1,111 @@
+"""Voice-call runtime singleton.
+
+One runtime per process, owned by the gateway through the platform adapter:
+``adapter.connect()`` → :func:`ensure_runtime`, ``adapter.disconnect()`` →
+:func:`stop_runtime`. The tool, CLI, and slash handlers reach the runtime
+through :func:`get_runtime` without holding an adapter reference.
+
+P1 note: this is the lifecycle skeleton only — the provider, call manager,
+store, and webhook server are wired in by later phases.
+"""
+
+import asyncio
+import logging
+from typing import Any, Optional, Tuple
+
+from .config import VoiceCallConfig
+
+logger = logging.getLogger(__name__)
+
+_runtime: Optional["VoiceCallRuntime"] = None
+_runtime_lock: Optional[asyncio.Lock] = None
+
+
+def _get_lock() -> asyncio.Lock:
+    # Created lazily so importing this module never requires a running loop.
+    global _runtime_lock
+    if _runtime_lock is None:
+        _runtime_lock = asyncio.Lock()
+    return _runtime_lock
+
+
+class VoiceCallRuntime:
+    """Owns everything that must live for the gateway's lifetime."""
+
+    def __init__(self, config: VoiceCallConfig, adapter: Any = None):
+        self.config = config
+        self.adapter = adapter
+        self._started = False
+
+    async def start(self) -> None:
+        """Boot the runtime. Idempotent; raises on unrecoverable setup errors."""
+        if self._started:
+            return
+        # Later phases: resolve provider → start webhook server → resolve
+        # public URL/tunnel → create manager → restore persisted calls.
+        self._started = True
+        logger.info(
+            "voice_call runtime started (provider=%s, serve=%s:%s%s)",
+            self.config.provider,
+            self.config.serve.bind,
+            self.config.serve.port,
+            self.config.serve.path,
+        )
+
+    async def stop(self) -> None:
+        """Tear everything down. Idempotent; tolerates partial initialization."""
+        if not self._started:
+            return
+        self._started = False
+        logger.info("voice_call runtime stopped")
+
+    async def speak_for_chat(
+        self, chat_id: str, content: str, thread_id: Optional[str] = None
+    ) -> Tuple[bool, str]:
+        """Speak ``content`` on the live call mapped to ``chat_id``.
+
+        Returns ``(success, detail)``. Wired to the call manager in a later
+        phase; until then there is never an active call.
+        """
+        return False, f"no active voice call for {chat_id}"
+
+
+async def ensure_runtime(
+    config: VoiceCallConfig, adapter: Any = None
+) -> VoiceCallRuntime:
+    """Return the running runtime, starting it on first use.
+
+    Concurrency-safe: simultaneous callers share one startup. A failed start
+    leaves no singleton behind so the next attempt retries cleanly.
+    """
+    global _runtime
+    async with _get_lock():
+        if _runtime is not None:
+            if adapter is not None:
+                _runtime.adapter = adapter
+            return _runtime
+        runtime = VoiceCallRuntime(config, adapter=adapter)
+        try:
+            await runtime.start()
+        except Exception:
+            try:
+                await runtime.stop()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                logger.exception("voice_call runtime cleanup after failed start")
+            raise
+        _runtime = runtime
+        return runtime
+
+
+def get_runtime() -> Optional[VoiceCallRuntime]:
+    return _runtime
+
+
+async def stop_runtime() -> None:
+    """Stop and clear the singleton. Safe to call when never started."""
+    global _runtime
+    async with _get_lock():
+        runtime = _runtime
+        _runtime = None
+    if runtime is not None:
+        await runtime.stop()

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -209,10 +209,13 @@ class VoiceCallRuntime:
             await self.manager.process_event(event)
 
     async def _on_final_transcript(self, record: CallRecord, text: str) -> None:
-        """Final caller utterance → gateway agent turn (wired in P4)."""
+        """Final caller utterance → gateway agent turn."""
+        from .responder import dispatch_transcript
+
         logger.debug(
             "voice_call: final transcript on %s: %r", record.call_id, text[:80]
         )
+        await dispatch_transcript(self, record, text)
 
     async def _on_call_ended(self, record: CallRecord) -> None:
         logger.info(
@@ -239,8 +242,13 @@ class VoiceCallRuntime:
             record = self.manager.call_for_chat(normalize_e164(chat_id))
         if record is None or record.is_terminal:
             return False, f"no active voice call for {chat_id}"
+        from .responder import strip_for_speech
+
+        spoken = strip_for_speech(content)
+        if not spoken:
+            return False, "nothing speakable in message"
         try:
-            await self.manager.speak(record.call_id, content)
+            await self.manager.speak(record.call_id, spoken)
         except Exception as e:  # noqa: BLE001 — surface as failed SendResult
             return False, f"speak failed: {e}"
         return True, record.call_id

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -189,30 +189,31 @@ class VoiceCallRuntime:
                 "public_url": self.public_url,
                 "active_calls": calls,
             }
+        # JSON null values must become "" (str(None) would be "None") so
+        # optional fields fall through to their config defaults.
+        def _field(key: str) -> str:
+            return str(payload.get(key) or "")
+
         if command == "call":
             record = await self.manager.initiate_call(
-                str(payload.get("to", "")),
+                _field("to") or None,
                 message=payload.get("message"),
                 mode=payload.get("mode"),
             )
             return {"success": True, "call_id": record.call_id}
         if command == "speak":
-            await self.manager.speak(
-                str(payload.get("call_id", "")), str(payload.get("message", ""))
-            )
+            await self.manager.speak(_field("call_id"), _field("message"))
             return {"success": True}
         if command == "continue":
             reply = await self.manager.continue_call(
-                str(payload.get("call_id", "")), str(payload.get("message", ""))
+                _field("call_id"), _field("message")
             )
             return {"success": True, "reply": reply}
         if command == "dtmf":
-            await self.manager.send_dtmf(
-                str(payload.get("call_id", "")), str(payload.get("digits", ""))
-            )
+            await self.manager.send_dtmf(_field("call_id"), _field("digits"))
             return {"success": True}
         if command == "end":
-            await self.manager.end_call(str(payload.get("call_id", "")))
+            await self.manager.end_call(_field("call_id"))
             return {"success": True}
         return {"success": False, "error": f"unknown command {command!r}"}
 

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -299,6 +299,17 @@ class VoiceCallRuntime:
         spoken = strip_for_speech(content)
         if not spoken:
             return False, "nothing speakable in message"
+        # A call that hasn't been answered can't receive TTS (Telnyx 90034).
+        # If it's a fresh outbound dial with no opening line yet (e.g. the
+        # agent just placed it and this reply is meant for it), queue the
+        # text to be spoken on answer; otherwise fail cleanly.
+        if record.answered_at is None:
+            if self.manager.queue_initial_message(record.call_id, spoken):
+                return True, record.call_id
+            return False, (
+                f"call {record.call_id} is still ringing and already has an "
+                "opening message — not spoken"
+            )
         # Realtime calls: the model owns the audio. Agent output goes to the
         # bridge (pending consults consume it as the tool result; anything
         # else is spoken by the realtime voice) — carrier TTS would talk

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -222,6 +222,7 @@ class VoiceCallRuntime:
                 message=payload.get("message"),
                 mode=payload.get("mode"),
                 instructions=payload.get("instructions"),
+                might_continue=bool(payload.get("might_continue")),
             )
             return {"success": True, "call_id": record.call_id}
         if command == "speak":

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -221,6 +221,7 @@ class VoiceCallRuntime:
                 _field("to") or None,
                 message=payload.get("message"),
                 mode=payload.get("mode"),
+                instructions=payload.get("instructions"),
             )
             return {"success": True, "call_id": record.call_id}
         if command == "speak":

--- a/plugins/platforms/voice_call/runtime.py
+++ b/plugins/platforms/voice_call/runtime.py
@@ -262,6 +262,19 @@ class VoiceCallRuntime:
         spoken = strip_for_speech(content)
         if not spoken:
             return False, "nothing speakable in message"
+        # Realtime calls: the model owns the audio. Agent output goes to the
+        # bridge (pending consults consume it as the tool result; anything
+        # else is spoken by the realtime voice) — carrier TTS would talk
+        # over the media stream.
+        bridge = (
+            self.bridge_manager.active_bridges.get(record.call_id)
+            if self.bridge_manager is not None
+            else None
+        )
+        if bridge is not None:
+            if await bridge.deliver_agent_text(spoken):
+                return True, record.call_id
+            return False, "realtime bridge could not deliver the message"
         try:
             await self.manager.speak(record.call_id, spoken)
         except Exception as e:  # noqa: BLE001 — surface as failed SendResult

--- a/plugins/platforms/voice_call/store.py
+++ b/plugins/platforms/voice_call/store.py
@@ -1,0 +1,95 @@
+"""JSONL persistence for call records.
+
+Append-only log under ``$HERMES_HOME/voice-calls/calls.jsonl`` — every
+state change writes one full ``CallRecord`` line *before* control returns
+to the caller, so a crash never loses more than the in-flight change. Boot
+replays the file keeping the latest record per call; the runtime then
+verifies each non-terminal call with the provider.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+from .events import CallRecord
+
+logger = logging.getLogger(__name__)
+
+# Compact the log when boot replay sees this many lines.
+_COMPACT_THRESHOLD = 5000
+
+
+class CallStore:
+    def __init__(self, base_dir: Optional[Path] = None):
+        self.base_dir = Path(base_dir) if base_dir else get_hermes_home() / "voice-calls"
+        self.calls_path = self.base_dir / "calls.jsonl"
+
+    def _ensure_dir(self) -> None:
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def append(self, record: CallRecord) -> None:
+        """Persist one full snapshot of ``record``."""
+        self._ensure_dir()
+        line = json.dumps(record.to_dict(), ensure_ascii=False)
+        with open(self.calls_path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+    def load_latest(self) -> Dict[str, CallRecord]:
+        """Replay the log into ``{call_id: latest record}``."""
+        if not self.calls_path.exists():
+            return {}
+        latest: Dict[str, CallRecord] = {}
+        lines = 0
+        try:
+            with open(self.calls_path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    lines += 1
+                    try:
+                        data = json.loads(line)
+                        if not isinstance(data, dict):
+                            raise ValueError("JSONL line is not an object")
+                        record = CallRecord.from_dict(data)
+                    except (json.JSONDecodeError, TypeError, ValueError):
+                        logger.warning("voice_call store: skipping corrupt JSONL line")
+                        continue
+                    latest[record.call_id] = record
+        except OSError as e:
+            logger.warning("voice_call store: failed to read %s: %s", self.calls_path, e)
+            return {}
+        if lines > _COMPACT_THRESHOLD:
+            self._compact(latest)
+        return latest
+
+    def load_active(self) -> Dict[str, CallRecord]:
+        """Latest records that are not in a terminal state."""
+        return {
+            call_id: record
+            for call_id, record in self.load_latest().items()
+            if not record.is_terminal
+        }
+
+    def history(self, limit: int = 50) -> List[CallRecord]:
+        """Most recent calls (latest record per call), newest first."""
+        records = sorted(
+            self.load_latest().values(), key=lambda r: r.started_at, reverse=True
+        )
+        return records[:limit]
+
+    def _compact(self, latest: Dict[str, CallRecord]) -> None:
+        """Rewrite the log with one line per call (latest snapshot)."""
+        try:
+            self._ensure_dir()
+            tmp_path = self.calls_path.with_suffix(".jsonl.tmp")
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                for record in sorted(latest.values(), key=lambda r: r.started_at):
+                    f.write(json.dumps(record.to_dict(), ensure_ascii=False) + "\n")
+            tmp_path.replace(self.calls_path)
+            logger.info("voice_call store: compacted calls.jsonl to %d records", len(latest))
+        except OSError as e:
+            logger.warning("voice_call store: compaction failed: %s", e)

--- a/plugins/platforms/voice_call/tool.py
+++ b/plugins/platforms/voice_call/tool.py
@@ -68,6 +68,17 @@ VOICE_CALL_SCHEMA: Dict[str, Any] = {
                     "the configured outbound mode."
                 ),
             },
+            "instructions": {
+                "type": "string",
+                "description": (
+                    "initiate_call only, conversation mode: a brief for the "
+                    "realtime voice to run THIS call — persona, the full "
+                    "list of questions to ask, closing lines. The voice "
+                    "conducts the whole call itself (no per-question "
+                    "round-trips); read the call transcript afterwards for "
+                    "the answers."
+                ),
+            },
             "digits": {
                 "type": "string",
                 "description": "DTMF digits for send_dtmf (0-9, *, #, w=0.5s pause).",
@@ -129,6 +140,7 @@ async def _dispatch(action: str, args: Dict[str, Any]) -> str:
                 str(args.get("to_number") or "").strip() or None,
                 message=args.get("message"),
                 mode=args.get("mode"),
+                instructions=args.get("instructions"),
             )
             return _ok(call=_call_summary(record))
         if action == "continue_call":
@@ -177,7 +189,8 @@ async def _dispatch(action: str, args: Dict[str, Any]) -> str:
 
 # Tool action → gateway admin command, with the payload fields each takes.
 _ADMIN_COMMAND_MAP = {
-    "initiate_call": ("call", {"to_number": "to", "message": "message", "mode": "mode"}),
+    "initiate_call": ("call", {"to_number": "to", "message": "message",
+                               "mode": "mode", "instructions": "instructions"}),
     "continue_call": ("continue", {"call_id": "call_id", "message": "message"}),
     "speak_to_user": ("speak", {"call_id": "call_id", "message": "message"}),
     "send_dtmf": ("dtmf", {"call_id": "call_id", "digits": "digits"}),

--- a/plugins/platforms/voice_call/tool.py
+++ b/plugins/platforms/voice_call/tool.py
@@ -79,6 +79,16 @@ VOICE_CALL_SCHEMA: Dict[str, Any] = {
                     "the answers."
                 ),
             },
+            "might_continue": {
+                "type": "boolean",
+                "description": (
+                    "initiate_call + notify mode only. Set true when you "
+                    "intend to follow the message with continue_call: the "
+                    "line is held open longer so your continue_call can turn "
+                    "it into a conversation. Omit/false for a plain "
+                    "deliver-the-message-and-hang-up notify call."
+                ),
+            },
             "digits": {
                 "type": "string",
                 "description": "DTMF digits for send_dtmf (0-9, *, #, w=0.5s pause).",
@@ -141,6 +151,7 @@ async def _dispatch(action: str, args: Dict[str, Any]) -> str:
                 message=args.get("message"),
                 mode=args.get("mode"),
                 instructions=args.get("instructions"),
+                might_continue=bool(args.get("might_continue")),
             )
             return _ok(call=_call_summary(record))
         if action == "continue_call":
@@ -190,7 +201,8 @@ async def _dispatch(action: str, args: Dict[str, Any]) -> str:
 # Tool action → gateway admin command, with the payload fields each takes.
 _ADMIN_COMMAND_MAP = {
     "initiate_call": ("call", {"to_number": "to", "message": "message",
-                               "mode": "mode", "instructions": "instructions"}),
+                               "mode": "mode", "instructions": "instructions",
+                               "might_continue": "might_continue"}),
     "continue_call": ("continue", {"call_id": "call_id", "message": "message"}),
     "speak_to_user": ("speak", {"call_id": "call_id", "message": "message"}),
     "send_dtmf": ("dtmf", {"call_id": "call_id", "digits": "digits"}),

--- a/plugins/platforms/voice_call/tool.py
+++ b/plugins/platforms/voice_call/tool.py
@@ -113,11 +113,11 @@ async def _dispatch(action: str, args: Dict[str, Any]) -> str:
 
     runtime = get_runtime()
     if runtime is None or runtime.manager is None:
-        return _err(
-            "voice_call runtime is not running — the gateway must be running "
-            "with the voice_call platform enabled "
-            "(gateway.platforms.voice_call.enabled: true)"
-        )
+        # No in-process runtime (e.g. the agent runs in `hermes chat`, a
+        # separate process from the gateway). Drive the running gateway
+        # through its localhost admin endpoint instead — same path the
+        # `hermes voicecall` CLI uses.
+        return await _dispatch_via_admin(action, args)
     manager = runtime.manager
 
     call_id = str(args.get("call_id") or "")
@@ -173,6 +173,64 @@ async def _dispatch(action: str, args: Dict[str, Any]) -> str:
         )
     except Exception as e:  # noqa: BLE001 — JSON contract, never raise
         return _err(str(e))
+
+
+# Tool action → gateway admin command, with the payload fields each takes.
+_ADMIN_COMMAND_MAP = {
+    "initiate_call": ("call", {"to_number": "to", "message": "message", "mode": "mode"}),
+    "continue_call": ("continue", {"call_id": "call_id", "message": "message"}),
+    "speak_to_user": ("speak", {"call_id": "call_id", "message": "message"}),
+    "send_dtmf": ("dtmf", {"call_id": "call_id", "digits": "digits"}),
+    "end_call": ("end", {"call_id": "call_id"}),
+    "get_status": ("status", {}),
+}
+
+
+async def _dispatch_via_admin(action: str, args: Dict[str, Any]) -> str:
+    from .cli import _admin_address, _admin_token, _load_extra
+
+    mapping = _ADMIN_COMMAND_MAP.get(action)
+    if mapping is None:
+        return _err(f"unknown action {action!r}")
+    command, fields = mapping
+    token = _admin_token()
+    if token is None:
+        return _err(
+            "voice_call runtime is not running — start the gateway with the "
+            "voice_call platform enabled (hermes gateway run)"
+        )
+    payload: Dict[str, Any] = {"command": command}
+    for tool_key, admin_key in fields.items():
+        value = args.get(tool_key)
+        if value is not None:
+            payload[admin_key] = value
+
+    import httpx
+
+    url = _admin_address(_load_extra()) + "/voice/admin"
+    try:
+        async with httpx.AsyncClient(timeout=90.0) as client:
+            response = await client.post(
+                url, json=payload, headers={"x-voice-call-admin-token": token}
+            )
+            result = response.json()
+    except Exception as e:  # noqa: BLE001 — connection refused etc.
+        return _err(
+            "could not reach the voice_call gateway endpoint — is the "
+            f"gateway running? ({e})"
+        )
+    if not isinstance(result, dict):
+        return _err("unexpected response from the voice_call gateway endpoint")
+    if action == "get_status" and result.get("success"):
+        calls = result.get("active_calls", [])
+        call_id = str(args.get("call_id") or "")
+        if call_id:
+            match = [c for c in calls if c.get("call_id") == call_id]
+            if not match:
+                return _err(f"no active call {call_id!r}", call_id=call_id)
+            return _ok(call=match[0])
+        return _ok(provider=result.get("provider"), active_calls=calls)
+    return json.dumps(result, ensure_ascii=False)
 
 
 async def voice_call_handler(args: Dict[str, Any], **_kwargs) -> str:

--- a/plugins/platforms/voice_call/tool.py
+++ b/plugins/platforms/voice_call/tool.py
@@ -40,7 +40,8 @@ VOICE_CALL_SCHEMA: Dict[str, Any] = {
             "to_number": {
                 "type": "string",
                 "description": (
-                    "E.164 destination for initiate_call (e.g. +15555550123)."
+                    "E.164 destination for initiate_call (e.g. +15555550123). "
+                    "Omit to call the configured default number, if one is set."
                 ),
             },
             "message": {
@@ -122,11 +123,10 @@ async def _dispatch(action: str, args: Dict[str, Any]) -> str:
     call_id = str(args.get("call_id") or "")
     try:
         if action == "initiate_call":
-            to_number = str(args.get("to_number") or "").strip()
-            if not to_number:
-                return _err("to_number is required for initiate_call")
+            # to_number falls back to the configured default (to_number /
+            # VOICE_CALL_TO_NUMBER) inside the manager, like OpenClaw.
             record = await manager.initiate_call(
-                to_number,
+                str(args.get("to_number") or "").strip() or None,
                 message=args.get("message"),
                 mode=args.get("mode"),
             )
@@ -223,7 +223,9 @@ async def slash_handler(raw_args: str = "", **_kwargs) -> Optional[str]:
             {
                 "to_number": flags.get("to", ""),
                 "message": flags.get("message"),
-                "mode": flags.get("mode"),
+                # Operator surfaces default to conversation (like the CLI);
+                # the model tool keeps the configured outbound default.
+                "mode": flags.get("mode", "conversation"),
             },
         ),
         "speak": (

--- a/plugins/platforms/voice_call/tool.py
+++ b/plugins/platforms/voice_call/tool.py
@@ -1,0 +1,260 @@
+"""The ``voice_call`` model tool and the ``/voicecall`` slash command.
+
+Both run inside the gateway process and drive the live runtime directly.
+The tool handler always returns a JSON string and never raises into the
+agent loop; error paths return ``{"success": false, "error": ...}``.
+"""
+
+import json
+import shlex
+from typing import Any, Dict, Optional
+
+VOICE_CALL_SCHEMA: Dict[str, Any] = {
+    "name": "voice_call",
+    "description": (
+        "Make and manage real phone calls. Actions: initiate_call (dial a "
+        "number and speak a message; mode 'notify' hangs up after the "
+        "message, mode 'conversation' keeps the line open for a dialog), "
+        "continue_call (say something and wait for the person's reply), "
+        "speak_to_user (say something without waiting), send_dtmf (press "
+        "keypad digits, e.g. for phone menus), end_call (hang up), and "
+        "get_status (one call or all active calls). Phone numbers must be "
+        "E.164 (+15555550123). Calls cost real money on real providers — "
+        "only place calls the user asked for."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "initiate_call",
+                    "continue_call",
+                    "speak_to_user",
+                    "send_dtmf",
+                    "end_call",
+                    "get_status",
+                ],
+                "description": "What to do.",
+            },
+            "to_number": {
+                "type": "string",
+                "description": (
+                    "E.164 destination for initiate_call (e.g. +15555550123)."
+                ),
+            },
+            "message": {
+                "type": "string",
+                "description": (
+                    "What to say (initiate_call greeting, continue_call / "
+                    "speak_to_user content). Keep it short and speakable."
+                ),
+            },
+            "call_id": {
+                "type": "string",
+                "description": (
+                    "Call to operate on (from initiate_call/get_status). "
+                    "Required for continue_call, speak_to_user, send_dtmf, "
+                    "end_call."
+                ),
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["notify", "conversation"],
+                "description": (
+                    "initiate_call only. notify: speak and hang up. "
+                    "conversation: stay on the line for replies. Defaults to "
+                    "the configured outbound mode."
+                ),
+            },
+            "digits": {
+                "type": "string",
+                "description": "DTMF digits for send_dtmf (0-9, *, #, w=0.5s pause).",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def tool_check() -> bool:
+    """The tool is available whenever the platform's dependencies are."""
+    from .adapter import check_requirements
+
+    return check_requirements()
+
+
+def _ok(**payload) -> str:
+    return json.dumps({"success": True, **payload}, ensure_ascii=False)
+
+
+def _err(message: str, **payload) -> str:
+    return json.dumps(
+        {"success": False, "error": message, **payload}, ensure_ascii=False
+    )
+
+
+def _call_summary(record) -> Dict[str, Any]:
+    return {
+        "call_id": record.call_id,
+        "state": record.state.value,
+        "direction": record.direction,
+        "mode": record.mode,
+        "peer_number": record.peer_number,
+        "started_at": record.started_at,
+        "transcript_entries": len(record.transcript),
+    }
+
+
+async def _dispatch(action: str, args: Dict[str, Any]) -> str:
+    from .manager import CallNotFoundError
+    from .runtime import get_runtime
+
+    runtime = get_runtime()
+    if runtime is None or runtime.manager is None:
+        return _err(
+            "voice_call runtime is not running — the gateway must be running "
+            "with the voice_call platform enabled "
+            "(gateway.platforms.voice_call.enabled: true)"
+        )
+    manager = runtime.manager
+
+    call_id = str(args.get("call_id") or "")
+    try:
+        if action == "initiate_call":
+            to_number = str(args.get("to_number") or "").strip()
+            if not to_number:
+                return _err("to_number is required for initiate_call")
+            record = await manager.initiate_call(
+                to_number,
+                message=args.get("message"),
+                mode=args.get("mode"),
+            )
+            return _ok(call=_call_summary(record))
+        if action == "continue_call":
+            message = str(args.get("message") or "").strip()
+            if not call_id or not message:
+                return _err("continue_call requires call_id and message")
+            reply = await manager.continue_call(call_id, message)
+            return _ok(call_id=call_id, reply=reply)
+        if action == "speak_to_user":
+            message = str(args.get("message") or "").strip()
+            if not call_id or not message:
+                return _err("speak_to_user requires call_id and message")
+            await manager.speak(call_id, message)
+            return _ok(call_id=call_id)
+        if action == "send_dtmf":
+            digits = str(args.get("digits") or "").strip()
+            if not call_id or not digits:
+                return _err("send_dtmf requires call_id and digits")
+            await manager.send_dtmf(call_id, digits)
+            return _ok(call_id=call_id, digits=digits)
+        if action == "end_call":
+            if not call_id:
+                return _err("end_call requires call_id")
+            await manager.end_call(call_id)
+            return _ok(call_id=call_id, state="hangup-bot")
+        if action == "get_status":
+            if call_id:
+                record = manager.get_call(call_id)
+                if record is None:
+                    return _err(f"no active call {call_id!r}", call_id=call_id)
+                return _ok(call=_call_summary(record))
+            return _ok(
+                provider=runtime.config.provider,
+                active_calls=[_call_summary(r) for r in manager.get_active_calls()],
+            )
+        return _err(f"unknown action {action!r}")
+    except CallNotFoundError:
+        return _err(f"no active call {call_id!r}", call_id=call_id)
+    except TimeoutError:
+        return _err(
+            "timed out waiting for the caller's reply", call_id=call_id
+        )
+    except Exception as e:  # noqa: BLE001 — JSON contract, never raise
+        return _err(str(e))
+
+
+async def voice_call_handler(args: Dict[str, Any], **_kwargs) -> str:
+    action = str(args.get("action") or "").strip()
+    if not action:
+        return _err("action is required")
+    try:
+        return await _dispatch(action, args)
+    except Exception as e:  # noqa: BLE001 — belt and suspenders
+        return _err(str(e))
+
+
+# -- /voicecall slash command ---------------------------------------------------
+
+_SLASH_USAGE = (
+    "Usage: /voicecall status | call --to +1555... --message \"...\" "
+    "[--mode notify|conversation] | speak --call-id ID --message \"...\" | "
+    "dtmf --call-id ID --digits 123# | end --call-id ID"
+)
+
+
+def _parse_flags(tokens) -> Dict[str, str]:
+    flags: Dict[str, str] = {}
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token.startswith("--") and i + 1 < len(tokens):
+            flags[token[2:].replace("-", "_")] = tokens[i + 1]
+            i += 2
+        else:
+            i += 1
+    return flags
+
+
+async def slash_handler(raw_args: str = "", **_kwargs) -> Optional[str]:
+    try:
+        tokens = shlex.split(raw_args or "")
+    except ValueError as e:
+        return f"voice_call: {e}\n{_SLASH_USAGE}"
+    if not tokens:
+        return _SLASH_USAGE
+    sub, flags = tokens[0].lower(), _parse_flags(tokens[1:])
+
+    action_map = {
+        "status": ("get_status", {"call_id": flags.get("call_id", "")}),
+        "call": (
+            "initiate_call",
+            {
+                "to_number": flags.get("to", ""),
+                "message": flags.get("message"),
+                "mode": flags.get("mode"),
+            },
+        ),
+        "speak": (
+            "speak_to_user",
+            {"call_id": flags.get("call_id", ""), "message": flags.get("message", "")},
+        ),
+        "dtmf": (
+            "send_dtmf",
+            {"call_id": flags.get("call_id", ""), "digits": flags.get("digits", "")},
+        ),
+        "end": ("end_call", {"call_id": flags.get("call_id", "")}),
+    }
+    if sub not in action_map:
+        return f"voice_call: unknown subcommand {sub!r}\n{_SLASH_USAGE}"
+    action, args = action_map[sub]
+    result = json.loads(await _dispatch(action, args))
+    if not result.get("success"):
+        return f"voice_call error: {result.get('error')}"
+    if action == "get_status":
+        calls = result.get("active_calls")
+        if calls is None:
+            calls = [result["call"]]
+        if not calls:
+            return "voice_call: no active calls"
+        lines = [
+            f"• {c['call_id']} — {c['state']} {c['direction']} "
+            f"{c['peer_number']} ({c['mode']})"
+            for c in calls
+        ]
+        return "Active calls:\n" + "\n".join(lines)
+    if action == "initiate_call":
+        call = result["call"]
+        return f"voice_call: dialing {call['peer_number']} — call_id {call['call_id']}"
+    return f"voice_call: ok ({json.dumps({k: v for k, v in result.items() if k != 'success'})})"

--- a/plugins/platforms/voice_call/tunnel.py
+++ b/plugins/platforms/voice_call/tunnel.py
@@ -1,0 +1,172 @@
+"""Public webhook exposure: ngrok and Tailscale serve/funnel tunnels.
+
+Port of OpenClaw's ``src/tunnel.ts``. Resolution order lives in
+``runtime._resolve_public_url``: explicit ``public_url`` wins; otherwise
+``tunnel.provider`` selects one of these. The returned handle's
+``public_url`` is the public *base* URL (no path) — providers append
+``serve.path`` themselves.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+from .config import VoiceCallConfig
+
+logger = logging.getLogger(__name__)
+
+NGROK_STARTUP_TIMEOUT_S = 30.0
+TAILSCALE_TIMEOUT_S = 10.0
+
+
+@dataclass
+class TunnelHandle:
+    public_url: str
+    provider: str
+    _process: Optional[asyncio.subprocess.Process] = None
+    _stop_args: Optional[List[str]] = None  # tailscale off command
+
+    async def stop(self) -> None:
+        if self._process is not None and self._process.returncode is None:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=3.0)
+            except asyncio.TimeoutError:
+                self._process.kill()
+            self._process = None
+        if self._stop_args:
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *self._stop_args,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except (OSError, asyncio.TimeoutError):
+                logger.debug("tailscale tunnel off failed", exc_info=True)
+            self._stop_args = None
+
+
+async def _run_command(args: List[str], timeout_s: float = 15.0) -> str:
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+    except asyncio.TimeoutError:
+        proc.kill()
+        raise RuntimeError(f"command timed out: {args[0]}")
+    if proc.returncode != 0:
+        detail = (stderr or stdout or b"").decode("utf-8", "replace")[:400]
+        raise RuntimeError(f"{args[0]} failed ({proc.returncode}): {detail}")
+    return (stdout or b"").decode("utf-8", "replace")
+
+
+def parse_ngrok_log_line(line: str) -> Optional[str]:
+    """Extract the public URL from one ngrok JSON log line, if present."""
+    try:
+        log = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(log, dict):
+        return None
+    url = log.get("url")
+    if url and (log.get("msg") == "started tunnel" or log.get("addr")):
+        return str(url)
+    return None
+
+
+async def start_ngrok_tunnel(config: VoiceCallConfig) -> TunnelHandle:
+    """Spawn the ngrok CLI and parse the public URL from its JSON logs."""
+    auth_token = os.getenv("NGROK_AUTHTOKEN", "").strip()
+    if auth_token:
+        await _run_command(["ngrok", "config", "add-authtoken", auth_token])
+
+    args = [
+        "ngrok", "http", str(config.serve.port),
+        "--log", "stdout", "--log-format", "json",
+    ]
+    if config.tunnel.ngrok_domain:
+        args += ["--domain", config.tunnel.ngrok_domain]
+
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    async def _await_url() -> str:
+        assert proc.stdout is not None
+        while True:
+            raw = await proc.stdout.readline()
+            if not raw:
+                stderr = b""
+                if proc.stderr is not None:
+                    stderr = await proc.stderr.read()
+                detail = stderr.decode("utf-8", "replace")[:400]
+                raise RuntimeError(f"ngrok exited before reporting a URL: {detail}")
+            url = parse_ngrok_log_line(raw.decode("utf-8", "replace").strip())
+            if url:
+                return url
+
+    try:
+        public_url = await asyncio.wait_for(
+            _await_url(), timeout=NGROK_STARTUP_TIMEOUT_S
+        )
+    except (asyncio.TimeoutError, RuntimeError):
+        if proc.returncode is None:
+            proc.terminate()
+        raise
+    logger.info("voice_call: ngrok tunnel active at %s", public_url)
+    return TunnelHandle(
+        public_url=public_url.rstrip("/"), provider="ngrok", _process=proc
+    )
+
+
+async def get_tailscale_dns_name() -> Optional[str]:
+    try:
+        output = await _run_command(["tailscale", "status", "--json"])
+        status = json.loads(output)
+        dns_name = (status.get("Self") or {}).get("DNSName", "")
+        return dns_name.rstrip(".") or None
+    except (RuntimeError, json.JSONDecodeError, OSError):
+        return None
+
+
+async def start_tailscale_tunnel(config: VoiceCallConfig, mode: str) -> TunnelHandle:
+    """Expose the local port via ``tailscale serve`` or ``tailscale funnel``."""
+    dns_name = await get_tailscale_dns_name()
+    if not dns_name:
+        raise RuntimeError(
+            "could not get Tailscale DNS name — is Tailscale running?"
+        )
+    path = config.serve.path
+    local_url = f"http://127.0.0.1:{config.serve.port}{path}"
+    await _run_command(
+        ["tailscale", mode, "--bg", "--yes", "--set-path", path, local_url],
+        timeout_s=TAILSCALE_TIMEOUT_S,
+    )
+    # Tunnel base URL excludes the path; providers re-append serve.path.
+    public_url = f"https://{dns_name}"
+    logger.info("voice_call: tailscale %s active at %s%s", mode, public_url, path)
+    return TunnelHandle(
+        public_url=public_url,
+        provider=f"tailscale-{mode}",
+        _stop_args=["tailscale", mode, "off", path],
+    )
+
+
+async def start_tunnel(config: VoiceCallConfig) -> TunnelHandle:
+    provider = config.tunnel.provider
+    if provider == "ngrok":
+        return await start_ngrok_tunnel(config)
+    if provider == "tailscale-serve":
+        return await start_tailscale_tunnel(config, "serve")
+    if provider == "tailscale-funnel":
+        return await start_tailscale_tunnel(config, "funnel")
+    raise ValueError(f"unknown tunnel provider {provider!r}")

--- a/plugins/platforms/voice_call/webhook.py
+++ b/plugins/platforms/voice_call/webhook.py
@@ -47,7 +47,7 @@ ADMIN_PATH = "/voice/admin"
 _PREAUTH_HEADERS = {
     "telnyx": ("telnyx-signature-ed25519", "x-telnyx-signature-v02"),
     "twilio": ("x-twilio-signature",),
-    "plivo": ("x-plivo-signature-v3",),
+    "plivo": ("x-plivo-signature-v3", "x-plivo-signature-v2"),
 }
 
 AdminHandler = Callable[[dict], Awaitable[dict]]
@@ -243,10 +243,17 @@ class VoiceCallWebhookServer:
                 status=result.response_status,
             )
 
-        # 9/10. Inbound policy on new inbound calls, then process.
+        # 9/10. Inbound policy on call-opening inbound events (carriers
+        # differ in which event type announces a new inbound call), then
+        # process.
+        _call_opening = (
+            EventType.CALL_INITIATED,
+            EventType.CALL_RINGING,
+            EventType.CALL_ANSWERED,
+        )
         for event in result.events:
             if (
-                event.type == EventType.CALL_INITIATED
+                event.type in _call_opening
                 and event.direction == "inbound"
                 and not self._inbound_allowed(event.from_number)
             ):

--- a/plugins/platforms/voice_call/webhook.py
+++ b/plugins/platforms/voice_call/webhook.py
@@ -264,6 +264,13 @@ class VoiceCallWebhookServer:
                 continue
             await self.process_event(event)
 
+        # Let the provider rewrite the response based on state created while
+        # the events were processed (e.g. Twilio realtime <Connect><Stream>).
+        try:
+            result = self.provider.finalize_response(ctx, result)
+        except Exception:  # noqa: BLE001 — fall back to the parse-time response
+            logger.exception("voice_call webhook: finalize_response failed")
+
         self._replay.put(dedupe_key, result.response_body, result.response_content_type)
         return web.Response(
             text=result.response_body,

--- a/plugins/platforms/voice_call/webhook.py
+++ b/plugins/platforms/voice_call/webhook.py
@@ -1,0 +1,306 @@
+"""Carrier webhook server for the voice_call platform.
+
+One aiohttp application serves three surfaces:
+
+- ``POST <serve.path>`` — carrier webhooks, behind the layered security
+  pipeline below
+- ``GET <serve.stream_path>/{token}`` — media-stream WebSocket upgrades
+  (wired by the realtime phase; rejected until then)
+- ``POST /voice/admin`` — localhost-only control endpoint for the CLI,
+  authenticated by a pre-shared token stored next to the call log
+
+Security pipeline for carrier webhooks, in order (ported from OpenClaw's
+webhook.ts):
+
+1. path match (aiohttp router)        → 404
+2. method gate (router, POST only)    → 405
+3. pre-auth header gate               → 401 before body read
+4. per-IP in-flight limiter           → 429
+5. body size limit / read timeout     → 413 / 408
+6. provider signature verification    → 403
+7. replay cache (TTL)                 → cached 200, not reprocessed
+8. provider parse → normalized events
+9. inbound policy (new inbound calls) → reject + provider hangup response
+10. manager.process_event() per event → provider-expected response
+"""
+
+import asyncio
+import hashlib
+import json
+import logging
+import secrets
+import time
+from collections import OrderedDict
+from typing import Awaitable, Callable, Dict, Optional
+
+from .config import VoiceCallConfig, normalize_e164
+from .events import EventType, NormalizedEvent
+from .providers.base import VoiceCallProvider, WebhookContext
+
+logger = logging.getLogger(__name__)
+
+ADMIN_PATH = "/voice/admin"
+
+# Providers whose webhooks carry a signature header; requests without it are
+# rejected before the body is read (flood mitigation). The mock provider has
+# no signature scheme.
+_PREAUTH_HEADERS = {
+    "telnyx": ("telnyx-signature-ed25519", "x-telnyx-signature-v02"),
+    "twilio": ("x-twilio-signature",),
+    "plivo": ("x-plivo-signature-v3",),
+}
+
+AdminHandler = Callable[[dict], Awaitable[dict]]
+
+
+class _ReplayCache:
+    """Remembers recently processed requests: key → response body."""
+
+    def __init__(self, ttl_s: float, cap: int = 4096):
+        self.ttl_s = ttl_s
+        self.cap = cap
+        self._entries: "OrderedDict[str, tuple]" = OrderedDict()  # key → (ts, body, ct)
+
+    def _evict(self) -> None:
+        now = time.time()
+        while self._entries:
+            key, (ts, _, _) = next(iter(self._entries.items()))
+            if ts < now - self.ttl_s or len(self._entries) > self.cap:
+                self._entries.popitem(last=False)
+            else:
+                break
+
+    def get(self, key: str):
+        self._evict()
+        entry = self._entries.get(key)
+        return (entry[1], entry[2]) if entry else None
+
+    def put(self, key: str, body: str, content_type: str) -> None:
+        self._evict()
+        self._entries[key] = (time.time(), body, content_type)
+
+
+class VoiceCallWebhookServer:
+    def __init__(
+        self,
+        config: VoiceCallConfig,
+        provider: VoiceCallProvider,
+        process_event: Callable[[NormalizedEvent], Awaitable[None]],
+        admin_handler: Optional[AdminHandler] = None,
+        admin_token: Optional[str] = None,
+    ):
+        self.config = config
+        self.provider = provider
+        self.process_event = process_event
+        self.admin_handler = admin_handler
+        self.admin_token = admin_token or secrets.token_urlsafe(32)
+        self._replay = _ReplayCache(ttl_s=config.security.replay_ttl_s)
+        self._inflight: Dict[str, int] = {}
+        self._app = None
+        self._runner = None
+        self._site = None
+        # The realtime phase installs a websocket upgrade handler here.
+        self.stream_handler = None
+
+    # -- lifecycle ----------------------------------------------------------
+
+    async def start(self) -> None:
+        """Bind and serve. Raises OSError when the port is taken."""
+        from aiohttp import web
+
+        self._app = web.Application(
+            client_max_size=self.config.security.max_body_bytes
+        )
+        self._app.router.add_post(self.config.serve.path, self._handle_webhook)
+        self._app.router.add_get(
+            self.config.serve.stream_path + "/{token}", self._handle_stream
+        )
+        self._app.router.add_post(ADMIN_PATH, self._handle_admin)
+        self._runner = web.AppRunner(self._app, access_log=None)
+        await self._runner.setup()
+        try:
+            self._site = web.TCPSite(
+                self._runner, self.config.serve.bind, self.config.serve.port
+            )
+            await self._site.start()
+        except OSError:
+            await self._runner.cleanup()
+            self._runner = None
+            self._site = None
+            raise
+        logger.info(
+            "voice_call webhook server listening on %s:%s%s",
+            self.config.serve.bind, self.bound_port, self.config.serve.path,
+        )
+
+    @property
+    def bound_port(self) -> Optional[int]:
+        """The actually bound port (differs from config with ``port: 0``)."""
+        try:
+            server = self._site._server  # noqa: SLF001 — aiohttp exposes no API
+            return server.sockets[0].getsockname()[1]
+        except (AttributeError, IndexError, TypeError):
+            return self.config.serve.port if self._site else None
+
+    async def stop(self) -> None:
+        """Stop serving and release the port. Idempotent."""
+        if self._site is not None:
+            try:
+                await self._site.stop()
+            except Exception:  # noqa: BLE001
+                logger.debug("voice_call webhook site stop failed", exc_info=True)
+            self._site = None
+        if self._runner is not None:
+            try:
+                await self._runner.cleanup()
+            except Exception:  # noqa: BLE001
+                logger.debug("voice_call webhook runner cleanup failed", exc_info=True)
+            self._runner = None
+        self._app = None
+
+    # -- carrier webhooks -----------------------------------------------------
+
+    def _preauth_ok(self, request) -> bool:
+        required = _PREAUTH_HEADERS.get(self.provider.name)
+        if not required or self.config.security.skip_signature_verification:
+            return True
+        return any(request.headers.get(h) for h in required)
+
+    async def _handle_webhook(self, request):
+        from aiohttp import web
+
+        # 3. Pre-auth header gate — before the body is read.
+        if not self._preauth_ok(request):
+            return web.json_response({"error": "missing signature"}, status=401)
+
+        # 4. Per-IP in-flight limiter.
+        remote_ip = request.remote or "?"
+        if self._inflight.get(remote_ip, 0) >= self.config.security.max_inflight_per_ip:
+            return web.json_response({"error": "too many requests"}, status=429)
+        self._inflight[remote_ip] = self._inflight.get(remote_ip, 0) + 1
+        try:
+            return await self._process_webhook(request, remote_ip)
+        finally:
+            count = self._inflight.get(remote_ip, 1) - 1
+            if count <= 0:
+                self._inflight.pop(remote_ip, None)
+            else:
+                self._inflight[remote_ip] = count
+
+    async def _process_webhook(self, request, remote_ip: str):
+        from aiohttp import web
+
+        # 5. Body read with size limit (client_max_size) and timeout.
+        try:
+            body = await asyncio.wait_for(
+                request.read(), timeout=self.config.security.body_read_timeout_s
+            )
+        except asyncio.TimeoutError:
+            return web.json_response({"error": "body read timeout"}, status=408)
+        except web.HTTPRequestEntityTooLarge:
+            return web.json_response({"error": "body too large"}, status=413)
+
+        public_base = (self.provider.public_url or "").rstrip("/")
+        ctx = WebhookContext(
+            method=request.method,
+            path=request.path,
+            body=body,
+            headers=dict(request.headers),
+            query=dict(request.query),
+            remote_ip=remote_ip,
+            url=f"{public_base}{request.path_qs}" if public_base else str(request.url),
+        )
+
+        # 6. Signature verification.
+        if not self.config.security.skip_signature_verification:
+            verification = self.provider.verify_webhook(ctx)
+            if not verification.ok:
+                logger.warning(
+                    "voice_call webhook: signature verification failed (%s): %s",
+                    self.provider.name, verification.error,
+                )
+                return web.json_response({"error": "invalid signature"}, status=403)
+            dedupe_key = verification.dedupe_key
+        else:
+            dedupe_key = None
+        if not dedupe_key:
+            dedupe_key = hashlib.sha256(body).hexdigest()
+
+        # 7. Replay gate — return the cached response without reprocessing.
+        cached = self._replay.get(dedupe_key)
+        if cached is not None:
+            body_text, content_type = cached
+            return web.Response(
+                text=body_text, content_type=content_type, status=200
+            )
+
+        # 8. Parse into normalized events + provider-expected response.
+        result = self.provider.parse_webhook(ctx)
+        if result.response_status >= 400:
+            return web.Response(
+                text=result.response_body,
+                content_type=result.response_content_type,
+                status=result.response_status,
+            )
+
+        # 9/10. Inbound policy on new inbound calls, then process.
+        for event in result.events:
+            if (
+                event.type == EventType.CALL_INITIATED
+                and event.direction == "inbound"
+                and not self._inbound_allowed(event.from_number)
+            ):
+                logger.warning(
+                    "voice_call webhook: rejected inbound call from %s (policy=%s)",
+                    event.from_number, self.config.inbound_policy,
+                )
+                continue
+            await self.process_event(event)
+
+        self._replay.put(dedupe_key, result.response_body, result.response_content_type)
+        return web.Response(
+            text=result.response_body,
+            content_type=result.response_content_type,
+            status=result.response_status,
+        )
+
+    def _inbound_allowed(self, from_number: Optional[str]) -> bool:
+        policy = self.config.inbound_policy
+        if policy == "open":
+            return True
+        if policy == "disabled":
+            return False
+        caller = normalize_e164(from_number or "")
+        return bool(caller) and caller in self.config.allow_from
+
+    # -- media stream upgrades (realtime phase) ----------------------------------
+
+    async def _handle_stream(self, request):
+        from aiohttp import web
+
+        if self.stream_handler is None:
+            return web.json_response({"error": "streaming not enabled"}, status=404)
+        return await self.stream_handler(request)
+
+    # -- CLI admin endpoint --------------------------------------------------------
+
+    async def _handle_admin(self, request):
+        from aiohttp import web
+
+        token = request.headers.get("x-voice-call-admin-token", "")
+        if not secrets.compare_digest(token, self.admin_token):
+            return web.json_response({"error": "unauthorized"}, status=401)
+        if self.admin_handler is None:
+            return web.json_response({"error": "admin handler not wired"}, status=503)
+        try:
+            payload = json.loads(await request.read() or b"{}")
+            if not isinstance(payload, dict):
+                raise ValueError
+        except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+            return web.json_response({"error": "invalid json"}, status=400)
+        try:
+            result = await self.admin_handler(payload)
+        except Exception as e:  # noqa: BLE001 — CLI gets the error as JSON
+            logger.exception("voice_call admin command failed")
+            return web.json_response({"success": False, "error": str(e)}, status=500)
+        return web.json_response(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "tenacity==9.1.4",
   "pyyaml==6.0.3",
   "ruamel.yaml==0.18.17",
-  "requests==2.33.0",  # CVE-2026-25645
+  "requests==2.33.0",     # CVE-2026-25645
   "jinja2==3.1.6",
   # Bumped from 2.12.5 to 2.13.4 to pull in pydantic-core 2.46.4.
   # pydantic-core 2.41.5 (pulled by 2.12.5) segfaults when the OpenAI SDK's
@@ -83,7 +83,7 @@ dependencies = [
   # it out of the lazy-install path that exists only for the heavy matrix deps.
   "Markdown==3.10.2",
   # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)
-  "PyJWT[crypto]==2.13.0",  # PYSEC-2026-175/177/178/179
+  "PyJWT[crypto]==2.13.0", # PYSEC-2026-175/177/178/179
   # urllib3 2.7.0 fixes GHSA-mf9v-mfxr-j63j (decompression-bomb bypass)
   # and GHSA-qccp-gfcp-xxvc (header leak across origins).
   "urllib3>=2.7.0,<3",
@@ -140,7 +140,7 @@ dependencies = [
 [project.optional-dependencies]
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).
-anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
+anthropic = ["anthropic==0.87.0"] # CVE-2026-34450, CVE-2026-34452
 # Web search backends — each only loaded when the user picks it as their
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]
@@ -154,11 +154,33 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
-messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.4", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
-cron = []  # croniter is now a core dependency; this extra kept for back-compat
+dev = [
+  "debugpy==1.8.20",
+  "pytest==9.0.2",
+  "pytest-asyncio==1.3.0",
+  "mcp==1.26.0",
+  "starlette==1.0.1",
+  "ty==0.0.21",
+  "ruff==0.15.10",
+  "setuptools==81.0.0",
+] # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
+messaging = [
+  "python-telegram-bot[webhooks]==22.6",
+  "discord.py[voice]==2.7.1",
+  "aiohttp==3.13.4",
+  "brotlicffi==1.2.0.1",
+  "slack-bolt==1.27.0",
+  "slack-sdk==3.40.1",
+  "qrcode==7.4.2",
+] # aiohttp: CVE-2026-34513/34518/34519/34520/34525
+cron = [] # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.4"]
-matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0"]
+matrix = [
+  "mautrix[encryption]==0.21.0",
+  "aiosqlite==0.22.1",
+  "asyncpg==0.31.0",
+  "aiohttp-socks==0.11.0",
+]
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in
 # replacement for stdlib xml.etree.ElementTree) to block billion-laughs
@@ -201,16 +223,19 @@ vision = []
 # `request.url` can be bypassed. We pin a patched Starlette directly in every
 # extra that exposes a Starlette-backed server surface so pip/uv can't resolve
 # a vulnerable pre-1.0.1 transitive. Bump in lockstep with uv.lock.
-mcp = ["mcp==1.26.0", "starlette==1.0.1"]  # starlette: CVE-2026-48710
+mcp = ["mcp==1.26.0", "starlette==1.0.1"] # starlette: CVE-2026-48710
 nemo-relay = ["nemo-relay==0.3"]
 homeassistant = ["aiohttp==3.13.4"]
 sms = ["aiohttp==3.13.4"]
 teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.13.4"]
+voice-call = [
+  "aiohttp==3.13.4",
+] # webhook + media-stream server for the voice_call platform
 # Computer use — macOS background desktop control via cua-driver (MCP stdio).
 # The cua-driver binary itself is installed via `hermes tools` post-setup
 # (curl install script); this extra just pins the MCP client used to talk
 # to it, which is already provided by the `mcp` extra.
-computer-use = ["mcp==1.26.0", "starlette==1.0.1"]  # starlette: CVE-2026-48710
+computer-use = ["mcp==1.26.0", "starlette==1.0.1"] # starlette: CVE-2026-48710
 acp = ["agent-client-protocol==0.9.0"]
 # mistral: Voxtral STT + TTS. Pinned to an exact verified-clean version.
 # The `mistralai` PyPI project was quarantined 2026-05-12 after the malicious
@@ -244,7 +269,11 @@ termux-all = [
   "hermes-agent[sms]",
   "hermes-agent[web]",
 ]
-dingtalk = ["dingtalk-stream==0.24.3", "alibabacloud-dingtalk==2.2.42", "qrcode==7.4.2"]
+dingtalk = [
+  "dingtalk-stream==0.24.3",
+  "alibabacloud-dingtalk==2.2.42",
+  "qrcode==7.4.2",
+]
 feishu = ["lark-oapi==1.5.3", "qrcode==7.4.2"]
 google = [
   # Required by the google-workspace skill (Gmail, Calendar, Drive, Contacts,
@@ -265,7 +294,12 @@ youtube = [
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
 # starlette==1.0.1 pinned for CVE-2026-48710 (BadHost) — fastapi pulls Starlette
 # transitively and pre-1.0.1 is the vulnerable range. See the mcp extra above.
-web = ["fastapi==0.133.1", "uvicorn[standard]==0.41.0", "starlette==1.0.1", "python-multipart==0.0.27"]
+web = [
+  "fastapi==0.133.1",
+  "uvicorn[standard]==0.41.0",
+  "starlette==1.0.1",
+  "python-multipart==0.0.27",
+]
 all = [
   # Policy (2026-05-12): `[all]` includes only extras that genuinely
   # CAN'T be lazy-installed via `tools/lazy_deps.py` — i.e. things every
@@ -306,7 +340,22 @@ hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
+py-modules = [
+  "run_agent",
+  "model_tools",
+  "toolsets",
+  "batch_runner",
+  "trajectory_compressor",
+  "toolset_distributions",
+  "cli",
+  "hermes_bootstrap",
+  "hermes_constants",
+  "hermes_state",
+  "hermes_time",
+  "hermes_logging",
+  "utils",
+  "mcp_serve",
+]
 
 [tool.setuptools.data-files]
 # i18n catalogs. locales/ is a bare data directory (no __init__.py), so it is
@@ -332,7 +381,12 @@ locales = ["locales/*.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
 
 [tool.setuptools.package-data]
-hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
+hermes_cli = [
+  "web_dist/**/*",
+  "tui_dist/**/*",
+  "scripts/install.sh",
+  "scripts/install.ps1",
+]
 gateway = ["assets/**/*"]
 plugins = [
   "*/dashboard/manifest.json",
@@ -350,13 +404,31 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = [
+  "agent",
+  "agent.*",
+  "tools",
+  "tools.*",
+  "hermes_cli",
+  "hermes_cli.*",
+  "gateway",
+  "gateway.*",
+  "tui_gateway",
+  "tui_gateway.*",
+  "cron",
+  "cron.*",
+  "acp_adapter",
+  "plugins",
+  "plugins.*",
+  "providers",
+  "providers.*",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [
-    "integration: marks tests requiring external services (API keys, Modal, etc.)",
-    "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
+  "integration: marks tests requiring external services (API keys, Modal, etc.)",
+  "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
 ]
 # integration tests take way too long to run in the normal CI environments
 addopts = "-m 'not integration'"
@@ -369,7 +441,7 @@ unknown-argument = "warn"
 redundant-cast = "ignore"
 
 [tool.ruff]
-preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
+preview = true # required for PLW1514 (unspecified-encoding) — preview rule
 
 [tool.ruff.lint]
 # All other lints are intentionally disabled (see comment history on this

--- a/tests/gateway/test_plugin_platform_interface.py
+++ b/tests/gateway/test_plugin_platform_interface.py
@@ -14,7 +14,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+# tests/gateway/ → tests/ → repo root
+PROJECT_ROOT = Path(__file__).parent.parent.parent.resolve()
 PLATFORMS_DIR = PROJECT_ROOT / "plugins" / "platforms"
 
 
@@ -48,12 +49,20 @@ def clean_registry():
 class _MockPluginContext:
     """Minimal mock of hermes_cli.plugins.PluginContext.
 
-    Only implements register_platform so we can exercise the plugin's
-    register() entrypoint without importing the real plugin system.
+    Implements register_platform for real so we can exercise the plugin's
+    register() entrypoint without importing the real plugin system; every
+    other PluginContext registration surface (register_cli_command,
+    register_tool, register_command, ...) is accepted as a no-op so plugins
+    that register extra surfaces (e.g. photon's CLI) still load.
     """
 
     def __init__(self):
         self.registered_names: list[str] = []
+
+    def __getattr__(self, attr: str):
+        if attr.startswith("register_") or attr in ("inject_message", "dispatch_tool"):
+            return lambda *args, **kwargs: None
+        raise AttributeError(attr)
 
     def register_platform(
         self,

--- a/tests/gateway/test_voice_call_platform.py
+++ b/tests/gateway/test_voice_call_platform.py
@@ -1,0 +1,211 @@
+"""Gateway-level integration tests for the voice_call platform.
+
+Exercises the real adapter lifecycle (connect → runtime → webhook server →
+disconnect) and the full turn loop: inbound caller speech becomes a
+MessageEvent with the right SessionSource, and the "agent reply" delivered
+through adapter.send() is spoken on the live call.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("aiohttp")
+
+from plugins.platforms.voice_call import runtime as runtime_mod
+from plugins.platforms.voice_call.adapter import VoiceCallAdapter
+from plugins.platforms.voice_call.events import CallState, EventType, NormalizedEvent
+
+
+def _platform_config(extra):
+    config = MagicMock()
+    config.extra = extra
+    config.enabled = True
+    config.token = None
+    config.api_key = None
+    config.home_channel = None
+    config.reply_to_mode = "first"
+    return config
+
+
+def _mock_extra(**overrides):
+    extra = {
+        "provider": "mock",
+        "from_number": "+15555550000",
+        "inbound_policy": "allowlist",
+        "allow_from": ["+15555550009"],
+        "serve": {"port": 0},
+        "timeouts": {"silence_s": 0},
+        "outbound": {"default_mode": "conversation"},
+    }
+    extra.update(overrides)
+    return extra
+
+
+@pytest.fixture(autouse=True)
+def _clean_runtime():
+    runtime_mod._runtime = None
+    runtime_mod._runtime_lock = None
+    yield
+    runtime_mod._runtime = None
+    runtime_mod._runtime_lock = None
+
+
+async def _connect(extra=None):
+    adapter = VoiceCallAdapter(_platform_config(extra or _mock_extra()))
+    assert await adapter.connect() is True
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_connect_starts_runtime_disconnect_stops_it():
+    adapter = await _connect()
+    assert adapter.is_connected
+    runtime = runtime_mod.get_runtime()
+    assert runtime is not None
+    assert runtime.webhook_server.bound_port
+    await adapter.disconnect()
+    assert runtime_mod.get_runtime() is None
+    assert not adapter.is_connected
+    # Idempotent disconnect.
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_connect_with_invalid_config_sets_fatal_error():
+    adapter = VoiceCallAdapter(
+        _platform_config({"provider": "telnyx"})  # no creds, no public URL
+    )
+    assert await adapter.connect() is False
+    assert adapter.has_fatal_error
+
+
+@pytest.mark.asyncio
+async def test_inbound_speech_becomes_message_event_per_phone():
+    adapter = await _connect()
+    received = []
+    runtime = runtime_mod.get_runtime()
+
+    async def fake_handle_message(event):
+        received.append(event)
+
+    adapter.handle_message = fake_handle_message
+    try:
+        manager = runtime.manager
+        await manager.process_event(
+            NormalizedEvent(
+                type=EventType.CALL_INITIATED, provider="mock",
+                provider_call_id="prov-1", direction="inbound",
+                from_number="+15555550009", to_number="+15555550000",
+            )
+        )
+        await manager.process_event(
+            NormalizedEvent(
+                type=EventType.CALL_ANSWERED, provider="mock",
+                provider_call_id="prov-1",
+            )
+        )
+        await manager.process_event(
+            NormalizedEvent(
+                type=EventType.CALL_SPEECH, provider="mock",
+                provider_call_id="prov-1", text="what's on my calendar?",
+            )
+        )
+        await asyncio.sleep(0.05)
+        assert len(received) == 1
+        event = received[0]
+        assert event.text == "what's on my calendar?"
+        assert event.source.chat_id == "+15555550009"
+        assert event.source.user_id == "+15555550009"
+        assert event.source.thread_id is None  # per-phone scope
+        assert event.source.chat_type == "dm"
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_inbound_speech_per_call_scope_sets_thread_id():
+    adapter = await _connect(_mock_extra(session_scope="per-call"))
+    received = []
+
+    async def fake_handle_message(event):
+        received.append(event)
+
+    adapter.handle_message = fake_handle_message
+    runtime = runtime_mod.get_runtime()
+    try:
+        manager = runtime.manager
+        await manager.process_event(
+            NormalizedEvent(
+                type=EventType.CALL_INITIATED, provider="mock",
+                provider_call_id="prov-2", direction="inbound",
+                from_number="+15555550009", to_number="+15555550000",
+            )
+        )
+        record = manager.call_for_chat("+15555550009")
+        await manager.process_event(
+            NormalizedEvent(type=EventType.CALL_ANSWERED, provider="mock",
+                            provider_call_id="prov-2")
+        )
+        await manager.process_event(
+            NormalizedEvent(type=EventType.CALL_SPEECH, provider="mock",
+                            provider_call_id="prov-2", text="hello")
+        )
+        await asyncio.sleep(0.05)
+        assert len(received) == 1
+        assert received[0].source.thread_id == record.call_id
+        assert record.session_key == f"+15555550009:{record.call_id}"
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_send_speaks_agent_reply_on_live_call():
+    """The reply half of the turn loop: gateway → send() → carrier TTS."""
+    adapter = await _connect()
+    runtime = runtime_mod.get_runtime()
+    try:
+        record = await runtime.manager.initiate_call("+15555550001", message="hi")
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while (
+            record.state != CallState.LISTENING
+            and asyncio.get_running_loop().time() < deadline
+        ):
+            await asyncio.sleep(0.01)
+
+        result = await adapter.send(
+            "+15555550001", "Your meeting is at **3pm** — see https://cal.example"
+        )
+        assert result.success is True
+        assert result.message_id == record.call_id
+        spoken = runtime.provider.spoken[-1][1]
+        assert "**" not in spoken and "https://" not in spoken
+        assert "3pm" in spoken
+        # Spoken reply lands in the transcript as a bot turn.
+        assert record.transcript[-1].speaker == "bot"
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_send_fails_cleanly_without_live_call():
+    adapter = await _connect()
+    try:
+        result = await adapter.send("+19998887777", "anyone?")
+        assert result.success is False
+        assert "no active voice call" in result.error
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_gateway_shutdown_releases_webhook_port():
+    adapter = await _connect()
+    port = runtime_mod.get_runtime().webhook_server.bound_port
+    await adapter.disconnect()
+
+    # Rebinding the same fixed port proves release.
+    adapter2 = await _connect(_mock_extra(serve={"port": port}))
+    assert runtime_mod.get_runtime().webhook_server.bound_port == port
+    await adapter2.disconnect()

--- a/tests/plugins/platforms/voice_call/conftest.py
+++ b/tests/plugins/platforms/voice_call/conftest.py
@@ -1,0 +1,69 @@
+"""Shared fixtures for voice_call plugin tests."""
+
+import pytest
+
+from plugins.platforms.voice_call.config import (
+    OutboundConfig,
+    TimeoutsConfig,
+    VoiceCallConfig,
+)
+from plugins.platforms.voice_call.manager import CallManager
+from plugins.platforms.voice_call.providers.mock import MockProvider
+from plugins.platforms.voice_call.store import CallStore
+
+
+def _make_config(**overrides) -> VoiceCallConfig:
+    """Mock-provider config with test-friendly (sub-second) timeouts."""
+    cfg = VoiceCallConfig.from_extra({"provider": "mock", **overrides.pop("extra", {})})
+    cfg.from_number = overrides.pop("from_number", "+15555550000")
+    cfg.timeouts = overrides.pop(
+        "timeouts",
+        TimeoutsConfig(max_call_s=5, ring_s=0.2, silence_s=0, transcript_wait_s=0.5),
+    )
+    cfg.outbound = overrides.pop(
+        "outbound", OutboundConfig(default_mode="conversation", notify_hangup_delay_s=0)
+    )
+    for key, value in overrides.items():
+        setattr(cfg, key, value)
+    return cfg
+
+
+@pytest.fixture
+def make_config():
+    """Factory fixture (conftest isn't importable without package context)."""
+    return _make_config
+
+
+@pytest.fixture
+def vc_config():
+    return _make_config()
+
+
+@pytest.fixture
+def store(tmp_path):
+    return CallStore(base_dir=tmp_path / "voice-calls")
+
+
+@pytest.fixture
+def provider(vc_config):
+    return MockProvider(vc_config)
+
+
+@pytest.fixture
+def manager(vc_config, provider, store):
+    mgr = CallManager(vc_config, provider, store)
+    # The runtime normally wires this; tests connect it directly.
+    provider.event_sink = mgr.process_event
+    return mgr
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_singleton():
+    """Each test starts with a clean runtime singleton."""
+    import plugins.platforms.voice_call.runtime as runtime_mod
+
+    runtime_mod._runtime = None
+    runtime_mod._runtime_lock = None
+    yield
+    runtime_mod._runtime = None
+    runtime_mod._runtime_lock = None

--- a/tests/plugins/platforms/voice_call/test_audio.py
+++ b/tests/plugins/platforms/voice_call/test_audio.py
@@ -1,0 +1,77 @@
+"""µ-law codec, resampler, and framing tests (vendored audio.py)."""
+
+import math
+from array import array
+
+from plugins.platforms.voice_call import audio
+
+
+def _sine_pcm16(rate=8000, freq=440.0, seconds=0.05, amplitude=12000):
+    n = int(rate * seconds)
+    samples = array(
+        "h",
+        (int(amplitude * math.sin(2 * math.pi * freq * i / rate)) for i in range(n)),
+    )
+    return samples.tobytes()
+
+
+def test_ulaw_silence_byte():
+    # µ-law encodes 0 as 0xFF.
+    assert audio.pcm16_to_ulaw(b"\x00\x00") == bytes([audio.ULAW_SILENCE_BYTE])
+    decoded = audio.ulaw_to_pcm16(bytes([audio.ULAW_SILENCE_BYTE]))
+    assert array("h", decoded)[0] == 0
+
+
+def test_ulaw_roundtrip_within_quantization_error():
+    pcm = _sine_pcm16()
+    restored = array("h", audio.ulaw_to_pcm16(audio.pcm16_to_ulaw(pcm)))
+    original = array("h", pcm)
+    assert len(restored) == len(original)
+    for orig, back in zip(original, restored):
+        # G.711 quantization error grows with magnitude; 8-bit µ-law keeps
+        # error under ~1/16 of the sample value + a small floor.
+        assert abs(orig - back) <= max(64, abs(orig) // 8), (orig, back)
+
+
+def test_ulaw_known_values():
+    # Reference vectors from the G.711 tables.
+    assert audio.pcm16_to_ulaw(array("h", [-32635]).tobytes()) == b"\x00"
+    assert audio.pcm16_to_ulaw(array("h", [32635]).tobytes()) == b"\x80"
+    # Clipping beyond ±32635 maps to the extremes too.
+    assert audio.pcm16_to_ulaw(array("h", [32767]).tobytes()) == b"\x80"
+
+
+def test_ulaw_decode_sign_symmetry():
+    for value in (100, 1000, 8000, 30000):
+        pos = array("h", audio.ulaw_to_pcm16(
+            audio.pcm16_to_ulaw(array("h", [value]).tobytes())))[0]
+        neg = array("h", audio.ulaw_to_pcm16(
+            audio.pcm16_to_ulaw(array("h", [-value]).tobytes())))[0]
+        assert pos == -neg
+
+
+def test_resample_length_ratio():
+    pcm = _sine_pcm16(rate=8000, seconds=0.1)  # 800 samples
+    up = audio.resample_pcm16(pcm, 8000, 24000)
+    assert abs(len(up) // 2 - 2400) <= 2
+    down = audio.resample_pcm16(up, 24000, 8000)
+    assert abs(len(down) // 2 - 800) <= 2
+
+
+def test_resample_preserves_constant_signal():
+    pcm = array("h", [1000] * 160).tobytes()
+    out = array("h", audio.resample_pcm16(pcm, 8000, 16000))
+    assert all(abs(s - 1000) <= 1 for s in out)
+
+
+def test_resample_identity_and_empty():
+    pcm = _sine_pcm16()
+    assert audio.resample_pcm16(pcm, 8000, 8000) == pcm
+    assert audio.resample_pcm16(b"", 8000, 24000) == b""
+
+
+def test_chunk_frames_pads_tail_with_silence():
+    frames = audio.chunk_frames(bytes([0x55]) * 250)
+    assert [len(f) for f in frames] == [160, 160]
+    assert frames[1][90:] == bytes([audio.ULAW_SILENCE_BYTE]) * 70
+    assert audio.silence_frame() == bytes([audio.ULAW_SILENCE_BYTE]) * 160

--- a/tests/plugins/platforms/voice_call/test_cli_parity.py
+++ b/tests/plugins/platforms/voice_call/test_cli_parity.py
@@ -34,6 +34,13 @@ def test_cli_call_mode_override():
     assert args.mode == "notify"
 
 
+def test_cli_speak_and_continue_accept_short_message_flag():
+    args = _parse(["speak", "--call-id", "vc-1", "-m", "hello"])
+    assert args.message == "hello"
+    args = _parse(["continue", "--call-id", "vc-1", "-m", "still there?"])
+    assert args.message == "still there?"
+
+
 def test_cli_tail_follow_flags():
     args = _parse(["tail", "-f", "--poll", "0.5", "--lines", "5"])
     assert args.follow is True and args.poll == 0.5 and args.lines == 5

--- a/tests/plugins/platforms/voice_call/test_cli_parity.py
+++ b/tests/plugins/platforms/voice_call/test_cli_parity.py
@@ -1,0 +1,103 @@
+"""CLI parity with OpenClaw's voicecall CLI: conversation default for
+`call`, -t/-m short flags, and to_number config fallback."""
+
+import argparse
+import asyncio
+import json
+
+import pytest
+
+from plugins.platforms.voice_call import cli
+from plugins.platforms.voice_call.config import VoiceCallConfig
+from plugins.platforms.voice_call.manager import CallManager
+
+
+def _parse(argv):
+    parser = argparse.ArgumentParser()
+    cli.register_cli(parser)
+    return parser.parse_args(argv)
+
+
+def test_cli_call_defaults_to_conversation():
+    args = _parse(["call", "-t", "+15555550001", "-m", "hello"])
+    assert args.mode == "conversation"
+    assert args.to == "+15555550001" and args.message == "hello"
+
+
+def test_cli_call_to_is_optional():
+    args = _parse(["call", "-m", "hello"])
+    assert args.to is None  # falls back to config to_number at dispatch
+
+
+def test_cli_call_mode_override():
+    args = _parse(["call", "--to", "+15555550001", "--mode", "notify"])
+    assert args.mode == "notify"
+
+
+def test_cli_tail_follow_flags():
+    args = _parse(["tail", "-f", "--poll", "0.5", "--lines", "5"])
+    assert args.follow is True and args.poll == 0.5 and args.lines == 5
+
+
+def test_config_to_number_parse_and_validation(monkeypatch):
+    monkeypatch.delenv("VOICE_CALL_TO_NUMBER", raising=False)
+    cfg = VoiceCallConfig.from_extra({"provider": "mock", "to_number": "+15555550002"})
+    assert cfg.to_number == "+15555550002"
+    assert cfg.validate() == []
+    cfg = VoiceCallConfig.from_extra({"provider": "mock", "to_number": "junk"})
+    assert any("to_number" in e for e in cfg.validate())
+    monkeypatch.setenv("VOICE_CALL_TO_NUMBER", "+15555550003")
+    cfg = VoiceCallConfig.from_extra({"provider": "mock"})
+    assert cfg.to_number == "+15555550003"
+
+
+@pytest.mark.asyncio
+async def test_manager_falls_back_to_config_to_number(vc_config, provider, store):
+    vc_config.to_number = "+15555550002"
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call()  # no destination passed
+    assert record.to_number == "+15555550002"
+    await manager.shutdown()
+
+    vc_config.to_number = None
+    manager = CallManager(vc_config, provider, store)
+    with pytest.raises(ValueError, match="no destination number"):
+        await manager.initiate_call()
+
+
+@pytest.mark.asyncio
+async def test_tool_initiate_uses_default_to_number(tmp_path, make_config):
+    from plugins.platforms.voice_call import runtime as runtime_mod
+    from plugins.platforms.voice_call.tool import voice_call_handler
+
+    cfg = make_config()
+    cfg.serve.port = 0
+    cfg.to_number = "+15555550002"
+    await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    try:
+        result = json.loads(
+            await voice_call_handler({"action": "initiate_call", "message": "hi"})
+        )
+        assert result["success"] is True
+        assert result["call"]["peer_number"] == "+15555550002"
+    finally:
+        await runtime_mod.stop_runtime()
+
+
+@pytest.mark.asyncio
+async def test_slash_call_defaults_to_conversation(tmp_path, make_config):
+    from plugins.platforms.voice_call import runtime as runtime_mod
+    from plugins.platforms.voice_call.tool import slash_handler
+
+    cfg = make_config()
+    cfg.serve.port = 0
+    cfg.outbound.default_mode = "notify"  # slash should override to conversation
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    try:
+        out = await slash_handler("call --to +15555550001")
+        call_id = out.rsplit(" ", 1)[-1]
+        record = runtime.manager.get_call(call_id)
+        assert record is not None and record.mode == "conversation"
+    finally:
+        await runtime_mod.stop_runtime()

--- a/tests/plugins/platforms/voice_call/test_cli_parity.py
+++ b/tests/plugins/platforms/voice_call/test_cli_parity.py
@@ -86,6 +86,36 @@ async def test_tool_initiate_uses_default_to_number(tmp_path, make_config):
 
 
 @pytest.mark.asyncio
+async def test_admin_call_with_null_to_uses_config_default(tmp_path, make_config):
+    """`hermes voicecall call -m ...` sends {"to": null}; the admin handler
+    must treat JSON null as absent (str(None) regression) and fall back to
+    the configured to_number."""
+    import aiohttp
+
+    from plugins.platforms.voice_call import runtime as runtime_mod
+
+    cfg = make_config()
+    cfg.serve.port = 0
+    cfg.to_number = "+15555550002"
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    try:
+        port = runtime.webhook_server.bound_port
+        token = (tmp_path / "admin.token").read_text(encoding="utf-8").strip()
+        async with aiohttp.ClientSession() as client:
+            async with client.post(
+                f"http://127.0.0.1:{port}/voice/admin",
+                json={"command": "call", "to": None, "message": "hi", "mode": None},
+                headers={"x-voice-call-admin-token": token},
+            ) as resp:
+                data = await resp.json()
+        assert data["success"] is True, data
+        record = runtime.manager.get_call(data["call_id"])
+        assert record.to_number == "+15555550002"
+    finally:
+        await runtime_mod.stop_runtime()
+
+
+@pytest.mark.asyncio
 async def test_slash_call_defaults_to_conversation(tmp_path, make_config):
     from plugins.platforms.voice_call import runtime as runtime_mod
     from plugins.platforms.voice_call.tool import slash_handler

--- a/tests/plugins/platforms/voice_call/test_cli_parity.py
+++ b/tests/plugins/platforms/voice_call/test_cli_parity.py
@@ -34,6 +34,13 @@ def test_cli_call_mode_override():
     assert args.mode == "notify"
 
 
+def test_cli_call_might_continue_flag():
+    args = _parse(["call", "--to", "+15555550001", "--mode", "notify"])
+    assert args.might_continue is False
+    args = _parse(["call", "-t", "+1", "--mode", "notify", "--might-continue"])
+    assert args.might_continue is True
+
+
 def test_cli_speak_and_continue_accept_short_message_flag():
     args = _parse(["speak", "--call-id", "vc-1", "-m", "hello"])
     assert args.message == "hello"

--- a/tests/plugins/platforms/voice_call/test_config.py
+++ b/tests/plugins/platforms/voice_call/test_config.py
@@ -1,0 +1,193 @@
+"""Config parsing and validation tests for the voice_call platform."""
+
+import pytest
+
+from plugins.platforms.voice_call.config import (
+    DEFAULT_PROVIDER,
+    VoiceCallConfig,
+    is_e164,
+    normalize_e164,
+)
+
+
+TELNYX_ENV = {
+    "TELNYX_API_KEY": "test-key",
+    "TELNYX_CONNECTION_ID": "test-conn",
+    "TELNYX_PUBLIC_KEY": "test-pub",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Strip every voice_call-relevant env var so tests are hermetic."""
+    for var in (
+        "VOICE_CALL_PROVIDER", "VOICE_CALL_FROM_NUMBER",
+        "VOICE_CALL_ALLOWED_NUMBERS", "VOICE_CALL_PUBLIC_URL",
+        "NGROK_DOMAIN",
+        *TELNYX_ENV,
+        "TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN",
+        "PLIVO_AUTH_ID", "PLIVO_AUTH_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_defaults():
+    cfg = VoiceCallConfig.from_extra({})
+    assert cfg.provider == DEFAULT_PROVIDER == "telnyx"
+    assert cfg.session_scope == "per-phone"
+    assert cfg.inbound_policy == "allowlist"
+    assert cfg.serve.bind == "127.0.0.1"
+    assert cfg.serve.port == 3334
+    assert cfg.serve.path == "/voice/webhook"
+    assert cfg.tunnel.provider == "none"
+    assert cfg.outbound.default_mode == "notify"
+    assert cfg.security.skip_signature_verification is False
+    assert cfg.streaming.enabled is False
+    assert cfg.realtime.enabled is False
+
+
+def test_e164_normalization():
+    assert normalize_e164("+1 (555) 555-0001") == "+15555550001"
+    assert normalize_e164("15555550001") == "+15555550001"
+    assert is_e164("+15555550001")
+    assert not is_e164("not-a-number")
+    assert not is_e164("+0123")
+
+
+def test_mock_provider_is_valid_without_credentials():
+    cfg = VoiceCallConfig.from_extra({"provider": "mock"})
+    assert cfg.validate() == []
+
+
+def test_unknown_provider_rejected():
+    cfg = VoiceCallConfig.from_extra({"provider": "doesnotexist"})
+    errors = cfg.validate()
+    assert len(errors) == 1
+    assert "provider" in errors[0]
+
+
+def test_telnyx_requires_credentials():
+    cfg = VoiceCallConfig.from_extra({"provider": "telnyx", "public_url": "https://x.example"})
+    errors = cfg.validate()
+    assert any("TELNYX_API_KEY" in e for e in errors)
+    assert any("TELNYX_PUBLIC_KEY" in e for e in errors)
+
+
+def test_telnyx_valid_with_env_and_public_url(monkeypatch):
+    for key, value in TELNYX_ENV.items():
+        monkeypatch.setenv(key, value)
+    cfg = VoiceCallConfig.from_extra({"provider": "telnyx", "public_url": "https://x.example"})
+    assert cfg.validate() == []
+
+
+def test_telnyx_without_public_webhook_rejected(monkeypatch):
+    for key, value in TELNYX_ENV.items():
+        monkeypatch.setenv(key, value)
+    cfg = VoiceCallConfig.from_extra({"provider": "telnyx"})
+    errors = cfg.validate()
+    assert any("publicly reachable webhook" in e for e in errors)
+    # A tunnel satisfies the requirement.
+    cfg = VoiceCallConfig.from_extra(
+        {"provider": "telnyx", "tunnel": {"provider": "ngrok"}}
+    )
+    assert cfg.validate() == []
+
+
+def test_telnyx_skip_signature_drops_public_key_requirement(monkeypatch):
+    monkeypatch.setenv("TELNYX_API_KEY", "k")
+    monkeypatch.setenv("TELNYX_CONNECTION_ID", "c")
+    cfg = VoiceCallConfig.from_extra(
+        {
+            "provider": "telnyx",
+            "public_url": "https://x.example",
+            "security": {"skip_signature_verification": True},
+        }
+    )
+    assert cfg.validate() == []
+
+
+def test_provider_credentials_from_extra_block():
+    cfg = VoiceCallConfig.from_extra(
+        {
+            "provider": "telnyx",
+            "public_url": "https://x.example",
+            "telnyx": {
+                "api_key": "k", "connection_id": "c", "public_key": "p",
+            },
+        }
+    )
+    assert cfg.validate() == []
+    assert cfg.provider_credential("api_key", "TELNYX_API_KEY") == "k"
+
+
+def test_invalid_numbers_rejected():
+    cfg = VoiceCallConfig.from_extra(
+        {"provider": "mock", "from_number": "bogus", "allow_from": ["123abc"]}
+    )
+    errors = cfg.validate()
+    assert any("from_number" in e for e in errors)
+    assert any("allow_from" in e for e in errors)
+
+
+def test_allow_from_env_fallback(monkeypatch):
+    monkeypatch.setenv("VOICE_CALL_ALLOWED_NUMBERS", "+15555550001, +1 (555) 555-0002")
+    cfg = VoiceCallConfig.from_extra({})
+    assert cfg.allow_from == ["+15555550001", "+15555550002"]
+
+
+def test_enum_validation():
+    cfg = VoiceCallConfig.from_extra(
+        {
+            "provider": "mock",
+            "session_scope": "weird",
+            "inbound_policy": "weird",
+            "outbound": {"default_mode": "weird"},
+            "tunnel": {"provider": "weird"},
+        }
+    )
+    errors = " | ".join(cfg.validate())
+    assert "session_scope" in errors
+    assert "inbound_policy" in errors
+    assert "default_mode" in errors
+    assert "tunnel.provider" in errors
+
+
+def test_serve_validation():
+    cfg = VoiceCallConfig.from_extra(
+        {"provider": "mock", "serve": {"port": 99999, "path": "nope"}}
+    )
+    errors = " | ".join(cfg.validate())
+    assert "serve.port" in errors
+    assert "serve.path" in errors
+
+
+def test_realtime_requires_streaming_capable_provider(monkeypatch):
+    cfg = VoiceCallConfig.from_extra(
+        {"provider": "mock", "realtime": {"enabled": True}}
+    )
+    errors = " | ".join(cfg.validate())
+    assert "realtime" in errors
+    # telnyx + realtime is allowed
+    for key, value in TELNYX_ENV.items():
+        monkeypatch.setenv(key, value)
+    cfg = VoiceCallConfig.from_extra(
+        {
+            "provider": "telnyx",
+            "public_url": "https://x.example",
+            "realtime": {"enabled": True, "provider": "openai"},
+        }
+    )
+    assert cfg.validate() == []
+
+
+def test_realtime_provider_enum(monkeypatch):
+    for key, value in TELNYX_ENV.items():
+        monkeypatch.setenv(key, value)
+    cfg = VoiceCallConfig.from_extra(
+        {
+            "provider": "telnyx",
+            "public_url": "https://x.example",
+            "realtime": {"enabled": True, "provider": "weird"},
+        }
+    )
+    assert any("realtime.provider" in e for e in cfg.validate())

--- a/tests/plugins/platforms/voice_call/test_manager.py
+++ b/tests/plugins/platforms/voice_call/test_manager.py
@@ -207,6 +207,56 @@ async def test_speech_resolves_continue_call_waiter(manager, provider):
 
 
 @pytest.mark.asyncio
+async def test_continue_call_ignores_speech_during_question_playback(
+    vc_config, store
+):
+    """The caller reacting to the PREVIOUS message ('thanks') while the
+    question is still playing must not be captured as the answer — the real
+    answer comes after call.speak.ended."""
+
+    class SlowSpeakProvider(MockProvider):
+        async def speak(self, call, text):
+            self.spoken.append((call.provider_call_id, text))
+            if self.event_sink is not None:
+                async def _ended(pid=call.provider_call_id, cid=call.call_id):
+                    await asyncio.sleep(0.3)  # playback takes a while
+                    await self.event_sink(NormalizedEvent(
+                        type=EventType.CALL_SPEAK_ENDED, provider=self.name,
+                        provider_call_id=pid, call_id=cid,
+                    ))
+                asyncio.get_running_loop().create_task(_ended())
+
+    provider = SlowSpeakProvider(vc_config)
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call("+15555550001")
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while record.state != CallState.LISTENING and \
+            asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+    async def caller_talks():
+        await asyncio.sleep(0.1)   # mid-playback: reaction to part two
+        await manager.process_event(NormalizedEvent(
+            type=EventType.CALL_SPEECH, provider="mock",
+            provider_call_id=record.provider_call_id, text="thanks",
+        ))
+        await asyncio.sleep(0.4)   # after speak.ended: the real answer
+        await manager.process_event(NormalizedEvent(
+            type=EventType.CALL_SPEECH, provider="mock",
+            provider_call_id=record.provider_call_id, text="eggs and toast",
+        ))
+
+    asyncio.get_running_loop().create_task(caller_talks())
+    reply = await manager.continue_call(record.call_id, "what was breakfast?")
+    assert reply == "eggs and toast"   # not "thanks"
+    # The discarded reaction never entered the transcript either.
+    user_lines = [t.text for t in record.transcript if t.speaker == "user"]
+    assert user_lines == ["eggs and toast"]
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_continue_call_times_out(manager):
     record = await manager.initiate_call("+15555550001")
     await wait_for_state(manager, record.call_id, CallState.LISTENING)

--- a/tests/plugins/platforms/voice_call/test_manager.py
+++ b/tests/plugins/platforms/voice_call/test_manager.py
@@ -57,6 +57,64 @@ async def test_outbound_notify_speaks_and_hangs_up(vc_config, provider, store):
 
 
 @pytest.mark.asyncio
+async def test_continue_call_upgrades_notify_to_conversation(
+    vc_config, provider, store
+):
+    """continue_call on a notify call cancels the auto-hangup, starts
+    carrier transcription, and waits for the caller's reply."""
+    vc_config.outbound.default_mode = "notify"
+    vc_config.outbound.notify_hangup_delay_s = 0.3
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call("+15555550001", message="deploy is ready")
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while not record.answered_at and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+    async def caller_replies():
+        await asyncio.sleep(0.1)
+        await manager.process_event(NormalizedEvent(
+            type=EventType.CALL_SPEECH, provider="mock",
+            provider_call_id=record.provider_call_id, text="yes ship it",
+        ))
+
+    asyncio.get_running_loop().create_task(caller_replies())
+    reply = await manager.continue_call(record.call_id, "shall I proceed?")
+    assert reply == "yes ship it"
+    assert record.mode == "conversation"          # upgraded
+    assert provider.listening == [record.provider_call_id]  # transcription on
+    await asyncio.sleep(0.5)
+    assert manager.get_call(record.call_id) is not None  # no auto-hangup
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_speak_on_notify_call_rearms_hangup(vc_config, provider, store):
+    """speak_to_user on a notify call holds the auto-hangup while the new
+    message plays, then re-arms it — hang up after the LAST message."""
+    vc_config.outbound.default_mode = "notify"
+    vc_config.outbound.notify_hangup_delay_s = 0.25
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call("+15555550001", message="first part")
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while not record.answered_at and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+    await asyncio.sleep(0.1)
+    await manager.speak(record.call_id, "and one more thing")
+    await asyncio.sleep(0.15)
+    # Original timer (would have fired at 0.25 after answer) was re-armed.
+    assert manager.get_call(record.call_id) is not None
+    await asyncio.sleep(0.25)
+    assert manager.get_call(record.call_id) is None  # then it hung up
+    assert record.end_reason == "notify-complete"
+    assert [t.text for t in record.transcript if t.speaker == "bot"] == [
+        "first part", "and one more thing",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_ring_timeout_marks_no_answer(store, make_config):
     cfg = make_config(timeouts=TimeoutsConfig(max_call_s=5, ring_s=0.05, silence_s=0,
                                               transcript_wait_s=0.5))

--- a/tests/plugins/platforms/voice_call/test_manager.py
+++ b/tests/plugins/platforms/voice_call/test_manager.py
@@ -1,0 +1,314 @@
+"""CallManager state machine, timers, and mock end-to-end flows."""
+
+import asyncio
+
+import pytest
+
+from plugins.platforms.voice_call.config import TimeoutsConfig
+from plugins.platforms.voice_call.events import (
+    CallState,
+    EventType,
+    NormalizedEvent,
+)
+from plugins.platforms.voice_call.manager import CallManager, CallNotFoundError
+from plugins.platforms.voice_call.providers.mock import MockProvider
+
+
+
+async def wait_for_state(manager, call_id, state, timeout=1.0):
+    """Poll until the call reaches ``state`` (events flow through tasks)."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        record = manager.get_call(call_id)
+        if record is not None and record.state == state:
+            return record
+        await asyncio.sleep(0.01)
+    record = manager.get_call(call_id)
+    raise AssertionError(
+        f"call {call_id} never reached {state}; now: "
+        f"{record.state if record else 'gone'}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_outbound_conversation_reaches_listening(manager, provider):
+    record = await manager.initiate_call("+15555550001", message="hello there")
+    assert record.provider_call_id.startswith("mock-")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+    # Initial message was spoken after answer.
+    assert provider.spoken == [(record.provider_call_id, "hello there")]
+    assert provider.listening == [record.provider_call_id]
+    assert [t.speaker for t in record.transcript] == ["bot"]
+
+
+@pytest.mark.asyncio
+async def test_outbound_notify_speaks_and_hangs_up(vc_config, provider, store):
+    vc_config.outbound.default_mode = "notify"
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call("+15555550001", message="your build is done")
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while manager.get_call(record.call_id) and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+    assert manager.get_call(record.call_id) is None  # finalized
+    assert provider.spoken == [(record.provider_call_id, "your build is done")]
+    assert provider.hangups == [record.provider_call_id]
+    assert record.state == CallState.HANGUP_BOT
+
+
+@pytest.mark.asyncio
+async def test_ring_timeout_marks_no_answer(store, make_config):
+    cfg = make_config(timeouts=TimeoutsConfig(max_call_s=5, ring_s=0.05, silence_s=0,
+                                              transcript_wait_s=0.5))
+    cfg.provider_extra = {"mock": {"auto_answer": False}}
+    provider = MockProvider(cfg)
+    manager = CallManager(cfg, provider, store)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call("+15555550001")
+    await asyncio.sleep(0.15)
+    assert record.state == CallState.NO_ANSWER
+    assert record.end_reason == "ring-timeout"
+    assert provider.hangups == [record.provider_call_id]
+
+
+@pytest.mark.asyncio
+async def test_initiate_failure_finalizes_failed(store, make_config):
+    cfg = make_config()
+    cfg.provider_extra = {"mock": {"fail_initiate": True}}
+    provider = MockProvider(cfg)
+    manager = CallManager(cfg, provider, store)
+    with pytest.raises(RuntimeError):
+        await manager.initiate_call("+15555550001")
+    assert manager.get_active_calls() == []
+
+
+@pytest.mark.asyncio
+async def test_initiate_validates_numbers(manager):
+    with pytest.raises(ValueError):
+        await manager.initiate_call("not-a-number")
+    manager.config.from_number = None
+    with pytest.raises(ValueError):
+        await manager.initiate_call("+15555550001")
+
+
+@pytest.mark.asyncio
+async def test_inbound_call_answers_greets_and_listens(manager, provider):
+    await manager.process_event(
+        NormalizedEvent(
+            type=EventType.CALL_INITIATED,
+            provider="mock",
+            provider_call_id="mock-in-1",
+            direction="inbound",
+            from_number="+15555550009",
+            to_number="+15555550000",
+        )
+    )
+    record = manager.call_for_chat("+15555550009")
+    assert record is not None
+    assert provider.answered == ["mock-in-1"]
+    await manager.process_event(
+        NormalizedEvent(type=EventType.CALL_ANSWERED, provider="mock",
+                        provider_call_id="mock-in-1")
+    )
+    assert record.state == CallState.LISTENING
+    # Greeting spoken
+    assert provider.spoken[0][1] == manager.config.inbound_greeting
+    assert record.session_key == "+15555550009"  # per-phone scope
+
+
+@pytest.mark.asyncio
+async def test_session_key_per_call_scope(vc_config, provider, store):
+    vc_config.session_scope = "per-call"
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call("+15555550001")
+    assert record.session_key == f"+15555550001:{record.call_id}"
+
+
+@pytest.mark.asyncio
+async def test_speech_resolves_continue_call_waiter(manager, provider):
+    record = await manager.initiate_call("+15555550001")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+
+    async def deliver_speech():
+        await asyncio.sleep(0.05)
+        await manager.process_event(
+            NormalizedEvent(
+                type=EventType.CALL_SPEECH,
+                provider="mock",
+                provider_call_id=record.provider_call_id,
+                text="yes please",
+            )
+        )
+
+    asyncio.get_running_loop().create_task(deliver_speech())
+    reply = await manager.continue_call(record.call_id, "shall I proceed?")
+    assert reply == "yes please"
+    speakers = [t.speaker for t in record.transcript]
+    assert speakers.count("user") == 1
+
+
+@pytest.mark.asyncio
+async def test_continue_call_times_out(manager):
+    record = await manager.initiate_call("+15555550001")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+    with pytest.raises(asyncio.TimeoutError):
+        await manager.continue_call(record.call_id, "anyone there?")
+
+
+@pytest.mark.asyncio
+async def test_transcript_callback_fires_without_waiter(vc_config, provider, store):
+    received = []
+
+    async def on_transcript(record, text):
+        received.append((record.call_id, text))
+
+    manager = CallManager(vc_config, provider, store, on_final_transcript=on_transcript)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call("+15555550001")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+    await manager.process_event(
+        NormalizedEvent(
+            type=EventType.CALL_SPEECH, provider="mock",
+            provider_call_id=record.provider_call_id, text="hello bot",
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert received == [(record.call_id, "hello bot")]
+    # Partial transcripts never dispatch.
+    await manager.process_event(
+        NormalizedEvent(
+            type=EventType.CALL_SPEECH, provider="mock",
+            provider_call_id=record.provider_call_id, text="par", is_final=False,
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert len(received) == 1
+
+
+@pytest.mark.asyncio
+async def test_user_hangup_finalizes_and_breaks_waiter(manager, provider):
+    record = await manager.initiate_call("+15555550001")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+
+    async def hang_up():
+        await asyncio.sleep(0.05)
+        await manager.process_event(
+            NormalizedEvent(
+                type=EventType.CALL_ENDED, provider="mock",
+                provider_call_id=record.provider_call_id, reason="hangup",
+            )
+        )
+
+    asyncio.get_running_loop().create_task(hang_up())
+    with pytest.raises(RuntimeError, match="call ended"):
+        await manager.continue_call(record.call_id, "still there?")
+    assert record.state == CallState.HANGUP_USER
+    assert manager.get_call(record.call_id) is None
+    assert manager.call_for_chat("+15555550001") is None
+
+
+@pytest.mark.asyncio
+async def test_event_dedupe(manager, provider):
+    record = await manager.initiate_call("+15555550001")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+    event = NormalizedEvent(
+        type=EventType.CALL_SPEECH, provider="mock",
+        provider_call_id=record.provider_call_id, text="once",
+        dedupe_key="evt-1",
+    )
+    await manager.process_event(event)
+    await manager.process_event(event)
+    user_lines = [t for t in record.transcript if t.speaker == "user"]
+    assert len(user_lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_orphan_outbound_event_replayed_after_initiate(manager, provider):
+    """A webhook racing initiate_call() is stashed and drained, not lost."""
+    provider.auto_answer = False
+    orig_initiate = provider.initiate_call
+
+    async def slow_initiate(call):
+        pid = await orig_initiate(call)
+        # Event arrives while initiate is still in flight (before mapping).
+        await manager.process_event(
+            NormalizedEvent(
+                type=EventType.CALL_ANSWERED, provider="mock", provider_call_id=pid,
+            )
+        )
+        return pid
+
+    provider.initiate_call = slow_initiate
+    record = await manager.initiate_call("+15555550001")
+    # Drained orphan advanced the call: answered → listening (conversation).
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+    assert record.answered_at is not None
+
+
+@pytest.mark.asyncio
+async def test_end_call_and_unknown_call_errors(manager, provider):
+    record = await manager.initiate_call("+15555550001")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+    await manager.end_call(record.call_id)
+    assert record.state == CallState.HANGUP_BOT
+    with pytest.raises(CallNotFoundError):
+        await manager.end_call(record.call_id)
+    with pytest.raises(CallNotFoundError):
+        await manager.speak("nope", "hi")
+
+
+@pytest.mark.asyncio
+async def test_dtmf_send_and_receive(manager, provider):
+    record = await manager.initiate_call("+15555550001")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+    await manager.send_dtmf(record.call_id, "123#")
+    assert provider.dtmf_sent == [(record.provider_call_id, "123#")]
+    await manager.process_event(
+        NormalizedEvent(
+            type=EventType.CALL_DTMF, provider="mock",
+            provider_call_id=record.provider_call_id, digits="9",
+        )
+    )
+    assert record.metadata["dtmf_sent"] == ["123#"]
+    assert record.metadata["dtmf_received"] == ["9"]
+
+
+@pytest.mark.asyncio
+async def test_max_duration_hangs_up(store, provider, make_config):
+    cfg = make_config(
+        timeouts=TimeoutsConfig(max_call_s=0.1, ring_s=5, silence_s=0,
+                                transcript_wait_s=0.5)
+    )
+    manager = CallManager(cfg, provider, store)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call("+15555550001")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+    await asyncio.sleep(0.2)
+    assert record.state == CallState.TIMEOUT
+    assert record.end_reason == "max-duration"
+
+
+@pytest.mark.asyncio
+async def test_silence_timeout_ends_conversation(store, provider, make_config):
+    cfg = make_config(
+        timeouts=TimeoutsConfig(max_call_s=5, ring_s=5, silence_s=0.1,
+                                transcript_wait_s=0.5)
+    )
+    manager = CallManager(cfg, provider, store)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call("+15555550001")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+    await asyncio.sleep(0.25)
+    assert record.state == CallState.TIMEOUT
+    assert record.end_reason == "silence-timeout"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_timers_and_waiters(manager):
+    record = await manager.initiate_call("+15555550001")
+    await wait_for_state(manager, record.call_id, CallState.LISTENING)
+    await manager.shutdown()
+    assert manager._timers == {}
+    # Call record is still active (it survives restarts via the store).
+    assert manager.get_call(record.call_id) is not None

--- a/tests/plugins/platforms/voice_call/test_manager.py
+++ b/tests/plugins/platforms/voice_call/test_manager.py
@@ -57,6 +57,35 @@ async def test_outbound_notify_speaks_and_hangs_up(vc_config, provider, store):
 
 
 @pytest.mark.asyncio
+async def test_might_continue_holds_line_longer_than_plain_notify(
+    vc_config, provider, store
+):
+    """--might-continue uses the longer notify_continue_window_s so a
+    follow-up continue_call has time to arrive; plain notify uses the short
+    delay and drops fast."""
+    vc_config.outbound.notify_hangup_delay_s = 0.2
+    vc_config.outbound.notify_continue_window_s = 1.0
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+
+    plain = await manager.initiate_call("+15555550001", message="hi", mode="notify")
+    holds = await manager.initiate_call(
+        "+15555550002", message="hi", mode="notify", might_continue=True
+    )
+    for r in (plain, holds):
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while not r.answered_at and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+
+    await asyncio.sleep(0.45)  # past the plain window, inside the hold window
+    assert manager.get_call(plain.call_id) is None      # plain hung up
+    assert manager.get_call(holds.call_id) is not None  # might_continue still up
+    await asyncio.sleep(0.8)
+    assert manager.get_call(holds.call_id) is None       # then it too hangs up
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_continue_call_upgrades_notify_to_conversation(
     vc_config, provider, store
 ):

--- a/tests/plugins/platforms/voice_call/test_provider_conformance.py
+++ b/tests/plugins/platforms/voice_call/test_provider_conformance.py
@@ -1,0 +1,108 @@
+"""Shared conformance suite: every provider honors the VoiceCallProvider ABC.
+
+Parametrized over all four providers — anything provider-shaped that the
+manager or webhook server relies on is asserted here once.
+"""
+
+import inspect
+
+import pytest
+
+from plugins.platforms.voice_call.config import VoiceCallConfig
+from plugins.platforms.voice_call.providers import PROVIDER_FACTORIES, create_provider
+from plugins.platforms.voice_call.providers.base import (
+    VoiceCallProvider,
+    WebhookContext,
+    WebhookParseResult,
+    WebhookVerificationResult,
+)
+
+CRED_ENV = {
+    "telnyx": {
+        "TELNYX_API_KEY": "k", "TELNYX_CONNECTION_ID": "c",
+        "TELNYX_PUBLIC_KEY": "cHVibGljLWtleS1ieXRlcy0zMi1sb25nLXBhZGRpbmc=",
+    },
+    "twilio": {"TWILIO_ACCOUNT_SID": "AC1", "TWILIO_AUTH_TOKEN": "t"},
+    "plivo": {"PLIVO_AUTH_ID": "MA1", "PLIVO_AUTH_TOKEN": "t"},
+    "mock": {},
+}
+
+PROVIDERS = sorted(PROVIDER_FACTORIES)
+
+
+@pytest.fixture
+def make_provider(monkeypatch):
+    def _make(name: str) -> VoiceCallProvider:
+        for var, value in CRED_ENV[name].items():
+            monkeypatch.setenv(var, value)
+        cfg = VoiceCallConfig.from_extra(
+            {"provider": name, "public_url": "https://hooks.example"}
+        )
+        provider = create_provider(cfg)
+        provider.set_public_url("https://hooks.example")
+        return provider
+
+    return _make
+
+
+@pytest.mark.parametrize("name", PROVIDERS)
+def test_provider_shape(name, make_provider):
+    provider = make_provider(name)
+    assert isinstance(provider, VoiceCallProvider)
+    assert provider.name == name
+    # Real carriers need a public webhook; the mock doesn't.
+    assert provider.requires_public_webhook == (name != "mock")
+    assert provider.webhook_url == "https://hooks.example/voice/webhook"
+    # Required async methods are coroutine functions.
+    for method in ("initiate_call", "answer_call", "hangup_call", "speak",
+                   "send_dtmf", "start_listening", "stop_listening",
+                   "get_call_status"):
+        assert inspect.iscoroutinefunction(getattr(provider, method)), method
+    # streaming_fields returns a dict (may be empty for non-streaming carriers).
+    assert isinstance(provider.streaming_fields("wss://x/y", "tok"), dict)
+
+
+@pytest.mark.parametrize("name", PROVIDERS)
+def test_verify_webhook_returns_result_not_exception(name, make_provider):
+    """Garbage requests produce a clean verification failure (mock: pass)."""
+    provider = make_provider(name)
+    ctx = WebhookContext(
+        method="POST", path="/voice/webhook", body=b"\xff\x00garbage",
+        headers={"X-Junk": "1"}, url="https://hooks.example/voice/webhook",
+    )
+    result = provider.verify_webhook(ctx)
+    assert isinstance(result, WebhookVerificationResult)
+    assert result.ok is (name == "mock")
+    if not result.ok:
+        assert result.error
+
+
+@pytest.mark.parametrize("name", PROVIDERS)
+def test_parse_webhook_tolerates_garbage(name, make_provider):
+    """Unparseable bodies return a WebhookParseResult, never raise."""
+    provider = make_provider(name)
+    ctx = WebhookContext(
+        method="POST", path="/voice/webhook", body=b"\xff\x00garbage",
+        url="https://hooks.example/voice/webhook",
+    )
+    result = provider.parse_webhook(ctx)
+    assert isinstance(result, WebhookParseResult)
+    assert result.events == [] or result.response_status >= 400
+
+
+@pytest.mark.parametrize("name", PROVIDERS)
+def test_parse_webhook_empty_body(name, make_provider):
+    provider = make_provider(name)
+    ctx = WebhookContext(
+        method="POST", path="/voice/webhook", body=b"",
+        url="https://hooks.example/voice/webhook",
+    )
+    result = provider.parse_webhook(ctx)
+    assert isinstance(result, WebhookParseResult)
+
+
+def test_factory_rejects_unknown_provider():
+    cfg = VoiceCallConfig.from_extra({"provider": "mock"})
+    cfg.provider = "smoke-signals"
+    with pytest.raises(ValueError, match="unknown voice_call provider"):
+        create_provider(cfg)

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -840,6 +840,41 @@ async def test_bridge_ulaw_passthrough_skips_transcoding(fake_runtime):
     assert b64.b64decode(media[0]["media"]["payload"]) == bytes([0x55]) * 160
 
 
+def test_per_call_instructions_merge_into_session_config(fake_runtime):
+    """initiate_call(instructions=...) rides the record into the realtime
+    session so the model conducts the whole call (no per-question
+    round-trips); calls without a brief use the base config unchanged."""
+    manager = RealtimeBridgeManager(fake_runtime)
+    fake_runtime.config.realtime.instructions = "Base persona."
+
+    record = _record()
+    record.metadata["realtime_instructions"] = (
+        "Ask: 1) does she love him? 2) dream destination? Then say the "
+        "Punjabi closing line."
+    )
+    cfg = manager._session_config_for(record)
+    assert cfg.instructions.startswith("Base persona.")
+    assert "specific brief" in cfg.instructions
+    assert "dream destination" in cfg.instructions
+    assert cfg.provider == fake_runtime.config.realtime.provider
+
+    plain = _record()
+    assert manager._session_config_for(plain) is fake_runtime.config.realtime
+
+
+@pytest.mark.asyncio
+async def test_initiate_call_carries_instructions(vc_config, provider, store):
+    from plugins.platforms.voice_call.manager import CallManager
+
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    record = await manager.initiate_call(
+        "+15555550001", mode="conversation", instructions="The script."
+    )
+    assert record.metadata["realtime_instructions"] == "The script."
+    await manager.shutdown()
+
+
 @pytest.mark.asyncio
 async def test_deliver_waits_for_session_ready(fake_runtime):
     """Text delivered right after a mid-call upgrade must wait for the model

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -1036,6 +1036,93 @@ async def test_speak_and_continue_route_through_bridge_on_realtime_calls(
 
 
 @pytest.mark.asyncio
+async def test_realtime_invariant_no_carrier_fallback_or_double_responder(
+    vc_config, provider, store
+):
+    """Once the realtime model owns a call's audio: a failed bridge delivery
+    must NOT fall back to carrier TTS (two voices), and a stray carrier
+    transcript must NOT dispatch a second responder."""
+    from plugins.platforms.voice_call.events import EventType, NormalizedEvent
+    from plugins.platforms.voice_call.manager import CallManager
+
+    dispatched = []
+
+    async def on_transcript(record, text):
+        dispatched.append(text)
+
+    manager = CallManager(vc_config, provider, store,
+                          on_final_transcript=on_transcript)
+    provider.event_sink = manager.process_event
+
+    async def failing_bridge_speaker(record, text):
+        return False  # bridge gone / not ready
+
+    manager.prepare_call = lambda record: record.metadata.update(realtime=True)
+    manager.realtime_speaker = failing_bridge_speaker
+
+    record = await manager.initiate_call("+15555550001")
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while not record.answered_at and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+    with pytest.raises(RuntimeError, match="not falling back"):
+        await manager.speak(record.call_id, "hello?")
+    assert provider.spoken == []  # carrier TTS never fired
+
+    # Stray carrier transcript on a realtime call → ignored, no dispatch.
+    await manager.process_event(NormalizedEvent(
+        type=EventType.CALL_SPEECH, provider="mock",
+        provider_call_id=record.provider_call_id, text="hello bot",
+    ))
+    await asyncio.sleep(0.05)
+    assert dispatched == []
+    assert all(t.speaker != "user" for t in record.transcript)
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_realtime_upgrade_stops_carrier_transcription(
+    vc_config, provider, store
+):
+    """A successful mid-call realtime upgrade turns carrier transcription
+    OFF so the bridge is the only transcript source."""
+    from plugins.platforms.voice_call.manager import CallManager
+
+    vc_config.outbound.default_mode = "notify"
+    vc_config.outbound.notify_hangup_delay_s = 5  # keep the call alive
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    # Simulate transcription having been started at some earlier point.
+    spoken_via_bridge = []
+
+    async def upgrade(record):
+        record.metadata["realtime"] = True
+        return True
+
+    async def bridge_speaker(record, text):
+        spoken_via_bridge.append(text)
+        return True
+
+    manager.upgrade_realtime = upgrade
+    manager.realtime_speaker = bridge_speaker
+    record = await manager.initiate_call("+15555550001", message="hi")
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while not record.answered_at and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+    provider.listening = [record.provider_call_id]  # pretend STT was on
+
+    async def caller_replies():
+        await asyncio.sleep(0.1)
+        manager.append_transcript(record.call_id, "user", "yes")
+
+    asyncio.get_running_loop().create_task(caller_replies())
+    reply = await manager.continue_call(record.call_id, "ok?")
+    assert reply == "yes"
+    assert provider.listening == []  # stop_listening ran after the upgrade
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_manager_skips_carrier_tts_for_realtime_calls(
     vc_config, provider, store
 ):

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -841,6 +841,30 @@ async def test_bridge_ulaw_passthrough_skips_transcoding(fake_runtime):
 
 
 @pytest.mark.asyncio
+async def test_deliver_waits_for_session_ready(fake_runtime):
+    """Text delivered right after a mid-call upgrade must wait for the model
+    session to connect — injecting earlier is a silent drop (the caller
+    heard nothing and the question vanished)."""
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    bridge = _bridge(fake_runtime, _record(), session)
+
+    delivered = asyncio.create_task(
+        bridge.deliver_agent_text("what did you have for breakfast?")
+    )
+    await asyncio.sleep(0.05)
+    assert not delivered.done()          # parked on ready, not dropped
+    assert session.injected_text == []
+
+    run = asyncio.create_task(bridge.run(ws))  # connects → ready
+    assert await asyncio.wait_for(delivered, 2) is True
+    assert session.injected_text == ["what did you have for breakfast?"]
+
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+
+@pytest.mark.asyncio
 async def test_midcall_upgrade_to_realtime(fake_runtime):
     """upgrade_to_realtime attaches a stream to a live call and waits for
     the carrier to connect; carriers without mid-call streaming refuse."""

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -552,6 +552,49 @@ async def test_newer_consult_supersedes_pending_one(fake_runtime):
 
 
 @pytest.mark.asyncio
+async def test_speak_for_chat_on_ringing_call_queues_or_fails_cleanly(
+    tmp_path, make_config
+):
+    """Agent replies landing on a not-yet-answered call must never hit the
+    carrier speak API (Telnyx 422 'not answered yet'): queue as the opening
+    message when there is none, fail cleanly when there is."""
+    cfg = make_config()
+    cfg.serve.port = 0
+    cfg.provider_extra = {"mock": {"auto_answer": False}}  # stays ringing
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    try:
+        # No message → the late agent reply becomes the opening line.
+        record = await runtime.manager.initiate_call("+15555550001")
+        ok, call_id = await runtime.speak_for_chat(
+            "+15555550001", "Your build finished successfully."
+        )
+        assert ok and call_id == record.call_id
+        assert record.metadata["initial_message"] == (
+            "Your build finished successfully."
+        )
+        assert runtime.provider.spoken == []  # nothing spoken pre-answer
+
+        # When answered, the queued line is what gets spoken.
+        from plugins.platforms.voice_call.events import EventType, NormalizedEvent
+
+        await runtime.manager.process_event(NormalizedEvent(
+            type=EventType.CALL_ANSWERED, provider="mock",
+            provider_call_id=record.provider_call_id,
+        ))
+        assert runtime.provider.spoken[0][1] == "Your build finished successfully."
+
+        # A ringing call that ALREADY has an opening message → clean failure.
+        record2 = await runtime.manager.initiate_call(
+            "+15555550002", message="already queued"
+        )
+        ok, error = await runtime.speak_for_chat("+15555550002", "late reply")
+        assert not ok and "still ringing" in error
+        assert record2.metadata["initial_message"] == "already queued"
+    finally:
+        await runtime_mod.stop_runtime()
+
+
+@pytest.mark.asyncio
 async def test_speak_for_chat_routes_to_bridge_for_realtime_calls(
     tmp_path, make_config
 ):
@@ -563,6 +606,9 @@ async def test_speak_for_chat_routes_to_bridge_for_realtime_calls(
     runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
     try:
         record = await runtime.manager.initiate_call("+15555550001")
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while not record.answered_at and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
         delivered = []
 
         class FakeBridge:

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -391,6 +391,81 @@ async def test_consult_routes_through_gateway_agent(fake_runtime):
 
 
 @pytest.mark.asyncio
+async def test_interim_sends_do_not_resolve_consults_and_are_not_spoken(
+    fake_runtime,
+):
+    """Tool-progress chrome and other unmarked sends must neither resolve a
+    pending consult (the 0.3s-garbage-answer bug) nor be read aloud."""
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    bridge = _bridge(fake_runtime, _record(), session)
+
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    fut = asyncio.get_running_loop().create_future()
+    bridge._consult_future = fut
+
+    assert await bridge.deliver_agent_text("🔍 web_search: weather…", final=False)
+    assert not fut.done()                  # consult still waiting
+    assert session.injected_text == []     # nothing spoken
+
+    assert await bridge.deliver_agent_text("It is sunny, 24 degrees.", final=True)
+    assert fut.result() == "It is sunny, 24 degrees."
+
+    # With no consult pending, final text is spoken; interim still dropped.
+    assert await bridge.deliver_agent_text("Reminder: standup at 10.", final=True)
+    assert session.injected_text == ["Reminder: standup at 10."]
+    assert await bridge.deliver_agent_text("⚙️ exec: ls", final=False)
+    assert session.injected_text == ["Reminder: standup at 10."]
+
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+
+@pytest.mark.asyncio
+async def test_newer_consult_supersedes_pending_one(fake_runtime):
+    """A second question while a consult is in flight resolves the first
+    future benignly instead of leaving its tool result hanging."""
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    record = _record()
+    bridge = _bridge(fake_runtime, record, session)
+    dispatched = []
+
+    class FakeAdapter:
+        def build_source(self, **kwargs):
+            return kwargs
+
+        async def handle_message(self, event):
+            dispatched.append(event.text)
+            # Only the SECOND turn completes (the first was interrupted).
+            if len(dispatched) == 2:
+                asyncio.get_running_loop().create_task(
+                    bridge.deliver_agent_text("Dublin is 14 and raining.")
+                )
+
+    fake_runtime.adapter = FakeAdapter()
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    session.push(RealtimeEvent(
+        type="tool_call", tool_call_id="c-oman", tool_name="agent_consult",
+        tool_args={"question": "weather in Oman?"},
+    ))
+    await asyncio.sleep(0.05)
+    session.push(RealtimeEvent(
+        type="tool_call", tool_call_id="c-dublin", tool_name="agent_consult",
+        tool_args={"question": "weather in Dublin?"},
+    ))
+    await asyncio.sleep(0.15)
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+    results = dict(session.tool_results)
+    assert "Superseded" in results["c-oman"]
+    assert results["c-dublin"] == "Dublin is 14 and raining."
+
+
+@pytest.mark.asyncio
 async def test_speak_for_chat_routes_to_bridge_for_realtime_calls(
     tmp_path, make_config
 ):
@@ -405,14 +480,19 @@ async def test_speak_for_chat_routes_to_bridge_for_realtime_calls(
         delivered = []
 
         class FakeBridge:
-            async def deliver_agent_text(self, text):
-                delivered.append(text)
+            async def deliver_agent_text(self, text, final=True):
+                delivered.append((text, final))
                 return True
 
         runtime.bridge_manager.active_bridges[record.call_id] = FakeBridge()
-        ok, call_id = await runtime.speak_for_chat("+15555550001", "agent says hi")
+        # Final responses carry the gateway's notify flag; interim sends don't.
+        ok, call_id = await runtime.speak_for_chat(
+            "+15555550001", "agent says hi", metadata={"notify": True}
+        )
         assert ok and call_id == record.call_id
-        assert delivered == ["agent says hi"]
+        ok, _ = await runtime.speak_for_chat("+15555550001", "🔍 web_search: …")
+        assert ok
+        assert delivered == [("agent says hi", True), ("🔍 web_search: …", False)]
         # Carrier TTS was bypassed entirely.
         assert runtime.provider.spoken == []
     finally:

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -709,7 +709,7 @@ def test_openai_session_update_uses_ga_shape(monkeypatch):
     for beta_key in ("modalities", "voice", "input_audio_format",
                      "output_audio_format", "input_audio_transcription"):
         assert beta_key not in s, beta_key
-    assert s["tools"][0]["name"] == "agent_consult"
+    assert [t["name"] for t in s["tools"]] == ["agent_consult", "end_call"]
 
 
 def test_waiting_etiquette_appended_to_instructions(monkeypatch):
@@ -792,6 +792,42 @@ async def test_bridge_ulaw_passthrough_skips_transcoding(fake_runtime):
 
     media = [m for m in ws.sent if m.get("event") == "media"]
     assert b64.b64decode(media[0]["media"]["payload"]) == bytes([0x55]) * 160
+
+
+@pytest.mark.asyncio
+async def test_model_end_call_tool_hangs_up(fake_runtime, vc_config, provider, store):
+    """The realtime model can end the call: goodbye drains, then the carrier
+    hangup goes through manager.end_call (provider-agnostic)."""
+    from plugins.platforms.voice_call.events import CallState
+    from plugins.platforms.voice_call.manager import CallManager
+
+    manager = CallManager(vc_config, provider, store)
+    record = _record()
+    record.metadata["realtime"] = True
+    manager.active[record.call_id] = record
+    manager._by_provider_id[record.provider_call_id] = record.call_id
+    fake_runtime.manager = manager
+
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    bridge = _bridge(fake_runtime, record, session)
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    session.push(RealtimeEvent(
+        type="tool_call", tool_call_id="c-end", tool_name="end_call",
+        tool_args={"reason": "caller said goodbye"},
+    ))
+    deadline = asyncio.get_running_loop().time() + 3.0
+    while (manager.get_call(record.call_id) is not None
+           and asyncio.get_running_loop().time() < deadline):
+        await asyncio.sleep(0.05)
+
+    assert manager.get_call(record.call_id) is None       # finalized
+    assert record.state == CallState.HANGUP_BOT
+    assert provider.hangups == [record.provider_call_id]  # carrier hangup issued
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+    await manager.shutdown()
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -135,6 +135,7 @@ class _FakeRuntime:
         self.public_url = "https://hooks.example"
         self.provider = None
         self.manager = manager
+        self.adapter = None  # consults fall back to the plugin LLM path
 
 
 @pytest.fixture
@@ -347,6 +348,75 @@ async def test_bridge_consult_tool_roundtrip(fake_runtime, monkeypatch):
     ]
     # The caller heard a filler while the consult ran.
     assert fake_runtime.config.responder.thinking_phrase in session.injected_text
+
+
+@pytest.mark.asyncio
+async def test_consult_routes_through_gateway_agent(fake_runtime):
+    """With a gateway adapter attached, consults become normal gateway
+    messages (full agent with tools); the reply comes back through
+    deliver_agent_text as the tool result — the openclaw-equivalent path."""
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    record = _record()
+    bridge = _bridge(fake_runtime, record, session)
+    seen_events = []
+
+    class FakeAdapter:
+        def build_source(self, **kwargs):
+            return kwargs
+
+        async def handle_message(self, event):
+            seen_events.append(event)
+            # Simulate gateway agent turn → adapter.send → speak_for_chat
+            # → bridge.deliver_agent_text with the tool-using answer.
+            asyncio.get_running_loop().create_task(
+                bridge.deliver_agent_text("It is 14 degrees and raining in Dublin.")
+            )
+
+    fake_runtime.adapter = FakeAdapter()
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    session.push(RealtimeEvent(
+        type="tool_call", tool_call_id="call-w", tool_name="agent_consult",
+        tool_args={"question": "what's the weather in Dublin?"},
+    ))
+    await asyncio.sleep(0.15)
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+    assert seen_events and seen_events[0].text == "what's the weather in Dublin?"
+    assert session.tool_results == [
+        ("call-w", "It is 14 degrees and raining in Dublin.")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_speak_for_chat_routes_to_bridge_for_realtime_calls(
+    tmp_path, make_config
+):
+    """Agent replies to a realtime-bridged call go to the bridge (consult
+    result or model speech), never carrier TTS over the media stream."""
+    cfg = make_config()
+    cfg.serve.port = 0
+    cfg.realtime.enabled = True
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    try:
+        record = await runtime.manager.initiate_call("+15555550001")
+        delivered = []
+
+        class FakeBridge:
+            async def deliver_agent_text(self, text):
+                delivered.append(text)
+                return True
+
+        runtime.bridge_manager.active_bridges[record.call_id] = FakeBridge()
+        ok, call_id = await runtime.speak_for_chat("+15555550001", "agent says hi")
+        assert ok and call_id == record.call_id
+        assert delivered == ["agent says hi"]
+        # Carrier TTS was bypassed entirely.
+        assert runtime.provider.spoken == []
+    finally:
+        await runtime_mod.stop_runtime()
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -795,6 +795,47 @@ async def test_bridge_ulaw_passthrough_skips_transcoding(fake_runtime):
 
 
 @pytest.mark.asyncio
+async def test_speak_and_continue_route_through_bridge_on_realtime_calls(
+    vc_config, provider, store
+):
+    """speak_to_user / continue_call on a realtime call must go through the
+    bridge (carrier TTS would talk over the stream), and the reply waiter
+    resolves from bridge transcripts (carrier transcription is off)."""
+    from plugins.platforms.voice_call.manager import CallManager
+
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    spoken_via_bridge = []
+
+    async def bridge_speaker(record, text):
+        spoken_via_bridge.append(text)
+        return True
+
+    manager.prepare_call = lambda record: record.metadata.update(realtime=True)
+    manager.realtime_speaker = bridge_speaker
+
+    record = await manager.initiate_call("+15555550001")
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while not record.answered_at and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+    await manager.speak(record.call_id, "an update")
+    assert spoken_via_bridge == ["an update"]
+    assert provider.spoken == []  # no carrier TTS
+
+    async def caller_replies():
+        await asyncio.sleep(0.05)
+        # The bridge mirrors realtime user transcripts via append_transcript.
+        manager.append_transcript(record.call_id, "user", "yes go ahead")
+
+    asyncio.get_running_loop().create_task(caller_replies())
+    reply = await manager.continue_call(record.call_id, "shall I deploy?")
+    assert reply == "yes go ahead"
+    assert spoken_via_bridge == ["an update", "shall I deploy?"]
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_manager_skips_carrier_tts_for_realtime_calls(
     vc_config, provider, store
 ):

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -384,7 +384,9 @@ async def test_consult_routes_through_gateway_agent(fake_runtime):
     session.push(RealtimeEvent(type="closed"))
     await asyncio.wait_for(run, 2)
 
-    assert seen_events and seen_events[0].text == "what's the weather in Dublin?"
+    assert seen_events
+    assert seen_events[0].text.endswith("what's the weather in Dublin?")
+    assert seen_events[0].text.startswith("[Voice consult")  # speed contract
     assert session.tool_results == [
         ("call-w", "It is 14 degrees and raining in Dublin.")
     ]
@@ -494,7 +496,8 @@ async def test_empty_args_consult_joins_in_flight_one(fake_runtime):
         tool_args={},  # the flail
     ))
     await asyncio.sleep(0.05)
-    assert dispatched == ["weather in Dublin?"]  # no second gateway turn
+    assert len(dispatched) == 1  # no second gateway turn
+    assert dispatched[0].endswith("weather in Dublin?")
     # The real answer lands; both tool calls get it.
     await bridge.deliver_agent_text("Fourteen degrees and raining.")
     await asyncio.sleep(0.05)

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -391,7 +391,35 @@ async def test_stream_upgrade_rejects_bad_and_reused_tokens(tmp_path, make_confi
 
 def test_openai_session_update_uses_ga_shape(monkeypatch):
     """Accounts on the GA realtime API reject the 2024 beta shape with
-    beta_api_shape_disabled — the session.update must be GA-shaped."""
+    beta_api_shape_disabled — the session.update must be GA-shaped, and we
+    declare audio/pcmu so the model speaks the phone line's codec."""
+    from plugins.platforms.voice_call.config import RealtimeConfig
+    from plugins.platforms.voice_call.realtime.openai_realtime import (
+        OpenAIRealtimeSession,
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    session = OpenAIRealtimeSession(
+        RealtimeConfig(enabled=True, provider="openai", model="gpt-realtime-2")
+    )
+    assert session.audio_wire_format == "ulaw"
+    update = session._session_update()
+    s = update["session"]
+    assert s["type"] == "realtime" and s["model"] == "gpt-realtime-2"
+    assert s["output_modalities"] == ["audio"]
+    assert s["audio"]["input"]["format"] == {"type": "audio/pcmu"}
+    assert s["audio"]["output"]["format"] == {"type": "audio/pcmu"}
+    assert s["audio"]["output"]["voice"] == "marin"
+    # Beta-era keys must be absent.
+    for beta_key in ("modalities", "voice", "input_audio_format",
+                     "output_audio_format", "input_audio_transcription"):
+        assert beta_key not in s, beta_key
+    assert s["tools"][0]["name"] == "agent_consult"
+
+
+def test_openai_tool_calls_from_response_done_with_dedupe(monkeypatch):
+    """GA delivers function calls inside response.done output items; the
+    standalone arguments.done event may also fire — surface each call once."""
     from plugins.platforms.voice_call.config import RealtimeConfig
     from plugins.platforms.voice_call.realtime.openai_realtime import (
         OpenAIRealtimeSession,
@@ -399,17 +427,57 @@ def test_openai_session_update_uses_ga_shape(monkeypatch):
 
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     session = OpenAIRealtimeSession(RealtimeConfig(enabled=True, provider="openai"))
-    update = session._session_update()
-    s = update["session"]
-    assert s["type"] == "realtime" and s["model"] == "gpt-realtime"
-    assert s["output_modalities"] == ["audio"]
-    assert s["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
-    assert s["audio"]["output"]["voice"] == "marin"
-    # Beta-era keys must be absent.
-    for beta_key in ("modalities", "voice", "input_audio_format",
-                     "output_audio_format", "input_audio_transcription"):
-        assert beta_key not in s, beta_key
-    assert s["tools"][0]["name"] == "agent_consult"
+
+    events = session._translate({
+        "type": "response.function_call_arguments.done",
+        "call_id": "call_1", "name": "agent_consult",
+        "arguments": '{"question": "q1"}',
+    })
+    assert [e.type for e in events] == ["tool_call"]
+    assert events[0].tool_args == {"question": "q1"}
+
+    # Same call inside response.done → deduped; a new one surfaces.
+    events = session._translate({
+        "type": "response.done",
+        "response": {"output": [
+            {"type": "function_call", "call_id": "call_1",
+             "name": "agent_consult", "arguments": '{"question": "q1"}'},
+            {"type": "function_call", "call_id": "call_2",
+             "name": "agent_consult", "arguments": '{"question": "q2"}'},
+            {"type": "message", "content": []},
+        ]},
+    })
+    assert [e.type for e in events] == ["tool_call", "response_done"]
+    assert events[0].tool_call_id == "call_2"
+
+
+@pytest.mark.asyncio
+async def test_bridge_ulaw_passthrough_skips_transcoding(fake_runtime):
+    """With a ulaw-native session, carrier frames pass through unmodified."""
+    ulaw = bytes(range(160)) + bytes([0x7F]) * 0  # arbitrary µ-law payload
+    ws = FakeCarrierWs([
+        json.dumps({"event": "start", "stream_id": "s1",
+                    "start": {"call_control_id": "v3:rt"}}),
+        _media_frame(ulaw),
+    ])
+    session = FakeSession()
+    session.audio_wire_format = "ulaw"
+    bridge = _bridge(fake_runtime, _record(), session)
+
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.wait_for(ws._consumed.wait(), 2)
+    await asyncio.sleep(0.02)
+    # Inbound: exact bytes, no decode/resample.
+    assert session.received_audio == [ulaw]
+    # Outbound: model µ-law goes straight to the pacer → carrier frames.
+    session.push(RealtimeEvent(type="audio", audio=bytes([0x55]) * 160))
+    await asyncio.sleep(0.1)
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+    import base64 as b64
+
+    media = [m for m in ws.sent if m.get("event") == "media"]
+    assert b64.b64decode(media[0]["media"]["payload"]) == bytes([0x55]) * 160
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -712,6 +712,25 @@ def test_openai_session_update_uses_ga_shape(monkeypatch):
     assert s["tools"][0]["name"] == "agent_consult"
 
 
+def test_waiting_etiquette_appended_to_instructions(monkeypatch):
+    """Custom instructions still get the wait-etiquette suffix — without it
+    the model improvises negatively ('I don't have the result yet')."""
+    from plugins.platforms.voice_call.config import RealtimeConfig
+    from plugins.platforms.voice_call.realtime.base import WAITING_ETIQUETTE
+    from plugins.platforms.voice_call.realtime.openai_realtime import (
+        OpenAIRealtimeSession,
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    session = OpenAIRealtimeSession(
+        RealtimeConfig(enabled=True, provider="openai",
+                       instructions="You are a custom voice bot.")
+    )
+    assert session.instructions.startswith("You are a custom voice bot.")
+    assert session.instructions.endswith(WAITING_ETIQUETTE)
+    assert "Still checking" in session.instructions
+
+
 def test_openai_tool_calls_from_response_done_with_dedupe(monkeypatch):
     """GA delivers function calls inside response.done output items; the
     standalone arguments.done event may also fire — surface each call once."""

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -423,6 +423,89 @@ async def test_interim_sends_do_not_resolve_consults_and_are_not_spoken(
 
 
 @pytest.mark.asyncio
+async def test_consult_filler_plays_after_function_call_response_ends(
+    fake_runtime, monkeypatch
+):
+    """At tool_call time the function-call response is still active, so the
+    filler must play on the following response_done (this was silently
+    skipped before — callers sat in silence during consults)."""
+    import time as time_mod
+
+    class SlowLlm:
+        def complete(self, messages, **kwargs):
+            time_mod.sleep(0.2)  # consult outlives the response_done below
+
+            class R:
+                text = "slow answer"
+            return R()
+
+    monkeypatch.setattr(bridge_mod, "_plugin_llm_factory", lambda: SlowLlm())
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    session.response_active = True  # mid function-call response
+    bridge = _bridge(fake_runtime, _record(), session)
+
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    session.push(RealtimeEvent(
+        type="tool_call", tool_call_id="c-slow", tool_name="agent_consult",
+        tool_args={"question": "anything slow"},
+    ))
+    await asyncio.sleep(0.05)
+    assert session.injected_text == []  # response still active → no filler yet
+    session.response_active = False
+    session.push(RealtimeEvent(type="response_done"))
+    await asyncio.sleep(0.05)
+    assert session.injected_text == [fake_runtime.config.responder.thinking_phrase]
+    await asyncio.sleep(0.3)
+    assert ("c-slow", "slow answer") in session.tool_results
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+
+@pytest.mark.asyncio
+async def test_empty_args_consult_joins_in_flight_one(fake_runtime):
+    """A flailing empty-args agent_consult must share the running consult's
+    answer instead of superseding it (which used to interrupt the gateway
+    turn mid-research)."""
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    record = _record()
+    bridge = _bridge(fake_runtime, record, session)
+    dispatched = []
+
+    class FakeAdapter:
+        def build_source(self, **kwargs):
+            return kwargs
+
+        async def handle_message(self, event):
+            dispatched.append(event.text)
+
+    fake_runtime.adapter = FakeAdapter()
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    session.push(RealtimeEvent(
+        type="tool_call", tool_call_id="c-1", tool_name="agent_consult",
+        tool_args={"question": "weather in Dublin?"},
+    ))
+    await asyncio.sleep(0.05)
+    session.push(RealtimeEvent(
+        type="tool_call", tool_call_id="c-2", tool_name="agent_consult",
+        tool_args={},  # the flail
+    ))
+    await asyncio.sleep(0.05)
+    assert dispatched == ["weather in Dublin?"]  # no second gateway turn
+    # The real answer lands; both tool calls get it.
+    await bridge.deliver_agent_text("Fourteen degrees and raining.")
+    await asyncio.sleep(0.05)
+    results = dict(session.tool_results)
+    assert results["c-1"] == "Fourteen degrees and raining."
+    assert results["c-2"] == "Fourteen degrees and raining."
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+
+@pytest.mark.asyncio
 async def test_newer_consult_supersedes_pending_one(fake_runtime):
     """A second question while a consult is in flight resolves the first
     future benignly instead of leaving its tool result hanging."""

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -795,6 +795,100 @@ async def test_bridge_ulaw_passthrough_skips_transcoding(fake_runtime):
 
 
 @pytest.mark.asyncio
+async def test_midcall_upgrade_to_realtime(fake_runtime):
+    """upgrade_to_realtime attaches a stream to a live call and waits for
+    the carrier to connect; carriers without mid-call streaming refuse."""
+
+    class StreamingProvider:
+        supports_midcall_streaming = True
+
+        def __init__(self):
+            self.started = []
+
+        async def start_media_stream(self, record, stream_url, token):
+            self.started.append((record.call_id, stream_url, token))
+
+    provider = StreamingProvider()
+    fake_runtime.provider = provider
+    manager = RealtimeBridgeManager(fake_runtime)
+    record = _record()
+
+    async def carrier_connects():
+        await asyncio.sleep(0.05)
+        manager.active_bridges[record.call_id] = object()  # bridge appeared
+
+    asyncio.get_running_loop().create_task(carrier_connects())
+    assert await manager.upgrade_to_realtime(record, timeout=2.0) is True
+    assert record.metadata["realtime"] is True
+    call_id, stream_url, token = provider.started[0]
+    assert call_id == record.call_id
+    assert stream_url.endswith(token)
+    # Token maps back to the call for the WS upgrade.
+    assert manager._tokens == {} or token not in manager._tokens or True
+
+    # Carrier never connects → clean fallback.
+    manager.active_bridges.clear()
+    record2 = _record()
+    record2.call_id = "vc-rt-2"
+    assert await manager.upgrade_to_realtime(record2, timeout=0.3) is False
+    assert "realtime" not in record2.metadata
+
+    # Provider without mid-call streaming → immediate refusal.
+    class PlainProvider:
+        supports_midcall_streaming = False
+
+    fake_runtime.provider = PlainProvider()
+    record3 = _record()
+    record3.call_id = "vc-rt-3"
+    assert await manager.upgrade_to_realtime(record3) is False
+
+
+@pytest.mark.asyncio
+async def test_notify_continue_upgrades_all_the_way_to_realtime(
+    vc_config, provider, store
+):
+    """A notify-born call continue()d with realtime available goes to the
+    realtime voice: no carrier transcription, question via the bridge,
+    reply via the bridge transcript."""
+    from plugins.platforms.voice_call.manager import CallManager
+
+    vc_config.outbound.default_mode = "notify"
+    vc_config.outbound.notify_hangup_delay_s = 5
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    spoken_via_bridge = []
+
+    async def upgrade(record):
+        record.metadata["realtime"] = True  # stream attached
+        return True
+
+    async def bridge_speaker(record, text):
+        spoken_via_bridge.append(text)
+        return True
+
+    manager.upgrade_realtime = upgrade
+    manager.realtime_speaker = bridge_speaker
+
+    record = await manager.initiate_call("+15555550001", message="notify part")
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while not record.answered_at and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+    async def caller_replies():
+        await asyncio.sleep(0.1)
+        manager.append_transcript(record.call_id, "user", "sounds great")
+
+    asyncio.get_running_loop().create_task(caller_replies())
+    reply = await manager.continue_call(record.call_id, "how does that sound?")
+    assert reply == "sounds great"
+    assert record.mode == "conversation"
+    assert record.metadata["realtime"] is True
+    assert spoken_via_bridge == ["how does that sound?"]   # model spoke it
+    assert provider.listening == []                        # no carrier STT
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_model_end_call_tool_hangs_up(fake_runtime, vc_config, provider, store):
     """The realtime model can end the call: goodbye drains, then the carrier
     hangup goes through manager.end_call (provider-agnostic)."""

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -1,0 +1,413 @@
+"""Realtime bridge: tokens, pacer cadence, barge-in, consult dispatch.
+
+Uses a scripted fake carrier WebSocket and a scripted fake realtime
+session — no network, no realtime API keys.
+"""
+
+import asyncio
+import json
+from array import array
+
+import pytest
+
+pytest.importorskip("aiohttp")
+from aiohttp import WSMsgType
+
+from plugins.platforms.voice_call import audio
+from plugins.platforms.voice_call import runtime as runtime_mod
+from plugins.platforms.voice_call.events import CallRecord
+from plugins.platforms.voice_call.realtime import bridge as bridge_mod
+from plugins.platforms.voice_call.realtime.base import (
+    RealtimeEvent,
+    RealtimeVoiceSession,
+)
+from plugins.platforms.voice_call.realtime.bridge import (
+    AudioPacer,
+    RealtimeBridgeManager,
+    RealtimeCallBridge,
+)
+from plugins.platforms.voice_call.realtime.frames import TelnyxStreamFrameAdapter
+
+
+class FakeWsMessage:
+    def __init__(self, data):
+        self.type = WSMsgType.TEXT
+        self.data = data
+
+
+class FakeCarrierWs:
+    """Iterates scripted carrier frames; collects what the bridge sends."""
+
+    def __init__(self, messages):
+        self._messages = list(messages)
+        self.sent = []
+        self.closed = False
+        self._consumed = asyncio.Event()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._messages:
+            return FakeWsMessage(self._messages.pop(0))
+        self._consumed.set()
+        # Keep the connection "open" until the bridge tears down.
+        await asyncio.sleep(3600)
+        raise StopAsyncIteration
+
+    async def send_str(self, data):
+        self.sent.append(json.loads(data))
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeSession(RealtimeVoiceSession):
+    name = "fake"
+    input_sample_rate = 24000
+    output_sample_rate = 24000
+
+    def __init__(self, scripted_events=None):
+        self.received_audio = []
+        self.injected_text = []
+        self.tool_results = []
+        self.cancelled = 0
+        self.closed = False
+        self._events = asyncio.Queue()
+        for event in scripted_events or []:
+            self._events.put_nowait(event)
+
+    async def connect(self):
+        pass
+
+    async def send_audio(self, pcm16):
+        self.received_audio.append(pcm16)
+
+    async def events(self):
+        while True:
+            event = await self._events.get()
+            yield event
+            if event.type == "closed":
+                return
+
+    def push(self, event):
+        self._events.put_nowait(event)
+
+    async def send_tool_result(self, tool_call_id, result):
+        self.tool_results.append((tool_call_id, result))
+
+    async def inject_text(self, text):
+        self.injected_text.append(text)
+
+    async def cancel_response(self):
+        self.cancelled += 1
+
+    async def close(self):
+        self.closed = True
+
+
+def _record(direction="outbound", **metadata):
+    record = CallRecord(
+        call_id="vc-rt", provider="telnyx", direction=direction,
+        from_number="+15555550000", to_number="+15555550001",
+        provider_call_id="v3:rt", mode="conversation",
+    )
+    record.metadata.update(metadata)
+    return record
+
+
+def _media_frame(payload: bytes) -> str:
+    import base64
+
+    return json.dumps({
+        "event": "media", "stream_id": "s1",
+        "media": {"payload": base64.b64encode(payload).decode(),
+                  "track": "inbound_track"},
+    })
+
+
+class _FakeRuntime:
+    """Just enough of VoiceCallRuntime for the bridge."""
+
+    def __init__(self, make_config, manager=None):
+        self.config = make_config()
+        self.config.realtime.enabled = True
+        self.public_url = "https://hooks.example"
+        self.provider = None
+        self.manager = manager
+
+
+@pytest.fixture
+def fake_runtime(make_config):
+    return _FakeRuntime(make_config)
+
+
+def _bridge(runtime, record, session):
+    return RealtimeCallBridge(
+        runtime=runtime, record=record,
+        frame_adapter=TelnyxStreamFrameAdapter(), session=session,
+    )
+
+
+# -- token lifecycle -----------------------------------------------------------
+
+
+def test_tokens_are_one_shot_and_expire(fake_runtime, monkeypatch):
+    manager = RealtimeBridgeManager(fake_runtime)
+    token = manager.mint_token("vc-1")
+    assert manager.consume_token(token) == "vc-1"
+    assert manager.consume_token(token) is None  # one-shot
+    assert manager.consume_token("never-minted") is None
+
+    stale = manager.mint_token("vc-2")
+    manager._tokens[stale] = ("vc-2", 0.0)  # minted long ago
+    assert manager.consume_token(stale) is None
+
+
+def test_prepare_call_attaches_stream_metadata(fake_runtime):
+    manager = RealtimeBridgeManager(fake_runtime)
+    record = _record()
+    manager.prepare_call(record)
+    assert record.metadata["realtime"] is True
+    url = record.metadata["stream_url"]
+    token = record.metadata["stream_auth_token"]
+    assert url.startswith("wss://hooks.example/voice/stream/")
+    assert url.endswith(token)
+    assert manager.consume_token(token) == record.call_id
+
+    notify = _record()
+    notify.mode = "notify"
+    manager.prepare_call(notify)
+    assert "stream_url" not in notify.metadata  # notify keeps carrier TTS
+
+
+# -- pacer ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pacer_cadence_and_clear():
+    sent_at = []
+    loop = asyncio.get_running_loop()
+
+    async def send(frame):
+        sent_at.append(loop.time())
+
+    pacer = AudioPacer(send)
+    task = loop.create_task(pacer.run())
+    pacer.push(audio.silence_frame() * 5)  # 5 frames = 100 ms of audio
+    await asyncio.sleep(0.15)
+    pacer.stop()
+    task.cancel()
+
+    assert len(sent_at) == 5
+    gaps = [b - a for a, b in zip(sent_at, sent_at[1:])]
+    assert all(0.01 < gap < 0.05 for gap in gaps), gaps
+
+    pacer.push(audio.silence_frame() * 10)
+    assert pacer.clear() == 10 and pacer.pending == 0
+
+
+# -- bridge dataflow ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bridge_pumps_carrier_audio_into_session(fake_runtime):
+    ulaw = bytes([0x55]) * 160
+    ws = FakeCarrierWs([
+        json.dumps({"event": "start", "stream_id": "s1",
+                    "start": {"call_control_id": "v3:rt"}}),
+        _media_frame(ulaw),
+    ])
+    session = FakeSession()
+    bridge = _bridge(fake_runtime, _record(), session)
+
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.wait_for(ws._consumed.wait(), 2)
+    await asyncio.sleep(0.05)
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+    assert len(session.received_audio) == 1
+    pcm = session.received_audio[0]
+    # 160 µ-law samples @8k → ~480 samples @24k → 960 bytes.
+    assert abs(len(pcm) - 960) <= 8
+    assert session.closed
+
+
+@pytest.mark.asyncio
+async def test_bridge_sends_model_audio_as_paced_media_frames(fake_runtime):
+    ws = FakeCarrierWs([])
+    # 40 ms of model audio @24k → 2 carrier frames @8k.
+    pcm = array("h", [1000] * (24000 // 25)).tobytes()
+    session = FakeSession()
+    bridge = _bridge(fake_runtime, _record(), session)
+
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    session.push(RealtimeEvent(type="audio", audio=pcm))
+    await asyncio.sleep(0.15)
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+    media = [m for m in ws.sent if m.get("event") == "media"]
+    assert len(media) == 2
+    assert all("payload" in m["media"] for m in media)
+
+
+@pytest.mark.asyncio
+async def test_bridge_barge_in_clears_carrier_queue(fake_runtime):
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    record = _record()
+    bridge = _bridge(fake_runtime, record, session)
+    bridge._greeting_until = 0.0
+
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    # Queue a lot of audio, then the caller starts talking.
+    session.push(RealtimeEvent(
+        type="audio", audio=array("h", [500] * 24000).tobytes()))
+    await asyncio.sleep(0.03)
+    session.push(RealtimeEvent(type="speech_started"))
+    await asyncio.sleep(0.05)
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+    assert any(m.get("event") == "clear" for m in ws.sent)
+    assert session.cancelled == 1
+
+
+@pytest.mark.asyncio
+async def test_bridge_greeting_window_suppresses_barge_in(fake_runtime):
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    record = _record(direction="inbound")
+    bridge = _bridge(fake_runtime, record, session)
+
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    assert session.injected_text == [fake_runtime.config.inbound_greeting]
+    session.push(RealtimeEvent(type="speech_started"))  # within greeting window
+    await asyncio.sleep(0.05)
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+    assert not any(m.get("event") == "clear" for m in ws.sent)
+    assert session.cancelled == 0
+
+
+@pytest.mark.asyncio
+async def test_bridge_consult_tool_roundtrip(fake_runtime, monkeypatch):
+    class FakeLlm:
+        def complete(self, messages, **kwargs):
+            class R:
+                text = "Your next meeting is at three PM."
+            assert messages[-1]["content"] == "what's on the calendar?"
+            return R()
+
+    monkeypatch.setattr(bridge_mod, "_plugin_llm_factory", lambda: FakeLlm())
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    bridge = _bridge(fake_runtime, _record(), session)
+
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    session.push(RealtimeEvent(
+        type="tool_call", tool_call_id="call-1", tool_name="agent_consult",
+        tool_args={"question": "what's on the calendar?"},
+    ))
+    await asyncio.sleep(0.1)
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+    assert session.tool_results == [
+        ("call-1", "Your next meeting is at three PM.")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bridge_transcripts_mirror_into_call_record(
+    fake_runtime, vc_config, provider, store
+):
+    from plugins.platforms.voice_call.manager import CallManager
+
+    manager = CallManager(vc_config, provider, store)
+    record = _record()
+    manager.active[record.call_id] = record
+    fake_runtime.manager = manager
+
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    bridge = _bridge(fake_runtime, record, session)
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    session.push(RealtimeEvent(type="transcript", role="user", text="hello"))
+    session.push(RealtimeEvent(type="transcript", role="assistant", text="hi there"))
+    await asyncio.sleep(0.05)
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+    assert [(t.speaker, t.text) for t in record.transcript] == [
+        ("user", "hello"), ("bot", "hi there"),
+    ]
+    await manager.shutdown()
+
+
+# -- stream upgrade endpoint --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_upgrade_rejects_bad_and_reused_tokens(tmp_path, make_config):
+    import aiohttp
+
+    cfg = make_config()
+    cfg.serve.port = 0
+    cfg.realtime.enabled = True
+    cfg.realtime.provider = "openai"
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    try:
+        assert runtime.bridge_manager is not None
+        port = runtime.webhook_server.bound_port
+        async with aiohttp.ClientSession() as client:
+            async with client.get(
+                f"http://127.0.0.1:{port}/voice/stream/not-a-token"
+            ) as resp:
+                assert resp.status == 403
+
+            # Minted token for a call that doesn't exist → 404, and the
+            # token is consumed (second use → 403).
+            token = runtime.bridge_manager.mint_token("vc-ghost")
+            async with client.get(
+                f"http://127.0.0.1:{port}/voice/stream/{token}"
+            ) as resp:
+                assert resp.status == 404
+            async with client.get(
+                f"http://127.0.0.1:{port}/voice/stream/{token}"
+            ) as resp:
+                assert resp.status == 403
+    finally:
+        await runtime_mod.stop_runtime()
+
+
+@pytest.mark.asyncio
+async def test_manager_skips_carrier_tts_for_realtime_calls(
+    vc_config, provider, store
+):
+    """A realtime call's greeting comes from the model, not carrier TTS."""
+    from plugins.platforms.voice_call.events import EventType, NormalizedEvent
+    from plugins.platforms.voice_call.manager import CallManager
+
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    manager.prepare_call = lambda record: record.metadata.update(realtime=True)
+
+    record = await manager.initiate_call("+15555550001", message="hi")
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while not record.answered_at and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.02)
+    assert provider.spoken == []        # no carrier TTS
+    assert provider.listening == []     # no carrier transcription
+    # The initial message stays in metadata for the bridge to inject.
+    assert record.metadata["initial_message"] == "hi"
+    await manager.shutdown()

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -389,6 +389,29 @@ async def test_stream_upgrade_rejects_bad_and_reused_tokens(tmp_path, make_confi
         await runtime_mod.stop_runtime()
 
 
+def test_openai_session_update_uses_ga_shape(monkeypatch):
+    """Accounts on the GA realtime API reject the 2024 beta shape with
+    beta_api_shape_disabled — the session.update must be GA-shaped."""
+    from plugins.platforms.voice_call.config import RealtimeConfig
+    from plugins.platforms.voice_call.realtime.openai_realtime import (
+        OpenAIRealtimeSession,
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    session = OpenAIRealtimeSession(RealtimeConfig(enabled=True, provider="openai"))
+    update = session._session_update()
+    s = update["session"]
+    assert s["type"] == "realtime" and s["model"] == "gpt-realtime"
+    assert s["output_modalities"] == ["audio"]
+    assert s["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
+    assert s["audio"]["output"]["voice"] == "marin"
+    # Beta-era keys must be absent.
+    for beta_key in ("modalities", "voice", "input_audio_format",
+                     "output_audio_format", "input_audio_transcription"):
+        assert beta_key not in s, beta_key
+    assert s["tools"][0]["name"] == "agent_consult"
+
+
 @pytest.mark.asyncio
 async def test_manager_skips_carrier_tts_for_realtime_calls(
     vc_config, provider, store

--- a/tests/plugins/platforms/voice_call/test_realtime_bridge.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_bridge.py
@@ -258,6 +258,7 @@ async def test_bridge_sends_model_audio_as_paced_media_frames(fake_runtime):
 async def test_bridge_barge_in_clears_carrier_queue(fake_runtime):
     ws = FakeCarrierWs([])
     session = FakeSession()
+    session.response_active = True  # the bot is mid-utterance
     record = _record()
     bridge = _bridge(fake_runtime, record, session)
     bridge._greeting_until = 0.0
@@ -275,6 +276,27 @@ async def test_bridge_barge_in_clears_carrier_queue(fake_runtime):
 
     assert any(m.get("event") == "clear" for m in ws.sent)
     assert session.cancelled == 1
+
+
+@pytest.mark.asyncio
+async def test_bridge_ignores_caller_speech_when_bot_is_silent(fake_runtime):
+    """Caller speaking while the bot is idle is a normal turn — clearing or
+    cancelling here used to dump already-generated answers from the pacer
+    and spam 'no active response found' errors."""
+    ws = FakeCarrierWs([])
+    session = FakeSession()  # response_active stays False, pacer empty
+    bridge = _bridge(fake_runtime, _record(), session)
+    bridge._greeting_until = 0.0
+
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    session.push(RealtimeEvent(type="speech_started"))
+    await asyncio.sleep(0.05)
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
+
+    assert not any(m.get("event") == "clear" for m in ws.sent)
+    assert session.cancelled == 0
 
 
 @pytest.mark.asyncio
@@ -323,6 +345,43 @@ async def test_bridge_consult_tool_roundtrip(fake_runtime, monkeypatch):
     assert session.tool_results == [
         ("call-1", "Your next meeting is at three PM.")
     ]
+    # The caller heard a filler while the consult ran.
+    assert fake_runtime.config.responder.thinking_phrase in session.injected_text
+
+
+@pytest.mark.asyncio
+async def test_tool_result_deferred_while_response_active(fake_runtime, monkeypatch):
+    """A consult result arriving mid-filler waits for response_done —
+    response.create during an active response is rejected by the API."""
+
+    class FakeLlm:
+        def complete(self, messages, **kwargs):
+            class R:
+                text = "deferred answer"
+            return R()
+
+    monkeypatch.setattr(bridge_mod, "_plugin_llm_factory", lambda: FakeLlm())
+    ws = FakeCarrierWs([])
+    session = FakeSession()
+    session.response_active = True  # filler/utterance still playing
+    bridge = _bridge(fake_runtime, _record(), session)
+
+    run = asyncio.create_task(bridge.run(ws))
+    await asyncio.sleep(0.02)
+    session.push(RealtimeEvent(
+        type="tool_call", tool_call_id="call-9", tool_name="agent_consult",
+        tool_args={"question": "anything"},
+    ))
+    await asyncio.sleep(0.1)
+    assert session.tool_results == []  # held back
+
+    session.response_active = False
+    session.push(RealtimeEvent(type="response_done"))
+    await asyncio.sleep(0.05)
+    assert session.tool_results == [("call-9", "deferred answer")]
+
+    session.push(RealtimeEvent(type="closed"))
+    await asyncio.wait_for(run, 2)
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/voice_call/test_realtime_frames.py
+++ b/tests/plugins/platforms/voice_call/test_realtime_frames.py
@@ -1,0 +1,119 @@
+"""Carrier stream frame adapter goldens (ported from openclaw's
+stream-frame-adapter.test.ts vectors)."""
+
+import base64
+import json
+
+import pytest
+
+from plugins.platforms.voice_call.realtime.frames import (
+    TelnyxStreamFrameAdapter,
+    TwilioStreamFrameAdapter,
+    adapter_for_provider,
+)
+
+
+def test_adapter_factory():
+    assert adapter_for_provider("telnyx").name == "telnyx"
+    assert adapter_for_provider("twilio").name == "twilio"
+    with pytest.raises(ValueError):
+        adapter_for_provider("plivo")
+
+
+# -- Telnyx -------------------------------------------------------------------
+
+
+def test_telnyx_parses_start_frame():
+    adapter = TelnyxStreamFrameAdapter()
+    frame = adapter.parse(json.dumps({
+        "event": "start",
+        "sequence_number": "1",
+        "stream_id": "telnyx-stream-7",
+        "start": {
+            "call_control_id": "v3:carrier-call-id",
+            "call_session_id": "session-1",
+            "media_format": {"encoding": "PCMU", "sample_rate": 8000, "channels": 1},
+        },
+    }))
+    assert frame.type == "start"
+    assert frame.stream_id == "telnyx-stream-7"
+    assert frame.provider_call_id == "v3:carrier-call-id"
+
+
+def test_telnyx_parses_media_mark_stop():
+    adapter = TelnyxStreamFrameAdapter()
+    frame = adapter.parse(json.dumps({
+        "event": "media",
+        "stream_id": "telnyx-stream-7",
+        "media": {"payload": "AAA=", "timestamp": 40, "track": "inbound_track"},
+    }))
+    assert frame.type == "media"
+    assert frame.payload == base64.b64decode("AAA=")
+    assert frame.track == "inbound_track"
+
+    assert adapter.parse(json.dumps(
+        {"event": "mark", "mark": {"name": "m1"}})).mark_name == "m1"
+    assert adapter.parse(json.dumps({"event": "stop"})).type == "stop"
+
+
+def test_telnyx_surfaces_error_frames():
+    adapter = TelnyxStreamFrameAdapter()
+    frame = adapter.parse(json.dumps({
+        "event": "error",
+        "stream_id": "s",
+        "payload": {"code": 100002, "title": "malformed_frame",
+                    "detail": "bad payload"},
+    }))
+    assert frame.type == "error"
+    assert "malformed_frame" in frame.error and "100002" in frame.error
+
+
+def test_telnyx_serializes_outbound_frames():
+    adapter = TelnyxStreamFrameAdapter()
+    media = json.loads(adapter.serialize_media(b"payload-bytes"))
+    assert media == {
+        "event": "media",
+        "media": {"payload": base64.b64encode(b"payload-bytes").decode()},
+    }
+    assert json.loads(adapter.serialize_clear()) == {"event": "clear"}
+    assert json.loads(adapter.serialize_mark("m")) == {
+        "event": "mark", "mark": {"name": "m"},
+    }
+
+
+def test_telnyx_tolerates_garbage():
+    adapter = TelnyxStreamFrameAdapter()
+    assert adapter.parse("not json").type == "unknown"
+    assert adapter.parse('"a string"').type == "unknown"
+    assert adapter.parse(json.dumps({"event": "media", "media": {"payload": "!!"}})
+                         ).payload == b""
+
+
+# -- Twilio --------------------------------------------------------------------
+
+
+def test_twilio_start_captures_stream_sid_for_outbound_envelope():
+    adapter = TwilioStreamFrameAdapter()
+    frame = adapter.parse(json.dumps({
+        "event": "start",
+        "streamSid": "MZ123",
+        "start": {"callSid": "CA1", "mediaFormat": {"encoding": "audio/x-mulaw"}},
+    }))
+    assert frame.type == "start"
+    assert frame.stream_id == "MZ123"
+    assert frame.provider_call_id == "CA1"
+    # Outbound frames now carry the captured streamSid.
+    media = json.loads(adapter.serialize_media(b"x"))
+    assert media["streamSid"] == "MZ123"
+    assert json.loads(adapter.serialize_clear())["streamSid"] == "MZ123"
+
+
+def test_twilio_parses_media_and_connected():
+    adapter = TwilioStreamFrameAdapter()
+    assert adapter.parse(json.dumps({"event": "connected"})).type == "connected"
+    frame = adapter.parse(json.dumps({
+        "event": "media", "streamSid": "MZ1",
+        "media": {"payload": base64.b64encode(b"\x01\x02").decode(),
+                  "track": "inbound"},
+    }))
+    assert frame.type == "media" and frame.payload == b"\x01\x02"

--- a/tests/plugins/platforms/voice_call/test_registration.py
+++ b/tests/plugins/platforms/voice_call/test_registration.py
@@ -1,0 +1,169 @@
+"""Registration and adapter-shape tests for the voice_call platform plugin.
+
+The generic contract is also covered by
+``tests/gateway/test_plugin_platform_interface.py`` (which auto-discovers
+this plugin); these tests pin voice_call-specific registration details.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.platforms import voice_call as voice_call_plugin
+from plugins.platforms.voice_call import events
+from plugins.platforms.voice_call.events import CallState, is_valid_transition
+
+
+@pytest.fixture
+def clean_registry():
+    from gateway.platform_registry import platform_registry
+
+    original = dict(platform_registry._entries)
+    platform_registry._entries.clear()
+    yield platform_registry
+    platform_registry._entries.clear()
+    platform_registry._entries.update(original)
+
+
+class _Ctx:
+    """Mock PluginContext implementing only register_platform."""
+
+    def __init__(self):
+        self.entries = {}
+
+    def register_platform(self, *, name, label, adapter_factory, check_fn, **kwargs):
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        entry = PlatformEntry(
+            name=name, label=label,
+            adapter_factory=adapter_factory, check_fn=check_fn,
+            **kwargs,
+        )
+        platform_registry.register(entry)
+        self.entries[name] = entry
+
+
+def _mock_platform_config(extra=None):
+    cfg = MagicMock()
+    cfg.extra = extra or {}
+    cfg.enabled = True
+    cfg.token = None
+    cfg.api_key = None
+    cfg.home_channel = None
+    cfg.reply_to_mode = "first"
+    return cfg
+
+
+def test_registers_voice_call_entry(clean_registry):
+    ctx = _Ctx()
+    voice_call_plugin.register(ctx)
+    entry = ctx.entries["voice_call"]
+    assert entry.label == "Voice Calls"
+    assert entry.pii_safe is True
+    assert entry.emoji == "📞"
+    assert entry.max_message_length == 1000
+    assert "phone call" in entry.platform_hint
+    assert entry.allowed_users_env == "VOICE_CALL_ALLOWED_NUMBERS"
+    assert entry.cron_deliver_env_var == "VOICE_CALL_HOME_NUMBER"
+
+
+def test_adapter_constructs_from_magicmock_config(clean_registry):
+    """__init__ must be side-effect-free and tolerate synthetic configs."""
+    ctx = _Ctx()
+    voice_call_plugin.register(ctx)
+    adapter = ctx.entries["voice_call"].adapter_factory(_mock_platform_config())
+    assert adapter.platform.value == "voice_call"
+    assert adapter.enforces_own_access_policy is True
+    assert adapter.is_connected is False
+
+
+def test_validate_config_returns_bool_not_errors(clean_registry):
+    ctx = _Ctx()
+    voice_call_plugin.register(ctx)
+    entry = ctx.entries["voice_call"]
+    # Unconfigured (default telnyx, no creds) → not valid, but a clean bool.
+    assert entry.validate_config(_mock_platform_config()) is False
+    # Mock provider needs no credentials.
+    assert entry.validate_config(_mock_platform_config({"provider": "mock"})) is True
+
+
+def test_env_enablement_requires_explicit_opt_in(clean_registry, monkeypatch):
+    """Credential presence alone must not auto-enable a port-binding platform."""
+    from plugins.platforms.voice_call.adapter import _env_enablement
+
+    monkeypatch.delenv("VOICE_CALL_ENABLED", raising=False)
+    monkeypatch.setenv("TELNYX_API_KEY", "k")
+    assert _env_enablement() is None
+
+    monkeypatch.setenv("VOICE_CALL_ENABLED", "true")
+    monkeypatch.setenv("VOICE_CALL_PROVIDER", "mock")
+    monkeypatch.setenv("VOICE_CALL_HOME_NUMBER", "+15555550001")
+    seed = _env_enablement()
+    assert seed is not None
+    assert seed["provider"] == "mock"
+    assert seed["home_channel"]["chat_id"] == "+15555550001"
+
+
+@pytest.mark.asyncio
+async def test_connect_fails_cleanly_on_invalid_config(clean_registry):
+    """Invalid config → connect() returns False with a non-retryable error."""
+    ctx = _Ctx()
+    voice_call_plugin.register(ctx)
+    adapter = ctx.entries["voice_call"].adapter_factory(
+        _mock_platform_config({"provider": "doesnotexist"})
+    )
+    assert await adapter.connect() is False
+    assert adapter.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_send_without_runtime_fails_cleanly(clean_registry):
+    ctx = _Ctx()
+    voice_call_plugin.register(ctx)
+    adapter = ctx.entries["voice_call"].adapter_factory(
+        _mock_platform_config({"provider": "mock"})
+    )
+    result = await adapter.send("+15555550001", "hello")
+    assert result.success is False
+    assert "runtime" in (result.error or "")
+
+
+# -- events.py shape ---------------------------------------------------------
+
+
+def test_state_transitions():
+    assert is_valid_transition(CallState.INITIATED, CallState.RINGING)
+    assert is_valid_transition(CallState.RINGING, CallState.ANSWERED)
+    assert is_valid_transition(CallState.ANSWERED, CallState.ACTIVE)
+    assert is_valid_transition(CallState.SPEAKING, CallState.LISTENING)
+    assert is_valid_transition(CallState.LISTENING, CallState.SPEAKING)
+    assert is_valid_transition(CallState.ACTIVE, CallState.COMPLETED)
+    assert is_valid_transition(CallState.INITIATED, CallState.NO_ANSWER)
+    # No backwards moves, no leaving terminal states, no self-loops.
+    assert not is_valid_transition(CallState.ACTIVE, CallState.RINGING)
+    assert not is_valid_transition(CallState.COMPLETED, CallState.ACTIVE)
+    assert not is_valid_transition(CallState.COMPLETED, CallState.FAILED)
+    assert not is_valid_transition(CallState.ACTIVE, CallState.ACTIVE)
+
+
+def test_call_record_roundtrip():
+    record = events.CallRecord(
+        call_id=events.new_call_id(),
+        provider="mock",
+        direction="outbound",
+        to_number="+15555550001",
+        from_number="+15555550000",
+        mode="notify",
+    )
+    record.transcript.append(
+        events.TranscriptEntry(timestamp=1.0, speaker="bot", text="hi")
+    )
+    restored = events.CallRecord.from_dict(record.to_dict())
+    assert restored == record
+
+
+def test_call_record_from_dict_tolerates_garbage():
+    restored = events.CallRecord.from_dict({"state": "made-up", "transcript": ["junk"]})
+    assert restored.state == CallState.ERROR
+    assert restored.transcript == []
+    assert restored.call_id  # generated

--- a/tests/plugins/platforms/voice_call/test_store_runtime.py
+++ b/tests/plugins/platforms/voice_call/test_store_runtime.py
@@ -1,0 +1,198 @@
+"""CallStore persistence/restore and runtime singleton lifecycle."""
+
+import asyncio
+import json
+
+import pytest
+
+from plugins.platforms.voice_call import runtime as runtime_mod
+from plugins.platforms.voice_call.events import CallRecord, CallState, new_call_id
+from plugins.platforms.voice_call.manager import CallManager
+from plugins.platforms.voice_call.providers.mock import MockProvider
+from plugins.platforms.voice_call.store import CallStore
+
+
+
+def _record(state=CallState.ACTIVE, **kwargs) -> CallRecord:
+    record = CallRecord(
+        call_id=kwargs.pop("call_id", new_call_id()),
+        provider="mock",
+        direction=kwargs.pop("direction", "outbound"),
+        from_number="+15555550000",
+        to_number="+15555550001",
+        **kwargs,
+    )
+    record.state = state
+    return record
+
+
+# -- store ---------------------------------------------------------------
+
+
+def test_store_appends_and_replays_latest(store):
+    record = _record(state=CallState.INITIATED)
+    store.append(record)
+    record.state = CallState.ACTIVE
+    store.append(record)
+    other = _record(state=CallState.COMPLETED)
+    store.append(other)
+
+    latest = store.load_latest()
+    assert latest[record.call_id].state == CallState.ACTIVE
+    assert latest[other.call_id].state == CallState.COMPLETED
+
+    active = store.load_active()
+    assert record.call_id in active
+    assert other.call_id not in active
+
+
+def test_store_skips_corrupt_lines(store):
+    record = _record()
+    store.append(record)
+    with open(store.calls_path, "a", encoding="utf-8") as f:
+        f.write("{not json}\n")
+        f.write('"a string, not an object"\n')
+    latest = store.load_latest()
+    assert list(latest) == [record.call_id]
+
+
+def test_store_history_newest_first(store):
+    first = _record(state=CallState.COMPLETED)
+    first.started_at = 100.0
+    second = _record(state=CallState.COMPLETED)
+    second.started_at = 200.0
+    store.append(first)
+    store.append(second)
+    history = store.history(limit=1)
+    assert [r.call_id for r in history] == [second.call_id]
+
+
+def test_store_compaction(tmp_path, monkeypatch):
+    import plugins.platforms.voice_call.store as store_mod
+
+    monkeypatch.setattr(store_mod, "_COMPACT_THRESHOLD", 5)
+    store = CallStore(base_dir=tmp_path)
+    record = _record()
+    for _ in range(10):
+        store.append(record)
+    store.load_latest()  # triggers compaction
+    with open(store.calls_path, encoding="utf-8") as f:
+        lines = [line for line in f if line.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["call_id"] == record.call_id
+
+
+# -- manager restore -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restore_keeps_live_call_and_drops_terminal(store, provider, make_config):
+    cfg = make_config()
+    live = _record(state=CallState.ACTIVE)
+    done = _record(state=CallState.ACTIVE, call_id=new_call_id())
+    live.provider_call_id = "mock-live"
+    done.provider_call_id = "mock-done"
+    store.append(live)
+    store.append(done)
+    provider._terminal.add("mock-done")  # carrier says this one ended
+
+    manager = CallManager(cfg, provider, store)
+    await manager.initialize()
+    assert manager.get_call(live.call_id) is not None
+    assert manager.get_call(done.call_id) is None
+    # The terminal one was finalized and persisted as completed.
+    assert store.load_latest()[done.call_id].state == CallState.COMPLETED
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_restore_hangs_up_expired_calls(store, provider, make_config):
+    cfg = make_config()
+    cfg.timeouts.max_call_s = 10
+    stale = _record(state=CallState.ACTIVE)
+    stale.provider_call_id = "mock-stale"
+    stale.started_at = 1.0  # eons ago
+    store.append(stale)
+
+    manager = CallManager(cfg, provider, store)
+    await manager.initialize()
+    assert manager.get_call(stale.call_id) is None
+    assert provider.hangups == ["mock-stale"]
+    assert store.load_latest()[stale.call_id].state == CallState.TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_restore_keeps_call_on_unknown_status(store, make_config):
+    cfg = make_config()
+
+    class FlakyProvider(MockProvider):
+        async def get_call_status(self, call):
+            raise ConnectionError("carrier 502")
+
+    provider = FlakyProvider(cfg)
+    live = _record(state=CallState.ACTIVE)
+    live.provider_call_id = "mock-flaky"
+    store.append(live)
+
+    manager = CallManager(cfg, provider, store)
+    await manager.initialize()
+    # Unknown status → keep the call, rely on the max-duration timer.
+    assert manager.get_call(live.call_id) is not None
+    assert (live.call_id, "max") in manager._timers
+    await manager.shutdown()
+
+
+# -- runtime singleton -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_runtime_is_singleton_and_concurrency_safe(tmp_path, make_config):
+    cfg = make_config()
+    results = await asyncio.gather(
+        *[runtime_mod.ensure_runtime(cfg, store_dir=tmp_path) for _ in range(5)]
+    )
+    assert all(r is results[0] for r in results)
+    assert runtime_mod.get_runtime() is results[0]
+    await runtime_mod.stop_runtime()
+    assert runtime_mod.get_runtime() is None
+
+
+@pytest.mark.asyncio
+async def test_stop_runtime_idempotent(tmp_path, make_config):
+    cfg = make_config()
+    await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    await runtime_mod.stop_runtime()
+    await runtime_mod.stop_runtime()  # second stop is a no-op
+    assert runtime_mod.get_runtime() is None
+
+
+@pytest.mark.asyncio
+async def test_failed_start_leaves_no_singleton(tmp_path, make_config):
+    cfg = make_config()
+    cfg.provider = "definitely-not-a-provider"
+    with pytest.raises(ValueError):
+        await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    assert runtime_mod.get_runtime() is None
+    # And a subsequent good start works.
+    cfg.provider = "mock"
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    assert runtime is not None
+    await runtime_mod.stop_runtime()
+
+
+@pytest.mark.asyncio
+async def test_runtime_speak_for_chat_mock_e2e(tmp_path, make_config):
+    cfg = make_config()
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    record = await runtime.manager.initiate_call("+15555550001", message="hi")
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while record.state != record.state.LISTENING and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+    ok, call_id = await runtime.speak_for_chat("+15555550001", "an update for you")
+    assert ok and call_id == record.call_id
+    assert runtime.provider.spoken[-1] == (record.provider_call_id, "an update for you")
+
+    ok, error = await runtime.speak_for_chat("+19999999999", "nobody home")
+    assert not ok and "no active voice call" in error
+    await runtime_mod.stop_runtime()

--- a/tests/plugins/platforms/voice_call/test_telnyx_provider.py
+++ b/tests/plugins/platforms/voice_call/test_telnyx_provider.py
@@ -309,6 +309,23 @@ async def test_action_request_shapes(provider, api_calls):
 
 
 @pytest.mark.asyncio
+async def test_midcall_streaming_start_shape(provider, api_calls):
+    """Telnyx can attach a media stream to a LIVE call (streaming_start) —
+    the basis for notify → realtime upgrades."""
+    assert provider.supports_midcall_streaming is True
+    record = _call_record()
+    await provider.start_media_stream(
+        record, "wss://hooks.example/voice/stream/tok2", "tok2"
+    )
+    request = api_calls[0]
+    assert request["url"].endswith("/calls/v3:abc/actions/streaming_start")
+    body = request["json_body"]
+    assert body["stream_url"] == "wss://hooks.example/voice/stream/tok2"
+    assert body["stream_bidirectional_mode"] == "rtp"
+    assert body["stream_auth_token"] == "tok2"
+
+
+@pytest.mark.asyncio
 async def test_get_call_status_mapping(provider, monkeypatch):
     import plugins.platforms.voice_call.providers.telnyx as telnyx_mod
 

--- a/tests/plugins/platforms/voice_call/test_telnyx_provider.py
+++ b/tests/plugins/platforms/voice_call/test_telnyx_provider.py
@@ -1,0 +1,386 @@
+"""Telnyx provider: credentials, Ed25519 verification, event parsing,
+request shapes, host guard, and ngrok log parsing."""
+
+import base64
+import json
+import time
+
+import pytest
+
+cryptography = pytest.importorskip("cryptography")
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from plugins.platforms.voice_call.config import VoiceCallConfig
+from plugins.platforms.voice_call.events import CallRecord, EventType
+from plugins.platforms.voice_call.providers import _http
+from plugins.platforms.voice_call.providers.base import WebhookContext
+from plugins.platforms.voice_call.providers.telnyx import (
+    TelnyxProvider,
+    build_streaming_fields,
+)
+from plugins.platforms.voice_call.tunnel import parse_ngrok_log_line, start_tunnel
+
+
+@pytest.fixture
+def keypair():
+    private = Ed25519PrivateKey.generate()
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+    )
+
+    public_b64 = base64.b64encode(
+        private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    ).decode()
+    return private, public_b64
+
+
+@pytest.fixture
+def provider(keypair, monkeypatch):
+    _, public_b64 = keypair
+    monkeypatch.setenv("TELNYX_API_KEY", "test-key")
+    monkeypatch.setenv("TELNYX_CONNECTION_ID", "conn-1")
+    monkeypatch.setenv("TELNYX_PUBLIC_KEY", public_b64)
+    cfg = VoiceCallConfig.from_extra(
+        {"provider": "telnyx", "public_url": "https://hooks.example"}
+    )
+    p = TelnyxProvider(cfg)
+    p.set_public_url("https://hooks.example")
+    return p
+
+
+def _signed_ctx(private, body: dict, timestamp: int | None = None) -> WebhookContext:
+    raw = json.dumps(body).encode()
+    ts = str(timestamp if timestamp is not None else int(time.time()))
+    signature = private.sign(ts.encode() + b"|" + raw)
+    return WebhookContext(
+        method="POST",
+        path="/voice/webhook",
+        body=raw,
+        headers={
+            "telnyx-signature-ed25519": base64.b64encode(signature).decode(),
+            "telnyx-timestamp": ts,
+        },
+    )
+
+
+def _telnyx_event(event_type, **payload):
+    return {"data": {"id": "evt-1", "event_type": event_type, "payload": payload}}
+
+
+# -- credentials ---------------------------------------------------------------
+
+
+def test_requires_api_key_and_connection_id(monkeypatch):
+    for var in ("TELNYX_API_KEY", "TELNYX_CONNECTION_ID", "TELNYX_PUBLIC_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(ValueError, match="API key"):
+        TelnyxProvider(VoiceCallConfig.from_extra({"provider": "telnyx"}))
+    monkeypatch.setenv("TELNYX_API_KEY", "k")
+    with pytest.raises(ValueError, match="connection ID"):
+        TelnyxProvider(VoiceCallConfig.from_extra({"provider": "telnyx"}))
+
+
+# -- Ed25519 verification ---------------------------------------------------------
+
+
+def test_verify_valid_signature(provider, keypair):
+    private, _ = keypair
+    ctx = _signed_ctx(private, _telnyx_event("call.answered"))
+    result = provider.verify_webhook(ctx)
+    assert result.ok is True
+    assert result.dedupe_key.startswith("telnyx:")
+
+
+def test_verify_invalid_signature(provider, keypair):
+    private, _ = keypair
+    ctx = _signed_ctx(private, _telnyx_event("call.answered"))
+    ctx.body = b'{"tampered": true}'
+    result = provider.verify_webhook(ctx)
+    assert result.ok is False and "invalid signature" in result.error
+
+
+def test_verify_wrong_key(provider):
+    other = Ed25519PrivateKey.generate()
+    ctx = _signed_ctx(other, _telnyx_event("call.answered"))
+    assert provider.verify_webhook(ctx).ok is False
+
+
+def test_verify_missing_headers(provider):
+    ctx = WebhookContext(method="POST", path="/voice/webhook", body=b"{}", headers={})
+    result = provider.verify_webhook(ctx)
+    assert result.ok is False and "missing signature" in result.error
+
+
+def test_verify_stale_timestamp(provider, keypair):
+    private, _ = keypair
+    ctx = _signed_ctx(
+        private, _telnyx_event("call.answered"), timestamp=int(time.time()) - 3600
+    )
+    result = provider.verify_webhook(ctx)
+    assert result.ok is False and "too old" in result.error
+
+
+def test_verify_garbage_signature(provider):
+    ctx = WebhookContext(
+        method="POST", path="/voice/webhook", body=b"{}",
+        headers={
+            "telnyx-signature-ed25519": "!!!not-base64!!!",
+            "telnyx-timestamp": str(int(time.time())),
+        },
+    )
+    assert provider.verify_webhook(ctx).ok is False
+
+
+# -- event parsing ---------------------------------------------------------------
+
+
+def _parse_single(provider, body):
+    ctx = WebhookContext(
+        method="POST", path="/voice/webhook", body=json.dumps(body).encode()
+    )
+    result = provider.parse_webhook(ctx)
+    assert result.response_status == 200
+    return result.events
+
+
+def test_parse_call_initiated_inbound(provider):
+    events = _parse_single(
+        provider,
+        _telnyx_event(
+            "call.initiated",
+            call_control_id="v3:abc", direction="incoming",
+            **{"from": "+15555550009", "to": "+15555550000"},
+        ),
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event.type == EventType.CALL_INITIATED
+    assert event.direction == "inbound"
+    assert event.provider_call_id == "v3:abc"
+    assert event.from_number == "+15555550009"
+    assert event.dedupe_key == "evt-1"
+
+
+def test_parse_client_state_roundtrips_call_id(provider):
+    call_id = "vc-roundtrip"
+    events = _parse_single(
+        provider,
+        _telnyx_event(
+            "call.answered",
+            call_control_id="v3:abc",
+            client_state=base64.b64encode(call_id.encode()).decode(),
+        ),
+    )
+    assert events[0].call_id == call_id
+
+
+def test_parse_transcription_event(provider):
+    events = _parse_single(
+        provider,
+        _telnyx_event(
+            "call.transcription",
+            call_control_id="v3:abc",
+            transcription_data={"transcript": "hello world", "is_final": True},
+        ),
+    )
+    event = events[0]
+    assert event.type == EventType.CALL_SPEECH
+    assert event.text == "hello world" and event.is_final is True
+
+
+def test_parse_hangup_cause_mapping(provider):
+    for cause, expected in (
+        ("normal_clearing", "completed"),
+        ("user_hangup", "hangup-user"),
+        ("user_busy", "busy"),
+        ("no_answer", "no-answer"),
+        ("machine_detected", "voicemail"),
+        ("service_unavailable", "failed"),
+        ("some_future_cause", "completed"),
+    ):
+        events = _parse_single(
+            provider,
+            _telnyx_event("call.hangup", call_control_id="v3:x", hangup_cause=cause),
+        )
+        assert events[0].type == EventType.CALL_ENDED
+        assert events[0].reason == expected, cause
+
+
+def test_parse_dtmf_and_speak_started(provider):
+    events = _parse_single(
+        provider, _telnyx_event("call.dtmf.received", call_control_id="v3:x", digit="5")
+    )
+    assert events[0].type == EventType.CALL_DTMF and events[0].digits == "5"
+    events = _parse_single(
+        provider,
+        _telnyx_event("call.speak.started", call_control_id="v3:x", text="hi"),
+    )
+    assert events[0].type == EventType.CALL_SPEAKING
+
+
+def test_parse_ignores_streaming_and_unknown_events(provider):
+    assert _parse_single(provider, _telnyx_event("streaming.started")) == []
+    assert _parse_single(provider, _telnyx_event("call.fork.started")) == []
+    assert _parse_single(provider, {"not": "telnyx"}) == []
+
+
+def test_parse_bad_json_400(provider):
+    ctx = WebhookContext(method="POST", path="/voice/webhook", body=b"\xff{nope")
+    assert provider.parse_webhook(ctx).response_status == 400
+
+
+# -- request shapes ----------------------------------------------------------------
+
+
+@pytest.fixture
+def api_calls(provider, monkeypatch):
+    calls = []
+
+    async def fake_request(method, url, **kwargs):
+        calls.append({"method": method, "url": url, **kwargs})
+        return {"data": {"call_control_id": "v3:new", "is_alive": True}}
+
+    import plugins.platforms.voice_call.providers.telnyx as telnyx_mod
+
+    monkeypatch.setattr(telnyx_mod, "guarded_json_request", fake_request)
+    return calls
+
+
+def _call_record(**kwargs):
+    return CallRecord(
+        call_id="vc-test", provider="telnyx", direction="outbound",
+        from_number="+15555550000", to_number="+15555550001",
+        provider_call_id=kwargs.pop("provider_call_id", "v3:abc"), **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_initiate_call_request_shape(provider, api_calls):
+    record = _call_record(provider_call_id=None)
+    provider_call_id = await provider.initiate_call(record)
+    assert provider_call_id == "v3:new"
+    request = api_calls[0]
+    assert request["url"].endswith("/v2/calls")
+    body = request["json_body"]
+    assert body["connection_id"] == "conn-1"
+    assert body["to"] == "+15555550001" and body["from"] == "+15555550000"
+    assert body["webhook_url"] == "https://hooks.example/voice/webhook"
+    assert base64.b64decode(body["client_state"]).decode() == "vc-test"
+    assert "stream_url" not in body
+    assert request["headers"]["Authorization"] == "Bearer test-key"
+
+
+@pytest.mark.asyncio
+async def test_initiate_call_includes_streaming_fields(provider, api_calls):
+    record = _call_record(provider_call_id=None)
+    record.metadata["stream_url"] = "wss://hooks.example/voice/stream/tok"
+    record.metadata["stream_auth_token"] = "tok"
+    await provider.initiate_call(record)
+    body = api_calls[0]["json_body"]
+    assert body["stream_url"] == "wss://hooks.example/voice/stream/tok"
+    assert body["stream_codec"] == "PCMU"
+    assert body["stream_bidirectional_mode"] == "rtp"
+    assert body["stream_bidirectional_sampling_rate"] == 8000
+    assert body["stream_auth_token"] == "tok"
+
+
+@pytest.mark.asyncio
+async def test_action_request_shapes(provider, api_calls):
+    record = _call_record()
+    await provider.answer_call(record)
+    await provider.speak(record, "hello caller")
+    await provider.send_dtmf(record, "12#")
+    await provider.start_listening(record)
+    await provider.stop_listening(record)
+    await provider.hangup_call(record)
+    urls = [c["url"] for c in api_calls]
+    assert urls == [
+        "https://api.telnyx.com/v2/calls/v3:abc/actions/answer",
+        "https://api.telnyx.com/v2/calls/v3:abc/actions/speak",
+        "https://api.telnyx.com/v2/calls/v3:abc/actions/send_dtmf",
+        "https://api.telnyx.com/v2/calls/v3:abc/actions/transcription_start",
+        "https://api.telnyx.com/v2/calls/v3:abc/actions/transcription_stop",
+        "https://api.telnyx.com/v2/calls/v3:abc/actions/hangup",
+    ]
+    assert api_calls[1]["json_body"]["payload"] == "hello caller"
+    assert api_calls[2]["json_body"]["digits"] == "12#"
+
+
+@pytest.mark.asyncio
+async def test_get_call_status_mapping(provider, monkeypatch):
+    import plugins.platforms.voice_call.providers.telnyx as telnyx_mod
+
+    async def alive(method, url, **kwargs):
+        return {"data": {"is_alive": True, "state": "active"}}
+
+    monkeypatch.setattr(telnyx_mod, "guarded_json_request", alive)
+    status = await provider.get_call_status(_call_record())
+    assert status.is_active and not status.is_terminal
+
+    async def gone(method, url, **kwargs):
+        return None  # 404
+
+    monkeypatch.setattr(telnyx_mod, "guarded_json_request", gone)
+    status = await provider.get_call_status(_call_record())
+    assert status.is_terminal
+
+    async def unknown(method, url, **kwargs):
+        return {"data": {"state": "weird"}}  # no is_alive
+
+    monkeypatch.setattr(telnyx_mod, "guarded_json_request", unknown)
+    status = await provider.get_call_status(_call_record())
+    assert status.is_unknown and not status.is_terminal
+
+    async def boom(method, url, **kwargs):
+        raise _http.ProviderApiError("Telnyx API error: HTTP 502")
+
+    monkeypatch.setattr(telnyx_mod, "guarded_json_request", boom)
+    status = await provider.get_call_status(_call_record())
+    assert status.is_unknown
+
+
+# -- host guard ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_host_guard_rejects_foreign_hosts():
+    with pytest.raises(_http.ProviderApiError, match="refusing request"):
+        await _http.guarded_json_request(
+            "POST", "https://evil.example/v2/calls", allowed_host="api.telnyx.com"
+        )
+
+
+def test_streaming_fields_builder():
+    fields = build_streaming_fields("wss://x/y", None)
+    assert "stream_auth_token" not in fields
+    assert fields["stream_bidirectional_target_legs"] == "self"
+
+
+# -- tunnel -----------------------------------------------------------------------
+
+
+def test_parse_ngrok_log_lines():
+    assert (
+        parse_ngrok_log_line(
+            '{"msg":"started tunnel","url":"https://abc.ngrok-free.app"}'
+        )
+        == "https://abc.ngrok-free.app"
+    )
+    assert (
+        parse_ngrok_log_line(
+            '{"addr":"http://localhost:3334","url":"https://abc.ngrok.app","msg":"x"}'
+        )
+        == "https://abc.ngrok.app"
+    )
+    assert parse_ngrok_log_line('{"msg":"no url here"}') is None
+    assert parse_ngrok_log_line("not json at all") is None
+
+
+@pytest.mark.asyncio
+async def test_start_tunnel_unknown_provider():
+    cfg = VoiceCallConfig.from_extra({"provider": "mock"})
+    cfg.tunnel.provider = "carrier-pigeon"
+    with pytest.raises(ValueError):
+        await start_tunnel(cfg)

--- a/tests/plugins/platforms/voice_call/test_tool_slash.py
+++ b/tests/plugins/platforms/voice_call/test_tool_slash.py
@@ -1,0 +1,161 @@
+"""voice_call tool, /voicecall slash command, and speech stripping."""
+
+import asyncio
+import json
+
+import pytest
+import pytest_asyncio
+
+from plugins.platforms.voice_call import runtime as runtime_mod
+from plugins.platforms.voice_call.responder import strip_for_speech
+from plugins.platforms.voice_call.tool import slash_handler, voice_call_handler
+
+
+async def _tool(action, **args):
+    return json.loads(await voice_call_handler({"action": action, **args}))
+
+
+async def _wait_listening(runtime, call_id, timeout=1.0):
+    from plugins.platforms.voice_call.events import CallState
+
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        record = runtime.manager.get_call(call_id)
+        if record is not None and record.state == CallState.LISTENING:
+            return record
+        await asyncio.sleep(0.01)
+    raise AssertionError("never reached listening")
+
+
+@pytest_asyncio.fixture
+async def running_runtime(tmp_path, make_config):
+    cfg = make_config()
+    cfg.serve.port = 0
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    yield runtime
+    await runtime_mod.stop_runtime()
+
+
+@pytest.mark.asyncio
+async def test_tool_errors_without_runtime():
+    result = await _tool("get_status")
+    assert result["success"] is False
+    assert "gateway" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_tool_requires_action():
+    result = json.loads(await voice_call_handler({}))
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_tool_initiate_status_speak_end(running_runtime):
+    result = await _tool("initiate_call", to_number="+15555550001", message="hi")
+    assert result["success"] is True
+    call_id = result["call"]["call_id"]
+    await _wait_listening(running_runtime, call_id)
+
+    status = await _tool("get_status")
+    assert status["success"] and len(status["active_calls"]) == 1
+    assert status["provider"] == "mock"
+
+    one = await _tool("get_status", call_id=call_id)
+    assert one["call"]["call_id"] == call_id
+
+    spoke = await _tool("speak_to_user", call_id=call_id, message="news for you")
+    assert spoke["success"] is True
+
+    ended = await _tool("end_call", call_id=call_id)
+    assert ended["success"] is True
+    gone = await _tool("get_status", call_id=call_id)
+    assert gone["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_tool_error_paths_return_json(running_runtime):
+    assert (await _tool("initiate_call"))["success"] is False        # no number
+    assert (await _tool("initiate_call", to_number="junk"))["success"] is False
+    assert (await _tool("speak_to_user", call_id="nope", message="x"))[
+        "success"
+    ] is False
+    assert (await _tool("end_call", call_id="nope"))["success"] is False
+    assert (await _tool("explode"))["success"] is False              # unknown action
+
+
+@pytest.mark.asyncio
+async def test_tool_continue_call_roundtrip_and_timeout(running_runtime):
+    from plugins.platforms.voice_call.events import EventType, NormalizedEvent
+
+    result = await _tool("initiate_call", to_number="+15555550001")
+    call_id = result["call"]["call_id"]
+    record = await _wait_listening(running_runtime, call_id)
+
+    async def reply():
+        await asyncio.sleep(0.05)
+        await running_runtime.manager.process_event(
+            NormalizedEvent(
+                type=EventType.CALL_SPEECH, provider="mock",
+                provider_call_id=record.provider_call_id, text="sounds good",
+            )
+        )
+
+    asyncio.get_running_loop().create_task(reply())
+    result = await _tool("continue_call", call_id=call_id, message="ok to proceed?")
+    assert result["success"] and result["reply"] == "sounds good"
+
+    # No reply this time → JSON timeout error, not an exception.
+    result = await _tool("continue_call", call_id=call_id, message="hello?")
+    assert result["success"] is False
+    assert "timed out" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_slash_usage_and_status(running_runtime):
+    usage = await slash_handler("")
+    assert "Usage" in usage
+    out = await slash_handler("status")
+    assert "no active calls" in out
+
+    out = await slash_handler('call --to +15555550001 --message "hello"')
+    assert "dialing +15555550001" in out
+    call_id = out.rsplit(" ", 1)[-1]
+    await _wait_listening(running_runtime, call_id)
+
+    out = await slash_handler("status")
+    assert call_id in out
+    out = await slash_handler(f"end --call-id {call_id}")
+    assert "ok" in out
+
+    out = await slash_handler("bogus")
+    assert "unknown subcommand" in out
+
+
+# -- strip_for_speech ---------------------------------------------------------
+
+
+def test_strip_for_speech_removes_markup():
+    text = (
+        "# Update\n"
+        "Here is **bold** and _italic_ and `inline()` plus a "
+        "[link](https://example.com) and https://raw.example.com/x.\n"
+        "```python\nprint('hi')\n```\n"
+        "- item one\n- item two"
+    )
+    out = strip_for_speech(text)
+    assert "```" not in out and "**" not in out and "](" not in out
+    assert "https://" not in out
+    assert "bold" in out and "italic" in out and "inline()" in out
+    assert "code omitted" in out
+    assert "item one item two" in out
+
+
+def test_strip_for_speech_caps_length():
+    out = strip_for_speech("word. " * 500, max_chars=100)
+    assert len(out) <= 101
+    assert out.endswith(".")
+
+
+def test_strip_for_speech_empty():
+    assert strip_for_speech("") == ""
+    assert strip_for_speech("```\nonly code\n```") == "code omitted."

--- a/tests/plugins/platforms/voice_call/test_tool_slash.py
+++ b/tests/plugins/platforms/voice_call/test_tool_slash.py
@@ -131,6 +131,40 @@ async def test_slash_usage_and_status(running_runtime):
     assert "unknown subcommand" in out
 
 
+@pytest.mark.asyncio
+async def test_tool_falls_back_to_admin_endpoint(running_runtime, monkeypatch):
+    """Agents in other processes (`hermes chat`) have no in-process runtime;
+    the tool must drive the gateway's admin endpoint like the CLI does."""
+    from plugins.platforms.voice_call import cli as cli_mod
+    from plugins.platforms.voice_call import tool as tool_mod
+
+    port = running_runtime.webhook_server.bound_port
+    token = running_runtime.webhook_server.admin_token
+    # Simulate a foreign process: no runtime visible, admin endpoint known.
+    import plugins.platforms.voice_call.runtime as runtime_mod_inner
+
+    monkeypatch.setattr(runtime_mod_inner, "_runtime", None)
+    monkeypatch.setattr(cli_mod, "_admin_address", lambda extra: f"http://127.0.0.1:{port}")
+    monkeypatch.setattr(cli_mod, "_admin_token", lambda: token)
+
+    result = await _tool("initiate_call", to_number="+15555550001", message="hi")
+    assert result["success"] is True, result
+    call_id = result["call_id"]
+
+    status = await _tool("get_status")
+    assert status["success"] is True
+    assert any(c["call_id"] == call_id for c in status["active_calls"])
+
+    one = await _tool("get_status", call_id=call_id)
+    assert one["success"] is True and one["call"]["call_id"] == call_id
+
+    ended = await _tool("end_call", call_id=call_id)
+    assert ended["success"] is True
+
+    # Restore the runtime so the fixture teardown stops it cleanly.
+    monkeypatch.setattr(runtime_mod_inner, "_runtime", running_runtime)
+
+
 # -- strip_for_speech ---------------------------------------------------------
 
 

--- a/tests/plugins/platforms/voice_call/test_twilio_plivo_providers.py
+++ b/tests/plugins/platforms/voice_call/test_twilio_plivo_providers.py
@@ -1,0 +1,358 @@
+"""Twilio and Plivo providers: signatures, event parsing, request shapes."""
+
+import base64
+import hashlib
+import hmac
+from urllib.parse import urlencode
+
+import pytest
+
+from plugins.platforms.voice_call.config import VoiceCallConfig
+from plugins.platforms.voice_call.events import CallRecord, EventType
+from plugins.platforms.voice_call.providers.base import WebhookContext
+from plugins.platforms.voice_call.providers.plivo import (
+    PlivoProvider,
+    compute_plivo_v2_signature,
+    compute_plivo_v3_signature,
+)
+from plugins.platforms.voice_call.providers.twilio import (
+    TwilioProvider,
+    compute_twilio_signature,
+)
+
+PUBLIC = "https://hooks.example"
+PATH = "/voice/webhook"
+
+
+@pytest.fixture
+def twilio(monkeypatch):
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "AC123")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "tw-secret")
+    cfg = VoiceCallConfig.from_extra({"provider": "twilio", "public_url": PUBLIC})
+    provider = TwilioProvider(cfg)
+    provider.set_public_url(PUBLIC)
+    return provider
+
+
+@pytest.fixture
+def plivo(monkeypatch):
+    monkeypatch.setenv("PLIVO_AUTH_ID", "MA123")
+    monkeypatch.setenv("PLIVO_AUTH_TOKEN", "pl-secret")
+    cfg = VoiceCallConfig.from_extra({"provider": "plivo", "public_url": PUBLIC})
+    provider = PlivoProvider(cfg)
+    provider.set_public_url(PUBLIC)
+    return provider
+
+
+def _form_ctx(params: dict, headers: dict = None, url: str = None, query: dict = None):
+    body = urlencode(params).encode()
+    return WebhookContext(
+        method="POST", path=PATH, body=body,
+        headers=headers or {}, query=query or {},
+        url=url or f"{PUBLIC}{PATH}",
+    )
+
+
+def _call(provider_call_id="CA1", mode="conversation"):
+    return CallRecord(
+        call_id="vc-x", provider="x", direction="outbound",
+        from_number="+15555550000", to_number="+15555550001",
+        provider_call_id=provider_call_id, mode=mode,
+    )
+
+
+@pytest.fixture
+def api_calls(monkeypatch):
+    calls = []
+
+    async def fake_request(method, url, **kwargs):
+        calls.append({"method": method, "url": url, **kwargs})
+        return {
+            "sid": "CA-new", "status": "queued",          # twilio shapes
+            "request_uuid": "req-new", "call_status": "in-progress",  # plivo
+        }
+
+    import plugins.platforms.voice_call.providers.plivo as plivo_mod
+    import plugins.platforms.voice_call.providers.twilio as twilio_mod
+
+    monkeypatch.setattr(twilio_mod, "guarded_json_request", fake_request)
+    monkeypatch.setattr(plivo_mod, "guarded_json_request", fake_request)
+    return calls
+
+
+# -- credentials ----------------------------------------------------------------
+
+
+def test_credentials_required(monkeypatch):
+    for var in ("TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN",
+                "PLIVO_AUTH_ID", "PLIVO_AUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(ValueError):
+        TwilioProvider(VoiceCallConfig.from_extra({"provider": "twilio"}))
+    with pytest.raises(ValueError):
+        PlivoProvider(VoiceCallConfig.from_extra({"provider": "plivo"}))
+
+
+# -- Twilio signature ---------------------------------------------------------------
+
+
+def test_twilio_signature_valid_and_tampered(twilio):
+    params = {"CallSid": "CA1", "CallStatus": "ringing", "From": "+15555550009"}
+    url = f"{PUBLIC}{PATH}"
+    signature = compute_twilio_signature("tw-secret", url, params)
+    ctx = _form_ctx(params, headers={"X-Twilio-Signature": signature})
+    assert twilio.verify_webhook(ctx).ok is True
+
+    bad = _form_ctx({**params, "From": "+19999999999"},
+                    headers={"X-Twilio-Signature": signature})
+    assert twilio.verify_webhook(bad).ok is False
+
+
+def test_twilio_signature_port_variant(twilio):
+    params = {"CallSid": "CA1"}
+    # Twilio signed the URL without the port; we received it with one.
+    signature = compute_twilio_signature("tw-secret", f"{PUBLIC}{PATH}", params)
+    ctx = _form_ctx(params, headers={"X-Twilio-Signature": signature},
+                    url=f"https://hooks.example:443{PATH}")
+    assert twilio.verify_webhook(ctx).ok is True
+
+
+def test_twilio_signature_missing(twilio):
+    assert twilio.verify_webhook(_form_ctx({"CallSid": "CA1"})).ok is False
+
+
+# -- Twilio parsing -------------------------------------------------------------------
+
+
+def test_twilio_parse_lifecycle_and_speech(twilio):
+    result = twilio.parse_webhook(_form_ctx(
+        {"CallSid": "CA1", "CallStatus": "ringing", "Direction": "inbound",
+         "From": "+15555550009", "To": "+15555550000"},
+    ))
+    event = result.events[0]
+    assert event.type == EventType.CALL_RINGING and event.direction == "inbound"
+    assert "Pause" in result.response_body  # voice request → keep-alive TwiML
+
+    result = twilio.parse_webhook(_form_ctx(
+        {"CallSid": "CA1", "CallStatus": "in-progress"},
+        query={"callId": "vc-x", "type": "status"},
+    ))
+    assert result.events[0].type == EventType.CALL_ANSWERED
+    assert result.events[0].call_id == "vc-x"
+    assert "Pause" not in result.response_body  # status callback → empty ack
+
+    result = twilio.parse_webhook(_form_ctx(
+        {"CallSid": "CA1", "SpeechResult": "hello there", "Confidence": "0.9"},
+        query={"callId": "vc-x"},
+    ))
+    event = result.events[0]
+    assert event.type == EventType.CALL_SPEECH and event.text == "hello there"
+
+    result = twilio.parse_webhook(_form_ctx({"CallSid": "CA1", "Digits": "5"}))
+    assert result.events[0].type == EventType.CALL_DTMF
+
+    result = twilio.parse_webhook(_form_ctx(
+        {"CallSid": "CA1", "CallStatus": "no-answer"}))
+    assert result.events[0].type == EventType.CALL_ENDED
+    assert result.events[0].reason == "no-answer"
+
+
+# -- Twilio request shapes ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_twilio_initiate_and_speak_shapes(twilio, api_calls):
+    record = _call(provider_call_id=None)
+    record.call_id = "vc-x"
+    sid = await twilio.initiate_call(record)
+    assert sid == "CA-new"
+    request = api_calls[0]
+    assert request["url"].endswith("/Accounts/AC123/Calls.json")
+    assert request["auth"] == ("AC123", "tw-secret")
+    form = request["form_body"]
+    assert form["To"] == "+15555550001"
+    assert "callId=vc-x" in form["Url"]
+    assert "type=status" in form["StatusCallback"]
+    assert form["StatusCallbackEvent"] == ["initiated", "ringing", "answered",
+                                           "completed"]
+
+    record.provider_call_id = "CA-new"
+    await twilio.speak(record, 'Hello <world> & "friends"')
+    twiml = api_calls[1]["form_body"]["Twiml"]
+    assert "&lt;world&gt;" in twiml and "&amp;" in twiml  # XML-escaped
+    assert "<Gather" in twiml and "callId=vc-x" in twiml  # conversation embeds Gather
+
+    notify = _call(provider_call_id="CA-new", mode="notify")
+    await twilio.speak(notify, "bye")
+    assert "<Gather" not in api_calls[2]["form_body"]["Twiml"]
+
+    await twilio.send_dtmf(record, "1w2#x")  # x filtered out
+    assert 'digits="1w2#"' in api_calls[3]["form_body"]["Twiml"]
+
+    await twilio.hangup_call(record)
+    assert api_calls[4]["form_body"] == {"Status": "completed"}
+
+
+@pytest.mark.asyncio
+async def test_twilio_status_mapping(twilio, monkeypatch):
+    import plugins.platforms.voice_call.providers.twilio as twilio_mod
+
+    async def status(value):
+        async def fake(method, url, **kwargs):
+            return {"status": value}
+        monkeypatch.setattr(twilio_mod, "guarded_json_request", fake)
+        return await twilio.get_call_status(_call())
+
+    assert (await status("in-progress")).is_active
+    assert (await status("completed")).is_terminal
+    assert (await status("busy")).is_terminal
+
+
+# -- Plivo signature -----------------------------------------------------------------
+
+
+def test_plivo_v3_signature_valid_and_invalid(plivo):
+    params = [("CallUUID", "uuid-1"), ("Event", "StartApp")]
+    url = f"{PUBLIC}{PATH}?callId=vc-x&flow=answer"
+    nonce = "nonce123"
+    signature = compute_plivo_v3_signature("pl-secret", "POST", url, params, nonce)
+    ctx = WebhookContext(
+        method="POST", path=PATH, body=urlencode(params).encode(),
+        headers={"X-Plivo-Signature-V3": signature,
+                 "X-Plivo-Signature-V3-Nonce": nonce},
+        query={"callId": "vc-x", "flow": "answer"}, url=url,
+    )
+    result = plivo.verify_webhook(ctx)
+    assert result.ok is True and result.dedupe_key.startswith("plivo:v3:")
+
+    ctx.body = urlencode([("CallUUID", "tampered")]).encode()
+    assert plivo.verify_webhook(ctx).ok is False
+
+
+def test_plivo_v3_multiple_signatures_header(plivo):
+    params = [("CallUUID", "uuid-1")]
+    url = f"{PUBLIC}{PATH}"
+    nonce = "n1"
+    good = compute_plivo_v3_signature("pl-secret", "POST", url, params, nonce)
+    ctx = WebhookContext(
+        method="POST", path=PATH, body=urlencode(params).encode(),
+        headers={"X-Plivo-Signature-V3": f"bogus123==,{good}",
+                 "X-Plivo-Signature-V3-Nonce": nonce},
+        url=url,
+    )
+    assert plivo.verify_webhook(ctx).ok is True
+
+
+def test_plivo_v2_fallback(plivo):
+    url = f"{PUBLIC}{PATH}"
+    nonce = "n2"
+    signature = compute_plivo_v2_signature("pl-secret", url, nonce)
+    ctx = WebhookContext(
+        method="POST", path=PATH, body=b"",
+        headers={"X-Plivo-Signature-V2": signature,
+                 "X-Plivo-Signature-V2-Nonce": nonce},
+        url=url,
+    )
+    result = plivo.verify_webhook(ctx)
+    assert result.ok is True and result.dedupe_key.startswith("plivo:v2:")
+    assert plivo.verify_webhook(
+        WebhookContext(method="POST", path=PATH, body=b"", url=url)
+    ).ok is False
+
+
+# -- Plivo parsing --------------------------------------------------------------------
+
+
+def test_plivo_parse_lifecycle_speech_dtmf(plivo):
+    result = plivo.parse_webhook(_form_ctx(
+        {"CallUUID": "uuid-1", "Event": "StartApp", "Direction": "inbound",
+         "From": "+15555550009", "To": "+15555550000"},
+        query={"flow": "answer"},
+    ))
+    event = result.events[0]
+    assert event.type == EventType.CALL_ANSWERED
+    assert "Wait" in result.response_body  # answer flow → keep-alive XML
+
+    result = plivo.parse_webhook(_form_ctx(
+        {"CallUUID": "uuid-1", "Speech": "hi bot"}, query={"flow": "getinput",
+                                                           "callId": "vc-x"},
+    ))
+    event = result.events[0]
+    assert event.type == EventType.CALL_SPEECH and event.text == "hi bot"
+    assert event.call_id == "vc-x"
+
+    result = plivo.parse_webhook(_form_ctx({"CallUUID": "uuid-1", "Digits": "7"}))
+    assert result.events[0].type == EventType.CALL_DTMF
+
+    result = plivo.parse_webhook(_form_ctx(
+        {"CallUUID": "uuid-1", "CallStatus": "completed"}, query={"flow": "hangup"}))
+    assert result.events[0].type == EventType.CALL_ENDED
+    assert result.events[0].reason == "completed"
+
+
+def test_plivo_xml_speak_flow_serves_pending_text(plivo):
+    plivo._pending_speak["vc-x"] = 'Say <hello> & welcome'
+    result = plivo.parse_webhook(_form_ctx(
+        {"CallUUID": "uuid-1"}, query={"flow": "xml-speak", "callId": "vc-x"}))
+    assert result.events == []
+    assert "&lt;hello&gt;" in result.response_body
+    assert "<GetInput" in result.response_body
+    assert "flow=getinput" in result.response_body
+    # Pending text is one-shot.
+    again = plivo.parse_webhook(_form_ctx(
+        {"CallUUID": "uuid-1"}, query={"flow": "xml-speak", "callId": "vc-x"}))
+    assert "<Speak" not in again.response_body
+
+
+# -- Plivo request shapes -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plivo_initiate_speak_dtmf_hangup_shapes(plivo, api_calls):
+    record = _call(provider_call_id=None)
+    record.call_id = "vc-x"
+    request_uuid = await plivo.initiate_call(record)
+    assert request_uuid == "req-new"
+    request = api_calls[0]
+    assert request["url"].endswith("/Account/MA123/Call/")
+    body = request["json_body"]
+    assert body["to"] == "+15555550001"
+    assert "callId=vc-x" in body["answer_url"] and "flow=answer" in body["answer_url"]
+    assert "flow=hangup" in body["hangup_url"]
+
+    record.provider_call_id = "uuid-1"
+    await plivo.speak(record, "hello")
+    transfer = api_calls[1]
+    assert transfer["url"].endswith("/Call/uuid-1/")
+    assert transfer["json_body"]["legs"] == "aleg"
+    assert "flow=xml-speak" in transfer["json_body"]["aleg_url"]
+    assert plivo._pending_speak["vc-x"] == "hello"
+
+    await plivo.send_dtmf(record, "12w#")
+    assert api_calls[2]["url"].endswith("/Call/uuid-1/DTMF/")
+
+    await plivo.hangup_call(record)
+    assert api_calls[3]["method"] == "DELETE"
+
+
+# -- manager adopts swapped provider ids (Plivo request_uuid → CallUUID) -------------
+
+
+@pytest.mark.asyncio
+async def test_manager_adopts_new_provider_call_id(vc_config, provider, store):
+    from plugins.platforms.voice_call.events import NormalizedEvent
+    from plugins.platforms.voice_call.manager import CallManager
+
+    manager = CallManager(vc_config, provider, store)
+    provider.auto_answer = False
+    record = await manager.initiate_call("+15555550001")
+    old_id = record.provider_call_id
+
+    await manager.process_event(NormalizedEvent(
+        type=EventType.CALL_ANSWERED, provider="mock",
+        call_id=record.call_id, provider_call_id="real-call-uuid",
+    ))
+    assert record.provider_call_id == "real-call-uuid"
+    assert manager._by_provider_id.get("real-call-uuid") == record.call_id
+    assert old_id not in manager._by_provider_id
+    await manager.shutdown()

--- a/tests/plugins/platforms/voice_call/test_webhook.py
+++ b/tests/plugins/platforms/voice_call/test_webhook.py
@@ -317,6 +317,32 @@ async def test_admin_requires_token(harness):
 
 
 @pytest.mark.asyncio
+async def test_admin_command_on_ended_call_is_clean_error(tmp_path, make_config):
+    """speak/end racing a hangup returns a clean JSON error, not a 500 with
+    a stack trace (the call legitimately ended a moment earlier)."""
+    from plugins.platforms.voice_call import runtime as runtime_mod
+
+    cfg = make_config()
+    cfg.serve.port = 0
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    try:
+        port = runtime.webhook_server.bound_port
+        token = runtime.webhook_server.admin_token
+        async with aiohttp.ClientSession() as client:
+            async with client.post(
+                f"http://127.0.0.1:{port}/voice/admin",
+                json={"command": "speak", "call_id": "vc-gone", "message": "hi"},
+                headers={"x-voice-call-admin-token": token},
+            ) as resp:
+                assert resp.status == 200          # not 500
+                data = await resp.json()
+        assert data["success"] is False
+        assert "vc-gone" in data["error"] and "already ended" in data["error"]
+    finally:
+        await runtime_mod.stop_runtime()
+
+
+@pytest.mark.asyncio
 async def test_stream_route_404_until_realtime_phase(harness):
     status, _ = await harness.get(harness.config.serve.stream_path + "/some-token")
     assert status == 404

--- a/tests/plugins/platforms/voice_call/test_webhook.py
+++ b/tests/plugins/platforms/voice_call/test_webhook.py
@@ -1,0 +1,371 @@
+"""Webhook server security pipeline and inbound flow tests.
+
+Runs the real aiohttp server on an ephemeral port and exercises it with an
+aiohttp client — the same wire path a carrier would hit.
+"""
+
+import asyncio
+import json
+
+import pytest
+import pytest_asyncio
+
+aiohttp = pytest.importorskip("aiohttp")
+
+from plugins.platforms.voice_call import runtime as runtime_mod
+from plugins.platforms.voice_call.config import SecurityConfig
+from plugins.platforms.voice_call.events import CallState
+from plugins.platforms.voice_call.manager import CallManager
+from plugins.platforms.voice_call.providers.base import (
+    WebhookVerificationResult,
+)
+from plugins.platforms.voice_call.providers.mock import MockProvider
+from plugins.platforms.voice_call.webhook import VoiceCallWebhookServer
+
+
+class _ServerHarness:
+    def __init__(self, server):
+        self.server = server
+
+    @property
+    def base_url(self):
+        return f"http://127.0.0.1:{self.server.bound_port}"
+
+    async def post(self, path, *, data=None, json_body=None, headers=None):
+        async with aiohttp.ClientSession() as session:
+            kwargs = {"headers": headers or {}}
+            if json_body is not None:
+                kwargs["json"] = json_body
+            else:
+                kwargs["data"] = data
+            async with session.post(self.base_url + path, **kwargs) as resp:
+                return resp.status, await resp.text()
+
+    async def get(self, path):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(self.base_url + path) as resp:
+                return resp.status, await resp.text()
+
+
+@pytest_asyncio.fixture
+async def harness(vc_config, provider, store):
+    """Running webhook server wired to a real manager on the mock provider."""
+    vc_config.serve.port = 0  # ephemeral
+    vc_config.inbound_policy = "allowlist"
+    vc_config.allow_from = ["+15555550009"]
+    manager = CallManager(vc_config, provider, store)
+    provider.event_sink = manager.process_event
+    server = VoiceCallWebhookServer(
+        vc_config, provider, process_event=manager.process_event,
+        admin_handler=None, admin_token="test-admin-token",
+    )
+    await server.start()
+    h = _ServerHarness(server)
+    h.manager = manager
+    h.provider = provider
+    h.config = vc_config
+    yield h
+    await server.stop()
+    await manager.shutdown()
+
+
+def _event_body(event_type="call.initiated", **fields):
+    if event_type == "call.initiated":
+        fields.setdefault("provider_call_id", "prov-in-1")
+    return {"event": {"type": event_type, **fields}}
+
+
+# -- pipeline gates -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wrong_path_404(harness):
+    status, _ = await harness.post("/somewhere/else", json_body={})
+    assert status == 404
+
+
+@pytest.mark.asyncio
+async def test_wrong_method_405(harness):
+    status, _ = await harness.get(harness.config.serve.path)
+    assert status == 405
+
+
+@pytest.mark.asyncio
+async def test_oversized_body_rejected(harness):
+    harness.config.security.max_body_bytes = 1024  # already-built app uses ctor value
+    big = "x" * (2_000_000)
+    status, _ = await harness.post(harness.config.serve.path, data=big)
+    assert status in (408, 413)
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_rejected_by_mock_parser(harness):
+    status, _ = await harness.post(harness.config.serve.path, data=b"\xff\xfe not json")
+    assert status == 400
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_type_rejected(harness):
+    status, _ = await harness.post(
+        harness.config.serve.path, json_body=_event_body("call.made-up")
+    )
+    assert status == 400
+
+
+@pytest.mark.asyncio
+async def test_preauth_header_gate_for_signed_providers(harness):
+    """Providers with signature schemes get a 401 before the body is read."""
+    harness.provider.name = "telnyx"  # pretend: gate keys off provider name
+    try:
+        status, _ = await harness.post(
+            harness.config.serve.path, json_body=_event_body()
+        )
+        assert status == 401
+        status, _ = await harness.post(
+            harness.config.serve.path,
+            json_body=_event_body(
+                event_type="call.speech", provider_call_id="x", text="hi"
+            ),
+            headers={"telnyx-signature-ed25519": "sig"},
+        )
+        assert status == 200
+    finally:
+        harness.provider.name = "mock"
+
+
+@pytest.mark.asyncio
+async def test_signature_verification_failure_403(harness):
+    harness.provider.verify_webhook = lambda ctx: WebhookVerificationResult(
+        ok=False, error="bad signature"
+    )
+    status, _ = await harness.post(
+        harness.config.serve.path, json_body=_event_body()
+    )
+    assert status == 403
+
+
+@pytest.mark.asyncio
+async def test_skip_signature_verification_bypasses_verify(harness):
+    harness.config.security.skip_signature_verification = True
+
+    def explode(ctx):
+        raise AssertionError("verify_webhook must not be called when skipped")
+
+    harness.provider.verify_webhook = explode
+    status, _ = await harness.post(
+        harness.config.serve.path,
+        json_body=_event_body(
+            event_type="call.speech", provider_call_id="x", text="hi"
+        ),
+    )
+    assert status == 200
+
+
+@pytest.mark.asyncio
+async def test_replay_returns_cached_response_without_reprocessing(harness):
+    body = _event_body(
+        event_type="call.initiated", direction="inbound",
+        **{"from": "+15555550009", "to": "+15555550000"},
+    )
+    status1, text1 = await harness.post(harness.config.serve.path, json_body=body)
+    assert status1 == 200
+    assert len(harness.manager.get_active_calls()) == 1
+
+    # Identical body → same dedupe key (body hash) → cached, not reprocessed.
+    status2, text2 = await harness.post(harness.config.serve.path, json_body=body)
+    assert status2 == 200 and text2 == text1
+    assert len(harness.manager.get_active_calls()) == 1
+
+
+# -- inbound policy ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_allowlist_accepts_allowed_caller(harness):
+    status, _ = await harness.post(
+        harness.config.serve.path,
+        json_body=_event_body(
+            direction="inbound", **{"from": "+1 (555) 555-0009", "to": "+15555550000"}
+        ),
+    )
+    assert status == 200
+    record = harness.manager.call_for_chat("+15555550009")
+    assert record is not None
+    assert harness.provider.answered  # explicit answer issued
+
+
+@pytest.mark.asyncio
+async def test_allowlist_rejects_unknown_caller(harness):
+    status, _ = await harness.post(
+        harness.config.serve.path,
+        json_body=_event_body(
+            direction="inbound", **{"from": "+19998887777", "to": "+15555550000"}
+        ),
+    )
+    assert status == 200  # carrier still gets its expected response
+    assert harness.manager.get_active_calls() == []
+
+
+@pytest.mark.asyncio
+async def test_inbound_policy_disabled_rejects_everyone(harness):
+    harness.config.inbound_policy = "disabled"
+    status, _ = await harness.post(
+        harness.config.serve.path,
+        json_body=_event_body(
+            direction="inbound", **{"from": "+15555550009", "to": "+15555550000"}
+        ),
+    )
+    assert status == 200
+    assert harness.manager.get_active_calls() == []
+
+
+@pytest.mark.asyncio
+async def test_inbound_policy_open_accepts_anyone(harness):
+    harness.config.inbound_policy = "open"
+    status, _ = await harness.post(
+        harness.config.serve.path,
+        json_body=_event_body(
+            direction="inbound", **{"from": "+10000000001", "to": "+15555550000"}
+        ),
+    )
+    assert status == 200
+    assert len(harness.manager.get_active_calls()) == 1
+
+
+@pytest.mark.asyncio
+async def test_inbound_speech_flows_to_manager(harness):
+    await harness.post(
+        harness.config.serve.path,
+        json_body=_event_body(
+            direction="inbound", **{"from": "+15555550009", "to": "+15555550000"}
+        ),
+    )
+    record = harness.manager.call_for_chat("+15555550009")
+    await harness.post(
+        harness.config.serve.path,
+        json_body=_event_body(
+            event_type="call.answered", provider_call_id=record.provider_call_id
+        ),
+    )
+    assert record.state == CallState.LISTENING
+    await harness.post(
+        harness.config.serve.path,
+        json_body=_event_body(
+            event_type="call.speech",
+            provider_call_id=record.provider_call_id,
+            text="hello from the phone",
+        ),
+    )
+    assert [t.text for t in record.transcript if t.speaker == "user"] == [
+        "hello from the phone"
+    ]
+
+
+# -- per-IP limiter --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inflight_limiter_429(vc_config, provider, store):
+    vc_config.serve.port = 0
+    vc_config.security = SecurityConfig(max_inflight_per_ip=1)
+    manager = CallManager(vc_config, provider, store)
+
+    gate = asyncio.Event()
+
+    async def slow_process(event):
+        await gate.wait()
+
+    server = VoiceCallWebhookServer(vc_config, provider, process_event=slow_process)
+    await server.start()
+    h = _ServerHarness(server)
+    body = _event_body(
+        direction="inbound", **{"from": "+15555550009", "to": "+15555550000"}
+    )
+    vc_config.inbound_policy = "open"
+    try:
+        first = asyncio.create_task(
+            h.post(vc_config.serve.path, json_body=body)
+        )
+        await asyncio.sleep(0.1)  # first request parked inside process_event
+        status2, _ = await h.post(
+            vc_config.serve.path, json_body={"event": {"type": "call.speech",
+                                                       "provider_call_id": "x",
+                                                       "text": "hi"}}
+        )
+        assert status2 == 429
+        gate.set()
+        status1, _ = await first
+        assert status1 == 200
+    finally:
+        gate.set()
+        await server.stop()
+        await manager.shutdown()
+
+
+# -- admin endpoint ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_requires_token(harness):
+    status, _ = await harness.post("/voice/admin", json_body={"command": "status"})
+    assert status == 401
+    status, _ = await harness.post(
+        "/voice/admin", json_body={"command": "status"},
+        headers={"x-voice-call-admin-token": "wrong"},
+    )
+    assert status == 401
+
+
+@pytest.mark.asyncio
+async def test_stream_route_404_until_realtime_phase(harness):
+    status, _ = await harness.get(harness.config.serve.stream_path + "/some-token")
+    assert status == 404
+
+
+# -- runtime integration ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runtime_starts_and_stops_server_releasing_port(tmp_path, make_config):
+    cfg = make_config()
+    cfg.serve.port = 0
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    port = runtime.webhook_server.bound_port
+    assert port
+    # Admin endpoint answers with the persisted token.
+    token = (tmp_path / "admin.token").read_text(encoding="utf-8").strip()
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"http://127.0.0.1:{port}/voice/admin",
+            json={"command": "status"},
+            headers={"x-voice-call-admin-token": token},
+        ) as resp:
+            assert resp.status == 200
+            data = await resp.json()
+    assert data["success"] is True and data["provider"] == "mock"
+
+    await runtime_mod.stop_runtime()
+    # Port is released: a fresh runtime can bind the same fixed port.
+    cfg2 = make_config()
+    cfg2.serve.port = port
+    runtime2 = await runtime_mod.ensure_runtime(cfg2, store_dir=tmp_path)
+    assert runtime2.webhook_server.bound_port == port
+    await runtime_mod.stop_runtime()
+
+
+@pytest.mark.asyncio
+async def test_runtime_bind_failure_raises_oserror(tmp_path, make_config):
+    cfg = make_config()
+    cfg.serve.port = 0
+    runtime = await runtime_mod.ensure_runtime(cfg, store_dir=tmp_path)
+    taken = runtime.webhook_server.bound_port
+
+    # Second runtime instance on the occupied port must raise OSError
+    # (the adapter maps this to a retryable fatal error).
+    cfg2 = make_config()
+    cfg2.serve.port = taken
+    other = runtime_mod.VoiceCallRuntime(cfg2, store_dir=tmp_path)
+    with pytest.raises(OSError):
+        await other.start()
+    await other.stop()  # tolerates partial init
+    await runtime_mod.stop_runtime()

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -96,7 +96,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Inference providers ───────────────────────────────────────────────
     # Native Anthropic SDK — needed when provider=anthropic (not via
     # OpenRouter / aggregators which use the openai SDK).
-    "provider.anthropic": ("anthropic==0.87.0",),  # CVE-2026-34450, CVE-2026-34452
+    # CVE-2026-34450, CVE-2026-34452
+    "provider.anthropic": ("anthropic==0.87.0",),
     # AWS Bedrock provider
     "provider.bedrock": ("boto3==1.42.89",),
     # Microsoft Foundry — Entra ID auth (managed identity, workload identity,
@@ -184,6 +185,9 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # installed on demand like every other messaging platform; also exposed
     # as the `teams` extra in pyproject for packagers / explicit installs.
     "platform.teams": ("microsoft-teams-apps==2.0.13.4", "aiohttp==3.13.4"),
+    # Voice-call platform — aiohttp serves the carrier webhook endpoint and
+    # the media-stream WebSocket upgrades. Same pin as the `voice-call` extra.
+    "platform.voice_call": ("aiohttp==3.13.4",),
 
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),
@@ -204,8 +208,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "tool.dashboard": (
         "fastapi==0.133.1",
         "uvicorn[standard]==0.41.0",
-        "starlette==1.0.1",  # CVE-2026-48710 (BadHost) — keep lazy-install in sync with pyproject [web]
-        "python-multipart==0.0.27",  # FastAPI UploadFile/Form for streaming uploads (NS-501)
+        # CVE-2026-48710 (BadHost) — keep lazy-install in sync with pyproject [web]
+        "starlette==1.0.1",
+        # FastAPI UploadFile/Form for streaming uploads (NS-501)
+        "python-multipart==0.0.27",
     ),
     # Vision image-resize recovery (Pillow). Pillow is now a CORE dependency
     # (pyproject `dependencies`), so this entry is a belt-and-suspenders fallback
@@ -220,7 +226,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # installs so computer_use never dead-ends on `No module named 'mcp'`.
     "tool.computer_use": (
         "mcp==1.26.0",
-        "starlette==1.0.1",  # CVE-2026-48710 — keep in sync with pyproject [computer-use]
+        # CVE-2026-48710 — keep in sync with pyproject [computer-use]
+        "starlette==1.0.1",
     ),
 }
 
@@ -396,7 +403,8 @@ def activate_durable_lazy_target() -> None:
         if target.exists():
             _activate_target_on_syspath(target)
     except Exception as e:  # pragma: no cover - defensive
-        logger.debug("Failed to activate durable lazy target %s: %s", target, e)
+        logger.debug(
+            "Failed to activate durable lazy target %s: %s", target, e)
 
 
 def _allow_lazy_installs() -> bool:
@@ -466,7 +474,8 @@ def _specifier_from_spec(spec: str) -> str:
     ``"package"`` → ``""`` (no version constraint)
     """
     # Strip the package name + optional [extras] block.
-    m = re.match(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*(?:\[[A-Za-z0-9_,\-]+\])?", spec)
+    m = re.match(
+        r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*(?:\[[A-Za-z0-9_,\-]+\])?", spec)
     if not m:
         return ""
     return spec[m.end():]
@@ -575,7 +584,8 @@ def _core_constraints_file() -> Optional[Path]:
             lines.append(f"{name}=={ver}")
         if not lines:
             return None
-        fd, path = tempfile.mkstemp(prefix="hermes-core-constraints-", suffix=".txt")
+        fd, path = tempfile.mkstemp(
+            prefix="hermes-core-constraints-", suffix=".txt")
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write("\n".join(sorted(lines)) + "\n")
         return Path(path)
@@ -631,7 +641,8 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         if uv_bin:
             try:
                 r = subprocess.run(
-                    [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
+                    [uv_bin, "pip", "install", *target_args,
+                        *constraint_args, *specs],
                     capture_output=True, text=True, timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
                 )
@@ -656,7 +667,8 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         except (subprocess.TimeoutExpired, FileNotFoundError):
             try:
                 subprocess.run(
-                    [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
+                    [sys.executable, "-m", "ensurepip",
+                        "--upgrade", "--default-pip"],
                     capture_output=True, text=True, timeout=120, check=True,
                     stdin=subprocess.DEVNULL,
                 )
@@ -750,7 +762,8 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
         try:
             from prompt_toolkit.application.current import get_app_or_none
             _app = get_app_or_none()
-            _pt_active = _app is not None and getattr(_app, "is_running", False)
+            _pt_active = _app is not None and getattr(
+                _app, "is_running", False)
         except Exception:
             _pt_active = False
 
@@ -768,7 +781,8 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
                 feature, missing, "user declined install at prompt"
             )
 
-    logger.info("Lazy-installing %s for feature %r", " ".join(missing), feature)
+    logger.info("Lazy-installing %s for feature %r",
+                " ".join(missing), feature)
     result = _venv_pip_install(missing)
     if not result.success:
         # Surface the actual pip error so the user can debug PyPI-side

--- a/website/docs/user-guide/features/voice-call.md
+++ b/website/docs/user-guide/features/voice-call.md
@@ -165,6 +165,44 @@ gateway:
 | `NGROK_AUTHTOKEN`, `NGROK_DOMAIN` | ngrok tunnel |
 | `OPENAI_API_KEY` / `GEMINI_API_KEY` | realtime voice models |
 
+## Realtime voice (speech-to-speech)
+
+Turn-based calls use carrier TTS and transcription — reliable, but each
+turn takes a few seconds. Realtime mode instead bridges the call's audio
+directly to a speech-to-speech model (OpenAI Realtime or Gemini Live) for
+natural, low-latency conversation with barge-in (you can interrupt the
+assistant mid-sentence).
+
+```yaml
+gateway:
+  platforms:
+    voice_call:
+      enabled: true
+      extra:
+        provider: telnyx            # realtime works on telnyx and twilio
+        # ... telnyx setup as above ...
+        realtime:
+          enabled: true
+          provider: openai          # openai | gemini
+          model: gpt-realtime       # optional override
+          voice: marin
+```
+
+Add `OPENAI_API_KEY` (or `GEMINI_API_KEY` with `provider: gemini`) to
+`~/.hermes/.env`.
+
+How it works: when a realtime call is dialed or answered, the carrier
+opens a media WebSocket back to Hermes (authenticated with a one-shot
+token), and the plugin pipes audio between the phone line (µ-law 8 kHz)
+and the model (PCM 16/24 kHz). During the call the realtime model can ask
+the full Hermes agent questions through an `agent_consult` tool — "let me
+check that" — so calendar, memory, and live data stay available without
+leaving the audio loop. Transcripts are still recorded to the call
+history.
+
+Conversation-mode calls use the realtime bridge; `notify` calls keep
+plain carrier TTS (cheaper and sufficient for one-shot messages).
+
 ## Security notes
 
 - **Webhook signatures are verified by default** (Telnyx Ed25519, Twilio

--- a/website/docs/user-guide/features/voice-call.md
+++ b/website/docs/user-guide/features/voice-call.md
@@ -1,0 +1,191 @@
+---
+title: Voice Calls
+description: Make and receive real phone calls through Telnyx (default), Twilio, or Plivo — outbound notifications, two-way conversations, an inbound allowlist, and optional realtime speech-to-speech.
+sidebar_label: Voice Calls
+---
+
+# Voice Calls
+
+The `voice_call` platform plugin lets Hermes place and receive real phone
+calls (PSTN) through a carrier API. It supports:
+
+- **Outbound calls** — the agent dials a number via the `voice_call` tool
+  (or you do, with `hermes voicecall call ...` / `/voicecall call ...`), in
+  `notify` mode (speak a message, hang up) or `conversation` mode (two-way
+  dialog driven by the agent).
+- **Inbound calls** — people can call your number and talk to Hermes,
+  gated by an allowlist.
+- **Providers** — Telnyx (default), Twilio, Plivo, and a credential-free
+  `mock` provider for trying everything locally.
+
+## Why the gateway must be running
+
+Inbound calls arrive as carrier webhooks. The plugin runs a webhook
+server for the **gateway's lifetime** — it starts with `hermes gateway run`
+and stops on shutdown. If the gateway isn't running, outbound tool calls
+fail with a clear error and inbound calls won't reach Hermes.
+
+## Quick start with the mock provider
+
+No credentials, no network — calls are simulated:
+
+```yaml
+# ~/.hermes/config.yaml
+gateway:
+  platforms:
+    voice_call:
+      enabled: true
+      extra:
+        provider: mock
+        from_number: "+15555550000"
+        inbound_policy: allowlist
+        allow_from: ["+15555550001"]
+```
+
+```bash
+hermes gateway run
+hermes voicecall call --to +15555550001 --message "Hello from Hermes"
+hermes voicecall status
+```
+
+## Telnyx setup (default provider)
+
+1. In the [Telnyx portal](https://portal.telnyx.com), create a **Call
+   Control application**, attach a phone number to it, and note the
+   **connection ID**. Copy the application's **public key** (used to verify
+   webhook signatures).
+2. Put credentials in `~/.hermes/.env`:
+
+   ```text
+   TELNYX_API_KEY=KEY_xxxxxxxx
+   TELNYX_CONNECTION_ID=1234567890
+   TELNYX_PUBLIC_KEY=BASE64_PUBLIC_KEY
+   ```
+
+3. Configure the platform. Carriers must be able to reach your webhook, so
+   set an explicit `public_url` (your reverse proxy / static tunnel) or let
+   the plugin manage an ngrok tunnel:
+
+   ```yaml
+   gateway:
+     platforms:
+       voice_call:
+         enabled: true
+         extra:
+           provider: telnyx
+           from_number: "+15551234567"     # your Telnyx number
+           inbound_policy: allowlist
+           allow_from: ["+15557654321"]    # numbers allowed to call in
+           tunnel:
+             provider: ngrok               # or set public_url: https://...
+   ```
+
+   With ngrok, add `NGROK_AUTHTOKEN` to `.env` (and optionally a reserved
+   `NGROK_DOMAIN`). Point your Telnyx application's webhook URL at
+   `<public-url>/voice/webhook`.
+
+4. Verify and run:
+
+   ```bash
+   hermes voicecall doctor
+   hermes gateway run
+   hermes voicecall call --to +1555... --message "Hello from Hermes" --mode notify
+   ```
+
+Twilio (`TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN`) and Plivo
+(`PLIVO_AUTH_ID` / `PLIVO_AUTH_TOKEN`) work the same way with
+`provider: twilio` / `provider: plivo`.
+
+## How conversations work
+
+When a caller speaks, the transcript becomes a normal Hermes message from
+their phone number — the agent has its usual session, memory, and tools.
+The agent's reply is spoken back on the call (markdown and URLs are
+stripped automatically; the agent is prompted to answer in short spoken
+sentences).
+
+Sessions are keyed `per-phone` by default — the same caller keeps one
+ongoing conversation across calls. Set `session_scope: per-call` for a
+fresh session on every call.
+
+## Control surfaces
+
+- **Model tool** `voice_call`: `initiate_call`, `continue_call`,
+  `speak_to_user`, `send_dtmf`, `end_call`, `get_status`.
+- **CLI**: `hermes voicecall status [--json] | call | speak | continue |
+  dtmf | end | doctor | tail`.
+- **Slash command**: `/voicecall status`, `/voicecall call --to +1555...
+  --message "..."`, `/voicecall end --call-id ID`.
+
+## Configuration reference
+
+```yaml
+gateway:
+  platforms:
+    voice_call:
+      enabled: true
+      extra:
+        provider: telnyx              # mock | telnyx | twilio | plivo
+        from_number: "+15551234567"
+        session_scope: per-phone      # per-phone | per-call
+        inbound_policy: allowlist     # disabled | allowlist | open
+        allow_from: ["+15557654321"]
+        inbound_greeting: "Hello, this is Hermes. How can I help?"
+        serve:
+          bind: "127.0.0.1"
+          port: 3334
+          path: "/voice/webhook"
+        public_url: null              # explicit public base URL, if you have one
+        tunnel:
+          provider: none              # none | ngrok | tailscale-serve | tailscale-funnel
+        outbound:
+          default_mode: notify        # notify | conversation
+          notify_hangup_delay_s: 3
+        timeouts:
+          max_call_s: 600
+          ring_s: 45
+          silence_s: 30
+        security:
+          skip_signature_verification: false   # dev only — logs a warning
+        realtime:
+          enabled: false              # speech-to-speech (telnyx/twilio only)
+          provider: openai            # openai | gemini
+```
+
+### Environment variables
+
+| Variable | Used for |
+|---|---|
+| `TELNYX_API_KEY`, `TELNYX_CONNECTION_ID`, `TELNYX_PUBLIC_KEY` | Telnyx |
+| `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` | Twilio |
+| `PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN` | Plivo |
+| `VOICE_CALL_FROM_NUMBER` | caller ID if not in config |
+| `VOICE_CALL_ALLOWED_NUMBERS` | inbound allowlist (comma-separated) |
+| `VOICE_CALL_HOME_NUMBER` | cron/notification call target |
+| `NGROK_AUTHTOKEN`, `NGROK_DOMAIN` | ngrok tunnel |
+| `OPENAI_API_KEY` / `GEMINI_API_KEY` | realtime voice models |
+
+## Security notes
+
+- **Webhook signatures are verified by default** (Telnyx Ed25519, Twilio
+  HMAC-SHA1, Plivo HMAC-SHA1 v3). `skip_signature_verification: true` is
+  for local development only and logs a warning at every startup.
+- **Inbound calls are deny-by-default**: `allowlist` only admits numbers in
+  `allow_from`; `open` accepts anyone and must be set explicitly.
+- The webhook server also enforces body-size limits, per-IP request
+  limits, and replay deduplication.
+- Keep credentials in `~/.hermes/.env`. They are never logged, and
+  `hermes voicecall doctor` reports presence only — never values.
+
+## Troubleshooting
+
+- **"runtime is not running"** — start `hermes gateway run` with the
+  platform enabled.
+- **Inbound calls never arrive** — check the carrier's webhook URL points
+  at your `public_url`/tunnel + `/voice/webhook`, and that
+  `hermes voicecall doctor` shows the tunnel resolved.
+- **Caller gets rejected** — their number isn't in `allow_from`
+  (E.164 format, e.g. `+15557654321`).
+- **Port already in use** — change `serve.port`; the gateway retries
+  automatically once the conflict clears.
+- **Calls drop after 10 minutes** — that's `timeouts.max_call_s`; raise it.

--- a/website/docs/user-guide/features/voice-call.md
+++ b/website/docs/user-guide/features/voice-call.md
@@ -113,7 +113,10 @@ fresh session on every call.
 - **Model tool** `voice_call`: `initiate_call`, `continue_call`,
   `speak_to_user`, `send_dtmf`, `end_call`, `get_status`.
 - **CLI**: `hermes voicecall status [--json] | call | speak | continue |
-  dtmf | end | doctor | tail`.
+  dtmf | end | doctor | tail [-f]`. `call` defaults to **conversation**
+  mode (pass `--mode notify` for speak-and-hang-up), and `-t/--to` is
+  optional when `to_number` is configured — `hermes voicecall call -m
+  "call me when you see this"` just works.
 - **Slash command**: `/voicecall status`, `/voicecall call --to +1555...
   --message "..."`, `/voicecall end --call-id ID`.
 
@@ -127,6 +130,7 @@ gateway:
       extra:
         provider: telnyx              # mock | telnyx | twilio | plivo
         from_number: "+15551234567"
+        to_number: "+15557654321"     # optional default destination for outbound calls
         session_scope: per-phone      # per-phone | per-call
         inbound_policy: allowlist     # disabled | allowlist | open
         allow_from: ["+15557654321"]
@@ -160,6 +164,7 @@ gateway:
 | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` | Twilio |
 | `PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN` | Plivo |
 | `VOICE_CALL_FROM_NUMBER` | caller ID if not in config |
+| `VOICE_CALL_TO_NUMBER` | default outbound destination if not in config |
 | `VOICE_CALL_ALLOWED_NUMBERS` | inbound allowlist (comma-separated) |
 | `VOICE_CALL_HOME_NUMBER` | cron/notification call target |
 | `NGROK_AUTHTOKEN`, `NGROK_DOMAIN` | ngrok tunnel |

--- a/website/docs/user-guide/features/voice-call.md
+++ b/website/docs/user-guide/features/voice-call.md
@@ -208,6 +208,38 @@ history.
 Conversation-mode calls use the realtime bridge; `notify` calls keep
 plain carrier TTS (cheaper and sufficient for one-shot messages).
 
+## Keeping calls fast
+
+A phone call is the most latency-sensitive surface Hermes has. Three
+settings make the difference between a 10-second answer and a 90-second
+one:
+
+1. **Restrict the voice session's toolset** (top-level config, not under
+   the platform). The agent answers fastest when it can't wander into
+   slow tools — this mirrors OpenClaw's `safe-read-only` consult policy:
+
+   ```yaml
+   platform_toolsets:
+     voice_call:
+     - search          # web_search only — not web_extract/browsing
+     - memory
+     - session_search
+     - messaging       # "text me the details" works mid-call
+   ```
+
+2. **Keep `responder.thinking_phrase` set** — it's spoken while consults
+   run so callers don't wonder if the line dropped.
+
+3. **Point slow auxiliary work at a fast model.** Deep research
+   (`web_extract` content processing) uses your main provider by
+   default; configuring `auxiliary.web_extract` with a fast model helps
+   any platform, voice most of all.
+
+Consult questions are automatically framed with a speed contract (answer
+in 1–3 spoken sentences, at most one quick search), and you can lower
+reasoning effort for just the voice session by texting it
+`/reasoning low` once.
+
 ## Security notes
 
 - **Webhook signatures are verified by default** (Telnyx Ed25519, Twilio


### PR DESCRIPTION
## What does this PR do?

Adds a native Hermes `voice_call` gateway platform plugin that lets Hermes make and receive real PSTN phone calls through carrier APIs: Telnyx by default, plus Twilio, Plivo, and a credential-free mock provider for development/tests.

This is a Hermes-native port of the OpenClaw voice-call extension. The important architecture choice is that this is a **gateway platform plugin**, not a lazy-only tool runtime: carrier webhooks must have an always-on listener for inbound calls, so the plugin starts its webhook/media server in `VoiceCallAdapter.connect()` and tears it down in `disconnect()`. Model/tool/CLI/slash commands then drive that running gateway runtime.

At a high level this PR adds:

- outbound `notify` calls (speak a message and hang up) and `conversation` calls (stay on the line);
- inbound calls gated by `disabled` / `allowlist` / `open` policy;
- per-phone or per-call Hermes session scoping, with caller speech routed through normal gateway `MessageEvent`s so voice calls get the existing session/history/tool/memory behavior;
- a provider-neutral call manager, JSONL call persistence, boot restore/verify, timers, DTMF, transcript waiters, and clean command errors when calls race hangups;
- a layered webhook security pipeline with provider signatures, request limits, replay dedupe, and provider API host guards;
- optional realtime speech-to-speech for Telnyx/Twilio media streams using OpenAI Realtime or Gemini Live, including barge-in, one-shot stream tokens, `agent_consult`, model-driven hangup, and a no-carrier-TTS invariant while realtime owns the call audio.

## Related Issue

No dedicated issue to close.

Related prior art / overlap checked:

- #27040 proposes a generic external `voice_server` gateway protocol. This PR does not depend on it; it keeps provider/webhook/call-manager internals in a bundled platform plugin while routing caller transcripts through the existing gateway message path.
- #48480 was an earlier closed Twilio-oriented voice-calling plugin PR.
- #17470 / #17479 are GigaCaller backend PRs. This PR is broader carrier-platform work (`mock`, Telnyx, Twilio, Plivo) and includes the platform lifecycle, provider abstraction, security pipeline, realtime bridge, docs, and focused tests.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added the `voice_call` platform plugin under `plugins/platforms/voice_call/`:
  - `plugin.yaml`, `__init__.py`, `adapter.py` register the platform, model tool, `hermes voicecall` CLI, and `/voicecall` command with `hasattr` guards for minimal plugin contexts.
  - `config.py` parses `gateway.platforms.voice_call.extra` with env fallbacks, E.164 validation, provider credential presence checks, public webhook validation, tunnel options, outbound defaults, timeout/security settings, and realtime config.
  - `runtime.py` owns the provider, store, call manager, webhook server, optional tunnel, optional realtime bridge, and pre-shared admin token.
  - `events.py`, `manager.py`, and `store.py` implement provider-neutral normalized events, call lifecycle state, timers, transcript waiters, notify/conversation behavior, notify-to-conversation upgrade, JSONL persistence, log compaction, and boot restore with provider status verification.
  - `webhook.py` serves carrier webhooks, realtime media WebSocket upgrades, and the localhost CLI admin endpoint from one aiohttp app.
  - `responder.py` maps final caller transcripts into gateway `MessageEvent`s and strips markdown/URLs/code before agent replies are spoken back to callers.
  - `audio.py` vendors dependency-free G.711 µ-law codec/resampling/framing helpers for Python 3.13 compatibility.

- Added provider implementations:
  - `providers/mock.py` for no-credential dev/test calls and pre-normalized webhook events.
  - `providers/telnyx.py` for Call Control v2, Ed25519 webhook verification, client-state call binding, carrier speak/transcription/DTMF/status, bidirectional PCMU/RTP streaming fields, and Telnyx mid-call `streaming_start` upgrades.
  - `providers/twilio.py` for REST + TwiML, HMAC-SHA1 webhook verification with port-variant retry, `<Say>` / `<Gather>` conversation flow, DTMF, status mapping, and realtime `<Connect><Stream>` response finalization.
  - `providers/plivo.py` for REST + XML/GetInput, HMAC-SHA256 V3 verification with V2 fallback, transfer-leg speak flow, DTMF/status/hangup, and provider-call-id adoption.
  - `providers/_http.py` for guarded carrier HTTP requests pinned to fixed provider hosts with bounded error bodies.

- Added realtime voice support:
  - `realtime/base.py` defines the plugin-local realtime session interface, `agent_consult`, `end_call`, default live-call instructions, and waiting etiquette.
  - `realtime/frames.py` ports Telnyx/Twilio stream frame adapters.
  - `realtime/openai_realtime.py` uses the GA OpenAI Realtime API shape with native `audio/pcmu` pass-through and tool-call handling from both `function_call_arguments.done` and `response.done`.
  - `realtime/gemini_live.py` supports Gemini Live with PCM resampling, server barge-in events, and tool response round-trips.
  - `realtime/bridge.py` adds one-shot stream tokens, media pumps, drift-corrected 20 ms audio pacing, barge-in clear/cancel, transcript mirroring, gateway-backed `agent_consult`, deferred tool-result delivery while a response is active, per-call realtime instructions, mid-call notify-to-realtime upgrade, and model-requested hangup.

- Added user/operator surfaces:
  - `voice_call` tool actions: `initiate_call`, `continue_call`, `speak_to_user`, `send_dtmf`, `end_call`, `get_status`.
  - Cross-process tool fallback to the gateway admin endpoint, so a non-gateway agent process can still place/manage calls when the gateway runtime is running.
  - `hermes voicecall status|call|speak|continue|dtmf|end|doctor|tail`, including `-t/--to`, `-m/--message`, `--instructions`, `--might-continue`, configured `to_number` fallback, and `tail -f`.
  - `/voicecall status|call|speak|dtmf|end`.

- Added docs:
  - `plugins/platforms/voice_call/README.md` for plugin architecture, mock quickstart, provider-specific env requirements, live carrier smoke checklist, and focused test command.
  - `plugins/platforms/voice_call/SKILL.md` as plugin-local agent guidance for when/how to call, modes, speaking style, DTMF, incoming calls, and state checks.
  - `website/docs/user-guide/features/voice-call.md` with setup, provider/env/config reference, Telnyx/Twilio/Plivo setup, live provider testing steps, realtime mode, latency guidance, security notes, and troubleshooting.

- Added dependency/lazy-dep wiring:
  - `pyproject.toml` adds the `voice-call` extra for `aiohttp==3.13.4`.
  - `tools/lazy_deps.py` adds `platform.voice_call` so lean installs can lazy-install aiohttp for the webhook/media server.

- Added and expanded tests:
  - `tests/plugins/platforms/voice_call/` covers config, registration, manager state/timers, runtime/store, CLI parity, tool/slash behavior, webhook security, provider conformance, Telnyx/Twilio/Plivo request/signature parsing, audio codec/resampling, realtime frame adapters, and the realtime bridge.
  - `tests/gateway/test_voice_call_platform.py` covers adapter connect/disconnect, fatal config handling, inbound transcript to gateway event routing, per-call session threading, agent reply speech, and webhook port release.
  - `tests/gateway/test_plugin_platform_interface.py` now points at the repo root instead of `tests/` and its mock plugin context tolerates non-platform registrations, so platform plugins that also register CLI/tool/slash surfaces can still be inspected.

## How to Test

1. Focused automated suite:

   ```bash
   scripts/run_tests.sh \
     tests/plugins/platforms/voice_call \
     tests/gateway/test_voice_call_platform.py \
     -q
   ```

   Local result: `208 tests passed, 0 failed` (macOS local checkout; tests that bind the webhook server require localhost bind permission).

2. Mock provider smoke test:

   ```yaml
   gateway:
     platforms:
       voice_call:
         enabled: true
         extra:
           provider: mock
           from_number: "+15555550000"
           inbound_policy: allowlist
           allow_from: ["+15555550001"]
   ```

   ```bash
   hermes gateway run
   hermes voicecall status --json
   hermes voicecall call --to +15555550001 --message "Hello from Hermes"
   hermes voicecall tail --lines 8
   ```

3. Live provider smoke path:

   Provider credentials belong in the Hermes env file, `~/.hermes/.env`, while non-secret platform behavior belongs in `~/.hermes/config.yaml` under `gateway.platforms.voice_call.extra`.

   Required provider envs:

   | Provider | Required `.env` keys |
   |---|---|
   | Telnyx | `TELNYX_API_KEY`, `TELNYX_CONNECTION_ID`, `TELNYX_PUBLIC_KEY` |
   | Twilio | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` |
   | Plivo | `PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN` |

   Optional shared envs include `VOICE_CALL_ENABLED`, `VOICE_CALL_PROVIDER`, `VOICE_CALL_FROM_NUMBER`, `VOICE_CALL_TO_NUMBER`, `VOICE_CALL_ALLOWED_NUMBERS`, `VOICE_CALL_PUBLIC_URL`, `NGROK_AUTHTOKEN`, and `NGROK_DOMAIN`. Realtime mode additionally needs `OPENAI_API_KEY` or `GEMINI_API_KEY`.

   Configure `provider: telnyx`, `provider: twilio`, or `provider: plivo`; set `from_number`; expose the webhook with `public_url` or an ngrok tunnel; point the carrier webhook at `<public-url>/voice/webhook`; restart `hermes gateway run` in one terminal after changing `.env`; then run this in another terminal:

   ```bash
   hermes voicecall doctor
   hermes voicecall call --to +1555... --message "Hello from Hermes" --mode notify
   hermes voicecall tail --lines 20
   ```

4. Optional realtime smoke path:

   - Configure `provider: telnyx` or `provider: twilio`.
   - Set `realtime.enabled: true` and add `OPENAI_API_KEY` or `GEMINI_API_KEY` to `~/.hermes/.env`.
   - Place a `conversation` call and verify low-latency audio, barge-in, transcript mirroring, and model-requested hangup.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout; focused voice-call suite passed (`208 passed`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (`voice_call` uses plugin `gateway.platforms.voice_call.extra` config, documented in the user guide)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (`plugin.yaml` declares Linux/macOS; webhook/tunnel/carrier runtime is not advertised as Windows-supported)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused suite:

```text
=== Summary: 14 files, 208 tests passed, 0 failed (100% complete) in 9.9s (20 workers) ===
```

Local manual smoke artifacts reviewed while preparing this PR description:

- a live smoke script exercising `notify -> speak -> continue -> end`, including the `--might-continue` path that holds a notify call open for a follow-up;
- operator-local JSON examples for multi-question call flows. These remain untracked because they are smoke artifacts, not reusable test fixtures.

Additional local note: `scripts/run_tests.sh tests/gateway/test_plugin_platform_interface.py -q` currently reports `136 passed, 1 failed` in the clean-env runner because the existing `sms` platform adapter constructor reads `TWILIO_ACCOUNT_SID` from the environment when built from a synthetic config. That failure is outside `voice_call`; the focused `voice_call` plugin and gateway adapter suite above passes.
