### PR TITLE
fix(desktop): evict stale lane entry when overlay moves session to worktree

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -684,6 +684,39 @@ describe('overlayLiveLanes', () => {
     expect(overlaid.repos[0].groups[0].sessions.map(s => s.id)).toEqual(['keep'])
     expect(overlaid.sessionCount).toBe(1)
   })
+
+  it('evicts a session from the main lane when the live overlay places it into a worktree lane', () => {
+    // Session was in main when the backend tree was captured, but the live
+    // $sessions cache now has it under a worktree cwd. The overlay must place
+    // it ONLY in the worktree lane — not both.
+    const session = makeSession('/www/app/.worktrees/feature', { id: 'moved', git_branch: 'feature' })
+
+    const project = projectNode({
+      id: '/www/app',
+      repos: [
+        {
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 1,
+          groups: [
+            lane({ id: '/www/app::branch::main', label: 'main', isMain: true, path: '/www/app', sessions: [session] }),
+            lane({ id: '/www/app/.worktrees/feature', label: 'feature', path: '/www/app/.worktrees/feature', sessions: [] })
+          ]
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [session])
+    const mainLane = overlaid.repos[0].groups.find(g => g.isMain)
+    const featureLane = overlaid.repos[0].groups.find(g => g.path === '/www/app/.worktrees/feature')
+
+    // Session must NOT appear in the main lane
+    expect(mainLane?.sessions ?? []).toHaveLength(0)
+    // Session must appear only in the worktree lane
+    expect(featureLane?.sessions.map(s => s.id)).toEqual(['moved'])
+    expect(overlaid.sessionCount).toBe(1)
+  })
 })
 
 describe('overlayLivePreviews', () => {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -494,6 +494,22 @@ export function overlayRepoLanes(
       }
     }
 
+    // Evict the session from any OTHER lane the backend snapshot may have
+    // placed it in (e.g. a turn that moved the session's cwd from main to a
+    // new worktree — the overlay places it into the worktree lane, but without
+    // this eviction the stale main-lane entry persists and the session appears
+    // under both groups until the next backend tree refresh).
+    for (const g of lanes) {
+      if (g !== lane) {
+        const idx = g.sessions.findIndex(s => s.id === session.id)
+
+        if (idx >= 0) {
+          g.sessions = [...g.sessions.slice(0, idx), ...g.sessions.slice(idx + 1)]
+          changed = true
+        }
+      }
+    }
+
     lane.sessions = upsertSession(lane.sessions, session)
     changed = true
   }


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in the desktop sidebar where a session appears under **both** the new worktree group and the main branch group simultaneously after creating a worktree via the sidebar's fork button.

The root cause is that `overlayRepoLanes()` is additive-only — when it places a live session into a lane matching the session's current `cwd`, it never evicts a stale entry the backend snapshot left in a different lane. When a session's `cwd` moves from the main checkout to a new worktree, the overlay inserts it into the worktree lane but the old main-lane entry persists, producing the duplicate.

## Related Issue

Fixes #55725

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts`: Added a cross-lane eviction loop in `overlayRepoLanes()` that removes a session from all other lanes before inserting it into the target lane. This ensures a session that moved worktrees no longer appears in both the old and new lane.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts`: Added regression test `'evicts a session from the main lane when the live overlay places it into a worktree lane'` that verifies a session is only in the worktree lane, not duplicated in main.

## How to Test

1. Run `npx vitest run apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts` — all 37 tests should pass (36 existing + 1 new).
2. Open the desktop sidebar in project mode with a git repo on `main`.
3. Click the fork button to create a new worktree, start a conversation.
4. The session should appear **only** under the new worktree group — not duplicated under `main`.
5. No workaround needed (previously required leaving and re-entering the project view).

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
