### PR TITLE
Fix desktop file link downloads

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-file-links.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-file-links.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $connection } from '@/store/session'
+
+import { MarkdownTextContent } from './markdown-text'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+
+afterEach(() => {
+  cleanup()
+  $connection.set(null)
+  vi.restoreAllMocks()
+
+  if (initialHermesDesktop) {
+    desktopWindow.hermesDesktop = initialHermesDesktop
+  } else {
+    delete desktopWindow.hermesDesktop
+  }
+})
+
+describe('MarkdownTextContent file links', () => {
+  it('opens file links through the remote download endpoint', () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+    desktopWindow.hermesDesktop = { openExternal } as unknown as Window['hermesDesktop']
+    $connection.set({ baseUrl: 'https://gw', mode: 'remote', token: 's e/cret' } as never)
+
+    render(<MarkdownTextContent isRunning={false} text="[Report](file:///tmp/a%20b.pdf)" />)
+
+    fireEvent.click(screen.getByRole('link', { name: 'Open a b.pdf' }))
+
+    expect(openExternal).toHaveBeenCalledWith(
+      'https://gw/api/files/download?path=%2Ftmp%2Fa%20b.pdf&token=s%20e%2Fcret'
+    )
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -213,6 +213,21 @@ function MediaAttachment({ path }: { path: string }) {
     )
   }
 
+  if (kind === 'file') {
+    return (
+      <a
+        className="font-semibold text-foreground underline underline-offset-4 decoration-current/20 wrap-anywhere"
+        href="#"
+        onClick={event => {
+          event.preventDefault()
+          openExternalLink(mediaExternalUrl(path))
+        }}
+      >
+        Open {name}
+      </a>
+    )
+  }
+
   return (
     <a
       className="font-semibold text-foreground underline underline-offset-4 decoration-current/20 wrap-anywhere"

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -16,6 +16,7 @@ const INLINE_CODE_SPLIT_RE = /(`[^`\n]+`)/g
 // and keeps the emphasis run intact. Other trailing punctuation is still peeled
 // off by the final `[^\s<>"'`*.,;:!?]` class.
 const RAW_URL_RE = /https?:\/\/[^\s<>"'`*]+[^\s<>"'`*.,;:!?]/g
+const LOCAL_FILE_LINK_RE = /(?<!!)\[([^\]\n]+)\]\((file:\/\/[^)\s]+|\/[^)\s]+)\)/g
 const LOCAL_PREVIEW_URL_RE = /(^|\s)https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?[^\s<>"'`]*/gi
 const LOCAL_PREVIEW_ONLY_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?$/i
 const URL_ONLY_LINE_RE = /^\s*https?:\/\/\S+\s*$/i
@@ -138,6 +139,43 @@ function autoLinkRawUrls(text: string): string {
   })
 }
 
+function filePathFromHref(href: string): string {
+  if (/^file:/i.test(href)) {
+    try {
+      return decodeURIComponent(new URL(href).pathname)
+    } catch {
+      return href.replace(/^file:\/\//i, '')
+    }
+  }
+
+  try {
+    return decodeURIComponent(href)
+  } catch {
+    return href
+  }
+}
+
+function isAbsoluteFileHref(href: string): boolean {
+  if (/^file:/i.test(href)) {
+    return true
+  }
+
+  const clean = href.split(/[?#]/, 1)[0] || ''
+  const name = clean.split('/').filter(Boolean).pop() || ''
+
+  return /^\.[A-Za-z0-9]{1,12}$/.test(name.slice(name.lastIndexOf('.')))
+}
+
+function rewriteLocalFileLinks(text: string): string {
+  return text.replace(LOCAL_FILE_LINK_RE, (match: string, label: string, href: string) => {
+    if (!isAbsoluteFileHref(href)) {
+      return match
+    }
+
+    return `[${label}](#media:${encodeURIComponent(filePathFromHref(href))})`
+  })
+}
+
 function normalizeVisibleProse(text: string): string {
   return text
     .split(INLINE_CODE_SPLIT_RE)
@@ -145,7 +183,9 @@ function normalizeVisibleProse(text: string): string {
       part.startsWith('`')
         ? part
         : autoLinkRawUrls(
-            part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+            rewriteLocalFileLinks(
+              part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+            )
           )
     )
     .join('')


### PR DESCRIPTION
## What does this PR do?

Fixes Hermes Desktop handling for local file links returned in assistant messages. Streamdown blocks raw `file://` markdown links, and remote desktop sessions need gateway-local files to open through Hermes' authenticated download endpoint rather than the client's local filesystem. This PR normalizes local file markdown links into Hermes media links before markdown rendering and renders generic files as immediate `Open <name>` links.

## Related Issue

Related: #44523, #44538

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added markdown preprocessing in `apps/desktop/src/lib/markdown-preprocess.ts` to rewrite local file links to `#media:` links before Streamdown blocks them.
- Updated `apps/desktop/src/components/assistant-ui/markdown-text.tsx` so generic file media links open directly through the existing media download path.
- Added `apps/desktop/src/components/assistant-ui/markdown-file-links.test.tsx` covering remote file-link downloads.

## How to Test

1. `npm run test:ui --workspace apps/desktop -- src/components/assistant-ui/markdown-file-links.test.tsx src/components/assistant-ui/markdown-text.test.ts src/lib/media.remote.test.ts src/lib/chat-messages.test.ts`
2. `npm run typecheck --workspace apps/desktop`
3. From `apps/desktop`: `npx eslint src/components/assistant-ui/markdown-file-links.test.tsx src/components/assistant-ui/markdown-text.tsx src/lib/markdown-preprocess.ts`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused desktop tests and typecheck pass. The full `npm run lint --workspace apps/desktop -- ...` script still reports pre-existing unrelated lint errors in `apps/desktop/electron/titlebar-overlay-width.cjs`; the three changed files lint cleanly with direct ESLint from `apps/desktop`.
