### PR TITLE
feat(desktop): copy Mermaid source from rendered diagrams

### DIFF
--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import MermaidRenderer from './mermaid-embed'
+
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn().mockResolvedValue({
+      svg: '<svg role="img" viewBox="0 0 10 10"><text>A</text></svg>'
+    })
+  }
+}))
+
+describe('MermaidRenderer', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('copies the original Mermaid source from the rendered diagram', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const code = 'graph TD\n  A --> B'
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    })
+
+    render(
+      <I18nProvider configClient={null}>
+        <MermaidRenderer code={code} />
+      </I18nProvider>
+    )
+
+    const copyButton = await screen.findByRole('button', { name: 'Copy Mermaid source' })
+
+    fireEvent.click(copyButton)
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(code))
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
+import { zhHant } from '@/i18n/zh-hant'
 
 import MermaidRenderer from './mermaid-embed'
 
@@ -30,12 +31,12 @@ describe('MermaidRenderer', () => {
     })
 
     render(
-      <I18nProvider configClient={null}>
+      <I18nProvider configClient={null} initialLocale="zh-hant">
         <MermaidRenderer code={code} />
       </I18nProvider>
     )
 
-    const copyButton = await screen.findByRole('button', { name: 'Copy Mermaid source' })
+    const copyButton = await screen.findByRole('button', { name: zhHant.assistant.tool.copyCode })
 
     fireEvent.click(copyButton)
 

--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
@@ -3,6 +3,7 @@
 import mermaid from 'mermaid'
 import { useEffect, useState } from 'react'
 
+import { CopyButton } from '@/components/ui/copy-button'
 import { Zoomable } from '@/components/ui/zoomable'
 import { copySvgAsPng } from '@/lib/svg-image'
 import { cn } from '@/lib/utils'
@@ -94,20 +95,30 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
   // overlay keeps the diagram's natural width (capped to the viewport) so it
   // renders before any zoom; the inline version stays capped at 33dvh.
   return (
-    <Zoomable
-      label="Open diagram"
-      onCopy={() => copySvgAsPng(svg)}
-      overlay={
+    <div className="group/mermaid relative">
+      <Zoomable
+        label="Open diagram"
+        onCopy={() => copySvgAsPng(svg)}
+        overlay={
+          <div
+            className="[&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-h-[80vh] [&_svg]:max-w-[85vw]"
+            dangerouslySetInnerHTML={{ __html: svg }}
+          />
+        }
+      >
         <div
-          className="[&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-h-[80vh] [&_svg]:max-w-[85vw]"
+          className="overflow-hidden p-3 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-h-[33dvh] [&_svg]:max-w-full"
           dangerouslySetInnerHTML={{ __html: svg }}
         />
-      }
-    >
-      <div
-        className="overflow-hidden p-3 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-h-[33dvh] [&_svg]:max-w-full"
-        dangerouslySetInnerHTML={{ __html: svg }}
+      </Zoomable>
+      <CopyButton
+        appearance="icon"
+        buttonSize="icon-sm"
+        className="absolute left-2 top-2 opacity-0 shadow-sm backdrop-blur transition-opacity group-hover/mermaid:opacity-100 focus-visible:opacity-100"
+        label="Copy Mermaid source"
+        stopPropagation
+        text={code}
       />
-    </Zoomable>
+    </div>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 
 import { CopyButton } from '@/components/ui/copy-button'
 import { Zoomable } from '@/components/ui/zoomable'
+import { useI18n } from '@/i18n'
 import { copySvgAsPng } from '@/lib/svg-image'
 import { cn } from '@/lib/utils'
 
@@ -44,6 +45,7 @@ function SourcePreview({ code, muted }: { code: string; muted?: boolean }) {
 // the source while the message streams (partial syntax throws) and falls back
 // to source on parse failure.
 export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
+  const { t } = useI18n()
   const isDark = useIsDark()
   const [svg, setSvg] = useState('')
   const [failed, setFailed] = useState(false)
@@ -115,7 +117,7 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
         appearance="icon"
         buttonSize="icon-sm"
         className="absolute left-2 top-2 opacity-0 shadow-sm backdrop-blur transition-opacity group-hover/mermaid:opacity-100 focus-visible:opacity-100"
-        label="Copy Mermaid source"
+        label={t.assistant.tool.copyCode}
         stopPropagation
         text={code}
       />


### PR DESCRIPTION
## What does this PR do?

Adds a small copy-source button to rendered Mermaid diagrams in the Desktop app.

The existing fullscreen copy button still copies the rendered diagram image. This new button copies the original Mermaid text, so users can paste it into docs, GitHub, Obsidian, or mermaid.live.

## Related Issue

Closes #55679

## Changes Made

- Added a rendered-diagram copy-source action in `mermaid-embed.tsx`.
- Reused the existing Desktop copy button behavior.
- Added a focused test for copying the original Mermaid source.

## Verification

- `npm --workspace apps/desktop run test:ui -- mermaid-embed.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `git diff --check`

## Checklist

- [x] Linked the source issue.
- [x] Added focused test coverage.
- [x] Kept the change limited to the Desktop Mermaid renderer.
