### PR TITLE
fix(moa): resolve Copilot api_mode per-model so mixed GPT-5.x + Claude presets work

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -94,6 +94,37 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
 
         rt = resolve_runtime_provider(requested=provider, target_model=model)
         resolved_provider = str(rt.get("provider") or provider).strip().lower()
+
+        # Copilot serves models on DIFFERENT endpoints by model family: GPT-5.x
+        # require the Responses API (codex_responses) while Claude / Gemini stay
+        # on chat_completions. ``resolve_runtime_provider`` derives api_mode from
+        # the *session* default model, not this slot's model, so within one MoA
+        # preset it can't distinguish a gpt-5.5 reference from a claude
+        # aggregator — every Copilot slot gets the session default's api_mode.
+        # That mismatch is doubly harmful because api_mode participates in the
+        # auxiliary client cache key: the first Copilot slot to build a client
+        # (say gpt-5.5 → Responses) poisons the cache for every later Copilot
+        # slot in the same turn, so the Claude models reuse the Responses client
+        # and 400 with "model claude-* does not support Responses API" (and,
+        # symmetrically, a Claude-first ordering 400s the gpt-5.x slot on
+        # chat_completions). Resolve api_mode from THIS slot's own model via the
+        # canonical per-model resolver and keep the provider identified by name
+        # (no base_url → call_llm builds the real Copilot request, not a generic
+        # custom endpoint). Pinning the correct per-model api_mode also keys the
+        # client cache per-mode, so mixed GPT-5.x + Claude presets stop poisoning
+        # each other.
+        if resolved_provider == "copilot":
+            try:
+                from hermes_cli.models import copilot_model_api_mode
+
+                out["api_mode"] = copilot_model_api_mode(model)
+            except Exception:
+                # Fall back to the runtime-resolved api_mode (best effort) so a
+                # resolver import/lookup failure still attempts the call.
+                if rt.get("api_mode"):
+                    out["api_mode"] = rt["api_mode"]
+            return out
+
         # call_llm treats an explicit base_url as a custom endpoint. That is
         # correct for ordinary OpenAI-compatible targets, but wrong for OAuth /
         # provider-backed targets whose provider branch adds auth refresh,

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -200,6 +200,136 @@ def test_moa_codex_slot_preserves_provider_identity(monkeypatch):
     assert rt == {"provider": "openai-codex", "model": "gpt-5.5"}
 
 
