### PR TITLE
fix(cli): strip ASCII control characters in save_env_value

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6706,7 +6706,7 @@ def save_env_value(key: str, value: str):
     if not _ENV_VAR_NAME_RE.match(key):
         raise ValueError(f"Invalid environment variable name: {key!r}")
     _reject_denylisted_env_var(key)
-    value = value.replace("\n", "").replace("\r", "")
+    value = "".join(ch for ch in value if not (ord(ch) <= 31 or ord(ch) == 127))
     # API keys / tokens must be ASCII — strip non-ASCII with a warning.
     value = _check_non_ascii_credential(key, value)
     ensure_hermes_home()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -313,6 +313,19 @@ class TestSaveEnvValueSecure:
             env_values = load_env()
             assert env_values["TENOR_API_KEY"] == "sk-test-secret"
 
+    def test_save_env_value_strips_ascii_control_characters(self, tmp_path):
+        """save_env_value must strip C0 controls (0x00-0x1f) and DEL (0x7f) from values."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            os.environ.pop("OPENAI_API_KEY", None)
+            # sk- + NUL + live + TAB + key + DEL + \nnext\r
+            dirty_value = "sk-" + chr(0) + "live" + chr(9) + "key" + chr(127) + "\nnext\r"
+            save_env_value("OPENAI_API_KEY", dirty_value)
+            
+            # Should have stripped NUL (0), TAB (9), DEL (127), \n (10), \r (13)
+            # Resulting value should be "sk-livekeynext"
+            assert os.environ["OPENAI_API_KEY"] == "sk-livekeynext"
+            assert load_env()["OPENAI_API_KEY"] == "sk-livekeynext"
+
     def test_secure_save_returns_metadata_only(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             result = save_env_value_secure("GITHUB_TOKEN", "ghp_test_secret")


### PR DESCRIPTION
## Summary

`save_env_value()` only removed `\\n` and `\\r` before writing credential values to `~/.hermes/.env`. Other ASCII control characters (C0 range, 0x00-0x1F, and DEL, 0x7F) could still be persisted.

- On Windows, saving a copied key containing a NUL byte causes `os.environ[key] = value` to crash with `ValueError: embedded null character`, leaving a partially written and dirty `.env` file.
- On other systems, control bytes such as TAB or DEL survive, resulting in confusing request authorization/header failures at request time.

## Fix

Strip all ASCII control characters (0x00-0x1F and 0x7F) from values in `save_env_value()` before performing other validations or writes. This also handles the previous `\\n` and `\\r` removal.

## Tests

Adds `test_save_env_value_strips_ascii_control_characters` to verify NUL, TAB, CR, LF, DEL, etc. are stripped cleanly from both process env and loaded env.

Fixes #55335