### PR TITLE
fix(cli): include breakaway flag for hidden Windows subprocesses

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -15,7 +15,9 @@ Several common subprocess patterns break silently-or-loudly on Windows:
 
 * Console-window flashes — every ``subprocess.Popen`` of a ``.exe`` on
   Windows spawns a cmd window briefly unless ``CREATE_NO_WINDOW`` is
-  passed.  Cosmetic but jarring for background daemons.
+  passed.  Electron/Tauri hosts often run Hermes inside a job object where
+  ``CREATE_NO_WINDOW`` alone is ignored, so hidden children also need
+  ``CREATE_BREAKAWAY_FROM_JOB``.
 
 This module centralizes the platform-branching logic so the rest of the
 codebase doesn't sprinkle ``if sys.platform == "win32":`` everywhere.
@@ -191,6 +193,13 @@ def windows_hide_flags() -> int:
     operation (``taskkill``, ``where``, version probes) where we want no
     flash but also want to collect stdout/exit code synchronously.
 
+    ``CREATE_BREAKAWAY_FROM_JOB`` is included even though this is not a
+    detach helper. Electron/Tauri wrappers run Hermes inside Win32 job
+    objects, and in that context ``CREATE_NO_WINDOW`` by itself can be
+    ignored by console children, producing visible ``cmd.exe`` / ``git.exe``
+    flashes. Breakaway lets the no-window flag take effect while keeping
+    stdio attached for capture.
+
     The key difference from :func:`windows_detach_flags`: NO
     ``DETACHED_PROCESS`` — the child still inherits stdio handles so
     ``capture_output=True`` works.  ``DETACHED_PROCESS`` would sever
@@ -198,7 +207,7 @@ def windows_hide_flags() -> int:
     """
     if not IS_WINDOWS:
         return 0
-    return _CREATE_NO_WINDOW
+    return _CREATE_NO_WINDOW | _CREATE_BREAKAWAY_FROM_JOB
 
 
 def windows_detach_popen_kwargs() -> dict:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -89,6 +89,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
 
@@ -7816,7 +7817,7 @@ def _default_spawn(
             stderr=subprocess.STDOUT,
             env=env,
             start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
         )
     except FileNotFoundError:
         log_f.close()

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -601,6 +601,16 @@ class TestSubprocessCompatHelpers:
             "can respawn the gateway after Electron exits."
         )
 
+    def test_windows_hide_flags_includes_breakaway_from_job(self, monkeypatch):
+        """Hidden short-lived probes must also escape Electron job objects."""
+        from hermes_cli import _subprocess_compat as sc
+
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        flags = sc.windows_hide_flags()
+        assert flags & 0x08000000, "missing CREATE_NO_WINDOW"
+        assert flags & 0x01000000, "missing CREATE_BREAKAWAY_FROM_JOB"
+        assert not flags & 0x00000008, "hide flags must not detach stdio"
+
     def test_windows_detach_flags_without_breakaway_drops_only_that_bit(
         self, monkeypatch
     ):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -46,6 +46,7 @@ import uuid
 _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.thread_context import propagate_context_to_thread
 
 # Availability gate.  On Windows we fall back to loopback TCP for the
@@ -1308,7 +1309,7 @@ def execute_code(
             stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
         )
 
         # --- Poll loop: watch for exit, timeout, and interrupt ---
@@ -1652,7 +1653,7 @@ def _is_usable_python(python_path: str) -> bool:
              "import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)"],
             timeout=5,
             capture_output=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
             stdin=subprocess.DEVNULL,
         )
         return result.returncode == 0


### PR DESCRIPTION
Fixes #55604.\n\n## Summary\n- include CREATE_BREAKAWAY_FROM_JOB in windows_hide_flags so short-lived probes can stay hidden under Electron/Tauri job objects\n- route remaining hard-coded CREATE_NO_WINDOW subprocess spawns through windows_hide_flags\n- add regression coverage for the hide flag bundle\n\n## Tests\n- scripts/run_tests.sh tests/tools/test_windows_native_support.py tests/test_windows_subprocess_no_window_flags.py