### PR TITLE
[codex] fix Photon platform plugin CLI loading

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1955,11 +1955,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             # explicitly disabled it, never re-enable here just because
             # check_fn() / is_connected() pass (e.g. a token is present but the
             # user set telegram.enabled: false). #41112.
-            if (
-                existing_cfg is not None
-                and not existing_cfg.enabled
-                and bool((existing_cfg.extra or {}).get("_enabled_explicit", False))
-            ):
+            if existing_cfg is not None and not existing_cfg.enabled:
                 continue
             # Seed candidate extras from ``env_enablement_fn`` so plugins
             # whose ``is_connected`` reads ``config.extra`` (e.g. Google

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13521,6 +13521,28 @@ def main():
 
     _processed_argv = _coalesce_session_name_args(sys.argv[1:])
 
+    if _plugin_cli_discovery_needed():
+        try:
+            from hermes_cli.plugins import discover_plugins, get_plugin_cli_commands
+
+            discover_plugins()
+            for _name, _spec in get_plugin_cli_commands().items():
+                if _name in getattr(subparsers, "choices", {}):
+                    continue
+                _plugin_parser = subparsers.add_parser(
+                    _name,
+                    help=_spec.get("help") or "Plugin command",
+                    description=_spec.get("description") or None,
+                )
+                _setup_fn = _spec.get("setup_fn")
+                if callable(_setup_fn):
+                    _setup_fn(_plugin_parser)
+                _handler_fn = _spec.get("handler_fn")
+                if callable(_handler_fn):
+                    _plugin_parser.set_defaults(func=_handler_fn)
+        except Exception:
+            logger.warning("plugin CLI command discovery failed", exc_info=True)
+
     # ── Defensive subparser routing (bpo-9338 workaround) ───────────
     # On some Python versions (notably <3.11), argparse fails to route
     # subcommand tokens when the parent parser has nargs='?' optional

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1398,7 +1398,20 @@ class PluginManager:
             # is imported only when the gateway / cron / setup / send_message
             # path actually asks for that platform. Every platform Hermes ships
             # remains available out of the box — it just loads on first use.
+            #
+            # Exception: an explicitly-enabled bundled platform must load
+            # normally so plugin-owned CLI commands (for example
+            # `hermes photon setup`) are registered during plugin CLI
+            # discovery. Otherwise the plugin can appear enabled in
+            # `hermes plugins list` while its setup command is unreachable.
             if manifest.source == "bundled" and manifest.kind == "platform":
+                is_enabled = (
+                    enabled is not None
+                    and (lookup_key in enabled or manifest.name in enabled)
+                )
+                if is_enabled:
+                    self._load_plugin(manifest)
+                    continue
                 self._register_deferred_platform(manifest)
                 continue
 
@@ -1954,6 +1967,10 @@ class PluginManager:
             )
         return result
 
+    def get_cli_commands(self) -> Dict[str, dict]:
+        """Return plugin-registered top-level CLI commands."""
+        return dict(self._cli_commands)
+
     # -----------------------------------------------------------------------
     # Plugin skill lookups
     # -----------------------------------------------------------------------
