### PR TITLE
fix(stt): register elevenlabs as a built-in transcription provider

### DIFF
--- a/agent/transcription_registry.py
+++ b/agent/transcription_registry.py
@@ -11,8 +11,8 @@ the configured ``stt.provider`` name is not a built-in.
 Built-ins-always-win
 --------------------
 Plugin names that collide with a built-in STT provider (``local``,
-``local_command``, ``groq``, ``openai``, ``mistral``, ``xai``) are
-rejected at registration with a warning. This invariant is also
+``local_command``, ``groq``, ``openai``, ``mistral``, ``xai``,
+``elevenlabs``) are rejected at registration with a warning. This invariant is also
 re-checked at dispatch time in
 :func:`tools.transcription_tools._dispatch_to_plugin_provider`.
 """
@@ -44,6 +44,7 @@ _BUILTIN_NAMES = frozenset({
     "openai",
     "mistral",
     "xai",
+    "elevenlabs",
 })
 
 

--- a/tests/agent/test_transcription_registry.py
+++ b/tests/agent/test_transcription_registry.py
@@ -91,7 +91,7 @@ class TestRegistration:
 
     @pytest.mark.parametrize(
         "builtin",
-        ["local", "local_command", "groq", "openai", "mistral", "xai"],
+        ["local", "local_command", "groq", "openai", "mistral", "xai", "elevenlabs"],
     )
     def test_rejects_builtin_shadow_with_warning(self, builtin, caplog):
         p = _FakeProvider(name=builtin)

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -229,7 +229,7 @@ def _try_lazy_install_stt() -> bool:
     return False
 
 
-# Names of the 6 STT providers with native handlers in this module.
+# Names of the 7 STT providers with native handlers in this module.
 # Kept in sync with ``agent.transcription_registry._BUILTIN_NAMES`` —
 # a regression test fails if they drift. The plugin hook from
 # issue #30398-style follow-up rejects plugins registering under any
@@ -242,6 +242,7 @@ BUILTIN_STT_PROVIDERS = frozenset({
     "openai",
     "mistral",
     "xai",
+    "elevenlabs",
 })
 
 


### PR DESCRIPTION
## What does this PR do?

`elevenlabs` is a fully-implemented **native** STT provider in
`tools/transcription_tools.py` — it has a dedicated handler
(`_transcribe_elevenlabs`), an explicit branch in `transcribe_audio`, and an
auto-detect branch — but it was missing from both registries of built-in
provider names:

- `BUILTIN_STT_PROVIDERS` in `tools/transcription_tools.py`
- `_BUILTIN_NAMES` in `agent/transcription_registry.py`

Because of the omission, the **built-ins-always-win** invariant did not hold
for `elevenlabs`:

- `register_provider()` only rejects names found in `_BUILTIN_NAMES`. Since
  `elevenlabs` wasn't there, a plugin registering under the name `elevenlabs`
  was silently accepted into the registry — yet `transcribe_audio` always
  routes `elevenlabs` to the native handler, so the plugin could never run.
  The collision the guard exists to warn about went undetected.
- `_get_named_stt_provider_config` / `_iter_command_stt_providers` treated
  `stt.providers.elevenlabs` as a user-declared *command* provider rather than
  a built-in.

The existing drift-guard test passed only because **both** sets were missing
the name in the same way (it asserts the two sets are equal, not that they
contain the right names). The hardcoded shadow-rejection parametrization also
only listed 6 of the 7 native handlers, so it never exercised `elevenlabs`.

## Related Issue

No existing issue — found via a code audit of the STT dispatch path. Happy to
open one first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/transcription_tools.py` — add `"elevenlabs"` to `BUILTIN_STT_PROVIDERS` (now 7 native handlers); fix the stale "6 providers" comment.
- `agent/transcription_registry.py` — add `"elevenlabs"` to `_BUILTIN_NAMES`; update the docstring's built-in list.
- `tests/agent/test_transcription_registry.py` — add `"elevenlabs"` to the `test_rejects_builtin_shadow_with_warning` parametrization (this case fails without the fix).

## How to Test

1. `scripts/run_tests.sh tests/agent/test_transcription_registry.py -q` → all pass.
2. Regression proof: revert either set change and the new `elevenlabs`
   parametrize case fails — `register_provider(_FakeProvider(name="elevenlabs"))`
   is accepted instead of being rejected with the "shadows a built-in name"
   warning, so `get_provider("elevenlabs")` returns the plugin.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(stt):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] Affected test module passes — `tests/agent/test_transcription_registry.py` (28 passed). The full 17k-test suite wasn't run locally.
- [x] I've added a test (the shadow-rejection case now covers `elevenlabs`)
- [x] I've tested on my platform: Ubuntu (WSL2)

### Documentation & Housekeeping

- [x] Updated docstrings/comments listing the built-in providers
- [x] No config keys changed — N/A for `cli-config.yaml.example`
- [x] No architecture/workflow change — N/A for `CONTRIBUTING.md`/`AGENTS.md`
- [x] No tool schema/description change — N/A
