### PR TITLE
fix(dashboard-auth): coalesce concurrent refresh requests to prevent RT reuse detection

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -16,7 +16,10 @@ binds.
 """
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import logging
+import time as _time
 from typing import Awaitable, Callable
 
 from fastapi import Request
@@ -34,6 +37,26 @@ from hermes_cli.dashboard_auth.cookies import (
 from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
 
 _log = logging.getLogger(__name__)
+
+# In-process replay cache for rotated refresh tokens.
+#
+# When the browser discovers an expired access-token cookie it can fire a
+# burst of parallel fetch() calls (session, profile, status, ws-ticket …).
+# Each carries the same old ``hermes_session_rt`` cookie.  The first request
+# rotates the RT and gets new cookies back via ``Set-Cookie``, but sibling
+# in-flight requests still carry the *old* RT.  Without coalescing, each of
+# those replays the now-stale RT and the provider's reuse-detection revokes
+# the whole session — kicking the remote UI back to login.
+#
+# ``_refresh_cache`` maps ``sha256(old_refresh_token)`` to
+# ``(new_session, provider_name, monotonic_timestamp)``.  A hit within
+# ``_REFRESH_CACHE_TTL_S`` seconds means "another in-process request already
+# rotated this exact RT — use the fresh session instead of hitting the
+# provider again."  The asyncio lock serializes concurrent misses so at most
+# one request per old-RT ever reaches the provider.
+_refresh_cache: dict[str, tuple] = {}
+_refresh_cache_lock = asyncio.Lock()
+_REFRESH_CACHE_TTL_S = 120  # seconds
 
 # Prefixes that bypass the auth gate. Match via ``path == prefix`` or
 # ``path.startswith(prefix)`` — so ``/assets/`` (with trailing slash)
@@ -350,7 +373,7 @@ async def gated_auth_middleware(
         # one). On success we re-set the rotated cookies on the response and
         # serve the request transparently; on RefreshExpiredError (RT dead /
         # revoked / reuse-detected) we fall through to clear-and-relogin.
-        refreshed = _attempt_refresh(request, refresh_token=_rt)
+        refreshed = await _attempt_refresh(request, refresh_token=_rt)
         if refreshed is not None:
             new_session, refreshing_provider = refreshed
             request.state.session = new_session
@@ -416,7 +439,7 @@ def _expires_in_seconds(session) -> int:
     return max(60, int(session.expires_at) - int(time.time()))
 
 
-def _attempt_refresh(request: Request, *, refresh_token):
+async def _attempt_refresh(request: Request, *, refresh_token):
     """Try to rotate an expired session via the refresh token.
 
     Returns ``(new_session, provider_name)`` on success, or ``None`` if
@@ -427,35 +450,75 @@ def _attempt_refresh(request: Request, *, refresh_token):
     here — re-raising would 500 the request; instead we log and return None so
     the caller forces a clean re-login, which is the safer UX than a hard
     error on a transient network blip during the narrow refresh window.
