### PR TITLE
feat(scripts): add context file brief helper

### DIFF
--- a/docs/plans/nightly-context-file-brief.md
+++ b/docs/plans/nightly-context-file-brief.md
@@ -1,0 +1,28 @@
+# Nightly context file brief helper
+
+## Goal
+
+Add a small local-first helper that scans agent context files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `SOUL.md`, `.cursorrules`) for prompt-budget bloat and produces a deterministic morning brief.
+
+## Why
+
+Joe's Hermes workflow depends on durable context, but oversized rule files silently increase prompt cost and make instruction drift harder to review. A read-only helper lets cron or manual runs flag files that need trimming without touching private content or secrets.
+
+## Requirements
+
+- Read-only: never modifies or deletes files.
+- Local-first: no network calls or credentials.
+- Deterministic output for cron usage.
+- Scan a configurable root recursively while skipping common generated/vendor directories.
+- Report file status by byte size:
+  - `ok`: below warn threshold
+  - `warn`: at/above warn threshold and below over threshold
+  - `over`: at/above over threshold
+- Support Markdown output for humans and JSON output for automation.
+- Support exact `[SILENT]` when all discovered files are `ok`.
+
+## Test plan
+
+- Unit tests for classification thresholds and scan exclusions.
+- CLI tests for Markdown, JSON, and silent behavior.
+- Focused wrapper run: `scripts/run_tests.sh tests/scripts/test_context_file_brief.py`.

