### PR TITLE
fix(yuanbao): await the loading heartbeat (coroutine was created and discarded)

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -2160,7 +2160,7 @@ class ForwardedRecordsParseMiddleware(InboundMiddleware):
     async def handle(self, ctx: InboundContext, next_fn) -> None:
         try:
             if ctx.forwarded_records:
-                self._send_loading_heartbeat(ctx)
+                await self._send_loading_heartbeat(ctx)
                 ctx.raw_text = self.build_forward_text(ctx.forwarded_records, ctx=ctx, is_dispatch=True)
         except Exception as exc:
             # Degrade gracefully: leave ctx.raw_text as-is.

--- a/tests/test_yuanbao_pipeline.py
+++ b/tests/test_yuanbao_pipeline.py
@@ -1346,3 +1346,44 @@ class TestPatchAnchorsMiddleware:
         )
         assert out == text
 
+
+
+# ============================================================
+# ForwardedRecordsParseMiddleware: loading heartbeat must be awaited
+# ============================================================
+
+class TestForwardedRecordsLoadingHeartbeat:
+    """The RUNNING heartbeat coroutine must actually be awaited.
+
+    Regression: ``handle`` called ``self._send_loading_heartbeat(ctx)``
+    without ``await``, so the coroutine was created and discarded - the
+    loading bubble never showed and Python logged "coroutine ... was never
+    awaited".
+    """
+
+    @pytest.mark.asyncio
+    async def test_loading_heartbeat_is_awaited(self):
+        from gateway.platforms.yuanbao import ForwardedRecordsParseMiddleware
+
+        adapter = make_adapter()
+        hb = AsyncMock()
+        adapter._outbound = MagicMock()
+        adapter._outbound.heartbeat.send_heartbeat_once = hb
+
+        ctx = make_ctx(
+            adapter=adapter,
+            forwarded_records=[{"any": "record"}],
+            chat_id="direct:alice",
+        )
+
+        ran = {"next": 0}
+
+        async def next_fn():
+            ran["next"] += 1
+
+        await ForwardedRecordsParseMiddleware()(ctx, next_fn)
+
+        # The coroutine must have been awaited (heartbeat actually sent),
+        # not created-and-discarded.
+        hb.assert_awaited()
+        assert ran["next"] == 1


### PR DESCRIPTION
### Summary

`ForwardedRecordsParseMiddleware.handle` calls `self._send_loading_heartbeat(ctx)` without `await`:

```python
async def handle(self, ctx, next_fn):
    try:
        if ctx.forwarded_records:
            self._send_loading_heartbeat(ctx)        # <-- missing await
            ctx.raw_text = self.build_forward_text(...)
    ...
```

`_send_loading_heartbeat` is an `async` coroutine that awaits a real WS send:

```python
@staticmethod
async def _send_loading_heartbeat(ctx) -> None:
    try:
        await ctx.adapter._outbound.heartbeat.send_heartbeat_once(ctx.chat_id, WS_HEARTBEAT_RUNNING)
    except Exception:
        pass
```

Because the call isn't awaited, the coroutine is created and immediately discarded — the RUNNING heartbeat (the loading bubble) is never sent, and Python logs `RuntimeWarning: coroutine 'ForwardedRecordsParseMiddleware._send_loading_heartbeat' was never awaited` on every forwarded-records message.

### Fix

`await self._send_loading_heartbeat(ctx)`. `handle` is already a coroutine, so awaiting is valid.

### Tests

Adds a regression test that drives `handle` with `forwarded_records` set and a mocked heartbeat, asserting the heartbeat coroutine is awaited (sent). Before the change the test fails and emits the "never awaited" warning; after, it passes.

Fixes #55784
