### PR TITLE
fix(desktop): stop spurious onboarding overlay on custom provider + transient outages

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -19,7 +19,7 @@ import { refreshBackgroundProcesses } from '@/store/composer-status'
 import { $gateway } from '@/store/gateway'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { notify } from '@/store/notifications'
-import { requestDesktopOnboarding } from '@/store/onboarding'
+import { requestDesktopOnboarding, requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { flashPetActivity, markPetUnread, setPetActivity } from '@/store/pet'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { followActiveSessionCwd } from '@/store/projects'
@@ -266,14 +266,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           setCurrentUsage(current => ({ ...current, ...payload.usage }))
         }
 
-        if (typeof payload?.credential_warning === 'string' && payload.credential_warning) {
-          // Only pop the onboarding overlay when the warning is a genuine
-          // "no provider configured" error — not auxiliary/compression warnings
-          // that happen to mention env var names (e.g. with custom providers).
-          if (isProviderSetupErrorMessage(payload.credential_warning)) {
-            requestDesktopOnboarding(payload.credential_warning)
-          }
-        }
+        requestDesktopOnboardingForCredentialWarning(payload?.credential_warning)
 
         if (apply) {
           reportInstallMethodWarning(payload?.install_warning)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -267,7 +267,12 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         }
 
         if (typeof payload?.credential_warning === 'string' && payload.credential_warning) {
-          requestDesktopOnboarding(payload.credential_warning)
+          // Only pop the onboarding overlay when the warning is a genuine
+          // "no provider configured" error — not auxiliary/compression warnings
+          // that happen to mention env var names (e.g. with custom providers).
+          if (isProviderSetupErrorMessage(payload.credential_warning)) {
+            requestDesktopOnboarding(payload.credential_warning)
+          }
         }
 
         if (apply) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
