### PR TITLE
fix(gateway): ignore stale compression session splits

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10423,13 +10423,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             }
             await self.hooks.emit("agent:start", hook_ctx)
 
-            # Run the agent
+            # Run the agent. Capture the session id that this run was launched
+            # against so post-run compression publication can be identity-guarded
+            # below; a /new or another lifecycle transition may move
+            # session_entry.session_id while the old run is still unwinding.
+            _run_start_session_id = session_entry.session_id
             agent_result = await self._run_agent(
                 message=message_text,
                 context_prompt=context_prompt,
                 history=history,
                 source=source,
-                session_id=session_entry.session_id,
+                session_id=_run_start_session_id,
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
@@ -10538,12 +10542,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
-                session_entry.session_id = agent_result["session_id"]
-                self.session_store._save()
-                await asyncio.to_thread(
-                    self._sync_telegram_topic_binding,
-                    source, session_entry, reason="agent-result-compression",
-                )
+                if session_entry.session_id == _run_start_session_id:
+                    session_entry.session_id = agent_result["session_id"]
+                    self.session_store._save()
+                    await asyncio.to_thread(
+                        self._sync_telegram_topic_binding,
+                        source, session_entry, reason="agent-result-compression",
+                    )
+                else:
+                    logger.info(
+                        "Skipping agent-result session split sync for %s because "
+                        "the session binding moved from %s to %s before "
+                        "compression finished",
+                        session_key or "?",
+                        _run_start_session_id,
+                        session_entry.session_id,
+                    )
 
             # Prepend reasoning/thinking if display is enabled (per-platform).
             # Mattermost requires explicit per-platform opt-in because this is
@@ -17096,9 +17110,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_id, agent_session_id,
                 )
                 entry = self.session_store._entries.get(session_key)
+                _session_split_entry_persisted = False
                 if entry:
-                    entry.session_id = agent_session_id
-                    self.session_store._save()
+                    entry_session_id = getattr(entry, "session_id", None)
+                    if not _run_still_current():
+                        logger.info(
+                            "Skipping session split sync for stale run %s — "
+                            "generation %s is no longer current",
+                            session_key or "?",
+                            run_generation,
+                        )
+                    elif entry_session_id == agent_session_id:
+                        _session_split_entry_persisted = True
+                    elif entry_session_id != session_id:
+                        logger.info(
+                            "Skipping session split sync for %s because the "
+                            "session binding moved from %s to %s before "
+                            "compression finished",
+                            session_key or "?",
+                            session_id,
+                            entry_session_id,
+                        )
+                    else:
+                        entry.session_id = agent_session_id
+                        self.session_store._save()
+                        _session_split_entry_persisted = True
 
                 # If this is a Telegram DM and source.thread_id was lost during
                 # the session split (synthetic / recovered event), restore it
@@ -17106,8 +17142,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # correct message_thread_id instead of routing to the General
                 # thread.  Failure here is non-fatal — we log and continue;
                 # worst case the message lands in General, which is the
