### PR TITLE
fix(agent): handle content_filter in Codex incomplete response handling

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1475,6 +1475,8 @@ def run_conversation(
                         incomplete_reason = getattr(incomplete_details, "reason", None)
                     if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
                         finish_reason = "length"
+                    elif status == "incomplete" and incomplete_reason == "content_filter":
+                        finish_reason = "content_filter"
                     else:
                         finish_reason = "stop"
                 elif agent.api_mode == "anthropic_messages":


### PR DESCRIPTION
## Summary
Handle `content_filter` as an incomplete reason in Codex Responses mode so content-policy refusals are properly classified instead of being treated as normal completions.

## Problem (P2 #55637)
Codex Responses can return `status="incomplete"` with `incomplete_details.reason="content_filter"` and no output items. The existing code only handled `max_output_tokens`/`length` as incomplete reasons — `content_filter` fell through to the `else` branch and was treated as `finish_reason="stop"`, causing the response to be processed as a normal completion instead of a content-policy refusal.

This means:
1. The refusal is silently accepted as a valid response
2. No failover to a fallback model is attempted
3. The user sees an empty or nonsensical response

## Fix
Add explicit check for `incomplete_reason == "content_filter"` to set `finish_reason = "content_filter"`, which routes through the existing content-policy refusal handling (failover, retry with fallback model).

## Changes
- `agent/conversation_loop.py`: Add `elif` branch for content_filter (2 lines added)

Fixes #55637