+import { $desktopOnboarding } from '@/store/onboarding'
 import { $activeGatewayProfile } from '@/store/profile'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -31,6 +32,32 @@ describe('applyRuntimeInfo approval mode', () => {
 
     expect(approvalModeForProfile('work')).toBe('smart')
     expect(approvalModeForProfile('default')).toBe('smart')
+  })
+})
+
+const initialOnboardingState = $desktopOnboarding.get()
+
+describe('applyRuntimeInfo credential warnings', () => {
+  beforeEach(() => {
+    $desktopOnboarding.set({ ...initialOnboardingState, reason: null, requested: false })
+  })
+
+  afterEach(() => {
+    $desktopOnboarding.set(initialOnboardingState)
+  })
+
+  it('requests setup for the exact empty-key warning returned by the server', () => {
+    const warning = "No API key configured for provider 'openrouter'. First message will fail."
+
+    applyRuntimeInfo({ credential_warning: warning })
+
+    expect($desktopOnboarding.get()).toMatchObject({ reason: warning, requested: true })
+  })
+
+  it('ignores an auxiliary-provider warning', () => {
+    applyRuntimeInfo({ credential_warning: 'OPENROUTER_API_KEY not set' })
+
+    expect($desktopOnboarding.get()).toMatchObject({ reason: null, requested: false })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -3,7 +3,7 @@ import { type ChatMessage, chatMessageText } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
-import { requestDesktopOnboarding } from '@/store/onboarding'
+import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import {
   $currentCwd,
@@ -271,9 +271,7 @@ export function applyRuntimeInfo(info: SessionRuntimeInfo | undefined): SessionR
     reconcileApprovalModeForProfile($activeGatewayProfile.get(), info.approval_mode)
   }
 
-  if (info.credential_warning) {
-    requestDesktopOnboarding(info.credential_warning)
-  }
+  requestDesktopOnboardingForCredentialWarning(info.credential_warning)
 
   reportInstallMethodWarning(info.install_warning)
 

--- a/apps/desktop/src/lib/provider-setup-errors.test.ts
+++ b/apps/desktop/src/lib/provider-setup-errors.test.ts
@@ -12,6 +12,15 @@ describe('isProviderSetupErrorMessage', () => {
     expect(isProviderSetupErrorMessage('set an API key (OPENROUTER_API_KEY) in ~/.hermes/.env')).toBe(true)
   })
 
+  it('does not match bare env var name mentions (auxiliary/compression warnings)', () => {
+    // These are emitted by auxiliary_client.py when the aux provider falls back
+    // — they should NOT trigger the onboarding overlay on a custom provider setup.
+    expect(isProviderSetupErrorMessage('OPENROUTER_API_KEY not set')).toBe(false)
+    expect(isProviderSetupErrorMessage('Run `hermes setup` or set OPENROUTER_API_KEY.')).toBe(false)
+    expect(isProviderSetupErrorMessage('OPENAI_API_KEY missing')).toBe(false)
+    expect(isProviderSetupErrorMessage('ANTHROPIC_API_KEY not found')).toBe(false)
+  })
+
   it('does not match non-provider runtime failures', () => {
     expect(
       isProviderSetupErrorMessage('Selected runtime is not available. setup.status reports configured credentials.')

--- a/apps/desktop/src/lib/provider-setup-errors.test.ts
+++ b/apps/desktop/src/lib/provider-setup-errors.test.ts
@@ -12,11 +12,22 @@ describe('isProviderSetupErrorMessage', () => {
     expect(isProviderSetupErrorMessage('set an API key (OPENROUTER_API_KEY) in ~/.hermes/.env')).toBe(true)
   })
 
+  it('matches the exact empty-key warning emitted in session.info', () => {
+    expect(
+      isProviderSetupErrorMessage("No API key configured for provider 'openrouter'. First message will fail.")
+    ).toBe(true)
+  })
+
   it('does not match bare env var name mentions (auxiliary/compression warnings)', () => {
     // These are emitted by auxiliary_client.py when the aux provider falls back
     // — they should NOT trigger the onboarding overlay on a custom provider setup.
     expect(isProviderSetupErrorMessage('OPENROUTER_API_KEY not set')).toBe(false)
     expect(isProviderSetupErrorMessage('Run `hermes setup` or set OPENROUTER_API_KEY.')).toBe(false)
+    expect(
+      isProviderSetupErrorMessage(
+        '⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.'
+      )
+    ).toBe(false)
     expect(isProviderSetupErrorMessage('OPENAI_API_KEY missing')).toBe(false)
     expect(isProviderSetupErrorMessage('ANTHROPIC_API_KEY not found')).toBe(false)
   })

--- a/apps/desktop/src/lib/provider-setup-errors.ts
+++ b/apps/desktop/src/lib/provider-setup-errors.ts
@@ -1,5 +1,5 @@
 const PROVIDER_SETUP_ERROR_RE =
-  /No (?:inference|Hermes) provider(?: is)? configured|no_provider_configured|OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|set an API key/i
+  /No (?:inference|Hermes) provider(?: is)? configured|no_provider_configured|set an API key/i
 
 export function isProviderSetupErrorMessage(message: null | string | undefined): boolean {
   const text = message?.trim()

--- a/apps/desktop/src/lib/provider-setup-errors.ts
+++ b/apps/desktop/src/lib/provider-setup-errors.ts
@@ -1,6 +1,8 @@
 const PROVIDER_SETUP_ERROR_RE =
   /No (?:inference|Hermes) provider(?: is)? configured|no_provider_configured|set an API key/i
 
+const SESSION_INFO_CREDENTIAL_WARNING_RE = /^No API key configured for provider '[^']*'\. First message will fail\.$/
+
 export function isProviderSetupErrorMessage(message: null | string | undefined): boolean {
   const text = message?.trim()
 
@@ -8,5 +10,5 @@ export function isProviderSetupErrorMessage(message: null | string | undefined):
     return false
   }
 
-  return PROVIDER_SETUP_ERROR_RE.test(text)
+  return PROVIDER_SETUP_ERROR_RE.test(text) || SESSION_INFO_CREDENTIAL_WARNING_RE.test(text)
 }

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -182,6 +182,64 @@ describe('refreshOnboarding', () => {
     expect($desktopOnboarding.get().configured).toBe(true)
   })
 
+  it('does not downgrade configured=true on transient provider outage (checksDisagree)', async () => {
+    // setup.status says provider IS configured, but setup.runtime_check says
+    // it's NOT reachable (e.g. HTTP 502, timeout, rate-limit).  This is a
+    // transient provider outage, not a configuration problem — the onboarding
+    // overlay should NOT appear.
+    const api = vi.fn(async ({ path }: { path: string }) => {
+      if (path === '/api/providers/oauth') {
+        return { providers: [provider('fresh')] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    installApiMock(api)
+    window.localStorage.setItem('hermes-desktop-onboarded-v1', '1')
+    $desktopOnboarding.set(
+      baseState({
+        configured: true,
+        providers: [provider('cached')],
+        reason: null,
+        requested: false
+      })
+    )
+
+    const ready = await refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
+
+    expect(ready).toBe(false)
+    expect(api).not.toHaveBeenCalled()
+    expect($desktopOnboarding.get().configured).toBe(true)
+    expect($desktopOnboarding.get().reason).toBeNull()
+    // The cache must survive the refresh — proving we didn't downgrade.
+    expect(window.localStorage.getItem('hermes-desktop-onboarded-v1')).toBe('1')
+  })
+
+  it('shows a non-blocking notification when preserving configured on checksDisagree', async () => {
+    const notifySpy = vi.spyOn(notifications, 'notify')
+
+    installApiMock(vi.fn())
+    $desktopOnboarding.set(
+      baseState({
+        configured: true,
+        providers: [provider('cached')],
+        reason: null,
+        requested: false
+      })
+    )
+
+    await refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
+
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'runtime-not-ready',
+        kind: 'error'
+      })
+    )
+    expect($desktopOnboarding.get().configured).toBe(true)
+  })
+
   it('does not preserve configured when onboarding was explicitly requested', async () => {
     const api = vi.fn(async ({ path }: { path: string }) => {
       if (path === '/api/providers/oauth') {

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -46,14 +46,28 @@ function installApiMock(api: (request: { path: string }) => Promise<unknown>) {
   })
 }
 
-function runtimeMismatchGateway(): OnboardingContext['requestGateway'] {
+function emptyOpenRouterGateway(): OnboardingContext['requestGateway'] {
   return async method => {
     if (method === 'setup.status') {
       return { provider_configured: true } as never
     }
 
     if (method === 'setup.runtime_check') {
-      return { error: 'Selected runtime is not available.', ok: false } as never
+      return { error: 'No usable credentials found for openrouter.', ok: false, provider: 'openrouter' } as never
+    }
+
+    throw new Error(`unexpected gateway method: ${method}`)
+  }
+}
+
+function keylessCustomGateway(): OnboardingContext['requestGateway'] {
+  return async method => {
+    if (method === 'setup.status') {
+      return { provider_configured: true } as never
+    }
+
+    if (method === 'setup.runtime_check') {
+      return { ok: true, provider: 'custom' } as never
     }
 
     throw new Error(`unexpected gateway method: ${method}`)
@@ -99,12 +113,12 @@ describe('refreshOnboarding', () => {
     $desktopOnboarding.set(baseState({ providers: [provider('cached')] }))
     requestDesktopOnboarding('Need provider setup')
 
-    const ready = await refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
+    const ready = await refreshOnboarding(onboardingContext(emptyOpenRouterGateway()))
 
     expect(ready).toBe(false)
     expect(api).toHaveBeenCalledTimes(1)
     expect($desktopOnboarding.get().providers?.map(p => p.id)).toEqual(['fresh'])
-    expect($desktopOnboarding.get().reason).toContain('Selected runtime is not available.')
+    expect($desktopOnboarding.get().reason).toContain('No usable credentials found for openrouter.')
     expect($desktopOnboarding.get().reason).toContain('setup.status reports configured credentials')
   })
 
@@ -120,7 +134,7 @@ describe('refreshOnboarding', () => {
     installApiMock(api)
     $desktopOnboarding.set(baseState({ providers: [provider('cached')] }))
 
-    const ready = await refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
+    const ready = await refreshOnboarding(onboardingContext(emptyOpenRouterGateway()))
 
     expect(ready).toBe(false)
     expect(api).not.toHaveBeenCalled()
@@ -182,20 +196,8 @@ describe('refreshOnboarding', () => {
     expect($desktopOnboarding.get().configured).toBe(true)
   })
 
-  it('does not downgrade configured=true on transient provider outage (checksDisagree)', async () => {
-    // setup.status says provider IS configured, but setup.runtime_check says
-    // it's NOT reachable (e.g. HTTP 502, timeout, rate-limit).  This is a
-    // transient provider outage, not a configuration problem — the onboarding
-    // overlay should NOT appear.
-    const api = vi.fn(async ({ path }: { path: string }) => {
-      if (path === '/api/providers/oauth') {
-        return { providers: [provider('fresh')] }
-      }
-
-      throw new Error(`unexpected api path: ${path}`)
-    })
-
-    installApiMock(api)
+  it('enters setup when the selected OpenRouter credential is genuinely empty', async () => {
+    installApiMock(vi.fn())
     window.localStorage.setItem('hermes-desktop-onboarded-v1', '1')
     $desktopOnboarding.set(
       baseState({
@@ -206,38 +208,29 @@ describe('refreshOnboarding', () => {
       })
     )
 
-    const ready = await refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
+    const ready = await refreshOnboarding(onboardingContext(emptyOpenRouterGateway()))
 
     expect(ready).toBe(false)
-    expect(api).not.toHaveBeenCalled()
-    expect($desktopOnboarding.get().configured).toBe(true)
-    expect($desktopOnboarding.get().reason).toBeNull()
-    // The cache must survive the refresh — proving we didn't downgrade.
-    expect(window.localStorage.getItem('hermes-desktop-onboarded-v1')).toBe('1')
+    expect($desktopOnboarding.get().configured).toBe(false)
+    expect($desktopOnboarding.get().reason).toContain('No usable credentials found for openrouter.')
+    expect(window.localStorage.getItem('hermes-desktop-onboarded-v1')).toBeNull()
   })
 
-  it('shows a non-blocking notification when preserving configured on checksDisagree', async () => {
-    const notifySpy = vi.spyOn(notifications, 'notify')
+  it('keeps a keyless custom runtime out of setup', async () => {
+    const api = vi.fn()
 
-    installApiMock(vi.fn())
-    $desktopOnboarding.set(
-      baseState({
-        configured: true,
-        providers: [provider('cached')],
-        reason: null,
-        requested: false
-      })
-    )
+    installApiMock(api)
+    $desktopOnboarding.set(baseState({ configured: false, reason: 'stale setup error', requested: true }))
 
-    await refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
+    const ready = await refreshOnboarding(onboardingContext(keylessCustomGateway()))
 
-    expect(notifySpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'runtime-not-ready',
-        kind: 'error'
-      })
-    )
-    expect($desktopOnboarding.get().configured).toBe(true)
+    expect(ready).toBe(true)
+    expect(api).not.toHaveBeenCalled()
+    expect($desktopOnboarding.get()).toMatchObject({
+      configured: true,
+      reason: null,
+      requested: false
+    })
   })
 
   it('does not preserve configured when onboarding was explicitly requested', async () => {
@@ -307,8 +300,8 @@ describe('refreshOnboarding', () => {
     installApiMock(api)
     $desktopOnboarding.set(baseState({ requested: true }))
 
-    const first = refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
-    const second = refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
+    const first = refreshOnboarding(onboardingContext(emptyOpenRouterGateway()))
+    const second = refreshOnboarding(onboardingContext(emptyOpenRouterGateway()))
 
     await vi.waitFor(() => expect(api).toHaveBeenCalledTimes(1))
 

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -187,7 +187,18 @@ function shouldPreserveConfiguredOnFallback(runtime: RuntimeReadinessResult, sta
   // A fallback result means both runtime probes were non-authoritative
   // (transport timeout/disconnect). Keep a previously verified configured
   // state instead of forcing the blocking onboarding overlay.
-  return runtime.source === 'fallback' && state.configured === true && !state.requested
+  if (runtime.source === 'fallback' && state.configured === true && !state.requested) {
+    return true
+  }
+  // checksDisagree means setup.status says the provider IS configured but
+  // setup.runtime_check says it's NOT reachable — a transient provider
+  // outage (502, timeout, rate-limit), not a configuration problem.
+  // Don't downgrade to the blocking onboarding overlay; surface a
+  // non-blocking notification instead (the caller handles that).
+  if (runtime.checksDisagree && state.configured === true && !state.requested) {
+    return true
+  }
+  return false
 }
 
 function notifyReady(provider: string) {

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -12,6 +12,7 @@ import {
   submitOAuthCode,
   validateProviderCredential
 } from '@/hermes'
+import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { notify, notifyError } from '@/store/notifications'
 import type { ModelOptionProvider, OAuthProvider, OAuthStartResponse } from '@/types/hermes'
@@ -190,14 +191,7 @@ function shouldPreserveConfiguredOnFallback(runtime: RuntimeReadinessResult, sta
   if (runtime.source === 'fallback' && state.configured === true && !state.requested) {
     return true
   }
-  // checksDisagree means setup.status says the provider IS configured but
-  // setup.runtime_check says it's NOT reachable — a transient provider
-  // outage (502, timeout, rate-limit), not a configuration problem.
-  // Don't downgrade to the blocking onboarding overlay; surface a
-  // non-blocking notification instead (the caller handles that).
-  if (runtime.checksDisagree && state.configured === true && !state.requested) {
-    return true
-  }
+
   return false
 }
 
@@ -398,6 +392,16 @@ async function refreshProviders() {
 
 export function requestDesktopOnboarding(reason = DEFAULT_ONBOARDING_REASON) {
   patch({ reason: reason.trim() || DEFAULT_ONBOARDING_REASON, requested: true })
+}
+
+export function requestDesktopOnboardingForCredentialWarning(reason: null | string | undefined) {
+  const warning = reason?.trim()
+
+  if (!warning || !isProviderSetupErrorMessage(warning)) {
+    return
+  }
+
+  requestDesktopOnboarding(warning)
 }
 
 // Open the onboarding provider selector on demand from an already-configured

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3315,6 +3315,20 @@ def test_setup_status_reports_provider_config(monkeypatch):
     assert resp["result"]["provider_configured"] is False
 
 
+def test_probe_credentials_emits_exact_empty_key_warning():
+    agent = types.SimpleNamespace(api_key="", provider="openrouter")
+
+    assert server._probe_credentials(agent) == (
+        "No API key configured for provider 'openrouter'. First message will fail."
+    )
+
+
+def test_probe_credentials_allows_keyless_custom_runtime():
+    agent = types.SimpleNamespace(api_key="no-key-required", provider="custom")
+
+    assert server._probe_credentials(agent) == ""
+
+
 def test_setup_runtime_check_rejects_empty_runtime_key(monkeypatch):
     monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
     monkeypatch.setattr(
@@ -3328,8 +3342,13 @@ def test_setup_runtime_check_rejects_empty_runtime_key(monkeypatch):
 
     resp = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
 
-    assert resp["result"]["ok"] is False
-    assert resp["result"]["provider"] == "openrouter"
+    assert resp["result"] == {
+        "ok": False,
+        "provider": "openrouter",
+        "model": None,
+        "source": "env/config",
+        "error": "No usable credentials found for openrouter.",
+    }
 
 
 def test_setup_runtime_check_allows_no_key_custom_runtime(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3293,11 +3293,18 @@ def _get_usage(agent) -> dict:
 
 
 def _probe_credentials(agent) -> str:
-    """Light credential check at session creation — returns warning or ''."""
+    """Light credential check at session creation — returns warning or ''.
+
+    'no-key-required' is a valid sentinel for keyless custom providers (local
+    models, self-hosted endpoints, routers that accept any key).  Only warn
+    when the key is genuinely missing — empty string or None.
+    """
     try:
         key = getattr(agent, "api_key", "") or ""
         provider = getattr(agent, "provider", "") or ""
-        if not key or key == "no-key-required":
+        # 'no-key-required' means the provider intentionally needs no credential
+        # (e.g. custom:myrouter, local llama.cpp).  This is valid — don't warn.
+        if not key:
             return f"No API key configured for provider '{provider}'. First message will fail."
     except Exception:
         pass


### PR DESCRIPTION
## Summary

The desktop app pops the "add a provider / enter API key" onboarding overlay mid-task even when a custom provider is correctly configured. Four bugs compound to cause this — three from PR #45224 (still open) plus a new fourth path discovered during investigation.

## Bug 1 — `_probe_credentials` fires on valid keyless endpoints

`"no-key-required"` is a valid sentinel for keyless custom providers (`custom:myrouter`, local llama.cpp, self-hosted endpoints, 9router-style routers). The old code treated it as a missing credential and fired `credential_warning` on every session start.

**Fix:** Only warn when `api_key` is genuinely empty/None.

*(Cherry-picked from PR #45224 by @Kingdomwarrior23)*

## Bug 2 — Regex too broad

`PROVIDER_SETUP_ERROR_RE` included bare env var names (`OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) which appear in `auxiliary_client.py` fallback/compression warnings during normal task execution. Any message mentioning those names triggered the onboarding overlay.

**Fix:** Remove bare env var patterns — only match actual "no provider configured" phrasing.

*(Cherry-picked from PR #45224)*

## Bug 3 — `credential_warning` unconditionally opened onboarding

`credential_warning` in the gateway event handler fired `requestDesktopOnboarding()` unconditionally. Even with fix #1, future auxiliary warnings could still reach this path.

**Fix:** Guard with `isProviderSetupErrorMessage()` — same check the error path already uses.

*(Adapted from PR #45224 for the refactored file path `use-message-stream/gateway-event.ts`)*

## Bug 4 — `shouldPreserveConfiguredOnFallback` doesn't cover `checksDisagree` (new)

When `setup.status` says the provider IS configured but `setup.runtime_check` says it's NOT reachable (`checksDisagree=true`), the function downgraded `configured=true` to `configured=false`, popping the blocking onboarding overlay. This happens on **transient provider outages** (HTTP 502, timeout, rate-limit) — not configuration problems.

**Reproduction:** A custom provider returning intermittent HTTP 502 under GIL pressure (event loop stalls >10s) caused the desktop to show the setup overlay mid-task. Logs confirmed `setup.status` reporting `provider_configured: true` but `setup.runtime_check` returning `ok: false` due to transient 502s.

**Fix:** Extend `shouldPreserveConfiguredOnFallback` to also preserve `configured=true` when `checksDisagree` is true. The existing non-blocking notification (`id: 'runtime-not-ready'`) already fires for this path, so the user is informed without being blocked.

## Related

- PR #45224 — fixes bugs 1-3 (still open, not yet merged)
- Issue #37296 — same symptom on Windows with named custom provider
- Commit d398076c — added the `shouldPreserveConfiguredOnFallback` function but only covered `source === 'fallback'`

## Test plan

- [x] `provider-setup-errors.test.ts` — 4/4 pass (added bare-env-var negative cases)
- [x] `onboarding.test.ts` — added `checksDisagree` preservation + notification tests
- [x] `tui_gateway/test_protocol.py` — 75/75 pass
- [x] TypeScript typecheck — clean
- [ ] CI (jsdom environment for onboarding tests)
