### PR TITLE
fix(agent): gate credential pools by provider

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -52,6 +52,35 @@ def _load_config_safe() -> Optional[dict]:
         return None
 
 
+def credential_pool_matches_provider(
+    pool: Any,
+    provider: Optional[str],
+    base_url: Optional[str] = None,
+) -> bool:
+    """Return whether ``pool`` is safe to use for ``provider``.
+
+    Missing pool/provider metadata is treated as compatible to preserve legacy
+    callers and tests that pass lightweight pool doubles. Real CredentialPool
+    instances carry ``provider`` and are rejected on cross-provider mismatch.
+    """
+    if pool is None:
+        return True
+
+    current_provider = provider.strip().lower() if isinstance(provider, str) else ""
+    raw_pool_provider = getattr(pool, "provider", "")
+    pool_provider = raw_pool_provider.strip().lower() if isinstance(raw_pool_provider, str) else ""
+    if not current_provider or not pool_provider:
+        return True
+    if current_provider == pool_provider:
+        return True
+
+    if current_provider == "custom" and pool_provider.startswith(CUSTOM_POOL_PREFIX):
+        pool_key = get_custom_provider_pool_key((base_url or "").strip())
+        return bool(pool_key) and pool_key.strip().lower() == pool_provider
+
+    return False
+
+
 # --- Status and type constants ---
 
 STATUS_OK = "ok"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3589,7 +3589,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         mode, attach `request_overrides` so the API call is marked
         accordingly.
         """
+        from agent.credential_pool import credential_pool_matches_provider
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        credential_pool = runtime_kwargs.get("credential_pool")
+        if not credential_pool_matches_provider(
+            credential_pool,
+            runtime_kwargs.get("provider"),
+            runtime_kwargs.get("base_url"),
+        ):
+            credential_pool = None
 
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
@@ -3598,7 +3607,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "api_mode": runtime_kwargs.get("api_mode"),
             "command": runtime_kwargs.get("command"),
             "args": list(runtime_kwargs.get("args") or []),
-            "credential_pool": runtime_kwargs.get("credential_pool"),
+            "credential_pool": credential_pool,
             "max_tokens": runtime_kwargs.get("max_tokens"),
         }
         route = {

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -179,7 +179,12 @@ class CLIAgentSetupMixin:
         Processing / Anthropic fast mode, attach `request_overrides` so the
         API call is marked accordingly.
         """
