### PR TITLE
fix(agent): chat()/main() raise KeyError('final_response') on run_conversation error paths

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5465,7 +5465,12 @@ class AIAgent:
             str: Final assistant response
         """
         result = self.run_conversation(message, stream_callback=stream_callback)
-        return result["final_response"]
+        # run_conversation's error/exhaustion paths (invalid response after
+        # max retries, payload-too-large after compression, compaction
+        # disabled, …) return a result dict with an ``error`` key but no
+        # ``final_response``. Use .get so chat() degrades to an empty string
+        # instead of raising KeyError — matching every other call site.
+        return result.get("final_response") or ""
 
     def _run_codex_app_server_turn(
         self,
@@ -5658,10 +5663,10 @@ def main(
     print(f"📞 API Calls: {result['api_calls']}")
     print(f"💬 Messages: {len(result['messages'])}")
     
-    if result['final_response']:
+    if result.get('final_response'):
         print("\n🎯 FINAL RESPONSE:")
         print("-" * 30)
-        print(result['final_response'])
+        print(result.get('final_response'))
     
     # Save sample trajectory to UUID-named file if requested
     if save_sample:

--- a/tests/run_agent/test_chat_error_result_no_keyerror.py
+++ b/tests/run_agent/test_chat_error_result_no_keyerror.py
@@ -1,0 +1,47 @@
+"""Regression: AIAgent.chat() raised KeyError on run_conversation error paths.
+
+``run_conversation`` returns a result dict WITHOUT a ``final_response`` key on
+several error/exhaustion paths (invalid response after max retries,
+payload-too-large after compression, compaction disabled, …). ``chat()`` read
+it via ``result["final_response"]`` (subscript), so those paths crashed with
+``KeyError: 'final_response'`` instead of degrading gracefully — unlike every
+other call site, which uses ``.get``.
+"""
+
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent
+
+
+# Mirrors the shapes returned by run_conversation's error/exhaustion paths
+# (agent/conversation_loop.py) — note the absence of "final_response".
+_ERROR_RESULTS = [
+    {
+        "messages": [], "completed": False, "api_calls": 3,
+        "error": "Request payload too large: max compression attempts (3) reached.",
+        "partial": True, "failed": True, "compression_exhausted": True,
+    },
+    {
+        "messages": [], "completed": False, "api_calls": 5,
+        "error": "Invalid API response after 5 retries: empty content",
+        "failed": True,
+    },
+]
+
+
+def test_chat_returns_gracefully_on_error_result():
+    for err in _ERROR_RESULTS:
+        agent = MagicMock()
+        agent.run_conversation.return_value = err
+        # Must not raise KeyError — degrade to empty string.
+        out = AIAgent.chat(agent, "hello")
+        assert out == ""
+
+
+def test_chat_returns_final_response_on_success():
+    agent = MagicMock()
+    agent.run_conversation.return_value = {
+        "final_response": "the answer",
+        "messages": [], "completed": True, "api_calls": 1,
+    }
+    assert AIAgent.chat(agent, "hi") == "the answer"


### PR DESCRIPTION
### Summary

`AIAgent.chat()` and the direct-CLI `main()` read the turn result with subscript access:

```python
# chat()
return result["final_response"]

# main()
if result['final_response']:
    ...
    print(result['final_response'])
```

But `run_conversation` returns a result dict **without** a `final_response` key on its error/exhaustion paths — those dicts carry an `error` key instead. There are 8 such returns in `agent/conversation_loop.py` (invalid response after max retries, payload-too-large after compression exhaustion, compaction disabled, context-overflow give-up, …). On any of them, `chat()`/`main()` raise `KeyError: 'final_response'` with an opaque traceback rather than surfacing the error.

Every other call site in the codebase already reads it defensively with `.get("final_response", ...)`.

### Reproduction

```python
from unittest.mock import MagicMock
from run_agent import AIAgent

agent = MagicMock()
agent.run_conversation.return_value = {
    "messages": [], "completed": False, "api_calls": 3,
    "error": "Request payload too large: max compression attempts (3) reached.",
    "partial": True, "failed": True, "compression_exhausted": True,
}
AIAgent.chat(agent, "hello")
# KeyError: 'final_response'
```

### Fix

Read `final_response` with `.get` in `chat()` (degrading to `""`, honoring the `-> str` contract) and `main()`, matching the rest of the codebase. No change to `run_conversation`'s error-dict contract.

### Tests

Adds a regression test asserting `chat()` returns gracefully (`""`) on the error-result shapes — it raised `KeyError` before the change — and still returns the response on success.

Fixes #55822