-                # pre-fix behaviour.
-                if (
+                # pre-fix behaviour. Only do this after this run successfully
+                # published its session split; a stale /stop→/new predecessor
+                # must not mutate routing/binding state for the fresh session.
+                if _session_split_entry_persisted and (
                     getattr(source, "platform", None) == Platform.TELEGRAM
                     and getattr(source, "chat_type", None) == "dm"
                     and getattr(source, "thread_id", None) is None
@@ -17131,7 +17169,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Failed to restore thread_id from binding after session split",
                             exc_info=True,
                         )
-                if entry:
+                if _session_split_entry_persisted:
                     self._sync_telegram_topic_binding(
                         source, entry, reason="agent-run-compression",
                     )

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -119,7 +119,7 @@ def _runner(session_store):
     return runner
 
 
-def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
+def _install_compression_failure_agent(monkeypatch):
     fake_run_agent = types.ModuleType("run_agent")
     fake_run_agent.AIAgent = _CompressionThenFailureAgent
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
@@ -132,11 +132,9 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
 
     monkeypatch.setattr(tools_config, "_get_platform_tools", lambda *_args, **_kwargs: {"core"})
 
-    session_store = _SessionStore()
-    runner = _runner(session_store)
-    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
 
-    result = asyncio.run(
+def _run_compression_failure_turn(runner, source, *, run_generation=None):
+    return asyncio.run(
         asyncio.wait_for(
             runner._run_agent(
                 message="continue",
@@ -145,10 +143,21 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
                 source=source,
                 session_id="session-before-compression",
                 session_key=SESSION_KEY,
+                run_generation=run_generation,
             ),
             timeout=2,
         )
     )
+
+
+def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
+    _install_compression_failure_agent(monkeypatch)
+
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+
+    result = _run_compression_failure_turn(runner, source)
 
     assert result["failed"] is True
     assert result["session_id"] == "session-after-compression"
@@ -158,3 +167,53 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
     runner._sync_telegram_topic_binding.assert_called_once_with(
         source, session_store.entry, reason="agent-run-compression"
     )
+
+
+def test_stale_run_does_not_overwrite_new_session_after_compression(monkeypatch):
+    """A /stop + /new can invalidate a run while its compression is still unwinding.
+
+    The stale run may still return with a rotated agent.session_id, but it must
+    not publish that old compressed child back into the channel's active session
+    binding. The outer gateway stale-result check will discard the response too;
+    this regression covers the earlier side effect inside _run_agent().
+    """
+    _install_compression_failure_agent(monkeypatch)
+
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    runner._session_run_generation[SESSION_KEY] = 2
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+
+    result = _run_compression_failure_turn(runner, source, run_generation=1)
+
+    assert result["failed"] is True
+    assert result["session_id"] == "session-after-compression"
+    assert result["history_offset"] == 0
+    assert session_store.entry.session_id == "session-before-compression"
+    assert session_store.save_calls == 0
+    assert getattr(runner._sync_telegram_topic_binding, "call_count") == 0
+
+
+def test_session_split_sync_skips_when_binding_already_moved(monkeypatch):
+    """A live session binding is identity-guarded, not blindly overwritten.
+
+    This catches the exact race where an old run starts with session A, /new
+    moves the binding to fresh session B, and the old run finishes compression
+    into child C. C must not replace B.
+    """
+    _install_compression_failure_agent(monkeypatch)
+
+    session_store = _SessionStore()
+    session_store.entry.session_id = "fresh-session-after-new"
+    runner = _runner(session_store)
+    runner._session_run_generation[SESSION_KEY] = 1
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+
+    result = _run_compression_failure_turn(runner, source, run_generation=1)
+
+    assert result["failed"] is True
+    assert result["session_id"] == "session-after-compression"
+    assert result["history_offset"] == 0
+    assert session_store.entry.session_id == "fresh-session-after-new"
+    assert session_store.save_calls == 0
+    assert getattr(runner._sync_telegram_topic_binding, "call_count") == 0


### PR DESCRIPTION
## Summary

Fixes a gateway race where a generation-invalidated run can finish context compression after `/stop` + `/new` and publish its compressed child session back into the active channel binding.

The change makes compression session-split publication identity-guarded:

- `_run_agent` only writes the compressed `agent.session_id` back if the run generation is still current and the active binding still points at the session the run started with.
- `_handle_message_with_agent` captures the launch session id and applies the same binding-moved guard before propagating `agent_result["session_id"]`.
- Telegram topic binding refresh now only runs after the session split was actually published.

This preserves the existing valid compression-sync behavior while preventing stale cancelled runs from stealing a fresh `/new` session.

## Repro / bug shape

Observed sequence:

1. A gateway run is near context compression.
2. User runs `/stop`, then `/new` rather than waiting for compaction.
3. The old task does not exit within the 5s cancellation drain and continues unwinding in the background.
4. The old run finishes compression and rotates from session A to compressed child C.
5. Before this fix, that stale run could overwrite the active session binding, even though `/new` had already moved the chat to fresh session B.
6. The next user message then routes into the old compacted context.

## Tests

Added regressions in `tests/gateway/test_compression_failure_session_sync.py`:

- stale generation after compression does not overwrite the active binding
- moved binding after `/new` is not overwritten by the old compressed child
- existing failed-turn compression sync behavior still works

Validation run:

```text
python -m py_compile gateway/run.py tests/gateway/test_compression_failure_session_sync.py
python -m pytest -q -o addopts='' tests/gateway/test_compression_failure_session_sync.py tests/gateway/test_compression_session_id_persistence.py tests/gateway/test_session_split_brain_11016.py tests/gateway/test_session_race_guard.py tests/run_agent/test_compression_persistence.py
# 48 passed in 10.29s

python -m pytest -q -o addopts='' tests/gateway/test_telegram_approval_buttons.py::TestTelegramExecApproval::test_send_update_prompt_escapes_dynamic_prompt tests/gateway/test_telegram_approval_buttons.py::TestTelegramApprovalCallback::test_approval_callback_escapes_dynamic_user_name tests/gateway/test_telegram_model_picker.py::TestTelegramModelPicker::test_send_model_picker_escapes_dynamic_provider_label tests/gateway/test_telegram_model_picker.py::TestTelegramModelPicker::test_back_button_escapes_dynamic_provider_label tests/gateway/test_telegram_model_picker.py::TestTelegramModelPicker::test_model_selected_edits_message_on_success tests/gateway/test_telegram_slash_confirm.py::TestSendSlashConfirm::test_uses_markdown_v2_and_escapes_special_chars
# 6 passed in 0.62s
```

I also ran the full `tests/gateway` suite. It reported 9 failures, but the checked failures are pre-existing/baseline in this environment: the Discord reaction and Matrix table-markdown failures reproduce on clean `upstream/main`, and the Telegram parse-mode failures pass when run focused.

## Risk

Low. This only narrows when a completed compression split may mutate gateway session routing. Current, identity-matching runs still publish their split as before; stale or binding-moved runs keep their internal result but cannot overwrite the active chat binding.