### PR TITLE
fix(gateway): skip port-conflicting multiplex profiles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1412,8 +1412,8 @@ from contextlib import contextmanager as _contextmanager
 # multiplexer the default profile owns the single shared listener and serves
 # every profile through the /p/<profile>/ URL prefix, so a SECONDARY profile
 # enabling one of these is always a misconfiguration: it would try to bind a
-# port already held by the default's listener. We hard-error on it rather than
-# silently dropping the adapter (see _start_one_profile_adapters).
+# port already held by the default's listener. Skip that secondary profile so a
+# single bad profile cannot take down the whole multiplexer.
 # Stored as platform .value strings since the Platform enum is imported below.
 _PORT_BINDING_PLATFORM_VALUES = frozenset({
     "webhook",
@@ -1429,12 +1429,16 @@ _PORT_BINDING_PLATFORM_VALUES = frozenset({
 
 
 class MultiplexConfigError(RuntimeError):
-    """A profile multiplexer config is invalid (fail-fast at startup).
+    """A profile multiplexer config is invalid.
 
-    Distinct from a transient adapter-connect failure: a transient error is
-    logged and the gateway stays alive to retry, but a config error means the
-    operator must fix config.yaml, so it aborts startup cleanly.
+    Distinct from a transient adapter-connect failure: a config error means the
+    operator must fix config.yaml. Fatal configuration errors propagate to the
+    startup guard instead of being treated as retryable adapter noise.
     """
+
+
+class SecondaryPortBindingConfigError(MultiplexConfigError):
+    """A secondary profile conflicts with the multiplexer's shared listener."""
 
 
 @_contextmanager
@@ -8620,10 +8624,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 connected += await self._start_one_profile_adapters(
                     profile_name, profile_home, claimed
                 )
+            except SecondaryPortBindingConfigError as e:
+                logger.warning(
+                    "Skipping secondary profile '%s' due to port-binding config error: %s",
+                    profile_name,
+                    e,
+                )
             except MultiplexConfigError:
-                # Config error (e.g. a secondary profile binding a port) is not
-                # transient — propagate so startup aborts cleanly instead of
-                # limping along with a half-configured multiplexer.
                 raise
             except Exception as e:
                 logger.error(
@@ -8665,26 +8672,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "'open'."
             )
 
+        port_binding_platforms = sorted(
+            platform.value
+            for platform, platform_config in profile_cfg.platforms.items()
+            if platform_config.enabled and platform.value in _PORT_BINDING_PLATFORM_VALUES
+        )
+        if port_binding_platforms:
+            joined = ", ".join(port_binding_platforms)
+            raise SecondaryPortBindingConfigError(
+                f"Profile '{profile_name}' enables port-binding platform(s) "
+                f"{joined}, but gateway.multiplex_profiles is on. The default "
+                f"profile owns the single shared HTTP listener and serves every "
+                f"profile through the /p/{profile_name}/ URL prefix. Remove "
+                f"these platform entries from profile '{profile_name}'s config.yaml "
+                f"or configure them only on the default profile."
+            )
+
         profile_map = self._profile_adapters.setdefault(profile_name, {})
         connected = 0
         for platform, platform_config in profile_cfg.platforms.items():
             if not platform_config.enabled:
                 continue
-            # A secondary profile must NOT enable a port-binding platform: the
-            # default profile's listener already serves every profile via the
-            # /p/<profile>/ prefix, so a second bind can only collide. This is a
-            # config error, not a transient failure — fail fast and loud.
-            if platform.value in _PORT_BINDING_PLATFORM_VALUES:
-                raise MultiplexConfigError(
-                    f"Profile '{profile_name}' enables the port-binding platform "
-                    f"'{platform.value}', but gateway.multiplex_profiles is on. The "
-                    f"default profile owns the single shared HTTP listener and "
-                    f"serves every profile through the /p/{profile_name}/ URL "
-                    f"prefix — a secondary profile cannot bind its own port. "
-                    f"Remove platforms.{platform.value} from profile "
-                    f"'{profile_name}'s config.yaml (configure it only on the "
-                    f"default profile)."
-                )
             with _profile_runtime_scope(profile_home):
                 adapter = self._create_adapter(platform, platform_config)
             if not adapter:

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -1,4 +1,6 @@
 """Phase 3: secondary-profile adapter registry + same-token conflict detection."""
+import logging
+
 import pytest
 
 from gateway.run import GatewayRunner
@@ -90,12 +92,12 @@ class TestProfileMessageHandler:
         assert seen["profile"] == "writer"
 
 
-class TestPortBindingHardError:
-    """A secondary profile enabling a port-binding platform aborts startup."""
+class TestSecondaryProfileConfigHandling:
+    """Secondary config errors degrade only when the profile is safe to skip."""
 
     @pytest.mark.asyncio
-    async def test_secondary_webhook_raises(self, monkeypatch):
-        from gateway.run import MultiplexConfigError
+    async def test_secondary_webhook_uses_degradable_error(self, monkeypatch):
+        from gateway.run import SecondaryPortBindingConfigError
         from gateway.config import GatewayConfig, Platform, PlatformConfig
 
         runner = GatewayRunner.__new__(GatewayRunner)
@@ -111,10 +113,143 @@ class TestPortBindingHardError:
             "gateway.config.load_gateway_config", lambda: reviewer_cfg
         )
 
-        with pytest.raises(MultiplexConfigError) as ei:
+        with pytest.raises(SecondaryPortBindingConfigError) as ei:
             await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
         assert "webhook" in str(ei.value)
         assert "reviewer" in str(ei.value)
+        assert "reviewer" not in runner._profile_adapters
+
+    @pytest.mark.asyncio
+    async def test_secondary_reports_all_port_binding_platforms(self, monkeypatch):
+        from gateway.run import SecondaryPortBindingConfigError
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {
+            Platform.FEISHU: PlatformConfig(enabled=True),
+            Platform.WEBHOOK: PlatformConfig(enabled=True, extra={"port": 8644}),
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="t"),
+        }
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: reviewer_cfg
+        )
+
+        with pytest.raises(SecondaryPortBindingConfigError) as ei:
+            await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
+        message = str(ei.value)
+        assert "feishu" in message
+        assert "webhook" in message
+        assert "telegram" not in message
+        assert "reviewer" not in runner._profile_adapters
+
+    @pytest.mark.asyncio
+    async def test_multiplexer_skips_bad_profile_and_continues(self, monkeypatch, caplog):
+        from pathlib import Path
+        from gateway.config import GatewayConfig
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner.adapters = {}
+        runner._profile_adapters = {}
+
+        async def fake_start_one(profile_name, profile_home, claimed):
+            if profile_name == "bad":
+                from gateway.run import SecondaryPortBindingConfigError
+                raise SecondaryPortBindingConfigError("bad enables webhook")
+            runner._profile_adapters[profile_name] = {}
+            return 2
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex: [
+                ("default", Path("/tmp/default")),
+                ("bad", Path("/tmp/bad")),
+                ("good", Path("/tmp/good")),
+            ],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name",
+            lambda: "default",
+        )
+        monkeypatch.setattr(runner, "_start_one_profile_adapters", fake_start_one)
+        monkeypatch.setattr(
+            "gateway.status.write_runtime_status",
+            lambda **kwargs: None,
+        )
+
+        caplog.set_level(logging.WARNING, logger="gateway.run")
+        connected = await runner._start_secondary_profile_adapters()
+
+        assert connected == 2
+        assert "good" in runner._profile_adapters
+        assert "bad" not in runner._profile_adapters
+        assert "Skipping secondary profile 'bad'" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_multiplexer_propagates_security_config_error(self, monkeypatch):
+        from pathlib import Path
+        from gateway.config import GatewayConfig
+        from gateway.run import MultiplexConfigError
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner.adapters = {}
+        runner._profile_adapters = {}
+
+        async def fake_start_one(profile_name, profile_home, claimed):
+            raise MultiplexConfigError(
+                f"Profile '{profile_name}' enables open policy without allow-all opt-in"
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex: [
+                ("default", Path("/tmp/default")),
+                ("unsafe", Path("/tmp/unsafe")),
+            ],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name",
+            lambda: "default",
+        )
+        monkeypatch.setattr(runner, "_start_one_profile_adapters", fake_start_one)
+
+        with pytest.raises(MultiplexConfigError, match="open policy"):
+            await runner._start_secondary_profile_adapters()
+
+    @pytest.mark.asyncio
+    async def test_open_policy_uses_fatal_config_error(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import (
+            MultiplexConfigError,
+            SecondaryPortBindingConfigError,
+        )
+
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("WECOM_ALLOW_ALL_USERS", raising=False)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        unsafe_cfg = GatewayConfig(multiplex_profiles=True)
+        unsafe_cfg.platforms = {
+            Platform.WECOM: PlatformConfig(
+                enabled=True,
+                extra={"dm_policy": "open"},
+            ),
+        }
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: unsafe_cfg)
+
+        with pytest.raises(MultiplexConfigError, match="open policy") as exc_info:
+            await runner._start_one_profile_adapters("unsafe", "/tmp/unsafe", {})
+
+        assert not isinstance(exc_info.value, SecondaryPortBindingConfigError)
+        assert "unsafe" not in runner._profile_adapters
 
     @pytest.mark.asyncio
     async def test_secondary_non_binding_platform_ok(self, monkeypatch):
