### PR TITLE
fix(qqbot): add missing is_reconnect parameter to connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Description

The QQ Bot adapter's `connect()` method was missing the `is_reconnect`
keyword argument that the gateway passes during reconnection. All
other platform adapters (Telegram, Discord, Slack, Feishu, etc.)
accept this parameter.

Without it, the QQ bot disconnects once and can never reconnect,
causing permanent disconnection until the gateway is restarted.

## Bug
```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

## Fix

Added `*, is_reconnect: bool = False` to the connect method signature,
matching the pattern used by all other platform adapters.