### PR TITLE
fix(codex): route app-server subprocess env through hermes_subprocess_env

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -25,6 +25,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from tools.environments.local import hermes_subprocess_env
+
 # Default minimum codex version we test against. The PR sets this from the
 # `codex --version` parsed at install time; bumping is a one-line change here.
 MIN_CODEX_VERSION = (0, 125, 0)
@@ -74,7 +76,13 @@ class CodexAppServerClient:
         env: Optional[dict[str, str]] = None,
     ) -> None:
         self._codex_bin = codex_bin
-        spawn_env = os.environ.copy()
+        # Codex app-server is a model-driving CLI executor: it legitimately
+        # needs LLM provider credentials, so inherit_credentials=True. But it
+        # still must not inherit Tier-1 secrets (gateway bot tokens, GitHub
+        # auth, infra tokens) that have nothing to do with running code —
+        # the previous `os.environ.copy()` handed those over unfiltered to
+        # every codex subprocess (#29157 sibling gap).
+        spawn_env = hermes_subprocess_env(inherit_credentials=True)
         if env:
             spawn_env.update(env)
         if codex_home:

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -295,3 +295,103 @@ class TestSpawnEnvIsolation:
         )
         assert "sandbox_workspace_write.network_access=false" in cmd
         assert all("danger" not in part for part in cmd)
+
+
+class TestSpawnEnvSecretStripping:
+    """Codex app-server is a model-driving CLI executor (sibling of the
+    #29157 subprocess-env-leak class): it legitimately needs LLM provider
+    credentials, but must not inherit Tier-1 secrets (gateway bot tokens,
+    GitHub auth, infra tokens) that have nothing to do with running code.
+
+    Before this fix, ``spawn_env`` was a raw ``os.environ.copy()`` with no
+    filtering at all — every secret in the Hermes process environment was
+    handed unfiltered to the spawned ``codex`` subprocess.
+    """
+
+    def test_tier1_secrets_stripped_from_spawn_env(self, monkeypatch):
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["env"] = kwargs.get("env", {}).copy()
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setenv("HOME", "/users/alice")
+        monkeypatch.setenv("GH_TOKEN", "ghp_super_secret")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-secret")
+        monkeypatch.setenv("MODAL_TOKEN_SECRET", "modal-secret")
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "dash-secret")
+
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        env = captured["env"]
+        for leaked in (
+            "GH_TOKEN",
+            "TELEGRAM_BOT_TOKEN",
+            "MODAL_TOKEN_SECRET",
+            "HERMES_DASHBOARD_SESSION_TOKEN",
+        ):
+            assert leaked not in env, f"{leaked} leaked into codex subprocess env"
+        # The Tier-1 strip must not collide with HOME preservation
+        # (TestSpawnEnvIsolation) — codex's own shell tool still needs it.
+        assert env.get("HOME") == "/users/alice"
+
+    def test_provider_credentials_still_reach_codex(self, monkeypatch):
+        """Codex is a model-driving CLI — it needs its own provider auth
+        (e.g. OPENAI_API_KEY) to actually authenticate. The Tier-1 strip
+        must not collaterally remove the credential codex itself needs."""
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["env"] = kwargs.get("env", {}).copy()
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setenv("HOME", "/users/alice")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-fake-codex-key")
+
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        assert captured["env"].get("OPENAI_API_KEY") == "sk-fake-codex-key"


### PR DESCRIPTION
## Summary
- `CodexAppServerClient.__init__` built its spawn env via a raw `os.environ.copy()`, completely bypassing the centralized `hermes_subprocess_env()` credential-stripping helper.
- Every spawned `codex app-server` subprocess inherited the full Hermes process environment unfiltered — including Tier-1 secrets that no child process should ever see (`GH_TOKEN`, gateway bot tokens, Modal/Daytona infra secrets, the dashboard session token).
- This is the same subprocess-env-leak class as #29157, on a spawn path that predates the centralized helper and was never migrated to it.

## Why
`codex_app_server` is an opt-in runtime (`model.openai_runtime: codex_app_server`) that drives an agentic shell-executing subprocess. It's exactly the kind of surface the existing `_ALWAYS_STRIP_KEYS` Tier-1 strip is designed to protect — the comment on that constant explicitly names "codex" as one of the model-driving CLIs that should never see these secrets, even with full credential inheritance. The unfiltered `os.environ.copy()` violated that documented invariant.

## Fix
Switch to `hermes_subprocess_env(inherit_credentials=True)`, matching the existing pattern already used by the other model-driving CLI executor (`agent/copilot_acp_client.py`):
- Tier-1 secrets (gateway bot tokens, GitHub auth, infra tokens) are always stripped.
- Provider credentials (`OPENAI_API_KEY`, etc.) still flow through, since codex genuinely needs them to authenticate.
- `CODEX_HOME`, `HOME`, and the Kanban writable-root env vars are unaffected — none of those are in the strip lists.

## Test plan
- Added `TestSpawnEnvSecretStripping` to `tests/agent/transports/test_codex_app_server_runtime.py`:
  - `test_tier1_secrets_stripped_from_spawn_env` — verifies `GH_TOKEN`, `TELEGRAM_BOT_TOKEN`, `MODAL_TOKEN_SECRET`, `HERMES_DASHBOARD_SESSION_TOKEN` no longer reach the spawned codex subprocess env.
  - `test_provider_credentials_still_reach_codex` — verifies `OPENAI_API_KEY` still reaches the subprocess (codex needs it to authenticate).
- Existing `TestSpawnEnvIsolation` tests (HOME passthrough, `CODEX_HOME` override, Kanban writable-root injection) still pass unchanged — confirms no regression to prior spawn-env behavior.
- `python -m pytest tests/agent/transports/test_codex_app_server_runtime.py tests/agent/transports/test_codex_app_server_session.py -q` → 86 passed
- `ruff check` and `ty check` on both changed files → clean

- [x] Tier-1 secrets stripped from codex subprocess env
- [x] Provider credentials still reach codex
- [x] HOME / CODEX_HOME / Kanban writable-root behavior unchanged
- [x] Lint + type check clean