### PR TITLE
fix(desktop): refresh session list after worktree creation in sidebar

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -693,10 +693,19 @@ export function DesktopController() {
             restoreWorktree(resolved)
             void followActiveSessionCwd(resolved)
           }
+
+          // After a worktree is created via the sidebar fork button, the
+          // backend session tree is stale. When the project already has
+          // sessions the overlay masks the staleness (leading to the
+          // duplicate-lane bug fixed separately); when the project has ZERO
+          // sessions the stale tree is empty and the sidebar renders nothing
+          // until an unrelated event triggers a refresh. Kick a session-list
+          // refresh so the new worktree session appears at once.
+          void refreshSessions().catch(() => undefined)
         })
         .catch(() => undefined)
     },
-    [requestGateway, startFreshSessionDraft]
+    [refreshSessions, requestGateway, startFreshSessionDraft]
   )
 
   // Composer "branch off into a new worktree": the composer already created the


### PR DESCRIPTION
## What does this PR do?

Fixes sidebar showing nothing after creating a worktree via the fork button in project mode with zero existing sessions.

The root cause is that `startSessionInWorkspace` in `desktop-controller.tsx` never calls `refreshSessions()` after the gateway RPC resolves. With existing sessions the overlay masks the stale backend tree (leading to the duplicate-lane bug fixed in #55736); with **zero** sessions the stale tree is empty and the sidebar renders nothing until an unrelated event triggers a refresh.

## Related Issue

Fixes #55762

Complements #55736 (which fixes the duplicate-lane symptom at the overlay layer — a different file, no conflict).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/desktop-controller.tsx`: added `refreshSessions()` call in `startSessionInWorkspace` after the worktree restore, and added `refreshSessions` to the `useCallback` dependency array.

## How to Test

1. Open Desktop sidebar in project mode, enter a git repo workspace
2. Ensure the project has **zero sessions** (fresh project or all archived/deleted)
3. Click the fork button (repo-forked icon) in the workspace group header
4. Sidebar should immediately show the new worktree group with the session — not a blank list

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Typecheck passes (`tsc --noEmit` in `apps/desktop`)
- [x] Related tests pass (workspace-groups.test.ts, desktop-controller-utils.test.ts)
- [ ] I've added tests for my changes — the fix is a single `refreshSessions()` call in a React callback that requires the full `DesktopController` component tree to test; the overlay-level behavior is already covered by existing tests
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] N/A — no documentation or config changes needed