--- a/scripts/context_file_brief.py
+++ b/scripts/context_file_brief.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Scan agent context files for prompt-budget bloat.
+
+This helper is intentionally read-only and local-first. It is useful from cron
+jobs that should warn when AGENTS.md / CLAUDE.md / SOUL.md-style files grow
+large enough to waste context or hide stale instructions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+DEFAULT_CONTEXT_NAMES = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    "GEMINI.md",
+    "SOUL.md",
+    ".cursorrules",
+)
+DEFAULT_SKIP_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "venv",
+    "env",
+    "node_modules",
+    "dist",
+    "build",
+    "__pycache__",
+}
+DEFAULT_WARN_BYTES = 20_000
+DEFAULT_OVER_BYTES = 50_000
+
+
+@dataclass(frozen=True)
+class ContextFileReport:
+    path: Path
+    size_bytes: int
+    status: str
+
+    def as_dict(self, root: Path) -> dict:
+        return {
+            "path": _display_path(self.path, root),
+            "size_bytes": self.size_bytes,
+            "status": self.status,
+        }
+
+
+def classify_size(size_bytes: int, *, warn_bytes: int, over_bytes: int) -> str:
+    """Classify a context file size against inclusive thresholds."""
+    if over_bytes <= warn_bytes:
+        raise ValueError("over_bytes must be greater than warn_bytes")
+    if size_bytes >= over_bytes:
+        return "over"
+    if size_bytes >= warn_bytes:
+        return "warn"
+    return "ok"
+
+
+def scan_context_files(
+    root: Path | str,
+    *,
+    names: Sequence[str] = DEFAULT_CONTEXT_NAMES,
+    skip_dirs: Iterable[str] = DEFAULT_SKIP_DIRS,
+    warn_bytes: int = DEFAULT_WARN_BYTES,
+    over_bytes: int = DEFAULT_OVER_BYTES,
+) -> list[ContextFileReport]:
+    """Return reports for matching context files under ``root``.
+
+    The walk prunes common generated/vendor directories so a repository's
+    vendored dependencies do not dominate the report.
+    """
+    root_path = Path(root).expanduser().resolve()
+    wanted = set(names)
+    skipped = set(skip_dirs)
+    reports: list[ContextFileReport] = []
+
+    if not root_path.exists():
+        raise FileNotFoundError(f"root does not exist: {root_path}")
+    if root_path.is_file():
+        candidates = [root_path] if root_path.name in wanted else []
+    else:
+        candidates = []
+        for dirpath, dirnames, filenames in os.walk(root_path):
+            dirnames[:] = [name for name in dirnames if name not in skipped]
+            for filename in filenames:
+                if filename in wanted:
+                    candidates.append(Path(dirpath) / filename)
+
+    for path in sorted(candidates, key=lambda p: str(p.relative_to(root_path) if p != root_path else p)):
+        size = path.stat().st_size
+        reports.append(
+            ContextFileReport(
+                path=path,
+                size_bytes=size,
+                status=classify_size(size, warn_bytes=warn_bytes, over_bytes=over_bytes),
+            )
+        )
+    return reports
+
+
+def render_json(reports: Sequence[ContextFileReport], root: Path | str) -> str:
+    root_path = Path(root).expanduser().resolve()
+    counts = Counter(report.status for report in reports)
+    payload = {
+        "root": str(root_path),
+        "counts": {"ok": counts.get("ok", 0), "warn": counts.get("warn", 0), "over": counts.get("over", 0)},
+        "files": [report.as_dict(root_path) for report in reports],
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=False)
+
+
+def render_markdown(
+    reports: Sequence[ContextFileReport],
+    root: Path | str,
+    *,
+    include_ok: bool = False,
+    silent_if_ok: bool = False,
+) -> str:
+    root_path = Path(root).expanduser().resolve()
+    attention = [report for report in reports if include_ok or report.status != "ok"]
+    if silent_if_ok and not any(report.status != "ok" for report in reports):
+        return "[SILENT]"
+
+    counts = Counter(report.status for report in reports)
+    if not reports:
+        return f"# Context file brief\n\nNo context files found under `{root_path}`."
+
+    lines = [
+        "# Context file brief",
+        "",
+        f"Root: `{root_path}`",
+        f"Summary: {counts.get('over', 0)} over / {counts.get('warn', 0)} warn / {counts.get('ok', 0)} ok",
+        "",
+    ]
+
+    if attention:
+        lines.extend([
+            "## Files needing attention",
+            "",
+            "| Status | Size | Path |",
+            "| --- | ---: | --- |",
+        ])
+        for report in attention:
+            lines.append(
+                f"| {report.status} | {_format_bytes(report.size_bytes)} | `{_display_path(report.path, root_path)}` |"
+            )
+        lines.extend([
+            "",
+            "Next action: trim duplicated rules, move procedural detail into skills/references, or split repo-specific context into narrower subdirectory files.",
+        ])
+    else:
+        lines.append("All discovered context files are within the configured budget.")
+
+    return "\n".join(lines)
+
+
+def _display_path(path: Path, root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _format_bytes(size: int) -> str:
+    if size < 1024:
+        return f"{size} B"
+    if size < 1024 * 1024:
+        return f"{size / 1024:.1f} KiB"
+    return f"{size / (1024 * 1024):.1f} MiB"
+
+
+def _parse_names(value: str) -> tuple[str, ...]:
+    return tuple(name.strip() for name in value.split(",") if name.strip())
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="Directory or file to scan (default: current directory)")
+    parser.add_argument("--names", default=",".join(DEFAULT_CONTEXT_NAMES), help="Comma-separated file names to scan")
+    parser.add_argument("--warn-bytes", type=int, default=DEFAULT_WARN_BYTES, help="Inclusive warning threshold")
+    parser.add_argument("--over-bytes", type=int, default=DEFAULT_OVER_BYTES, help="Inclusive over-budget threshold")
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    parser.add_argument("--include-ok", action="store_true", help="Include ok files in Markdown output")
+    parser.add_argument("--silent-if-ok", action="store_true", help="Print exactly [SILENT] when every discovered file is ok")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = Path(args.root).expanduser().resolve()
+    reports = scan_context_files(
+        root,
+        names=_parse_names(args.names),
+        warn_bytes=args.warn_bytes,
+        over_bytes=args.over_bytes,
+    )
+    if args.format == "json":
+        print(render_json(reports, root))
+    else:
+        print(render_markdown(reports, root, include_ok=args.include_ok, silent_if_ok=args.silent_if_ok))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_context_file_brief.py
+++ b/tests/scripts/test_context_file_brief.py
@@ -1,0 +1,77 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import scripts.context_file_brief as brief
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "context_file_brief.py"
+
+
+def test_scan_classifies_context_files_and_skips_vendor_dirs(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("a" * 9, encoding="utf-8")
+    nested = tmp_path / "project"
+    nested.mkdir()
+    (nested / "CLAUDE.md").write_text("b" * 10, encoding="utf-8")
+    (nested / "SOUL.md").write_text("c" * 15, encoding="utf-8")
+    vendor = tmp_path / "node_modules"
+    vendor.mkdir()
+    (vendor / "AGENTS.md").write_text("d" * 100, encoding="utf-8")
+
+    results = brief.scan_context_files(tmp_path, warn_bytes=10, over_bytes=15)
+
+    by_name = {item.path.name: item for item in results}
+    assert by_name["AGENTS.md"].status == "ok"
+    assert by_name["CLAUDE.md"].status == "warn"
+    assert by_name["SOUL.md"].status == "over"
+    assert all("node_modules" not in item.path.parts for item in results)
+
+
+def test_markdown_silent_when_everything_is_ok(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("small", encoding="utf-8")
+
+    results = brief.scan_context_files(tmp_path, warn_bytes=100, over_bytes=200)
+
+    assert brief.render_markdown(results, tmp_path, silent_if_ok=True) == "[SILENT]"
+
+
+def test_markdown_lists_only_attention_items_by_default(tmp_path):
+    ok = brief.ContextFileReport(tmp_path / "AGENTS.md", 5, "ok")
+    warn = brief.ContextFileReport(tmp_path / "CLAUDE.md", 11, "warn")
+    over = brief.ContextFileReport(tmp_path / "SOUL.md", 20, "over")
+
+    output = brief.render_markdown([ok, warn, over], tmp_path)
+
+    assert "CLAUDE.md" in output
+    assert "SOUL.md" in output
+    assert "AGENTS.md" not in output
+    assert "Next action" in output
+
+
+def test_json_cli_outputs_machine_readable_summary(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("a" * 10, encoding="utf-8")
+    (tmp_path / "CLAUDE.md").write_text("b" * 20, encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(tmp_path),
+            "--warn-bytes",
+            "15",
+            "--over-bytes",
+            "20",
+            "--format",
+            "json",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert payload["root"] == str(tmp_path)
+    assert payload["counts"] == {"ok": 1, "warn": 0, "over": 1}
+    assert [item["status"] for item in payload["files"]] == ["ok", "over"]


### PR DESCRIPTION
## Summary

- Adds `scripts/context_file_brief.py`, a read-only local helper that scans agent context files for prompt-budget bloat.
- Supports Markdown and JSON output, configurable thresholds/names, generated/vendor directory skips, and exact `[SILENT]` output when all files are within budget.
- Adds a small spec plus focused tests for classification, scan exclusions, Markdown rendering, and JSON CLI behavior.

## Why

Large `AGENTS.md` / `CLAUDE.md` / `SOUL.md` files silently increase prompt cost and make instruction drift harder to spot. This gives Joe's nightly/proactive workflows a deterministic way to flag context hygiene work without reading secrets, touching network, or mutating files.

## Testing

- `scripts/run_tests.sh tests/scripts/test_context_file_brief.py`
- Smoke: `python scripts/context_file_brief.py --root . --warn-bytes 20000 --over-bytes 50000 --format json`

## Post-Deploy Monitoring & Validation

No additional production monitoring required: this is a standalone read-only helper script and test coverage. Manual validation is the CLI smoke command above; failure signal is a non-zero exit or malformed Markdown/JSON output.
