### PR TITLE
fix(agent): keep truncation internals out of client replies

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1315,7 +1315,15 @@ def _normalize_codex_response(
         codex_message_items=message_items_raw or None,
     )
 
-    if tool_calls:
+    provider_finish_reason = getattr(response, "finish_reason", None)
+    if isinstance(provider_finish_reason, str):
+        provider_finish_reason = provider_finish_reason.strip().lower()
+    else:
+        provider_finish_reason = None
+
+    if provider_finish_reason in {"length", "max_tokens", "max_output_tokens"}:
+        finish_reason = "length"
+    elif tool_calls:
         finish_reason = "tool_calls"
     elif leaked_tool_call_text:
         finish_reason = "incomplete"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -437,6 +437,14 @@ def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List
 # exception path (a provider moderation error classified as
 # ``content_policy_blocked``) end with the same actionable next steps, so they
 # share one trailer to keep the guidance from drifting between the two sites.
+
+
+def _client_safe_truncation_response() -> str:
+    return (
+        "⚠️ I hit an internal response limit while working on this, so I stopped before sending an incomplete answer. "
+        "Please ask me to continue or narrow the request, and I can pick up safely."
+    )
+
 _CONTENT_POLICY_RECOVERY_HINT = (
     "Try rephrasing the request, narrowing the context, or "
     "adding a fallback provider with `hermes fallback add`."
@@ -1466,13 +1474,21 @@ def run_conversation(
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":
                     status = getattr(response, "status", None)
+                    provider_finish_reason = getattr(response, "finish_reason", None)
+                    if isinstance(provider_finish_reason, str):
+                        provider_finish_reason = provider_finish_reason.strip().lower()
+                    else:
+                        provider_finish_reason = None
                     incomplete_details = getattr(response, "incomplete_details", None)
                     incomplete_reason = None
                     if isinstance(incomplete_details, dict):
                         incomplete_reason = incomplete_details.get("reason")
                     else:
                         incomplete_reason = getattr(incomplete_details, "reason", None)
-                    if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
+                    if (
+                        provider_finish_reason in {"length", "max_tokens", "max_output_tokens"}
+                        or (status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"})
+                    ):
                         finish_reason = "length"
                     else:
                         finish_reason = "stop"
@@ -1615,6 +1631,16 @@ def run_conversation(
                             f"(finish_reason='length') - model hit max output tokens",
                             force=True,
                         )
+
+                    # The ChatGPT Codex backend rejects explicit max_output_tokens,
+                    # so a Codex length stop cannot be fixed by increasing the
+                    # request cap. Keep Codex as primary, but fail over for this
+                    # turn when a fallback is configured; otherwise the safe
+                    # truncation response below prevents leaking internals.
+                    if agent.api_mode == "codex_responses" and getattr(agent, "_fallback_chain", None):
+                        agent._emit_status("⚠️ Codex hit output cap — switching to fallback provider...")
+                        if agent._try_activate_fallback():
+                            continue
 
                     # Normalize the truncated response to a single OpenAI-style
                     # message shape so text-continuation and tool-call retry
@@ -1800,7 +1826,7 @@ def run_conversation(
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
-                                "final_response": partial_response or None,
+                                "final_response": partial_response or _client_safe_truncation_response(),
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
@@ -1859,18 +1885,18 @@ def run_conversation(
                                 )
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
+                            _safe_error = (
+                                "Stream repeatedly dropped mid tool-call (network); the tool was not executed"
+                                if _is_stub_stall
+                                else "Response truncated due to output length limit"
+                            )
                             return {
-                                "final_response": None,
+                                "final_response": _client_safe_truncation_response(),
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": (
-                                    "Stream repeatedly dropped mid tool-call (network); "
-                                    "the tool was not executed"
-                                    if _is_stub_stall
-                                    else "Response truncated due to output length limit"
-                                ),
+                                "error": _safe_error,
                             }
 
                     # If we have prior messages, roll back to last complete state
@@ -1881,26 +1907,28 @@ def run_conversation(
                         agent._cleanup_task_resources(effective_task_id)
                         agent._persist_session(messages, conversation_history)
 
+                        _safe_error = "Response truncated due to output length limit"
                         return {
-                            "final_response": None,
+                            "final_response": _client_safe_truncation_response(),
                             "messages": rolled_back_messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
-                            "error": "Response truncated due to output length limit"
+                            "error": _safe_error,
                         }
                     else:
                         # First message was truncated - mark as failed
                         agent._flush_status_buffer()
                         agent._vprint(f"{agent.log_prefix}❌ First response truncated - cannot recover", force=True)
                         agent._persist_session(messages, conversation_history)
+                        _safe_error = "First response truncated due to output length limit"
                         return {
-                            "final_response": None,
+                            "final_response": _client_safe_truncation_response(),
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "failed": True,
-                            "error": "First response truncated due to output length limit"
+                            "error": _safe_error,
                         }
                 
                 # Track actual token usage from response for context management
@@ -4185,13 +4213,14 @@ def run_conversation(
                         agent._invalid_json_retries = 0
                         agent._cleanup_task_resources(effective_task_id)
                         agent._persist_session(messages, conversation_history)
+                        _safe_error = "Response truncated due to output length limit"
                         return {
-                            "final_response": None,
+                            "final_response": _client_safe_truncation_response(),
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
-                            "error": "Response truncated due to output length limit",
+                            "error": _safe_error,
                         }
 
                     # Track retries for invalid JSON arguments

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4827,6 +4827,9 @@ class TestRunConversation:
         # (up to 3), not immediately fire thinking-exhaustion.
         assert result["api_calls"] == 3
         assert result["completed"] is False
+        assert result["final_response"] is not None
+        assert "internal response limit" in result["final_response"]
+        assert "Response remained truncated" not in result["final_response"]
 
     def test_length_with_tool_calls_returns_partial_without_executing_tools(self, agent):
         self._setup_agent(agent)
@@ -4849,6 +4852,9 @@ class TestRunConversation:
         assert result["completed"] is False
         assert result["partial"] is True
         assert "truncated due to output length limit" in result["error"]
+        assert result["final_response"] is not None
+        assert "internal response limit" in result["final_response"]
+        assert "Response truncated due to output length limit" not in result["final_response"]
         mock_handle_function_call.assert_not_called()
 
     def test_truncated_tool_call_retries_once_before_refusing(self, agent):
@@ -4960,6 +4966,9 @@ class TestRunConversation:
         assert result["completed"] is False
         assert result["partial"] is True
         assert "truncated due to output length limit" in result["error"]
+        assert result["final_response"] is not None
+        assert "internal response limit" in result["final_response"]
+        assert "Response truncated due to output length limit" not in result["final_response"]
         mock_handle_function_call.assert_not_called()
 
     def test_kanban_block_called_on_iteration_exhaustion(self, agent, monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -752,6 +752,47 @@ def test_run_conversation_codex_empty_output_no_output_text_retries(monkeypatch)
     assert result["final_response"] == "Recovered"
 
 
+def test_run_conversation_codex_length_uses_configured_fallback(monkeypatch):
+    """Codex length stops cannot be fixed by raising max_output_tokens.
+    Use the configured fallback before falling into generic truncation failure."""
+    agent = _build_agent(monkeypatch)
+    calls = {"api": 0, "fallback": 0}
+    agent._fallback_chain = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4.7"}]
+    agent._fallback_index = 0
+
+    def _codex_length_response(api_kwargs):
+        calls["api"] += 1
+        if calls["api"] == 1:
+            return SimpleNamespace(
+                output=[
+                    SimpleNamespace(
+                        type="message",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text="Partial")],
+                    )
+                ],
+                usage=SimpleNamespace(input_tokens=5, output_tokens=1, total_tokens=6),
+                status="completed",
+                model="gpt-5-codex",
+                finish_reason="length",
+            )
+        return _codex_message_response("Recovered on fallback")
+
+    def _activate_fallback(reason=None):
+        calls["fallback"] += 1
+        agent._fallback_index = len(agent._fallback_chain)
+        return True
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _codex_length_response)
+    monkeypatch.setattr(agent, "_try_activate_fallback", _activate_fallback)
+
+    result = agent.run_conversation("Say hello")
+
+    assert calls == {"api": 2, "fallback": 1}
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered on fallback"
+
+
 def test_run_conversation_codex_refreshes_after_401_and_retries(monkeypatch):
     agent = _build_agent(monkeypatch)
     calls = {"api": 0, "refresh": 0}


### PR DESCRIPTION
## Summary
- Preserve Codex Responses length-stop metadata so fallback can run.
- Route Codex length stops to configured fallback before generic truncation failure.
- Return a client-safe final response when truncation remains unrecoverable instead of exposing raw runtime errors.

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /home/spark-stella/venv/bin/python -m pytest tests/run_agent/test_run_agent.py tests/run_agent/test_partial_stream_finish_reason.py tests/run_agent/test_run_agent_codex_responses.py -k 'truncat or length or codex_length' -q
- Result: 21 passed, 475 deselected.
