### PR TITLE
fix(tools): alias a tool's input_schema to parameters in the registry

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -824,6 +824,37 @@ class TestInputSchemaAlias:
         assert "input_schema" not in fn
         assert any("input_schema" in r.getMessage() for r in caplog.records)
 
+    def test_repeated_registration_warns_once(self, caplog):
+        reg = ToolRegistry()
+        schema = {
+            "name": "legacy",
+            "description": "declares input_schema like an Anthropic tool spec",
+            "input_schema": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+            },
+        }
+
+        with caplog.at_level(logging.WARNING, logger="tools.registry"):
+            reg.register(
+                name="legacy",
+                toolset="s1",
+                schema=schema,
+                handler=_dummy_handler,
+            )
+            reg.register(
+                name="legacy",
+                toolset="s1",
+                schema=schema,
+                handler=_dummy_handler,
+            )
+
+        warnings = [
+            record for record in caplog.records
+            if "legacy" in record.getMessage() and "input_schema" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+
     def test_parameters_wins_over_stray_input_schema(self, caplog):
         reg = ToolRegistry()
         schema = {
@@ -860,3 +891,42 @@ class TestInputSchemaAlias:
         # The original dict the caller passed is left intact.
         assert "input_schema" in schema
         assert "parameters" not in schema
+
+    def test_assembled_model_tool_preserves_aliased_parameters(self):
+        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+        from tools.registry import registry
+
+        name = "test_input_schema_alias_assembled"
+        toolset = "test-input-schema-alias"
+        parameters = {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        }
+        registry.register(
+            name=name,
+            toolset=toolset,
+            schema={
+                "name": name,
+                "description": "integration test tool",
+                "input_schema": parameters,
+            },
+            handler=_dummy_handler,
+        )
+        try:
+            definitions = get_tool_definitions(
+                enabled_toolsets=[toolset],
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+            )
+            assembled = next(
+                definition["function"]
+                for definition in definitions
+                if definition["function"]["name"] == name
+            )
+        finally:
+            registry.deregister(name)
+            _clear_tool_defs_cache()
+
+        assert assembled["parameters"] == parameters
+        assert "input_schema" not in assembled

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -1,6 +1,7 @@
 """Tests for the central tool registry."""
 
 import json
+import logging
 import threading
 from pathlib import Path
 from unittest.mock import patch
@@ -794,3 +795,68 @@ class TestDeregisterAuthorization:
             evil_handler = eval("lambda *a, **k: 'hijacked'", {"__name__": "hermes_plugins.evil"})
             reg.register(name="protected", toolset="evil-ts", schema={}, handler=evil_handler, override=True)
         assert reg._tools["protected"].handler({}) == "built-in"
+class TestInputSchemaAlias:
+    """A plugin that writes the Anthropic/MCP ``input_schema`` key instead of
+    ``parameters`` should still expose its schema to the model, with a warning."""
+
+    def test_input_schema_is_aliased_to_parameters(self, caplog):
+        reg = ToolRegistry()
+        schema = {
+            "name": "legacy",
+            "description": "declares input_schema like an Anthropic tool spec",
+            "input_schema": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "required": ["x"],
+            },
+        }
+        with caplog.at_level(logging.WARNING, logger="tools.registry"):
+            reg.register(
+                name="legacy",
+                toolset="s1",
+                schema=schema,
+                handler=_dummy_handler,
+            )
+
+        fn = reg.get_definitions({"legacy"})[0]["function"]
+        assert fn["parameters"]["properties"] == {"x": {"type": "string"}}
+        assert fn["parameters"]["required"] == ["x"]
+        assert "input_schema" not in fn
+        assert any("input_schema" in r.getMessage() for r in caplog.records)
+
+    def test_parameters_wins_over_stray_input_schema(self, caplog):
+        reg = ToolRegistry()
+        schema = {
+            "name": "both",
+            "description": "has both keys",
+            "parameters": {"type": "object", "properties": {"p": {"type": "string"}}},
+            "input_schema": {"type": "object", "properties": {"i": {"type": "string"}}},
+        }
+        with caplog.at_level(logging.WARNING, logger="tools.registry"):
+            reg.register(
+                name="both",
+                toolset="s1",
+                schema=schema,
+                handler=_dummy_handler,
+            )
+
+        fn = reg.get_definitions({"both"})[0]["function"]
+        assert fn["parameters"]["properties"] == {"p": {"type": "string"}}
+        assert not any("input_schema" in r.getMessage() for r in caplog.records)
+
+    def test_caller_schema_dict_not_mutated(self):
+        reg = ToolRegistry()
+        schema = {
+            "name": "legacy2",
+            "description": "d",
+            "input_schema": {"type": "object", "properties": {}},
+        }
+        reg.register(
+            name="legacy2",
+            toolset="s1",
+            schema=schema,
+            handler=_dummy_handler,
+        )
+        # The original dict the caller passed is left intact.
+        assert "input_schema" in schema
+        assert "parameters" not in schema

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -27,7 +27,7 @@ from typing import Callable, Dict, List, Optional, Set
 logger = logging.getLogger(__name__)
 
 
-def _normalize_tool_schema_keys(name: str, schema: dict) -> dict:
+def _normalize_tool_schema_keys(schema: dict) -> tuple[dict, bool]:
     """Adopt a tool's ``input_schema`` as ``parameters`` when only the former is set.
 
     The OpenAI tool format — and therefore everything downstream of the
@@ -42,27 +42,20 @@ def _normalize_tool_schema_keys(name: str, schema: dict) -> dict:
     error anywhere.
 
     When a schema carries ``input_schema`` but no ``parameters``, alias it and
-    warn so the mistake is visible and fixable. A schema that already has
-    ``parameters`` is left untouched (it wins over any stray ``input_schema``).
+    report that normalization occurred so the registry can warn once. A schema
+    that already has ``parameters`` is left untouched (it wins over any stray
+    ``input_schema``).
     """
     if (
         isinstance(schema, dict)
         and "parameters" not in schema
         and isinstance(schema.get("input_schema"), dict)
     ):
-        logger.warning(
-            "Tool %r declares its JSON Schema under 'input_schema'; the tool "
-            "registry and OpenAI tool format read it from 'parameters'. "
-            "Aliasing it automatically, but rename the key to 'parameters' in "
-            "the tool's schema — otherwise a tool that gets this wrong is "
-            "exposed to the model with no parameters and called with no "
-            "arguments, silently.",
-            name,
-        )
         params = schema["input_schema"]
         schema = {k: v for k, v in schema.items() if k != "input_schema"}
         schema["parameters"] = params
-    return schema
+        return schema, True
+    return schema, False
 
 
 def _is_registry_register_call(node: ast.AST) -> bool:
@@ -265,6 +258,7 @@ class ToolRegistry:
         self._plugin_override_policy: Dict[str, bool] = {}
         self._toolset_checks: Dict[str, Callable] = {}
         self._toolset_aliases: Dict[str, str] = {}
+        self._warned_input_schema_aliases: Set[str] = set()
         # MCP dynamic refresh can mutate the registry while other threads are
         # reading tool metadata, so keep mutations serialized and readers on
         # stable snapshots.
@@ -423,8 +417,19 @@ class ToolRegistry:
         registrations that would shadow an existing tool from a different
         toolset are rejected to prevent accidental overwrites.
         """
-        schema = _normalize_tool_schema_keys(name, schema)
+        schema, aliased_input_schema = _normalize_tool_schema_keys(schema)
         with self._lock:
+            if aliased_input_schema and name not in self._warned_input_schema_aliases:
+                self._warned_input_schema_aliases.add(name)
+                logger.warning(
+                    "Tool %r declares its JSON Schema under 'input_schema'; the tool "
+                    "registry and OpenAI tool format read it from 'parameters'. "
+                    "Aliasing it automatically, but rename the key to 'parameters' in "
+                    "the tool's schema — otherwise a tool that gets this wrong is "
+                    "exposed to the model with no parameters and called with no "
+                    "arguments, silently.",
+                    name,
+                )
             existing = self._tools.get(name)
             if existing and existing.toolset != toolset:
                 # Allow MCP-to-MCP overwrites (legitimate: server refresh,

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -27,6 +27,44 @@ from typing import Callable, Dict, List, Optional, Set
 logger = logging.getLogger(__name__)
 
 
+def _normalize_tool_schema_keys(name: str, schema: dict) -> dict:
+    """Adopt a tool's ``input_schema`` as ``parameters`` when only the former is set.
+
+    The OpenAI tool format — and therefore everything downstream of the
+    registry (the ``{"type": "function", ...}`` wrap in
+    :meth:`ToolRegistry.get_definitions`, the schema sanitizer, every
+    transport) — reads a tool's JSON Schema from the ``parameters`` key.
+    Anthropic and MCP tool definitions instead carry it under
+    ``input_schema``. A plugin author who copies an Anthropic-shaped tool spec
+    therefore registers a schema the registry silently ignores: ``parameters``
+    is absent, ``schema_sanitizer`` substitutes an empty object, and the model
+    ends up calling the tool with no arguments — a silent failure with no
+    error anywhere.
+
+    When a schema carries ``input_schema`` but no ``parameters``, alias it and
+    warn so the mistake is visible and fixable. A schema that already has
+    ``parameters`` is left untouched (it wins over any stray ``input_schema``).
+    """
+    if (
+        isinstance(schema, dict)
+        and "parameters" not in schema
+        and isinstance(schema.get("input_schema"), dict)
+    ):
+        logger.warning(
+            "Tool %r declares its JSON Schema under 'input_schema'; the tool "
+            "registry and OpenAI tool format read it from 'parameters'. "
+            "Aliasing it automatically, but rename the key to 'parameters' in "
+            "the tool's schema — otherwise a tool that gets this wrong is "
+            "exposed to the model with no parameters and called with no "
+            "arguments, silently.",
+            name,
+        )
+        params = schema["input_schema"]
+        schema = {k: v for k, v in schema.items() if k != "input_schema"}
+        schema["parameters"] = params
+    return schema
+
+
 def _is_registry_register_call(node: ast.AST) -> bool:
     """Return True when *node* is a ``registry.register(...)`` call expression."""
     if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
@@ -385,6 +423,7 @@ class ToolRegistry:
         registrations that would shadow an existing tool from a different
         toolset are rejected to prevent accidental overwrites.
         """
+        schema = _normalize_tool_schema_keys(name, schema)
         with self._lock:
             existing = self._tools.get(name)
             if existing and existing.toolset != toolset:


### PR DESCRIPTION
## What & why

A plugin that declares its JSON Schema under `input_schema` — the canonical Anthropic/MCP key — instead of `parameters` (the OpenAI tool-format key the registry reads) **silently loses its schema**:

- `tools/registry.py` stores the schema verbatim and `get_definitions()` wraps it as `{"type": "function", "function": {**schema, "name": ...}}`, reading args from `parameters`.
- With `parameters` absent, `tools/schema_sanitizer.py` substitutes the minimal `{"type": "object", "properties": {}}`.
- The model then sees a tool with **no parameters** and calls it with no arguments. The handler fails (or misbehaves) with no error pointing back at the cause.

This is an easy trap: copying an Anthropic-shaped tool spec into a plugin is a natural mistake, and nothing tells you what went wrong.

## The fix

Normalize at the single ingestion point (`registry.register()`): when a schema carries `input_schema` but **no** `parameters`, adopt it as `parameters` and emit a one-time `warning` so the mistake is visible and fixable.

- Strictly scoped to `input_schema` present **and** `parameters` absent — a zero-false-positive trigger. Arg-less tools that legitimately omit/empty `parameters` are untouched.
- A schema that already has `parameters` wins over any stray `input_schema`.
- The caller's dict is not mutated (a normalized copy is stored).

The warning is the load-bearing part (silent failure → loud, actionable); the alias is convenience so the tool works meanwhile.

## How to test

```bash
scripts/run_tests.sh tests/tools/test_registry.py -q
```

New `TestInputSchemaAlias` covers: `input_schema` → `parameters` aliasing + warning, `parameters` winning over a stray `input_schema` (no warning), and the caller's dict left intact.

## Platforms

Logic-only change (no I/O, no process/terminal handling); platform-independent. Tests run on macOS (Python 3.14).