### PR TITLE
[codex] Flag stale Windows gateway task definitions

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -36,6 +36,7 @@ import shutil
 import subprocess
 import sys
 import time
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from xml.sax.saxutils import escape
 
@@ -1288,6 +1289,94 @@ def query_task_status() -> dict[str, str]:
     return info
 
 
+def _query_scheduled_task_xml(task_name: str) -> str | None:
+    """Return Task Scheduler XML for ``task_name`` when it can be read."""
+    code, out, _err = _exec_schtasks(["/Query", "/TN", task_name, "/XML"])
+    if code != 0:
+        return None
+    out = out.strip()
+    return out or None
+
+
+def _task_xml_text(root: ET.Element, local_name: str) -> str:
+    for elem in root.iter():
+        if elem.tag.rsplit("}", 1)[-1] == local_name:
+            return (elem.text or "").strip()
+    return ""
+
+
+def _task_xml_command_basename(command: str) -> str:
+    normalized = command.strip().strip("\"'").replace("\\", "/")
+    return normalized.rsplit("/", 1)[-1].lower()
+
+
+def _scheduled_task_definition_warnings(task_name: str | None = None) -> list[str]:
+    """Return warnings for old Windows task definitions that are not resilient.
+
+    Older installs launched ``Hermes_Gateway.cmd`` directly, disabled
+    StartWhenAvailable/restart-on-failure, and kept battery defaults that can
+    stop the gateway. Merely saying "Scheduled Task registered" hides that
+    drift, leaving users with a gateway that can silently disappear until a
+    manual restart.
+    """
+    task_name = task_name or get_task_name()
+    xml_text = _query_scheduled_task_xml(task_name)
+    if not xml_text:
+        return []
+
+    try:
+        root = ET.fromstring(xml_text.lstrip("\ufeff"))
+    except ET.ParseError:
+        return [
+            "Scheduled Task definition could not be parsed; run "
+            "`hermes gateway install` to refresh it."
+        ]
+
+    warnings: list[str] = []
+    command = _task_xml_text(root, "Command")
+    arguments = _task_xml_text(root, "Arguments")
+    if _task_xml_command_basename(command) != "wscript.exe":
+        warnings.append(
+            "Scheduled Task uses a legacy gateway launcher; run "
+            "`hermes gateway install` to refresh it."
+        )
+    elif ".vbs" not in arguments.lower():
+        warnings.append(
+            "Scheduled Task is not using the console-less gateway launcher; run "
+            "`hermes gateway install` to refresh it."
+        )
+
+    try:
+        restart_count = int(_task_xml_text(root, "Count") or "0")
+    except ValueError:
+        restart_count = 0
+    if restart_count <= 0:
+        warnings.append(
+            "Scheduled Task restart-on-failure is disabled; the gateway will "
+            "not relaunch after an unexpected exit."
+        )
+
+    if _task_xml_text(root, "StartWhenAvailable").lower() != "true":
+        warnings.append(
+            "Scheduled Task StartWhenAvailable is disabled; missed logon starts "
+            "may not be retried."
+        )
+
+    if _task_xml_text(root, "DisallowStartIfOnBatteries").lower() == "true":
+        warnings.append(
+            "Scheduled Task is blocked while on battery power; the gateway may "
+            "not start on laptops."
+        )
+
+    if _task_xml_text(root, "StopIfGoingOnBatteries").lower() == "true":
+        warnings.append(
+            "Scheduled Task is configured to stop on battery power; the gateway "
+            "can disappear when power state changes."
+        )
+
+    return warnings
+
+
 def _gateway_pids() -> list[int]:
     """Reuse the cross-platform PID scanner in gateway.py."""
     from hermes_cli.gateway import find_gateway_pids
@@ -1443,6 +1532,8 @@ def status(deep: bool = False) -> None:
             for key in ("status", "last run time", "last run result"):
                 if key in info:
                     print(f"  {key.title()}: {info[key]}")
