### PR TITLE
fix(agent): classify Codex content-filter incompletes

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -103,6 +103,23 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
     return None
 
 
+def _codex_response_finish_reason(response: Any) -> str:
+    """Map Codex Responses terminal status details to chat-style finish reasons."""
+    status = getattr(response, "status", None)
+    incomplete_details = getattr(response, "incomplete_details", None)
+    incomplete_reason = None
+    if isinstance(incomplete_details, dict):
+        incomplete_reason = incomplete_details.get("reason")
+    else:
+        incomplete_reason = getattr(incomplete_details, "reason", None)
+
+    if status == "incomplete" and incomplete_reason == "content_filter":
+        return "content_filter"
+    if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
+        return "length"
+    return "stop"
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -1466,17 +1483,7 @@ def run_conversation(
 
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":
-                    status = getattr(response, "status", None)
-                    incomplete_details = getattr(response, "incomplete_details", None)
-                    incomplete_reason = None
-                    if isinstance(incomplete_details, dict):
-                        incomplete_reason = incomplete_details.get("reason")
-                    else:
-                        incomplete_reason = getattr(incomplete_details, "reason", None)
-                    if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
-                        finish_reason = "length"
-                    else:
-                        finish_reason = "stop"
+                    finish_reason = _codex_response_finish_reason(response)
                 elif agent.api_mode == "anthropic_messages":
                     _tfr = agent._get_transport()
                     finish_reason = _tfr.map_finish_reason(response.stop_reason)

--- a/tests/agent/test_conversation_loop_codex_finish_reason.py
+++ b/tests/agent/test_conversation_loop_codex_finish_reason.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+from agent.conversation_loop import _codex_response_finish_reason
+
+
+def test_codex_incomplete_content_filter_maps_to_content_filter_dict():
+    response = SimpleNamespace(
+        status="incomplete",
+        incomplete_details={"reason": "content_filter"},
+    )
+
+    assert _codex_response_finish_reason(response) == "content_filter"
+
+
+def test_codex_incomplete_content_filter_maps_to_content_filter_object():
+    response = SimpleNamespace(
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason="content_filter"),
+    )
+
+    assert _codex_response_finish_reason(response) == "content_filter"
+
+
+def test_codex_incomplete_length_reasons_still_map_to_length():
+    for reason in ("max_output_tokens", "length"):
+        response = SimpleNamespace(
+            status="incomplete",
+            incomplete_details={"reason": reason},
+        )
+        assert _codex_response_finish_reason(response) == "length"
+
+
+def test_codex_completed_response_maps_to_stop():
+    response = SimpleNamespace(status="completed", incomplete_details=None)
+
+    assert _codex_response_finish_reason(response) == "stop"


### PR DESCRIPTION
Fixes #55637.\n\n## Summary\n- map Codex Responses incomplete_details.reason=content_filter to finish_reason=content_filter\n- preserve existing length handling for max_output_tokens/length incomplete reasons\n- add focused regression coverage for dict and object-shaped incomplete_details\n\n## Tests\n- scripts/run_tests.sh tests/agent/test_conversation_loop_codex_finish_reason.py