### PR TITLE
fix(feishu): render markdown tables as CardKit v2 interactive cards

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -671,7 +671,31 @@ class GatewayStreamConsumer:
                     # full response again.
                     if self._accumulated:
                         if self._fallback_final_send:
-                            await self._send_fallback_final(self._accumulated)
+                            # When the adapter prefers fresh-final streaming
+                            # (e.g. Feishu tables that need interactive cards),
+                            # intercept the fallback and send the FULL content
+                            # as a fresh message instead of just the continuation
+                            # tail.  This ensures the complete table renders as
+                            # a single interactive card and the partial streaming
+                            # preview is deleted.
+                            if self._adapter_prefers_fresh_final(self._accumulated):
+                                logger.debug(
+                                    "[StreamConsumer] fallback → _try_fresh_final "
+                                    "for table content (len=%d)",
+                                    len(self._accumulated),
+                                )
+                                sent = await self._try_fresh_final(
+                                    self._accumulated,
+                                    is_turn_final=True,
+                                )
+                                if sent:
+                                    self._final_response_sent = True
+                                    self._final_content_delivered = True
+                                    self._fallback_final_send = False
+                                else:
+                                    await self._send_fallback_final(self._accumulated)
+                            else:
+                                await self._send_fallback_final(self._accumulated)
                         elif self._final_response_sent:
                             # A finalize=True tick above already delivered the
                             # final answer via the adapter's fresh-final path
@@ -1446,8 +1470,20 @@ class GatewayStreamConsumer:
                     # finalize=True edit even when content is unchanged, so
                     # their streaming UI can transition out of the in-
                     # progress state.  Everyone else short-circuits.
+                    #
+                    # Also skip the short-circuit when the adapter prefers
+                    # fresh-final delivery for this content (e.g. Feishu
+                    # with markdown tables): the streaming preview was sent
+                    # as post-type pipe text, but the finalize path can
+                    # re-render it as an interactive CardKit v2 table.
+                    # The fresh-final path (send + delete preview) runs
+                    # regardless of content equality, so we must not
+                    # short-circuit before it.
                     if text == self._last_sent_text and not (
-                        finalize and self._adapter_requires_finalize
+                        finalize and (
+                            self._adapter_requires_finalize
+                            or self._adapter_prefers_fresh_final(text)
+                        )
                     ):
                         return True
                     # Fresh-final for long-lived previews: when finalizing

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -152,12 +152,14 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _MARKDOWN_HINT_RE = re.compile(
-    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
+    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)|(^\s*\|.+\|\s*$)",
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
 # Feishu post-type 'md' elements do not render tables, so we force text mode.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
+_MARKDOWN_TABLE_LINE_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+_MARKDOWN_TABLE_DIVIDER_RE = re.compile(r"^\s*\|(?:[-:]+\|)+\s*$")
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -547,6 +549,220 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 # ---------------------------------------------------------------------------
 # Post payload builders and parsers
 # ---------------------------------------------------------------------------
