### PR TITLE
fix(signal): convert UTF-16 mention offsets to code-point indices in _render_mentions

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -193,11 +193,30 @@ def _remux_aac_to_m4a(aac_data: bytes) -> Optional[Tuple[bytes, str]]:
         return None
 
 
+def _utf16_to_codepoint_index(text: str, utf16_offset: int) -> int:
+    """Convert a UTF-16 code-unit offset into a Python code-point index.
+
+    signal-cli reports mention offsets in UTF-16 code units (the same protocol
+    fact ``signal_format._utf16_len`` relies on), while Python ``str`` slicing
+    is code-point indexed. A non-BMP char (e.g. an emoji) counts as two UTF-16
+    units but one code point, so the two indices diverge after it.
+    """
+    units = 0
+    for idx, ch in enumerate(text):
+        if units >= utf16_offset:
+            return idx
+        units += 2 if ord(ch) > 0xFFFF else 1
+    return len(text)
+
+
 def _render_mentions(text: str, mentions: list) -> str:
     """Replace Signal mention placeholders (\\uFFFC) with readable @identifiers.
 
     Signal encodes @mentions as the Unicode object replacement character
     with out-of-band metadata containing the mentioned user's UUID/number.
+
+    The ``start``/``length`` metadata is expressed in UTF-16 code units, so it
+    is mapped to code-point indices before slicing the Python ``str``.
     """
     if not mentions or "\uFFFC" not in text:
         return text
@@ -207,10 +226,14 @@ def _render_mentions(text: str, mentions: list) -> str:
     for mention in sorted_mentions:
         start = mention.get("start", 0)
         length = mention.get("length", 1)
+        # signal-cli offsets are UTF-16 code units; convert to code-point
+        # indices so emoji-before-mention text slices at the right boundary.
+        start_cp = _utf16_to_codepoint_index(text, start)
+        end_cp = _utf16_to_codepoint_index(text, start + length)
         # Use the mention's number or UUID as the replacement
         identifier = mention.get("number") or mention.get("uuid") or "user"
         replacement = f"@{identifier}"
-        text = text[:start] + replacement + text[start + length:]
+        text = text[:start_cp] + replacement + text[end_cp:]
     return text
 
 

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -298,6 +298,43 @@ class TestSignalHelpers:
         result = _render_mentions(text, [])
         assert result == "Hello world"
 
+    def test_render_mentions_emoji_before_mention(self):
+        # signal-cli reports mention offsets in UTF-16 code units. A non-BMP
+        # emoji (👋 = 2 UTF-16 units, 1 code point) before the placeholder
+        # makes the reported start (3) exceed the code-point index (2). If the
+        # str is sliced by the raw UTF-16 offset, the ￼ placeholder is left
+        # in and the @identifier lands one position too far.
+        from gateway.platforms.signal import _render_mentions
+        text = "\U0001F44B ￼ hi"  # 👋 ￼ hi
+        mentions = [{"start": 3, "length": 1, "number": "+15551230000"}]
+        result = _render_mentions(text, mentions)
+        assert result == "\U0001F44B @+15551230000 hi"
+        assert "￼" not in result
+
+    def test_render_mentions_bmp_only_unchanged(self):
+        # Regression guard: with no non-BMP char before the mention the UTF-16
+        # offset equals the code-point index, so behavior is identical.
+        from gateway.platforms.signal import _render_mentions
+        text = "hi ￼ there"
+        mentions = [{"start": 3, "length": 1, "number": "+15551230000"}]
+        result = _render_mentions(text, mentions)
+        assert result == "hi @+15551230000 there"
+        assert "￼" not in result
+
+    def test_render_mentions_multiple_with_emoji(self):
+        # Two mentions, an emoji before both. Reverse-by-start replacement must
+        # still land each @identifier at the right code-point position.
+        from gateway.platforms.signal import _render_mentions
+        text = "\U0001F44B ￼ and ￼"  # 👋 ￼ and ￼
+        # UTF-16 offsets: 👋=2 units -> first ￼ at u16 3, second ￼ at u16 9.
+        mentions = [
+            {"start": 3, "length": 1, "number": "+15550000001"},
+            {"start": 9, "length": 1, "number": "+15550000002"},
+        ]
+        result = _render_mentions(text, mentions)
+        assert result == "\U0001F44B @+15550000001 and @+15550000002"
+        assert "￼" not in result
+
     def test_check_requirements_missing(self, monkeypatch):
         from gateway.platforms.signal import check_signal_requirements
         monkeypatch.delenv("SIGNAL_HTTP_URL", raising=False)


### PR DESCRIPTION
## What does this PR do?

`_render_mentions` (`gateway/platforms/signal.py`) replaces Signal's `￼` mention placeholders with readable `@identifier` text. It reads each mention's `start`/`length` from signal-cli metadata and slices the Python `str`:

```python
text = text[:start] + replacement + text[start + length:]
```

But **signal-cli reports those offsets in UTF-16 code units**, while Python `str` slicing is **code-point indexed**. A non-BMP character (e.g. an emoji) counts as two UTF-16 units but one code point, so once one precedes a mention the raw `start` overshoots: the `￼` placeholder is left in and the `@identifier` lands one-or-more positions too far.

This is the same protocol fact the sibling `gateway/platforms/signal_format.py` already documents and handles (via `_utf16_len`) for the **outbound** direction. This PR adds the inbound counterpart.

### Reproduction (before the fix)

```python
_render_mentions('👋 ￼ hi', [{'start': 3, 'length': 1, 'number': '+15551230000'}])
# OBSERVED: '👋 ￼@+15551230000hi'   (placeholder retained, @ misplaced)
# EXPECTED: '👋 @+15551230000 hi'
```

(`👋` is 2 UTF-16 units / 1 code point, so the `￼` at code point 2 is reported at UTF-16 offset 3.)

## Related Issue

Code-originated; found by cross-checking against `signal_format._utf16_len`. No filed issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/signal.py`: add `_utf16_to_codepoint_index` and map each mention's `start` / `start + length` from UTF-16 units to code-point indices before slicing. Mirrors `signal_format._utf16_len`'s protocol handling.
- `tests/gateway/test_signal.py`: add emoji-before-mention, multi-mention-with-emoji, and a BMP-only regression-guard case.

## How to Test

```
uv run --with pytest python3 -m pytest tests/gateway/test_signal.py -v
```

The two emoji cases fail before the production change (placeholder retained / `@` misplaced) and pass after. The BMP-only guard passes in both directions, proving no regression when no non-BMP char precedes the mention.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched test suites (`test_signal.py`, `test_signal_format.py`) and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the `_render_mentions` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure string-handling logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A