### PR TITLE
fix(mcp-oauth): graceful fallback when OAuth callback port is already bound

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -512,7 +512,7 @@ def cmd_mcp_add(args):
     print(color(f"  Connecting to '{name}'...", Colors.CYAN))
 
     try:
-        tools = _probe_single_server(name, server_config)
+        tools = _probe_single_server(name, server_config, connect_timeout=600)
     except Exception as exc:
         _error(f"Failed to connect: {exc}")
         if _confirm("Save config anyway (you can test later)?", default=False):

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -650,19 +650,18 @@ async def _wait_for_callback() -> tuple[str, str | None]:
     # We just need to poll for the result.
     handler_cls, result = _make_callback_handler()
 
-    # Start a temporary server on the known port
+    # Start a temporary server on the known port.  The MCP SDK may have
+    # already started its own callback server on the same port — if so,
+    # we just poll for the result without creating a second one.
+    server = None
     try:
         server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
+        server_thread = threading.Thread(target=server.handle_request, daemon=True)
+        server_thread.start()
     except OSError:
-        # Port already in use — the server from build_oauth_auth is running.
-        # Fall back to polling the server started by build_oauth_auth.
-        raise OAuthNonInteractiveError(
-            "OAuth callback timed out — could not bind callback port. "
-            "Complete the authorization in a browser first, then retry."
-        )
-
-    server_thread = threading.Thread(target=server.handle_request, daemon=True)
-    server_thread.start()
+        # Port already in use — the server from the MCP SDK is running.
+        # Fall back to polling: the SDK's server will handle the callback.
+        pass
 
     # Optional paste-fallback thread: only on interactive TTYs. Reads one
     # line from stdin and writes the parsed code/state into the shared
@@ -692,7 +691,8 @@ async def _wait_for_callback() -> tuple[str, str | None]:
             await asyncio.sleep(poll_interval)
             elapsed += poll_interval
     finally:
-        server.server_close()
+        if server is not None:
+            server.server_close()
 
     if result["error"] == _USER_SKIPPED_SENTINEL:
         raise OAuthNonInteractiveError("user_skipped")


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `hermes mcp login` where `_wait_for_callback()` tries to bind a second `HTTPServer` to the same port already occupied by the MCP SDK's `build_oauth_auth()` callback server, causing `OSError: Address already in use` that aborts the entire OAuth flow.

Instead of raising `OAuthNonInteractiveError`, the fix gracefully falls through to polling the SDK's existing server.

## Related Issue

N/A (no existing issue found for this specific double-bind bug)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/mcp_oauth.py`**: On `OSError` (port already in use by SDK server), `pass` instead of raising `OAuthNonInteractiveError`, allowing the polling loop to detect the callback result from the SDK's server. Guard `server.server_close()` with `if server is not None` to handle the unbound variable in the fallback path.
- **`hermes_cli/mcp_config.py`**: Bump `_probe_single_server()` connect_timeout from default 30s to 600s, giving users enough time to complete interactive browser-based OAuth authorization.

## How to Test

1. Configure an MCP server requiring OAuth (e.g. Google Drive MCP)
2. Run `hermes mcp login <server-name>`
3. **Without the fix**: crashes with `OSError: Address already in use` → `OAuthNonInteractiveError`
4. **With the fix**: browser opens, user authorizes, callback captured by SDK server, polling loop detects result, login succeeds

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated cli-config.yaml.example — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — N/A
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas — N/A