### PR TITLE
fix(hindsight): replace destructive aretain_batch with safe file-based retain

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -163,7 +163,7 @@ _MEMORY_REVIEW_PROMPT = (
     "preferences, or personal details worth remembering?\n"
     "2. Has the user expressed expectations about how you should behave, their work "
     "style, or ways they want you to operate?\n\n"
-    "If something stands out, save it using the memory tool. "
+    "Evaluate this turn: write long-term essential core info to memory.md, store important on-demand info to memory provider tools. "
     "If nothing is worth saving, just say 'Nothing to save.' and stop."
 )
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -39,6 +39,7 @@ import os
 import queue
 import sys
 import threading
+from uuid import uuid4
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List
@@ -293,8 +294,11 @@ def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT):
 RETAIN_SCHEMA = {
     "name": "hindsight_retain",
     "description": (
-        "Store information to long-term memory. Hindsight automatically "
-        "extracts structured facts, resolves entities, and indexes for retrieval."
+        "This tool grants one dedicated extra memory record. Hindsight's auto_retain "
+        "continuously maintains memories in the background — do not use this tool for "
+        "routine memory retention. All long-term essential core information must be "
+        "stored in memory.md; saving such content through this tool is prohibited "
+        "under all circumstances."
     ),
     "parameters": {
         "type": "object",
@@ -1707,21 +1711,47 @@ class HindsightMemoryProvider(MemoryProvider):
                 return tool_error("Missing required parameter: content")
             context = args.get("context")
             try:
-                item = self._build_retain_kwargs(
-                    content,
-                    context=context,
-                    tags=args.get("tags"),
+                # Build a unique filename to prevent document overwrites.
+                # Each call creates a new Hindsight document via file retain.
+                agent_name = self._agent_identity or "hermes"
+                channel = self._platform or "unknown"
+                user = (self._user_id or self._user_name or "unknown")
+                session = self._session_id or "unknown"
+                uid = str(uuid4())
+                # Sanitize components for filesystem safety
+                safe_agent = agent_name.replace("/", "_").replace(":", "_")
+                safe_channel = channel.replace("/", "_").replace(":", "_")
+                safe_user = user.replace("/", "_").replace(":", "_")
+                safe_session = session.replace("/", "_").replace(":", "_")
+                filename = f"{safe_agent}_{safe_channel}_{safe_user}_{safe_session}_{uid}.md"
+
+                file_content = content.encode("utf-8")
+
+                logger.debug(
+                    "Tool hindsight_retain: bank=%s, filename=%s, content_len=%d, context=%s",
+                    self._bank_id, filename, len(content), context,
                 )
-                # aretain_batch takes bank_id/retain_async as call args, not item keys.
-                item.pop("bank_id", None)
-                item.pop("retain_async", None)
-                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
+
+                # Build file metadata with optional tags
+                file_meta = {
+                    "context": context or "memory retain",
+                }
+                tags = args.get("tags")
+                if tags:
+                    file_meta["tags"] = tags
+
                 self._run_hindsight_operation(
-                    lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
+                    lambda client: client.files.file_retain(
+                        bank_id=self._bank_id,
+                        files=[(filename, file_content)],
+                        request=json.dumps({
+                            "files_metadata": [file_meta]
+                        }),
+                    )
                 )
-                logger.debug("Tool hindsight_retain: success")
-                return json.dumps({"result": "Memory stored successfully."})
+
+                logger.debug("Tool hindsight_retain file retain: success (%s)", filename)
+                return json.dumps({"result": "Memory stored successfully as a new document."})
             except Exception as e:
                 logger.warning("hindsight_retain failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to store memory: {e}")


### PR DESCRIPTION
## Summary

Background Review fork was calling `hindsight_retain` with the parent session_id, causing destructive overwrites of auto-retained session documents in Hindsight. The tool description was misleading — it advertised "Store information" without disclosing that every retain is a full document overwrite (not an incremental append) and that `auto_retain` already continuously maintains memories in the background.

## Changes

### 1. `plugins/memory/hindsight/__init__.py` — Safe file-based retain

`hindsight_retain` tool now uses Hindsight's file retain API instead of direct `aretain_batch`. Each call generates a unique filename:

`{agent}_{channel}_{user}_{session}_{uuid}.md`

The UUID guarantees no collision with auto-retained session documents. File retain also enables richer content (markdown formatting, structured text).

### 2. `plugins/memory/hindsight/__init__.py` — Accurate tool description

Old: "Store information to long-term memory. Hindsight automatically extracts structured facts, resolves entities, and indexes for retrieval."

New: "This tool grants one dedicated extra memory record. Hindsight's auto_retain continuously maintains memories in the background — do not use this tool for routine memory retention. All long-term essential core information must be stored in memory.md; saving such content through this tool is prohibited under all circumstances."

### 3. `agent/background_review.py` — Guided prompt

The `_MEMORY_REVIEW_PROMPT` now tells the model to:
- Write long-term essential core info to `memory.md`
- Store important on-demand info to memory provider tools
- Skip if nothing worth saving

## Verification

- Dry-run: filename generation verified (all components present, sanitization works)
- Real API test: file retain submitted successfully against live Hindsight instance (operation tracked)
- Syntax: all modified files pass `py_compile`
- Auto-retain (`sync_turn`) is completely unaffected — it uses the internal `aretain_batch` API, not the tool

Closes #55816
