### PR TITLE
fix(gateway): percent-encode path separators in session key IDs (fixes DingTalk DM session loss on restart)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -89,6 +89,23 @@ def _is_path_unsafe(value: object) -> bool:
     return len(s) >= 2 and s[0].isalpha() and s[1] == ":"
 
 
+def _sanitize_id_for_key(value: str) -> str:
+    """Percent-encode path-separator characters in an ID before embedding it
+    in a session key.
+
+    Some platform-native identifiers (e.g. DingTalk base64-like DM chat IDs
+    such as ``cidNcWXuYmxUGBIug3mN5iy/9w/Ez8547TrWG+V8QP0w/E=``) contain
+    ``/`` or ``\\``, which ``_is_path_unsafe`` correctly rejects when the key
+    is later loaded from disk — causing the session to be silently skipped.
+
+    Only the two filesystem path-separator characters are encoded
+    (``/`` → ``%2F``, ``\\`` → ``%5C``).  All other characters — letters,
+    digits, ``@``, ``+``, ``=``, ``-``, ``.``, etc. — pass through unchanged,
+    so every existing session key is byte-identical after this change.
+    """
+    return value.replace("\\", "%5C").replace("/", "%2F")
+
+
 @dataclass
 class SessionSource:
     """
@@ -730,8 +747,9 @@ def build_session_key(
             dm_chat_id = canonical_whatsapp_identifier(source.chat_id)
 
         if dm_chat_id:
+            dm_chat_id = _sanitize_id_for_key(dm_chat_id)
             if source.thread_id:
-                return f"{ns}:{platform}:dm:{dm_chat_id}:{source.thread_id}"
+                return f"{ns}:{platform}:dm:{dm_chat_id}:{_sanitize_id_for_key(source.thread_id)}"
             return f"{ns}:{platform}:dm:{dm_chat_id}"
         # No chat_id — fall back to the sender's own identifier before the
         # bare per-platform sink.  Without this, every DM from every user that
@@ -746,11 +764,12 @@ def build_session_key(
                 or dm_participant_id
             )
         if dm_participant_id:
+            dm_participant_id = _sanitize_id_for_key(str(dm_participant_id))
             if source.thread_id:
-                return f"{ns}:{platform}:dm:{dm_participant_id}:{source.thread_id}"
+                return f"{ns}:{platform}:dm:{dm_participant_id}:{_sanitize_id_for_key(source.thread_id)}"
             return f"{ns}:{platform}:dm:{dm_participant_id}"
         if source.thread_id:
-            return f"{ns}:{platform}:dm:{source.thread_id}"
+            return f"{ns}:{platform}:dm:{_sanitize_id_for_key(source.thread_id)}"
         return f"{ns}:{platform}:dm"
 
     participant_id = source.user_id_alt or source.user_id
@@ -762,9 +781,9 @@ def build_session_key(
     key_parts = [ns, platform, source.chat_type]
 
     if source.chat_id:
-        key_parts.append(source.chat_id)
+        key_parts.append(_sanitize_id_for_key(source.chat_id))
     if source.thread_id:
-        key_parts.append(source.thread_id)
+        key_parts.append(_sanitize_id_for_key(source.thread_id))
 
     # In threads, default to shared sessions (all participants see the same
     # conversation).  Per-user isolation only applies when explicitly enabled
@@ -774,7 +793,7 @@ def build_session_key(
         isolate_user = False
 
     if isolate_user and participant_id:
-        key_parts.append(str(participant_id))
+        key_parts.append(_sanitize_id_for_key(str(participant_id)))
 
     return ":".join(key_parts)
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1105,6 +1105,105 @@ class TestSessionEntryFromDictTraversalValidation:
             SessionEntry.from_dict(self._entry(session_key="agent:main:good/sub"))
 
 
+class TestDingTalkSlashChatIdSessionKey:
+    """Regression: DingTalk DM chat_ids containing '/' must produce path-safe
+    session keys and survive the _is_path_unsafe validation on reload.
+
+    Fixes #55617 — DingTalk DM session_key rejected as directory traversal.
+    """
+
+    DINGTALK_CHAT_ID = "cidNcWXuYmxUGBIug3mN5iy/9w/Ez8547TrWG+V8QP0w/E="
+
+    def test_build_session_key_encodes_slash(self):
+        """build_session_key must percent-encode '/' in DingTalk chat_ids."""
+        source = SessionSource(
+            platform=Platform.DINGTALK,
+            chat_id=self.DINGTALK_CHAT_ID,
+            chat_type="dm",
+        )
+        key = build_session_key(source)
+        assert "/" not in key, (
+            f"Session key contains unencoded '/': {key!r}"
+        )
+        assert "\\" not in key
+        assert "%2F" in key  # slash must be percent-encoded
+
+    def test_build_session_key_stable_across_calls(self):
+        """Same chat_id must always produce the same key."""
+        source = SessionSource(
+            platform=Platform.DINGTALK,
+            chat_id=self.DINGTALK_CHAT_ID,
+            chat_type="dm",
+        )
+        assert build_session_key(source) == build_session_key(source)
+
+    def test_session_key_passes_path_unsafe_check(self):
+        """The key built from a slash-containing DingTalk chat_id must NOT be
+        flagged by _is_path_unsafe (i.e. it must load cleanly from disk)."""
+        from gateway.session import _is_path_unsafe
+        source = SessionSource(
+            platform=Platform.DINGTALK,
+            chat_id=self.DINGTALK_CHAT_ID,
+            chat_type="dm",
+        )
+        key = build_session_key(source)
+        assert not _is_path_unsafe(key), (
+            f"_is_path_unsafe incorrectly flagged key: {key!r}"
+        )
+
+    def test_session_entry_round_trips_with_slash_chat_id(self):
+        """A SessionEntry built from a DingTalk-style key must survive
+        to_dict() → from_dict() without raising ValueError."""
+        from gateway.session import SessionEntry
+        from datetime import datetime
+        source = SessionSource(
+            platform=Platform.DINGTALK,
+            chat_id=self.DINGTALK_CHAT_ID,
+            chat_type="dm",
+        )
+        key = build_session_key(source)
+        entry = SessionEntry(
+            session_key=key,
+            session_id="abc-123",
+            created_at=datetime(2026, 1, 1),
+            updated_at=datetime(2026, 1, 1),
+            origin=source,
+        )
+        # Must not raise ValueError("potential directory traversal")
+        restored = SessionEntry.from_dict(entry.to_dict())
+        assert restored.session_key == key
+        assert restored.session_id == "abc-123"
+
+    def test_normal_platform_ids_unchanged(self):
+        """IDs from platforms that don't use '/' (Telegram, Discord, etc.) must
+        produce byte-identical keys before and after the sanitization change."""
+        cases = [
+            (Platform.TELEGRAM, "99", "dm", "agent:main:telegram:dm:99"),
+            (Platform.DISCORD, "guild-123", "group", "agent:main:discord:group:guild-123"),
+            (Platform.SLACK, "C0123456", "group", "agent:main:slack:group:C0123456"),
+        ]
+        for platform, chat_id, chat_type, expected in cases:
+            source = SessionSource(
+                platform=platform,
+                chat_id=chat_id,
+                chat_type=chat_type,
+            )
+            assert build_session_key(source) == expected, (
+                f"Key changed for {platform.value}:{chat_id}"
+            )
+
+    def test_group_chat_with_slash_in_chat_id(self):
+        """Slash-containing IDs in group/channel sessions are also encoded."""
+        source = SessionSource(
+            platform=Platform.DINGTALK,
+            chat_id="cidNcWXuYmxUGBIug3mN5iy/9w==",
+            chat_type="group",
+        )
+        key = build_session_key(source)
+        assert "/" not in key
+        assert "%2F" in key
+
+
 class TestEnsureLoadedSkipsInvalidEntries:
     """Regression: one bad sessions.json entry must not block valid entries from loading."""
 


### PR DESCRIPTION
## Summary

DingTalk DM chat_ids are base64-like strings that contain `/` and `+`, e.g.:
```
cidNcWXuYmxUGBIug3mN5iy/9w/Ez8547TrWG+V8QP0w/E=
```

`build_session_key()` embedded the raw `chat_id` directly into the colon-delimited session key. On gateway restart, `SessionEntry.from_dict()` runs `_is_path_unsafe()` on the persisted key and **correctly** rejects values containing `/` — triggering:

```
WARNING gateway.session: Skipping invalid session entry agent:main:dingtalk:dm:cidNcWXuYmxUGBIug3mN5iy/9w/Ez8547TrWG+V8QP0w/E=:
Invalid session_key: potential directory traversal detected
```

This silently drops **all** historical DingTalk DM session context on every gateway restart. DMs still send/receive (live routing is unaffected), but the agent starts a new session each time and loses conversation history.

## Root cause

`build_session_key()` concatenates ID segments with `:` and never sanitizes them. The `_is_path_unsafe` guard is correct security behavior — the bug is that construction never encoded the separators.

## Fix

Introduce `_sanitize_id_for_key()` — a one-liner that replaces the two filesystem path-separator characters before embedding any ID into a key:
- `/` → `%2F`
- `\` → `%5C`

**All other characters** (`@`, `+`, `=`, `.`, letters, digits, etc.) pass through **unchanged**, so every session key produced by every normal platform (Telegram, Discord, WhatsApp, Slack, Signal, Matrix, etc.) is **byte-identical** after this change. Zero migration needed.

Applied to all ID segments in `build_session_key()`: `chat_id`, `thread_id`, `participant_id`.

## Why this over the alternatives

| Approach | Verdict |
|---|---|
| Add `import re` to `_is_path_unsafe` to only reject `../` patterns | Weakens security — a `/` in a key can still escape the sessions dir via non-traversal absolute paths |
| Skip validation for specific platforms (e.g. `dingtalk`) | Brittle — any future platform with base64-like IDs silently breaks again |
| Hash the chat_id | Destroys the human-readable prefix; makes debugging impossible |
| **Encode at construction time (this PR)** | Correct — keys stay path-safe, existing keys are unchanged, fix generalizes to any future platform |

## Tests added — `TestDingTalkSlashChatIdSessionKey` (6 invariant tests)

- `test_build_session_key_encodes_slash` — `/` must not appear in the built key; `%2F` must be present
- `test_build_session_key_stable_across_calls` — same input always gives same key
- `test_session_key_passes_path_unsafe_check` — `_is_path_unsafe` must not flag a legitimately built key
- `test_session_entry_round_trips_with_slash_chat_id` — `to_dict() → from_dict()` must not raise `ValueError`
- `test_normal_platform_ids_unchanged` — Telegram / Discord / Slack keys are byte-identical (no regression)
- `test_group_chat_with_slash_in_chat_id` — group sessions with slash IDs are also encoded

## Test results

```
94 passed, 8 warnings in 3.72s  ✅
```
All 94 `tests/gateway/test_session.py` tests pass, including all pre-existing WhatsApp JID/LID canonicalisation tests.

## Files changed

| File | Change |
|---|---|
| `gateway/session.py` | +`_sanitize_id_for_key()` helper; apply to all ID segments in `build_session_key()` |
| `tests/gateway/test_session.py` | +`TestDingTalkSlashChatIdSessionKey` (6 tests) |

Fixes #55617