### PR TITLE
fix(bedrock): tolerate null image_url values

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -519,7 +519,8 @@ def _convert_content_to_converse(content) -> List[Dict]:
                 blocks.append({"text": text if text else " "})
             elif part_type == "image_url":
                 image_url = part.get("image_url", {})
-                url = image_url.get("url", "") if isinstance(image_url, dict) else ""
+                url = image_url.get("url") if isinstance(image_url, dict) else ""
+                url = url if isinstance(url, str) else ""
                 if url.startswith("data:"):
                     # data:image/jpeg;base64,/9j/4AAQ...
                     header, _, data = url.partition(",")

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -347,6 +347,20 @@ class TestConvertMessagesToConverse:
         assert len(image_blocks) == 1
         assert image_blocks[0]["image"]["format"] == "png"
 
+    def test_image_url_with_null_url_does_not_crash(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {"type": "image_url", "image_url": {"url": None}},
+            ],
+        }]
+        system, msgs = convert_messages_to_converse(messages)
+        content = msgs[0]["content"]
+        assert system is None
+        assert {"text": "[Image: ]"} in content
+
     def test_multiple_system_messages_merged(self):
         from agent.bedrock_adapter import convert_messages_to_converse
         messages = [


### PR DESCRIPTION
Fixes #55686.\n\nBedrock Converse conversion now treats non-string image_url.url values as an empty URL before checking for data URLs, avoiding AttributeError on null values. Added a regression test covering the null-url case.\n\nTests:\n- scripts/run_tests.sh tests/agent/test_bedrock_adapter.py -k 'image_url_with_null_url or image_data_url_converted'