### PR TITLE
fix(desktop): consume ANSI extended-background (48;5/48;2) args so they don't corrupt segment style

### DIFF
--- a/apps/desktop/src/lib/ansi.test.ts
+++ b/apps/desktop/src/lib/ansi.test.ts
@@ -69,6 +69,37 @@ describe('parseAnsi', () => {
     expect(segments[0].text).toBe('rgb')
   })
 
+  it('skips extended-background (48;5;n) trailing args instead of leaking them as SGR codes', () => {
+    // We don't paint backgrounds, but the parser must still consume the
+    // `;5;<n>` payload after 48 so its index value isn't re-read as a
+    // standalone SGR code. Here `1` would otherwise turn bold on.
+    const segments = parseAnsi(`${ESC}[48;5;1mtext`)
+
+    expect(segments).toEqual([{ bold: false, fg: null, text: 'text' }])
+  })
+
+  it('does not let a 48;5 index value leak in and set a foreground color', () => {
+    // `31` is the leaked index here; before the fix it was parsed as the
+    // standalone red-foreground code.
+    const segments = parseAnsi(`${ESC}[48;5;31mtext`)
+
+    expect(segments).toEqual([{ bold: false, fg: null, text: 'text' }])
+  })
+
+  it('skips truecolor extended-background (48;2;r;g;b) trailing args', () => {
+    // The trailing `0` would otherwise be read as a full reset (SGR 0).
+    const segments = parseAnsi(`${ESC}[1;31m${ESC}[48;2;255;0;0mtext`)
+
+    expect(segments).toEqual([{ bold: true, fg: 'red', text: 'text' }])
+  })
+
+  it('keeps the foreground when a 48 background is set in the same SGR run', () => {
+    // 31 (red fg) then 48;5;2 (bg) — the bg index must not clobber the fg.
+    const segments = parseAnsi(`${ESC}[31;48;5;2mtext`)
+
+    expect(segments).toEqual([{ bold: false, fg: 'red', text: 'text' }])
+  })
+
   it('drops non-SGR CSI sequences (cursor motion, erase) without consuming surrounding text', () => {
     const input = `before${ESC}[2Jmiddle${ESC}[10;5Hafter`
 

--- a/apps/desktop/src/lib/ansi.ts
+++ b/apps/desktop/src/lib/ansi.ts
@@ -118,8 +118,11 @@ export function parseAnsi(input: string): AnsiSegment[] {
           fg = null
         } else if (code in FG_BY_CODE) {
           fg = FG_BY_CODE[code]
-        } else if (code === 38) {
-          // 256-color / truecolor — skip the trailing args we don't render.
+        } else if (code === 38 || code === 48) {
+          // 256-color / truecolor foreground (38) or background (48) — skip
+          // the trailing index/RGB args we don't render so they can't be
+          // re-read as standalone SGR codes and corrupt the segment's
+          // bold/fg state.
           if (codes[i + 1] === 5) {
             i += 2
           } else if (codes[i + 1] === 2) {


### PR DESCRIPTION
## What does this PR do?

Fixes a parsing bug in the desktop chat-card ANSI parser (`apps/desktop/src/lib/ansi.ts`). In `parseAnsi`, the SGR loop only consumes the trailing index/RGB payload for the extended **foreground** color code `38`. The extended **background** color code `48` has no branch, so after `48` the parser falls through *without* skipping its `5;N` / `2;R;G;B` arguments. Those leftover numeric params are then re-read left-to-right as standalone SGR codes, corrupting the segment's `bold`/`fg` state.

The fix treats `48` exactly like `38` in the arg-skip branch — consuming the same `5;N` (`i += 2`) / `2;R;G;B` (`i += 4`) payload — while painting nothing. This matches the file's documented intent (comment at the bottom of the SGR loop) to ignore backgrounds and keep the prior `bold`/`fg` state.

## Related Issue

Code-originated regression found while reading the parser; no filed issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/ansi.ts`: extend the extended-color arg-skip branch from `code === 38` to `code === 38 || code === 48` so background-color payload params are consumed instead of leaking.
- `apps/desktop/src/lib/ansi.test.ts`: add regression cases mirroring the existing `38;5` / `38;2` arg-skip tests.

## How to Test

Run the desktop UI unit tests:

```
cd apps/desktop && vitest run --environment jsdom src/lib/ansi.test.ts
```

Reproduction (before the fix, leaked params corrupt the segment):

- `parseAnsi('\x1b[48;5;1mtext')` → leaked `1` set `bold: true` (should stay `false`)
- `parseAnsi('\x1b[48;5;31mtext')` → leaked `31` set `fg: 'red'` (should stay `null`)
- `parseAnsi('\x1b[1;31m\x1b[48;2;255;0;0mtext')` → leaked `0` triggered a full reset, dropping the prior bold+red

After the fix all three preserve the correct style and the four new tests pass (`ansi.test.ts` goes 14 → 18 tests, all green).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched test suite (`vitest run --environment jsdom src/lib/ansi.test.ts`) and it passes
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure string-parsing logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A