@@ -190,6 +325,15 @@ class TestPortBindingHardError:
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES
         # Every adapter that binds a TCP port must be in the guard set.
-        for p in ("webhook", "api_server", "msgraph_webhook", "feishu",
-                  "wecom_callback", "bluebubbles", "sms"):
+        for p in (
+            "webhook",
+            "api_server",
+            "msgraph_webhook",
+            "feishu",
+            "wecom_callback",
+            "bluebubbles",
+            "sms",
+            "whatsapp_cloud",
+            "line",
+        ):
             assert p in _PORT_BINDING_PLATFORM_VALUES

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -142,18 +142,26 @@ POST http://host:8644/p/coder/webhooks/<route>
 An unknown or unconfigured profile in the prefix returns `404`. Because the one
 shared listener already serves every profile this way, a **secondary profile
 must not enable a port-binding platform itself** — doing so is a config error
-and the gateway refuses to start, naming the profile and platform:
+that skips the entire secondary profile while the default and other healthy
+profiles continue. The warning names the skipped profile and every conflicting
+platform:
 
 ```
-Profile 'coder' enables the port-binding platform 'webhook', but
-gateway.multiplex_profiles is on. ... Remove platforms.webhook from profile
-'coder's config.yaml (configure it only on the default profile).
+Skipping secondary profile 'coder' due to port-binding config error: Profile
+'coder' enables port-binding platform(s) webhook, but gateway.multiplex_profiles
+is on. ... Remove these platform entries from profile 'coder's config.yaml or
+configure them only on the default profile.
 ```
 
 Port-binding platforms covered by this rule: `webhook`, `api_server`,
