### PR TITLE
fix(usage): capture reasoning_tokens from completion_tokens_details

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -799,6 +799,17 @@ def normalize_usage(
     output_details = getattr(response_usage, "output_tokens_details", None)
     if output_details:
         reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+    if not reasoning_tokens:
+        # Chat Completions providers (DeepSeek thinking, OpenAI o-series via
+        # chat, etc.) report reasoning under completion_tokens_details, NOT the
+        # Responses-API output_tokens_details. completion_tokens already
+        # INCLUDES these, so this only restores the informational breakdown —
+        # total_tokens (prompt+output) and cost (output-priced) are unaffected,
+        # no double-count. Without it, e.g. DeepSeek's reasoning_tokens are
+        # silently dropped to 0 even though the model returns reasoning_content.
+        completion_details = getattr(response_usage, "completion_tokens_details", None)
+        if completion_details:
+            reasoning_tokens = _to_int(getattr(completion_details, "reasoning_tokens", 0))
 
     return CanonicalUsage(
         input_tokens=input_tokens,

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -39,6 +39,29 @@ def test_normalize_usage_openai_subtracts_cached_prompt_tokens():
     assert normalized.output_tokens == 700
 
 
+def test_normalize_usage_reads_chat_completions_reasoning_tokens():
+    """DeepSeek thinking (and OpenAI o-series via chat) report reasoning under
+    completion_tokens_details, not the Responses-API output_tokens_details.
+
+    Regression for reasoning_tokens being silently dropped to 0. Shape is taken
+    verbatim from a live deepseek-v4-flash response (completion_tokens already
+    includes the reasoning, so output_tokens stays the full count — no
+    double-count).
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=19,
+        completion_tokens=61,
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=59),
+        prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+    )
+
+    normalized = normalize_usage(usage, provider="deepseek", api_mode="chat_completions")
+
+    assert normalized.reasoning_tokens == 59
+    assert normalized.output_tokens == 61  # unchanged; reasoning is a subset
+    assert normalized.total_tokens == 80  # prompt(19)+output(61), reasoning NOT added
+
+
 def test_normalize_usage_openai_reads_top_level_anthropic_cache_fields():
     """Some OpenAI-compatible proxies (OpenRouter, Cline) expose
     Anthropic-style cache token counts at the top level of the usage object when


### PR DESCRIPTION
## What does this PR do?

`normalize_usage` only reads reasoning tokens from `output_tokens_details`
(the Responses-API field). Chat Completions providers — DeepSeek thinking,
OpenAI o-series via chat completions, etc. — report it under
`completion_tokens_details` instead, so `reasoning_tokens` is silently dropped
to `0` even when the model returns `reasoning_content`.

This reads `completion_tokens_details.reasoning_tokens` as a fallback.
`completion_tokens` already includes those reasoning tokens, so `total_tokens`
(`prompt + output`) and cost (priced off `output_tokens`) are unchanged — this
only restores the dropped informational breakdown.

## Related Issue

<!-- No existing issue; happy to file one if preferred. -->

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/usage_pricing.py` — in `normalize_usage`, fall back to
  `completion_tokens_details.reasoning_tokens` when `output_tokens_details`
  doesn't carry it.
- `tests/agent/test_usage_pricing.py` — regression test using a real
  `deepseek-v4-flash` usage shape.

## How to Test

1. `pytest tests/agent/test_usage_pricing.py -q` (new test
   `test_normalize_usage_reads_chat_completions_reasoning_tokens` passes).
2. Or live: call a DeepSeek thinking model and inspect the normalized usage —
   `reasoning_tokens` is now non-zero (was `0`).

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran tests/agent/test_usage_pricing.py: 16 passed -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure token math)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Raw usage from a live `deepseek-v4-flash` response (thinking enabled) — the
model returned 143 chars of `reasoning_content`, and `reasoning_tokens` lives
under `completion_tokens_details`:

```json
{
  "completion_tokens": 61,
  "prompt_tokens": 19,
  "total_tokens": 80,
  "completion_tokens_details": { "reasoning_tokens": 59 }
}
```

Before this fix `normalize_usage(...).reasoning_tokens` came out `0`; after, `59`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