+        from agent.credential_pool import credential_pool_matches_provider
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        credential_pool = getattr(self, "_credential_pool", None)
+        if not credential_pool_matches_provider(credential_pool, self.provider, self.base_url):
+            credential_pool = None
 
         runtime = {
             "api_key": self.api_key,
@@ -188,7 +193,7 @@ class CLIAgentSetupMixin:
             "api_mode": self.api_mode,
             "command": self.acp_command,
             "args": list(self.acp_args or []),
-            "credential_pool": getattr(self, "_credential_pool", None),
+            "credential_pool": credential_pool,
         }
         route = {
             "model": self.model,
@@ -330,6 +335,11 @@ class CLIAgentSetupMixin:
                 pass
         
         try:
+            from agent.credential_pool import credential_pool_matches_provider
+
+            credential_pool = getattr(self, "_credential_pool", None)
+            if not credential_pool_matches_provider(credential_pool, self.provider, self.base_url):
+                credential_pool = None
             runtime = runtime_override or {
                 "api_key": self.api_key,
                 "base_url": self.base_url,
@@ -337,7 +347,7 @@ class CLIAgentSetupMixin:
                 "api_mode": self.api_mode,
                 "command": self.acp_command,
                 "args": list(self.acp_args or []),
-                "credential_pool": getattr(self, "_credential_pool", None),
+                "credential_pool": credential_pool,
             }
             effective_model = model_override or self.model
             self.agent = AIAgent(

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -8,8 +8,45 @@ Covers:
 5. Full 429 rotation cycle: retry-same → rotate → exhaust → fallback
 """
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Provider guard helper
+# ---------------------------------------------------------------------------
+
+class TestCredentialPoolProviderGuard:
+    def test_custom_pool_matches_registered_base_url(self):
+        from agent.credential_pool import credential_pool_matches_provider
+
+        pool = MagicMock(name="CustomPool")
+        pool.provider = "custom:deepseek"
+
+        with patch(
+            "agent.credential_pool.get_custom_provider_pool_key",
+            return_value="custom:deepseek",
+        ):
+            assert credential_pool_matches_provider(
+                pool,
+                "custom",
+                "https://api.deepseek.com/v1",
+            )
+
+    def test_custom_pool_rejects_different_registered_base_url(self):
+        from agent.credential_pool import credential_pool_matches_provider
+
+        pool = MagicMock(name="CustomPool")
+        pool.provider = "custom:openai-codex"
+
+        with patch(
+            "agent.credential_pool.get_custom_provider_pool_key",
+            return_value="custom:deepseek",
+        ):
+            assert not credential_pool_matches_provider(
+                pool,
+                "custom",
+                "https://api.deepseek.com/v1",
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -19,24 +56,45 @@ from unittest.mock import MagicMock, patch
 class TestCliTurnRoutePool:
     def test_resolve_turn_includes_pool(self):
         """CLI's _resolve_turn_agent_config must pass credential_pool in runtime."""
-        fake_pool = MagicMock(name="FakePool")
-        shell = SimpleNamespace(
-            model="gpt-5.4",
-            api_key="sk-test",
-            base_url=None,
-            provider="openai-codex",
-            api_mode="codex_responses",
-            acp_command=None,
-            acp_args=[],
-            _credential_pool=fake_pool,
-            service_tier=None,
-        )
-
         from cli import HermesCLI
-        bound = HermesCLI._resolve_turn_agent_config.__get__(shell)
-        route = bound("test message")
+
+        fake_pool = MagicMock(name="FakePool")
+        fake_pool.provider = "openai-codex"
+        shell = HermesCLI.__new__(HermesCLI)
+        shell.model = "gpt-5.4"
+        shell.api_key = "sk-test"
+        shell.base_url = None
+        shell.provider = "openai-codex"
+        shell.api_mode = "codex_responses"
+        shell.acp_command = None
+        shell.acp_args = []
+        shell._credential_pool = fake_pool
+        shell.service_tier = None
+
+        route = shell._resolve_turn_agent_config("test message")
 
         assert route["runtime"]["credential_pool"] is fake_pool
+
+    def test_resolve_turn_drops_mismatched_pool(self):
+        """CLI must not carry a pool from a different provider into the turn."""
+        from cli import HermesCLI
+
+        stale_pool = MagicMock(name="StaleCodexPool")
+        stale_pool.provider = "openai-codex"
+        shell = HermesCLI.__new__(HermesCLI)
+        shell.model = "deepseek-v4-pro"
+        shell.api_key = "deepseek-key"
+        shell.base_url = "https://api.deepseek.com/v1"
+        shell.provider = "deepseek"
+        shell.api_mode = "chat_completions"
+        shell.acp_command = None
+        shell.acp_args = []
+        shell._credential_pool = stale_pool
+        shell.service_tier = None
+
+        route = shell._resolve_turn_agent_config("test message")
+
+        assert route["runtime"]["credential_pool"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +107,9 @@ class TestGatewayTurnRoutePool:
         from gateway.run import GatewayRunner
 
         fake_pool = MagicMock(name="FakePool")
-        runner = SimpleNamespace(_service_tier=None)
+        fake_pool.provider = "openai-codex"
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._service_tier = None
         runtime_kwargs = {
             "api_key": "***",
             "base_url": None,
@@ -60,10 +120,31 @@ class TestGatewayTurnRoutePool:
             "credential_pool": fake_pool,
         }
 
-        bound = GatewayRunner._resolve_turn_agent_config.__get__(runner)
-        route = bound("test message", "gpt-5.4", runtime_kwargs)
+        route = runner._resolve_turn_agent_config("test message", "gpt-5.4", runtime_kwargs)
 
         assert route["runtime"]["credential_pool"] is fake_pool
+
+    def test_resolve_turn_drops_mismatched_pool(self):
+        """Gateway must not carry a pool from a different provider into the turn."""
+        from gateway.run import GatewayRunner
+
+        stale_pool = MagicMock(name="StaleCodexPool")
+        stale_pool.provider = "openai-codex"
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._service_tier = None
+        runtime_kwargs = {
+            "api_key": "deepseek-key",
+            "base_url": "https://api.deepseek.com/v1",
+            "provider": "deepseek",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": stale_pool,
+        }
+
+        route = runner._resolve_turn_agent_config("test message", "deepseek-v4-pro", runtime_kwargs)
+
+        assert route["runtime"]["credential_pool"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Credential pools are now only forwarded into a turn when the pool belongs to the same provider as the resolved runtime. This prevents a session that has switched to another provider from carrying a stale pool, such as an `openai-codex` pool into a `deepseek` turn, where requests can be sent with the wrong credential/base URL and fail before the existing recovery guard can help.

The fix adds one shared provider-match helper and applies it at the CLI and gateway turn-routing boundaries, with custom-provider handling kept base-url aware so legitimate `custom:<name>` pools still work.

## Related Issue

Fixes #52777

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `credential_pool_matches_provider()` in `agent/credential_pool.py`.
- Gated CLI turn credential pools in `hermes_cli/cli_agent_setup_mixin.py`.
- Gated gateway turn credential pools in `gateway/run.py`.
- Added regression coverage for CLI, gateway, and `custom:<name>` pool matching in `tests/agent/test_credential_pool_routing.py`.

## How to Test

1. Apply the new regression tests to `origin/main` without the fix and run:
   `python -m pytest tests/agent/test_credential_pool_routing.py -q`
   The mismatched-pool CLI and gateway assertions fail.
2. On this branch, run:
   `uv run pytest tests/agent/test_credential_pool_routing.py tests/cli/test_fast_command.py tests/gateway/test_fast_command.py`
   Result: `53 passed`.
3. Run the local CI mirror:
   `scripts/check.sh`
   Result: all blocking gates passed. `ty` remains advisory with pre-existing upstream diagnostics/panic.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant pytest suite via `scripts/check.sh` and targeted pytest commands, and all blocking tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing docs changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
uv run pytest tests/agent/test_credential_pool_routing.py tests/cli/test_fast_command.py tests/gateway/test_fast_command.py
53 passed in 1.91s

scripts/check.sh
✓ All blocking gates passed.
```
