### PR TITLE
fix(bedrock): tolerate null/non-string image_url in Converse content conversion

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -566,7 +566,18 @@ def _convert_content_to_converse(content) -> List[Dict]:
                 blocks.append({"text": _safe_text(text)})
             elif part_type == "image_url":
                 image_url = part.get("image_url", {})
-                url = image_url.get("url", "") if isinstance(image_url, dict) else ""
+                # ``image_url`` may be a dict ({"url": ...}) or, for some
+                # producers, a bare URL string.  A dict whose ``url`` is null
+                # or a non-string must not reach ``url.startswith`` - that
+                # raises ``AttributeError`` and aborts the whole message
+                # conversion.  The Gemini and Codex converters already guard
+                # this; mirror that here.
+                if isinstance(image_url, dict):
+                    url = image_url.get("url")
+                else:
+                    url = image_url
+                if not isinstance(url, str):
+                    url = ""
                 if url.startswith("data:"):
                     # data:image/jpeg;base64,/9j/4AAQ...
                     header, _, data = url.partition(",")

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -221,6 +221,41 @@ class TestConvertMessagesToConverse:
 # Response normalization: Converse → OpenAI
 # ---------------------------------------------------------------------------
 
+    def test_image_url_with_null_url_does_not_crash(self):
+        """A null ``url`` inside an image_url part must not abort conversion.
+
+        ``url.startswith`` on a ``None``/non-string url raised
+        ``AttributeError`` and dropped the entire message. The Gemini and
+        Codex converters already tolerate this shape.
+        """
+        from agent.bedrock_adapter import _convert_content_to_converse
+        blocks = _convert_content_to_converse([
+            {"type": "text", "text": "look"},
+            {"type": "image_url", "image_url": {"url": None}},
+        ])
+        # The text block survives; the unusable image is skipped, not fatal.
+        assert any(b.get("text") == "look" for b in blocks)
+
+    def test_image_url_with_non_string_url_does_not_crash(self):
+        """A non-string url (e.g. int) is also tolerated."""
+        from agent.bedrock_adapter import _convert_content_to_converse
+        blocks = _convert_content_to_converse([
+            {"type": "image_url", "image_url": {"url": 123}},
+        ])
+        assert isinstance(blocks, list)
+
+    def test_image_url_bare_string_data_url_converted(self):
+        """A bare-string data: image_url (no wrapping dict) is converted."""
+        from agent.bedrock_adapter import _convert_content_to_converse
+        blocks = _convert_content_to_converse([
+            {"type": "image_url",
+             "image_url": "data:image/png;base64,iVBORw0KGgo="},
+        ])
+        image_blocks = [b for b in blocks if "image" in b]
+        assert len(image_blocks) == 1
+        assert image_blocks[0]["image"]["format"] == "png"
+
+
 class TestNormalizeConverseResponse:
     """Test Bedrock Converse response → OpenAI format conversion."""
 


### PR DESCRIPTION
### Summary

`_convert_content_to_converse` (agent/bedrock_adapter.py) reads an image part's url with:

```python
url = image_url.get("url", "") if isinstance(image_url, dict) else ""
if url.startswith("data:"):
```

The `""` default only applies when the `url` key is missing. When the key is present but its value is `None` (or any non-string), `url` becomes that value and `url.startswith("data:")` raises `AttributeError: 'NoneType' object has no attribute 'startswith'`. The exception propagates out of `convert_messages_to_converse`, so the whole user message fails to convert and the turn errors out instead of degrading gracefully.

### Reproduction

```python
from agent.bedrock_adapter import _convert_content_to_converse

_convert_content_to_converse([
    {"type": "text", "text": "look"},
    {"type": "image_url", "image_url": {"url": None}},
])
# AttributeError: 'NoneType' object has no attribute 'startswith'
```

### Consistency

The sibling converters already tolerate this. Gemini's `_extract_multimodal_parts` uses `((item.get("image_url") or {}).get("url") or "")`, and Codex's `_chat_content_to_responses_parts` does `if not isinstance(url, str) or not url: continue`. Bedrock is the one converter that crashes.

### Fix

Resolve the url for both the dict (`{"url": ...}`) and bare-string forms, then coerce a null/non-string url to an empty string before the `data:` check. As a side benefit, a bare-string `data:` url now converts to an image block instead of being silently dropped (the previous `else ""` discarded it).

### Tests

Adds regression tests for the null-url crash, the non-string-url crash, and bare-string `data:` url conversion. The first two fail with `AttributeError` before the change and pass after.

Fixes #55686
