### PR TITLE
fix(tools): concurrent-execution heartbeat names wrong tools when a call is guardrail-blocked

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -282,6 +282,24 @@ def _run_agent_tool_execution_middleware(
     return result, observed_args
 
 
+def _running_tool_names(not_done, futures, runnable_calls) -> list:
+    """Names of the still-running tools, for the progress heartbeat.
+
+    ``futures`` is built in lock-step with ``runnable_calls`` (one future per
+    submitted runnable call, in submit order), so a future's position in
+    ``futures`` indexes ``runnable_calls`` — NOT ``parsed_calls``. ``parsed_calls``
+    also contains guardrail-blocked calls, which are absent from ``runnable_calls``;
+    indexing it with a futures position therefore reports the wrong tool name (and
+    shifts further with each blocked call that precedes a runnable one).
+    """
+    names = []
+    for f in not_done:
+        if f in futures:
+            # runnable_calls entries are (orig_index, tool_call, name, args).
+            names.append(runnable_calls[futures.index(f)][2])
+    return names
+
+
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
@@ -687,11 +705,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     _conc_elapsed = int(time.time() - _conc_start)
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
-                        _still_running = [
-                            parsed_calls[futures.index(f)][1]
-                            for f in not_done
-                            if f in futures
-                        ]
+                        _still_running = _running_tool_names(
+                            not_done, futures, runnable_calls
+                        )
                         agent._touch_activity(
                             f"concurrent tools running ({_conc_elapsed}s, "
                             f"{len(not_done)} remaining: {', '.join(_still_running[:3])})"

--- a/tests/run_agent/test_tool_executor_heartbeat_names.py
+++ b/tests/run_agent/test_tool_executor_heartbeat_names.py
@@ -1,0 +1,45 @@
+"""Regression: the concurrent-tool progress heartbeat reported the wrong
+tool names when a batch mixed guardrail-blocked and runnable calls.
+
+``execute_tool_calls_concurrent`` builds ``futures`` in lock-step with
+``runnable_calls`` (the non-blocked calls), but the heartbeat looked up the
+still-running tool names with ``parsed_calls[futures.index(f)]`` — indexing
+``parsed_calls`` (which also includes blocked calls) by a *futures* position.
+When a blocked call precedes a runnable one, the indices shift and the
+heartbeat status line ("concurrent tools running (… remaining: …)") lists the
+wrong tool names.
+"""
+
+from agent.tool_executor import _running_tool_names
+
+
+class _F:
+    """Stand-in for a concurrent.futures.Future (identity only)."""
+
+
+def test_running_names_correct_with_blocked_call_offset():
+    # parsed_calls = [blocked, runnableA, runnableB]; runnable_calls keeps the
+    # original indices, so it is [(1, .., 'read_file', ..), (2, .., 'web_search', ..)].
+    runnable_calls = [
+        (1, object(), "read_file", {}),
+        (2, object(), "web_search", {}),
+    ]
+    fA, fB = _F(), _F()
+    futures = [fA, fB]  # parallel to runnable_calls
+
+    # Only the second runnable tool (web_search) is still running.
+    assert _running_tool_names({fB}, futures, runnable_calls) == ["web_search"]
+    # Only the first (read_file).
+    assert _running_tool_names({fA}, futures, runnable_calls) == ["read_file"]
+
+
+def test_running_names_skip_futures_not_in_list():
+    runnable_calls = [(0, object(), "terminal", {})]
+    f0 = _F()
+    futures = [f0]
+    stray = _F()  # a future that isn't one of ours
+    assert _running_tool_names({f0, stray}, futures, runnable_calls) == ["terminal"]
+
+
+def test_running_names_empty():
+    assert _running_tool_names(set(), [], []) == []


### PR DESCRIPTION
### Summary

In `execute_tool_calls_concurrent` (agent/tool_executor.py), the periodic progress heartbeat computes the still-running tool names with:

```python
_still_running = [
    parsed_calls[futures.index(f)][1]
    for f in not_done
    if f in futures
]
```

`futures` is built in lock-step with `runnable_calls` (one future per submitted non-blocked call, in submit order), so a future's position in `futures` indexes **`runnable_calls`**, not `parsed_calls`. `parsed_calls` also contains guardrail-blocked / out-of-scope calls (which never get a future). When a blocked call precedes a runnable one, the positions shift and the heartbeat names the wrong tools.

The heartbeat is the `concurrent tools running (Ns, K remaining: …)` status line emitted via `_touch_activity` during long (>30s) concurrent tool batches, so users/operators watching the activity feed see incorrect tool names.

### Reproduction

```python
# parsed_calls = [blocked, runnable("read_file"), runnable("web_search")]
# runnable_calls = [(1, .., "read_file", {}), (2, .., "web_search", {})]
# futures        = [fA, fB]   # parallel to runnable_calls
# web_search (fB) still running:
[parsed_calls[futures.index(f)][1] for f in {fB} if f in futures]
# -> ["read_file"]   (wrong; should be ["web_search"])
```

### Fix

Extract the future→name lookup into `_running_tool_names(not_done, futures, runnable_calls)`, indexed against `runnable_calls`, and call it from the heartbeat. This is a pure status/logging fix — tool execution, result collection (which already uses the original index), and ordering are unchanged.

### Tests

Adds `tests/run_agent/test_tool_executor_heartbeat_names.py` covering the blocked-call offset case, a stray-future guard, and the empty case. With the old `parsed_calls`-indexed mapping these assertions fail; with the fix they pass. Existing tool-executor tests still pass.

### Severity

Low / cosmetic — it only affects the names shown in the progress heartbeat; no behavioral impact on tool execution.

Fixes #55809
