### PR TITLE
fix(compression): strip whitespace from tool_call_id in _sanitize_tool_pairs

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2061,8 +2061,8 @@ This compaction should PRIORITISE preserving all information related to the focu
     def _get_tool_call_id(tc) -> str:
         """Extract the call ID from a tool_call entry (dict or SimpleNamespace)."""
         if isinstance(tc, dict):
-            return tc.get("call_id", "") or tc.get("id", "") or ""
-        return getattr(tc, "call_id", "") or getattr(tc, "id", "") or ""
+            return (tc.get("call_id", "") or tc.get("id", "") or "").strip()
+        return (getattr(tc, "call_id", "") or getattr(tc, "id", "") or "").strip()
 
     def _sanitize_tool_pairs(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Fix orphaned tool_call / tool_result pairs after compression.
@@ -2089,7 +2089,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         result_call_ids: set = set()
         for msg in messages:
             if msg.get("role") == "tool":
-                cid = msg.get("tool_call_id")
+                cid = (msg.get("tool_call_id") or "").strip()
                 if cid:
                     result_call_ids.add(cid)
 
@@ -2098,7 +2098,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         if orphaned_results:
             messages = [
                 m for m in messages
-                if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+                if not (m.get("role") == "tool" and (m.get("tool_call_id") or "").strip() in orphaned_results)
             ]
             if not self.quiet_mode:
                 logger.info("Compression sanitizer: removed %d orphaned tool result(s)", len(orphaned_results))

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2782,3 +2782,60 @@ class TestPreflightSentinelGuard:
         compressor.last_prompt_tokens = 50_000
         result = self._seed(compressor.last_prompt_tokens, 10_000)
         assert result == 50_000
+
+
+class TestSanitizeToolPairsWhitespace:
+    """_sanitize_tool_pairs must strip whitespace from tool_call_id before
+    comparing, matching the fix applied to agent_runtime_helpers.py in
+    commit fa3ab2ffd.  Without stripping, a valid tool result whose
+    tool_call_id has surrounding whitespace is misclassified as orphaned
+    and silently replaced with a [Result unavailable] stub.
+    """
+
+    def _make(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            return ContextCompressor(model="test/model", quiet_mode=True,
+                                     protect_first_n=2, protect_last_n=2)
+
+    def _assistant(self, call_id):
+        return {
+            "role": "assistant", "content": "",
+            "tool_calls": [{"id": call_id, "type": "function",
+                             "function": {"name": "f", "arguments": "{}"}}],
+        }
+
+    def test_leading_whitespace_on_result_id_preserved(self):
+        c = self._make()
+        msgs = [
+            self._assistant("call_abc"),
+            {"role": "tool", "tool_call_id": " call_abc", "content": "ok"},
+        ]
+        out = c._sanitize_tool_pairs(msgs)
+        tool_msgs = [m for m in out if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["content"] == "ok", "valid result must not be treated as orphaned"
+
+    def test_trailing_whitespace_on_result_id_preserved(self):
+        c = self._make()
+        msgs = [
+            self._assistant("call_xyz"),
+            {"role": "tool", "tool_call_id": "call_xyz  ", "content": "data"},
+        ]
+        out = c._sanitize_tool_pairs(msgs)
+        tool_msgs = [m for m in out if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["content"] == "data"
+
+    def test_truly_orphaned_still_removed(self):
+        """Whitespace-trimmed ID that still has no match must be removed.
+        The assistant's call_real has no matching result, so a stub is
+        inserted in its place — the original orphaned entry must be gone."""
+        c = self._make()
+        msgs = [
+            self._assistant("call_real"),
+            {"role": "tool", "tool_call_id": " call_orphan ", "content": "stale"},
+        ]
+        out = c._sanitize_tool_pairs(msgs)
+        tool_call_ids = [m.get("tool_call_id") for m in out if m.get("role") == "tool"]
+        assert "call_orphan" not in tool_call_ids, "genuinely orphaned result must be removed"
+        assert " call_orphan " not in tool_call_ids, "original whitespace form must also be gone"


### PR DESCRIPTION
## Summary
- `ContextCompressor._sanitize_tool_pairs()` compares raw `tool_call_id` strings without stripping whitespace — the same bug `fa3ab2ffd` just fixed in `agent_runtime_helpers.py` / `run_agent.py`.
- `ContextCompressor` has its own near-identical reimplementation of the orphaned-pair repair logic that was left unpatched.
- When an assistant-side call ID and a result-side `tool_call_id` diverge only in surrounding whitespace, valid tool results are silently misclassified as orphaned and replaced with `[Result unavailable]` stubs — data loss on every compression cycle touching such pairs.

## Fix
Apply `.strip()` at all three sites that `_sanitize_tool_pairs` uses for ID comparison:
- `_get_tool_call_id()` (extracts IDs from assistant `tool_calls`)
- The `result_call_ids` accumulation loop
- The `orphaned_results` filter predicate

Mirrors the exact fix `fa3ab2ffd` applied to `_get_tool_call_id_static` and `sanitize_api_messages` in the pre-call sanitizer path.

## Test plan
- `test_leading_whitespace_on_result_id_preserved` — result with leading whitespace is kept, not stubbed
- `test_trailing_whitespace_on_result_id_preserved` — result with trailing whitespace is kept
- `test_truly_orphaned_still_removed` — genuinely unmatched result is still removed

`pytest tests/agent/test_context_compressor.py` → all passed