### PR TITLE
feat(memory): add memory write plugin hooks

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -135,6 +135,11 @@ _install_plugin_debug_handler()
 VALID_HOOKS: Set[str] = {
     "pre_tool_call",
     "post_tool_call",
+    # Generic memory write governance hooks. Observers may reject/skip/transform
+    # a write before it is persisted, or request one deterministic retry on
+    # over-limit writes. Keep hook semantics generic; plugins decide policy.
+    "pre_memory_write",
+    "post_memory_write",
     "transform_terminal_output",
     "transform_tool_result",
     # Transform LLM output before it's returned to the user.

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -291,6 +291,84 @@ class TestMemoryStoreAdd:
         assert result["success"] is True  # No error, just a note
         assert len(store.memory_entries) == 1  # Not duplicated
 
+    def test_pre_memory_write_hook_can_reject_add(self, store, monkeypatch):
+        calls = []
+
+        def fake_has_hook(name):
+            return name == "pre_memory_write"
+
+        def fake_invoke_hook(name, **kwargs):
+            calls.append((name, kwargs))
+            return [{"action": "reject", "response": {"success": False, "error": "blocked by test hook"}}]
+
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", fake_has_hook)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+        result = store.add("memory", "blocked fact")
+
+        assert result == {"success": False, "error": "blocked by test hook"}
+        assert store.memory_entries == []
+        assert calls[0][0] == "pre_memory_write"
+        assert calls[0][1]["stage"] == "before_add"
+        assert calls[0][1]["target"] == "memory"
+
+    def test_pre_memory_write_hook_can_skip_duplicate_like_add(self, store, monkeypatch):
+        def fake_has_hook(name):
+            return name == "pre_memory_write"
+
+        def fake_invoke_hook(name, **kwargs):
+            return [{"action": "skip", "message": "normalized duplicate"}]
+
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", fake_has_hook)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+        result = store.add("memory", "duplicate-ish fact")
+
+        assert result["success"] is True
+        assert "normalized duplicate" in result["message"]
+        assert store.memory_entries == []
+
+    def test_pre_memory_write_hook_can_retry_after_over_limit_cleanup(self, store, monkeypatch):
+        store.memory_entries = ["x" * 480]
+        store.save_to_disk("memory")
+
+        def fake_has_hook(name):
+            return name == "pre_memory_write"
+
+        def fake_invoke_hook(name, **kwargs):
+            if kwargs["stage"] != "over_limit":
+                return []
+            store.memory_entries = []
+            store.save_to_disk("memory")
+            return [{"action": "retry", "response_metadata": {"hook_retry": True}}]
+
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", fake_has_hook)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+        result = store.add("memory", "new fact after cleanup")
+
+        assert result["success"] is True
+        assert result["hook_retry"] is True
+        assert store.memory_entries == ["new fact after cleanup"]
+
+    def test_post_memory_write_hook_runs_after_successful_add(self, store, monkeypatch):
+        calls = []
+
+        def fake_has_hook(name):
+            return name == "post_memory_write"
+
+        def fake_invoke_hook(name, **kwargs):
+            calls.append((name, kwargs))
+            return []
+
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", fake_has_hook)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+        result = store.add("memory", "stored fact")
+
+        assert result["success"] is True
+        assert calls == [("post_memory_write", {"action": "add", "target": "memory", "content": "stored fact", "store": store})]
+
     def test_add_exceeding_limit_rejected(self, store):
         # Fill up to near limit
         store.add("memory", "x" * 490)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -344,6 +344,23 @@ class MemoryStore:
         if scan_error:
             return {"success": False, "error": scan_error}
 
+        def _invoke_memory_hooks(stage: str, **extra: Any) -> list:
+            try:
+                from hermes_cli.plugins import has_hook, invoke_hook
+                if not has_hook("pre_memory_write"):
+                    return []
+                return invoke_hook(
+                    "pre_memory_write",
+                    action="add",
+                    target=target,
+                    content=content,
+                    store=self,
+                    stage=stage,
+                    **extra,
+                )
+            except Exception:
+                return []
+
         with self._file_lock(self._path_for(target)):
             # Re-read from disk under lock to pick up writes from other sessions.
             # For add (append-only), we skip the drift guard — appending never
@@ -356,7 +373,27 @@ class MemoryStore:
             entries = self._entries_for(target)
             limit = self._char_limit(target)
 
-            # Reject exact duplicates
+            for hook_result in _invoke_memory_hooks(
+                "before_add",
+                entries=list(entries),
+                limit=limit,
+                already_locked=True,
+            ):
+                if not isinstance(hook_result, dict):
+                    continue
+                action = hook_result.get("action")
+                if isinstance(hook_result.get("content"), str):
+                    content = hook_result["content"].strip()
+                    if not content:
+                        return {"success": False, "error": "Content cannot be empty."}
+                if action == "reject":
+                    response = hook_result.get("response")
+                    return response if isinstance(response, dict) else {"success": False, "error": hook_result.get("message", "Memory write rejected by plugin.")}
+                if action == "skip":
+                    return self._success_response(target, str(hook_result.get("message") or "Entry already exists (no duplicate added)."))
+
+            # Core keeps backward-compatible exact duplicate behavior. Plugins
+            # may add normalized/semantic duplicate policy via pre_memory_write.
             if content in entries:
                 return self._success_response(target, "Entry already exists (no duplicate added).")
 
@@ -366,7 +403,32 @@ class MemoryStore:
 
             if new_total > limit:
                 current = self._char_count(target)
-                return self._consolidation_failure({
+                retry_metadata: Dict[str, Any] = {}
+                for hook_result in _invoke_memory_hooks(
+                    "over_limit",
+                    entries=list(entries),
+                    limit=limit,
+                    current_chars=current,
+                    new_total=new_total,
+                    already_locked=True,
+                ):
+                    if isinstance(hook_result, dict):
+                        metadata = hook_result.get("response_metadata")
+                        if isinstance(metadata, dict):
+                            retry_metadata.update(metadata)
+                        if hook_result.get("action") == "retry":
+                            entries = self._entries_for(target)
+                            new_entries = entries + [content]
+                            new_total = len(ENTRY_DELIMITER.join(new_entries))
+                            if new_total <= limit:
+                                entries.append(content)
+                                self._set_entries(target, entries)
+                                self.save_to_disk(target)
+                                response = self._success_response(target, "Entry added after memory write hook retry.")
+                                response.update(retry_metadata)
+                                return response
+
+                result = self._consolidation_failure({
                     "success": False,
                     "error": (
                         f"Memory at {current:,}/{limit:,} chars. "
@@ -378,10 +440,19 @@ class MemoryStore:
                     "current_entries": entries,
                     "usage": f"{current:,}/{limit:,}",
                 })
+                result.update(retry_metadata)
+                return result
 
             entries.append(content)
             self._set_entries(target, entries)
             self.save_to_disk(target)
+
+        try:
+            from hermes_cli.plugins import has_hook, invoke_hook
+            if has_hook("post_memory_write"):
+                invoke_hook("post_memory_write", action="add", target=target, content=content, store=self)
+        except Exception:
+            pass
 
         return self._success_response(target, "Entry added.")
 


### PR DESCRIPTION
## What does this PR do?

Adds generic plugin lifecycle hooks around built-in memory additions:

- `pre_memory_write`
- `post_memory_write`

These hooks let plugins observe or govern writes to Hermes' built-in `MEMORY.md` / `USER.md` storage without replacing the memory backend.

Hermes plugins can currently register tools, commands, and several lifecycle hooks, but there is no supported extension point around memory writes. That leaves memory-governance plugins with only two options: run manually after the fact, or patch/monkey-patch `tools/memory_tool.py` out-of-band.

This PR provides a small, generic host-level hook so plugins can implement memory hygiene/governance through a stable extension point instead of modifying Hermes core files themselves.

Potential uses include:

- normalized duplicate prevention
- sensitive/secret memory rejection
- memory quality scoring
- deterministic safe cleanup on over-limit pressure
- audit metadata / sidecars
- post-write indexing or observability

The hooks are intentionally generic and do not depend on any specific memory-governance plugin.

## Related Issue

N/A — proposed extension point.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py`
  - Adds `pre_memory_write` and `post_memory_write` to `VALID_HOOKS`.

- `tools/memory_tool.py`
  - Invokes `pre_memory_write` inside `MemoryStore.add()` before exact duplicate handling.
  - Invokes `pre_memory_write` again when an add would exceed the memory character limit, allowing one deterministic cleanup/retry path.
  - Invokes `post_memory_write` after a successful add.
  - Keeps existing exact duplicate and over-limit behavior unchanged when no plugin hook is registered.
  - Preserves the existing `_consolidation_failure()` over-limit loop guard on failed retries.

- `tests/tools/test_memory_tool.py`
  - Adds tests for:
    - hook rejection
    - hook skip
    - over-limit retry
    - post-write invocation

## How to Test

1. Run the targeted memory tool tests using the project wrapper:

```bash
scripts/run_tests.sh tests/tools/test_memory_tool.py -q
```

2. Compile the changed files:

```bash
python -m py_compile hermes_cli/plugins.py tools/memory_tool.py tests/tools/test_memory_tool.py
```

3. Check the diff for whitespace issues and Windows footguns:

```bash
git diff --check origin/main..HEAD
python scripts/check-windows-footguns.py --diff origin/main
```

4. Optionally verify the hook names are available:

```bash
python - <<'PY'
from hermes_cli.plugins import VALID_HOOKS

assert 'pre_memory_write' in VALID_HOOKS
assert 'post_memory_write' in VALID_HOOKS

print('memory write hooks available')
PY
```

Local validation run:

```text
$ scripts/run_tests.sh tests/tools/test_memory_tool.py -q
87 tests passed, 0 failed

$ python -m py_compile hermes_cli/plugins.py tools/memory_tool.py tests/tools/test_memory_tool.py
# passed

$ git diff --check origin/main..HEAD
# passed

$ python scripts/check-windows-footguns.py --diff origin/main
✓ No Windows footguns found (3 file(s) scanned).

$ python -m pytest tests/ -q -x
FAILED tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback
# Same failure reproduced on clean origin/main and in a fresh official clone with .[all,dev].
```

I also ran the full `pytest tests/ -q` command locally. It fails before reaching the memory-tool tests with an order-dependent approval isolation failure that reproduces unchanged on clean `origin/main` in the same environment:

```text
FAILED tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback
```

Because that failure is present on upstream `main` and also reproduces in a fresh official clone installed with `.[all,dev]`, I have left the full-suite checkbox unchecked and kept this PR limited to the memory-hook change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing issues and PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

```text
$ scripts/run_tests.sh tests/tools/test_memory_tool.py -q
▶ running per-file parallel test suite via run_tests_parallel.py
Discovered 1 test files (~87 tests) under ['tests/tools/test_memory_tool.py']; running with -j 32
[100.0% |    87/~87 | ✓87 | ✗ 0] ✓ tests/tools/test_memory_tool.py (87✓, 1.1s)

=== Summary: 1 files, 87 tests passed, 0 failed (100% complete) in 1.1s (32 workers) ===

$ python scripts/check-windows-footguns.py --diff origin/main
✓ No Windows footguns found (3 file(s) scanned).

$ python -m pytest tests/ -q -x
FAILED tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback
# Same failure reproduced on clean origin/main and in a fresh official clone with .[all,dev].
```

## Safety / Compatibility Notes

- The hooks are fail-open: if hook lookup or invocation raises, memory writes continue with existing behavior.
- No plugin is required.
- The built-in memory backend is not replaced.
- Existing exact duplicate handling remains in core.
- `replace` and `remove` are untouched.
- The over-limit retry path only succeeds if a plugin has already reduced stored memory enough for the same add to fit; otherwise it falls back to the existing consolidation failure response path.
