### PR TITLE
fix(agent): detect CJK intent-ack replies in looks_like_codex_intermediate_ack

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2341,7 +2341,14 @@ def looks_like_codex_intermediate_ack(
     has_future_ack = bool(
         re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
     )
-    if not has_future_ack:
+    # Parallel CJK substring check — \b word boundaries don't apply to CJK,
+    # so the English regex can't be extended. #55664: this made intent-ack
+    # continuation a no-op for CJK users even with the all-api_mode opt-in.
+    cjk_future_acks = (
+        "我先", "我來", "我会", "我會", "讓我", "让我", "我直接", "接下來我", "接下来我",
+    )
+    has_cjk_future_ack = any(phrase in assistant_text for phrase in cjk_future_acks)
+    if not has_future_ack and not has_cjk_future_ack:
         return False
 
     action_markers = (
@@ -2365,6 +2372,11 @@ def looks_like_codex_intermediate_ack(
         "report back",
         "summarize",
     )
+    cjk_action_markers = (
+        "載入", "加载", "查", "執行", "执行", "掃描", "扫描", "檢查", "检查",
+        "分析", "讀取", "读取", "搜尋", "搜寻", "測試", "测试", "修復", "修复",
+        "除錯", "除错", "找", "打開", "打开", "看一下", "檢視", "检视",
+    )
     workspace_markers = (
         "directory",
         "current directory",
@@ -2381,7 +2393,10 @@ def looks_like_codex_intermediate_ack(
         "path",
     )
 
-    assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
+    assistant_mentions_action = any(
+        marker in assistant_text
+        for marker in action_markers + cjk_action_markers
+    )
     if not assistant_mentions_action:
         return False
 

--- a/tests/agent/test_intent_ack_continuation.py
+++ b/tests/agent/test_intent_ack_continuation.py
@@ -181,3 +181,48 @@ def test_long_response_is_not_treated_as_an_ack():
     assert not looks_like_codex_intermediate_ack(
         a, REPRO_USER, long_ack, msgs, require_workspace=False
     )
+
+
+# ── detector: CJK replies (#55664) ────────────────────────────────────────
+
+
+def test_cjk_future_ack_fires_with_action_verb():
+    """#55664: Chinese reply announcing intent + action verb must fire.
+
+    Repro from the reporter (Traditional Chinese, MoA aggregator): the
+    model replies "我先載入 skill 確認用法…" and ends the turn. The English
+    regex alone never matches, so the all-api_mode opt-in was effectively
+    dead for CJK users.
+    """
+    a = _agent(True, "chat_completions")
+    user_msg = "幫我看看伺服器目前的狀態"
+    cjk_ack = "我先載入 skill 確認用法，再掃描一次相關檔案。"
+    msgs = [{"role": "user", "content": user_msg}]
+    assert looks_like_codex_intermediate_ack(
+        a, user_msg, cjk_ack, msgs, require_workspace=False
+    )
+
+
+def test_cjk_simplified_future_ack_fires():
+    """Simplified Chinese future-ack + action verb fires the detector."""
+    a = _agent(True, "chat_completions")
+    user_msg = "看一下这个仓库"
+    cjk_ack = "让我先检查一下代码结构。"
+    msgs = [{"role": "user", "content": user_msg}]
+    assert looks_like_codex_intermediate_ack(
+        a, user_msg, cjk_ack, msgs, require_workspace=False
+    )
+
+
+def test_cjk_reply_without_action_verb_does_not_fire():
+    """A CJK future-ack with no action verb must not trip the detector
+    (matches the English guardrail: 'I will help you brainstorm' is not
+    an action)."""
+    a = _agent(True, "chat_completions")
+    user_msg = "幫我想一下方案"
+    # Pure CJK future-ack with no action verb in the cjk_action_markers list.
+    cjk_no_verb = "讓我們一起想想接下來怎麼做。"
+    msgs = [{"role": "user", "content": user_msg}]
+    assert not looks_like_codex_intermediate_ack(
+        a, user_msg, cjk_no_verb, msgs, require_workspace=False
+    )


### PR DESCRIPTION
## Summary

The `looks_like_codex_intermediate_ack` detector used an English-only future-ack regex (`\b(i['’]ll|i will|let me|...)\b`) and English-only action verbs. With the `agent.intent_ack_continuation: true` opt-in (all api_modes path), the detector still returned `False` whenever the acting model replied in a non-English language — most visibly Chinese. The model would announce intent in CJK (e.g.「我先載入 skill 確認用法…」) and the turn ended without any tool running, making the documented safety net a no-op for CJK users (and especially MoA aggregator flows, where the model tends to summarize and stop).

## Fix

Add a parallel CJK substring check to the future-ack and action-verb gates:

- **Future-ack phrases:** 我先, 我來, 我会/我會, 讓我/让我, 我直接, 接下來我/接下来我
- **Action verbs:** 載入/加载, 查, 執行/执行, 掃描/扫描, 檢查/检查, 分析, 讀取/读取, 搜尋/搜寻, 測試/测试, 修復/修复, 除錯/除错, 找, 打開/打开, 看一下, 檢視/检视

The English path is untouched — CJK is a parallel fallback gated by the same short-content / no-prior-tool / action-verb requirements that already guard the English path. `\b` word boundaries cannot be used for CJK, so substring matching is the correct shape.

## Tests

Adds 3 regression tests to `tests/agent/test_intent_ack_continuation.py`:

- `test_cjk_future_ack_fires_with_action_verb` — Traditional Chinese, the reporter's exact repro pattern (`我先載入…再掃描…`).
- `test_cjk_simplified_future_ack_fires` — Simplified Chinese (`让我先检查…`).
- `test_cjk_reply_without_action_verb_does_not_fire` — guards against the false-positive (`讓我們一起想想接下來怎麼做。` must NOT fire, mirroring the English `I will help you brainstorm` guardrail).

Verified that the 2 "fires" tests fail on `main` without the source change and pass with it. The 14 pre-existing tests in the file all still pass.

## Fixes

Closes #55664

## Out of scope

- A more general replacement of the heuristic with an auxiliary classifier is being discussed in #12567. This PR fixes the concrete, high-impact language gap directly; the broader redesign can land separately.