### PR TITLE
fix(memory): validate action parameter early with clear error messages

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -895,3 +895,36 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+# ── Action validation regression tests (#55755) ────────────────────────
+
+class TestMemoryToolActionValidation:
+    """Regression tests for #55755: invalid action should show actual value, not None."""
+
+    def test_none_action_returns_clear_error(self, tmp_path, monkeypatch):
+        """Calling memory_tool() with no action should produce a clear error."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore()
+        result = json.loads(memory_tool(action=None, store=store))
+        assert result["success"] is False
+        assert "Action is required" in result["error"]
+        assert "add, replace, remove" in result["error"]
+
+    def test_invalid_action_shows_actual_value(self, tmp_path, monkeypatch):
+        """Calling memory_tool(action='list') should show 'list' in the error, not None."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore()
+        result = json.loads(memory_tool(action="list", store=store))
+        assert result["success"] is False
+        assert "'list'" in result["error"]
+        assert "add, replace, remove" in result["error"]
+
+    def test_valid_actions_still_work(self, tmp_path, monkeypatch):
+        """Valid actions (add, replace, remove) should not be affected by the validation."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore()
+        # add
+        result = json.loads(memory_tool(action="add", content="test entry", store=store))
+        assert result["success"] is True
+

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -991,6 +991,13 @@ def memory_tool(
         return json.dumps(result, ensure_ascii=False)
 
     # --- Single-op path ---------------------------------------------------
+    # Validate action BEFORE checking required params so invalid/missing
+    # actions produce a clear error instead of falling through silently.
+    if action is None:
+        return tool_error("Action is required. Use: add, replace, remove", success=False)
+    if action not in {"add", "replace", "remove"}:
+        return tool_error(f"Unknown action '{action}'. Use: add, replace, remove", success=False)
+
     # Validate required params BEFORE the gate so an invalid write is rejected
     # immediately instead of being staged and only failing at approve time.
     if action == "add" and not content:


### PR DESCRIPTION
## What does this PR do?

Fixes confusing error messages when the memory tool receives an invalid or missing action parameter. Previously, calling memory(action='list') would produce 'Unknown action None' because the invalid action fell through to a catch-all else block.

## Related Issue

Fixes #55755

## Type of Change

- [x] Bug fix

## Changes Made

- tools/memory_tool.py: Add early validation for action parameter in memory_tool()
- tests/tools/test_memory_tool.py: Add 3 regression tests

## How to Test

1. Run pytest tests/tools/test_memory_tool.py::TestMemoryToolActionValidation -v
2. Call memory(action=list) - should show actual action value in error

## Checklist

- [x] Tests pass
- [x] Added regression tests