### PR TITLE
fix: avoid stale skill lookup collisions

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -47,7 +47,19 @@ EXCLUDED_SKILL_DIRS = frozenset(
 # skill_view(skill, file_path=...). They are not standalone skills and must not
 # be scanned for active SKILL.md/DESCRIPTION.md entries, even if a Curator or
 # archive workflow preserves a complete old skill package under references/.
-SKILL_SUPPORT_DIRS = frozenset(("references", "templates", "assets", "scripts"))
+# Accept common support/doc folder names used by bundled and community packs.
+SKILL_SUPPORT_DIRS = frozenset(
+    (
+        "references",
+        "reference",
+        "templates",
+        "assets",
+        "scripts",
+        "examples",
+        "reports",
+        "tests",
+    )
+)
 
 
 def is_excluded_skill_path(path) -> bool:

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -218,6 +218,43 @@ def test_iter_skill_index_files_prunes_skill_support_dirs(tmp_path):
     assert is_excluded_skill_path(package / "SKILL.md") is True
 
 
+def test_iter_skill_index_files_prunes_singular_reference_support_dir(tmp_path):
+    """Singular reference/ dirs are support docs too, not skill discovery roots."""
+    real = tmp_path / "umbrella"
+    real.mkdir()
+    (real / "SKILL.md").write_text("---\nname: umbrella\n---\n", encoding="utf-8")
+
+    package = real / "reference" / "old-skill-package"
+    package.mkdir(parents=True)
+    (package / "SKILL.md").write_text("---\nname: old-skill\n---\n", encoding="utf-8")
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    assert found == [real / "SKILL.md"]
+    assert is_skill_support_path(package / "SKILL.md") is True
+    assert is_excluded_skill_path(package / "SKILL.md") is True
+
+
+def test_iter_skill_index_files_prunes_common_doc_support_dirs(tmp_path):
+    """Example/report/test archives under a skill are support docs, not active skills."""
+    real = tmp_path / "umbrella"
+    real.mkdir()
+    (real / "SKILL.md").write_text("---\nname: umbrella\n---\n", encoding="utf-8")
+
+    for support_dir in ("examples", "reports", "tests"):
+        package = real / support_dir / "archived-skill"
+        package.mkdir(parents=True)
+        (package / "SKILL.md").write_text(
+            f"---\nname: archived-{support_dir}\n---\n", encoding="utf-8"
+        )
+        assert is_skill_support_path(package / "SKILL.md") is True
+        assert is_excluded_skill_path(package / "SKILL.md") is True
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    assert found == [real / "SKILL.md"]
+
+
 def test_iter_skill_index_files_keeps_support_named_categories(tmp_path):
     """A category named scripts/templates/assets/references is still valid."""
     scripts_skill = tmp_path / "scripts" / "bash-helper"

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -373,6 +373,50 @@ class TestSkillView:
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
 
+    def test_view_ignores_singular_reference_support_file_name_collision(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            umbrella = _make_skill(tmp_path, "umbrella")
+            support_dir = umbrella / "reference"
+            support_dir.mkdir()
+            (support_dir / "codex.md").write_text("# Archived support doc\n")
+            _make_skill(tmp_path, "codex", body="Load the real Codex skill.")
+            raw = skill_view("codex")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["name"] == "codex"
+        assert "Load the real Codex skill." in result["content"]
+
+    def test_view_ignores_directory_name_collision_when_frontmatter_name_is_unique(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "codex", body="Load the canonical Codex skill.")
+            gstack_dir = tmp_path / "gstack" / "codex"
+            gstack_dir.mkdir(parents=True)
+            (gstack_dir / "SKILL.md").write_text(
+                "---\n"
+                "name: gstack-codex\n"
+                "description: GStack-specific Codex wrapper.\n"
+                "---\n\n"
+                "# GStack Codex\n\n"
+                "Load the GStack Codex wrapper only by canonical or categorized name.\n"
+            )
+
+            bare_raw = skill_view("codex")
+            gstack_raw = skill_view("gstack/codex")
+            canonical_raw = skill_view("gstack-codex")
+
+        bare = json.loads(bare_raw)
+        gstack = json.loads(gstack_raw)
+        canonical = json.loads(canonical_raw)
+
+        assert bare["success"] is True
+        assert bare["name"] == "codex"
+        assert "Load the canonical Codex skill." in bare["content"]
+        assert gstack["success"] is True
+        assert "Load the GStack Codex wrapper" in gstack["content"]
+        assert canonical["success"] is True
+        assert "Load the GStack Codex wrapper" in canonical["content"]
+
     def test_view_skill_by_frontmatter_name_when_dir_differs(self, tmp_path):
         # The on-disk directory ("alias-dir") differs from the skill's
         # frontmatter name ("real-skill-name"). skills_list() exposes the

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1158,15 +1158,18 @@ def skill_view(
             # frontmatter name, so `skill_view(name)` must accept it too even
             # when the on-disk directory is a shorter category/alias.
             for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
-                if found_skill_md.parent.name == name:
-                    _record(found_skill_md.parent, found_skill_md)
-                    continue
                 try:
                     fm_content = found_skill_md.read_text(encoding="utf-8")
                     fm, _ = _parse_frontmatter(fm_content)
                 except Exception:
                     fm = {}
-                if fm.get("name") == name:
+                canonical_name = fm.get("name")
+                if found_skill_md.parent.name == name and (
+                    not canonical_name or canonical_name == name
+                ):
+                    _record(found_skill_md.parent, found_skill_md)
+                    continue
+                if canonical_name == name:
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.


### PR DESCRIPTION
## Problem

`skill_view("codex")` could refuse to load the canonical `codex` skill when either of these were installed beside it:

- a support document such as `some-skill/reference/codex.md`; or
- a categorized skill directory named `codex` whose frontmatter declares a different canonical name such as `gstack-codex`.

The first candidate is not a skill. The second is a real skill, but its directory basename is not its public bare lookup name. Treating both as `codex` creates a false ambiguity.

## Fix

- Treat common support/documentation folders directly under a skill package (`reference[s]`, `templates`, `assets`, `scripts`, `examples`, `reports`, `tests`) as non-discovery roots.
- Match a nested skill directory by basename only when its frontmatter has no canonical name or declares the same name.
- Preserve both canonical frontmatter lookup (`gstack-codex`) and explicit categorized-path lookup (`gstack/codex`).
- Add regressions for support-directory pruning, flat support-file collisions, canonical names, and categorized paths.

This covers the nested `SKILL.md` and directory/frontmatter mismatch cases that a flat linked-reference-file filter alone does not address.

## Validation

- Reproduced on current `main` with the test-only diff: 4 expected failures.
- `pytest tests/tools/test_skills_tool.py tests/agent/test_skill_utils.py -q` — 117 passed.
- Broad skill resolver/discovery suite — 821 passed, 1 skipped.
- Ruff on all changed Python files — passed.
- Fresh-process smoke against a populated skill catalog:
  - `codex` resolves to the canonical skill.
  - `gstack-codex` and `gstack/codex` both resolve to the categorized wrapper.
  - Other canonical bare-name lookups remain unambiguous.
