### PR TITLE
fix(google_meet): node-unavailable fallback crashes with NameError instead of printing its message

### DIFF
--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -88,12 +88,18 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
     try:
         from plugins.google_meet.node.cli import register_cli as _register_node_cli
         _register_node_cli(node_p)
-    except Exception as e:  # pragma: no cover — defensive
+    except Exception as e:
         # If the node module fails to import for any reason (optional dep
         # missing at import time etc.), leave the subparser present but
         # flag it. The argparse dispatch will surface a clear error.
+        # Capture the message into a regular local first: the ``except ... as
+        # e`` target is deleted when the block exits, so a closure that
+        # referenced ``e`` would raise NameError when invoked later instead of
+        # printing this fallback message.
+        _node_err = str(e)
+
         def _node_unavailable(args):
-            print(f"hermes meet node: module unavailable ({e})")
+            print(f"hermes meet node: module unavailable ({_node_err})")
             return 1
         node_p.set_defaults(func=_node_unavailable)
 

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -298,3 +298,39 @@ def test_cmd_install_refuses_windows(capsys):
     assert "Windows" in out
 
 
+
+
+
+
+# ---------------------------------------------------------------------------
+# `hermes meet node` fallback when the node submodule is unavailable
+# ---------------------------------------------------------------------------
+
+def test_node_unavailable_fallback_does_not_raise(monkeypatch, capsys):
+    """When the node CLI fails to register, the fallback must print a clear
+    message and return 1 - not crash with NameError.
+
+    Regression: the fallback closure referenced the ``except ... as e``
+    target, which Python deletes when the block exits, so invoking the
+    fallback later raised ``NameError: ... free variable 'e' ...`` instead of
+    surfacing the intended "module unavailable" message.
+    """
+    import argparse
+    import plugins.google_meet.node.cli as node_cli
+    from plugins.google_meet import cli as meet_cli
+
+    def _boom(*_a, **_k):
+        raise ImportError("simulated missing optional dependency")
+
+    monkeypatch.setattr(node_cli, "register_cli", _boom)
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    meet_cli.register_cli(parser)
+
+    args = parser.parse_args(["node"])
+    rc = args.func(args)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "module unavailable" in out
+    assert "simulated missing optional dependency" in out


### PR DESCRIPTION
### Summary

The `hermes meet node` subcommand installs a defensive fallback when the node submodule fails to import:

```python
except Exception as e:  # pragma: no cover — defensive
    def _node_unavailable(args):
        print(f"hermes meet node: module unavailable ({e})")
        return 1
    node_p.set_defaults(func=_node_unavailable)
```

The closure references `e`, the `except ... as e` target. Python deletes that target when the except block exits, so `e` becomes an unbound free variable in the closure. When argparse later dispatches to `_node_unavailable` (exactly the situation the fallback exists for), it raises `NameError: cannot access free variable 'e' ...` instead of printing the intended "module unavailable" message and returning 1.

### Reproduction

```python
def build():
    try:
        raise ImportError("boom")
    except Exception as e:
        def _node_unavailable(args):
            return f"module unavailable ({e})"
        return _node_unavailable

build()(None)
# NameError: cannot access free variable 'e' where it is not associated with a value
```

### Fix

Capture the message into a regular local (`_node_err = str(e)`) before defining the closure, so it survives the block exit. The `# pragma: no cover` is dropped since the path is now tested.

### Tests

Adds a regression test that forces the node CLI registration to fail, dispatches `node`, and asserts the fallback returns 1 and prints the message. It raised `NameError` before the change and passes after.

Fixes #55774
