### PR TITLE
fix(agent): count codex_reasoning_items in tail-protection token estimate

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -265,6 +265,12 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
     for tc in msg.get("tool_calls") or []:
         if isinstance(tc, dict):
             tokens += len(str(tc)) // _CHARS_PER_TOKEN
+    # Codex/Responses encrypted reasoning is real replayed wire payload;
+    # without it the protected tail under-measures Responses sessions by
+    # 100K+ tokens.  Count it when present (counting a non-existent key is
+    # a no-op anyway).
+    for it in msg.get("codex_reasoning_items") or []:
+        tokens += len(str(it)) // _CHARS_PER_TOKEN
     return tokens
 
 


### PR DESCRIPTION
Closes #55572

## Summary

The tail-protection estimator `_estimate_msg_budget_tokens()` was counting message content and `tool_calls` but **not** `codex_reasoning_items`.  For sessions running on the OpenAI Responses/Codex backend, those items carry the model's `encrypted_content` reasoning blobs — real wire payload replayed to the provider.  The estimator was blind to them, so the protected tail under-measured Responses sessions by 100K+ tokens (27% of session size in observed case), causing compaction to trigger too late.

## Root cause

`codex_reasoning_items` was simply absent from the token-counting loop in `_estimate_msg_budget_tokens`, despite being counted indirectly via full-dict stringify in the preflight estimator `estimate_messages_tokens_rough`.

## Fix

Add iteration over `codex_reasoning_items` using the same `len(str(it)) // _CHARS_PER_TOKEN` formula already used for `tool_calls`:



## Observed impact

A real 214-turn session carried **162 reasoning items** totalling **~459 KB (~115K tokens)** — none of which the old tail estimator counted.  The protected tail (~20K-token budget) silently held ~100K+ extra wire tokens.

## Note

Privacy is unaffected: `_serialize_for_summary` only reads `content`, `tool_calls`, and `tool_call_id`, so encrypted blobs are never sent to the auxiliary summarizer.