### PR TITLE
fix(skills): defer large prompt catalogs by category

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1139,6 +1139,9 @@ def _build_snapshot_entry(skill_file: Path, skills_dir: Path, frontmatter: dict,
     return entry
 
 
+LARGE_SKILL_INDEX_THRESHOLD = 40
+
+
 def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
     """Read a SKILL.md once -> (is_compatible, frontmatter, description); errors yield (True, {}, "")."""
     try:
@@ -1192,7 +1195,9 @@ def build_skills_system_prompt(
     """Compact skill index for the system prompt.
 
     External dirs (``skills.external_dirs``) are read-only and lose name collisions to local skills.
-    ``compact_categories`` (coding posture) demotes categories to a names-only line — nothing is ever hidden.
+    ``compact_categories`` (coding posture) demotes categories to a names-only line for small catalogs. Large
+    catalogs automatically render as category summaries; ``skills_list(category=...)`` / ``skill_view(name=...)``
+    provide the detailed lazy-loading path.
     ``skills_dir_override`` makes home resolution EXPLICIT: a build thread that never bound the HERMES_HOME
     ContextVar would otherwise leak the default profile's skills into a bot's prompt.
     """
@@ -1276,10 +1281,19 @@ def _render_skills_index(
     """Render the ## Skills block; "" when there is nothing to list."""
     if not skills_by_category:
         return ""
+    total_skill_count = sum(len(entries) for entries in skills_by_category.values())
+    category_index_only = total_skill_count > LARGE_SKILL_INDEX_THRESHOLD
     # Demoted categories collapse to one names-only line. NEVER drop entries — agent-created skills are the
     # model's project memory and it won't rediscover them via skills_list. Nested categories follow their parent.
-    demoted = frozenset(cat for cat in skills_by_category if cat.split("/", 1)[0] in (compact_categories or frozenset()))
+    demoted = frozenset(
+        cat for cat in skills_by_category
+        if not category_index_only and cat.split("/", 1)[0] in (compact_categories or frozenset())
+    )
     hidden_note = (
+        "\n(Large skill catalog mode: only categories are shown in the system prompt. "
+        "Call skills_list(category='<category>') to inspect a relevant category, then "
+        "skill_view(name) to load the chosen skill.)"
+    ) if category_index_only else (
         "\n(Categories marked [names only] are outside the current coding "
         "context, so their descriptions are omitted — the skills work "
         "normally and load with skill_view(name) as usual.)"
@@ -1289,6 +1303,14 @@ def _render_skills_index(
     index_lines = []
     for category in sorted(skills_by_category):
         entries = skills_by_category[category]
+        if category_index_only:
+            count = len({name for name, _ in entries})
+            cat_desc = category_descriptions.get(category, "")
+            suffix = f" — {cat_desc}" if cat_desc else ""
+            index_lines.append(
+                f"  {category}: {count} skill{'s' if count != 1 else ''}{suffix}"
+            )
+            continue
         if category in demoted:
             index_lines.append(f"  {category} [names only]: {', '.join(sorted({n for n, _ in entries}))}")
             continue
@@ -1313,6 +1335,8 @@ def _render_skills_index(
         "If a skill has issues, fix it with skill_manage(action='patch').\n"
         "After difficult/iterative tasks, offer to save as a skill. If a skill you loaded was missing steps, "
         "had wrong commands, or needed pitfalls you discovered, update it before finishing.\n"
+        "For large catalogs, the index may show categories only; when a category could match the task, call "
+        "skills_list(category='<category>') before deciding no skill applies.\n"
         "\n"
         "<available_skills>\n"
         + "\n".join(index_lines) + "\n"

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1508,6 +1508,9 @@ def _build_snapshot_entry(
 # Skills index
 # =========================================================================
 
+LARGE_SKILL_INDEX_THRESHOLD = 40
+
+
 def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
     """Read a SKILL.md once and return platform compatibility, frontmatter, and description.
 
@@ -1602,9 +1605,9 @@ def build_skills_system_prompt(
 
     ``compact_categories`` (e.g. from the coding posture — see
     agent/coding_context.py) demotes whole categories to a names-only line in
-    the rendered index. Nothing is ever hidden: every skill name stays
-    visible and loadable via ``skill_view`` / ``skills_list``; only the
-    descriptions are dropped, and a footer note explains the demotion.
+    the rendered index for small catalogs. Large catalogs automatically render
+    as category summaries only; the existing ``skills_list(category=...)`` /
+    ``skill_view(name=...)`` flow provides the detailed lazy-loading path.
     """
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
@@ -1786,6 +1789,9 @@ def build_skills_system_prompt(
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
 
+    total_skill_count = sum(len(items) for items in skills_by_category.values())
+    category_index_only = total_skill_count > LARGE_SKILL_INDEX_THRESHOLD
+
     # Posture-driven category demotion (e.g. non-coding skills while pairing
     # on code). Demoted categories stay in the index as a single names-only
     # line — descriptions are dropped to cut noise, but every skill name
@@ -1797,11 +1803,19 @@ def build_skills_system_prompt(
     # their parent.
     demoted = frozenset(
         cat for cat in skills_by_category
-        if cat.split("/", 1)[0] in (compact_categories or frozenset())
+        if not category_index_only
+        and cat.split("/", 1)[0] in (compact_categories or frozenset())
     )
 
     hidden_note = ""
-    if demoted:
+    if category_index_only:
+        hidden_note = (
+            "\n(Large skill catalog mode: only categories are shown in the "
+            "system prompt. Call skills_list(category='<category>') to inspect "
+            "a relevant category, then skill_view(name) to load the chosen "
+            "skill.)"
+        )
+    elif demoted:
         hidden_note = (
             "\n(Categories marked [names only] are outside the current coding "
             "context, so their descriptions are omitted — the skills work "
@@ -1815,6 +1829,14 @@ def build_skills_system_prompt(
         for category in sorted(skills_by_category.keys()):
             # Deduplicate and sort skills within each category
             seen = set()
+            if category_index_only:
+                count = len({name for name, _ in skills_by_category[category]})
+                cat_desc = category_descriptions.get(category, "")
+                suffix = f" — {cat_desc}" if cat_desc else ""
+                index_lines.append(
+                    f"  {category}: {count} skill{'s' if count != 1 else ''}{suffix}"
+                )
+                continue
             if category in demoted:
                 names = sorted({name for name, _ in skills_by_category[category]})
                 index_lines.append(f"  {category} [names only]: {', '.join(names)}")
@@ -1854,6 +1876,9 @@ def build_skills_system_prompt(
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "
             "pitfalls you discovered, update it before finishing.\n"
+            "For large catalogs, the index may show categories only; when a category "
+            "could match the task, call skills_list(category='<category>') before "
+            "deciding no skill applies.\n"
             "\n"
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import sys
 
@@ -23,6 +24,7 @@ from agent.prompt_builder import (
     _get_context_file_max_chars,
     _CONTEXT_FILE_DYNAMIC_CEILING,
     DEFAULT_AGENT_IDENTITY,
+    LARGE_SKILL_INDEX_THRESHOLD,
     drain_truncation_warnings,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
@@ -293,6 +295,58 @@ class TestBuildSkillsSystemPrompt:
         # "search" should appear only once per category
         assert result.count("- search") == 1
 
+
+    def test_large_skill_catalog_uses_category_index_only(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        for idx in range(LARGE_SKILL_INDEX_THRESHOLD + 1):
+            category = "devops" if idx % 2 else "creative"
+            d = skills_root / category / f"skill-{idx:02d}"
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                "---\n"
+                f"name: skill-{idx:02d}\n"
+                f"description: Detailed description {idx:02d}\n"
+                "---\n"
+            )
+
+        result = build_skills_system_prompt()
+
+        assert "Large skill catalog mode" in result
+        assert "skills_list(category='<category>')" in result
+        assert "  creative:" in result
+        assert "  devops:" in result
+        assert "skill-00" not in result
+        assert "Detailed description 00" not in result
+
+    def test_large_skill_catalog_nested_category_drills_down_with_rendered_key(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        category = "social-media/twitter"
+        skills_root = tmp_path / "skills"
+        for idx in range(LARGE_SKILL_INDEX_THRESHOLD + 1):
+            skill_dir = skills_root / category / f"skill-{idx:02d}"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\n"
+                f"name: skill-{idx:02d}\n"
+                f"description: Detailed description {idx:02d}\n"
+                "---\n"
+            )
+
+        prompt = build_skills_system_prompt()
+        rendered_category = next(
+            line.split(":", 1)[0].strip()
+            for line in prompt.splitlines()
+            if line.startswith(f"  {category}:")
+        )
+
+        from tools.skills_tool import skills_list
+
+        listing = json.loads(skills_list(category=rendered_category))
+        assert listing["count"] == LARGE_SKILL_INDEX_THRESHOLD + 1
+        assert {skill["category"] for skill in listing["skills"]} == {rendered_category}
 
     def test_compact_categories_demote_nested_and_miss_cache_separately(
         self, monkeypatch, tmp_path
@@ -919,5 +973,3 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import os
 import sys
@@ -25,6 +26,7 @@ from agent.prompt_builder import (
     _get_context_file_max_chars,
     _CONTEXT_FILE_DYNAMIC_CEILING,
     DEFAULT_AGENT_IDENTITY,
+    LARGE_SKILL_INDEX_THRESHOLD,
     drain_truncation_warnings,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
@@ -252,7 +254,7 @@ class TestParseSkillFile:
     def test_long_description_truncated(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
         long_desc = "A" * 100
-        skill_file.write_text(f"---\ndescription: {long_desc}\n---\n")
+        skill_file.write_text(f"---\ndescription: {long_desc}\n---\n", encoding="utf-8")
         _, _, desc = _parse_skill_file(skill_file)
         assert len(desc) <= 60
         assert desc.endswith("...")
@@ -260,7 +262,7 @@ class TestParseSkillFile:
 
     def test_logs_parse_failures_and_returns_defaults(self, tmp_path, monkeypatch, caplog):
         skill_file = tmp_path / "SKILL.md"
-        skill_file.write_text("---\nname: broken\n---\n")
+        skill_file.write_text("---\nname: broken\n---\n", encoding="utf-8")
 
         def boom(*args, **kwargs):
             raise OSError("read exploded")
@@ -319,11 +321,65 @@ class TestBuildSkillsSystemPrompt:
         for subdir in ["search", "search"]:
             d = cat_dir / subdir
             d.mkdir(parents=True, exist_ok=True)
-            (d / "SKILL.md").write_text("---\ndescription: Search stuff\n---\n")
+            (d / "SKILL.md").write_text("---\ndescription: Search stuff\n---\n", encoding="utf-8")
         result = build_skills_system_prompt()
         # "search" should appear only once per category
         assert result.count("- search") == 1
 
+
+    def test_large_skill_catalog_uses_category_index_only(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        for idx in range(LARGE_SKILL_INDEX_THRESHOLD + 1):
+            category = "devops" if idx % 2 else "creative"
+            d = skills_root / category / f"skill-{idx:02d}"
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                "---\n"
+                f"name: skill-{idx:02d}\n"
+                f"description: Detailed description {idx:02d}\n"
+                "---\n",
+                encoding="utf-8",
+            )
+
+        result = build_skills_system_prompt()
+
+        assert "Large skill catalog mode" in result
+        assert "skills_list(category='<category>')" in result
+        assert "  creative:" in result
+        assert "  devops:" in result
+        assert "skill-00" not in result
+        assert "Detailed description 00" not in result
+
+    def test_large_skill_catalog_nested_category_drills_down_with_rendered_key(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        category = "social-media/twitter"
+        skills_root = tmp_path / "skills"
+        for idx in range(LARGE_SKILL_INDEX_THRESHOLD + 1):
+            skill_dir = skills_root / category / f"skill-{idx:02d}"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\n"
+                f"name: skill-{idx:02d}\n"
+                f"description: Detailed description {idx:02d}\n"
+                "---\n",
+                encoding="utf-8",
+            )
+
+        prompt = build_skills_system_prompt()
+        rendered_category = next(
+            line.split(":", 1)[0].strip()
+            for line in prompt.splitlines()
+            if line.startswith(f"  {category}:")
+        )
+
+        from tools.skills_tool import skills_list
+
+        listing = json.loads(skills_list(category=rendered_category))
+        assert listing["count"] == LARGE_SKILL_INDEX_THRESHOLD + 1
+        assert {skill["category"] for skill in listing["skills"]} == {rendered_category}
 
     def test_compact_categories_demote_nested_and_miss_cache_separately(
         self, monkeypatch, tmp_path
@@ -412,7 +468,7 @@ class TestBuildContextFilesPrompt:
         assert "Hermes Agent" in result
 
     def test_loads_agents_md(self, tmp_path):
-        (tmp_path / "AGENTS.md").write_text("Use Ruff for linting.")
+        (tmp_path / "AGENTS.md").write_text("Use Ruff for linting.", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Ruff for linting" in result
         assert "Project Context" in result
@@ -423,13 +479,13 @@ class TestBuildContextFilesPrompt:
         # git-root AGENTS.md + intermediate + cwd are all merged, root first
         # and cwd last so deeper guidance takes precedence.
         (tmp_path / ".git").mkdir()
-        (tmp_path / "AGENTS.md").write_text("Root: use Ruff.")
+        (tmp_path / "AGENTS.md").write_text("Root: use Ruff.", encoding="utf-8")
         pkg = tmp_path / "packages"
         pkg.mkdir()
-        (pkg / "AGENTS.md").write_text("Packages: pnpm workspace.")
+        (pkg / "AGENTS.md").write_text("Packages: pnpm workspace.", encoding="utf-8")
         app = pkg / "webapp"
         app.mkdir()
-        (app / "AGENTS.md").write_text("Webapp: React 19 only.")
+        (app / "AGENTS.md").write_text("Webapp: React 19 only.", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(app), skip_soul=True)
         assert "Root: use Ruff." in result
         assert "Packages: pnpm workspace." in result
@@ -445,7 +501,7 @@ class TestBuildContextFilesPrompt:
     def test_agents_md_chain_skips_gaps(self, tmp_path):
         # Intermediate dirs without AGENTS.md contribute nothing.
         (tmp_path / ".git").mkdir()
-        (tmp_path / "AGENTS.md").write_text("Root rules.")
+        (tmp_path / "AGENTS.md").write_text("Root rules.", encoding="utf-8")
         deep = tmp_path / "a" / "b" / "c"
         deep.mkdir(parents=True)
         result = build_context_files_prompt(cwd=str(deep), skip_soul=True)
@@ -454,10 +510,10 @@ class TestBuildContextFilesPrompt:
 
     def test_agents_md_chain_dedupes_identical_content(self, tmp_path):
         (tmp_path / ".git").mkdir()
-        (tmp_path / "AGENTS.md").write_text("Same rules everywhere.")
+        (tmp_path / "AGENTS.md").write_text("Same rules everywhere.", encoding="utf-8")
         sub = tmp_path / "sub"
         sub.mkdir()
-        (sub / "AGENTS.md").write_text("Same rules everywhere.")
+        (sub / "AGENTS.md").write_text("Same rules everywhere.", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(sub), skip_soul=True)
         assert result.count("Same rules everywhere.") == 1
 
@@ -469,13 +525,13 @@ class TestBuildContextFilesPrompt:
         (tmp_path / ".git").mkdir()
         sub = tmp_path / "sub"
         sub.mkdir()
-        (sub / "AGENTS.md").write_text("Only file.")
+        (sub / "AGENTS.md").write_text("Only file.", encoding="utf-8")
         assert _load_agents_md(sub) == "## AGENTS.md\n\nOnly file."
 
     def test_agents_md_no_git_root_stays_cwd_only(self, tmp_path):
         # Without a git root, parents are never consulted (no picking up an
         # AGENTS.md planted in /tmp or $HOME).
-        (tmp_path / "AGENTS.md").write_text("Planted in parent.")
+        (tmp_path / "AGENTS.md").write_text("Planted in parent.", encoding="utf-8")
         sub = tmp_path / "sub"
         sub.mkdir()
         from agent.prompt_builder import _load_agents_md
@@ -485,22 +541,22 @@ class TestBuildContextFilesPrompt:
     # --- AGENTS.override.md personal override (port of pi#7681) ---
 
     def test_agents_override_md_wins_over_agents_md(self, tmp_path):
-        (tmp_path / "AGENTS.md").write_text("Use Ruff for linting.")
-        (tmp_path / "AGENTS.override.md").write_text("Use Black instead.")
+        (tmp_path / "AGENTS.md").write_text("Use Ruff for linting.", encoding="utf-8")
+        (tmp_path / "AGENTS.override.md").write_text("Use Black instead.", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Use Black instead" in result
         assert "Ruff for linting" not in result
         assert "AGENTS.override.md" in result
 
     def test_agents_override_md_loads_alone(self, tmp_path):
-        (tmp_path / "AGENTS.override.md").write_text("Override-only context.")
+        (tmp_path / "AGENTS.override.md").write_text("Override-only context.", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Override-only context" in result
         assert "Project Context" in result
 
     def test_hermes_md_still_wins_over_agents_override(self, tmp_path):
-        (tmp_path / ".hermes.md").write_text("Hermes-first context.")
-        (tmp_path / "AGENTS.override.md").write_text("Override context.")
+        (tmp_path / ".hermes.md").write_text("Hermes-first context.", encoding="utf-8")
+        (tmp_path / "AGENTS.override.md").write_text("Override context.", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Hermes-first context" in result
         assert "Override context" not in result
@@ -513,7 +569,7 @@ class TestBuildContextFilesPrompt:
         import agent.runtime_cwd as rt
 
         monkeypatch.setattr(rt, "_PACKAGE_ROOT", tmp_path.resolve())
-        (tmp_path / "AGENTS.md").write_text("Never give up on the right solution.")
+        (tmp_path / "AGENTS.md").write_text("Never give up on the right solution.", encoding="utf-8")
         monkeypatch.chdir(tmp_path)
         result = build_context_files_prompt(cwd=None, skip_soul=True)
         assert "Never give up" not in result
@@ -548,7 +604,7 @@ class TestBuildContextFilesPrompt:
 
 
     def test_loads_claude_md(self, tmp_path):
-        (tmp_path / "CLAUDE.md").write_text("Use type hints everywhere.")
+        (tmp_path / "CLAUDE.md").write_text("Use type hints everywhere.", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "type hints" in result
         assert "CLAUDE.md" in result
@@ -562,8 +618,8 @@ class TestBuildContextFilesPrompt:
     def test_claude_md_uppercase_takes_priority(self, tmp_path):
         uppercase = tmp_path / "CLAUDE.md"
         lowercase = tmp_path / "claude.md"
-        uppercase.write_text("From uppercase.")
-        lowercase.write_text("From lowercase.")
+        uppercase.write_text("From uppercase.", encoding="utf-8")
+        lowercase.write_text("From lowercase.", encoding="utf-8")
         if uppercase.samefile(lowercase):
             pytest.skip("filesystem is case-insensitive")
         result = build_context_files_prompt(cwd=str(tmp_path))
@@ -581,14 +637,14 @@ class TestBuildContextFilesPrompt:
 
 class TestFindHermesMd:
     def test_finds_in_cwd(self, tmp_path):
-        (tmp_path / ".hermes.md").write_text("rules")
+        (tmp_path / ".hermes.md").write_text("rules", encoding="utf-8")
         assert _find_hermes_md(tmp_path) == tmp_path / ".hermes.md"
 
 
 
     def test_walks_to_git_root(self, tmp_path):
         (tmp_path / ".git").mkdir()
-        (tmp_path / ".hermes.md").write_text("root rules")
+        (tmp_path / ".hermes.md").write_text("root rules", encoding="utf-8")
         sub = tmp_path / "a" / "b"
         sub.mkdir(parents=True)
         assert _find_hermes_md(sub) == tmp_path / ".hermes.md"
@@ -606,7 +662,7 @@ class TestFindHermesMd:
 
         parent = tmp_path / "parent"
         parent.mkdir()
-        (parent / ".hermes.md").write_text("planted by another user")
+        (parent / ".hermes.md").write_text("planted by another user", encoding="utf-8")
         cwd = parent / "work"
         cwd.mkdir()
         # No git root anywhere up the tree.
@@ -1159,8 +1215,8 @@ class TestParallelToolCallGuidance:
 class TestContextFileReadTimeout:
     def test_slow_hermes_md_is_skipped_and_agents_md_still_loads(self, tmp_path, monkeypatch, caplog):
         (tmp_path / ".git").mkdir()
-        (tmp_path / ".hermes.md").write_text("Hermes project rules.")
-        (tmp_path / "AGENTS.md").write_text("Agent fallback rules.")
+        (tmp_path / ".hermes.md").write_text("Hermes project rules.", encoding="utf-8")
+        (tmp_path / "AGENTS.md").write_text("Agent fallback rules.", encoding="utf-8")
         # Patch the module object build_context_files_prompt actually closes
         # over: an earlier test re-imports agent.prompt_builder, so the
         # sys.modules entry can be a different module object.

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -40,7 +40,7 @@ description: Description for {name}.
 
 {body}
 """
-    (skill_dir / "SKILL.md").write_text(content)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir
 
 
@@ -169,6 +169,26 @@ class TestGetCategoryFromPath:
             top_level.touch()
             assert _get_category_from_path(top_level) is None
 
+    def test_nested_categorized_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_md = (
+                tmp_path
+                / "foundations"
+                / "runtime"
+                / "explore-codebase"
+                / "SKILL.md"
+            )
+            skill_md.parent.mkdir(parents=True)
+            skill_md.touch()
+            assert _get_category_from_path(skill_md) == "foundations/runtime"
+
+    def test_uncategorized_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_md = tmp_path / "my-skill" / "SKILL.md"
+            skill_md.parent.mkdir(parents=True)
+            skill_md.touch()
+            assert _get_category_from_path(skill_md) is None
+
         # Paths outside SKILLS_DIR have no category.
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"):
             assert _get_category_from_path(tmp_path / "other" / "SKILL.md") is None
@@ -277,6 +297,7 @@ class TestSkillsList:
         assert all_result["count"] == 2
         assert filtered["count"] == 1
         assert filtered["skills"][0]["name"] == "skill-a"
+        assert filtered["category_counts"] == {"devops": 1, "mlops": 1}
 
     def test_category_filter_finds_symlinked_category(self, tmp_path):
         external_root = tmp_path / "repo"
@@ -363,7 +384,7 @@ class TestSkillView:
             skill_dir = _make_skill(tmp_path, "my-skill")
             refs_dir = skill_dir / "references"
             refs_dir.mkdir()
-            (refs_dir / "api.md").write_text("# API Docs\nEndpoint info.")
+            (refs_dir / "api.md").write_text("# API Docs\nEndpoint info.", encoding="utf-8")
 
             existing = json.loads(skill_view("my-skill", file_path="references/api.md"))
             missing = json.loads(skill_view("my-skill", file_path="references/nope.md"))
@@ -390,7 +411,7 @@ class TestSkillView:
             skill_dir = _make_skill(tmp_path, "my-skill")
             refs_dir = skill_dir / "references"
             refs_dir.mkdir()
-            (refs_dir / "api.md").write_text("# API Docs\nEndpoint info.")
+            (refs_dir / "api.md").write_text("# API Docs\nEndpoint info.", encoding="utf-8")
 
             result = json.loads(skill_view("my-skill", file_path="references"))
 
@@ -935,7 +956,7 @@ class TestSkillViewCollisionDetection:
             / "sketch.md"
         )
         support_file.parent.mkdir(parents=True, exist_ok=True)
-        support_file.write_text("# Sketch style support doc\n")
+        support_file.write_text("# Sketch style support doc\n", encoding="utf-8")
         _make_skill(local_dir, "sketch", category="creative", body="REAL SKETCH SKILL")
 
         p1, p2 = self._patch_dirs(local_dir, [external_dir])

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -169,6 +169,26 @@ class TestGetCategoryFromPath:
             top_level.touch()
             assert _get_category_from_path(top_level) is None
 
+    def test_nested_categorized_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_md = (
+                tmp_path
+                / "foundations"
+                / "runtime"
+                / "explore-codebase"
+                / "SKILL.md"
+            )
+            skill_md.parent.mkdir(parents=True)
+            skill_md.touch()
+            assert _get_category_from_path(skill_md) == "foundations/runtime"
+
+    def test_uncategorized_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_md = tmp_path / "my-skill" / "SKILL.md"
+            skill_md.parent.mkdir(parents=True)
+            skill_md.touch()
+            assert _get_category_from_path(skill_md) is None
+
         # Paths outside SKILLS_DIR have no category.
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"):
             assert _get_category_from_path(tmp_path / "other" / "SKILL.md") is None
@@ -277,6 +297,7 @@ class TestSkillsList:
         assert all_result["count"] == 2
         assert filtered["count"] == 1
         assert filtered["skills"][0]["name"] == "skill-a"
+        assert filtered["category_counts"] == {"devops": 1, "mlops": 1}
 
     def test_category_filter_finds_symlinked_category(self, tmp_path):
         external_root = tmp_path / "repo"

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -4,6 +4,7 @@ holding SKILL.md (YAML frontmatter + instructions) plus optional references/, te
 scripts/. `skills_list` returns name/description only; `skill_view` returns full content and
 linked files. Sibling modules (skills_tool_setup / _plugin / _dedup) re-export here."""
 
+from collections import Counter
 import json
 import logging
 import os
@@ -127,8 +128,8 @@ def check_skills_requirements() -> bool:
 
 
 def _get_category_from_path(skill_path: Path) -> Optional[str]:
-    """``~/.hermes/skills/mlops/axolotl/SKILL.md`` -> ``"mlops"``; active profile dir first
-    (respects test monkeypatching), then skills.external_dirs."""
+    """``~/.hermes/skills/mlops/axolotl/SKILL.md`` -> ``"mlops"``; nested categories retain
+    every directory component. Active profile dir first (respects test monkeypatching), then external dirs."""
     dirs_to_check = [_skills_dir()]
     with suppress(Exception):
         from agent.skill_utils import get_external_skills_dirs
@@ -136,7 +137,7 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     for skills_dir in dirs_to_check:
         with suppress(ValueError):
             if len(parts := skill_path.relative_to(skills_dir).parts) >= 3:
-                return parts[0]
+                return "/".join(parts[:-2])
     return None
 
 
@@ -252,12 +253,14 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         if not all_skills:
             return _json({"success": True, "skills": [], "categories": [],
                           "message": "No skills found in skills/ directory."})
+        category_counts = Counter(s.get("category") or "general" for s in all_skills)
         if category:
             all_skills = [s for s in all_skills if s.get("category") == category]
         all_skills = _sort_skills(all_skills)
         categories = sorted({s.get("category") for s in all_skills if s.get("category")})
         return _json({
             "success": True, "skills": all_skills, "categories": categories,
+            "category_counts": dict(sorted(category_counts.items())),
             "count": len(all_skills),
             "hint": "Use skill_view(name) to see full content, tags, and linked files"})
     except Exception as e:
@@ -599,7 +602,10 @@ def skill_view(
 
 SKILLS_LIST_SCHEMA = {
     "name": "skills_list",
-    "description": "List available skills (name + description). Use skill_view(name) to load full content.",
+    "description": (
+        "List available skills by category (name + description). Use category to drill into large "
+        "category-only skill indexes, then skill_view(name) to load full content."
+    ),
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -66,10 +66,11 @@ Usage:
     content = skill_view("axolotl", "references/dataset-formats.md")
 """
 
+from collections import Counter
 import json
 import logging
-import time
 import threading
+import time
 
 from hermes_constants import get_hermes_home, display_hermes_home
 import os
@@ -565,6 +566,8 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     Extract category from skill path based on directory structure.
 
     For paths like: ~/.hermes/skills/mlops/axolotl/SKILL.md -> "mlops"
+    For paths like: ~/.hermes/skills/foundations/runtime/explore/SKILL.md
+    -> "foundations/runtime"
     Also works for external skill dirs configured via skills.external_dirs.
     """
     # Try the active profile skills dir first (respects monkeypatching in tests),
@@ -580,7 +583,7 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
             rel_path = skill_path.relative_to(skills_dir)
             parts = rel_path.parts
             if len(parts) >= 3:
-                return parts[0]
+                return "/".join(parts[:-2])
         except ValueError:
             continue
     return None
@@ -825,6 +828,11 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 ensure_ascii=False,
             )
 
+        category_counts = Counter(
+            s.get("category") or "general"
+            for s in all_skills
+        )
+
         # Filter by category if specified
         if category:
             all_skills = [s for s in all_skills if s.get("category") == category]
@@ -842,6 +850,7 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 "success": True,
                 "skills": all_skills,
                 "categories": categories,
+                "category_counts": dict(sorted(category_counts.items())),
                 "count": len(all_skills),
                 "hint": "Use skill_view(name) to see full content, tags, and linked files",
             },
@@ -1758,7 +1767,11 @@ if __name__ == "__main__":
 
 SKILLS_LIST_SCHEMA = {
     "name": "skills_list",
-    "description": "List available skills (name + description). Use skill_view(name) to load full content.",
+    "description": (
+        "List available skills by category (name + description). Use category "
+        "to drill into large category-only skill indexes, then skill_view(name) "
+        "to load full content."
+    ),
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## What does this PR do?

Large skill catalogs now render a category-level `<available_skills>` index instead of injecting every skill name and description into the system prompt. The detailed discovery path stays on the existing `skills_list(category=...)` and `skill_view(name=...)` tools, and small catalogs keep the current full index behavior.

## Related Issue

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Shared root cause

- Hermes already has lazy `skill_view` loading, but `agent/prompt_builder.py` still eagerly rendered every visible skill name and description into the system prompt. That makes large installed skill sets expensive even when only a category, or no skill, is relevant.
- The coordinated fix preserves the existing scanner/snapshot and tool surface, but switches catalogs above `LARGE_SKILL_INDEX_THRESHOLD` to category summaries. The prompt now tells the model to drill down with `skills_list(category='<category>')` before deciding no skill applies.

## How this fixes each issue

- #34038: materially advances on-demand capability discovery for the skill facet of the broader tool/skill/MCP RFC by removing large skill schema/description dumps from the prompt and using an existing discovery tool for details.
- #37227: implements the category-aware lazy skill-indexing layer for large catalogs, so the prompt carries category names/counts and detailed skill matching happens through category-filtered `skills_list` followed by `skill_view`.

## Changes Made

- `agent/prompt_builder.py`: adds automatic large-catalog category-only rendering while keeping full name/description output for small catalogs and existing names-only demotion behavior.
- `tools/skills_tool.py`: returns `category_counts` from `skills_list` and updates the tool description to document category drill-down.
- `tests/agent/test_prompt_builder.py`: covers large-catalog category-only prompt rendering.
- `tests/tools/test_skills_tool.py`: covers category counts in filtered skill listings.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/agent/test_prompt_builder.py tests/tools/test_skills_tool.py -q -x --timeout=60'`
2. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`
3. `sh -c 'BASE=$(git merge-base origin/main HEAD); CHANGED_PY=$( { git diff --name-only --diff-filter=d "$BASE"; git ls-files --others --exclude-standard; } | grep -E "\.pyi?$" | sort -u ); [ -n "$CHANGED_PY" ] && ruff check $CHANGED_PY'`
4. `/opt/homebrew/bin/timeout -k 30 480 python scripts/check-windows-footguns.py agent/prompt_builder.py tools/skills_tool.py tests/agent/test_prompt_builder.py tests/tools/test_skills_tool.py`

## Test Results

- Focused changed-module tests: `250 passed, 1 skipped`.
- Changed-file lint: passed.
- Windows footgun check on changed files: passed.
- Full `pytest tests/ -q -x --timeout=60` was attempted and aborted during collection before reaching this change because the local Python environment lacks `fastapi`/`uvicorn`; lazy dependency installation is blocked by PEP 668 in the Homebrew-managed Python.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS on darwin-arm64

### Documentation & Housekeeping

- [x] Relevant documentation: N/A
- [x] `cli-config.yaml.example`: N/A, no config key added
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas updated

## Screenshots / Logs

Not applicable.

Refs #34038
Refs #37227

<!-- autocontrib:worker-id=pr-spanning-fa72da28 kind=pr-open -->