### PR TITLE
fix(cli): expand env vars in mcp_servers config watcher comparison

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9980,6 +9980,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return
 
         new_mcp = new_cfg.get("mcp_servers") or {}
+        # Expand ${VAR} templates so the comparison is consistent with the
+        # init snapshot (self._config_mcp_servers), which was populated from
+        # the deep-merged + expanded config.  Without this, any
+        # save_config_value() that rewrites config.yaml (even for unrelated
+        # keys) triggers a false-positive MCP reload because the raw yaml
+        # still has "${POWERMEM_API_KEY}" while the snapshot has the
+        # expanded value.
+        from hermes_cli.config import _expand_env_vars
+        new_mcp = _expand_env_vars(new_mcp)
         if new_mcp == self._config_mcp_servers:
             return  # mcp_servers unchanged (some other section was edited)
 


### PR DESCRIPTION
## Summary
- Config watcher now expands ${VAR} templates in mcp_servers before comparing
- Eliminates false-positive MCP reloads when `save_config_value` touches unrelated keys

## Problem
`_check_config_mcp_changes` compared `mcp_servers` from two inconsistent sources:
- **Init**: `self._config_mcp_servers = self.config.get("mcp_servers")` → from `load_config()` + `_expand_env_vars` → expanded values
- **Watcher**: `yaml.safe_load(cfg_path)` → raw `${VAR}` templates

When `mcp_servers` contains env-var templates like `${POWERMEM_API_KEY}`, every `save_config_value()` that rewrites config.yaml (even for unrelated keys) triggers a "change detected" → all 11 MCP servers reconnect.

## Root cause
Init stores expanded values, but watcher reads raw yaml. Comparison is always unequal when templates are used.

## Fix
Apply `_expand_env_vars()` to the watcher's raw mcp_servers before comparison. Both sides now use the same expanded representation. Real MCP server add/remove is still detected correctly — only template-vs-expanded false positives are eliminated.

## Test plan
- [x] `tests/cli/test_cli_mcp_config_watch.py` (6/6 pass)
- [x] Manual: save unrelated config key → no "MCP server config changed"
- [x] Manual: add/remove real MCP server → reload still triggers correctly
