### PR TITLE
fix(cli): update reasoning config in-place, avoid agent rebuild

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2999,7 +2999,14 @@ class CLICommandsMixin:
             return
 
         self.reasoning_config = parsed
-        self.agent = None  # Force agent re-init with new reasoning config
+        if self.agent is not None:
+            # reasoning_config is read dynamically on every API call
+            # (agent/chat_completion_helpers.py), so update in-place instead
+            # of destroying the agent — avoids MCP rediscovery storm, prompt
+            # cache invalidation, and "Agent updated — 0 tool(s) available".
+            self.agent.reasoning_config = parsed
+        else:
+            self.agent = None  # No live agent — re-init on next turn
 
         if explicit_global and save_config_value("agent.reasoning_effort", arg):
             agent_cfg = CLI_CONFIG.get("agent")
@@ -3103,7 +3110,14 @@ class CLICommandsMixin:
             _cprint(f"  {_DIM}Usage: /fast [normal|fast|status] [--global]{_RST}")
             return
 
-        self.agent = None  # Force agent re-init with new service-tier config
+        if self.agent is not None:
+            # service_tier is resolved per-turn via request_overrides
+            # (hermes_cli/cli_agent_setup_mixin.py), so update in-place
+            # instead of destroying the agent — avoids MCP rediscovery storm,
+            # prompt cache invalidation, and "Agent updated — 0 tool(s)".
+            self.agent.service_tier = self.service_tier
+        else:
+            self.agent = None  # No live agent — re-init on next turn
         if explicit_global and save_config_value("agent.service_tier", saved_value):
             _cprint(f"  {_ACCENT}✓ {feature_name} set to {label} (saved to config){_RST}")
         elif explicit_global:

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -70,7 +70,9 @@ class TestHandleFastCommand(unittest.TestCase):
         # Session-scoped by default: no config write.
         mock_save.assert_not_called()
         self.assertIsNone(stub.service_tier)
-        self.assertIsNone(stub.agent)
+        # Agent is updated in-place, not destroyed (prompt cache preserved).
+        self.assertIsNotNone(stub.agent)
+        self.assertEqual(stub.agent.service_tier, stub.service_tier)
 
 
     def test_unsupported_model_does_not_expose_fast(self):

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -101,7 +101,9 @@ class TestHandleReasoningCommand(unittest.TestCase):
 
         save_config.assert_not_called()
         self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "high"})
-        self.assertIsNone(stub.agent)
+        # Agent is updated in-place, not destroyed (prompt cache preserved).
+        self.assertIsNotNone(stub.agent)
+        self.assertEqual(stub.agent.reasoning_config, {"enabled": True, "effort": "high"})
 
 
 