+
+
+def _parse_markdown_table(text: str) -> List[Dict[str, Any]]:
+    """Parse markdown text and extract tables as segments.
+
+    Returns a list of dicts: each dict is either
+      {"type": "text", "content": str}
+    or
+      {"type": "table", "headers": [...], "rows": [[...], ...]}.
+
+    Tables inside fenced code blocks are left untouched — those lines become
+    part of a "text" segment so they render as code.
+    """
+    if not text or "|" not in text:
+        return [{"type": "text", "content": text}]
+
+    lines = text.splitlines(keepends=True)
+    segments: List[Dict[str, Any]] = []
+    non_table_parts: List[str] = []
+    table_lines: List[str] = []
+    in_table = False
+    in_code_block = False
+
+    def _flush_non_table() -> None:
+        if non_table_parts:
+            joined = "".join(non_table_parts)
+            if joined:
+                segments.append({"type": "text", "content": joined})
+            non_table_parts.clear()
+
+    def _flush_table() -> None:
+        nonlocal table_lines
+        if not table_lines:
+            return
+        header_line = table_lines[0].rstrip("\n")
+        # Collect data rows: skip ALL divider lines (|---|---|),
+        # not just the one immediately after the header.  This
+        # handles malformed tables where a second header-like row
+        # appears before the divider (e.g. | A | B |\n| C | D |\n|---|---|)
+        # — the divider is still a divider regardless of position.
+        row_lines = [
+            r for r in table_lines[1:]
+            if not _MARKDOWN_TABLE_DIVIDER_RE.match(r)
+        ]
+
+        def _parse_cells(line: str) -> List[str]:
+            stripped = line.strip()
+            if stripped.startswith("|"):
+                stripped = stripped[1:]
+            if stripped.endswith("|"):
+                stripped = stripped[:-1]
+            return [cell.strip() for cell in stripped.split("|")]
+
+        headers = _parse_cells(header_line)
+        rows = [_parse_cells(r) for r in row_lines]
+        # Normalize row length to match headers
+        for row in rows:
+            while len(row) < len(headers):
+                row.append("")
+            if len(row) > len(headers):
+                row[:] = row[: len(headers)]
+
+        segments.append({"type": "table", "headers": headers, "rows": rows})
+        table_lines = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Track fenced code blocks — pipes inside them must NOT be treated as tables
+        if not in_code_block and _MARKDOWN_FENCE_OPEN_RE.match(stripped):
+            if in_table:
+                _flush_table()
+                in_table = False
+            in_code_block = True
+            non_table_parts.append(line)
+            continue
+        if in_code_block and _MARKDOWN_FENCE_CLOSE_RE.match(stripped):
+            in_code_block = False
+            non_table_parts.append(line)
+            continue
+        if in_code_block:
+            non_table_parts.append(line)
+            continue
+
+        if _MARKDOWN_TABLE_LINE_RE.match(line):
+            if not in_table:
+                _flush_non_table()
+                in_table = True
+            table_lines.append(line)
+            continue
+
+        if in_table:
+            if stripped == "":
+                _flush_table()
+                in_table = False
+                non_table_parts.append(line)
+                continue
+            if _MARKDOWN_TABLE_DIVIDER_RE.match(line):
+                table_lines.append(line)
+                continue
+            if _MARKDOWN_TABLE_LINE_RE.match(line):
+                table_lines.append(line)
+                continue
+            _flush_table()
+            in_table = False
+            non_table_parts.append(line)
+            continue
+
+        non_table_parts.append(line)
+
+    if in_table:
+        _flush_table()
+    _flush_non_table()
+
+    return segments
+
+
+def _strip_md_bold(text: str) -> str:
+    """Strip markdown bold markers (** and __) from text."""
+    if not text:
+        return text
+    text = re.sub(r'\*\*', '', text)
+    text = re.sub(r'__', '', text)
+    return text.strip()
+
+
+def _build_table_card(headers: List[str], rows: List[List[str]]) -> Optional[Dict[str, Any]]:
+    """Build a Feishu CardKit v2 table component from headers and rows.
+
+    Ref: https://open.feishu.cn/document/feishu-cards/card-json-v2-components/content-components/table
+
+    CardKit v2 text data_type does NOT support markdown in cells, so bold
+    markers (** and __) are stripped and header styling is applied via
+    header_style instead.
+
+    Returns None when headers is empty (degenerate table like a bare ``|``).
+    """
+    if not headers:
+        return None
+
+    # Build columns definition
+    columns = []
+    for i, h in enumerate(headers):
+        col_name = f"col_{i}"
+        columns.append({
+            "name": col_name,
+            "display_name": _strip_md_bold(h) or " ",
+            "data_type": "text",
+            "width": "auto",
+        })
+
+    # Build rows as objects mapping col_name -> cell_value
+    data_rows = []
+    for row in rows:
+        row_obj = {}
+        for i, cell in enumerate(row):
+            if i < len(headers):
+                col_name = f"col_{i}"
+                row_obj[col_name] = _strip_md_bold(cell) or " "
+        data_rows.append(row_obj)
+
+    return {
+        "tag": "table",
+        "columns": columns,
+        "rows": data_rows,
+        "header_style": {
+            "bold": True,
+            "text_align": "left",
+            "text_size": "normal",
+            "background_style": "none",
+            "text_color": "default",
+            "lines": 1,
+        },
+    }
+
+
+def _build_interactive_card_with_tables(text: str) -> Optional[Dict[str, Any]]:
+    """Build a CardKit v2 interactive card if the text contains markdown tables.
+
+    Returns None if no tables are found (caller should fall back to post message).
+    Non-table text segments become markdown elements; table segments become
+    CardKit v2 table components.
+    """
+    segments = _parse_markdown_table(text)
+    has_table = any(s["type"] == "table" for s in segments)
+    if not has_table:
+        return None
+
+    elements: List[Dict[str, Any]] = []
+    for seg in segments:
+        if seg["type"] == "text":
+            content = seg["content"].strip()
+            if content:
+                elements.append({
+                    "tag": "markdown",
+                    "content": content,
+                })
+        elif seg["type"] == "table":
+            card = _build_table_card(seg["headers"], seg["rows"])
+            if card is not None:
+                elements.append(card)
+
+    if not elements:
+        return None
+
+    return {
+        "schema": "2.0",
+        "config": {
+            "wide_screen_mode": True,
+        },
+        "body": {
+            "elements": elements,
+        },
+    }
 
 
 def _build_markdown_post_payload(content: str) -> str:
@@ -1832,6 +2048,35 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
 
+    def prefers_fresh_final_streaming(
+        self,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Return True when content contains a markdown table so the stream
+        consumer finalizes by sending a fresh interactive card (and deleting
+        the post-type preview) instead of editing the preview in place.
+
+        During streaming, tables are sent as ``post`` type (pipe-delimited
+        text) because ``streaming=True`` skips the interactive-card builder.
+        At finalize, the content is re-evaluated with ``streaming=False`` and
+        an interactive CardKit v2 table is built — but the stream consumer's
+        skip-if-same optimization can short-circuit that final edit when the
+        text hasn't changed since the last streaming chunk.  Returning True
+        here tells the consumer to use the fresh-final path (send a new
+        message + delete the old preview), which always runs regardless of
+        content equality, so the table renders as a proper interactive card.
+        """
+        if not content:
+            return False
+        # Quick check: tables require pipe characters
+        if "|" not in content:
+            return False
+        # Defer to the table parser to confirm there's an actual table
+        # (not just a pipe inside a code block or prose).
+        segments = _parse_markdown_table(content)
+        return any(s["type"] == "table" for s in segments)
+
     async def send(
         self,
         chat_id: str,
@@ -1847,9 +2092,14 @@ class FeishuAdapter(BasePlatformAdapter):
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None
 
+        # When expect_edits is set (streaming preview), pass streaming=True
+        # to _build_outbound_payload so it avoids interactive cards that
+        # cannot be reliably updated mid-stream.
+        _is_streaming = bool((metadata or {}).get("expect_edits"))
+
         try:
             for chunk in chunks:
-                msg_type, payload = self._build_outbound_payload(chunk)
+                msg_type, payload = self._build_outbound_payload(chunk, streaming=_is_streaming)
                 try:
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
@@ -1903,7 +2153,14 @@ class FeishuAdapter(BasePlatformAdapter):
 
         content = self.format_message(content)
         try:
-            msg_type, payload = self._build_outbound_payload(content)
+            # During streaming edits (finalize=False), pass streaming=True
+            # so _build_outbound_payload avoids interactive cards.  On the
+            # final edit (finalize=True) we allow interactive cards so the
+            # complete table renders properly.
+            msg_type, payload = self._build_outbound_payload(
+                content, streaming=not finalize,
+            )
+
             body = self._build_update_message_body(msg_type=msg_type, content=payload)
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await self._run_blocking(self._client.im.v1.message.update, request)
@@ -1923,6 +2180,32 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    async def _delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent Feishu message.
+
+        Uses the im.v1.message.delete API.  Returns True on success.
+        """
+        if not self._client or not message_id:
+            return False
+        try:
+            from lark_oapi.api.im.v1 import DeleteMessageRequest
+            request = DeleteMessageRequest.builder().message_id(message_id).build()
+            response = await asyncio.to_thread(self._client.im.v1.message.delete, request)
+            return self._response_succeeded(response)
+        except Exception as exc:
+            logger.debug("[Feishu] delete_message %s failed: %s", message_id, exc)
+            return False
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Public delete_message for stream-consumer fresh-final cleanup.
+
+        The stream consumer's ``_try_fresh_final`` looks for a public
+        ``delete_message`` method via ``getattr(adapter, "delete_message", None)``
+        to clean up stale streaming previews.  Delegates to the private
+        ``_delete_message`` implementation.
+        """
+        return await self._delete_message(chat_id, message_id)
 
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
@@ -4441,13 +4724,20 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
-    def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+    def _build_outbound_payload(
+        self, content: str, *, streaming: bool = False,
+    ) -> tuple[str, str]:
+        # During streaming (finalize=False), never send as interactive card.
+        # Feishu's message.update API cannot reliably update interactive card
+        # content mid-stream, causing edit failures that split the response
+        # across multiple messages.  Instead, always use "post" during streaming
+        # and let the finalize edit (or delete-and-resend) switch to interactive
+        # when the table is complete.
+        if not streaming:
+            card = _build_interactive_card_with_tables(content)
+            if card is not None:
+                return "interactive", json.dumps(card, ensure_ascii=False)
+
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/test_feishu_table_rendering.py
+++ b/tests/test_feishu_table_rendering.py
@@ -1,0 +1,158 @@
+"""Unit tests for Feishu markdown table parsing and CardKit v2 card building."""
+import json
+import pytest
+from plugins.platforms.feishu.adapter import (
+    _parse_markdown_table,
+    _build_table_card,
+    _build_interactive_card_with_tables,
+    _MARKDOWN_TABLE_RE,
+)
+
+
+class TestParseMarkdownTable:
+    """Test _parse_markdown_table extracts tables correctly."""
+
+    def test_simple_table(self):
+        text = "| A | B |\n|---|---|\n| 1 | 2 |"
+        segs = _parse_markdown_table(text)
+        assert len(segs) == 1
+        assert segs[0]["type"] == "table"
+        assert segs[0]["headers"] == ["A", "B"]
+        assert segs[0]["rows"] == [["1", "2"]]
+
+    def test_no_table_returns_text(self):
+        text = "Hello world, no table here."
+        segs = _parse_markdown_table(text)
+        assert len(segs) == 1
+        assert segs[0]["type"] == "text"
+
+    def test_no_pipe_returns_text(self):
+        text = "Plain text without any pipes."
+        segs = _parse_markdown_table(text)
+        assert len(segs) == 1
+        assert segs[0]["type"] == "text"
+
+    def test_pipe_in_code_block_not_table(self):
+        text = "```\n| a | b |\n```"
+        segs = _parse_markdown_table(text)
+        assert all(s["type"] == "text" for s in segs)
+
+    def test_table_with_surrounding_text(self):
+        text = "Here's a table:\n\n| Name | Age |\n|------|-----|\n| Alice | 30 |\n\nDone."
+        segs = _parse_markdown_table(text)
+        assert len(segs) == 3  # text, table, text
+        assert segs[0]["type"] == "text"
+        assert segs[1]["type"] == "table"
+        assert segs[1]["headers"] == ["Name", "Age"]
+        assert segs[1]["rows"] == [["Alice", "30"]]
+        assert segs[2]["type"] == "text"
+
+    def test_large_table_10_rows(self):
+        header = "| # | Name |\n|---|------|\n"
+        rows = "".join(f"| {i} | User{i} |\n" for i in range(1, 11))
+        segs = _parse_markdown_table(header + rows)
+        assert len(segs) == 1
+        assert segs[0]["type"] == "table"
+        assert len(segs[0]["rows"]) == 10
+        assert segs[0]["rows"][0] == ["1", "User1"]
+        assert segs[0]["rows"][9] == ["10", "User10"]
+
+    def test_table_with_alignment_divider(self):
+        text = "| Left | Center | Right |\n|:-----|:------:|------:|\n| a | b | c |"
+        segs = _parse_markdown_table(text)
+        assert segs[0]["type"] == "table"
+        assert segs[0]["headers"] == ["Left", "Center", "Right"]
+        assert segs[0]["rows"] == [["a", "b", "c"]]
+
+    def test_uneven_row_columns_padded(self):
+        """Rows with fewer cells than headers should be padded with empty strings."""
+        text = "| A | B | C |\n|---|---|---|\n| 1 | 2 |"
+        segs = _parse_markdown_table(text)
+        assert segs[0]["rows"][0] == ["1", "2", ""]
+
+    def test_uneven_row_columns_truncated(self):
+        """Rows with more cells than headers should be truncated."""
+        text = "| A | B |\n|---|---|\n| 1 | 2 | 3 |"
+        segs = _parse_markdown_table(text)
+        assert segs[0]["rows"][0] == ["1", "2"]
+
+    def test_malformed_table_double_header_before_divider(self):
+        """When two header-like rows appear before the divider, the divider
+        is still recognized and stripped — no literal '---' in cells."""
+        text = "| A | B |\n| C | D |\n|---|---|\n| 1 | 2 |"
+        segs = _parse_markdown_table(text)
+        assert segs[0]["type"] == "table"
+        assert segs[0]["headers"] == ["A", "B"]
+        # C/D row and 1/2 row are both data; divider is not
+        assert segs[0]["rows"] == [["C", "D"], ["1", "2"]]
+        # No literal dashes leak into any cell
+        for row in segs[0]["rows"]:
+            for cell in row:
+                assert "---" not in cell
+
+    def test_bare_pipe_not_table(self):
+        """A single bare '|' should not produce a table with zero columns."""
+        text = "Just a pipe: |"
+        segs = _parse_markdown_table(text)
+        assert all(s["type"] == "text" for s in segs)
+
+
+class TestBuildTableCard:
+    """Test _build_table_card generates valid CardKit v2 table JSON."""
+
+    def test_card_structure(self):
+        card = _build_table_card(["Name", "Age"], [["Alice", "30"]])
+        assert card["tag"] == "table"
+        assert len(card["columns"]) == 2
+        assert card["columns"][0]["name"] == "col_0"
+        assert card["columns"][0]["display_name"] == "Name"
+        assert card["columns"][0]["data_type"] == "text"
+        assert card["rows"][0]["col_0"] == "Alice"
+        assert card["rows"][0]["col_1"] == "30"
+
+    def test_header_style_is_bold(self):
+        card = _build_table_card(["A"], [["1"]])
+        assert card["header_style"]["bold"] is True
+
+    def test_bold_markers_stripped_from_cells(self):
+        """CardKit v2 doesn't support markdown in cells."""
+        card = _build_table_card(["**Bold**"], [["**value**"]])
+        assert card["columns"][0]["display_name"] == "Bold"
+        assert card["rows"][0]["col_0"] == "value"
+
+    def test_empty_cell_becomes_space(self):
+        """Empty cells should become a single space, not empty string."""
+        card = _build_table_card(["A", "B"], [["val", ""]])
+        assert card["rows"][0]["col_1"] == " "
+
+    def test_empty_headers_returns_none(self):
+        """Degenerate table with no columns should return None, not a broken card."""
+        assert _build_table_card([], []) is None
+        assert _build_table_card([], [["1"]]) is None
+
+
+class TestBuildInteractiveCardWithTables:
+    """Test _build_interactive_card_with_tables builds complete cards."""
+
+    def test_returns_none_without_table(self):
+        assert _build_interactive_card_with_tables("No table here") is None
+
+    def test_card_schema(self):
+        text = "| A | B |\n|---|---|\n| 1 | 2 |"
+        card = _build_interactive_card_with_tables(text)
+        assert card is not None
+        assert card["schema"] == "2.0"
+        assert card["config"]["wide_screen_mode"] is True
+        assert len(card["body"]["elements"]) == 1
+        assert card["body"]["elements"][0]["tag"] == "table"
+
+    def test_mixed_text_and_table(self):
+        text = "Intro text\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nOutro text"
+        card = _build_interactive_card_with_tables(text)
+        assert card is not None
+        elements = card["body"]["elements"]
+        # Should have: markdown element, table element, markdown element
+        assert len(elements) == 3
+        assert elements[0]["tag"] == "markdown"
+        assert elements[1]["tag"] == "table"
+        assert elements[2]["tag"] == "markdown"


### PR DESCRIPTION
## Problem

During streaming, markdown tables in Feishu messages were rendered as pipe-delimited text instead of proper tables. Large tables (10+ rows) were also split across two messages.

## Root Cause

1. `_build_outbound_payload` forced `text` mode when markdown table syntax was detected — tables never reached the interactive card path.
2. Large tables hit Feishu's edit rate limit during streaming, causing the stream consumer to enter fallback mode. `_send_fallback_final` then created a second message without deleting the preview.

## Files Changed

### 1. `plugins/platforms/feishu/adapter.py` (+300 / -10)

| Component | Change |
|-----------|--------|
| `_MARKDOWN_HINT_RE` | Added `\|...\|` table-line pattern so tables are detected as "has markdown" |
| `_MARKDOWN_TABLE_LINE_RE` / `_MARKDOWN_TABLE_DIVIDER_RE` | New regexes for fine-grained table line detection (header/data rows vs divider) |
| `_parse_markdown_table()` | **New**: Parse markdown text into ordered segments (`text` / `table`). Handles code-block exclusion (pipes inside ` ``` ` are never tables), malformed tables (double header before divider), uneven rows (auto-pad/truncate to header length), bare pipes (not treated as zero-column tables) |
| `_strip_md_bold()` | **New**: Strip `**` and `__` markers — CardKit v2 `text` cells don't support inline markdown |
| `_build_table_card()` | **New**: Build CardKit v2 `table` JSON from headers + rows. Auto column naming (`col_0`, `col_1`...), `header_style: { bold: true }`, empty cells → single space (avoid collapse) |
| `_build_interactive_card_with_tables()` | **New**: Assemble complete CardKit v2 interactive card. Non-table text → `markdown` elements; table segments → `table` components. Returns `None` if no tables found (caller falls back to post) |
| `prefers_fresh_final_streaming()` | **New override**: Return `True` when content contains markdown tables. Uses existing base.py hook (line 2266, Telegram already uses it). Tells stream consumer to use fresh-final path (send + delete preview) instead of edit-in-place |
| `send()` | Pass `streaming=bool(metadata.expect_edits)` to `_build_outbound_payload` — during streaming, always use `post` type (interactive cards can't be reliably edited mid-stream) |
| `edit_message()` | Pass `streaming=not finalize` — during streaming edits use `post`, on final edit (`finalize=True`) allow interactive cards |
| `_delete_message()` | **New**: Wrapper for `im.v1.message.delete` API |
| `delete_message()` | **New public**: Used by stream consumer's `_try_fresh_final` for preview cleanup via `getattr(adapter, "delete_message")` |
| `_build_outbound_payload()` | **Rewritten**: Added `streaming` param. When `streaming=False`, try `_build_interactive_card_with_tables()` first → return `interactive` type. When `streaming=True`, skip interactive cards entirely (use `post` type). Removed old `_MARKDOWN_TABLE_RE` → `text` mode downgrade |

### 2. `gateway/stream_consumer.py` (+38 / -2)

| Location | Change |
|----------|--------|
| `run()` fallback path | When `adapter.prefers_fresh_final_streaming(content)` returns `True`, intercept fallback → `_try_fresh_final(content, is_turn_final=True)`. This sends the FULL content as a fresh interactive card and deletes the stale post-type preview. Falls back to `_send_fallback_final` if fresh-final fails |
| `_send_or_edit()` short-circuit | Bypass the skip-if-same-content optimization when `adapter.prefers_fresh_final_streaming(text)` returns `True`. This ensures the fresh-final path always runs (streaming preview was pipe-text, finalize needs to re-render as interactive card — content equality check would wrongly short-circuit) |

### 3. `tests/test_feishu_table_rendering.py` (+158 / new)

19 unit tests across 3 test classes:

- **`TestParseMarkdownTable`** (11 tests): Simple table, no-table text, pipe-in-code-block, table-with-surrounding-text, 10-row large table, alignment divider, uneven row padding/truncation, malformed double-header, bare pipe edge case
- **`TestBuildTableCard`** (4 tests): Card structure, bold header style, markdown stripping in cells, empty cell → space, empty headers → None
- **`TestBuildInteractiveCardWithTables`** (3 tests): No-table → None, card schema validation, mixed text+table segment ordering

## How It Works (Flow)

```
Streaming (finalize=False):
  content with table → _build_outbound_payload(streaming=True)
    → post type (pipe-delimited text)
    → user sees raw-ish table during streaming

Finalize (finalize=True):
  content with table → _build_outbound_payload(streaming=False)
    → _build_interactive_card_with_tables()
    → CardKit v2 interactive card with real table
    → sends fresh message + deletes post-type preview

Fallback (edit rate limit hit):
  adapter.prefers_fresh_final_streaming() → True
    → _try_fresh_final() sends full content as new interactive card
    → deletes stale preview
    → table renders in single message ✅
```

## Testing

- **19 unit tests** (table parsing, card building, edge cases) — all passing
- **Static security scan** — clean (no secrets, injection, eval, pickle, SQLi)
- **Independent reviewer subagent** — passed, no security concerns or logic errors
- **E2E validated** in real Feishu environment:
  - Simple 3-row table → single message, real table ✅
  - Complex 10×10 table → single message, complete table ✅
  - Large 20×13 table → single message, auto-paginated by CardKit ✅

## Notes

- `prefers_fresh_final_streaming` is an existing base class hook (line 2266 of `gateway/platforms/base.py`) designed exactly for this use case — Telegram already uses it for rich message finalization.
- During streaming, Feishu cannot reliably edit interactive cards (API limitation), so tables are streamed as post type and re-rendered as interactive cards at finalize.
- Compared to #46727 (same surface problem), this PR additionally handles the streaming fallback path (edit rate limit → message split) which #46727 does not cover.