+
+    **Refresh-token replay cache**: concurrent requests carrying the same
+    stale RT are coalesced.  The first request to reach the provider rotates
+    the RT and caches the result; siblings with the same old RT receive the
+    cached fresh session instead of replaying the now-rotated token (which
+    would trip reuse detection and revoke the session).
     """
     if not refresh_token:
         return None
-    for provider in list_session_providers():
-        try:
-            new_session = provider.refresh_session(refresh_token=refresh_token)
-        except RefreshExpiredError:
-            # This provider owns the RT but it's dead — stop trying others
-            # (an RT belongs to exactly one provider) and force re-login.
-            audit_log(
-                AuditEvent.REFRESH_FAILURE,
-                provider=provider.name,
-                reason="refresh_expired",
-                ip=_client_ip(request),
+
+    rt_hash = hashlib.sha256(refresh_token.encode()).hexdigest()
+    now_mono = _time.monotonic()
+
+    # Fast path — another request already refreshed this exact RT recently.
+    cached = _refresh_cache.get(rt_hash)
+    if cached is not None:
+        cached_session, cached_provider, cached_ts = cached
+        if now_mono - cached_ts < _REFRESH_CACHE_TTL_S:
+            _log.debug(
+                "dashboard-auth: refresh cache hit for RT hash %s…",
+                rt_hash[:12],
             )
-            return None
-        except ProviderError as e:
-            _log.warning(
-                "dashboard-auth: provider %r unreachable during refresh: %s",
-                provider.name, e,
-            )
-            audit_log(
-                AuditEvent.REFRESH_FAILURE,
-                provider=provider.name,
-                reason="provider_unreachable",
-                ip=_client_ip(request),
-            )
-            return None
-        if new_session is not None:
-            return new_session, provider.name
+            return cached_session, cached_provider
+
+    # Slow path — serialize so only one request per old-RT hits the provider.
+    async with _refresh_cache_lock:
+        # Double-check after acquiring the lock (another request may have
+        # populated the cache while we were waiting).
+        cached = _refresh_cache.get(rt_hash)
+        if cached is not None:
+            cached_session, cached_provider, cached_ts = cached
+            if now_mono - cached_ts < _REFRESH_CACHE_TTL_S:
+                _log.debug(
+                    "dashboard-auth: refresh cache hit (post-lock) for RT hash %s…",
+                    rt_hash[:12],
+                )
+                return cached_session, cached_provider
+
+        for provider in list_session_providers():
+            try:
+                new_session = provider.refresh_session(refresh_token=refresh_token)
+            except RefreshExpiredError:
+                # This provider owns the RT but it's dead — stop trying others
+                # (an RT belongs to exactly one provider) and force re-login.
+                audit_log(
+                    AuditEvent.REFRESH_FAILURE,
+                    provider=provider.name,
+                    reason="refresh_expired",
+                    ip=_client_ip(request),
+                )
+                return None
+            except ProviderError as e:
+                _log.warning(
+                    "dashboard-auth: provider %r unreachable during refresh: %s",
+                    provider.name, e,
+                )
+                audit_log(
+                    AuditEvent.REFRESH_FAILURE,
+                    provider=provider.name,
+                    reason="provider_unreachable",
+                    ip=_client_ip(request),
+                )
+                return None
+            if new_session is not None:
+                # Cache the rotated session so concurrent siblings don't
+                # replay the old RT and trip reuse detection.
+                _refresh_cache[rt_hash] = (
+                    new_session, provider.name, _time.monotonic(),
+                )
+                return new_session, provider.name
     return None
 

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -20,7 +20,8 @@ from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
 from hermes_cli.dashboard_auth import clear_providers, register_provider
-from hermes_cli.dashboard_auth.cookies import SESSION_AT_COOKIE
+from hermes_cli.dashboard_auth.cookies import SESSION_AT_COOKIE, SESSION_RT_COOKIE
+from hermes_cli.dashboard_auth.base import RefreshExpiredError
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 
 
@@ -593,3 +594,112 @@ def test_unverifiable_token_with_reachable_providers_redirects(_gated_state):
     r = client.get("/api/auth/me")
     assert r.status_code == 401
     assert "unreachable" not in r.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Refresh-token replay cache
+# ---------------------------------------------------------------------------
+
+
+class ReuseDetectingProvider(StubAuthProvider):
+    """Simulates a provider with refresh-token reuse detection.
+
+    On the *first* call to ``refresh_session`` with a given RT, it returns a
+    fresh session and records the RT.  On the *second* call with the same RT
+    (i.e. a concurrent sibling replayed the old token before the browser
+    applied the first response's ``Set-Cookie``), it raises
+    ``RefreshExpiredError`` — exactly what a real rotating-RT provider does
+    when it detects reuse.
+    """
+
+    def __init__(self, default_ttl: int = 3600):
+        super().__init__(default_ttl=default_ttl)
+        self._seen_rts: set[str] = set()
+        self.refresh_call_count = 0
+
+    def refresh_session(self, *, refresh_token: str):
+        self.refresh_call_count += 1
+        if refresh_token in self._seen_rts:
+            # Reuse detected — real providers revoke the whole session family.
+            raise RefreshExpiredError("reuse detected (stub)")
+        self._seen_rts.add(refresh_token)
+        return super().refresh_session(refresh_token=refresh_token)
+
+
+def test_refresh_token_replay_cache_prevents_reuse_detection():
+    """Consequent requests with the same stale RT must NOT replay it.
+
+    Regression for #55712: the browser sends a burst of parallel fetch()
+    calls when the access-token cookie expires.  The first request rotates
+    the RT; siblings carrying the old RT must hit the replay cache instead
+    of the provider, avoiding reuse-detection revocation.
+
+    Uses ``ReuseDetectingProvider`` which raises ``RefreshExpiredError`` on
+    the second call with the same RT — exactly the reuse-detection behaviour
+    that kills remote dashboard sessions.
+    """
+    from hermes_cli.dashboard_auth.middleware import _refresh_cache
+
+    _refresh_cache.clear()
+    provider = ReuseDetectingProvider(default_ttl=0)  # AT born expired
+    clear_providers()
+    register_provider(provider)
+
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+
+    try:
+        client = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+
+        # Walk the full OAuth round trip.  Because default_ttl=0, the AT is
+        # born expired — every subsequent request forces a refresh.
+        r1 = client.get("/auth/login?provider=stub", follow_redirects=False)
+        assert r1.status_code == 302
+        state = r1.headers["location"].split("state=")[1]
+        r2 = client.get(
+            f"/auth/callback?code=stub_code&state={state}",
+            follow_redirects=False,
+        )
+        assert r2.status_code == 302
+
+        # The AT is expired (default_ttl=0).  Verify we hold an RT cookie.
+        # HTTPS deploy uses __Host- prefix.
+        rt_val = (
+            client.cookies.get("__Host-" + SESSION_RT_COOKIE)
+            or client.cookies.get(SESSION_RT_COOKIE)
+        )
+        assert rt_val, "Expected a refresh-token cookie after login"
+
+        # First gated request: AT expired → middleware refreshes via provider.
+        r3 = client.get("/api/auth/me")
+        assert r3.status_code == 200, (
+            f"First request after AT-expiry should refresh transparently; "
+            f"got {r3.status_code}: {r3.text}"
+        )
+        assert provider.refresh_call_count == 1, (
+            f"Provider should be called once, got {provider.refresh_call_count}"
+        )
+
+        # Second gated request: AT is again expired (default_ttl=0), so the
+        # middleware will try to refresh again.  The replay cache must serve
+        # the previously-rotated session without calling the provider a second
+        # time (which would trip reuse detection).
+        r4 = client.get("/api/auth/me")
+        assert r4.status_code == 200, (
+            f"Second request should use cached refresh result; "
+            f"got {r4.status_code}: {r4.text}"
+        )
+        assert provider.refresh_call_count == 1, (
+            f"Provider should still have been called only once (cache hit); "
+            f"got {provider.refresh_call_count} calls"
+        )
+    finally:
+        _refresh_cache.clear()
+        clear_providers()
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in the dashboard auth middleware where concurrent requests after access-token expiry can trip refresh-token reuse detection, killing the remote dashboard session.

When the browser discovers an expired access-token cookie it fires a burst of parallel fetch() calls (session, profile, status, ws-ticket, etc.). Each carries the same old `hermes_session_rt` cookie. The first request rotates the RT and returns new cookies via `Set-Cookie`, but sibling in-flight requests still carry the old RT. Without coalescing, each replay triggers the provider's reuse-detection → `RefreshExpiredError` → session revoked → user kicked back to login.

## Related Issue

Fixes #55712

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/dashboard_auth/middleware.py` — Add in-process replay cache (`_refresh_cache`) mapping `sha256(old_refresh_token)` to `(new_session, provider_name, timestamp)`. An `asyncio.Lock` serializes concurrent refresh misses so at most one request per old-RT reaches the provider. Cache entries expire after 120 seconds. `_attempt_refresh` is now async to support the lock.
- `tests/hermes_cli/test_dashboard_auth_middleware.py` — Add `ReuseDetectingProvider` (raises `RefreshExpiredError` on second call with same RT) and `test_refresh_token_replay_cache_prevents_reuse_detection` regression test proving concurrent requests don't trip reuse detection.

## How to Test

1. Run `pytest tests/hermes_cli/test_dashboard_auth_middleware.py -x -q` — all 34 tests should pass (33 existing + 1 new regression test).
2. The new `test_refresh_token_replay_cache_prevents_reuse_detection` specifically validates that two sequential requests with an expired AT and the same RT both succeed, and the provider's `refresh_session` is called exactly once (the second request hits the cache).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (server-side middleware, no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Log evidence from the issue reporter showing the problem:

```json
{"event":"login_success","provider":"nous","ip":"192.168.64.117"}
{"event":"ws_ticket_minted","provider":"nous","ip":"192.168.64.117"}
...
{"event":"refresh_failure","provider":"nous","reason":"refresh_expired","ip":"192.168.64.117"}
{"event":"session_verify_failure","reason":"no_provider_recognises","ip":"192.168.64.117"}
```

The burst pattern (login_success → immediate refresh_failure) is the signature of concurrent requests replaying the same stale RT.
