### PR TITLE
fix(retaindb): skip stale prefetch cache on topic change

### DIFF
--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -460,7 +460,9 @@ class RetainDBMemoryProvider(MemoryProvider):
         self._agent_id = "hermes"
         self._lock = threading.Lock()
 
-        # Prefetch caches
+        # Prefetch caches — keyed to _prefetch_query so a stale result from
+        # the previous turn is not injected when the topic changes.
+        self._prefetch_query: str = ""
         self._context_result = ""
         self._dialectic_result = ""
         self._agent_model: dict = {}
@@ -547,6 +549,11 @@ class RetainDBMemoryProvider(MemoryProvider):
         # Prevents thread accumulation if turns fire faster than prefetches complete.
         for t in self._prefetch_threads:
             t.join(timeout=2.0)
+        with self._lock:
+            self._prefetch_query = query
+            self._context_result = ""
+            self._dialectic_result = ""
+            self._agent_model = {}
         threads = [
             threading.Thread(target=self._prefetch_context, args=(query,), name="retaindb-ctx", daemon=True),
             threading.Thread(target=self._prefetch_dialectic, args=(query,), name="retaindb-dialectic", daemon=True),
@@ -595,14 +602,26 @@ class RetainDBMemoryProvider(MemoryProvider):
         return "high"
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        """Consume prefetched results and return them as a context block."""
+        """Consume prefetched results and return them as a context block.
+
+        Only returns cached results when they were prefetched for *this exact
+        query* — returning results from a prior turn's background prefetch on
+        a topic-shifted question injects stale, irrelevant context.  Mirrors
+        the fix applied to the mem0 provider in c6eb7f9e7.
+        """
         with self._lock:
+            if self._prefetch_query != query:
+                self._context_result = ""
+                self._dialectic_result = ""
+                self._agent_model = {}
+                return ""
             context = self._context_result
             dialectic = self._dialectic_result
             agent_model = self._agent_model
             self._context_result = ""
             self._dialectic_result = ""
             self._agent_model = {}
+            self._prefetch_query = ""
 
         parts: list[str] = []
         if context:

--- a/tests/plugins/test_retaindb_plugin.py
+++ b/tests/plugins/test_retaindb_plugin.py
@@ -556,8 +556,11 @@ class TestPrefetch:
 
     def test_prefetch_consumes_context_result(self, tmp_path, monkeypatch):
         p = self._make_initialized_provider(tmp_path, monkeypatch)
-        # Manually set the cached result
+        # Manually set the cached result, tagged for the query we're about
+        # to consume it with — prefetch() only returns the cache when it
+        # matches the in-flight query (staleness guard).
         with p._lock:
+            p._prefetch_query = "test"
             p._context_result = "[RetainDB Context]\nProfile:\n- User likes tests"
         result = p.prefetch("test")
         assert "User likes tests" in result
@@ -568,6 +571,7 @@ class TestPrefetch:
     def test_prefetch_consumes_dialectic_result(self, tmp_path, monkeypatch):
         p = self._make_initialized_provider(tmp_path, monkeypatch)
         with p._lock:
+            p._prefetch_query = "test"
             p._dialectic_result = "User is a software engineer who prefers Python."
         result = p.prefetch("test")
         assert "[RetainDB User Synthesis]" in result
@@ -577,6 +581,7 @@ class TestPrefetch:
     def test_prefetch_consumes_agent_model(self, tmp_path, monkeypatch):
         p = self._make_initialized_provider(tmp_path, monkeypatch)
         with p._lock:
+            p._prefetch_query = "test"
             p._agent_model = {
                 "memory_count": 5,
                 "persona": "Helpful coding assistant",
@@ -593,6 +598,7 @@ class TestPrefetch:
     def test_prefetch_skips_empty_agent_model(self, tmp_path, monkeypatch):
         p = self._make_initialized_provider(tmp_path, monkeypatch)
         with p._lock:
+            p._prefetch_query = "test"
             p._agent_model = {"memory_count": 0}
         result = p.prefetch("test")
         assert "Agent Self-Model" not in result
@@ -736,3 +742,53 @@ class TestRegister:
         ctx.register_memory_provider.assert_called_once()
         arg = ctx.register_memory_provider.call_args[0][0]
         assert isinstance(arg, RetainDBMemoryProvider)
+
+
+class TestPrefetchStaleness:
+    """prefetch(query) must not return cached results from a prior turn's
+    background prefetch when the topic has changed.  Mirrors the fix applied
+    to the mem0 provider in c6eb7f9e7.
+    """
+
+    def _provider(self, hermes_home, monkeypatch):
+        monkeypatch.setenv("RETAINDB_API_KEY", "test-key")
+        p = RetainDBMemoryProvider()
+        p.initialize("sess", hermes_home=str(hermes_home))
+        return p
+
+    def test_matching_query_returns_cached_result(self, tmp_path, monkeypatch):
+        p = self._provider(tmp_path, monkeypatch)
+        with p._lock:
+            p._prefetch_query = "what is X?"
+            p._context_result = "X is a thing"
+        assert "X is a thing" in p.prefetch("what is X?")
+
+    def test_mismatched_query_returns_empty(self, tmp_path, monkeypatch):
+        """Prior turn prefetched for topic A; current turn asks about topic B
+        — stale context must not be injected."""
+        p = self._provider(tmp_path, monkeypatch)
+        with p._lock:
+            p._prefetch_query = "what is X?"
+            p._context_result = "X is a thing"
+            p._dialectic_result = "user likes X"
+        assert p.prefetch("what is Y?") == ""
+
+    def test_cache_cleared_after_consume(self, tmp_path, monkeypatch):
+        """Consumed cache must not persist for the next call."""
+        p = self._provider(tmp_path, monkeypatch)
+        with p._lock:
+            p._prefetch_query = "same question"
+            p._context_result = "some context"
+        p.prefetch("same question")
+        assert p.prefetch("same question") == ""
+
+    def test_queue_prefetch_stores_query(self, tmp_path, monkeypatch):
+        """queue_prefetch must record which query it will fetch for."""
+        p = self._provider(tmp_path, monkeypatch)
+        with (
+            patch.object(p, "_prefetch_context"),
+            patch.object(p, "_prefetch_dialectic"),
+            patch.object(p, "_prefetch_agent_model"),
+        ):
+            p.queue_prefetch("new question")
+        assert p._prefetch_query == "new question"


### PR DESCRIPTION
## Summary
- `RetainDBMemoryProvider.prefetch(query)` took a `query: str` parameter but never referenced it in its body — it unconditionally drained `_context_result`/`_dialectic_result`/`_agent_model` and returned whatever was cached, regardless of whether the background prefetch was for the current question or a prior turn's question.
- When the conversation topic shifts between turns (the normal case in multi-turn sessions), stale memory context from the previous turn's prefetch is silently injected into the prompt.
- This is the same bug `c6eb7f9e7` just fixed in the `mem0` provider.

## Fix
- `queue_prefetch(query)` now stores `self._prefetch_query = query` (under lock, clearing stale cache first).
- `prefetch(query)` checks `self._prefetch_query == query` before returning the cache; if the query has changed, it clears the stale entries and returns `""` — the `retaindb_search` tool remains the turn-level backstop, matching mem0's approach.

## Test plan
- `test_matching_query_returns_cached_result` — same query returns cache correctly
- `test_mismatched_query_returns_empty` — topic change → empty, stale context not injected
- `test_cache_cleared_after_consume` — consumed cache does not persist
- `test_queue_prefetch_stores_query` — queue_prefetch records the inflight query

`pytest tests/plugins/test_retaindb_plugin.py` → 32 passed