### PR TITLE
fix(cli): add CREATE_BREAKAWAY_FROM_JOB to windows_hide_flags()

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -198,7 +198,7 @@ def windows_hide_flags() -> int:
     """
     if not IS_WINDOWS:
         return 0
-    return _CREATE_NO_WINDOW
+    return _CREATE_NO_WINDOW | _CREATE_BREAKAWAY_FROM_JOB
 
 
 def windows_detach_popen_kwargs() -> dict:


### PR DESCRIPTION
## Summary
Adds `CREATE_BREAKAWAY_FROM_JOB` to `windows_hide_flags()` so subprocess console windows don't flash when Hermes runs inside an Electron/Tauri wrapper.

## Problem (P2 #55604)
`windows_hide_flags()` returns only `CREATE_NO_WINDOW` (0x08000000). Inside an Electron Job Object, `CREATE_NO_WINDOW` is silently ignored — cmd.exe flashes on every subprocess spawn.

## Fix
Add `CREATE_BREAKAWAY_FROM_JOB` (0x01000000) so child processes escape the parent Job Object. This flag already exists in the module and is used by `windows_detach_flags()`.

## Changes
- `hermes_cli/_subprocess_compat.py`: 1 line changed

Fixes #55604