--- a/tests/hermes_cli/test_reasoning_fast_inplace.py
+++ b/tests/hermes_cli/test_reasoning_fast_inplace.py
@@ -1,0 +1,155 @@
+"""Regression tests: /reasoning and /fast update agent config in-place.
+
+When a live agent exists, /reasoning <level> and /fast <mode> must update
+the agent's config attributes in-place rather than destroying the agent
+(self.agent = None).  Destroying the agent triggers:
+
+- MCP server rediscovery + disconnect storm on the next message
+- Prompt cache invalidation (per-conversation caching is sacred)
+- Visible UX error: "Agent updated — 0 tool(s) available"
+
+Both reasoning_config and service_tier are read dynamically on every API
+call (agent/chat_completion_helpers.py and cli_agent_setup_mixin.py), so
+an in-place update takes effect immediately without a rebuild.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+
+class _Stub(CLICommandsMixin):
+    """Minimal carrier for the attributes the commands read/write."""
+
+    def __init__(self, agent=None):
+        self.reasoning_config = None
+        self.show_reasoning = True
+        self.reasoning_full = False
+        self.service_tier = None
+        self.agent = agent
+
+    def _current_reasoning_callback(self):
+        return None
+
+    def _fast_command_available(self):
+        return True
+
+
+def _seed_config(tmp_path, monkeypatch):
+    hh = tmp_path / ".hermes"
+    hh.mkdir()
+    (hh / "config.yaml").write_text("display:\n  show_reasoning: true\n")
+    monkeypatch.setenv("HERMES_HOME", str(hh))
+    import cli
+    monkeypatch.setattr(cli, "_hermes_home", hh, raising=False)
+    return hh
+
+
+# ── /reasoning in-place ──────────────────────────────────────────────
+
+
+class TestReasoningInPlace:
+    """When agent is live, /reasoning updates config in-place."""
+
+    def test_reasoning_level_updates_agent_in_place(self, tmp_path, monkeypatch):
+        """Live agent: reasoning_config is set on the agent, not destroyed."""
+        _seed_config(tmp_path, monkeypatch)
+        agent = MagicMock()
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+        s = _Stub(agent=agent)
+
+        s._handle_reasoning_command("/reasoning high")
+
+        assert s.agent is agent  # agent NOT destroyed
+        assert s.reasoning_config == {"enabled": True, "effort": "high"}
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+
+    def test_reasoning_none_agent_stays_none(self, tmp_path, monkeypatch):
+        """No live agent: agent stays None (backward compatible)."""
+        _seed_config(tmp_path, monkeypatch)
+        s = _Stub(agent=None)
+
+        s._handle_reasoning_command("/reasoning high")
+
+        assert s.agent is None
+        assert s.reasoning_config == {"enabled": True, "effort": "high"}
+
+    def test_reasoning_preserves_agent_identity(self, tmp_path, monkeypatch):
+        """The exact same agent object survives across multiple /reasoning calls."""
+        _seed_config(tmp_path, monkeypatch)
+        agent = MagicMock()
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+        s = _Stub(agent=agent)
+
+        s._handle_reasoning_command("/reasoning high")
+        agent_after_first = s.agent
+
+        s._handle_reasoning_command("/reasoning max")
+        agent_after_second = s.agent
+
+        assert agent_after_first is agent
+        assert agent_after_second is agent
+        assert agent.reasoning_config == {"enabled": True, "effort": "max"}
+
+
+# ── /fast in-place ───────────────────────────────────────────────────
+
+
+class TestFastInPlace:
+    """When agent is live, /fast updates service_tier in-place."""
+
+    def test_fast_on_updates_agent_in_place(self, tmp_path, monkeypatch):
+        """Live agent: service_tier is set on the agent, not destroyed."""
+        _seed_config(tmp_path, monkeypatch)
+        agent = MagicMock()
+        agent.service_tier = None
+        s = _Stub(agent=agent)
+
+        s._handle_fast_command("/fast fast")
+
+        assert s.agent is agent  # agent NOT destroyed
+        assert s.service_tier == "priority"
+        assert agent.service_tier == "priority"
+
+    def test_fast_off_updates_agent_in_place(self, tmp_path, monkeypatch):
+        """Live agent: turning fast off clears service_tier in-place."""
+        _seed_config(tmp_path, monkeypatch)
+        agent = MagicMock()
+        agent.service_tier = "priority"
+        s = _Stub(agent=agent)
+        s.service_tier = "priority"
+
+        s._handle_fast_command("/fast normal")
+
+        assert s.agent is agent
+        assert s.service_tier is None
+        assert agent.service_tier is None
+
+    def test_fast_none_agent_stays_none(self, tmp_path, monkeypatch):
+        """No live agent: agent stays None (backward compatible)."""
+        _seed_config(tmp_path, monkeypatch)
+        s = _Stub(agent=None)
+
+        s._handle_fast_command("/fast fast")
+
+        assert s.agent is None
+        assert s.service_tier == "priority"
+
+    def test_fast_preserves_agent_identity(self, tmp_path, monkeypatch):
+        """The exact same agent object survives across multiple /fast calls."""
+        _seed_config(tmp_path, monkeypatch)
+        agent = MagicMock()
+        agent.service_tier = None
+        s = _Stub(agent=agent)
+
+        s._handle_fast_command("/fast fast")
+        agent_after_on = s.agent
+
+        s._handle_fast_command("/fast normal")
+        agent_after_off = s.agent
+
+        assert agent_after_on is agent
+        assert agent_after_off is agent


### PR DESCRIPTION
## Summary
- `/reasoning [effort]` no longer destroys the live Agent to apply changes
- `reasoning_config` is updated in-place on the existing agent
- Eliminates unnecessary MCP rediscovery + prompt cache invalidation

## Problem
`_handle_reasoning_command` executed `self.agent = None` to apply changes. This triggered Agent rebuild → `wait_for_mcp_discovery()` reconnects ALL MCP servers on the next message, invalidates prompt cache, and shows "Agent updated — 0 tool(s) available" UX error.

Also fixes the same pattern in `_handle_fast_command` (`/fast`) to update `request_overrides` in-place without destroying the agent.

## Root cause
`reasoning_config` is read **dynamically** by the transport layer on every API call (`chat_completion_helpers.py:572/648/753/785`):
```python
reasoning_config=agent.reasoning_config
```
So the agent rebuild is unnecessary — the transport picks up new values without it.

## Test plan
- [x] `tests/hermes_cli/test_reasoning_full_command.py` (5/5 pass)
- [x] `tests/cli/test_cli_mcp_config_watch.py` (6/6 pass)
- [x] `tests/tools/test_mcp_stability.py` (22/22 pass)
- [x] Manual: `/reasoning xhigh` no longer shows "MCP server config changed"
- [x] Manual: `/reasoning xhigh` → next message → no "Initializing agent..."
- [x] Manual: `/fast fast` → `/fast normal` cycle works without MCP reload
