### PR TITLE
refactor(desktop): extract VS Code Marketplace theme IPC from main.cjs into vscode-theme-ipc.cjs

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -41,7 +41,6 @@ const { adoptServedDashboardToken } = require('./dashboard-token.cjs')
 const { waitForDashboardPortAnnouncement } = require('./backend-ready.cjs')
 const { dashboardFallbackArgs, sourceDeclaresServe } = require('./backend-command.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
-const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
 const { buildDesktopBackendEnv, normalizeHermesHomeRoot } = require('./backend-env.cjs')
 const { readWindowsUserEnvVar } = require('./windows-user-env.cjs')
 const { readWslWindowsClipboardImage } = require('./wsl-clipboard-image.cjs')
@@ -62,6 +61,7 @@ const { registerTerminalIpc } = require('./terminal-ipc.cjs')
 const { registerUpdatesIpc } = require('./updates-ipc.cjs')
 const { registerLogsIpc } = require('./logs-ipc.cjs')
 const { registerProjectDirIpc } = require('./project-dir-ipc.cjs')
+const { registerVscodeThemeIpc } = require('./vscode-theme-ipc.cjs')
 const { OFFICIAL_REPO_HTTPS_URL, isOfficialSshRemote } = require('./update-remote.cjs')
 const { resolveBehindCount, shouldCountCommits } = require('./update-count.cjs')
 const { runRebuildWithRetry } = require('./update-rebuild.cjs')
@@ -7133,12 +7133,8 @@ ipcMain.handle('hermes:uninstall:run', async (_event, payload) => {
   return runDesktopUninstall(String(mode || ''))
 })
 
-// Download a VS Code Marketplace extension and return the raw color-theme JSON
-// it contributes. No theme code is executed — we only read JSON from the .vsix.
-ipcMain.handle('hermes:vscode-theme:fetch', async (_event, id) => fetchMarketplaceThemes(String(id || '')))
-
-// Search the Marketplace for color-theme extensions (empty query = top installs).
-ipcMain.handle('hermes:vscode-theme:search', async (_event, query) => searchMarketplaceThemes(String(query || ''), 20))
+// VS Code Marketplace theme IPC lives in vscode-theme-ipc.cjs.
+registerVscodeThemeIpc({ ipcMain })
 
 // ---------------------------------------------------------------------------
 // hermes:// deep links (e.g. hermes://blueprint/morning-brief?time=08:00).

--- a/apps/desktop/electron/vscode-theme-ipc.cjs
+++ b/apps/desktop/electron/vscode-theme-ipc.cjs
@@ -1,0 +1,19 @@
+'use strict'
+
+const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
+
+// VS Code Marketplace color-theme IPC: fetch a theme by extension id + search the
+// marketplace. Both delegate to the vscode-marketplace sibling module; no theme
+// code is ever executed (only JSON is read from the .vsix).
+function registerVscodeThemeIpc({ ipcMain }) {
+  // Download a VS Code Marketplace extension and return the raw color-theme JSON
+  // it contributes. No theme code is executed — we only read JSON from the .vsix.
+  ipcMain.handle('hermes:vscode-theme:fetch', async (_event, id) => fetchMarketplaceThemes(String(id || '')))
+
+  // Search the Marketplace for color-theme extensions (empty query = top installs).
+  ipcMain.handle('hermes:vscode-theme:search', async (_event, query) =>
+    searchMarketplaceThemes(String(query || ''), 20)
+  )
+}
+
+module.exports = { registerVscodeThemeIpc }

--- a/apps/desktop/electron/vscode-theme-ipc.test.cjs
+++ b/apps/desktop/electron/vscode-theme-ipc.test.cjs
@@ -1,0 +1,30 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const { registerVscodeThemeIpc } = require('./vscode-theme-ipc.cjs')
+
+function fakeIpcMain() {
+  const handlers = new Map()
+
+  return {
+    handlers,
+    handle(channel, handler) {
+      assert.ok(!handlers.has(channel), `duplicate registration for ${channel}`)
+      handlers.set(channel, handler)
+    }
+  }
+}
+
+test('registerVscodeThemeIpc wires only hermes:vscode-theme:* channels, each to a handler fn', () => {
+  const ipcMain = fakeIpcMain()
+
+  registerVscodeThemeIpc({ ipcMain })
+
+  assert.deepEqual([...ipcMain.handlers.keys()].sort(), ['hermes:vscode-theme:fetch', 'hermes:vscode-theme:search'])
+
+  for (const handler of ipcMain.handlers.values()) {
+    assert.equal(typeof handler, 'function')
+  }
+})


### PR DESCRIPTION
## Summary

Seventh `main.cjs` cluster peel, stacked on the project-dir PR (#55825). The two `hermes:vscode-theme:*` handlers — `fetch`, `search` — move **verbatim** into `electron/vscode-theme-ipc.cjs` behind a `registerVscodeThemeIpc({ ipcMain })` registrar.

- Both delegate to the `vscode-marketplace.cjs` sibling module, which the new module requires **directly** (zero injection) — so the now-dead `fetchMarketplaceThemes`/`searchMarketplaceThemes` require in `main.cjs` is removed.
- **Channel names unchanged** → preload + renderer untouched.

> Stacked on `bb/main-projectdir-ipc` → retargets to `main` as the stack merges.

## Test plan

- [x] `node --check` + `eslint` clean (incl. dead-require removal)
- [x] No inline `hermes:vscode-theme:*` handlers left in `main.cjs`
- [x] `node --test electron/vscode-theme-ipc.test.cjs` — surface invariant passes