### PR TITLE
fix: skip ControlMaster on Windows SSH backend

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -48,9 +48,15 @@ class TestBuildSSHCommand:
     def test_base_flags(self):
         env = SSHEnvironment(host="h", user="u")
         cmd = " ".join(env._build_ssh_command())
-        for flag in ("ControlMaster=auto", "ControlPersist=300",
-                      "BatchMode=yes", "StrictHostKeyChecking=accept-new"):
+        for flag in ("BatchMode=yes", "StrictHostKeyChecking=accept-new"):
             assert flag in cmd
+        if os.name == "nt":
+            # Windows: ControlMaster is disabled (ProxyCommand incompatibility)
+            assert "ControlMaster=auto" not in cmd
+            assert "ControlPersist=300" not in cmd
+        else:
+            for flag in ("ControlMaster=auto", "ControlPersist=300", "ControlPath="):
+                assert flag in cmd
 
     def test_custom_port(self):
         env = SSHEnvironment(host="h", user="u", port=2222)

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -82,9 +82,15 @@ class SSHEnvironment(BaseEnvironment):
 
     def _build_ssh_command(self, extra_args: list | None = None) -> list:
         cmd = ["ssh"]
-        cmd.extend(["-o", f"ControlPath={self.control_socket}"])
-        cmd.extend(["-o", "ControlMaster=auto"])
-        cmd.extend(["-o", "ControlPersist=300"])
+        # ControlMaster multiplexing passes file descriptors over a Unix-domain
+        # control socket. On Windows / MSYS this fails with "getsockname failed:
+        # Not a socket" or "mm_receive_fd: no message header" when the connection
+        # is a ProxyCommand stream (Cloudflare Access, bastions, etc.).
+        # Skip multiplexing on Windows — fresh SSH process per call instead.
+        if os.name != "nt":
+            cmd.extend(["-o", f"ControlPath={self.control_socket}"])
+            cmd.extend(["-o", "ControlMaster=auto"])
+            cmd.extend(["-o", "ControlPersist=300"])
         cmd.extend(["-o", "BatchMode=yes"])
         cmd.extend(["-o", "StrictHostKeyChecking=accept-new"])
         cmd.extend(["-o", "ConnectTimeout=10"])


### PR DESCRIPTION
## Problem

The SSH terminal backend adds `ControlMaster=auto`, `ControlPersist=300`, and `ControlPath` options to every SSH command. On Windows (native / MSYS OpenSSH), these options break when the connection is routed through a `ProxyCommand` stream — e.g. Cloudflare Access (`cloudflared access ssh`), bastion jump hosts, or any proxied SSH setup.

**Symptoms:**
```
getsockname failed: Not a socket
mm_receive_fd: no message header
Failed to connect to new control master
Connection closed by UNKNOWN port 65535
```

Manual `ssh` works because the user's `~/.ssh/config` ProxyCommand is applied without ControlMaster. But Hermes's `SSHEnvironment._build_ssh_command()` adds ControlMaster on every call, triggering the fd-passing codepath that Windows / MSYS OpenSSH can't handle through a proxy stream.

## Root Cause

ControlMaster multiplexing passes file descriptors over a Unix-domain control socket. On Windows, this mechanism is fundamentally incompatible with ProxyCommand-based connections — the proxied stdin/stdout pipe can't be combined with the Unix-domain socket fd-passing that ControlMaster relies on.

## Fix

Gate the three ControlMaster options behind `os.name != "nt"` so Windows uses a fresh SSH process per command (spawn-per-call, which is the existing fallback path). POSIX behavior is unchanged.

```python
if os.name != "nt":
    cmd.extend(["-o", f"ControlPath={self.control_socket}"])
    cmd.extend(["-o", "ControlMaster=auto"])
    cmd.extend(["-o", "ControlPersist=300"])
```

## Test Plan

- [x] `test_base_flags` updated to assert ControlMaster presence on POSIX and absence on Windows
- [x] All 14 unit tests pass (`pytest tests/tools/test_ssh_environment.py -o 'addopts='`)
- [x] E2E verified: real `terminal_tool()` call against a Cloudflare Access SSH tunnel (`vps.gcaplabs.com` via `cloudflared access ssh`) returns `SSH_VPS_OK:vps:m4` after the fix, where it previously failed with `getsockname failed: Not a socket`
- [x] 11 integration tests skipped (require live SSH server env vars — unchanged from before)