### PR TITLE
fix(agent): continue on CJK intent acknowledgements

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2338,8 +2338,13 @@ def looks_like_codex_intermediate_ack(
     if len(assistant_text) > 1200:
         return False
 
+    cjk_future_ack_markers = (
+        "我先", "我会", "我會", "我将", "我將", "我来", "我來",
+        "让我", "讓我", "先来", "先來", "先載", "先载", "先查", "先看",
+    )
     has_future_ack = bool(
         re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
+        or any(marker in assistant_text for marker in cjk_future_ack_markers)
     )
     if not has_future_ack:
         return False
@@ -2364,6 +2369,39 @@ def looks_like_codex_intermediate_ack(
         "walkthrough",
         "report back",
         "summarize",
+        # CJK action markers. Keep these as concrete tool-like verbs so a
+        # conversational acknowledgement in Chinese/Japanese/Korean does not
+        # trip continuation without an announced action.
+        "載入",
+        "载入",
+        "確認",
+        "确认",
+        "檢查",
+        "检查",
+        "查看",
+        "讀取",
+        "读取",
+        "運行",
+        "运行",
+        "執行",
+        "执行",
+        "搜尋",
+        "搜索",
+        "查找",
+        "分析",
+        "修復",
+        "修复",
+        "調試",
+        "调试",
+        "테스트",
+        "확인",
+        "검색",
+        "분석",
+        "実行",
+        "確認",
+        "検索",
+        "分析",
+        "修正",
     )
     workspace_markers = (
         "directory",

--- a/tests/agent/test_intent_ack_continuation.py
+++ b/tests/agent/test_intent_ack_continuation.py
@@ -144,6 +144,15 @@ def test_all_path_drops_workspace_requirement():
     )
 
 
+def test_non_english_cjk_future_ack_fires_when_opted_in():
+    """Non-English action acks should not be blocked by the English regex gate."""
+    a = _agent(True, "chat_completions")
+    user = "請檢查這個專案的 skill 用法"
+    ack = "我先載入 skill 確認用法，然後再繼續。"
+    msgs = [{"role": "user", "content": user}]
+    assert looks_like_codex_intermediate_ack(a, user, ack, msgs, require_workspace=False)
+
+
 # ── detector: guardrails that hold regardless of workspace ───────────────────
 
 


### PR DESCRIPTION
Fixes #55664.\n\nIntent-ack continuation now recognizes concrete CJK future-ack phrases and tool-like action verbs, so opted-in non-English responses that only announce the next action get continued instead of ending the turn. Added a regression test for the reported Chinese ack shape while keeping existing guardrail coverage.\n\nTests:\n- scripts/run_tests.sh tests/agent/test_intent_ack_continuation.py -k 'non_english_cjk or all_path_drops_workspace_requirement or conversational_reply_without_action_verb'