### PR TITLE
fix(cron): reject sub-minute recurring intervals (every 0m runaway)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -726,7 +726,19 @@ def _cron_schedule(
     return {"kind": "cron", "expr": expr, "display": display}
 
 
-def _interval_schedule(minutes: int) -> Dict[str, Any]:
+def _interval_schedule(minutes: int, original: Optional[str] = None) -> Dict[str, Any]:
+    """Build a recurring interval schedule, rejecting a sub-minute one.
+
+    A zero (or sub-minute) interval is not a recurrence: the next run computes to
+    ``last_run + 0 == last_run``, which is always in the past, so the job is perpetually
+    due and re-fires on every scheduler tick. Both interval forms ("every 0m" and a bare
+    "0m") land here, so the guard covers each of them.
+    """
+    if minutes < 1:
+        raise ValueError(
+            f"Invalid interval '{original if original is not None else f'{minutes}m'}': "
+            f"recurring interval must be at least 1 minute. "
+            f"Use e.g. 'every 1m', 'every 30m', or 'every 2h'.")
     return {"kind": "interval", "minutes": minutes, "display": f"every {minutes}m"}
 
 
@@ -750,7 +762,7 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             cron_expr, original,
             f"Weekday/time schedules like '{example}' require the 'croniter' package.", "schedule")
     if is_every:
-        return _interval_schedule(parse_duration(rest))
+        return _interval_schedule(parse_duration(rest), original)
 
     # Cron expression (5-6 fields). Letters are allowed so named months/weekdays (JAN-DEC, MON-FRI)
     # reach croniter, which supports them.
@@ -791,8 +803,15 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
                 f"Invalid duration '{duration_str}' after 'in '. Use e.g. 'in 30m', 'in 2h'.")
         run_at = _hermes_now() + timedelta(minutes=minutes)
         return {"kind": "once", "run_at": run_at.isoformat(), "display": f"once in {duration_str}"}
+    # Suppress only the "this is not a duration" failure, so a non-duration string still
+    # falls through to the generic help text below. A string that IS a duration but names an
+    # invalid interval ("0m") must surface _interval_schedule's specific message instead of
+    # being swallowed into that generic text.
+    bare_minutes = None
     with contextlib.suppress(ValueError):
