### PR TITLE
feat(cli): list plugin-registered slash commands in TUI /help

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6378,6 +6378,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     f"    [bold {_accent_hex()}]{('/' + name):<22}[/] [dim]-[/] {_escape(desc)}"
                 )
 
+        # Plugin-registered slash commands. These dispatch correctly via
+        # process_command() but were previously absent from /help, leaving
+        # users no way to discover them (issue #55609). Mirror the Skill
+        # Commands section above. Guarded defensively because plugin
+        # discovery can raise in degraded environments.
+        try:
+            from hermes_cli.plugins import get_plugin_commands
+            plugin_cmds = get_plugin_commands()
+        except Exception:
+            plugin_cmds = {}
+        if plugin_cmds:
+            _cprint(f"\n  🔌 {_BOLD}Plugin Commands{_RST} ({len(plugin_cmds)} available):")
+            for name, meta in sorted(plugin_cmds.items()):
+                desc = meta.get("description", "") if isinstance(meta, dict) else ""
+                ChatConsole().print(
+                    f"    [bold {_accent_hex()}]{('/' + name):<22}[/] [dim]-[/] {_escape(desc)}"
+                )
+
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
         _cprint(f"  {_DIM}Draft editor: Ctrl+G (Alt+G in VSCode/Cursor){_RST}")

--- a/tests/cli/test_help_plugin_commands.py
+++ b/tests/cli/test_help_plugin_commands.py
@@ -1,0 +1,61 @@
+"""Regression test for issue #55609.
+
+``/help`` (``HermesCLI.show_help``) must list plugin-registered slash commands
+so they are discoverable, mirroring the existing Skill Commands section. Before
+the fix, plugin commands worked at dispatch time but were never rendered by
+``show_help``, leaving users with no way to discover commands like
+``/ponytail``.
+"""
+from unittest.mock import MagicMock, patch
+
+import cli
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.conversation_history = []
+    cli_obj.session_id = None
+    cli_obj._pending_input = MagicMock()
+    return cli_obj
+
+
+def _render_help(plugin_commands):
+    """Render show_help with a fake plugin-command registry; return the text."""
+    cli_obj = _make_cli()
+    printed: list[str] = []
+
+    class _FakeConsole:
+        def print(self, *args, **kwargs):
+            printed.append(" ".join(str(a) for a in args))
+
+    with patch("hermes_cli.plugins.get_plugin_commands", return_value=plugin_commands), \
+         patch.object(cli, "_ensure_skill_commands", return_value={}), \
+         patch.object(cli, "get_skill_bundles", return_value={}), \
+         patch.object(HermesCLI, "_command_available", return_value=True), \
+         patch.object(cli, "ChatConsole", _FakeConsole), \
+         patch.object(cli, "_cprint", side_effect=lambda t: printed.append(str(t))):
+        cli_obj.show_help()
+
+    return "\n".join(printed)
+
+
+def test_show_help_lists_plugin_commands():
+    plugin_commands = {
+        "ponytail": {"description": "Run ponytail review", "handler": object(), "plugin": "ponytail"},
+        "ponytail-audit": {"description": "Audit with ponytail", "handler": object(), "plugin": "ponytail"},
+    }
+    out = _render_help(plugin_commands)
+
+    assert "Plugin Commands" in out
+    assert "/ponytail" in out
+    assert "/ponytail-audit" in out
+    assert "Run ponytail review" in out
+
+
+def test_show_help_no_plugin_section_when_empty():
+    out = _render_help({})
+    assert "Plugin Commands" not in out


### PR DESCRIPTION
## What

Adds a "Plugin Commands" section to the TUI `/help` output so plugin-registered slash commands show up alongside built-in, skill, and quick commands.

## Why

Plugin slash commands (for example `/ponytail`, `/ponytail-review`) already dispatch and run correctly through `process_command()`, which resolves them via `_get_plugin_cmd_handler_names()` and `get_plugin_command_handler()`. But `show_help()` only rendered built-in commands, skill commands, skill bundles, and quick commands. Plugin commands were never listed, so the only way to use one was to already know its name. There was no way to discover them from inside the TUI.

Fixes #55609.

## How it works

`show_help()` now reads the plugin command registry from `get_plugin_commands()` (which returns `name -> {handler, description, plugin}`) and prints a section in the same style as the existing Skill Commands block. The lookup is wrapped in a try/except so a plugin discovery failure in a degraded environment can't break `/help`. When no plugins register commands, the section is omitted.

## How to test

1. Enable any plugin that registers slash commands (for example ponytail).
2. Start a TUI session: `hermes --tui`.
3. Type `/help`.
4. The plugin's commands appear under a "Plugin Commands" section.
5. With no command-registering plugins enabled, the section does not appear.

A regression test in `tests/cli/test_help_plugin_commands.py` covers both cases (section rendered with the right names and descriptions when plugins are present, and absent when the registry is empty).

## Platforms

The change is in TUI help rendering only and has no platform-specific code, so it behaves the same on macOS, Linux, WSL2, and Windows.
