### PR TITLE
docs(config): align max_turns example with actual default (90)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -610,10 +610,10 @@ skills:
 # Agent Behavior
 # =============================================================================
 agent:
-  # Maximum tool-calling iterations per conversation
+  # Maximum tool-calling iterations per conversation (default: 90)
   # Higher = more room for complex tasks, but costs more tokens
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
-  max_turns: 60
+  max_turns: 90
 
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving


### PR DESCRIPTION
## Summary
The example config (`cli-config.yaml.example`) shipped `max_turns: 60`, but the actual default used across the codebase is `90`:
- `hermes_cli/config.py` ? `DEFAULT_CONFIG["agent"]["max_turns"] = 90`
- `hermes_cli/_parser.py` ? `--max-turns` help text states "default: 90"
- `AGENTS.md` ? `AIAgent.__init__(max_iterations: int = 90)`

This aligns the example file with the real default and adds the `(default: 90)` annotation, matching the style already used for other keys in the same file (e.g. `compression:`).

## Validation
- Docs/config-only change - no runtime code touched
- YAML validity checked
- Checked open PRs: no overlap (#25865 touches a different file)
- Checked merged history: PR #4020/#4031 set the real default to 90 but never updated this example file - this PR closes that gap

## Related
Related to the default-value work done in #4020 / #4031 (example file was missed)