### PR TITLE
fix(agent): guard Gemini enum sanitizer for array types

### DIFF
--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -83,7 +83,11 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
     # model enough guidance; the tool handler still validates the value.
     enum_val = cleaned.get("enum")
     type_val = cleaned.get("type")
-    if isinstance(enum_val, list) and type_val in {"integer", "number", "boolean"}:
+    if (
+        isinstance(enum_val, list)
+        and isinstance(type_val, str)
+        and type_val in {"integer", "number", "boolean"}
+    ):
         if any(not isinstance(item, str) for item in enum_val):
             cleaned.pop("enum", None)
 

--- a/tests/agent/test_gemini_schema.py
+++ b/tests/agent/test_gemini_schema.py
@@ -68,6 +68,13 @@ class TestSanitizeGeminiSchema:
         cleaned = sanitize_gemini_schema(schema)
         assert cleaned["enum"] == ["60", "1440", "4320", "10080"]
 
+    def test_preserves_enum_when_type_is_json_schema_array(self):
+        """JSON Schema permits array-valued ``type``; it must not crash sanitizing."""
+        schema = {"type": ["string", "null"], "enum": ["ready", None]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == ["string", "null"]
+        assert cleaned["enum"] == ["ready", None]
+
     def test_drops_nested_integer_enum_inside_properties(self):
         """The fix must apply recursively — the Discord case is nested."""
         schema = {


### PR DESCRIPTION
Fixes #55645.\n\n## Summary\n- guard Gemini enum sanitizer's scalar type check so JSON Schema array-valued type fields do not raise TypeError\n- add regression coverage for nullable array types with enums\n\n## Tests\n- scripts/run_tests.sh tests/agent/test_gemini_schema.py