### PR TITLE
fix(tools): guard against catastrophic content loss in background review patches

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -888,6 +888,32 @@ def _patch_skill(
     if err:
         return {"success": False, "error": err}
 
+    # Guard against catastrophic content loss from background review patches.
+    # The review agent may hallucinate old_string from the conversation
+    # transcript without reading the skill first.  When fuzzy matching
+    # finds a partial match, the replacement can silently delete most of the
+    # file.  Reject patches that shrink the file by more than 50% when
+    # called from a background review context (issue #55647).
+    try:
+        from tools.skill_provenance import is_background_review
+        if is_background_review() and len(content) > 0:
+            original_len = len(content)
+            new_len = len(new_content)
+            if new_len < original_len * 0.5:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Patch rejected: would reduce '{target_label}' from "
+                        f"{original_len} to {new_len} characters "
+                        f"({100 - new_len * 100 // original_len}% loss). "
+                        "Background review patches must not delete more than "
+                        "50% of a file. Read the skill with skill_view first, "
+                        "then make a targeted patch."
+                    ),
+                }
+    except Exception:
+        pass
+
     # If patching SKILL.md, validate frontmatter is still intact
     if not file_path:
         err = _validate_frontmatter(new_content)


### PR DESCRIPTION
## Summary
Adds a content-loss guard in `_patch_skill` to prevent the background review agent from silently corrupting skills via hallucinated patches.

## Problem (P1 #55647)
The background review agent can call `skill_manage(patch)` on a skill it has **not read** via `skill_view`. When the model hallucinates `old_string` from the conversation transcript alone, fuzzy matching may find a partial match and the replacement silently deletes most of the file. **Observed: 807 lines → 186 lines** in a real session.

## Fix
When `_patch_skill` is called from a background review context (`is_background_review()`), reject patches that would shrink the target file by more than 50%. The error message instructs the agent to read the skill first with `skill_view` before making targeted patches.

## Changes
- `tools/skill_manager_tool.py`: Add content-loss guard after size validation in `_patch_skill` (26 lines added)

Fixes #55647