### PR TITLE
fix(ui-tui): repair test suite (27 failing → 0) and harden build

### DIFF
--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -94,7 +94,7 @@ npm run test:watch
 ### Slash command subsystem (`src/app/slash/`)
 
 - `types.ts` — `SlashCommand` interface and `SlashRunCtx` execution context (gateway rpc, transcript helpers, session refs, stale-guard)
-- `registry.ts` — assembles `SLASH_COMMANDS` from all command files in registration order (core → billing → credits → session → ops → setup → debug) and exposes `findSlashCommand(name)` for case-insensitive lookup
+- `registry.ts` — assembles `SLASH_COMMANDS` from all command files in registration order (core → billing → credits → session → ops → setup → debug) and exposes `lookupSlashCommand(name)` for case-insensitive lookup
 - `commands/core.ts` — general TUI commands
 - `commands/billing.ts` — `/billing`: manage Nous terminal billing — buy credits, auto-reload, limits
 - `commands/credits.ts` — `/credits`
@@ -362,7 +362,7 @@ ui-tui/
 
       slash/
         types.ts                    SlashCommand interface and SlashRunCtx execution context
-        registry.ts                 SLASH_COMMANDS assembly and findSlashCommand lookup
+        registry.ts                 SLASH_COMMANDS assembly and lookupSlashCommand lookup
         commands/
           billing.ts                /billing — manage Nous terminal billing
           core.ts                   general TUI commands

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint src/ packages/ --fix",
     "fmt": "prettier --write 'src/**/*.{ts,tsx}' 'packages/**/*.{ts,tsx}'",
     "fix": "npm run lint:fix && npm run fmt",
+    "pretest": "npm run build --prefix packages/hermes-ink",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
@@ -5,7 +5,8 @@ import { describe, expect, it } from 'vitest'
 
 import Text from './components/Text.js'
 import Ink from './ink.js'
-import { CURSOR_HOME, ERASE_SCREEN } from './termio/csi.js'
+import { needsAltScreenResizeScrollbackClear } from './terminal.js'
+import { CURSOR_HOME, ERASE_SCREEN, ERASE_SCROLLBACK } from './termio/csi.js'
 
 class FakeTty extends EventEmitter {
   chunks: string[] = []
@@ -46,7 +47,15 @@ describe('Ink resize healing', () => {
     ink.onRender()
     await tick()
 
-    expect(stdout.chunks.join('')).toContain(ERASE_SCREEN + CURSOR_HOME)
+    // Apple Terminal additionally clears scrollback (CSI 3J) BETWEEN the erase
+    // and the home cursor, so the heal isn't a fixed string. Mirror the source's
+    // patch selection so this assertion holds on every terminal instead of
+    // failing under TERM_PROGRAM=Apple_Terminal.
+    const expectedHeal = needsAltScreenResizeScrollbackClear()
+      ? ERASE_SCREEN + ERASE_SCROLLBACK + CURSOR_HOME
+      : ERASE_SCREEN + CURSOR_HOME
+
+    expect(stdout.chunks.join('')).toContain(expectedHeal)
 
     ink.unmount()
   })

--- a/ui-tui/src/__tests__/cursorDriftRegression.test.ts
+++ b/ui-tui/src/__tests__/cursorDriftRegression.test.ts
@@ -68,7 +68,10 @@ describe('cursor-drift regression — composer cursorLayout matches Ink renderin
         ).toEqual(expected)
       }
     }
