### PR TITLE
fix(slack): render clarify prompts as block kit buttons

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -439,6 +439,11 @@ class SlackAdapter(BasePlatformAdapter):
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}
+        # Track clarify prompt choices for Block Kit callbacks.  Values are
+        # short-lived: wait_for_response() clears the gateway entry on resolve
+        # or timeout, and callbacks pop this state after a concrete choice.
+        self._clarify_state: Dict[str, List[str]] = {}
+        self._CLARIFY_STATE_MAX = 500
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
@@ -1170,6 +1175,13 @@ class SlackAdapter(BasePlatformAdapter):
                 "hermes_confirm_cancel",
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
+
+            # Register Block Kit action handlers for clarify buttons.
+            for _action_id in (
+                *(f"hermes_clarify_choice_{index}" for index in range(24)),
+                "hermes_clarify_other",
+            ):
+                self._app.action(_action_id)(self._handle_clarify_action)
 
             # Register plugin-provided Block Kit action handlers.
             #
@@ -3269,6 +3281,105 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error("[Slack] send_slash_confirm failed: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a clarify prompt as Slack Block Kit buttons."""
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+
+        def _flatten_choice(choice: Any) -> str:
+            if choice is None:
+                return ""
+            if isinstance(choice, str):
+                return choice.strip()
+            if isinstance(choice, dict):
+                for key in ("label", "description", "text", "title"):
+                    value = choice.get(key)
+                    if isinstance(value, str) and value.strip():
+                        return value.strip()
+                return ""
+            if isinstance(choice, (list, tuple)):
+                return " ".join(_flatten_choice(item) for item in choice).strip()
+            return str(choice).strip()
+
+        question_text = str(question or "").strip() or "Please clarify."
+        clean_choices = [
+            text for text in (_flatten_choice(choice) for choice in (choices or [])) if text
+        ][:24]
+
+        if not clean_choices:
+            return await self.send(
+                chat_id=chat_id,
+                content=f"❓ {question_text}",
+                metadata=metadata,
+            )
+
+        try:
+            option_lines = "\n".join(
+                f"{index + 1}. {choice}" for index, choice in enumerate(clean_choices)
+            )
+            body = f"❓ *Hermes needs your input*\n\n{question_text}\n\n{option_lines}"
+            if len(body) > 3000:
+                body = body[:2997] + "..."
+
+            elements = [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": str(index + 1)},
+                    "action_id": f"hermes_clarify_choice_{index}",
+                    "value": f"{clarify_id}|{index}",
+                }
+                for index in range(len(clean_choices))
+            ]
+            elements.append({
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Other"},
+                "action_id": "hermes_clarify_other",
+                "value": clarify_id,
+            })
+
+            blocks = [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": body},
+                },
+                {
+                    "type": "actions",
+                    "elements": elements,
+                },
+            ]
+
+            kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "text": f"Hermes needs your input: {question_text[:150]}",
+                "blocks": blocks,
+            }
+            thread_ts = self._resolve_thread_ts(None, metadata)
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+
+            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            self._clarify_state[clarify_id] = clean_choices
+            if len(self._clarify_state) > self._CLARIFY_STATE_MAX:
+                for old_id in list(self._clarify_state)[: self._CLARIFY_STATE_MAX // 2]:
+                    self._clarify_state.pop(old_id, None)
+
+            return SendResult(
+                success=True,
+                message_id=result.get("ts", ""),
+                raw_response=result,
+            )
+        except Exception as e:
+            logger.error("[Slack] send_clarify failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
     def _is_interactive_user_authorized(
         self,
         user_id: str,
@@ -3435,6 +3546,129 @@ class SlackAdapter(BasePlatformAdapter):
                 exc,
                 exc_info=True,
             )
+
+    async def _handle_clarify_action(self, ack, body, action) -> None:
+        """Handle a clarify button click from Block Kit."""
+        await ack()
+
+        action_id = action.get("action_id", "")
+        value = action.get("value", "")
+        message = body.get("message", {})
+        msg_ts = message.get("ts", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        user_name = body.get("user", {}).get("name", "unknown")
+        user_id = body.get("user", {}).get("id", "")
+
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized clarify click by %s (%s) - ignoring",
+                user_name, user_id,
+            )
+            return
+
+        if action_id.startswith("hermes_clarify_choice_"):
+            if "|" not in value:
+                logger.warning("[Slack] Malformed clarify value: %s", value)
+                return
+            clarify_id, index_text = value.split("|", 1)
+            choices = self._clarify_state.get(clarify_id)
+            if choices is None:
+                logger.warning("[Slack] Clarify choice for stale id %s", clarify_id)
+                return
+            try:
+                index = int(index_text)
+            except ValueError:
+                logger.warning("[Slack] Malformed clarify index: %s", index_text)
+                return
+            if index < 0 or index >= len(choices):
+                logger.warning("[Slack] Clarify index out of range: %s", index_text)
+                return
+            response = str(choices[index])
+            try:
+                from tools.clarify_gateway import resolve_gateway_clarify
+
+                resolved = resolve_gateway_clarify(clarify_id, response)
+            except Exception as exc:
+                logger.error(
+                    "Failed to resolve Slack clarify button: %s",
+                    exc,
+                    exc_info=True,
+                )
+                return
+            if resolved:
+                self._clarify_state.pop(clarify_id, None)
+                decision_text = f"✅ {user_name} selected: {response}"
+            else:
+                self._clarify_state.pop(clarify_id, None)
+                logger.warning(
+                    "[Slack] Clarify resolver reported stale id %s",
+                    clarify_id,
+                )
+                decision_text = "⚠️ This clarify prompt expired. Please ask again."
+        elif action_id == "hermes_clarify_other":
+            clarify_id = value
+            if clarify_id not in self._clarify_state:
+                logger.warning("[Slack] Clarify Other for stale id %s", clarify_id)
+                return
+            try:
+                from tools.clarify_gateway import mark_awaiting_text
+
+                awaiting_text = mark_awaiting_text(clarify_id)
+            except Exception as exc:
+                logger.error(
+                    "Failed to mark Slack clarify for text response: %s",
+                    exc,
+                    exc_info=True,
+                )
+                return
+            if awaiting_text:
+                decision_text = f"✏️ {user_name}, type your answer in this thread."
+            else:
+                self._clarify_state.pop(clarify_id, None)
+                logger.warning(
+                    "[Slack] Clarify text mode failed for stale id %s",
+                    clarify_id,
+                )
+                decision_text = "⚠️ This clarify prompt expired. Please ask again."
+        else:
+            logger.warning("[Slack] Unknown clarify action: %s", action_id)
+            return
+
+        original_text = ""
+        for block in message.get("blocks", []):
+            if block.get("type") == "section":
+                original_text = block.get("text", {}).get("text", "")
+                break
+
+        updated_blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": original_text or "Clarify prompt",
+                },
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {"type": "mrkdwn", "text": decision_text[:3000]},
+                ],
+            },
+        ]
+
+        try:
+            await self._get_client(channel_id).chat_update(
+                channel=channel_id,
+                ts=msg_ts,
+                text=decision_text,
+                blocks=updated_blocks,
+            )
+        except Exception as e:
+            logger.warning("[Slack] Failed to update clarify message: %s", e)
 
     async def _handle_approval_action(self, ack, body, action) -> None:
         """Handle an approval button click from Block Kit."""

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -348,6 +348,135 @@ class TestSlackSlashConfirmAction:
 
 
 # ===========================================================================