@@ -1999,6 +2016,11 @@ def discover_plugins(force: bool = False) -> None:
     manifests and reload state in the current process.
     """
     get_plugin_manager().discover_and_load(force=force)
+
+
+def get_plugin_cli_commands() -> Dict[str, dict]:
+    """Return plugin-registered top-level CLI command specs."""
+    return get_plugin_manager().get_cli_commands()
 
 
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:

--- a/tests/gateway/test_plugin_env_enablement.py
+++ b/tests/gateway/test_plugin_env_enablement.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+
+
+def _entry(name="photon"):
+    return SimpleNamespace(
+        name=name,
+        env_enablement_fn=lambda: {"project_id": "pid", "project_secret": "secret"},
+        is_connected=lambda cfg: True,
+        check_fn=lambda: True,
+    )
+
+
+def test_plugin_env_enablement_respects_existing_disabled_config():
+    platform = Platform("photon")
+    cfg = GatewayConfig(platforms={platform: PlatformConfig(enabled=False, extra={})})
+
+    with patch("hermes_cli.plugins.discover_plugins", lambda: None), patch(
+        "gateway.platform_registry.platform_registry.plugin_entries",
+        return_value=[_entry()],
+    ):
+        _apply_env_overrides(cfg)
+
+    assert cfg.platforms[platform].enabled is False
+
+
+def test_plugin_env_enablement_still_enables_env_only_platform():
+    platform = Platform("photon")
+    cfg = GatewayConfig(platforms={})
+
+    with patch("hermes_cli.plugins.discover_plugins", lambda: None), patch(
+        "gateway.platform_registry.platform_registry.plugin_entries",
+        return_value=[_entry()],
+    ):
+        _apply_env_overrides(cfg)
+
+    assert cfg.platforms[platform].enabled is True
+    assert cfg.platforms[platform].extra["project_id"] == "pid"

--- a/tests/plugins/test_bundled_platform_plugin_loading.py
+++ b/tests/plugins/test_bundled_platform_plugin_loading.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+from hermes_cli import plugins as plugins_mod
+from hermes_cli.plugins import PluginManager, PluginManifest
+
+
+def _fake_platform_manifest(tmp_path: Path) -> PluginManifest:
+    plugin_dir = tmp_path / "plugins" / "platforms" / "fake"
+    plugin_dir.mkdir(parents=True)
+    return PluginManifest(
+        name="fake-platform",
+        key="platforms/fake",
+        kind="platform",
+        source="bundled",
+        path=str(plugin_dir),
+    )
+
+
+def test_explicitly_enabled_bundled_platform_loads_for_cli(monkeypatch, tmp_path):
+    manifest = _fake_platform_manifest(tmp_path)
+    manager = PluginManager()
+    loaded = []
+    deferred = []
+
+    def fake_scan_directory(path, source, skip_names=None):
+        if Path(path).name == "platforms":
+            return [manifest]
+        return []
+
+    monkeypatch.setattr(manager, "_scan_directory", fake_scan_directory)
+    monkeypatch.setattr(manager, "_scan_entry_points", lambda: [])
+    monkeypatch.setattr(manager, "_load_plugin", lambda m: loaded.append(m.key))
+    monkeypatch.setattr(manager, "_register_deferred_platform", lambda m: deferred.append(m.key))
+    monkeypatch.setattr(plugins_mod, "_get_enabled_plugins", lambda: {"platforms/fake"})
+    monkeypatch.setattr(plugins_mod, "_get_disabled_plugins", lambda: set())
+
+    manager.discover_and_load(force=True)
+
+    assert loaded == ["platforms/fake"]
+    assert deferred == []
+
+
+def test_non_enabled_bundled_platform_still_defers(monkeypatch, tmp_path):
+    manifest = _fake_platform_manifest(tmp_path)
+    manager = PluginManager()
+    loaded = []
+    deferred = []
+
+    def fake_scan_directory(path, source, skip_names=None):
+        if Path(path).name == "platforms":
+            return [manifest]
+        return []
+
+    monkeypatch.setattr(manager, "_scan_directory", fake_scan_directory)
+    monkeypatch.setattr(manager, "_scan_entry_points", lambda: [])
+    monkeypatch.setattr(manager, "_load_plugin", lambda m: loaded.append(m.key))
+    monkeypatch.setattr(manager, "_register_deferred_platform", lambda m: deferred.append(m.key))
+    monkeypatch.setattr(plugins_mod, "_get_enabled_plugins", lambda: set())
+    monkeypatch.setattr(plugins_mod, "_get_disabled_plugins", lambda: set())
+
+    manager.discover_and_load(force=True)
+
+    assert loaded == []
+    assert deferred == ["platforms/fake"]


### PR DESCRIPTION
## Summary

Keep explicitly enabled bundled platform plugins loadable during plugin CLI discovery so plugin-owned commands such as `hermes photon setup` remain available.

Also tighten gateway env auto-enable behavior so an explicitly disabled platform stays disabled even when credentials are present in the environment.

## Root Cause

Bundled platform plugins are normally deferred to avoid importing every platform SDK on ordinary CLI startup. That is correct for the common path, but it also meant an explicitly enabled bundled platform could appear enabled while its plugin-owned top-level CLI command was never registered.

Separately, gateway env auto-enable only skipped disabled platform configs when an internal `_enabled_explicit` marker was present. User config that disabled a platform without that marker could be re-enabled by environment credentials.

## Changes

- Load explicitly enabled bundled platform plugins during plugin discovery so their CLI commands register.
- Expose plugin-registered top-level CLI command specs to the main CLI parser.
- Register plugin CLI commands before argparse routing.
- Respect any existing disabled platform config during env auto-enable.
- Add regression coverage for Photon-style env enablement and bundled platform CLI loading.

## Validation

- `scripts/run_tests.sh tests/gateway/test_plugin_env_enablement.py tests/plugins/test_bundled_platform_plugin_loading.py`
- `uv pip check --python /home/fnoor1/.hermes/hermes-agent/venv/bin/python`
- Live smoke: `hermes photon --help`