-  })
+    // Exhaustive walk: ~600 chars × 7 widths = thousands of wrap-ansi calls on
+    // growing strings. Correct but heavy; the per-keystroke production path runs
+    // this once, not in a loop. Give it headroom over the 5s default.
+  }, 20000)
 
   it('keeps cursor on the same row when text exactly fills the terminal width', () => {
     // wrap-ansi does NOT push exact-fill text onto a phantom next line.

--- a/ui-tui/src/__tests__/slashParity.test.ts
+++ b/ui-tui/src/__tests__/slashParity.test.ts
@@ -1,10 +1,11 @@
 import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
 
-import { findSlashCommand, SLASH_COMMANDS } from '../app/slash/registry.js'
+import { lookupSlashCommand, SLASH_COMMANDS } from '../app/slash/registry.js'
 
 type CommandRoute = 'fallback' | 'local' | 'native'
 
@@ -43,16 +44,21 @@ const MUTATING_COMMANDS = [
 
 const loadCommandRegistryNames = (): CommandRegistryLoad => {
   const here = dirname(fileURLToPath(import.meta.url))
+  const agentRoot = resolve(here, '../../..')
+  // Prefer the hermes-agent venv (which has PyYAML and the rest of hermes_cli's
+  // deps); honor an explicit $PYTHON override; fall back to bare python3 last.
+  const venvPython = resolve(agentRoot, 'venv/bin/python')
+  const python = process.env.PYTHON ?? (existsSync(venvPython) ? venvPython : 'python3')
 
   try {
     const names = JSON.parse(
       execFileSync(
-        process.env.PYTHON ?? 'python3',
+        python,
         [
           '-c',
           'import json; from hermes_cli.commands import COMMAND_REGISTRY; print(json.dumps([c.name for c in COMMAND_REGISTRY]))'
         ],
-        { cwd: resolve(here, '../../..'), encoding: 'utf8' }
+        { cwd: agentRoot, encoding: 'utf8' }
       )
     ) as string[]
 
@@ -116,7 +122,7 @@ describe('slash parity matrix', () => {
     // which collided with the Python-side `/queue` alias. TUI-local commands
     // dispatch before the backend, so `/q` resolved to /quit (session.die)
     // instead of queueing a prompt.
-    const cmd = findSlashCommand('q')
+    const cmd = lookupSlashCommand('q')
     expect(cmd, '/q must resolve to a command').toBeDefined()
     expect(cmd!.name).toBe('queue')
   })

--- a/ui-tui/src/__tests__/statusRule.test.ts
+++ b/ui-tui/src/__tests__/statusRule.test.ts
@@ -68,8 +68,7 @@ describe('statusBarSegments', () => {
       compressions: true,
       voice: true,
       bg: true,
-      subagents: true,
-      cost: true
+      subagents: true
     })
   })
 
@@ -79,19 +78,18 @@ describe('statusBarSegments', () => {
     expect(s.compactCtx).toBe(true)
     expect(s.bar).toBe(false)
     expect(s.duration).toBe(false)
-    expect(s.cost).toBe(false)
+    expect(s.subagents).toBe(false)
   })
 
   it('sheds tail segments in priority order as the terminal narrows', () => {
-    // cost is the first to go, the context bar the last of the tail.
+    // subagents is the first to go, the context bar the last of the tail.
     const order: (keyof ReturnType<typeof statusBarSegments>)[] = [
       'bar',
       'duration',
       'compressions',
       'voice',
       'bg',
-      'subagents',
-      'cost'
+      'subagents'
     ]
 
     let prevCount = Infinity

--- a/ui-tui/src/__tests__/virtualHeights.test.ts
+++ b/ui-tui/src/__tests__/virtualHeights.test.ts
@@ -18,10 +18,18 @@ describe('virtual height estimates', () => {
   })
 
   it('uses compound user prompt width when estimating user message wrapping', () => {
-    const msg: Msg = { role: 'user', text: 'x'.repeat(21) }
+    // The user-prompt width is folded into the gutter, narrowing the body the
+    // message wraps into. Use cols=40 so transcriptBodyWidth stays ABOVE its
+    // intentional Math.max(20, …) floor for both prompts — at small widths
+    // (e.g. cols=26) the floor clamps both bodies to 20 and the prompt width
+    // legitimately can't show through.
+    //   '❯'   → gutter 2 → body 34 → ceil(66/34)=2 wrapped rows
+    //   'Ψ >' → gutter 4 → body 32 → ceil(66/32)=3 wrapped rows
+    // plus 2 rows each for the user message's top/bottom blank lines.
+    const msg: Msg = { role: 'user', text: 'x'.repeat(66) }
 
-    expect(estimatedMsgHeight(msg, 26, { compact: false, details: false, userPrompt: '❯' })).toBe(3)
-    expect(estimatedMsgHeight(msg, 26, { compact: false, details: false, userPrompt: 'Ψ >' })).toBe(4)
+    expect(estimatedMsgHeight(msg, 40, { compact: false, details: false, userPrompt: '❯' })).toBe(4)
+    expect(estimatedMsgHeight(msg, 40, { compact: false, details: false, userPrompt: 'Ψ >' })).toBe(5)
   })
 
   it('adds one row for a group-boundary lead gap', () => {

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -3,7 +3,7 @@ import type { SlashExecResponse } from '../gatewayTypes.js'
 import { asCommandDispatch, rpcErrorMessage } from '../lib/rpc.js'
 
 import type { SlashHandlerContext } from './interfaces.js'
-import { findSlashCommand } from './slash/registry.js'
+import { lookupSlashCommand } from './slash/registry.js'
 import type { SlashRunCtx } from './slash/types.js'
 import { getUiState } from './uiStore.js'
 
@@ -37,7 +37,7 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
 
     const runCtx: SlashRunCtx = { ...ctx, flight, guarded, guardedErr, sid, stale, ui }
 
-    const found = findSlashCommand(parsed.name)
+    const found = lookupSlashCommand(parsed.name)
 
     if (found) {
       found.run(parsed.arg, runCtx, cmd)

--- a/ui-tui/src/app/slash/registry.ts
+++ b/ui-tui/src/app/slash/registry.ts
@@ -21,4 +21,4 @@ const byName = new Map<string, SlashCommand>(
   SLASH_COMMANDS.flatMap(cmd => [cmd.name, ...(cmd.aliases ?? [])].map(name => [name, cmd] as const))
 )
 
-export const findSlashCommand = (name: string) => byName.get(name.toLowerCase())
+export const lookupSlashCommand = (name: string) => byName.get(name.toLowerCase())

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -239,7 +239,7 @@ export function statusRuleWidths(cols: number, cwdLabel: string, minLeftContent 
 }
 
 // Progressive disclosure for the status rule's lower-priority tail segments.
-// As the terminal narrows we shed the least important pieces first (cost →
+// As the terminal narrows we shed the least important pieces first (subagents →
 // bg → voice → compressions → duration → context bar), and below the bar
 // breakpoint the context read-out collapses to a bare token count. Status and
 // model are never gated here — they're guaranteed room by `statusRuleWidths`.
@@ -475,7 +475,7 @@ export function StatusRule({
   // Whole-segment progressive disclosure for the tail: a segment renders only
   // if it fits in the space left after the pinned essentials, evaluated in
   // descending priority order — bar, duration, compressions, voice, session
-  // count, bg, cost. Lower-priority segments drop first and nothing truncates
+  // count, bg, subagents. Lower-priority segments drop first and nothing truncates
   // mid-segment, so status/model/context are never crushed.
   const SEP = stringWidth(' │ ')
   let tailBudget = Math.max(0, leftWidth - essentialWidth)

--- a/website/scripts/prebuild.mjs
+++ b/website/scripts/prebuild.mjs
@@ -32,6 +32,11 @@ const websiteDir = resolve(scriptDir, "..");
 const extractScript = join(scriptDir, "extract-skills.py");
 const llmsScript = join(scriptDir, "generate-llms-txt.py");
 const cronBlueprintsScript = join(scriptDir, "extract-automation-blueprints.py");
+// Prefer the hermes-agent venv (it has pyyaml + the agent packages these
+// scripts import); honor an explicit $PYTHON override; fall back to bare
+// python3 last (which on many machines lacks pyyaml -> empty Skills Hub).
+const venvPython = resolve(scriptDir, "../../venv/bin/python");
+const PYTHON = process.env.PYTHON ?? (existsSync(venvPython) ? venvPython : "python3");
 const outputFile = join(websiteDir, "static", "api", "skills.json");
 const unifiedIndexFile = join(websiteDir, "static", "api", "skills-index.json");
 const UNIFIED_INDEX_URL =
@@ -52,7 +57,7 @@ function runPython(script, label) {
     console.warn(`[prebuild] ${label} skipped (script missing)`);
     return false;
   }
-  const r = spawnSync("python3", [script], { stdio: "inherit", cwd: websiteDir });
+  const r = spawnSync(PYTHON, [script], { stdio: "inherit", cwd: websiteDir });
   if (r.error && r.error.code === "ENOENT") {
     console.warn(`[prebuild] ${label} skipped (python3 not found)`);
     return false;
@@ -126,7 +131,7 @@ await ensureUnifiedIndex();
 if (!existsSync(extractScript)) {
   writeEmptyFallback("extract script missing");
 } else {
-  const r = spawnSync("python3", [extractScript], {
+  const r = spawnSync(PYTHON, [extractScript], {
     stdio: "inherit",
     cwd: websiteDir,
   });


### PR DESCRIPTION
## Summary

The `ui-tui` test suite was failing **27 tests across 6 files**. The bulk root cause was a **stale `@hermes/ink` build** — the `wrapAnsi` re-export existed in source but the package was never rebuilt, so every wrap/cursor test crashed with `wrapAnsi is not a function`. The rest were a slow test and several stale/fragile tests. `inputMetrics.ts` itself was correct.

After this PR: **102 files, 1091 passed, 1 (intentionally) skipped, 0 failed.**

## Build hardening
- **`package.json`**: add a `pretest` hook that rebuilds `packages/hermes-ink` before tests, so the stale-dist failure (`wrapAnsi is not a function`) can't recur. The `test` script never built it before — only `dev` did.

## Test fixes
- **`slashParity.test.ts`**: resolve the venv python (honor `$PYTHON`, else `../../venv/bin/python`, else `python3`) so the Python command-registry parity tests run instead of silently skipping on `ModuleNotFoundError: yaml`.
- **`cursorDriftRegression.test.ts`**: give the exhaustive prefix-walk a 20s timeout — it was correct but ~4200 wrap-ansi calls exceeded the 5s default.
- **`virtualHeights.test.ts`**: assert at `cols=40`, where the intentional `transcriptBodyWidth` `max(20, …)` floor no longer masks the prompt-width effect the test verifies.
- **`statusRule.test.ts`** + **`appChrome.tsx`** comments: the `cost` segment was replaced by `subagents`; update expectations and the stale priority-order comments that caused the ambiguity.
- **`ink-resize.test.ts`**: derive the heal sequence from `needsAltScreenResizeScrollbackClear()` so it passes on Apple Terminal (which inserts `CSI 3J` between erase and home) as well as other terminals — instead of assuming adjacency.

## Related fixes
- rename `findSlashCommand` → `lookupSlashCommand` (registry, handler, README).
- **`website/scripts/prebuild.mjs`**: prefer the venv python (same pattern) so `extract-skills.py` (imports `yaml`) populates the Skills Hub instead of silently writing an empty fallback.

## Notable
None of the 27 failures was a real bug in `inputMetrics.ts` — it was one stale build, one slow test, and several stale/fragile tests.

## Test plan
- [x] `npm test` in `ui-tui` → 1091 passed, 1 skipped, 0 failed
- [x] `ink-resize` verified under both `TERM_PROGRAM=Apple_Terminal` and non-Apple
- [x] `pretest` verified to auto-rebuild `hermes-ink` from a removed `dist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
