### PR TITLE
fix(agent): handle list type in Gemini schema enum sanitization

### DIFF
--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -83,7 +83,10 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
     # model enough guidance; the tool handler still validates the value.
     enum_val = cleaned.get("enum")
     type_val = cleaned.get("type")
-    if isinstance(enum_val, list) and type_val in {"integer", "number", "boolean"}:
+    # type_val may be a JSON Schema array (e.g. ["string", "null"]) —
+    # ``in {...}`` would raise TypeError: unhashable type: 'list'.
+    # Only check for enum/type collision when type_val is a scalar string.
+    if isinstance(enum_val, list) and isinstance(type_val, str) and type_val in {"integer", "number", "boolean"}:
         if any(not isinstance(item, str) for item in enum_val):
             cleaned.pop("enum", None)
 


### PR DESCRIPTION
## Summary
Fixes `TypeError: unhashable type: 'list'` crash when a tool parameter declares `type` as a JSON Schema array (e.g. `["string", "null"]`) and also has an `enum`.

## Problem (P2 #55645)
In `sanitize_gemini_schema()`, the check `type_val in {"integer", "number", "boolean"}` hashes the value. When `type_val` is a list (standard JSON Schema nullable form), this raises `TypeError`. The crash happens before any request is sent, so **every turn fails** for that session.

## Fix
Add `isinstance(type_val, str)` guard before the set membership test. Array-typed properties skip the enum/type collision check.

## Changes
- `agent/gemini_schema.py`: Add type guard (1 line changed, 3 lines added for comment)

Fixes #55645