### PR TITLE
fix(bedrock): convert input_image and Anthropic image parts to Converse image blocks

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -536,12 +536,44 @@ def _safe_text(text) -> str:
     return text if text.strip() else _EMPTY_TEXT_PLACEHOLDER
 
 
+def _converse_image_block_from_data_url(url: str) -> Optional[Dict]:
+    """Build a Converse image block from a ``data:`` URL, or None if not one."""
+    if not isinstance(url, str) or not url.startswith("data:"):
+        return None
+    header, _, data = url.partition(",")
+    media_type = "image/jpeg"
+    if header.startswith("data:"):
+        mime_part = header[5:].split(";")[0]
+        if mime_part:
+            media_type = mime_part
+    # Decode base64 to raw bytes - boto3 re-encodes at the wire layer, so
+    # passing the base64 string directly results in double-encoding and
+    # Bedrock rejects it with "Failed to sanitize image".  Ref: #33317.
+    import base64
+    try:
+        raw_bytes = base64.b64decode(data)
+    except Exception:
+        raw_bytes = data.encode("utf-8")
+    return {
+        "image": {
+            "format": media_type.split("/")[-1] if "/" in media_type else "jpeg",
+            "source": {"bytes": raw_bytes},
+        }
+    }
+
+
 def _convert_content_to_converse(content) -> List[Dict]:
     """Convert OpenAI message content (string or list) to Converse content blocks.
 
     Handles:
       - Plain text strings → [{"text": "..."}]
-      - Content arrays with text/image_url parts → mixed text/image blocks
+      - Content arrays with text / image_url / input_image / Anthropic-style
+        ``image`` parts → mixed text/image blocks
+
+    The three image shapes (``image_url``, ``input_image``, and the
+    Anthropic-native ``image`` source block) are all treated as images, the
+    same way the Anthropic converter and the rest of the codebase do - Bedrock
+    frequently serves Claude models, so all three reach this converter.
 
     Replaces empty/whitespace-only text blocks with a non-whitespace
     placeholder — Bedrock's Converse API rejects messages where a text
@@ -594,6 +626,46 @@ def _convert_content_to_converse(content) -> List[Dict]:
                     # Remote URL — Converse doesn't support URLs directly,
                     # include as text reference for the model.
                     blocks.append({"text": f"[Image: {url}]"})
+            elif part_type == "input_image":
+                # OpenAI Responses shape: ``image_url`` is a bare URL string
+                # (or, defensively, the {"url": ...} dict form). The Anthropic
+                # converter accepts this; Converse must too.
+                image_url = part.get("image_url")
+                url = image_url.get("url") if isinstance(image_url, dict) else image_url
+                block = _converse_image_block_from_data_url(url)
+                if block is not None:
+                    blocks.append(block)
+                elif isinstance(url, str) and url:
+                    blocks.append({"text": f"[Image: {url}]"})
+            elif part_type == "image":
+                # Anthropic-native block: {"source": {"type": "base64",
+                # "media_type": ..., "data": ...}} or a url source.
+                source = part.get("source")
+                if isinstance(source, dict):
+                    src_type = source.get("type")
+                    data = source.get("data")
+                    if src_type == "base64" and isinstance(data, str) and data:
+                        media_type = source.get("media_type") or "image/jpeg"
+                        if not isinstance(media_type, str):
+                            media_type = "image/jpeg"
+                        # Decode to raw bytes - boto3 re-encodes at the wire
+                        # layer; a base64 string would be double-encoded and
+                        # rejected ("Failed to sanitize image"). Ref: #33317.
+                        import base64
+                        try:
+                            raw_bytes = base64.b64decode(data)
+                        except Exception:
+                            raw_bytes = data.encode("utf-8")
+                        blocks.append({
+                            "image": {
+                                "format": media_type.split("/")[-1] if "/" in media_type else "jpeg",
+                                "source": {"bytes": raw_bytes},
+                            }
+                        })
+                    else:
+                        src_url = source.get("url")
+                        if isinstance(src_url, str) and src_url:
+                            blocks.append({"text": f"[Image: {src_url}]"})
         return blocks if blocks else [{"text": _EMPTY_TEXT_PLACEHOLDER}]
     return [{"text": _safe_text(content)}]
 

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -221,6 +221,47 @@ class TestConvertMessagesToConverse:
 # Response normalization: Converse → OpenAI
 # ---------------------------------------------------------------------------
 
+    def test_input_image_part_converted_to_converse_image(self):
+        """Responses-style input_image parts must become Converse image blocks.
+
+        The Anthropic converter accepts input_image; the Bedrock converter
+        only handled image_url and silently dropped these, so the image was
+        invisible to Claude-on-Bedrock.
+        """
+        from agent.bedrock_adapter import _convert_content_to_converse
+        data_url = "data:image/png;base64,iVBORw0KGgo="
+        # Bare-string form (OpenAI Responses).
+        blocks = _convert_content_to_converse([
+            {"type": "input_image", "image_url": data_url},
+        ])
+        image_blocks = [b for b in blocks if "image" in b]
+        assert len(image_blocks) == 1
+        assert image_blocks[0]["image"]["format"] == "png"
+        # Dict form.
+        blocks = _convert_content_to_converse([
+            {"type": "input_image", "image_url": {"url": data_url}},
+        ])
+        assert any("image" in b for b in blocks)
+
+    def test_anthropic_image_source_block_converted_to_converse_image(self):
+        """Anthropic-native image source blocks must become Converse images."""
+        import base64
+        from agent.bedrock_adapter import _convert_content_to_converse
+        blocks = _convert_content_to_converse([
+            {"type": "image", "source": {
+                "type": "base64",
+                "media_type": "image/jpeg",
+                "data": "/9j/4AAQ",
+            }},
+        ])
+        image_blocks = [b for b in blocks if "image" in b]
+        assert len(image_blocks) == 1
+        assert image_blocks[0]["image"]["format"] == "jpeg"
+        # Raw decoded bytes, not the base64 string - boto3 re-encodes at the
+        # wire layer (ref: #33317).
+        assert image_blocks[0]["image"]["source"]["bytes"] == base64.b64decode("/9j/4AAQ")
+
+
 class TestNormalizeConverseResponse:
     """Test Bedrock Converse response → OpenAI format conversion."""
 


### PR DESCRIPTION
### Summary

`_convert_content_to_converse` (agent/bedrock_adapter.py) only recognized the OpenAI `image_url` part shape. The other two image shapes the rest of the codebase treats as images are dropped:

- `input_image` (OpenAI Responses): `image_url` is a bare URL string.
- Anthropic-native `image`: `{"source": {"type": "base64", "media_type": ..., "data": ...}}`.

Neither matched the `text`/`image_url` branches, so they fell through and the part produced only a single empty text block. The image was silently lost and the model never saw it.

This matters for Bedrock specifically: Bedrock frequently serves Claude models, so content commonly arrives in the Anthropic `image` and `input_image` shapes. The codebase treats `{"image", "image_url", "input_image"}` as the image-part set throughout (the Anthropic converter, the context compressor, message sanitization, model metadata), and `_supports_media_in_tool_results` explicitly lists `bedrock` as accepting `image` content blocks — but the Converse converter did not handle them.

### Reproduction

```python
from agent.bedrock_adapter import _convert_content_to_converse

_convert_content_to_converse([{"type": "input_image",
                               "image_url": "data:image/png;base64,iVBORw0KGgo="}])
# -> [{'text': ' '}]   (image dropped; no image block)

_convert_content_to_converse([{"type": "image", "source": {
    "type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo="}}])
# -> [{'text': ' '}]   (image dropped)
```

The Anthropic converter (`_convert_content_part_to_anthropic`) accepts all three shapes; Bedrock was the inconsistent one.

### Fix

Handle `input_image` and the Anthropic `image` source block in `_convert_content_to_converse`, emitting the same Converse image block already built for data-URL `image_url` parts (a small `_converse_image_block_from_data_url` helper is shared with the `input_image` path). The existing `image_url` branch is left untouched.

### Tests

Adds regression tests for the bare-string and dict `input_image` forms and the Anthropic base64 `image` source block. They produce no image block before the change and pass after; the full bedrock test file stays green.

Fixes #55705