-`msgraph_webhook`, `feishu`, `wecom_callback`, `bluebubbles`, `sms`. Configure
-any of these **only on the default profile**; every profile is reachable through
-its `/p/<profile>/` prefix.
+`msgraph_webhook`, `feishu`, `wecom_callback`, `bluebubbles`, `sms`,
+`whatsapp_cloud`, `line`. Configure any of these **only on the default profile**;
+every profile is reachable through its `/p/<profile>/` prefix.
+
+Only this shared-listener conflict degrades to a skipped profile. Security
+configuration errors remain fatal: for example, an `open` own-policy platform
+without `GATEWAY_ALLOW_ALL_USERS` or its platform-specific allow-all opt-in
+still aborts gateway startup rather than silently dropping the unsafe profile.
 
 #### 3. Per-credential platforms still need their own token per profile
 


### PR DESCRIPTION
## What does this PR do?

With `gateway.multiplex_profiles` enabled, a secondary profile that configures its own port-binding platform conflicts with the default profile's shared HTTP listener. That isolated mistake currently aborts the entire gateway, taking down the default profile and every healthy secondary profile.

This makes that one recoverable case degrade per profile: the conflicting profile is rejected before any adapter state is created, a precise warning is logged, and startup continues for healthy profiles. Fatal configuration errors remain fatal, especially an `open` own-policy platform without an explicit allow-all opt-in.

## Related Issue

Fixes #52796

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Regression tests

## Changes Made

- Add `SecondaryPortBindingConfigError` as the explicit recoverable subtype of `MultiplexConfigError`.
- Catch only that subtype while starting secondary profiles; re-raise all other multiplex configuration errors to the existing fatal startup guard.
- Validate all enabled port-binding platforms before creating the profile adapter map, preventing partial registration.
- Document the skipped-profile behavior, complete platform list, and unchanged fatal security contract.
- Cover subtype classification, all conflicting platforms, skip-and-continue behavior, no partial state, and fatal open-policy propagation.

## How to Test

1. `uv run --extra dev pytest -q tests/gateway/test_multiplex_adapter_registry.py`
2. `uv run --extra dev pytest -q tests/gateway/test_multiplex_profile_authz.py tests/gateway/test_multiplex_phase0.py tests/gateway/test_multiplex_http_routing.py`
3. `uv run --extra dev ruff check gateway/run.py tests/gateway/test_multiplex_adapter_registry.py`

The new fatal-propagation regression fails on the previous PR head because the broad catch logs and skips the unsafe profile. The final branch passes 15 changed-file tests and 41 adjacent multiplex tests.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] The commit follows Conventional Commits.
- [x] The PR remains limited to secondary-profile startup configuration handling.
- [x] Focused regression suites, Ruff, lockfile validation, and all blocking project gates pass.
- [x] Regression tests cover both the degradable and fatal branches.
- [x] Tested on macOS 26.5.

### Documentation & Housekeeping

- [x] The multi-profile gateway guide matches the runtime contract.
- [x] No configuration keys, dependencies, schemas, or architecture contracts changed.
- [x] The behavior is platform-independent and does not alter listener or adapter implementations.

## Screenshots / Logs

No visual UI changed. Runtime behavior and warning output are covered by the focused gateway tests.
