### PR TITLE
Show absolute token counts in runtime footer context_pct

### DIFF
--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -110,7 +110,10 @@ def format_runtime_footer(
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
-                parts.append(f"{pct}%")
+                # Format tokens in K (e.g. 38k, 200k)
+                ctx_k = f"{context_tokens // 1000}k" if context_tokens >= 1000 else str(context_tokens)
+                len_k = f"{context_length // 1000}k" if context_length >= 1000 else str(context_length)
+                parts.append(f"{pct}% ({ctx_k}/{len_k})")
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:


### PR DESCRIPTION
# PR: Show absolute token counts in runtime footer context_pct

## Summary

Changes the runtime footer's `context_pct` field from showing just a percentage (`19%`) to showing both percentage and absolute token counts (`19% (38k/200k)`).

## Motivation

**Current behavior:** When `display.runtime_footer.enabled: true`, the footer shows context usage as a bare percentage:
```
claude-opus-4-7 · 19% · 📅 2026-01-~
```

**Problem:** Users cannot tell if `19%` means "19k out of 100k" or "380k out of 2M". The absolute numbers matter for:
- Debugging context exhaustion issues
- Understanding when to use /new vs continuing
- Comparing models with different context windows (GPT-4 128k vs Claude Opus 200k)

**Proposed behavior:**
```
claude-opus-4-7 · 19% (38k/200k) · 📅 2026-01-~
```

Now users see both the percentage (quick visual scan) and the absolute counts (precise understanding).

## Changes

**File:** `gateway/runtime_footer.py`  
**Lines:** 128-132

```python
# Before
elif field == "context_pct":
    if context_length and context_length > 0 and context_tokens >= 0:
        pct = max(0, min(100, round((context_tokens / context_length) * 100)))
        parts.append(f"{pct}%")

# After
elif field == "context_pct":
    if context_length and context_length > 0 and context_tokens >= 0:
        pct = max(0, min(100, round((context_tokens / context_length) * 100)))
        # Format tokens in K (e.g. 38k, 200k)
        ctx_k = f"{context_tokens // 1000}k" if context_tokens >= 1000 else str(context_tokens)
        len_k = f"{context_length // 1000}k" if context_length >= 1000 else str(context_length)
        parts.append(f"{pct}% ({ctx_k}/{len_k})")
```

## Token formatting

- Values ≥1000 are shown in K: `38000` → `38k`, `200000` → `200k`
- Values <1000 are shown raw: `500` → `500`
- Rounds down to nearest K (integer division): `38999` → `38k`

This keeps the footer compact while providing human-readable precision.

## Backward compatibility

✅ **No breaking changes**
- Config schema unchanged (still `fields: [model, context_pct, cwd]`)
- Per-platform overrides still work (`display.platforms.telegram.runtime_footer`)
- Existing footer enable/disable behavior unchanged
- Only the *rendered format* of `context_pct` changes

## Testing

Verified on:
- Claude Opus 4 (200k context)
- Gemini Flash (1M context)
- Local models with small contexts (<10k)

**Before:**
```
19%
68%
2%
```

**After:**
```
19% (38k/200k)
68% (680k/1000k)
2% (200/10k)
```

## Visual impact

Footer becomes ~10 chars longer when `context_pct` is shown:
- Before: `model · 19% · cwd` (~20 chars)
- After: `model · 19% (38k/200k) · cwd` (~30 chars)

Still compact enough for mobile/narrow terminals. Users who want minimal footers can:
- Keep `runtime_footer.enabled: false` (default)
- Drop `context_pct` from `fields` list

## Documentation

Update needed in `website/docs/user-guide/configuration.md` (runtime_footer section):

```diff
- When enabled, shows e.g. `model · 68% · ~/projects/hermes`.
+ When enabled, shows e.g. `model · 68% (680k/1000k) · ~/projects/hermes`.
```

## Checklist

- [x] Code change tested locally
- [x] Backward compatible (config schema unchanged)
- [x] No new dependencies
- [ ] Documentation updated (waiting for PR acceptance)
- [ ] Changelog entry added (waiting for maintainer guidance on format)

## Related

This change pairs well with the existing `context_pct` field and doesn't conflict with:
- Auto-handoff thresholds (still use percentage-based config)
- Context compression triggers (still use raw token counts internally)
- Model switching logic (unaffected)

---

**Tested by:** @mukhachd (Dmitry Mukhach)  
**Date:** 2026-06-30  
**Hermes version:** Latest main branch (jun30)
