### PR TITLE
fix(agent): add CJK future-ack patterns for intent-ack continuation

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2338,9 +2338,26 @@ def looks_like_codex_intermediate_ack(
     if len(assistant_text) > 1200:
         return False
 
+    # English future-ack patterns.
     has_future_ack = bool(
-        re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
+        re.search(r"\b(i['']ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
     )
+    # CJK future-ack patterns: Chinese/Japanese/Korean intent markers.
+    # These languages don't use word boundaries (\b), so match directly.
+    if not has_future_ack:
+        _CJK_FUTURE_ACK = (
+            "\u6211\u4f1a",      # I will
+            "\u6211\u5148",      # I first / let me
+            "\u8ba9\u6211",      # let me
+            "\u6211\u6765",      # I'll come / let me
+            "\u78ba\u8a8d",      # confirm/check (Japanese/Traditional Chinese)
+            "\u8abf\u67fb",      # investigate (Japanese)
+            "\u3057\u307e\u3059",    # will do (Japanese)
+            "\u3066\u304f\u308c",    # will come (Japanese)
+            "\ud558\uaca0\uc2b5\ub2c8\ub2e4",  # will do (Korean)
+            "\uad00\ucc30",    # observe (Korean)
+        )
+        has_future_ack = any(marker in assistant_text for marker in _CJK_FUTURE_ACK)
     if not has_future_ack:
         return False
 


### PR DESCRIPTION
## Summary
Add Chinese/Japanese/Korean future-ack patterns to `looks_like_codex_intermediate_ack()` so intent-ack continuation fires for non-English responses.

## Problem (P2 #55664)
The detector gates intent-ack continuation on an **English-only** regex (`i'll|i will|let me|...`). When the model replies in CJK languages (e.g. "我先載入 skill 確認用法…"), the detector returns `False` and the turn ends after the model merely announces intent without executing any tool. The user must manually type "please continue" every turn.

This is especially visible with **Mixture-of-Agents (MoA)** where the aggregator tends to summarize the response plan in the user's language.

## Fix
Add CJK future-ack patterns as a fallback when the English regex doesn't match:
- Chinese: 我会/我先/让我/我来
- Japanese: 確認/調査/します/てくる
- Korean: 하겠습니다/관찰

CJK languages don't use word boundaries (`\b`), so match substrings directly. Only checked when the English regex doesn't match (no overhead for English responses).

## Changes
- `agent/agent_runtime_helpers.py`: Add CJK future-ack tuple and fallback check (18 lines added)

Fixes #55664