### PR TITLE
fix(signal): align setup guidance with native daemon

### DIFF
--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -549,7 +549,7 @@ const PLATFORM_INTRO: Record<string, string> = {
     'On your Mattermost server, create a bot account or personal access token, then paste the server URL and token here.',
   matrix: 'Sign in to your homeserver with the bot account, then copy the access token, user ID, and homeserver URL.',
   signal:
-    'Run a signal-cli REST bridge somewhere reachable, then point Hermes at the URL and the registered phone number.',
+    'Run the native signal-cli HTTP daemon somewhere reachable, then point Hermes at its URL and the linked phone number.',
   whatsapp:
     'Start the WhatsApp bridge that ships with Hermes, scan the QR code on first run, then enable the platform.',
   bluebubbles:

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -820,7 +820,7 @@ const PLATFORM_INTRO: Record<string, string> = {
     'On your Mattermost server, create a bot account or personal access token, then paste the server URL and token here.',
   matrix: 'Sign in to your homeserver with the bot account, then copy the access token, user ID, and homeserver URL.',
   signal:
-    'Run a signal-cli REST bridge somewhere reachable, then point Hermes at the URL and the registered phone number.',
+    'Run the native signal-cli HTTP daemon somewhere reachable, then point Hermes at its URL and the linked phone number.',
   whatsapp:
     'Start the WhatsApp bridge that ships with Hermes, scan the QR code on first run, then enable the platform.',
   bluebubbles:

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1276,11 +1276,11 @@ export const en: Translations = {
         help: 'Recommended. Comma-separated user IDs in @user:server format.'
       },
       SIGNAL_HTTP_URL: {
-        label: 'Signal bridge URL',
+        label: 'signal-cli HTTP URL',
         placeholder: 'http://127.0.0.1:8080',
-        help: 'URL of a running signal-cli REST bridge.'
+        help: 'URL of the native signal-cli HTTP daemon.'
       },
-      SIGNAL_ACCOUNT: { label: 'Phone number', help: 'The number registered with your signal-cli bridge.' },
+      SIGNAL_ACCOUNT: { label: 'Phone number', help: 'The phone number linked to signal-cli.' },
       SIGNAL_ALLOWED_USERS: { label: 'Allowed Signal users', help: 'Recommended. Comma-separated Signal identifiers.' },
       WHATSAPP_ENABLED: {
         label: 'Enable WhatsApp bridge',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1933,11 +1933,11 @@ export const en: Translations = {
         help: 'Recommended. Comma-separated user IDs in @user:server format.'
       },
       SIGNAL_HTTP_URL: {
-        label: 'Signal bridge URL',
+        label: 'signal-cli HTTP URL',
         placeholder: 'http://127.0.0.1:8080',
-        help: 'URL of a running signal-cli REST bridge.'
+        help: 'URL of the native signal-cli HTTP daemon.'
       },
-      SIGNAL_ACCOUNT: { label: 'Phone number', help: 'The number registered with your signal-cli bridge.' },
+      SIGNAL_ACCOUNT: { label: 'Phone number', help: 'The phone number linked to signal-cli.' },
       SIGNAL_ALLOWED_USERS: { label: 'Allowed Signal users', help: 'Recommended. Comma-separated Signal identifiers.' },
       WHATSAPP_ENABLED: {
         label: 'Enable WhatsApp bridge',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1212,11 +1212,11 @@ export const ja = defineLocale({
         help: '推奨。@user:server 形式のカンマ区切りユーザー ID。'
       },
       SIGNAL_HTTP_URL: {
-        label: 'Signal ブリッジ URL',
+        label: 'signal-cli HTTP URL',
         placeholder: 'http://127.0.0.1:8080',
-        help: '実行中の signal-cli REST ブリッジの URL。'
+        help: 'ネイティブ signal-cli HTTP デーモンの URL。'
       },
-      SIGNAL_ACCOUNT: { label: '電話番号', help: 'signal-cli ブリッジに登録した番号。' },
+      SIGNAL_ACCOUNT: { label: '電話番号', help: 'signal-cli にリンクした電話番号。' },
       SIGNAL_ALLOWED_USERS: {
         label: '許可する Signal ユーザー',
         help: '推奨。カンマ区切りの Signal 識別子。'

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1679,11 +1679,11 @@ export const ja = defineLocale({
         help: '推奨。@user:server 形式のカンマ区切りユーザー ID。'
       },
       SIGNAL_HTTP_URL: {
-        label: 'Signal ブリッジ URL',
+        label: 'signal-cli HTTP URL',
         placeholder: 'http://127.0.0.1:8080',
-        help: '実行中の signal-cli REST ブリッジの URL。'
+        help: 'ネイティブ signal-cli HTTP デーモンの URL。'
       },
-      SIGNAL_ACCOUNT: { label: '電話番号', help: 'signal-cli ブリッジに登録した番号。' },
+      SIGNAL_ACCOUNT: { label: '電話番号', help: 'signal-cli にリンクした電話番号。' },
       SIGNAL_ALLOWED_USERS: {
         label: '許可する Signal ユーザー',
         help: '推奨。カンマ区切りの Signal 識別子。'

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1172,11 +1172,11 @@ export const zhHant = defineLocale({
         help: '建議設定。@user:server 格式的逗號分隔使用者 ID。'
       },
       SIGNAL_HTTP_URL: {
-        label: 'Signal 橋接 URL',
+        label: 'signal-cli HTTP URL',
         placeholder: 'http://127.0.0.1:8080',
-        help: '執行中的 signal-cli REST 橋接的 URL。'
+        help: '原生 signal-cli HTTP 常駐程式的 URL。'
       },
-      SIGNAL_ACCOUNT: { label: '電話號碼', help: '在 signal-cli 橋接中註冊的號碼。' },
+      SIGNAL_ACCOUNT: { label: '電話號碼', help: '與 signal-cli 連結的電話號碼。' },
       SIGNAL_ALLOWED_USERS: { label: '允許的 Signal 使用者', help: '建議設定。逗號分隔的 Signal 識別碼。' },
       WHATSAPP_ENABLED: {
         label: '啟用 WhatsApp 橋接',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1613,11 +1613,11 @@ export const zhHant = defineLocale({
         help: '建議設定。@user:server 格式的逗號分隔使用者 ID。'
       },
       SIGNAL_HTTP_URL: {
-        label: 'Signal 橋接 URL',
+        label: 'signal-cli HTTP URL',
         placeholder: 'http://127.0.0.1:8080',
-        help: '執行中的 signal-cli REST 橋接的 URL。'
+        help: '原生 signal-cli HTTP 常駐程式的 URL。'
       },
-      SIGNAL_ACCOUNT: { label: '電話號碼', help: '在 signal-cli 橋接中註冊的號碼。' },
+      SIGNAL_ACCOUNT: { label: '電話號碼', help: '與 signal-cli 連結的電話號碼。' },
       SIGNAL_ALLOWED_USERS: { label: '允許的 Signal 使用者', help: '建議設定。逗號分隔的 Signal 識別碼。' },
       WHATSAPP_ENABLED: {
         label: '啟用 WhatsApp 橋接',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1435,11 +1435,11 @@ export const zh: Translations = {
       MATRIX_USER_ID: { label: 'Bot 用户 ID', placeholder: '@hermes:example.org' },
       MATRIX_ALLOWED_USERS: { label: '允许的 Matrix 用户 ID', help: '推荐。@user:server 格式的逗号分隔用户 ID。' },
       SIGNAL_HTTP_URL: {
-        label: 'Signal 桥接 URL',
+        label: 'signal-cli HTTP URL',
         placeholder: 'http://127.0.0.1:8080',
-        help: '运行中的 signal-cli REST 桥接的 URL。'
+        help: '原生 signal-cli HTTP 守护进程的 URL。'
       },
-      SIGNAL_ACCOUNT: { label: '电话号码', help: '在 signal-cli 桥接中注册的号码。' },
+      SIGNAL_ACCOUNT: { label: '电话号码', help: '与 signal-cli 关联的电话号码。' },
       SIGNAL_ALLOWED_USERS: { label: '允许的 Signal 用户', help: '推荐。逗号分隔的 Signal 标识符。' },
       WHATSAPP_ENABLED: { label: '启用 WhatsApp 桥接', help: '由下方开关自动设置。除非确知需要，否则请勿改动。' },
       WHATSAPP_MODE: { label: '桥接模式' },
@@ -1453,7 +1453,7 @@ export const zh: Translations = {
       slack: '创建 Slack 应用，启用 Socket Mode，安装到你的工作区，然后复制 bot 令牌和 app 级令牌。',
       mattermost: '在你的 Mattermost 服务器上，创建机器人账户或个人访问令牌，然后在此粘贴服务器 URL 和令牌。',
       matrix: '用机器人账户登录你的 homeserver，然后复制访问令牌、用户 ID 和 homeserver URL。',
-      signal: '在可访问的位置运行 signal-cli REST 桥接，然后把 Hermes 指向该 URL 和已注册的电话号码。',
+      signal: '在可访问的位置运行原生 signal-cli HTTP 守护进程，然后把 Hermes 指向该 URL 和已关联的电话号码。',
       whatsapp: '启动 Hermes 自带的 WhatsApp 桥接，首次运行时扫描二维码，然后启用该平台。',
       bluebubbles:
         '在装有 iMessage 的 Mac 上运行 BlueBubbles Server，暴露其 API，然后用服务器密码把 Hermes 指向该 URL。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2083,11 +2083,11 @@ export const zh: Translations = {
       MATRIX_USER_ID: { label: 'Bot 用户 ID', placeholder: '@hermes:example.org' },
       MATRIX_ALLOWED_USERS: { label: '允许的 Matrix 用户 ID', help: '推荐。@user:server 格式的逗号分隔用户 ID。' },
       SIGNAL_HTTP_URL: {
-        label: 'Signal 桥接 URL',
+        label: 'signal-cli HTTP URL',
         placeholder: 'http://127.0.0.1:8080',
-        help: '运行中的 signal-cli REST 桥接的 URL。'
+        help: '原生 signal-cli HTTP 守护进程的 URL。'
       },
-      SIGNAL_ACCOUNT: { label: '电话号码', help: '在 signal-cli 桥接中注册的号码。' },
+      SIGNAL_ACCOUNT: { label: '电话号码', help: '与 signal-cli 关联的电话号码。' },
       SIGNAL_ALLOWED_USERS: { label: '允许的 Signal 用户', help: '推荐。逗号分隔的 Signal 标识符。' },
       WHATSAPP_ENABLED: { label: '启用 WhatsApp 桥接', help: '由下方开关自动设置。除非确知需要，否则请勿改动。' },
       WHATSAPP_MODE: { label: '桥接模式' },
@@ -2101,7 +2101,7 @@ export const zh: Translations = {
       slack: '创建 Slack 应用，启用 Socket Mode，安装到你的工作区，然后复制 bot 令牌和 app 级令牌。',
       mattermost: '在你的 Mattermost 服务器上，创建机器人账户或个人访问令牌，然后在此粘贴服务器 URL 和令牌。',
       matrix: '用机器人账户登录你的 homeserver，然后复制访问令牌、用户 ID 和 homeserver URL。',
-      signal: '在可访问的位置运行 signal-cli REST 桥接，然后把 Hermes 指向该 URL 和已注册的电话号码。',
+      signal: '在可访问的位置运行原生 signal-cli HTTP 守护进程，然后把 Hermes 指向该 URL 和已关联的电话号码。',
       whatsapp: '启动 Hermes 自带的 WhatsApp 桥接，首次运行时扫描二维码，然后启用该平台。',
       bluebubbles:
         '在装有 iMessage 的 Mac 上运行 BlueBubbles Server，暴露其 API，然后用服务器密码把 Hermes 指向该 URL。',

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5845,7 +5845,9 @@ def _setup_signal():
             "    Linux:  download from https://github.com/AsamK/signal-cli/releases"
         )
         print_info("    macOS:  brew install signal-cli")
-        print_info("    Docker: bbernhard/signal-cli-rest-api")
+        print_info(
+            "    Use the native signal-cli HTTP daemon; REST wrappers are not compatible."
+        )
         print()
         print_info("  After installing, link your account and start the daemon:")
         print_info('    signal-cli link -n "HermesAgent"')

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5270,7 +5270,8 @@ def _setup_signal():
         _print_info_lines(
             "  Signal requires signal-cli running as an HTTP daemon.", "  Install options:",
             "    Linux:  download from https://github.com/AsamK/signal-cli/releases",
-            "    macOS:  brew install signal-cli", "    Docker: bbernhard/signal-cli-rest-api",
+            "    macOS:  brew install signal-cli",
+            "    Use the native signal-cli HTTP daemon; REST wrappers are not compatible.",
         )
         print()
         _print_info_lines(

--- a/hermes_cli/web_routers/messaging.py
+++ b/hermes_cli/web_routers/messaging.py
@@ -61,8 +61,8 @@ _GATEWAY_HEALTH_URL = LateState("_GATEWAY_HEALTH_URL")
 _MESSAGING_ENV_FALLBACKS: dict[str, dict[str, Any]] = {
     key: {"description": description, "prompt": prompt, **extra}
     for key, description, prompt, extra in (
-        ("SIGNAL_HTTP_URL", "signal-cli REST API base URL, e.g. http://127.0.0.1:8080", "Signal bridge URL", {"url": "https://github.com/bbernhard/signal-cli-rest-api"}),
-        ("SIGNAL_ACCOUNT", "Signal account phone number registered with the bridge", "Signal account", {}),
+        ("SIGNAL_HTTP_URL", "Native signal-cli HTTP daemon URL, e.g. http://127.0.0.1:8080", "signal-cli HTTP URL", {"url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal"}),
+        ("SIGNAL_ACCOUNT", "Signal account phone number linked to signal-cli", "Signal account", {}),
         ("SIGNAL_ALLOWED_USERS", "Comma-separated Signal users allowed to use the bot", "Allowed Signal users", {}),
         ("WHATSAPP_ENABLED", "Enable the WhatsApp gateway adapter", "Enable WhatsApp", {"advanced": True}),
         ("WHATSAPP_MODE", "WhatsApp bridge mode", "WhatsApp mode", {"advanced": True}),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6505,8 +6505,8 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
     },
     "signal": {
         "name": "Signal",
-        "description": "Connect through a signal-cli REST bridge.",
-        "docs_url": "https://github.com/bbernhard/signal-cli-rest-api",
+        "description": "Connect through the native signal-cli HTTP daemon.",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal",
         "env_vars": ("SIGNAL_HTTP_URL", "SIGNAL_ACCOUNT", "SIGNAL_ALLOWED_USERS"),
         "required_env": ("SIGNAL_HTTP_URL", "SIGNAL_ACCOUNT"),
     },
@@ -6691,12 +6691,12 @@ _PLATFORM_ORDER: tuple[str, ...] = (
 # falls back here so the UI can still render a friendly label.
 _MESSAGING_ENV_FALLBACKS: dict[str, dict[str, Any]] = {
     "SIGNAL_HTTP_URL": {
-        "description": "signal-cli REST API base URL, e.g. http://127.0.0.1:8080",
-        "prompt": "Signal bridge URL",
-        "url": "https://github.com/bbernhard/signal-cli-rest-api",
+        "description": "Native signal-cli HTTP daemon URL, e.g. http://127.0.0.1:8080",
+        "prompt": "signal-cli HTTP URL",
+        "url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal",
     },
     "SIGNAL_ACCOUNT": {
-        "description": "Signal account phone number registered with the bridge",
+        "description": "Signal account phone number linked to signal-cli",
         "prompt": "Signal account",
     },
     "SIGNAL_ALLOWED_USERS": {

--- a/hermes_cli/web_server_messaging.py
+++ b/hermes_cli/web_server_messaging.py
@@ -57,8 +57,8 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
         "required_env": ("MATRIX_HOMESERVER", "MATRIX_ACCESS_TOKEN", "MATRIX_USER_ID"),
     },
     "signal": {
-        "name": "Signal", "description": "Connect through a signal-cli REST bridge.",
-        "docs_url": "https://github.com/bbernhard/signal-cli-rest-api",
+        "name": "Signal", "description": "Connect through the native signal-cli HTTP daemon.",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal",
         "env_vars": ("SIGNAL_HTTP_URL", "SIGNAL_ACCOUNT", "SIGNAL_ALLOWED_USERS"),
         "required_env": ("SIGNAL_HTTP_URL", "SIGNAL_ACCOUNT"),
     },

--- a/tests/hermes_cli/test_signal_setup_metadata.py
+++ b/tests/hermes_cli/test_signal_setup_metadata.py
@@ -1,0 +1,46 @@
+"""Regression tests for native signal-cli setup guidance."""
+
+import shutil
+
+from hermes_cli import gateway, web_server
+
+
+def test_signal_setup_recommends_only_native_http_daemon(monkeypatch, capsys):
+    monkeypatch.setattr(gateway, "get_env_value", lambda _key: "")
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+    def cancel_setup(_prompt=""):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", cancel_setup)
+
+    gateway._setup_signal()
+
+    output = capsys.readouterr().out
+    assert "native signal-cli HTTP daemon" in output
+    assert "signal-cli --account +YOURNUMBER daemon --http" in output
+    assert "bbernhard/signal-cli-rest-api" not in output
+
+
+def test_signal_dashboard_metadata_describes_native_http_daemon():
+    signal = web_server._build_catalog_entry("signal")
+    http_url = web_server._messaging_env_info("SIGNAL_HTTP_URL")
+    account = web_server._messaging_env_info("SIGNAL_ACCOUNT")
+
+    assert signal["description"] == "Connect through the native signal-cli HTTP daemon."
+    assert signal["docs_url"] == (
+        "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal"
+    )
+    assert http_url["description"] == (
+        "Native signal-cli HTTP daemon URL, e.g. http://127.0.0.1:8080"
+    )
+    assert http_url["prompt"] == "signal-cli HTTP URL"
+    assert http_url["url"] == signal["docs_url"]
+    assert "bridge" not in " ".join(
+        (
+            signal["description"],
+            http_url["description"],
+            http_url["prompt"],
+            account["description"],
+        )
+    ).lower()

--- a/tests/hermes_cli/test_signal_setup_metadata.py
+++ b/tests/hermes_cli/test_signal_setup_metadata.py
@@ -2,7 +2,9 @@
 
 import shutil
 
-from hermes_cli import gateway, web_server
+from hermes_cli import gateway
+from hermes_cli.web_routers.messaging import _messaging_env_info
+from hermes_cli.web_server_messaging import _build_catalog_entry
 
 
 def test_signal_setup_recommends_only_native_http_daemon(monkeypatch, capsys):
@@ -23,9 +25,9 @@ def test_signal_setup_recommends_only_native_http_daemon(monkeypatch, capsys):
 
 
 def test_signal_dashboard_metadata_describes_native_http_daemon():
-    signal = web_server._build_catalog_entry("signal")
-    http_url = web_server._messaging_env_info("SIGNAL_HTTP_URL")
-    account = web_server._messaging_env_info("SIGNAL_ACCOUNT")
+    signal = _build_catalog_entry("signal")
+    http_url = _messaging_env_info("SIGNAL_HTTP_URL")
+    account = _messaging_env_info("SIGNAL_ACCOUNT")
 
     assert signal["description"] == "Connect through the native signal-cli HTTP daemon."
     assert signal["docs_url"] == (

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -19,7 +19,7 @@ The Signal adapter uses `httpx` (already a core Hermes dependency) for all commu
 ## Prerequisites
 
 - **signal-cli** — Java-based Signal client ([GitHub](https://github.com/AsamK/signal-cli))
-- **Java 17+** runtime — required by signal-cli
+- **Java 25+** runtime — required by current signal-cli 0.14.x releases
 - **A phone number** with Signal installed (for linking as a secondary device)
 
 ### Installing signal-cli
@@ -38,6 +38,38 @@ sudo ln -sf "/opt/signal-cli-${VERSION}/bin/signal-cli" /usr/local/bin/
 
 :::caution
 signal-cli is **not** in apt or snap repositories. The Linux install above downloads directly from [GitHub releases](https://github.com/AsamK/signal-cli/releases).
+
+Current signal-cli 0.14.x builds require Java 25 or newer. Distro-packaged
+Java 21 fails with `UnsupportedClassVersionError`, and older signal-cli 0.13.x
+builds are rejected by Signal's servers as deprecated.
+:::
+
+If your distro does not ship Java 25 yet, install a current JRE explicitly and
+point the daemon at it:
+
+```bash
+sudo mkdir -p /opt/java
+case "$(uname -m)" in
+  x86_64|amd64) ARCH=x64 ;;
+  aarch64|arm64) ARCH=aarch64 ;;
+  *) ARCH=x64 ;;
+esac
+curl -fsSL "https://api.adoptium.net/v3/binary/latest/25/ga/linux/${ARCH}/jre/hotspot/normal/eclipse?project=jdk" \
+  | sudo tar xz -C /opt/java
+sudo ln -sf /opt/java/jdk-25* /opt/java/current
+export JAVA_HOME=/opt/java/current
+```
+
+For a systemd service, set `Environment=JAVA_HOME=/opt/java/current` so
+signal-cli does not fall back to an older system JRE.
+
+:::warning Use the native signal-cli HTTP daemon
+Hermes currently speaks to signal-cli's native `--http` daemon. Do not
+substitute the popular `bbernhard/signal-cli-rest-api` Docker image unless your
+Hermes version explicitly documents support for it. That image exposes a
+different REST API (`/v1/about`, `/v2/send`, `/v1/health`, and different event
+payloads) and is not compatible with the native-daemon adapter, even if a reverse
+proxy makes the health check look green.
 :::
 
 ---
@@ -131,6 +163,15 @@ DM access follows the same pattern as all other Hermes platforms:
 2. **No allowlist set** → unknown users get a DM pairing code (approve via `hermes pairing approve signal CODE`)
 3. **`SIGNAL_ALLOW_ALL_USERS=true`** → anyone can message (use with caution)
 
+Signal's Phone Number Privacy can expose inbound DMs by ACI UUID instead of by
+E.164 phone number. If a trusted sender is rejected with a log line such as
+`Unauthorized user: 00000000-aaaa-bbbb-cccc-000000000000 (DisplayName) on signal`,
+add that UUID to `SIGNAL_ALLOWED_USERS` alongside the phone number:
+
+```bash
+SIGNAL_ALLOWED_USERS=+1234567890,+0987654321,00000000-aaaa-bbbb-cccc-000000000000
+```
+
 ### Group Access
 
 Group access is controlled by the `SIGNAL_GROUP_ALLOWED_USERS` env var:
@@ -223,9 +264,13 @@ The adapter monitors the SSE connection and automatically reconnects if:
 | Problem | Solution |
 |---------|----------|
 | **"Cannot reach signal-cli"** during setup | Ensure signal-cli daemon is running: `signal-cli --account +YOUR_NUMBER daemon --http 127.0.0.1:8080` |
-| **Messages not received** | Check that `SIGNAL_ALLOWED_USERS` includes the sender's number in E.164 format (with `+` prefix) |
-| **"signal-cli not found on PATH"** | Install signal-cli and ensure it's in your PATH, or use Docker |
-| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 17+ is installed. |
+| **Messages not received** | Check that `SIGNAL_ALLOWED_USERS` includes the sender's E.164 phone number or ACI UUID. |
+| **"signal-cli not found on PATH"** | Install signal-cli and ensure it's in your PATH. Do not substitute `bbernhard/signal-cli-rest-api` unless your Hermes version explicitly documents support for it. |
+| **`UnsupportedClassVersionError` on startup** | Install Java 25+ and set `JAVA_HOME` for the signal-cli daemon. |
+| **`Verify error: StatusCode: 499` / `DeprecatedVersionException`** | Upgrade to signal-cli 0.14.x or newer. Older clients are rejected by Signal's servers. |
+| **`409 AlreadyVerifiedException` during registration** | Complete and delete the Signal account once in the mobile app to clear the server-side registration state, then retry `signal-cli register --captcha`. |
+| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 25+ is installed. |
+| **Gateway starts before signal-cli after reboot** | Add a systemd drop-in that waits for `http://127.0.0.1:8080/api/v1/check`, or rely on the gateway reconnect watcher to recover after startup. |
 | **Group messages ignored** | Configure `SIGNAL_GROUP_ALLOWED_USERS` with specific group IDs, or `*` to allow all groups. |
 | **Bot responds to no one** | Configure `SIGNAL_ALLOWED_USERS`, use DM pairing, or explicitly allow all users through gateway policy if you want broader access. |
 | **Duplicate messages** | Ensure only one signal-cli instance is listening on your phone number |

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -19,7 +19,7 @@ The Signal adapter uses `httpx` (already a core Hermes dependency) for all commu
 ## Prerequisites
 
 - **signal-cli** — Java-based Signal client ([GitHub](https://github.com/AsamK/signal-cli))
-- **Java 17+** runtime — required by signal-cli
+- **Java 25+** runtime — required by current signal-cli 0.14.x releases
 - **A phone number** with Signal installed (for linking as a secondary device)
 
 ### Installing signal-cli
@@ -38,6 +38,38 @@ sudo ln -sf "/opt/signal-cli-${VERSION}/bin/signal-cli" /usr/local/bin/
 
 :::caution
 signal-cli is **not** in apt or snap repositories. The Linux install above downloads directly from [GitHub releases](https://github.com/AsamK/signal-cli/releases).
+
+Current signal-cli 0.14.x builds require Java 25 or newer. Distro-packaged
+Java 21 fails with `UnsupportedClassVersionError`, and older signal-cli 0.13.x
+builds are rejected by Signal's servers as deprecated.
+:::
+
+If your distro does not ship Java 25 yet, install a current JRE explicitly and
+point the daemon at it:
+
+```bash
+sudo mkdir -p /opt/java
+case "$(uname -m)" in
+  x86_64|amd64) ARCH=x64 ;;
+  aarch64|arm64) ARCH=aarch64 ;;
+  *) ARCH=x64 ;;
+esac
+curl -fsSL "https://api.adoptium.net/v3/binary/latest/25/ga/linux/${ARCH}/jre/hotspot/normal/eclipse?project=jdk" \
+  | sudo tar xz -C /opt/java
+sudo ln -sf /opt/java/jdk-25* /opt/java/current
+export JAVA_HOME=/opt/java/current
+```
+
+For a systemd service, set `Environment=JAVA_HOME=/opt/java/current` so
+signal-cli does not fall back to an older system JRE.
+
+:::warning Use the native signal-cli HTTP daemon
+Hermes currently speaks to signal-cli's native `--http` daemon. Do not
+substitute the popular `bbernhard/signal-cli-rest-api` Docker image unless your
+Hermes version explicitly documents support for it. That image exposes a
+different REST API (`/v1/about`, `/v2/send`, `/v1/health`, and different event
+payloads) and is not compatible with the native-daemon adapter, even if a reverse
+proxy makes the health check look green.
 :::
 
 ---
@@ -130,6 +162,15 @@ DM access follows the same pattern as all other Hermes platforms:
 1. **`SIGNAL_ALLOWED_USERS` set** → only those users can message
 2. **No allowlist set** → unknown users get a DM pairing code (approve via `hermes pairing approve signal CODE`)
 3. **`SIGNAL_ALLOW_ALL_USERS=true`** → anyone can message (use with caution)
+
+Signal's Phone Number Privacy can expose inbound DMs by ACI UUID instead of by
+E.164 phone number. If a trusted sender is rejected with a log line such as
+`Unauthorized user: 00000000-aaaa-bbbb-cccc-000000000000 (DisplayName) on signal`,
+add that UUID to `SIGNAL_ALLOWED_USERS` alongside the phone number:
+
+```bash
+SIGNAL_ALLOWED_USERS=+1234567890,+0987654321,00000000-aaaa-bbbb-cccc-000000000000
+```
 
 ### Group Access
 
@@ -227,9 +268,13 @@ The adapter monitors the SSE connection and automatically reconnects if:
 | Problem | Solution |
 |---------|----------|
 | **"Cannot reach signal-cli"** during setup | Ensure signal-cli daemon is running: `signal-cli --account +YOUR_NUMBER daemon --http 127.0.0.1:8080` |
-| **Messages not received** | Check that `SIGNAL_ALLOWED_USERS` includes the sender's number in E.164 format (with `+` prefix) |
-| **"signal-cli not found on PATH"** | Install signal-cli and ensure it's in your PATH, or use Docker |
-| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 17+ is installed. |
+| **Messages not received** | Check that `SIGNAL_ALLOWED_USERS` includes the sender's E.164 phone number or ACI UUID. |
+| **"signal-cli not found on PATH"** | Install signal-cli and ensure it's in your PATH. Do not substitute `bbernhard/signal-cli-rest-api` unless your Hermes version explicitly documents support for it. |
+| **`UnsupportedClassVersionError` on startup** | Install Java 25+ and set `JAVA_HOME` for the signal-cli daemon. |
+| **`Verify error: StatusCode: 499` / `DeprecatedVersionException`** | Upgrade to signal-cli 0.14.x or newer. Older clients are rejected by Signal's servers. |
+| **`409 AlreadyVerifiedException` during registration** | Complete and delete the Signal account once in the mobile app to clear the server-side registration state, then retry `signal-cli register --captcha`. |
+| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 25+ is installed. |
+| **Gateway starts before signal-cli after reboot** | Add a systemd drop-in that waits for `http://127.0.0.1:8080/api/v1/check`, or rely on the gateway reconnect watcher to recover after startup. |
 | **Group messages ignored** | Configure `SIGNAL_GROUP_ALLOWED_USERS` with specific group IDs, or `*` to allow all groups. |
 | **Bot responds to no one** | Configure `SIGNAL_ALLOWED_USERS`, use DM pairing, or explicitly allow all users through gateway policy if you want broader access. |
 | **Duplicate messages** | Ensure only one signal-cli instance is listening on your phone number |


### PR DESCRIPTION
## What does this PR do?

Hermes' native Signal adapter speaks directly to signal-cli's `--http` daemon, but the first-run wizard and dashboard still recommended an incompatible REST wrapper. This aligns every first-party setup surface with the adapter's real protocol and documents the setup failures reported in #31674.

The CLI wizard, dashboard metadata, desktop UI, maintained desktop locales, and Signal guide now consistently direct users to the native daemon. The guide also covers the current Java requirement, ACI UUID allowlisting, registration recovery, and startup ordering.

Rebased onto current `main`: the dashboard metadata and env-fallback code moved into sibling modules (`hermes_cli/web_server_messaging.py`, `hermes_cli/web_routers/messaging.py`) during the facade decomposition; the Signal copy changes now land there, and the metadata test imports from the new locations.

## Related Issue

Fixes #31674

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Regression tests

## Changes Made

- Remove the incompatible `bbernhard/signal-cli-rest-api` recommendation from `hermes_cli/gateway.py`.
- Point the dashboard metadata and help links in `hermes_cli/web_server_messaging.py` and `hermes_cli/web_routers/messaging.py` at the native signal-cli daemon setup.
- Align the desktop intro and all maintained locale field copy with the same terminology.
- Document Java 25+, ACI UUID allowlisting, registration recovery, and startup ordering in the Signal guide.
- Add focused regressions for the wizard output and generated dashboard metadata, importing from the sibling modules after the decomposition.

## How to Test

1. `uv run --extra dev pytest -q tests/hermes_cli/test_signal_setup_metadata.py`
2. `uv run --extra dev ruff check hermes_cli/gateway.py hermes_cli/web_server_messaging.py hermes_cli/web_routers/messaging.py tests/hermes_cli/test_signal_setup_metadata.py`
3. `npm run --prefix apps/desktop typecheck`
4. `npm run --prefix apps/desktop test:ui -- src/i18n/languages.test.ts src/i18n/runtime.test.ts`
5. From `website/`, run `npm ci && npm run build`.

The two new regression tests fail against the previous wizard and dashboard metadata and pass with this change.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] The commit follows Conventional Commits.
- [x] The PR is limited to the Signal setup inconsistency and its documentation.
- [x] Focused Python tests, Ruff, desktop typecheck, and locale tests pass; the full suite remains with sharded CI.
- [x] Regression tests cover both affected Python surfaces.
- [x] Tested on macOS 26.5.

### Documentation & Housekeeping

- [x] The Signal setup guide and all maintained desktop locales are updated.
- [x] No configuration keys, architecture contracts, or tool schemas changed.
- [x] Cross-platform guidance covers Linux and macOS installation without changing runtime behavior.

## Screenshots / Logs

No layout or runtime UI behavior changed; this corrects setup copy, metadata, and documentation.