### PR TITLE
fix(cron): reject zero-interval schedules (every 0m/every 0h)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -339,6 +339,11 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     if schedule_lower.startswith("every "):
         duration_str = schedule[6:].strip()
         minutes = parse_duration(duration_str)
+        if minutes <= 0:
+            raise ValueError(
+                f"Interval must be at least 1 minute, got '{duration_str}'. "
+                f"Use 'every N m' with N >= 1, or a cron expression for sub-minute scheduling."
+            )
         return {
             "kind": "interval",
             "minutes": minutes,


### PR DESCRIPTION
Closes #55727

## Summary

Zero-interval recurring schedules (`every 0m` or `every 0h`) were accepted by `parse_schedule()` and stored with `minutes=0`. `compute_next_run()` then produced a `next_run` equal to `last_run` (`last + 0 = last`), making the job appear perpetually due and re-firing on every scheduler tick.

## Fix

Added a guard in `parse_schedule()` that raises `ValueError` when the parsed interval is `<= 0`, with a helpful message pointing users to cron expressions for sub-minute scheduling:

```python
if minutes <= 0:
    raise ValueError(
        f"Interval must be at least 1 minute, got '{duration_str}'. "
        f"Use 'every N m' with N >= 1, or a cron expression for sub-minute scheduling."
    )
```

## Reproduction (before fix)

```python
from cron.jobs import parse_schedule, compute_next_run
sched = parse_schedule("every 0m")  # {'kind': 'interval', 'minutes': 0, ...}
compute_next_run(sched, last_run_at="2020-01-01T00:00:00+00:00")
# -> 2020-01-01T00:00:00+00:00  (already due; re-fires every tick)
```

## After fix

```python
parse_schedule("every 0m")
# -> ValueError: Interval must be at least 1 minute, got '0m'.
```