+        for warning in _scheduled_task_definition_warnings(task_name):
+            print(f"WARNING: {warning}")
     elif startup_installed:
         entry = get_startup_entry_path()
         if not entry.exists():

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -197,6 +197,106 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "cmd.exe" not in xml_seen["text"]
 
 
+def test_scheduled_task_definition_warnings_flag_legacy_task(monkeypatch):
+    """Status should flag stale Windows task definitions as unreliable."""
+    legacy_xml = """<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Settings>
+    <DisallowStartIfOnBatteries>true</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>true</StopIfGoingOnBatteries>
+    <StartWhenAvailable>false</StartWhenAvailable>
+    <RestartOnFailure>
+      <Interval>PT1M</Interval>
+      <Count>0</Count>
+    </RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>C:\\Users\\alice\\AppData\\Local\\hermes\\gateway-service\\Hermes_Gateway.cmd</Command>
+    </Exec>
+  </Actions>
+</Task>
+"""
+
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: (0, legacy_xml, ""),
+    )
+
+    warnings = gateway_windows._scheduled_task_definition_warnings("Hermes_Gateway")
+
+    assert any("legacy gateway launcher" in warning for warning in warnings)
+    assert any("`hermes gateway install`" in warning for warning in warnings)
+    assert all("--force" not in warning for warning in warnings)
+    assert any("restart-on-failure is disabled" in warning for warning in warnings)
+    assert any("StartWhenAvailable is disabled" in warning for warning in warnings)
+    assert any("blocked while on battery" in warning for warning in warnings)
+    assert any("stop on battery" in warning for warning in warnings)
+
+
+def test_scheduled_task_definition_warnings_accept_current_task(monkeypatch):
+    """The current VBS + restart-on-failure task definition should stay clean."""
+    current_xml = gateway_windows._build_scheduled_task_xml(
+        "Hermes_Gateway",
+        Path(r"C:\Users\alice\AppData\Local\hermes\gateway-service\Hermes_Gateway.vbs"),
+        r"DOMAIN\alice",
+    )
+
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: (0, current_xml, ""),
+    )
+
+    assert gateway_windows._scheduled_task_definition_warnings("Hermes_Gateway") == []
+
+
+def test_scheduled_task_definition_warnings_use_plain_reinstall(monkeypatch):
+    """Every definition-repair warning should name the effective install command."""
+    responses = iter([
+        "<not-valid-xml",
+        gateway_windows._build_scheduled_task_xml(
+            "Hermes_Gateway",
+            Path(r"C:\Users\alice\AppData\Local\hermes\gateway-service\Hermes_Gateway.cmd"),
+            r"DOMAIN\alice",
+        ),
+    ])
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: (0, next(responses), ""),
+    )
+
+    for _ in range(2):
+        warnings = gateway_windows._scheduled_task_definition_warnings("Hermes_Gateway")
+        remediation = [warning for warning in warnings if "run `hermes gateway" in warning]
+        assert remediation
+        assert all("`hermes gateway install`" in warning for warning in remediation)
+        assert all("--force" not in warning for warning in remediation)
+
+
+def test_status_prints_scheduled_task_definition_warnings(monkeypatch, capsys):
+    """A registered-but-stale task must not look fully healthy in status output."""
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "is_startup_entry_installed", lambda: False)
+    monkeypatch.setattr(gateway_windows, "query_task_status", lambda: {})
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+    monkeypatch.setattr(
+        gateway_windows,
+        "_scheduled_task_definition_warnings",
+        lambda task_name=None: ["Scheduled Task restart-on-failure is disabled."],
+    )
+
+    gateway_windows.status()
+
+    out = capsys.readouterr().out
+    assert "Scheduled Task registered: Hermes_Gateway" in out
+    assert "WARNING: Scheduled Task restart-on-failure is disabled." in out
+
+
 def test_gateway_vbs_script_is_console_less(monkeypatch):
     """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
     (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""


### PR DESCRIPTION
What does this PR do?
- Adds a Windows Scheduled Task definition audit to `hermes gateway status`.
- Warns when an upgraded install still has a pre-#45610 task shape: legacy `.cmd` launcher, no restart-on-failure, disabled `StartWhenAvailable`, or battery settings that can prevent/start-stop the gateway.
- Keeps the existing process liveness probes unchanged; this only adds diagnostics for stale task definitions.

Why?
- Fixes #55710.
- #45610 hardened newly-created Windows tasks, but existing installs can keep their old task definition when the user has not successfully refreshed the Scheduled Task. In that state `hermes gateway status` says the task is registered even though it will not relaunch after an unexpected gateway exit.

Review follow-up
- Rebased onto current `main`.
- Changed every definition-repair hint to `hermes gateway install`: Windows installs already recreate/reconcile the task, so `--force` is unnecessary API parity.
- Added regression coverage for malformed XML, a legacy launcher, and a non-VBS launcher; every repair hint now asserts the plain install command and rejects `--force`.

Proof at `7aa4980eee272455331f0422163ea86be3a1d072`
- `bash scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py -q` — 11/11 passed.
- Ruff check on both changed files — passed.
- `git diff --check` — passed.
- Scoped AutoReview — clean, patch correct (0.99 confidence).
- The original native-Windows reproduction confirmed that the audit detects an existing stale Scheduled Task; this review amendment only corrects the remediation command.

Notes
- This is intentionally diagnostic-only. It does not attempt to elevate, delete, or rewrite the user's Scheduled Task from `status`.