### PR TITLE
fix(feishu): reply to quoted message in DM conversations

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -102,7 +102,7 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
+    if platform == "feishu" and getattr(event, "reply_to_message_id", None):
         return getattr(event, "reply_to_message_id", None)
     return getattr(event, "message_id", None)
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4944,3 +4944,65 @@ class TestChatLockEviction(unittest.TestCase):
                 held.release()
 
         asyncio.run(_run())
+
+# ── Feishu DM reply anchor regression test (#55750) ────────────────────
+
+from gateway.config import Platform
+
+
+def test_feishu_dm_reply_anchor_returns_reply_to_message_id():
+    """Feishu DM quote-reply should anchor to the quoted message.
+
+    Regression test for #55750: the original condition required
+    ``thread_id`` to be truthy, but Feishu DMs have ``thread_id=None``,
+    causing the reply to fall through to ``message_id`` (the bot's own
+    message) instead of the user's quoted message.
+    """
+    from gateway.platforms.base import _reply_anchor_for_event
+
+    event = SimpleNamespace(
+        message_id="bot_msg_001",
+        reply_to_message_id="user_quoted_msg_042",
+        source=SimpleNamespace(
+            platform=Platform.FEISHU,
+            chat_type="p2p",
+            thread_id=None,
+        ),
+    )
+
+    assert _reply_anchor_for_event(event) == "user_quoted_msg_042"
+
+
+def test_feishu_group_reply_anchor_returns_reply_to_message_id():
+    """Feishu group chat reply-to should also anchor correctly."""
+    from gateway.platforms.base import _reply_anchor_for_event
+
+    event = SimpleNamespace(
+        message_id="bot_msg_002",
+        reply_to_message_id="user_msg_099",
+        source=SimpleNamespace(
+            platform=Platform.FEISHU,
+            chat_type="group",
+            thread_id="thread_abc",
+        ),
+    )
+
+    assert _reply_anchor_for_event(event) == "user_msg_099"
+
+
+def test_feishu_dm_no_reply_returns_message_id():
+    """Feishu DM without quote-reply should fall back to message_id."""
+    from gateway.platforms.base import _reply_anchor_for_event
+
+    event = SimpleNamespace(
+        message_id="bot_msg_003",
+        reply_to_message_id=None,
+        source=SimpleNamespace(
+            platform=Platform.FEISHU,
+            chat_type="p2p",
+            thread_id=None,
+        ),
+    )
+
+    assert _reply_anchor_for_event(event) == "bot_msg_003"
+


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu DM quote-reply routing. When a user in a Feishu DM uses "quote and reply" on a message, the bot's response was sent as a standalone message instead of threading under the quoted message. The root cause was a `thread_id` guard in `_reply_anchor_for_event()` that is always `None` in DM context.

## Related Issue

Fixes #55750

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Remove `thread_id` requirement from the Feishu branch in `_reply_anchor_for_event()`. Feishu DMs have `thread_id=None`, so the condition `platform == "feishu" and thread_id and reply_to_message_id` always evaluated to `False` in DM context. The fix changes it to `platform == "feishu" and reply_to_message_id`, which correctly handles both DM and group chat scenarios.
- `tests/gateway/test_feishu.py`: Add 3 regression tests covering DM with quote-reply, group chat with thread, and DM without quote-reply fallback.

## How to Test

1. Run `pytest tests/gateway/test_feishu.py::test_feishu_dm_reply_anchor_returns_reply_to_message_id tests/gateway/test_feishu.py::test_feishu_group_reply_anchor_returns_reply_to_message_id tests/gateway/test_feishu.py::test_feishu_dm_no_reply_returns_message_id -v` — all 3 should pass
2. In Feishu DM: long-press a message → quote and reply → send text. The bot's response should appear threaded under the quoted message (not as a standalone message).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before (bug)**: Bot reply sent as standalone message, not anchored to user's quoted message:
```
inbound message: ... reply_to_id=om_xxx    # quote correctly received
Sending response (59 chars) to oc_xxx       # sent without reply_to
```

**After (fix)**: Bot reply threads under the user's quoted message using `reply_to_message_id`.

