### PR TITLE
fix(file): count unterminated final line in read_file

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -284,7 +284,7 @@ class TestPaginationBounds:
                 return MagicMock(exit_code=0, stdout="line1\nline2\n")
             if command.startswith("sed -n"):
                 return MagicMock(exit_code=0, stdout="line1\n")
-            if command.startswith("wc -l"):
+            if command.startswith("awk "):
                 return MagicMock(exit_code=0, stdout="2")
             return MagicMock(exit_code=0, stdout="")
 
@@ -295,6 +295,35 @@ class TestPaginationBounds:
         assert "1|line1" in result.content
         sed_commands = [cmd for cmd in commands if cmd.startswith("sed -n")]
         assert sed_commands == ["sed -n '1,1p' 'notes.txt'"]
+
+    def test_read_file_counts_final_line_without_trailing_newline(self):
+        env = MagicMock()
+        env.cwd = "/tmp"
+        ops = ShellFileOperations(env)
+
+        def fake_exec(command, *args, **kwargs):
+            if command.startswith("wc -c"):
+                return MagicMock(exit_code=0, stdout="8")
+            if command.startswith("head -c"):
+                return MagicMock(exit_code=0, stdout="x1\nx2\nx3")
+            if command.startswith("sed -n '1,2p'"):
+                return MagicMock(exit_code=0, stdout="x1\nx2\n")
+            if command.startswith("sed -n '3,3p'"):
+                return MagicMock(exit_code=0, stdout="x3")
+            if command.startswith("awk "):
+                return MagicMock(exit_code=0, stdout="3\n")
+            return MagicMock(exit_code=0, stdout="")
+
+        with patch.object(ops, "_exec", side_effect=fake_exec):
+            first_page = ops.read_file("c.txt", offset=1, limit=2)
+            last_page = ops.read_file("c.txt", offset=3, limit=1)
+
+        assert first_page.total_lines == 3
+        assert first_page.truncated is True
+        assert first_page.hint == "Use offset=3 to continue reading (showing 1-2 of 3 lines)"
+        assert "3|x3" in last_page.content
+        assert last_page.total_lines == 3
+        assert last_page.truncated is False
 
     def test_search_clamps_offset_and_limit_before_building_head_pipeline(self):
         env = MagicMock()

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1115,12 +1115,14 @@ class ShellFileOperations(FileOperations):
         if offset == 1:
             read_output, _ = _strip_bom(read_output)
         
-        # Get total line count
-        wc_cmd = f"wc -l < {self._escape_shell_arg(path)}"
-        wc_result = self._exec(wc_cmd)
-        wc_output = _strip_terminal_fence_leaks(wc_result.stdout)
+        # Get total line count.  ``wc -l`` counts newline characters, so it
+        # undercounts a final unterminated line; awk's NR tracks logical
+        # records and includes that last line.
+        line_count_cmd = f"awk 'END {{ print NR + 0 }}' {self._escape_shell_arg(path)}"
+        line_count_result = self._exec(line_count_cmd)
+        line_count_output = _strip_terminal_fence_leaks(line_count_result.stdout)
         try:
-            total_lines = int(wc_output.strip())
+            total_lines = int(line_count_output.strip())
         except ValueError:
             total_lines = 0
         


### PR DESCRIPTION
Fixes #55697.\n\nShellFileOperations.read_file now uses awk record counting instead of wc -l so files without a trailing newline report the correct total_lines and pagination remains truncated when another logical line exists. Added regression coverage for the exact page-boundary case.\n\nTests:\n- scripts/run_tests.sh tests/tools/test_file_operations_edge_cases.py -k 'read_file_counts_final_line_without_trailing_newline or read_file_clamps_offset'