### PR TITLE
fix(agent): add CJK future-ack and action markers to intent-ack continuation detector

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2341,6 +2341,14 @@ def looks_like_codex_intermediate_ack(
     has_future_ack = bool(
         re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
     )
+    # CJK future-ack patterns — \b word boundaries don't apply to CJK
+    # characters, so use substring matching instead.
+    if not has_future_ack:
+        _cjk_future_ack = (
+            "我来", "让我", "我先", "我可以", "我会",  # simplified
+            "我來", "讓我",  # traditional
+        )
+        has_future_ack = any(p in assistant_text for p in _cjk_future_ack)
     if not has_future_ack:
         return False
 
@@ -2364,6 +2372,13 @@ def looks_like_codex_intermediate_ack(
         "walkthrough",
         "report back",
         "summarize",
+        # CJK action markers (simplified + traditional)
+        "载入", "查看", "检查", "分析", "搜索",
+        "修复", "调试", "运行", "测试", "读取",
+        "打开", "执行", "总结", "查找", "扫描",
+        "載入", "檢查", "分析", "搜尋",
+        "修復", "偵錯", "執行", "讀取",
+        "開啟", "總結", "查找", "掃描",
     )
     workspace_markers = (
         "directory",
@@ -2379,6 +2394,9 @@ def looks_like_codex_intermediate_ack(
         "file tree",
         "files",
         "path",
+        # CJK workspace markers (simplified + traditional)
+        "目录", "文件夹", "文件", "路径", "项目", "代码库",
+        "目錄", "檔案夾", "檔案", "路徑", "專案", "程式碼庫",
     )
 
     assistant_mentions_action = any(marker in assistant_text for marker in action_markers)

--- a/tests/agent/test_intent_ack_continuation.py
+++ b/tests/agent/test_intent_ack_continuation.py
@@ -181,3 +181,58 @@ def test_long_response_is_not_treated_as_an_ack():
     assert not looks_like_codex_intermediate_ack(
         a, REPRO_USER, long_ack, msgs, require_workspace=False
     )
+
+
+# ── detector: CJK (non-English) support ──────────────────────────────────
+
+CJK_ACK = "我来查看一下服务器的状态，先检查最近的日志。"
+CJK_USER = "帮我看看服务器有没有问题"
+
+
+def test_cjk_future_ack_with_action_fires():
+    """CJK future-ack + action marker should trigger continuation."""
+    a = _agent(True, "chat_completions")
+    msgs = [{"role": "user", "content": CJK_USER}]
+    assert looks_like_codex_intermediate_ack(
+        a, CJK_USER, CJK_ACK, msgs, require_workspace=False
+    )
+
+
+def test_cjk_ack_with_workspace_fires_for_codex():
+    """CJK ack mentioning workspace should fire under codex_only mode."""
+    a = _agent("auto", "codex_responses")
+    cjk_code_ack = "让我先检查一下代码库的目录结构。"
+    msgs = [{"role": "user", "content": "帮我看看项目"}]
+    assert looks_like_codex_intermediate_ack(
+        a, "帮我看看项目", cjk_code_ack, msgs, require_workspace=True
+    )
+
+
+def test_cjk_ack_without_action_does_not_fire():
+    """CJK future-ack without action marker should NOT trigger."""
+    a = _agent(True, "chat_completions")
+    no_action = "我来帮你想想这个问题。"
+    msgs = [{"role": "user", "content": "帮我决定"}]
+    assert not looks_like_codex_intermediate_ack(
+        a, "帮我决定", no_action, msgs, require_workspace=False
+    )
+
+
+def test_cjk_ack_without_future_ack_does_not_fire():
+    """CJK action marker without future-ack should NOT trigger."""
+    a = _agent(True, "chat_completions")
+    no_future = "检查完毕，服务器状态正常。"
+    msgs = [{"role": "user", "content": CJK_USER}]
+    assert not looks_like_codex_intermediate_ack(
+        a, CJK_USER, no_future, msgs, require_workspace=False
+    )
+
+
+def test_traditional_chinese_future_ack_fires():
+    """Traditional Chinese future-ack patterns should also work."""
+    a = _agent(True, "chat_completions")
+    tc_ack = "我來檢查一下檔案系統的狀態。"
+    msgs = [{"role": "user", "content": "幫我看看"}]
+    assert looks_like_codex_intermediate_ack(
+        a, "幫我看看", tc_ack, msgs, require_workspace=False
+    )


### PR DESCRIPTION
## What does this PR do?

Adds CJK (Chinese/Japanese/Korean) patterns to the `looks_like_codex_intermediate_ack()` intent-ack continuation detector. Currently the detector only recognizes English future-ack phrases ("I'll", "let me", "I will") and English action/workspace markers, so intent-ack continuation **never fires** for non-English model responses — the user must manually type "please continue" every turn.

## Related Issue

Fixes #55664

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py`: Added CJK future-ack substring patterns (我来/我來, 让我/讓我, 我先, 我可以, 我会) as a fallback when the English regex doesn't match. Added CJK action markers (查看, 检查/檢查, 分析, etc.) and workspace markers (目录/目錄, 文件/檔案, 项目/專案, etc.) covering both simplified and traditional Chinese.
- `tests/agent/test_intent_ack_continuation.py`: Added 5 regression tests covering CJK future-ack + action firing, CJK workspace detection under codex_only mode, negative cases (future-ack without action, action without future-ack), and traditional Chinese support.

## How to Test

1. Run `pytest tests/agent/test_intent_ack_continuation.py -v` — all 19 tests should pass (14 existing + 5 new CJK tests)
2. The new tests verify: CJK ack fires with action marker, CJK workspace detection works, CJK ack without action does NOT fire, action without future-ack does NOT fire, traditional Chinese patterns work

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
