### PR TITLE
fix(gateway): classify extensionless text uploads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1547,6 +1547,20 @@ def _resolve_media_ext(filename: str, mime_type: str) -> str:
     return ""
 
 
+def _looks_like_text_document(data: bytes) -> bool:
+    """Return True when extensionless bytes look like a plain UTF-8 text upload."""
+    if not data or b"\x00" in data:
+        return False
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    if not text.strip():
+        return False
+    control_chars = sum(1 for ch in text if ord(ch) < 32 and ch not in "\r\n\t")
+    return control_chars == 0
+
+
 def cache_media_bytes(
     data: bytes,
     *,
@@ -1604,12 +1618,17 @@ def cache_media_bytes(
     # uploads. Known extensions keep their precise MIME; everything else is
     # tagged application/octet-stream (or the caller-supplied MIME) so the
     # agent knows it's an arbitrary file and reaches for terminal tools.
-    fallback_name = filename or (f"document{ext}" if ext else "document.bin")
-    path = cache_document_from_bytes(data, fallback_name)
-    if ext in SUPPORTED_DOCUMENT_TYPES:
-        out_mime = SUPPORTED_DOCUMENT_TYPES[ext]
+    if not filename and not mime and not ext and _looks_like_text_document(data):
+        fallback_name = "document.txt"
+        out_mime = "text/plain"
+        display = fallback_name
     else:
-        out_mime = mime if mime else "application/octet-stream"
+        fallback_name = filename or (f"document{ext}" if ext else "document.bin")
+        if ext in SUPPORTED_DOCUMENT_TYPES:
+            out_mime = SUPPORTED_DOCUMENT_TYPES[ext]
+        else:
+            out_mime = mime if mime else "application/octet-stream"
+    path = cache_document_from_bytes(data, fallback_name)
     return CachedMedia(to_agent_visible_cache_path(path), out_mime, "document", display or fallback_name)
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1684,6 +1684,9 @@ class MessageEvent:
     # media_urls: local file paths (for vision tool access)
     media_urls: List[str] = field(default_factory=list)
     media_types: List[str] = field(default_factory=list)
+    # Whether each text attachment was actually inlined into ``text``.
+    # Legacy adapters leave this empty; cached-only paths set False explicitly.
+    media_text_inlined: List[bool] = field(default_factory=list)
     
     # Reply context
     reply_to_message_id: Optional[str] = None
@@ -1985,6 +1988,7 @@ def merge_pending_message_event(
         if existing_is_photo and incoming_is_photo:
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
+            existing.media_text_inlined.extend(getattr(event, "media_text_inlined", []))
             if event.text:
                 existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
             return
@@ -1993,6 +1997,7 @@ def merge_pending_message_event(
             if incoming_has_media:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
+                existing.media_text_inlined.extend(getattr(event, "media_text_inlined", []))
             if event.text:
                 if existing.text:
                     existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1888,23 +1888,30 @@ def _build_media_placeholder(event) -> str:
     return "\n".join(parts)
 
 
-def _build_document_context_note(display_name: str, agent_path: str, mtype: str) -> str:
+def _build_document_context_note(
+    display_name: str,
+    agent_path: str,
+    mtype: str,
+    *,
+    text_inlined: bool = True,
+) -> str:
     """Context note prepended to a user turn when they attach a document.
 
-    Text documents (``text/*``) have their content inlined upstream by the
-    platform adapter, so the note just confirms that and records the path.
-
-    Binary documents (PDF, DOCX, XLSX, …) cannot be inlined as text. The note
-    must tell the agent to *extract* the text itself before answering — earlier
-    wording ("Ask the user what they'd like you to do with it") steered the
-    model into punting back to the user, which is why attached PDFs/DOCX looked
-    "unreadable" to the agent even though it has the tools to read them.
+    ``text_inlined`` distinguishes text MIME from text content actually added
+    to the event. Cached-only text must point the agent at the file instead of
+    claiming that its content appears in the prompt.
     """
-    if mtype.startswith("text/"):
+    if mtype.startswith("text/") and text_inlined:
         return (
             f"[The user sent a text document: '{display_name}'. "
             f"Its content has been included below. "
             f"The file is also saved at: {agent_path}]"
+        )
+    if mtype.startswith("text/"):
+        return (
+            f"[The user sent a text document: '{display_name}'. "
+            f"It is saved at: {agent_path}, but its content was not inlined. "
+            f"Read the file before answering instead of asking the user to paste it.]"
         )
     return (
         f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
@@ -9535,7 +9542,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
                 agent_path = to_agent_visible_cache_path(path)
 
-                context_note = _build_document_context_note(display_name, agent_path, mtype)
+                inline_flags = getattr(event, "media_text_inlined", None) or []
+                # Older adapters may inline text without the signal; new
+                # cached-only paths explicitly set False.
+                text_inlined = inline_flags[i] if i < len(inline_flags) else True
+                context_note = _build_document_context_note(
+                    display_name, agent_path, mtype, text_inlined=text_inlined
+                )
                 message_text = f"{context_note}\n\n{message_text}"
 
         # Discord: surface the triggering message id per-turn on the user

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -75,7 +75,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_audio_from_bytes,
     cache_video_from_bytes,
-    cache_document_from_bytes,
+    cache_media_bytes,
     resolve_proxy_url,
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
@@ -6408,6 +6408,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event.media_urls = [cached.path]
         event.media_types = [cached.media_type]
+        event.media_text_inlined = [False]
         if cached.kind == "image":
             event.message_type = MessageType.PHOTO
         elif cached.kind == "video":
@@ -6450,6 +6451,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event.media_urls.append(cached.path)
         event.media_types.append(cached.media_type)
+        event.media_text_inlined.append(False)
         if len(event.media_urls) == 1:
             if cached.kind == "image":
                 event.message_type = MessageType.PHOTO
@@ -6841,6 +6843,7 @@ class TelegramAdapter(BasePlatformAdapter):
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
+                existing.media_text_inlined.extend(event.media_text_inlined)
 
         # Cancel any pending flush and restart the timer
         prior_task = self._pending_text_batch_tasks.get(key)
@@ -6933,6 +6936,7 @@ class TelegramAdapter(BasePlatformAdapter):
         else:
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
+            existing.media_text_inlined.extend(event.media_text_inlined)
             if event.text:
                 existing.text = self._merge_caption(existing.text, event.text)
 
@@ -7181,11 +7185,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 file_obj = await doc.get_file()
                 doc_bytes = await file_obj.download_as_bytearray()
                 raw_bytes = bytes(doc_bytes)
-                cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext or '.bin'}")
-                mime_type = SUPPORTED_DOCUMENT_TYPES.get(ext) or doc.mime_type or "application/octet-stream"
-                event.media_urls = [cached_path]
-                event.media_types = [mime_type]
-                logger.info("[Telegram] Cached user document at %s (%s)", cached_path, mime_type)
+                cached = cache_media_bytes(
+                    raw_bytes,
+                    filename=original_filename,
+                    mime_type=doc_mime,
+                    default_kind="document",
+                )
+                if cached is None:
+                    raise ValueError("document bytes could not be cached")
+                event.media_urls = [cached.path]
+                event.media_types = [cached.media_type]
+                event.media_text_inlined = [False]
+                logger.info("[Telegram] Cached user document at %s (%s)", cached.path, cached.media_type)
 
                 # For text-readable files, inject content into event.text (capped
                 # at 100 KB). Gate on a text-like extension/MIME — NOT a blind
@@ -7193,7 +7204,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 # decodable ASCII headers. Binary files are surfaced as a cached
                 # path only (run.py emits a path-pointing context note).
                 MAX_TEXT_INJECT_BYTES = 100 * 1024
-                _is_text = ext in _TEXT_INJECT_EXTENSIONS or (doc_mime or "").startswith("text/")
+                _is_text = (
+                    ext in _TEXT_INJECT_EXTENSIONS
+                    or (doc_mime or "").startswith("text/")
+                    or cached.media_type.startswith("text/")
+                )
                 if _is_text and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
                     try:
                         text_content = raw_bytes.decode("utf-8")
@@ -7204,6 +7219,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             event.text = f"{injection}\n\n{event.text}"
                         else:
                             event.text = injection
+                        event.media_text_inlined[0] = True
                     except UnicodeDecodeError:
                         # Binary file — agent has the cached path and can use
                         # terminal/read_file against it. No inline injection.
@@ -7237,6 +7253,7 @@ class TelegramAdapter(BasePlatformAdapter):
         else:
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
+            existing.media_text_inlined.extend(event.media_text_inlined)
             if event.text:
                 existing.text = self._merge_caption(existing.text, event.text)
 

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -218,6 +218,27 @@ class TestCacheMediaBytes:
         assert result.kind == "document"
         assert result.media_type == "text/csv"
 
+    def test_extensionless_utf8_upload_is_cached_as_text_document(self):
+        from gateway.platforms.base import cache_media_bytes
+
+        result = cache_media_bytes(b"hello\nsecond line\n", filename="", mime_type="")
+
+        assert result is not None
+        assert result.kind == "document"
+        assert result.media_type == "text/plain"
+        assert result.path.endswith(".txt")
+        assert Path(result.path).read_text() == "hello\nsecond line\n"
+
+    def test_extensionless_binary_upload_stays_octet_stream_document(self):
+        from gateway.platforms.base import cache_media_bytes
+
+        result = cache_media_bytes(b"\x00\xff\x00", filename="", mime_type="")
+
+        assert result is not None
+        assert result.kind == "document"
+        assert result.media_type == "application/octet-stream"
+        assert result.path.endswith(".bin")
+
     def test_unknown_document_cached_as_octet_stream(self):
         """Unknown file types are cached (not dropped) so the agent can inspect them.
 

--- a/tests/gateway/test_document_context_note.py
+++ b/tests/gateway/test_document_context_note.py
@@ -27,6 +27,14 @@ class TestTextDocumentNote:
         assert "/cache/doc_notes.txt" in note
         assert "included below" in note
 
+    def test_cached_only_text_note_requires_reading_the_file(self):
+        note = _build_document_context_note(
+            "document.txt", "/cache/document.txt", "text/plain", text_inlined=False
+        )
+        assert "content has been included below" not in note
+        assert "/cache/document.txt" in note
+        assert "read" in note.lower()
+
 
 class TestBinaryDocumentNote:
     @pytest.mark.parametrize(

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -219,6 +219,24 @@ class TestDocumentDownloadBlock:
         assert "[Content of notes.txt]" in event.text
 
     @pytest.mark.asyncio
+    async def test_extensionless_utf8_document_is_cached_and_inlined(self, adapter):
+        content = b"hello\nsecond line\n"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name="", mime_type="", file_size=len(content), file_obj=file_obj
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+
+        assert event.media_types == ["text/plain"]
+        assert event.media_urls[0].endswith(".txt")
+        assert "hello\nsecond line" in event.text
+        assert event.media_text_inlined == [True]
+
+    @pytest.mark.asyncio
     async def test_supported_md_injects_content(self, adapter):
         content = b"# Title\nSome markdown"
         file_obj = _make_file_obj(content)


### PR DESCRIPTION
## What does this PR do?

This PR fixes handling for extensionless plain-text uploads in the gateway media cache.

Some messaging platforms can deliver file uploads without a filename or MIME type. Before this change, those uploads were cached as generic `application/octet-stream` documents, even when the bytes were clearly UTF-8 text. That made plain-text attachments harder for the agent to inspect.

This change adds a conservative UTF-8 text sniffing path for attachments with:

- no filename
- no MIME type
- no resolved extension

When the bytes look like plain UTF-8 text, the upload is cached as `document.txt` with `text/plain`. Binary extensionless uploads still remain `application/octet-stream` documents.

## Related Issue

No existing issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`
  - Added `_looks_like_text_document()` to conservatively detect UTF-8 plain-text bytes.
  - Updated `cache_media_bytes()` so extensionless text uploads with no MIME type are cached as `document.txt` / `text/plain`.
  - Kept extensionless binary uploads as `document.bin` / `application/octet-stream`.

- `tests/gateway/test_document_cache.py`
  - Added regression coverage for extensionless UTF-8 text uploads.
  - Added coverage to ensure extensionless binary uploads are not misclassified as text.

## How to Test

1. Run the gateway document cache tests:

   bash
   python -m pytest tests/gateway/test_document_cache.py -q
   
2. Confirm extensionless UTF-8 uploads are cached as text documents:

   text
   filename=""
   mime_type=""
   data=b"hello\nsecond line\n"
   
   Expected result:

   text
   kind=document
   media_type=text/plain
   path ends with .txt
   
3. Confirm extensionless binary uploads remain generic binary documents:

   text
   filename=""
   mime_type=""
   data=b"\x00\xff\x00"
   
   Expected result:

   text
   kind=document
   media_type=application/octet-stream
   path ends with .bin
   
## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Oracle Linux / Linux 6.12.0 aarch64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Tested with:

bash
python -m pytest tests/gateway/test_document_cache.py -q

Result:

text
35 passed in 0.43s