### PR TITLE
fix(discord): expose /reasoning reset|show|hide as slash choices

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3846,8 +3846,25 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_model(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/model {name}".strip())
 
-        @tree.command(name="reasoning", description="Show or change reasoning effort")
-        @discord.app_commands.describe(effort="Reasoning effort: none, minimal, low, medium, high, or xhigh.")
+        @tree.command(name="reasoning", description="Show/change reasoning effort, or toggle showing it")
+        @discord.app_commands.describe(effort="Pick a level, reset the override, or show/hide reasoning. Leave empty to see current.")
+        @discord.app_commands.choices(effort=[
+            # Effort levels and the reset/show/hide subcommands all arrive on the
+            # gateway's single `/reasoning <arg>` handler. Discord's native UI has
+            # no subcommand affordance for a free-text field (it just funnels the
+            # user into the `effort` box), so expose every accepted value as an
+            # explicit choice. --global persistence stays reachable by typing the
+            # command as plain text.
+            discord.app_commands.Choice(name="none — disable reasoning", value="none"),
+            discord.app_commands.Choice(name="minimal", value="minimal"),
+            discord.app_commands.Choice(name="low", value="low"),
+            discord.app_commands.Choice(name="medium", value="medium"),
+            discord.app_commands.Choice(name="high", value="high"),
+            discord.app_commands.Choice(name="xhigh — maximum reasoning", value="xhigh"),
+            discord.app_commands.Choice(name="reset — clear this session's override", value="reset"),
+            discord.app_commands.Choice(name="show — reveal reasoning in replies", value="show"),
+            discord.app_commands.Choice(name="hide — hide reasoning from replies", value="hide"),
+        ])
         async def slash_reasoning(interaction: discord.Interaction, effort: str = ""):
             await self._run_simple_slash(interaction, f"/reasoning {effort}".strip())
 


### PR DESCRIPTION
## What does this PR do?

The Discord `/reasoning` command declared a single free-text `effort`
parameter, so the native UI funneled every invocation into that one box and
never surfaced the `reset` / `show` / `hide` subcommands the gateway handler
already supports. Replace the free-text param with an explicit `choices`
dropdown covering the effort levels plus `reset` / `show` / `hide`, mirroring
the existing `/tokens` and `/voice` commands. `--global` persistence stays
reachable by typing the command as plain text.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py` — replace the `/reasoning` free-text
  `effort` parameter with a `@discord.app_commands.choices` dropdown covering
  `none`/`minimal`/`low`/`medium`/`high`/`xhigh` plus `reset`/`show`/`hide`.

## How to Test

1. In Discord, type `/reasoning` — the `effort` parameter now shows a dropdown.
2. Pick `reset` / `show` / `hide` from the dropdown and confirm each reaches
   the gateway handler (previously unreachable from the slash UI).
3. Effort levels (`high`, `xhigh`, …) still work.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (focused suite: discord slash registration + reasoning/tokens/usage — 66+ passing; full-suite collection has 2 pre-existing Windows-only environment gaps unrelated to this change: ACP tests needing optional deps, and a /tmp path test)
- [ ] I've added tests for my changes <!-- no new test: existing discord slash registration tests exercise the registration -->
- [x] I've tested on my platform: Discord (live bot)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (Discord adapter only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`/reasoning` now offers `reset` / `show` / `hide` (plus the effort levels) as
selectable choices in Discord's native slash UI instead of a single free-text
box.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
