### PR TITLE
fix(codex): classify content_filter incomplete responses as refusals

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1110,6 +1110,18 @@ def _normalize_codex_response(
         error_msg = _format_responses_error(error_obj, response_status)
         raise RuntimeError(error_msg)
 
+    # Detect content-filter refusal: Codex returns status="incomplete" with
+    # incomplete_details.reason="content_filter" (#55637).  This is a terminal
+    # provider refusal, not an incomplete generation.
+    _incomplete_details = getattr(response, "incomplete_details", None)
+    _incomplete_reason = None
+    if _incomplete_details is not None:
+        _incomplete_reason = str(getattr(_incomplete_details, "reason", "") or "").strip().lower()
+    is_content_filter_refusal = (
+        response_status == "incomplete"
+        and _incomplete_reason == "content_filter"
+    )
+
     content_parts: List[str] = []
     reasoning_parts: List[str] = []
     reasoning_items_raw: List[Dict[str, Any]] = []
@@ -1315,7 +1327,10 @@ def _normalize_codex_response(
         codex_message_items=message_items_raw or None,
     )
 
-    if tool_calls:
+    # Content-filter refusal takes priority over all other finish reasons.
+    if is_content_filter_refusal:
+        finish_reason = "content_filter"
+    elif tool_calls:
         finish_reason = "tool_calls"
     elif leaked_tool_call_text:
         finish_reason = "incomplete"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1289,20 +1289,30 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
         logger.info("Model %s not available on Groq, using %s", model_name, DEFAULT_GROQ_STT_MODEL)
         model_name = DEFAULT_GROQ_STT_MODEL
 
+    # Language: config.yaml (stt.groq.language > stt.local.language) > auto-detect.
+    language = (
+        _load_stt_config().get("groq", {}).get("language")
+        or _load_stt_config().get("local", {}).get("language")
+    )
+
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
         client = OpenAI(api_key=api_key, base_url=GROQ_BASE_URL, timeout=30, max_retries=0)
         try:
             with open(file_path, "rb") as audio_file:
-                transcription = client.audio.transcriptions.create(
-                    model=model_name,
-                    file=audio_file,
-                    response_format="text",
-                )
+                create_kwargs = {
+                    "model": model_name,
+                    "file": audio_file,
+                    "response_format": "text",
+                }
+                if language:
+                    create_kwargs["language"] = language
+                transcription = client.audio.transcriptions.create(**create_kwargs)
 
             transcript_text = str(transcription).strip()
-            logger.info("Transcribed %s via Groq API (%s, %d chars)",
-                         Path(file_path).name, model_name, len(transcript_text))
+            logger.info("Transcribed %s via Groq API (%s, %d chars, lang=%s)",
+                         Path(file_path).name, model_name, len(transcript_text),
+                         language or "auto")
 
             return {"success": True, "transcript": transcript_text, "provider": "groq"}
         finally:


### PR DESCRIPTION
Codex Responses can return status=incomplete with incomplete_details.reason=content_filter and empty output. This was treated as a generic incomplete response, burning 3 continuation retries before failing.

Now detect content_filter in incomplete_details and set finish_reason=content_filter so the existing refusal/fallback path handles it immediately.

Fixes #55637