### PR TITLE
fix(whatsapp): bold whole header without leaking literal asterisks on partial emphasis

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -386,8 +386,13 @@ class WhatsAppBehaviorMixin:
         # which WhatsApp renders with literal asterisks).
         def _header_to_bold(m: re.Match) -> str:
             inner = m.group(1).strip()
-            while len(inner) > 1 and inner.startswith("*") and inner.endswith("*"):
-                inner = inner[1:-1].strip()
+            # The whole header becomes one bold span (*...*); strip any
+            # interior WhatsApp emphasis-asterisk spans first so the wrap can
+            # never emit literal "**" or a stray "*" (WhatsApp renders those
+            # verbatim). Handles the fully-wrapped case ("# **Title**" ->
+            # "*Title*") and partial emphasis ("# *italic* heading" ->
+            # "*italic heading*"); combined "*_x_*" keeps its "_" italic.
+            inner = re.sub(r"\*(\S(?:.*?\S)?)\*", r"\1", inner)
             return f"*{inner}*"
 
         result = re.sub(

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -386,13 +386,19 @@ class WhatsAppBehaviorMixin:
         # which WhatsApp renders with literal asterisks).
         def _header_to_bold(m: re.Match) -> str:
             inner = m.group(1).strip()
-            # The whole header becomes one bold span (*...*); strip any
-            # interior WhatsApp emphasis-asterisk spans first so the wrap can
-            # never emit literal "**" or a stray "*" (WhatsApp renders those
-            # verbatim). Handles the fully-wrapped case ("# **Title**" ->
+            # The whole header becomes one bold span (*...*). First strip any
+            # interior balanced WhatsApp emphasis-asterisk spans, then drop any
+            # surviving unmatched "*" (e.g. "# *nix" or "# C* lang"), so the
+            # wrap can never emit literal "**" or a stray "*" (WhatsApp renders
+            # those verbatim). Handles the fully-wrapped case ("# **Title**" ->
             # "*Title*") and partial emphasis ("# *italic* heading" ->
             # "*italic heading*"); combined "*_x_*" keeps its "_" italic.
             inner = re.sub(r"\*(\S(?:.*?\S)?)\*", r"\1", inner)
+            inner = inner.replace("*", "")
+            if not inner:
+                # Header was nothing but asterisks; bolding an empty span would
+                # itself produce "**", so leave the original text untouched.
+                return m.group(0)
             return f"*{inner}*"
 
         result = re.sub(

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -110,6 +110,19 @@ class TestFormatMessage:
         out2 = adapter.format_message("# normal *em* tail")
         assert "**" not in out2
         assert out2 == "*normal em tail*"
+        # An UNMATCHED lone "*" must not survive into the wrap either: a
+        # balanced-span strip alone would leave "# *nix" -> "**nix*" (leading
+        # literal "**"). The surviving asterisk is dropped before wrapping.
+        out3 = adapter.format_message("# *nix")
+        assert "**" not in out3
+        assert out3 == "*nix*"
+        out4 = adapter.format_message("# C* programming")
+        assert "**" not in out4
+        assert out4 == "*C programming*"
+        # Odd asterisk count: one balanced span strips, the stray pair is dropped.
+        out5 = adapter.format_message("# a *b* c *d*")
+        assert "**" not in out5
+        assert out5 == "*a b c d*"
         # existing whole-line cases still hold
         assert adapter.format_message("# **Title**") == "*Title*"
         assert adapter.format_message("# Title") == "*Title*"

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -98,6 +98,22 @@ class TestFormatMessage:
         assert adapter.format_message("# **Title**") == "*Title*"
         assert adapter.format_message("## __Strong__") == "*Strong*"
 
+    def test_header_partial_emphasis_no_literal_asterisks(self):
+        """A header with emphasis on only PART of the line must still bold the
+        whole line without leaking literal "**" or a stray "*" (WhatsApp renders
+        those verbatim). Sibling to the combined-emphasis fix in #55298, which
+        covers step-3 ***bold-italic***; this covers the step-4 header wrap."""
+        adapter = _make_adapter()
+        out1 = adapter.format_message("# *italic* heading")
+        assert "**" not in out1
+        assert out1 == "*italic heading*"
+        out2 = adapter.format_message("# normal *em* tail")
+        assert "**" not in out2
+        assert out2 == "*normal em tail*"
+        # existing whole-line cases still hold
+        assert adapter.format_message("# **Title**") == "*Title*"
+        assert adapter.format_message("# Title") == "*Title*"
+
     def test_links_converted(self):
         adapter = _make_adapter()
         result = adapter.format_message("[click here](https://example.com)")


### PR DESCRIPTION
## This is a sibling follow-up to #55298

- **What #55298 covers:** step-3 combined bold+italic conversion (`***x***` / `___x___` / mixed → `*_x_*`) in `format_message`, so combined-emphasis spans don't leave literal asterisks.
- **What #55298 does NOT touch:** the step-4 header path (`_header_to_bold`). Its hunks are entirely in step 3.
- **What this adds:** fixes the step-4 header wrap so a header with emphasis on only PART of the line doesn't leak literal `**` / stray `*`. Non-overlapping with #55298 (step 3 vs step 4), so no merge conflict.

## What does this PR do?

WhatsApp markdown headers that contain emphasis on only PART of the line currently leak literal asterisks. `_header_to_bold` only unwraps emphasis when the ENTIRE header is one `*...*` span (its while-loop strips from both ends only when the whole string starts and ends with `*`), so a partial-emphasis header collides with the whole-line bold wrap:

- `# *italic* heading` → `**italic* heading*`  (leading `**` renders as literal `**`)
- `# normal *em* tail` → `*normal *em* tail*`  (stray `*` mid-string)

The fix strips interior WhatsApp emphasis-asterisk spans inside the header before applying the whole-line bold wrap, so the wrap can never produce `**` or a stray `*`. The fully-wrapped case (`# **Title**` → `*Title*`) and plain headers are unchanged; combined bold+italic (`*_x_*`) keeps its `_` italic.

## Related Issue

Net-new (code-originated, no filed issue). Sibling to #55298.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/whatsapp_common.py` — `_header_to_bold`: replace the whole-span unwrap `while` loop with an interior emphasis-span strip (`re.sub(r"\*(\S(?:.*?\S)?)\*", r"\1", inner)`) before the bold wrap, so the wrap can never emit `**` or a stray `*`.
- `tests/gateway/test_whatsapp_formatting.py` — add `test_header_partial_emphasis_no_literal_asterisks` covering partial-emphasis headers plus the existing whole-line cases.

## How to Test

1. Before the fix: `format_message("# *italic* heading")` returns `**italic* heading*` (leading literal `**`) and `format_message("# normal *em* tail")` returns `*normal *em* tail*` (stray `*`).
2. After the fix: those return `*italic heading*` and `*normal em tail*` respectively — no `**`, no stray `*`.
3. `pytest tests/gateway/test_whatsapp_formatting.py -q` — the new regression test fails before the prod hunk and passes after; all existing header/format tests still pass (28 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_whatsapp_formatting.py -q` and all tests pass (28 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure string/regex transform, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A