### PR TITLE
fix(desktop): clear stuck compaction overlay and de-dupe terminal tool-title verb (#55775)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getSession } from '@/hermes'
 import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { $compactingSessions, setSessionCompacting } from '@/store/compaction'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
 import { $notifications, clearNotifications } from '@/store/notifications'
@@ -4119,6 +4120,35 @@ describe('usePromptActions busy-gateway churn tolerance (#64327)', () => {
 
     expect(await submitting).toBe(false)
     expect(calls.some(c => c.method === 'prompt.submit')).toBe(false)
+  })
+})
+
+describe('usePromptActions cancelRun', () => {
+  afterEach(() => {
+    cleanup()
+    $compactingSessions.set({})
+    vi.restoreAllMocks()
+  })
+
+  it('clears a stuck compaction overlay so Stop dismisses "Summarizing thread"', async () => {
+    // A hung compaction never emits message.start/complete/error, so the
+    // per-session compacting flag (and its overlay) sticks. Stop is the user's
+    // only recourse and must clear it.
+    setSessionCompacting(RUNTIME_SESSION_ID, true)
+    expect($compactingSessions.get()[RUNTIME_SESSION_ID]).toBe(true)
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.cancelRun()
+
+    expect($compactingSessions.get()[RUNTIME_SESSION_ID]).toBeUndefined()
+    expect(requestGateway).toHaveBeenCalledWith('session.interrupt', { session_id: RUNTIME_SESSION_ID })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getSession } from '@/hermes'
 import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { $compactingSessions, setSessionCompacting } from '@/store/compaction'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
 import { $hudMode } from '@/store/hud'
@@ -4766,6 +4767,35 @@ describe('usePromptActions submit entry-time runtime ownership proof (#64789/#65
     expect(
       calls.find(c => c.method === 'prompt.submit' && c.params?.session_id === RUNTIME_SESSION_B_RESUMED)
     ).toBeDefined()
+  })
+})
+
+describe('usePromptActions cancelRun', () => {
+  afterEach(() => {
+    cleanup()
+    $compactingSessions.set({})
+    vi.restoreAllMocks()
+  })
+
+  it('clears a stuck compaction overlay so Stop dismisses "Summarizing thread"', async () => {
+    // A hung compaction never emits message.start/complete/error, so the
+    // per-session compacting flag (and its overlay) sticks. Stop is the user's
+    // only recourse and must clear it.
+    setSessionCompacting(RUNTIME_SESSION_ID, true)
+    expect($compactingSessions.get()[RUNTIME_SESSION_ID]).toBe(true)
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.cancelRun()
+
+    expect($compactingSessions.get()[RUNTIME_SESSION_ID]).toBeUndefined()
+    expect(requestGateway).toHaveBeenCalledWith('session.interrupt', { session_id: RUNTIME_SESSION_ID })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -12,6 +12,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { setMutableRef } from '@/lib/mutable-ref'
 import { normalize } from '@/lib/text'
 import { clearClarifyRequest } from '@/store/clarify'
+import { setSessionCompacting } from '@/store/compaction'
 import {
   $composerAttachments,
   type ComposerAttachment,
@@ -619,6 +620,11 @@ export function usePromptActions({
     clearSessionSubagents(sessionId)
     resetSessionBackground(sessionId)
     setSessionDraftingTool(sessionId, '')
+    // Auto-compaction sets a per-session flag that only clears on message.start
+    // / message.complete / error. A hung compaction emits none of those, so the
+    // "Summarizing thread" overlay sticks and Stop is the user's only recourse —
+    // clear it here too so cancelling actually dismisses the panel.
+    setSessionCompacting(sessionId, false)
     // Stop ends the turn, so the gateway is no longer blocked on any prompt it
     // raised. Drop this session's pending clarify / approval / sudo / secret so
     // a dead panel (and the sidebar "needs input" dot) can't linger and accept

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -12,6 +12,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { setMutableRef } from '@/lib/mutable-ref'
 import { normalize } from '@/lib/text'
 import { clearClarifyRequest } from '@/store/clarify'
+import { setSessionCompacting } from '@/store/compaction'
 import {
   $composerAttachments,
   type ComposerAttachment,
@@ -686,6 +687,11 @@ export function usePromptActions({
     clearSessionSubagents(sessionId)
     resetSessionBackground(sessionId)
     setSessionDraftingTool(sessionId, '')
+    // Auto-compaction sets a per-session flag that only clears on message.start
+    // / message.complete / error. A hung compaction emits none of those, so the
+    // "Summarizing thread" overlay sticks and Stop is the user's only recourse —
+    // clear it here too so cancelling actually dismisses the panel.
+    setSessionCompacting(sessionId, false)
     // Stop ends the turn, so the gateway is no longer blocked on any prompt it
     // raised. Drop this session's pending clarify / approval / sudo / secret so
     // a dead panel (and the sidebar "needs input" dot) can't linger and accept

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -362,6 +362,27 @@ describe('buildToolView title actions', () => {
     expect(view.detail).toBe('')
   })
 
+  it('does not double the action verb when the context already starts with it', () => {
+    // A model-authored `context` that opens with the same verb the template
+    // prepends ("Running grep …") otherwise renders as "Running Running grep …".
+    const view = buildToolView(
+      part({
+        args: { context: 'Running grep -rn -i "bedrock" ~/.hermes/' },
+        result: undefined,
+        toolName: 'terminal'
+      }),
+      ''
+    )
+
+    expect(view.title.startsWith('Running Running')).toBe(false)
+    expect(view.title).toBe('Running grep -rn -i "bedrock" ~/.hermes/')
+    expect(view.titleAction).toEqual({
+      prefix: '',
+      text: 'Running',
+      suffix: ' grep -rn -i "bedrock" ~/.hermes/'
+    })
+  })
+
   it('uses the runtime locale for title text and action placement', () => {
     setRuntimeI18nLocale('ja')
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -1306,6 +1306,22 @@ function titlePartsFromAction(title: string, action?: string): ToolTitleParts {
   }
 }
 
+// A model-authored terminal `context`/`preview` sometimes already opens with
+// the verb the title template prepends ("Running grep …"), which renders as a
+// doubled "Running Running grep …". Drop a leading word that matches the action
+// we're about to prefix so the verb appears once.
+function withoutLeadingAction(value: string, action: string): string {
+  const verb = action.trim()
+  const text = value.trimStart()
+  const boundary = text.search(/\s/)
+
+  if (!verb || boundary < 0) {
+    return value
+  }
+
+  return text.slice(0, boundary).toLowerCase() === verb.toLowerCase() ? text.slice(boundary + 1).trimStart() : value
+}
+
 function dynamicTitle(
   part: ToolPart,
   args: Record<string, unknown>,
@@ -1389,7 +1405,7 @@ function dynamicTitle(
         translateNow(
           'assistant.tool.titleTemplates.actionCommand',
           action,
-          compactPreview(summarizeShellCommand(command), 160)
+          withoutLeadingAction(compactPreview(summarizeShellCommand(command), 160), action)
         )
       )
     }


### PR DESCRIPTION
## What does this PR do?

Fixes the two desktop UI defects reported in #55775, both stemming from frontend logic (not the minified bundle):

1. **"Running Running" tool-title duplication.** A pending `terminal`/`execute_code` row builds its title as `"<verb> <command>"` (`Running grep …`). The displayed command is taken from the tool's `context`/`preview` field, which a model often writes as a human phrase that *already* starts with the same verb (`context: "Running grep …"`). The template then prepends `Running` a second time → `Running Running grep …`. Fixed by dropping a leading word that matches the action verb before prefixing it.

2. **Stuck "Summarizing thread" overlay.** The per-session auto-compaction flag is set on `status.update {kind: compacting}` and only cleared on `message.start` / `message.complete` / `error`. When the compaction worker hangs (the issue's `slash_worker` stuck ~6 min at zero CPU after a non-retryable provider error), none of those events fire, so the overlay persists indefinitely and **Stop** is the user's only recourse — but `cancelRun` cleared todos/subagents/background/prompts and never cleared the compaction flag. Fixed by clearing it alongside the other per-session resets in `cancelRun`.

The deeper cause of the worker hang itself (a `slash_worker` child not being reaped) is a separate backend concern and out of scope here; this PR makes the desktop UI recover correctly — the overlay clears on completion/failure as before, and now also when the user stops a hung turn.

## Related Issue

Fixes #55775

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/tool/fallback-model.ts` — add `withoutLeadingAction()` and apply it to the terminal/`execute_code` command summary in `dynamicTitle` so the action verb isn't doubled.
- `apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts` — test that a `context` starting with `Running` renders a single verb.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts` — `cancelRun` now calls `setSessionCompacting(sessionId, false)`.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx` — test that Stop clears a stuck compaction flag.

## How to Test

```
cd apps/desktop
npx vitest run --environment jsdom \
  src/components/assistant-ui/tool/fallback-model.test.ts \
  src/app/session/hooks/use-prompt-actions/index.test.tsx
```

Result: the two new tests pass (`does not double the action verb when the context already starts with it`, `clears a stuck compaction overlay so Stop dismisses "Summarizing thread"`).

Note: two unrelated `buildToolView browser_navigate title` tests fail on `upstream/main` independently of this change (they assert `hostnameOf` strips the URL path; verified failing on a clean checkout without this PR's edits). They touch no code in this PR.

`npm run lint` and `npm run typecheck` are clean for the changed files; `scripts/check-windows-footguns.py --diff upstream/main` passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (desktop TypeScript only; ran the affected vitest files instead)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no behavior/docs surface changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — UI string/state logic, platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
