### PR TITLE
fix(desktop): context-usage popover shows real numbers on a resumed session

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -224,6 +224,11 @@ _LONG_HANDLERS = frozenset(
         "setup.status",
         "session.branch",
         "session.compress",
+        # context_breakdown now build-on-demand + waits for the deferred agent
+        # build (up to 30s on a cold resume), so it must not run inline on the
+        # reader thread — that would freeze prompt.submit / session.interrupt
+        # exactly like the completion RPCs above.
+        "session.context_breakdown",
         "session.list",
         "session.resume",
         "shell.exec",
@@ -6500,7 +6505,16 @@ def _(rid, params: dict) -> dict:
 
 @method("session.context_breakdown")
 def _(rid, params: dict) -> dict:
-    session, err = _sess_nowait(params, rid)
+    # Build-on-demand + wait (like every other agent-dependent RPC) instead of
+    # _sess_nowait. A resumed session takes the deferred-build path, so its agent
+    # is constructed on a background timer; _sess_nowait returns before that lands
+    # and the handler below falls into the agent-is-None branch, reporting an
+    # all-zero breakdown (0%, 0/0, empty bar). The desktop context-usage popover
+    # fetches this once with no retry, so it latches onto those zeros until the
+    # user reopens it. _sess triggers the build and waits, so the popover gets
+    # real numbers on first open. (Routed to _LONG_HANDLERS so the up-to-30s wait
+    # never blocks the reader thread's fast path.)
+    session, err = _sess(params, rid)
     if err:
         return err
     agent = session.get("agent")


### PR DESCRIPTION
## Summary

The desktop status-bar **Context Usage** popover shows `0%` / `0/0` / an empty bar when opened on a session that was just **resumed** (come back to an existing chat, click the context bar → all zeros). Sometimes it works, which is the tell that it's a race.

## Root cause

A cold resume takes the **deferred-build** path in `session.resume` (`tui_gateway/server.py`): it returns the transcript immediately and constructs the `AIAgent` on a background timer so switching sessions doesn't freeze for seconds.

The `session.context_breakdown` handler used `_sess_nowait`, which does **not** wait for that build. While the build is still in flight, `agent is None`, so the handler returns an all-zero breakdown:

```python
{"categories": [], "context_max": 0, "context_percent": 0, "context_used": 0, ...}
```

The popover (`apps/desktop/src/app/shell/context-usage-panel.tsx`) fetches this **once** on open via a `useEffect` with no retry, so it latches onto the zero snapshot until the user closes and reopens it — by which point the agent has usually finished building (hence the intermittency).

## Fix

Use `_sess` instead of `_sess_nowait` in the `session.context_breakdown` handler, so it triggers the deferred build and waits for it (bounded by `_wait_agent`'s 30s timeout) — exactly like every other agent-dependent RPC. The panel already renders a loading state while the RPC is in flight, so the UX becomes a brief "loading" followed by real numbers on first open.

Because `_sess` can block for seconds during the build, `session.context_breakdown` is also added to `_LONG_HANDLERS` so it runs on the RPC thread pool rather than inline on the reader thread — otherwise the wait would stall `prompt.submit` / `session.interrupt`, the same reader-thread freeze the completion RPCs were already moved off the reader thread to avoid.

No frontend/Electron change required; this is backend-only and takes effect on a gateway restart.

## Test plan

- [x] `pytest tests/agent/test_context_breakdown.py tests/gateway/test_usage_command.py` — 11 passed
- [x] `python -m py_compile tui_gateway/server.py`
- [ ] Manual: resume an existing session, immediately click the Context Usage bar → shows loading then real % (no longer stuck at 0%)
