### PR TITLE
fix(model-picker): handle list-of-dict models: in provider config

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1958,8 +1958,14 @@ def list_authenticated_providers(
                         models_list.append(m)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                    # List entries are normally plain id strings, but hand-edited
+                    # configs sometimes use {id|model|name: ..., label: ...} dicts.
+                    # Extract the id so models_list stays a list[str]: every
+                    # downstream consumer (inventory dedup, capabilities, pricing)
+                    # assumes string ids and calls .lower() / uses them as keys.
+                    mid = (m.get("id") or m.get("model") or m.get("name") or "") if isinstance(m, dict) else m
+                    if mid and mid not in models_list:
+                        models_list.append(mid)
 
             # Official OpenAI API rows in providers: often have base_url but no
             # explicit models: dict — avoid a misleading zero count in /model.


### PR DESCRIPTION
## Summary

The desktop **model picker** was empty with `Error: 500: {"detail":"Failed to list model options"}` (Settings → Model and the composer dropdown). `GET /api/model/options` was throwing:

```
File hermes_cli/inventory.py, line 188, in build_models_payload
    user_models.update(m.lower() for m in (row.get("models") or []))
AttributeError: 'dict' object has no attribute 'lower'
```

## Root cause

`build_models_payload` and its downstream consumers (`inventory` dedup, `_apply_capabilities`, `_apply_pricing`) all assume each provider row's `models` is a `list[str]` of model ids — they call `m.lower()` and use the ids as dict keys.

`list_authenticated_providers` builds user-provider rows from `providers.<p>.models` in `config.yaml`. It handles two shapes (per its own comment): the **dict-keyed-by-id** form Hermes writes, and a plain **list-of-strings** form. But a hand-edited config using the **list-of-`{id, label}` dicts** form:

```yaml
providers:
  cerebras:
    models:
      - id: zai-glm-4.7
        label: GLM 4.7 (Cerebras)
```

fell into the `list` branch, which appended each entry **verbatim** — putting dicts into `models_list`, which then blew up every downstream `m.lower()` / `caps[model]`.

## Fix

In the `list` branch, extract the id (`id` → `model` → `name`) from dict entries so `models` stays a `list[str]` regardless of which config shape the user wrote. Plain-string entries are unchanged.

## Test plan

- [x] `build_models_payload(load_picker_context(), include_unconfigured=True, picker_hints=True, canonical_order=True, pricing=True, capabilities=True)` → returns **41 providers**, all `models` are strings, no `AttributeError`
- [x] user-defined rows now expose string ids, e.g. `cerebras → ['zai-glm-4.7', 'qwen-3-235b-a22b-instruct-2507', 'llama3.1-8b']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
