### PR TITLE
fix(stt): pass language parameter to Groq Whisper API

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1580,3 +1580,96 @@ class TestShellSafety:
         monkeypatch.delenv(LOCAL_STT_COMMAND_ENV, raising=False)
         use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
         assert use_shell is False
+
+
+# ============================================================================
+# Groq STT config — null-subsection guard
+# ============================================================================
+class TestGroqSttLanguageConfig:
+    """_transcribe_groq language lookup must survive stt.groq: null in config.
+
+    ``_load_stt_config().get("groq", {}).get("language")`` crashes when
+    ``stt.groq`` is explicitly ``null`` because ``.get("groq", {})`` returns
+    the null value (the default only applies when the key is *missing*).
+    All provider-subsection reads must use ``.get(key) or {}`` instead.
+    """
+
+    GROQ_API_KEY = "sk-test-groq-key-placeholder"
+
+    def _make_groq_config(self, groq_value, local_value=None):
+        """Build a fake _load_stt_config return dict."""
+        cfg = {}
+        if groq_value is not None:
+            cfg["groq"] = groq_value
+        if local_value is not None:
+            cfg["local"] = local_value
+        return cfg
+
+    def test_groq_override_present(self, monkeypatch):
+        """stt.groq.language is set -> used."""
+        cfg = self._make_groq_config({"language": "fr"})
+        monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: cfg)
+        monkeypatch.setattr("tools.transcription_tools.get_env_value", lambda k: self.GROQ_API_KEY if k == "GROQ_API_KEY" else None)
+        monkeypatch.setattr("tools.transcription_tools._HAS_OPENAI", True)
+
+        from tools.transcription_tools import _transcribe_groq
+        with patch("tools.transcription_tools.OpenAI") as mock_openai:
+            mock_client = mock_openai.return_value
+            mock_client.audio.transcriptions.create.return_value = "bonjour"
+            result = _transcribe_groq("/tmp/test.wav", "whisper-1")
+
+        assert result.get("success") is True
+        # The language should be passed as 'fr'
+        create_kwargs = mock_openai.return_value.audio.transcriptions.create.call_args[1]
+        assert create_kwargs.get("language") == "fr"
+
+    def test_local_fallback(self, monkeypatch):
+        """stt.groq is empty but stt.local.language is set -> fallback used."""
+        cfg = self._make_groq_config({}, {"language": "de"})
+        monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: cfg)
+        monkeypatch.setattr("tools.transcription_tools.get_env_value", lambda k: self.GROQ_API_KEY if k == "GROQ_API_KEY" else None)
+        monkeypatch.setattr("tools.transcription_tools._HAS_OPENAI", True)
+
+        from tools.transcription_tools import _transcribe_groq
+        with patch("tools.transcription_tools.OpenAI") as mock_openai:
+            mock_client = mock_openai.return_value
+            mock_client.audio.transcriptions.create.return_value = "guten tag"
+            result = _transcribe_groq("/tmp/test.wav", "whisper-1")
+
+        assert result.get("success") is True
+        create_kwargs = mock_openai.return_value.audio.transcriptions.create.call_args[1]
+        assert create_kwargs.get("language") == "de"
+
+    def test_no_language_configured(self, monkeypatch):
+        """Neither groq nor local has language -> None (auto-detect)."""
+        cfg = self._make_groq_config({}, {})
+        monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: cfg)
+        monkeypatch.setattr("tools.transcription_tools.get_env_value", lambda k: self.GROQ_API_KEY if k == "GROQ_API_KEY" else None)
+        monkeypatch.setattr("tools.transcription_tools._HAS_OPENAI", True)
+
+        from tools.transcription_tools import _transcribe_groq
+        with patch("tools.transcription_tools.OpenAI") as mock_openai:
+            mock_client = mock_openai.return_value
+            mock_client.audio.transcriptions.create.return_value = "hello"
+            result = _transcribe_groq("/tmp/test.wav", "whisper-1")
+
+        assert result.get("success") is True
+        create_kwargs = mock_openai.return_value.audio.transcriptions.create.call_args[1]
+        assert create_kwargs.get("language") is None
+
+    def test_stt_groq_null(self, monkeypatch):
+        """stt.groq is explicitly null (YAML null) — must not crash."""
+        cfg = self._make_groq_config(None, {})
+        monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: cfg)
+        monkeypatch.setattr("tools.transcription_tools.get_env_value", lambda k: self.GROQ_API_KEY if k == "GROQ_API_KEY" else None)
+        monkeypatch.setattr("tools.transcription_tools._HAS_OPENAI", True)
+
+        from tools.transcription_tools import _transcribe_groq
+        with patch("tools.transcription_tools.OpenAI") as mock_openai:
+            mock_client = mock_openai.return_value
+            mock_client.audio.transcriptions.create.return_value = "hello from null-guard"
+            result = _transcribe_groq("/tmp/test.wav", "whisper-1")
+
+        assert result.get("success") is True
+        create_kwargs = mock_openai.return_value.audio.transcriptions.create.call_args[1]
+        assert create_kwargs.get("language") is None  # null subsection -> no override

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -11,7 +11,7 @@ import struct
 import subprocess
 import types
 import wave
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -1613,7 +1613,8 @@ class TestGroqSttLanguageConfig:
         monkeypatch.setattr("tools.transcription_tools._HAS_OPENAI", True)
 
         from tools.transcription_tools import _transcribe_groq
