### PR TITLE
fix(gateway): split adjacent MEDIA tags so one tag does not consume the next

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1437,7 +1437,10 @@ _MEDIA_EXT_ALTERNATION = "|".join(
 MEDIA_TAG_CLEANUP_RE = re.compile(
     r'''[`"']?MEDIA:\s*'''
     r'''(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|'''
-    r'''(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
+    r'''(?:~/|/|[A-Za-z]:[/\\])'''
+    # Allow unquoted paths with spaces, but never let one tag consume the next
+    # MEDIA: token on the same line (e.g. ``MEDIA:/a.md, MEDIA:/b.md``).
+    r'''(?:(?![^\S\n]*MEDIA:)[^\n])+?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
     r'''(?=[\s`"',;:)\]}]|$)[`"']?''',
     re.IGNORECASE,
 )

--- a/tests/gateway/test_media_multi_tag_parsing.py
+++ b/tests/gateway/test_media_multi_tag_parsing.py
@@ -1,0 +1,34 @@
+"""Regression tests for adjacent MEDIA tag parsing."""
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+def test_extract_media_handles_multiple_tags_on_one_line_without_swallowing_second_path(tmp_path):
+    """Comma/space-separated MEDIA tags must become separate attachments.
+
+    The extractor supports paths with spaces, but that must not make one MEDIA:
+    tag consume the next ``MEDIA:`` tag on the same line.
+    """
+    first = tmp_path / "first note.md"
+    second = tmp_path / "second note.md"
+    first.write_text("# first\n")
+    second.write_text("# second\n")
+
+    content = f"Attached: MEDIA:{first}, MEDIA:{second}"
+
+    media, cleaned = BasePlatformAdapter.extract_media(content)
+
+    assert [path for path, _is_voice in media] == [str(first), str(second)]
+    assert "MEDIA:" not in cleaned
+    assert str(first) not in cleaned
+    assert str(second) not in cleaned
+
+
+def test_extract_media_still_allows_single_unquoted_path_with_spaces(tmp_path):
+    spaced = tmp_path / "monthly report.md"
+    spaced.write_text("# report\n")
+
+    media, cleaned = BasePlatformAdapter.extract_media(f"MEDIA:{spaced}")
+
+    assert media == [(str(spaced), False)]
+    assert cleaned == ""


### PR DESCRIPTION
The MEDIA tag regex allowed unquoted paths with spaces, but a greedy pattern could let one tag consume the next `MEDIA:` token on the same line.

Changes the regex so that the path-matching portion explicitly stops before another `MEDIA:` marker, turning `MEDIA:/a.md, MEDIA:/b.md` into two separate attachments.