-        return _interval_schedule(parse_duration(schedule))
+        bare_minutes = parse_duration(schedule)
+    if bare_minutes is not None:
+        return _interval_schedule(bare_minutes, original)
 
     raise ValueError(
         f"Invalid schedule '{original}'. Use:\n"
@@ -1100,6 +1119,10 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         minutes = schedule.get("minutes")
         if minutes is None:
             return None
+        # Clamp to a 1-minute floor so a legacy/persisted job that somehow carries a zero
+        # (or negative) interval still advances instead of re-firing every tick. New jobs
+        # are rejected at parse time; this is the recovery path for rows already on disk.
+        minutes = max(1, minutes)
         return (base_time + timedelta(minutes=minutes)).isoformat()
     if kind == "cron":
         expr = schedule.get("expr")

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -587,6 +587,15 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     if schedule_lower.startswith("every "):
         duration_str = schedule[6:].strip()
         minutes = parse_duration(duration_str)
+        # A zero (or sub-minute) interval is not a valid recurrence: the next
+        # run computes to last_run + 0 == last_run, which is always in the
+        # past, so the job is perpetually due and re-fires on every scheduler
+        # tick. Reject it with a clear message instead of accepting a runaway.
+        if minutes < 1:
+            raise ValueError(
+                f"Invalid interval '{original}': recurring interval must be at "
+                f"least 1 minute. Use e.g. 'every 1m', 'every 30m', or 'every 2h'."
+            )
         return {
             "kind": "interval",
             "minutes": minutes,
@@ -790,6 +799,10 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         minutes = schedule.get("minutes")
         if minutes is None:
             return None
+        # Clamp to a 1-minute floor so a legacy/persisted job that somehow
+        # carries a zero (or negative) interval still advances instead of
+        # re-firing every tick. New jobs are already rejected at parse time.
+        minutes = max(1, minutes)
         if last_run_at:
             try:
                 last = _ensure_aware(datetime.fromisoformat(last_run_at))

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -269,6 +269,52 @@ class TestParseSchedule:
 # Timezone-divergence regression (#51021)
 # =========================================================================
 
+    def test_zero_interval_rejected(self):
+        # "every 0m" parsed to a 0-minute interval, whose next run computes to
+        # last_run + 0 == last_run (always in the past), so the job re-fired on
+        # every scheduler tick. It must be rejected.
+        with pytest.raises(ValueError):
+            parse_schedule("every 0m")
+
+    def test_zero_hour_interval_rejected(self):
+        with pytest.raises(ValueError):
+            parse_schedule("every 0h")
+
+    def test_zero_bare_duration_interval_rejected(self):
+        # A bare duration is a RECURRING interval per the documented tool
+        # contract, so "0m" reaches the same runaway as "every 0m". Both forms
+        # now build through _interval_schedule, so one guard covers each.
+        with pytest.raises(ValueError) as exc:
+            parse_schedule("0m")
+        assert "at least 1 minute" in str(exc.value)
+
+    def test_rejection_names_the_schedule_the_user_typed(self):
+        with pytest.raises(ValueError) as exc:
+            parse_schedule("every 0h")
+        assert "every 0h" in str(exc.value)
+
+    def test_one_minute_interval_still_allowed(self):
+        result = parse_schedule("every 1m")
+        assert result["kind"] == "interval"
+        assert result["minutes"] == 1
+
+    def test_bare_duration_interval_still_allowed(self):
+        result = parse_schedule("30m")
+        assert result["kind"] == "interval"
+        assert result["minutes"] == 30
+
+    def test_compute_next_run_clamps_zero_interval(self):
+        # A legacy/persisted job carrying a 0-minute interval must still
+        # advance past last_run, not return last_run (which would be eternally
+        # due and re-fire every tick).
+        last = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        nxt = compute_next_run(
+            {"kind": "interval", "minutes": 0}, last_run_at=last.isoformat()
+        )
+        assert nxt is not None
+        assert datetime.fromisoformat(nxt) >= last + timedelta(minutes=1)
+
+
 class TestNaiveScheduleTimezoneDivergence:
     """End-to-end: a one-shot created with a naive recent-past timestamp must
     become due even when the configured Hermes timezone differs from the

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -114,6 +114,34 @@ class TestParseSchedule:
 # Timezone-divergence regression (#51021)
 # =========================================================================
 
+    def test_zero_interval_rejected(self):
+        # "every 0m" parsed to a 0-minute interval, whose next run computes to
+        # last_run + 0 == last_run (always in the past), so the job re-fired on
+        # every scheduler tick. It must be rejected.
+        with pytest.raises(ValueError):
+            parse_schedule("every 0m")
+
+    def test_zero_hour_interval_rejected(self):
+        with pytest.raises(ValueError):
+            parse_schedule("every 0h")
+
+    def test_one_minute_interval_still_allowed(self):
+        result = parse_schedule("every 1m")
+        assert result["kind"] == "interval"
+        assert result["minutes"] == 1
+
+    def test_compute_next_run_clamps_zero_interval(self):
+        # A legacy/persisted job carrying a 0-minute interval must still
+        # advance past last_run, not return last_run (which would be eternally
+        # due and re-fire every tick).
+        last = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        nxt = compute_next_run(
+            {"kind": "interval", "minutes": 0}, last_run_at=last.isoformat()
+        )
+        assert nxt is not None
+        assert datetime.fromisoformat(nxt) >= last + timedelta(minutes=1)
+
+
 class TestNaiveScheduleTimezoneDivergence:
     """End-to-end: a one-shot created with a naive recent-past timestamp must
     become due even when the configured Hermes timezone differs from the


### PR DESCRIPTION
### Summary

`parse_schedule` accepts `every 0m` (and `every 0h`) as a valid recurring interval with `minutes: 0`. `compute_next_run` then returns `last_run + timedelta(minutes=0) == last_run`, which is always in the past, so the job is perpetually due and re-fires on every scheduler tick — a runaway that repeatedly invokes the agent.

### Reproduction

```python
from cron.jobs import parse_schedule, compute_next_run

sched = parse_schedule("every 0m")
# {'kind': 'interval', 'minutes': 0, 'display': 'every 0m'}

compute_next_run(sched, last_run_at="2020-01-01T00:00:00+00:00")
# returns 2020-01-01T... — equal to last_run, i.e. already due.
# After each fire, last_run advances to ~now and next = now + 0 = now,
# so the job re-fires on the next tick, forever.
```

### Fix

- Reject a recurring interval below 1 minute at parse time with a clear, actionable error (so the user learns why `every 0m` is invalid).
- Clamp the interval to a 1-minute floor in `compute_next_run` so any already-persisted zero/negative-interval job advances by at least a minute instead of spinning.

### Tests

Adds regression tests for the parse-time rejection (`every 0m`, `every 0h`), the still-valid `every 1m` case, and the `compute_next_run` clamp on a stored zero-interval job. They fail before the change (interval accepted; next run == last run) and pass after.

Note: three pre-existing `TestGetDueJobs` failures in this file are unrelated — they require the `croniter` package and fail identically on `main` without it.

Fixes #55727
