### PR TITLE
fix(skills): auto-load triggered skills in cli

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -25,6 +25,7 @@ _skill_commands_platform: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+_SKILL_TRIGGER_WORD = re.compile(r"^\w[\w\s-]*\w$|^\w$")
 
 # ---------------------------------------------------------------------------
 # Skill-scaffolding markers and the canonical extractor.
@@ -188,6 +189,79 @@ def _resolve_skill_commands_platform() -> Optional[str]:
     except Exception:
         resolved_platform = os.getenv("HERMES_PLATFORM")
     return resolved_platform or None
+
+
+def _extract_skill_triggers(frontmatter: Dict[str, Any]) -> list[str]:
+    """Return normalized auto-trigger phrases declared in skill frontmatter."""
+    metadata = frontmatter.get("metadata")
+    hermes_meta = metadata.get("hermes") if isinstance(metadata, dict) else None
+    raw_triggers = None
+    if isinstance(hermes_meta, dict):
+        raw_triggers = hermes_meta.get("triggers")
+    if raw_triggers is None:
+        raw_triggers = frontmatter.get("triggers")
+
+    if raw_triggers is None:
+        return []
+    if not isinstance(raw_triggers, list):
+        raw_triggers = [raw_triggers]
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in raw_triggers:
+        trigger = re.sub(r"\s+", " ", str(value or "").strip())
+        if not trigger:
+            continue
+        dedupe_key = trigger.casefold()
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        normalized.append(trigger)
+    return normalized
+
+
+def _compile_skill_trigger_pattern(trigger: str) -> re.Pattern[str]:
+    """Build a boundary-aware regex for a skill trigger phrase."""
+    normalized = re.sub(r"\s+", " ", trigger.strip())
+    body = r"\s+".join(re.escape(part) for part in normalized.split(" "))
+    if _SKILL_TRIGGER_WORD.fullmatch(normalized):
+        pattern = rf"\b{body}\b"
+    else:
+        pattern = rf"(?<!\w){body}(?!\w)"
+    return re.compile(pattern, re.IGNORECASE)
+
+
+def find_triggered_skill_command(
+    user_message: str,
+) -> tuple[str, Dict[str, Any], str] | None:
+    """Return the best matching skill command for a plain user message."""
+    if not isinstance(user_message, str):
+        return None
+
+    text = user_message.strip()
+    if not text or text.startswith("/"):
+        return None
+
+    best_match: tuple[int, int, str, str, Dict[str, Any]] | None = None
+    for cmd_key, skill_info in get_skill_commands().items():
+        for trigger in skill_info.get("triggers") or []:
+            if not _compile_skill_trigger_pattern(trigger).search(text):
+                continue
+            candidate = (
+                len(trigger),
+                len(skill_info.get("name") or ""),
+                cmd_key,
+                trigger,
+                skill_info,
+            )
+            if best_match is None or candidate > best_match:
+                best_match = candidate
+
+    if best_match is None:
+        return None
+
+    _, _, cmd_key, trigger, skill_info = best_match
+    return cmd_key, skill_info, trigger
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
     """Load a skill by name/path and return (loaded_payload, skill_dir, display_name)."""
@@ -414,6 +488,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     if name in disabled:
                         continue
                     description = frontmatter.get('description', '')
+                    triggers = _extract_skill_triggers(frontmatter)
                     if not description:
                         for line in body.strip().split('\n'):
                             line = line.strip()
@@ -459,6 +534,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
                         "skill_dir": str(skill_md.parent),
+                        "triggers": triggers,
                     }
                 except Exception:
                     continue

--- a/cli.py
+++ b/cli.py
@@ -4049,6 +4049,12 @@ def build_preloaded_skills_prompt(*args, **kwargs):
     return _impl(*args, **kwargs)
 
 
+def find_triggered_skill_command(*args, **kwargs):
+    from agent.skill_commands import find_triggered_skill_command as _impl
+
+    return _impl(*args, **kwargs)
+
+
 def get_skill_bundles() -> dict:
     global _skill_bundles
     if _skill_bundles is None:
@@ -13974,6 +13980,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     "2-3 sentences max. No code blocks or markdown.] "
                 )
 
+            def _resolve_skill_trigger_message(user_text: str) -> tuple[str, Optional[str]]:
+                matched = find_triggered_skill_command(user_text)
+                if not matched:
+                    return user_text, None
+
+                cmd_key, skill_info, trigger = matched
+                expanded = build_skill_invocation_message(
+                    cmd_key,
+                    user_instruction=user_text,
+                    task_id=self.session_id,
+                    runtime_note=f'Auto-activated from skill trigger "{trigger}".',
+                )
+                if not expanded:
+                    return user_text, None
+
+                _cprint(
+                    f"  {_DIM}⚡ Auto-loading skill: "
+                    f"{skill_info.get('name') or cmd_key.lstrip('/')} "
+                    f"(trigger: {trigger}){_RST}"
+                )
+                return expanded, user_text
+
             def run_agent():
                 nonlocal result
                 # Set callbacks inside the agent thread so thread-local storage
