### PR TITLE
refactor(desktop): extract auto-update IPC handlers from main.cjs into updates-ipc.cjs

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -59,6 +59,7 @@ const {
 const { registerGitIpc } = require('./git-ipc.cjs')
 const { registerFsIpc } = require('./fs-ipc.cjs')
 const { registerTerminalIpc } = require('./terminal-ipc.cjs')
+const { registerUpdatesIpc } = require('./updates-ipc.cjs')
 const { OFFICIAL_REPO_HTTPS_URL, isOfficialSshRemote } = require('./update-remote.cjs')
 const { resolveBehindCount, shouldCountCommits } = require('./update-count.cjs')
 const { runRebuildWithRetry } = require('./update-rebuild.cjs')
@@ -6919,30 +6920,15 @@ registerTerminalIpc({
   terminalShellEnv
 })
 
-ipcMain.handle('hermes:updates:check', async () =>
-  checkUpdates().catch(error => ({
-    supported: true,
-    branch: readDesktopUpdateConfig().branch,
-    error: 'check-failed',
-    message: error?.message || String(error),
-    fetchedAt: Date.now()
-  }))
-)
-
-ipcMain.handle('hermes:updates:apply', async (_event, payload) =>
-  applyUpdates(payload || {}).catch(error => ({
-    ok: false,
-    error: 'apply-failed',
-    message: error?.message || String(error)
-  }))
-)
-
-ipcMain.handle('hermes:updates:branch:get', async () => readDesktopUpdateConfig())
-
-ipcMain.handle('hermes:updates:branch:set', async (_event, name) => {
-  const branch = typeof name === 'string' && name.trim() ? name.trim() : DEFAULT_UPDATE_BRANCH
-  writeDesktopUpdateConfig({ branch })
-  return { branch }
+// Auto-update IPC lives in updates-ipc.cjs; the update engine + on-disk
+// config stay in the main process and are injected.
+registerUpdatesIpc({
+  applyUpdates,
+  checkUpdates,
+  DEFAULT_UPDATE_BRANCH,
+  ipcMain,
+  readDesktopUpdateConfig,
+  writeDesktopUpdateConfig
 })
 
 // Resolve the canonical Hermes version (the one `release.py` bumps in

--- a/apps/desktop/electron/updates-ipc.cjs
+++ b/apps/desktop/electron/updates-ipc.cjs
@@ -1,0 +1,41 @@
+'use strict'
+
+// Auto-update IPC: check / apply / branch get+set. The update engine
+// (checkUpdates/applyUpdates) and the on-disk update config live in the main
+// process and are injected, so this module owns only the request wiring.
+function registerUpdatesIpc({
+  applyUpdates,
+  checkUpdates,
+  DEFAULT_UPDATE_BRANCH,
+  ipcMain,
+  readDesktopUpdateConfig,
+  writeDesktopUpdateConfig
+}) {
+  ipcMain.handle('hermes:updates:check', async () =>
+    checkUpdates().catch(error => ({
+      supported: true,
+      branch: readDesktopUpdateConfig().branch,
+      error: 'check-failed',
+      message: error?.message || String(error),
+      fetchedAt: Date.now()
+    }))
+  )
+
+  ipcMain.handle('hermes:updates:apply', async (_event, payload) =>
+    applyUpdates(payload || {}).catch(error => ({
+      ok: false,
+      error: 'apply-failed',
+      message: error?.message || String(error)
+    }))
+  )
+
+  ipcMain.handle('hermes:updates:branch:get', async () => readDesktopUpdateConfig())
+
+  ipcMain.handle('hermes:updates:branch:set', async (_event, name) => {
+    const branch = typeof name === 'string' && name.trim() ? name.trim() : DEFAULT_UPDATE_BRANCH
+    writeDesktopUpdateConfig({ branch })
+    return { branch }
+  })
+}
+
+module.exports = { registerUpdatesIpc }

--- a/apps/desktop/electron/updates-ipc.test.cjs
+++ b/apps/desktop/electron/updates-ipc.test.cjs
@@ -1,0 +1,76 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const { registerUpdatesIpc } = require('./updates-ipc.cjs')
+
+function fakeIpcMain() {
+  const handlers = new Map()
+
+  return {
+    handlers,
+    handle(channel, handler) {
+      assert.ok(!handlers.has(channel), `duplicate registration for ${channel}`)
+      handlers.set(channel, handler)
+    }
+  }
+}
+
+function deps(overrides = {}) {
+  return {
+    applyUpdates: async () => ({ ok: true }),
+    checkUpdates: async () => ({ supported: true }),
+    DEFAULT_UPDATE_BRANCH: 'main',
+    readDesktopUpdateConfig: () => ({ branch: 'main' }),
+    writeDesktopUpdateConfig: () => {},
+    ...overrides
+  }
+}
+
+test('registerUpdatesIpc wires only hermes:updates:* channels, each to a handler fn', () => {
+  const ipcMain = fakeIpcMain()
+
+  registerUpdatesIpc({ ipcMain, ...deps() })
+
+  assert.ok(ipcMain.handlers.size >= 4, `expected the full updates surface, got ${ipcMain.handlers.size}`)
+
+  for (const [channel, handler] of ipcMain.handlers) {
+    assert.match(channel, /^hermes:updates:/, `${channel} is not an updates channel`)
+    assert.equal(typeof handler, 'function', `${channel} should register a handler`)
+  }
+
+  for (const channel of ['hermes:updates:check', 'hermes:updates:apply', 'hermes:updates:branch:set']) {
+    assert.ok(ipcMain.handlers.has(channel), `missing ${channel}`)
+  }
+})
+
+test('branch:set falls back to the default branch for blank input and persists it', async () => {
+  const ipcMain = fakeIpcMain()
+  const writes = []
+
+  registerUpdatesIpc({ ipcMain, ...deps({ writeDesktopUpdateConfig: c => writes.push(c) }) })
+
+  assert.deepEqual(await ipcMain.handlers.get('hermes:updates:branch:set')({}, '   '), { branch: 'main' })
+  assert.deepEqual(await ipcMain.handlers.get('hermes:updates:branch:set')({}, 'dev'), { branch: 'dev' })
+  assert.deepEqual(writes, [{ branch: 'main' }, { branch: 'dev' }])
+})
+
+test('check swallows engine failures into a structured error payload', async () => {
+  const ipcMain = fakeIpcMain()
+
+  registerUpdatesIpc({
+    ipcMain,
+    ...deps({
+      checkUpdates: async () => {
+        throw new Error('network down')
+      }
+    })
+  })
+
+  const res = await ipcMain.handlers.get('hermes:updates:check')({})
+
+  assert.equal(res.error, 'check-failed')
+  assert.equal(res.message, 'network down')
+  assert.equal(res.branch, 'main')
+})


### PR DESCRIPTION
## Summary

Fourth `main.cjs` cluster peel, stacked on the terminal-ipc PR (#55817). The four `hermes:updates:*` handlers — `check`, `apply`, `branch:get`, `branch:set` — move **verbatim** into `electron/updates-ipc.cjs` behind a `registerUpdatesIpc({ ipcMain, checkUpdates, applyUpdates, readDesktopUpdateConfig, writeDesktopUpdateConfig, DEFAULT_UPDATE_BRANCH })` registrar.

- The update engine (`checkUpdates`/`applyUpdates`) and the on-disk update config readers/writers stay in the main process and are injected.
- The interleaved `resolveHermesVersion`/`showAboutPanelFresh` helpers + the `hermes:version` handler are **shared with the app menu**, so they're intentionally left in place (this PR is scoped to the contiguous `updates:*` block).
- **Channel names unchanged** → preload + renderer untouched.

> Stacked on `bb/main-terminal-ipc` → retargets to `main` as the stack merges.

## Test plan

- [x] `node --check` + `eslint` clean on `updates-ipc.cjs` + `main.cjs`
- [x] No inline `hermes:updates:*` handlers left in `main.cjs`; registrar wired once
- [x] `node --test electron/updates-ipc.test.cjs` — 3 passed (surface invariant; blank `branch:set` → default + persisted; `check` failure → structured `check-failed` payload)