### PR TITLE
fix(cli): log once when known plugin toolset is hidden from model

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -7,6 +7,16 @@ that need API keys, run through provider-aware configuration.
 
 Saves per-platform tool configuration to ~/.hermes/config.yaml under
 the `platform_toolsets` key.
+
+Plugin toolsets follow a two-key contract.  ``platform_toolsets.<platform>``
+is the live allowlist the model sees.  ``known_plugin_toolsets.<platform>``
+is a ledger of which plugin toolsets ``hermes tools`` has already shown for
+that platform -- it exists only to tell "brand-new plugin, default it on"
+apart from "operator saw it and deselected it".  Listing a toolset under
+``known_plugin_toolsets`` therefore HIDES it unless it also appears in
+``platform_toolsets.<platform>``.  To surface a plugin's tools, add the
+toolset to ``platform_toolsets.<platform>`` (or run ``hermes tools`` and
+enable it).
 """
 
 import json as _json
@@ -38,6 +48,11 @@ logger = logging.getLogger(__name__)
 # runtime check in _get_platform_tools warns once per platform instead of on
 # every tool resolution for a persistently-corrupt config (#38798).
 _warned_invalid_platform_toolsets: Set[str] = set()
+
+# "<platform>:<toolset>" pairs already surfaced as a known-but-disabled plugin
+# toolset.  _get_platform_tools runs on every tool resolution (per turn), so
+# the diagnostic is emitted once per pair instead of on every call.
+_warned_known_plugin_disabled: Set[str] = set()
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
@@ -1595,7 +1610,29 @@ def _get_platform_tools(
             elif pts not in known_for_platform:
                 # New plugin not yet seen by hermes tools — default enabled
                 enabled_toolsets.add(pts)
-            # else: known but not in config = user disabled it
+            else:
+                # Known but absent from platform_toolsets[platform]: the
+                # opt-out half of the contract.  Once `hermes tools` saves a
+                # selection for a platform, every plugin toolset is recorded in
+                # known_plugin_toolsets; one left out of platform_toolsets is
+                # treated as deliberately deselected and its tools stay hidden
+                # from the model.  This is intentional — but it is also the
+                # most common reason a freshly written plugin's tools never
+                # reach the model: the toolset became "known" (any prior
+                # `hermes tools` save) yet was never added to
+                # platform_toolsets.<platform>.  Listing it in
+                # known_plugin_toolsets alone is NOT enough.  Surface it once
+                # so the disabled state is diagnosable, not silent.
+                _seen_key = f"{platform}:{pts}"
+                if _seen_key not in _warned_known_plugin_disabled:
+                    _warned_known_plugin_disabled.add(_seen_key)
+                    logger.info(
+                        "Plugin toolset '%s' is known but not enabled for "
+                        "platform '%s'; its tools are hidden from the model. "
+                        "Run `hermes tools` and enable it, or add '%s' to "
+                        "platform_toolsets.%s in config.yaml to surface it.",
+                        pts, platform, pts, platform,
+                    )
 
     # Context-engine tools are runtime-provided by the active engine, so they
     # are not part of any static platform composite. When a non-default engine

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1756,3 +1756,39 @@ def test_save_platform_tools_disabling_a_toolset_does_not_touch_disabled_toolset
     assert "todo" not in config["platform_toolsets"]["cli"]
     # disabled_toolsets is untouched by a disable action.
     assert config["agent"]["disabled_toolsets"] == ["memory"]
+
+def test_known_plugin_disabled_logs_once_per_pair(caplog):
+    """A known-but-not-enabled plugin toolset emits an info log exactly once
+    per (platform, toolset) pair, and the toolset remains hidden (#55793)."""
+    import hermes_cli.tools_config as _tc
+
+    # Reset the dedup set so the test is deterministic regardless of prior runs.
+    _tc._warned_known_plugin_disabled.discard("cli:fake_plugin")
+
+    config = {
+        "platform_toolsets": {"cli": ["terminal"]},
+        "known_plugin_toolsets": {"cli": ["terminal", "fake_plugin"]},
+    }
+
+    # Stub _get_plugin_toolset_keys to include our fake plugin.
+    with patch.object(_tc, "_get_plugin_toolset_keys", return_value={"fake_plugin"}):
+        with caplog.at_level(logging.INFO, logger="hermes_cli.tools_config"):
+            # First call — should log once.
+            result1 = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+            hits1 = [
+                r for r in caplog.records
+                if "fake_plugin" in r.getMessage() and "known but not enabled" in r.getMessage()
+            ]
+            assert len(hits1) == 1, f"expected exactly one info log, got {len(hits1)}"
+            assert "fake_plugin" not in result1, "toolset must remain hidden"
+
+            # Second call — dedup suppresses the log.
+            caplog.clear()
+            result2 = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+            hits2 = [
+                r for r in caplog.records
+                if "fake_plugin" in r.getMessage() and "known but not enabled" in r.getMessage()
+            ]
+            assert len(hits2) == 0, f"expected deduped (zero) logs, got {len(hits2)}"
+            assert "fake_plugin" not in result2, "toolset must remain hidden on second call"
+


### PR DESCRIPTION
## What does this PR do?

Adds a once-per-(platform, toolset) `info` log when a plugin toolset is known but not enabled for a platform, making the "silently hidden tools" problem diagnosable. Also documents the two-key contract (`platform_toolsets` vs `known_plugin_toolsets`) in the module docstring.

**No behavior change** — the opt-out semantics remain identical. This is purely discoverability: a plugin developer whose toolset became "known" (any prior `hermes tools` save) but was never added to `platform_toolsets.<platform>` now gets a clear log line instead of silent tool suppression.

## Related Issue

Fixes #55793

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/tools_config.py`: Added `_warned_known_plugin_disabled` module-level set (mirrors existing `_warned_invalid_platform_toolsets` pattern from #38798). Replaced bare `# else:` comment in `_get_platform_tools()` with an `else` branch that emits a once-per-pair `logger.info()` diagnostic when a known plugin toolset is hidden.
- `hermes_cli/tools_config.py`: Added two-key contract documentation to the module docstring explaining the relationship between `platform_toolsets.<platform>` (live allowlist) and `known_plugin_toolsets.<platform>` (ledger).
- `tests/hermes_cli/test_tools_config.py`: Added regression test verifying the info log fires exactly once per (platform, toolset) pair and that the toolset remains hidden (no behavior change).

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_tools_config.py -x -q` — should pass (108 tests including the new one).
2. Configure a plugin toolset in `known_plugin_toolsets` but NOT in `platform_toolsets` for a platform. The info log should appear once on first tool resolution, not on subsequent calls.
3. Verify the toolset is still hidden from the model (behavior unchanged).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_tools_config.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
INFO:hermes_cli.tools_config:Plugin toolset 'my_plugin' is known but not enabled for platform 'cli'; its tools are hidden from the model. Run `hermes tools` and enable it, or add 'my_plugin' to platform_toolsets.cli in config.yaml to surface it.
```