-        with patch("tools.transcription_tools.OpenAI") as mock_openai:
+        with patch("openai.OpenAI") as mock_openai, \
+             patch("builtins.open", mock_open(read_data=b"fake audio data")):
             mock_client = mock_openai.return_value
             mock_client.audio.transcriptions.create.return_value = "bonjour"
             result = _transcribe_groq("/tmp/test.wav", "whisper-1")
@@ -1631,7 +1632,8 @@ class TestGroqSttLanguageConfig:
         monkeypatch.setattr("tools.transcription_tools._HAS_OPENAI", True)
 
         from tools.transcription_tools import _transcribe_groq
-        with patch("tools.transcription_tools.OpenAI") as mock_openai:
+        with patch("openai.OpenAI") as mock_openai, \
+             patch("builtins.open", mock_open(read_data=b"fake audio data")):
             mock_client = mock_openai.return_value
             mock_client.audio.transcriptions.create.return_value = "guten tag"
             result = _transcribe_groq("/tmp/test.wav", "whisper-1")
@@ -1648,7 +1650,8 @@ class TestGroqSttLanguageConfig:
         monkeypatch.setattr("tools.transcription_tools._HAS_OPENAI", True)
 
         from tools.transcription_tools import _transcribe_groq
-        with patch("tools.transcription_tools.OpenAI") as mock_openai:
+        with patch("openai.OpenAI") as mock_openai, \
+             patch("builtins.open", mock_open(read_data=b"fake audio data")):
             mock_client = mock_openai.return_value
             mock_client.audio.transcriptions.create.return_value = "hello"
             result = _transcribe_groq("/tmp/test.wav", "whisper-1")
@@ -1665,7 +1668,8 @@ class TestGroqSttLanguageConfig:
         monkeypatch.setattr("tools.transcription_tools._HAS_OPENAI", True)
 
         from tools.transcription_tools import _transcribe_groq
-        with patch("tools.transcription_tools.OpenAI") as mock_openai:
+        with patch("openai.OpenAI") as mock_openai, \
+             patch("builtins.open", mock_open(read_data=b"fake audio data")):
             mock_client = mock_openai.return_value
             mock_client.audio.transcriptions.create.return_value = "hello from null-guard"
             result = _transcribe_groq("/tmp/test.wav", "whisper-1")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1316,9 +1316,10 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
         model_name = DEFAULT_GROQ_STT_MODEL
 
     # Language: config.yaml (stt.groq.language > stt.local.language) > auto-detect.
+    stt_config = _load_stt_config()
     language = (
-        _load_stt_config().get("groq", {}).get("language")
-        or _load_stt_config().get("local", {}).get("language")
+        (stt_config.get("groq") or {}).get("language")
+        or (stt_config.get("local") or {}).get("language")
     )
 
     try:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1315,20 +1315,30 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
         logger.info("Model %s not available on Groq, using %s", model_name, DEFAULT_GROQ_STT_MODEL)
         model_name = DEFAULT_GROQ_STT_MODEL
 
+    # Language: config.yaml (stt.groq.language > stt.local.language) > auto-detect.
+    language = (
+        _load_stt_config().get("groq", {}).get("language")
+        or _load_stt_config().get("local", {}).get("language")
+    )
+
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
         client = OpenAI(api_key=api_key, base_url=GROQ_BASE_URL, timeout=30, max_retries=0)
         try:
             with open(file_path, "rb") as audio_file:
-                transcription = client.audio.transcriptions.create(
-                    model=model_name,
-                    file=audio_file,
-                    response_format="text",
-                )
+                create_kwargs = {
+                    "model": model_name,
+                    "file": audio_file,
+                    "response_format": "text",
+                }
+                if language:
+                    create_kwargs["language"] = language
+                transcription = client.audio.transcriptions.create(**create_kwargs)
 
             transcript_text = str(transcription).strip()
-            logger.info("Transcribed %s via Groq API (%s, %d chars)",
-                         Path(file_path).name, model_name, len(transcript_text))
+            logger.info("Transcribed %s via Groq API (%s, %d chars, lang=%s)",
+                         Path(file_path).name, model_name, len(transcript_text),
+                         language or "auto")
 
             return {"success": True, "transcript": transcript_text, "provider": "groq"}
         finally:


### PR DESCRIPTION
The Groq STT provider ignored stt.groq.language and stt.local.language from config.yaml, forcing auto-detection. This garbled non-English audio (e.g. Hebrew detected as English).

Read language from config (stt.groq.language > stt.local.language) and pass it to client.audio.transcriptions.create() when set.

Fixes #55551