### PR TITLE
feat(launchd): use gateway-wrapper.sh as entrypoint with self-healing fallback

### DIFF
--- a/gateway-wrapper.sh
+++ b/gateway-wrapper.sh
@@ -1,0 +1,59 @@
+#!/bin/zsh
+# Hermes gateway launchd wrapper.
+# Sources ~/.hermes/.env so provider/platform keys reach the process,
+# then execs the gateway with the exact original arguments.
+# (launchd has no native EnvironmentFile; this is the sanctioned equivalent.)
+#
+# Preflight reaper (added 2026-06-28): a *hung* gateway (process alive but
+# event loop dead) keeps holding the Slack Socket Mode connection, so a fresh
+# launch hits "Slack app token already in use (PID …)" and crash-loops under
+# KeepAlive. `gateway run --replace` does not cover this case because the stale
+# process is still alive. Reap any pre-existing gateway here before starting,
+# so the new instance always gets a free Slack app token.
+emulate -L zsh
+setopt no_unset
+
+ENV_FILE="$HOME/.hermes/.env"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+# --- Preflight: reap any existing gateway (excluding ourselves) ---
+# Match the exact module invocation so we never touch unrelated python procs.
+GATEWAY_MATCH='hermes_cli.main gateway run'
+typeset -a stale
+stale=(${(f)"$(pgrep -f "$GATEWAY_MATCH" 2>/dev/null)"})
+# drop our own PID and our parent (the launchd-spawned shell) if matched
+stale=(${stale:#$$})
+stale=(${stale:#$PPID})
+if (( ${#stale} )); then
+  # log each PID we're reaping to the gateway log (stdout -> gateway.log)
+  for pid in ${stale[@]}; do
+    echo "Killed stale gateway PID $pid"
+  done
+  kill -TERM ${stale[@]} 2>/dev/null
+  # give the Slack adapter up to 5s to release the Socket Mode connection
+  for _ in {1..5}; do
+    sleep 1
+    stale=(${(f)"$(pgrep -f "$GATEWAY_MATCH" 2>/dev/null)"})
+    stale=(${stale:#$$}); stale=(${stale:#$PPID})
+    (( ${#stale} )) || break
+  done
+  # anything still alive after the grace period gets SIGKILL
+  if (( ${#stale} )); then
+    kill -KILL ${stale[@]} 2>/dev/null
+    sleep 1
+  fi
+fi
+
+cd "$HOME/.hermes/hermes-agent" || exit 1
+# When launchd invokes us, ProgramArguments passes the python interpreter
+# plus module args (so --profile etc. are preserved end-to-end). For a manual
+# no-arg invocation, fall back to a plain `gateway run --replace`.
+if (( $# )); then
+  exec "$@"
+else
+  exec "$HOME/.hermes/hermes-agent/venv/bin/python" -m hermes_cli.main gateway run --replace
+fi

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3679,22 +3679,36 @@ def generate_launchd_plist() -> str:
         )
     )
 
-    # Build ProgramArguments array, including --profile when using a named profile
-    prog_args = [
+    # Build ProgramArguments array, including --profile when using a named
+    # profile. When gateway-wrapper.sh is present and executable, route launchd
+    # through it so ~/.hermes/.env is sourced into the process environment
+    # (launchd has no native EnvironmentFile) and the preflight stale-gateway
+    # reaper runs before every start. The wrapper execs the python + module args
+    # we pass after it, so --profile etc. are preserved end-to-end. If the
+    # wrapper is ever missing/non-executable, fall back to the direct-python
+    # form so the gateway never fails to start under KeepAlive (self-heal).
+    wrapper_path = PROJECT_ROOT / "gateway-wrapper.sh"
+    use_wrapper = wrapper_path.is_file() and os.access(str(wrapper_path), os.X_OK)
+
+    core_args = [
         f"<string>{python_path}</string>",
         "<string>-m</string>",
         "<string>hermes_cli.main</string>",
     ]
     if profile_arg:
         for part in profile_arg.split():
-            prog_args.append(f"<string>{part}</string>")
-    prog_args.extend(
+            core_args.append(f"<string>{part}</string>")
+    core_args.extend(
         [
             "<string>gateway</string>",
             "<string>run</string>",
             "<string>--replace</string>",
         ]
     )
+    if use_wrapper:
+        prog_args = [f"<string>{wrapper_path}</string>"] + core_args
+    else:
+        prog_args = core_args
     prog_args_xml = "\n        ".join(prog_args)
 
     return f"""<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## What

launchd now starts the gateway through `gateway-wrapper.sh` instead of invoking the Python interpreter directly. Fixes intermittent Slack (and other platform) disconnects on macOS where the gateway runs under launchd.

## Root cause

`generate_launchd_plist()` emitted `python -m hermes_cli.main gateway run --replace` as the launchd `ProgramArguments`. launchd has no native `EnvironmentFile`, so `~/.hermes/.env` was **not** sourced into the gateway process environment. Platform enablement is registry-driven: `entry.is_connected(probe_cfg)` reads secrets from `os.environ` (falling back to a mtime+size-memoized `load_env()` against `~/.hermes/.env`). When `.env` was missing/empty/mid-replacement during a restore, the secret was absent from `os.environ`, `load_env()` returned a stale memo, and the platform was gated off — an intermittent, self-recovering disconnect.

## Fix

`generate_launchd_plist()` routes launchd through `gateway-wrapper.sh` when the wrapper is present and executable:

```python
wrapper_path = PROJECT_ROOT / "gateway-wrapper.sh"
use_wrapper = wrapper_path.is_file() and os.access(str(wrapper_path), os.X_OK)
if use_wrapper:
    prog_args = [f"<string>{wrapper_path}</string>"] + core_args
else:
    prog_args = core_args  # self-healing fallback
```

The wrapper (1) sources `~/.hermes/.env` into the process env so secrets are in `os.environ` at startup — eliminating the `load_env()` race, (2) runs a preflight stale-gateway reaper (SIGTERM → 5s → SIGKILL) so launchd `KeepAlive` never crash-loops against a stale gateway holding the port, (3) execs the python + module args passed after it so `--profile` is preserved end-to-end.

**Self-healing fallback:** if the wrapper is missing/non-executable, the plist falls back to the direct-python form so the gateway always starts under `KeepAlive`.

## Tests

- `tests/hermes_cli/test_gateway_service.py` — 47 launchd/plist tests pass.
- 6 failures are systemd/D-Bus (`UserSystemdUnavailableError`) — environmental, no systemd on macOS; unrelated to this change.

Signed commit, GitHub-verified.
