### PR TITLE
fix(image-gen): honor image_gen.model for Nous/OpenRouter provider

### DIFF
--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -245,14 +245,19 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
         return dict(self._setup_schema)
 
     def _resolve_model(self, explicit: Optional[str] = None) -> str:
-        """Pick the image model: env override → config → :data:`DEFAULT_MODEL`."""
+        """Pick the image model (first of :meth:`_resolve_model_chain`)."""
         return self._resolve_model_chain(explicit)[0]
 
     def _resolve_model_chain(self, explicit: Optional[str] = None) -> list[str]:
         """Ordered model attempts for this request.
 
-        Explicit user/model config means "use this exact model", so no fallback.
-        Without overrides we run the quality-first default chain.
+        Precedence: explicit caller override (the ``model`` kwarg) → the
+        provider's ``*_IMAGE_MODEL`` env override → scoped
+        ``image_gen.<provider>.model`` → top-level ``image_gen.model`` (written
+        by ``hermes tools``) → the quality-first default chain.
+
+        Any explicit user/model selection means "use this exact model", so no
+        fallback. Only the bare default chain carries a Gemini fallback.
         """
         if isinstance(explicit, str) and explicit.strip():
             return [explicit.strip()]

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -46,8 +46,9 @@ logger = logging.getLogger(__name__)
 # image model first, then fall back to Gemini 3 Pro Image if the OpenAI model
 # is access-gated / unavailable / times out on this endpoint.
 #
-# Explicit override (OPENROUTER_IMAGE_MODEL or image_gen.<provider>.model):
-# use exactly that model (no auto fallback), so power users keep full control.
+# Explicit override (OPENROUTER_IMAGE_MODEL, image_gen.<provider>.model, or
+# image_gen.model from ``hermes tools``): use exactly that model (no auto
+# fallback), so power users keep full control.
 DEFAULT_MODEL = "openai/gpt-5.4-image-2"
 _FALLBACK_MODEL = "google/gemini-3-pro-image"
 _DEFAULT_MODEL_CHAIN = (DEFAULT_MODEL, _FALLBACK_MODEL)
@@ -243,16 +244,18 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
     def get_setup_schema(self) -> Dict[str, Any]:
         return dict(self._setup_schema)
 
-    def _resolve_model(self) -> str:
+    def _resolve_model(self, explicit: Optional[str] = None) -> str:
         """Pick the image model: env override → config → :data:`DEFAULT_MODEL`."""
-        return self._resolve_model_chain()[0]
+        return self._resolve_model_chain(explicit)[0]
 
-    def _resolve_model_chain(self) -> list[str]:
+    def _resolve_model_chain(self, explicit: Optional[str] = None) -> list[str]:
         """Ordered model attempts for this request.
 
         Explicit user/model config means "use this exact model", so no fallback.
         Without overrides we run the quality-first default chain.
         """
+        if isinstance(explicit, str) and explicit.strip():
+            return [explicit.strip()]
         env_override = os.environ.get(self._model_env_var, "").strip()
         if env_override:
             return [env_override]
@@ -262,6 +265,9 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
             value = scoped.get("model")
             if isinstance(value, str) and value.strip():
                 return [value.strip()]
+        top = cfg.get("model")
+        if isinstance(top, str) and top.strip():
+            return [top.strip()]
         return _dedupe_models(list(_DEFAULT_MODEL_CHAIN))
 
     def generate(
@@ -297,7 +303,7 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
                 aspect_ratio=aspect_ratio,
             )
 
-        model_chain = self._resolve_model_chain()
+        model_chain = self._resolve_model_chain(kwargs.get("model"))
         aspect = resolve_aspect_ratio(aspect_ratio)
         or_aspect = _ASPECT_RATIOS.get(aspect, "1:1")
 

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -121,6 +121,26 @@ class TestProviderClass:
         with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=cfg):
             assert _openrouter()._resolve_model() == "google/gemini-3.1-flash-image-preview"
 
+    def test_model_top_level_config_override(self):
+        cfg = {"model": "openai/gpt-image-2"}
+        with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=cfg):
+            assert _openrouter()._resolve_model_chain() == ["openai/gpt-image-2"]
+
+    def test_nous_honors_top_level_model(self):
+        from plugins.image_gen.openrouter import _build_providers
+
+        cfg = {"model": "openai/gpt-image-2"}
+        nous = {p.name: p for p in _build_providers()}["nous"]
+        with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=cfg):
+            assert nous._resolve_model_chain() == ["openai/gpt-image-2"]
+
+    def test_explicit_model_kwarg_wins_over_config(self):
+        cfg = {"model": "openai/gpt-image-2"}
+        with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=cfg):
+            assert _openrouter()._resolve_model_chain("google/gemini-3-pro-image") == [
+                "google/gemini-3-pro-image"
+            ]
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -266,6 +286,17 @@ class TestGenerate:
 
         headers = mock_post.call_args.kwargs["headers"]
         assert headers["Authorization"] == "Bearer sk-or-test"
+
+    def test_generate_uses_model_kwarg_from_dispatch(self):
+        """image_generate passes image_gen.model as a model kwarg — honor it."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_chat_response([_PNG_DATA_URI])) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            result = _openrouter().generate(prompt="a pet", model="openai/gpt-image-2")
+
+        assert result["success"] is True
+        assert result["model"] == "openai/gpt-image-2"
+        assert mock_post.call_args.kwargs["json"]["model"] == "openai/gpt-image-2"
 
     def test_posts_to_resolved_base_url(self):
         """Nous routes to its own base URL — proves the same code serves both."""


### PR DESCRIPTION
## Summary
The OpenRouter/Nous image-gen provider now honors the model you actually selected — both the top-level `image_gen.model` config key (written by `hermes tools`) and an explicit `model` kwarg — instead of silently ignoring them and always running the quality-first default chain (`gpt-5.4-image-2` → `gemini-3-pro-image`).

Root cause: `_resolve_model_chain()` only read the scoped `image_gen.<provider>.model` key, while `hermes tools` writes the user's pick to top-level `image_gen.model` and the `image_generate` dispatch passes it as a `model` kwarg — both were dropped. This made OpenRouter/Nous the lone outlier among the multi-model image-gen plugins (krea/openai/openai-codex/xai already read top-level `image_gen.model`).

## Changes
- `plugins/image_gen/openrouter/__init__.py`: `_resolve_model{,_chain}` accept an `explicit` override (the `model` kwarg) and resolve top-level `image_gen.model`, matching the established sibling precedence: explicit kwarg → `*_IMAGE_MODEL` env → scoped `image_gen.<provider>.model` → top-level `image_gen.model` → default chain.
- Docstrings aligned to the new precedence (follow-up commit).
- Tests: top-level config override, Nous honoring top-level, explicit-kwarg-wins, and `generate(model=...)` end-to-end.

## Validation
| Config | Before (main) | After |
|---|---|---|
| `image_gen.model: openai/gpt-image-2` | `[gpt-5.4-image-2, gemini-3-pro-image]` (ignored) | `[openai/gpt-image-2]` |
| explicit `model` kwarg | dropped | wins over config |
| no config | default chain | default chain (unchanged) |

- `tests/plugins/image_gen/` — 167 passed.
- E2E with real `config.yaml` + real config loader (temp HERMES_HOME): 6/6 assertions pass (both nous + openrouter honor top-level model; explicit kwarg overrides; no-config falls back correctly).
- ruff + ty: clean.

## Credit
Based on #55655 by @xxxigm. Cherry-picked to preserve authorship; docstring alignment added on top.

Closes #55655