+def test_moa_copilot_slot_resolves_api_mode_per_model(monkeypatch):
+    """Copilot slots must resolve api_mode from the SLOT's model, not the
+    session default.
+
+    Copilot serves GPT-5.x via the Responses API (codex_responses) and Claude
+    via chat_completions. ``resolve_runtime_provider`` derives api_mode from the
+    session default model, so for a Copilot slot it returns the same mode for
+    every model in a preset. ``_slot_runtime`` must override that by resolving
+    api_mode from each slot's own model via ``copilot_model_api_mode`` — and
+    must keep the provider identified by name (no base_url) so call_llm builds
+    the real Copilot request instead of a generic custom endpoint.
+    """
+    from agent import moa_loop
+
+    # resolve_runtime_provider returns the (wrong, session-default) mode for
+    # every Copilot model — the bug this fix works around.
+    def fake_resolve(*, requested, target_model=None):
+        return {
+            "provider": "copilot",
+            "api_mode": "chat_completions",  # session default leaks to all slots
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-token",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve
+    )
+
+    # Per-model resolver: GPT-5.x → responses, everything else → chat.
+    def fake_copilot_mode(model_id, **_kwargs):
+        return "codex_responses" if str(model_id).startswith("gpt-5") else "chat_completions"
+
+    monkeypatch.setattr(
+        "hermes_cli.models.copilot_model_api_mode", fake_copilot_mode
+    )
+
+    gpt = moa_loop._slot_runtime({"provider": "copilot", "model": "gpt-5.5"})
+    claude = moa_loop._slot_runtime({"provider": "copilot", "model": "claude-opus-4.8"})
+
+    # api_mode comes from the slot's OWN model, not the shared session default.
+    assert gpt["api_mode"] == "codex_responses"
+    assert claude["api_mode"] == "chat_completions"
+    # Provider stays identified by name; no base_url flattening to custom.
+    assert gpt["provider"] == "copilot" and "base_url" not in gpt
+    assert claude["provider"] == "copilot" and "base_url" not in claude
+
+
+def test_moa_mixed_copilot_preset_does_not_cross_contaminate_api_mode(monkeypatch):
+    """A mixed Copilot preset (GPT-5.x reference + Claude aggregator) must give
+    each model its own api_mode.
+
+    Regression for the client-cache-poisoning failure: because api_mode is part
+    of the auxiliary client cache key, a single shared api_mode across Copilot
+    slots let the first-built client (e.g. gpt-5.5 → Responses) poison the cache
+    for later Claude slots, which then 400'd with "does not support Responses
+    API". Resolving api_mode per model keys the cache per mode, so the modes the
+    slots request are mode-correct and never cross-contaminate.
+    """
+    from agent import moa_loop
+
+    def fake_resolve(*, requested, target_model=None):
+        return {
+            "provider": "copilot",
+            "api_mode": "chat_completions",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-token",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve
+    )
+
+    def fake_copilot_mode(model_id, **_kwargs):
+        return "codex_responses" if str(model_id).startswith("gpt-5") else "chat_completions"
+
+    monkeypatch.setattr(
+        "hermes_cli.models.copilot_model_api_mode", fake_copilot_mode
+    )
+
+    preset_models = [
+        "gpt-5.5",            # Responses
+        "claude-sonnet-4.6",  # chat
+        "claude-opus-4.6",    # chat
+        "claude-opus-4.8",    # chat (aggregator)
+    ]
+    modes = {
+        m: moa_loop._slot_runtime({"provider": "copilot", "model": m})["api_mode"]
+        for m in preset_models
+    }
+
+    assert modes["gpt-5.5"] == "codex_responses"
+    assert modes["claude-sonnet-4.6"] == "chat_completions"
+    assert modes["claude-opus-4.6"] == "chat_completions"
+    assert modes["claude-opus-4.8"] == "chat_completions"
+    # The GPT-5.x Responses mode must NOT leak onto any Claude slot.
+    assert {modes[m] for m in preset_models if m.startswith("claude")} == {"chat_completions"}
+
+
+def test_moa_copilot_slot_falls_back_when_per_model_resolver_unavailable(monkeypatch):
+    """If the per-model Copilot resolver raises, the slot still attempts the
+    call using the runtime-resolved api_mode rather than aborting."""
+    from agent import moa_loop
+
+    def fake_resolve(*, requested, target_model=None):
+        return {
+            "provider": "copilot",
+            "api_mode": "chat_completions",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-token",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve
+    )
+
+    def boom(model_id, **_kwargs):
+        raise RuntimeError("catalog unavailable")
+
+    monkeypatch.setattr(
+        "hermes_cli.models.copilot_model_api_mode", boom
+    )
+
+    rt = moa_loop._slot_runtime({"provider": "copilot", "model": "gpt-5.5"})
+    # Provider identity preserved; falls back to the runtime-resolved api_mode.
+    assert rt["provider"] == "copilot"
+    assert rt["model"] == "gpt-5.5"
+    assert rt["api_mode"] == "chat_completions"
+    assert "base_url" not in rt
+
+
 @pytest.mark.parametrize("provider", ["anthropic", "minimax-oauth", "qwen-oauth"])
 def test_moa_provider_backed_slot_survives_aux_resolution(monkeypatch, provider):
     """MoA can pass resolved endpoints for provider-backed slots without


### PR DESCRIPTION
## Summary

A MoA preset that mixes Copilot models served on **different API surfaces** fails. Concretely: a `gpt-5.5` reference (Copilot serves GPT-5.x only via the **Responses API**) sitting alongside Claude references/aggregator (`chat_completions`) produces `400` errors on some slots:

- `model "gpt-5.5" is not accessible via the /chat/completions endpoint`, or
- `model claude-sonnet-4.6 does not support Responses API`

…depending on slot ordering. This is the high-value MoA case — a cross-vendor OpenAI perspective next to Anthropic models, all on a single Copilot subscription — so it's worth getting right.

## Root cause

`agent/moa_loop.py::_slot_runtime` takes `api_mode` from `resolve_runtime_provider`, which derives it from the **session default** model, not the slot's model. So every Copilot slot in a preset receives the *same* api_mode.

Because `api_mode` is part of the auxiliary client **cache key** (`_get_cached_client` → `_client_cache_key`), the first Copilot slot to build a client poisons the cache for every later Copilot slot in that turn:

- gpt-5.5 builds first → Responses-mode client cached for `copilot` → the Claude slots reuse it → `400 does not support Responses API`.
- (Symmetrically, a Claude-first ordering caches a chat_completions client and 400s the gpt-5.x slot.)

The bug is order-dependent and only manifests with a **mixed-family** Copilot preset, which is why single-model checks pass while the real preset fails.

## Fix

In `_slot_runtime`, for Copilot slots resolve `api_mode` from the **slot's own model** via the canonical `copilot_model_api_mode()` (GPT-5.x → `codex_responses`, Claude/Gemini → `chat_completions`), and keep the provider identified by name (no `base_url`, so `call_llm` builds the real Copilot request rather than a generic custom endpoint). Pinning the correct per-model api_mode also keys the client cache per-mode, so a mixed preset stops cross-contaminating. Falls back to the runtime-resolved api_mode if the per-model resolver is unavailable.

The change is scoped to the Copilot branch; `nous` / `openai-codex` / `xai-oauth` identity preservation and the generic `base_url`/`api_key`/`api_mode` forwarding path are untouched.

## Test plan

- [x] Three new regression tests in `tests/run_agent/test_moa_loop_mode.py`:
  - per-model api_mode resolution (gpt-5.5 → responses, claude → chat) with provider identity preserved
  - mixed-preset **no-cross-contamination** invariant (the cache-poisoning regression)
  - resolver-unavailable fallback path
- [x] `tests/run_agent/test_moa_loop_mode.py` — 23 passed
- [x] MoA + auxiliary suites (`test_moa_config`, `test_moa_command`, `test_moa_one_shot_restore`, `test_moa_reference_emit`, `test_auxiliary_client`) — **325 passed, 0 failed**
- [x] **Live end-to-end** against the Copilot API: `gpt-5.5` + `claude-sonnet-4.6` + `claude-opus-4.6` references aggregated by `claude-opus-4.8`, all on the `copilot` provider — **0 reference failures** (previously 2–3 depending on slot order).

## Notes

- Behavior-contract tests (assert the invariant), not snapshots — no model lists or counts frozen.
- No new config keys, env vars, or tools; no change to prompt caching or message alternation.