@@ -14004,7 +14032,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 except Exception:
                     reset_current_session_key = None  # type: ignore[assignment]
                     _approval_session_token = None
-                agent_message = _voice_prefix + message if _voice_prefix else message
+                agent_message = message
+                if isinstance(message, str):
+                    agent_message, _ = _resolve_skill_trigger_message(message)
+                agent_message = _voice_prefix + agent_message if _voice_prefix else agent_message
                 # Prepend pending notes via _prepend_note_to_message, which
                 # handles both plain-string and multimodal content-parts list
                 # messages. Naive ``note + "\n\n" + agent_message`` crashed with

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -10,6 +10,7 @@ import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
+    find_triggered_skill_command,
     resolve_skill_command_key,
     scan_skill_commands,
 )
@@ -34,7 +35,7 @@ description: Description for {name}.
 
 {body}
 """
-    (skill_dir / "SKILL.md").write_text(content)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir
 
 
@@ -52,11 +53,58 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
 
 class TestScanSkillCommands:
 
+    def test_reads_frontmatter_triggers(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "market-watch",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [market, EUR/USD, market]\n"
+                ),
+            )
+            result = scan_skill_commands()
 
+        assert result["/market-watch"]["triggers"] == ["market", "EUR/USD"]
 
+    def test_finds_triggered_skill_by_word_boundary(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "market-watch",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [market]\n"
+                ),
+            )
+            scan_skill_commands()
+            matched = find_triggered_skill_command("What is the market doing today?")
+            not_matched = find_triggered_skill_command("This supermarket is busy.")
 
+        assert matched is not None
+        assert matched[0] == "/market-watch"
+        assert matched[2] == "market"
+        assert not_matched is None
 
+    def test_finds_triggered_skill_with_punctuation_phrase(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "fx-watch",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [EUR/USD]\n"
+                ),
+            )
+            scan_skill_commands()
+            matched = find_triggered_skill_command("What is happening with EUR/USD today?")
 
+        assert matched is not None
+        assert matched[0] == "/fx-watch"
+        assert matched[2] == "EUR/USD"
 
     def test_loads_skill_invocation_from_symlinked_skill_dir(self, tmp_path):
         """Slash commands should load skills symlinked under the local skills dir."""
@@ -479,7 +527,7 @@ class TestBuildSkillInvocationMessage:
             skill_dir = _make_skill(tmp_path, "test-skill")
             references = skill_dir / "references"
             references.mkdir()
-            (references / "api.md").write_text("reference")
+            (references / "api.md").write_text("reference", encoding="utf-8")
             scan_skill_commands()
             msg = build_skill_invocation_message("/test-skill", "do stuff")
 
@@ -506,7 +554,7 @@ class TestSkillDirectoryHeader:
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skill_dir = _make_skill(tmp_path, "scripted-skill")
             (skill_dir / "scripts").mkdir()
-            (skill_dir / "scripts" / "run.js").write_text("console.log('hi')")
+            (skill_dir / "scripts" / "run.js").write_text("console.log('hi')", encoding="utf-8")
             scan_skill_commands()
             msg = build_skill_invocation_message("/scripted-skill")
 

--- a/tests/cli/test_cli_auto_skill_triggers.py
+++ b/tests/cli/test_cli_auto_skill_triggers.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+class _ImmediateThread:
+    def __init__(self, *, target=None, daemon=None):
+        self._target = target
+        self._alive = False
+        self.ident = 1
+
+    def start(self):
+        self._alive = True
+        try:
+            if self._target is not None:
+                self._target()
+        finally:
+            self._alive = False
+
+    def is_alive(self):
+        return self._alive
+
+    def join(self, timeout=None):
+        return None
+
+
+def _make_cli_stub():
+    import cli as cli_mod
+
+    shell = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    shell._secret_capture_callback = MagicMock()
+    shell._sudo_password_callback = MagicMock()
+    shell._approval_callback = MagicMock()
+    shell._ensure_runtime_credentials = MagicMock(return_value=True)
+    shell._resolve_turn_agent_config = MagicMock(
+        return_value={
+            "signature": "same-route",
+            "model": None,
+            "runtime": None,
+            "request_overrides": None,
+        }
+    )
+    shell._active_agent_route_signature = "same-route"
+    shell._init_agent = MagicMock(return_value=True)
+    shell._reset_stream_state = MagicMock(
+        side_effect=lambda: setattr(shell, "_stream_started", False)
+    )
+    shell._flush_stream = MagicMock()
+    shell._flush_credit_notices = MagicMock()
+    shell._invalidate = MagicMock()
+    shell._transfer_session_yolo = MagicMock()
+    shell._voice_speak_response_async = MagicMock()
+    shell._pending_model_switch_note = None
+    shell._pending_skills_reload_note = None
+    shell._pending_moa_config = None
+    shell._pending_moa_disable_after_turn = False
+    shell._clarify_state = None
+    shell._clarify_freetext = None
+    shell._voice_tts = False
+    shell._voice_mode = False
+    shell._voice_continuous = False
+    shell.show_reasoning = False
+    shell.bell_on_complete = False
+    shell.show_timestamps = False
+    shell.final_response_markdown = "auto"
+    shell.session_id = "session-123"
+    shell.provider = "test-provider"
+    shell.model = "test-model"
+    shell.base_url = ""
+    shell.api_key = ""
+    shell.api_mode = "chat_completions"
+    shell._session_db = None
+    shell.conversation_history = []
+    shell.console = SimpleNamespace(width=80)
+    shell._stream_started = False
+    shell._stream_box_opened = False
+    shell._reasoning_shown_this_turn = False
+    shell.agent = SimpleNamespace(
+        session_id="session-123",
+        max_iterations=90,
+        run_conversation=MagicMock(
+            return_value={
+                "final_response": "",
+                "messages": [],
+                "completed": True,
+                "response_previewed": True,
+            }
+        ),
+    )
+    return shell
+
+
+def test_chat_auto_loads_triggered_skill_and_persists_original_message():
+    import cli as cli_mod
+
+    shell = _make_cli_stub()
+
+    with (
+        patch.object(cli_mod.threading, "Thread", _ImmediateThread),
+        patch.object(cli_mod, "ChatConsole", return_value=SimpleNamespace(print=MagicMock())),
+        patch.object(cli_mod, "_cprint"),
+        patch.object(
+            cli_mod,
+            "find_triggered_skill_command",
+            return_value=("/market-watch", {"name": "market-watch"}, "market"),
+        ),
+        patch.object(
+            cli_mod,
+            "build_skill_invocation_message",
+            return_value="[expanded skill payload]",
+        ),
+    ):
+        shell.chat("What is the market doing today?")
+
+    shell.agent.run_conversation.assert_called_once()
+    kwargs = shell.agent.run_conversation.call_args.kwargs
+    assert kwargs["user_message"] == "[expanded skill payload]"
+    assert kwargs["persist_user_message"] == "What is the market doing today?"
+
+
+def test_chat_leaves_plain_messages_unchanged_when_no_trigger_matches():
+    import cli as cli_mod
+
+    shell = _make_cli_stub()
+
+    with (
+        patch.object(cli_mod.threading, "Thread", _ImmediateThread),
+        patch.object(cli_mod, "ChatConsole", return_value=SimpleNamespace(print=MagicMock())),
+        patch.object(cli_mod, "_cprint"),
+        patch.object(cli_mod, "find_triggered_skill_command", return_value=None),
+    ):
+        shell.chat("Tell me a joke.")
+
+    kwargs = shell.agent.run_conversation.call_args.kwargs
+    assert kwargs["user_message"] == "Tell me a joke."
+    assert kwargs["persist_user_message"] is None


### PR DESCRIPTION
## What changed and why
Per the reporter's follow-up on 2026-06-30, this PR adds deterministic CLI-side skill auto-activation for skills that declare `metadata.hermes.triggers` in `SKILL.md` frontmatter. `agent/skill_commands.py` now parses and exposes trigger metadata, matches user turns with boundary-aware regexes, and picks the best matching skill. The CLI then routes matching turns through the existing skill invocation scaffolding before `run_conversation()`, which keeps prompt caching intact and reuses the established skill-loading path instead of inventing a parallel system prompt mutation flow.

The chat path also preserves the original user message in persisted session history even when the API-facing turn is expanded into skill scaffolding, so resumes and transcripts stay clean.

## How to test
1. Create or edit a skill with frontmatter like `metadata.hermes.triggers: [market, EUR/USD]`.
2. Start the CLI and send a matching plain-language prompt such as `What is happening with EUR/USD today?` without typing `/skill-name`.
3. Confirm Hermes prints the auto-loading notice and sends the turn through the skill invocation path.
4. Run the targeted regression tests:
```bash
pytest tests/agent/test_skill_commands.py tests/cli/test_cli_auto_skill_triggers.py -q
```
5. Verified under the timeout wrapper as well:
```bash
/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest -q -x --timeout=60 "$@"' sh tests/agent/test_skill_commands.py tests/cli/test_cli_auto_skill_triggers.py
```

## What platforms tested on
- macOS (local worker environment)

Fixes #4589

<!-- autocontrib:worker-id=issue-followup-5877f32f kind=pr-open -->