+# send_clarify — Block Kit choice buttons
+# ===========================================================================
+
+class TestSlackClarifyButtons:
+    """Test Slack-native clarify prompts and Block Kit callbacks."""
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_sends_blocks_without_raw_json_text(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "3000.1"})
+
+        result = await adapter.send_clarify(
+            chat_id="C1",
+            question="Which deployment target?",
+            choices=["staging", "production"],
+            clarify_id="clarify-1",
+            session_key="agent:main:slack:group:C1:1111",
+            metadata={"thread_id": "2000.1"},
+        )
+
+        assert result.success is True
+        assert result.message_id == "3000.1"
+        mock_client.chat_postMessage.assert_awaited_once()
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        assert kwargs["channel"] == "C1"
+        assert kwargs["thread_ts"] == "2000.1"
+        assert kwargs["text"] == "Hermes needs your input: Which deployment target?"
+        assert "choices_offered" not in kwargs["text"]
+        assert "{" not in kwargs["text"]
+
+        blocks = kwargs["blocks"]
+        assert blocks[0]["type"] == "section"
+        section_text = blocks[0]["text"]["text"]
+        assert "Which deployment target?" in section_text
+        assert "1. staging" in section_text
+        assert "2. production" in section_text
+        action_ids = [element["action_id"] for element in blocks[1]["elements"]]
+        assert action_ids == [
+            "hermes_clarify_choice_0",
+            "hermes_clarify_choice_1",
+            "hermes_clarify_other",
+        ]
+        assert len(set(action_ids)) == len(action_ids)
+        assert adapter._clarify_state["clarify-1"] == ["staging", "production"]
+
+    @pytest.mark.asyncio
+    async def test_clarify_choice_resolves_gateway_entry(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._clarify_state["clarify-1"] = ["staging", "production"]
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        ack = AsyncMock()
+        body = {
+            "message": {
+                "ts": "3000.1",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": "Original clarify prompt"},
+                    },
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_OWNER"},
+        }
+        action = {
+            "action_id": "hermes_clarify_choice_1",
+            "value": "clarify-1|1",
+        }
+
+        with patch(
+            "tools.clarify_gateway.resolve_gateway_clarify",
+            return_value=True,
+        ) as mock_resolve:
+            await adapter._handle_clarify_action(ack, body, action)
+
+        ack.assert_awaited_once()
+        mock_resolve.assert_called_once_with("clarify-1", "production")
+        assert "clarify-1" not in adapter._clarify_state
+        mock_client.chat_update.assert_awaited_once()
+        update_kwargs = mock_client.chat_update.call_args[1]
+        assert "owner selected: production" in update_kwargs["text"]
+        assert update_kwargs["blocks"][0]["text"]["text"] == "Original clarify prompt"
+
+    @pytest.mark.asyncio
+    async def test_clarify_other_switches_to_text_capture(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._clarify_state["clarify-2"] = ["staging", "production"]
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        ack = AsyncMock()
+        body = {
+            "message": {
+                "ts": "3000.2",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": "Original clarify prompt"},
+                    },
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_OWNER"},
+        }
+        action = {
+            "action_id": "hermes_clarify_other",
+            "value": "clarify-2",
+        }
+
+        with patch(
+            "tools.clarify_gateway.mark_awaiting_text",
+            return_value=True,
+        ) as mock_mark:
+            await adapter._handle_clarify_action(ack, body, action)
+
+        ack.assert_awaited_once()
+        mock_mark.assert_called_once_with("clarify-2")
+        assert "clarify-2" in adapter._clarify_state
+        mock_client.chat_update.assert_awaited_once()
+        update_kwargs = mock_client.chat_update.call_args[1]
+        assert "type your answer" in update_kwargs["text"]
+
+
+# ===========================================================================
 # _fetch_thread_context
 # ===========================================================================
 


### PR DESCRIPTION
## What does this PR do?

Slack now renders gateway `clarify` prompts as a single Block Kit prompt with choice buttons instead of inheriting the generic numbered-text fallback. That keeps the user-facing Slack message to the question, choices, and buttons, so the clarify tool result JSON is not exposed as a second raw text payload under the interactive UI.

The callback path mirrors the existing gateway clarify contract used by other rich platforms: numeric choices resolve via `resolve_gateway_clarify`, "Other" switches the pending prompt into text-capture mode with `mark_awaiting_text`, and expired prompts update as expired instead of showing a false selection.

## Related Issue

Fixes #52374

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added Slack `send_clarify` Block Kit rendering in `plugins/platforms/slack/adapter.py`.
- Registered Slack clarify button action handlers for choice and "Other" callbacks.
- Added regression coverage in `tests/gateway/test_slack_approval_buttons.py` for safe Slack fallback text, choice resolution, and text-capture mode.

## How to Test

1. `uv run pytest tests/gateway/test_slack_approval_buttons.py::TestSlackClarifyButtons -q`
2. `uv run pytest tests/gateway/test_slack_approval_buttons.py -q`
3. `uv run pytest tests/gateway/test_slack.py -q`
4. From the contributor harness: `./scripts/check.sh`

Local proof: the new regression tests assert that the Slack API payload contains `blocks` and a safe fallback `text` of `Hermes needs your input: ...`, not raw clarify JSON, and that button callbacks resolve through the gateway clarify primitive.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1

I did not run the full local `pytest tests/ -q` suite; I ran the scoped Slack tests above plus the repository contributor gate (`./scripts/check.sh`), and the full suite should run in CI.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Relevant local checks passed:

- `uv run pytest tests/gateway/test_slack_approval_buttons.py::TestSlackClarifyButtons -q` — 3 passed
- `uv run pytest tests/gateway/test_slack_approval_buttons.py -q` — 29 passed
- `uv run pytest tests/gateway/test_slack.py -q` — 209 passed
- `./scripts/check.sh` — all blocking gates passed
