### PR TITLE
fix(windows): add CREATE_BREAKAWAY_FROM_JOB to windows_hide_flags()

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -198,7 +198,12 @@ def windows_hide_flags() -> int:
     """
     if not IS_WINDOWS:
         return 0
-    return _CREATE_NO_WINDOW
+    # _CREATE_BREAKAWAY_FROM_JOB is needed even for short-lived synchronous
+    # children: Electron/Tauri desktop apps wrap their subprocesses in job
+    # objects, and without breakaway a child started with capture_output=True
+    # can be killed when the parent Electron/Tauri process exits — even though
+    # DETACHED_PROCESS is not set and stdio is still connected.
+    return _CREATE_NO_WINDOW | _CREATE_BREAKAWAY_FROM_JOB
 
 
 def windows_detach_popen_kwargs() -> dict:


### PR DESCRIPTION
Closes #55604

## Summary

`windows_hide_flags()` was returning only `_CREATE_NO_WINDOW`, missing `_CREATE_BREAKAWAY_FROM_JOB` which is already used by `windows_detach_flags()` for the same reason: Electron and Tauri desktop apps wrap their subprocesses in job objects, and without the breakaway flag a child process (e.g. cmd.exe windows flash) can be killed when the parent Electron/Tauri process exits.

## Root cause

`CREATE_BREAKAWAY_FROM_JOB` (0x01000000) already exists at line 110 of `_subprocess_compat.py` and is used by `windows_detach_flags()`. It was simply missing from `windows_hide_flags()`.

## Fix

Added `_CREATE_BREAKAWAY_FROM_JOB` to `windows_hide_flags()`:



Note: `DETACHED_PROCESS` is intentionally **not** added — `windows_hide_flags()` is for short-lived synchronous children where stdout capture is needed, and `DETACHED_PROCESS` would sever stdio.

## Related

- #53053 — "Subprocess calls flash black cmd.exe windows on Windows"
- #53273 — "Windows Desktop GUI: CREATE_NO_WINDOW insufficient"
- #53342 — "Hermes desktop client keeps flickering black command prompt windows"