### PR TITLE
fix(auxiliary): don't rotate a healthy OpenRouter key on upstream 429s

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2599,6 +2599,36 @@ def _is_rate_limit_error(exc: Exception) -> bool:
     return False
 
 
+def _is_openrouter_upstream_rate_limit(exc: Exception) -> bool:
+    """True when the 429 came from an upstream provider routed through
+    OpenRouter, not from the user's own OpenRouter account being throttled.
+
+    OpenRouter wraps upstream errors with ``{"error": {"message": "Provider
+    returned error", "metadata": {"raw": "..."}}}`` — the user's key is
+    healthy; only the upstream model is momentarily throttled.  Marking the
+    key exhausted and rotating credentials is the wrong recovery: it burns
+    the key for ~24min when a simple model retry would have succeeded.
+
+    Mirrors the detection logic in ``agent.error_classifier._is_openrouter_upstream_error``;
+    kept local to avoid a cyclic-import between auxiliary_client and the main
+    error classifier.
+    """
+    body = getattr(exc, "body", None)
+    if not isinstance(body, dict):
+        return False
+    err = body.get("error")
+    if not isinstance(err, dict):
+        return False
+    outer_msg = str(err.get("message") or "").strip().lower()
+    if outer_msg != "provider returned error":
+        return False
+    # Require the OpenRouter-specific metadata shape.
+    metadata = err.get("metadata")
+    return isinstance(metadata, dict) and (
+        "raw" in metadata or "provider_name" in metadata
+    )
+
+
 def _is_timeout_error(exc: Exception) -> bool:
     """Detect a request timeout — the full-budget stall, distinct from a fast
     connection drop.
@@ -3016,6 +3046,18 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
         return False
 
     if _is_payment_error(exc) or _is_rate_limit_error(exc):
+        # OpenRouter upstream 429: the upstream model (DeepSeek, Anthropic,
+        # etc.) is throttled, NOT the user's OpenRouter key — don't burn the
+        # key for a 24-min exhaustion window.  The main conversation loop
+        # already handles this via error_classifier.FailoverReason.
+        # upstream_rate_limit; this brings the auxiliary client to parity.
+        if _is_openrouter_upstream_rate_limit(exc):
+            logger.debug(
+                "Auxiliary client: upstream provider 429 via OpenRouter "
+                "(provider=%s) — skipping credential rotation, key is healthy.",
+                normalized,
+            )
+            return False
         fallback_status = 402 if _is_payment_error(exc) else 429
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=status_code if status_code is not None else fallback_status,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -22,6 +22,8 @@ from agent.auxiliary_client import (
     _get_provider_chain,
     _is_payment_error,
     _is_rate_limit_error,
+    _is_openrouter_upstream_rate_limit,
+    _recover_provider_pool,
     _is_model_not_found_error,
     _is_model_incompatible_error,
     _refresh_nous_recommended_model,
@@ -1802,6 +1804,106 @@ class TestIsRateLimitError:
     def test_no_status_code_no_keywords_is_not_rate_limit(self):
         exc = Exception("connection reset")
         assert _is_rate_limit_error(exc) is False
+
+
+class TestIsOpenRouterUpstreamRateLimit:
+    """_is_openrouter_upstream_rate_limit detects OpenRouter's
+    aggregator-wrapped upstream provider 429s, distinct from the user's own
+    OpenRouter account being throttled."""
+
+    def test_wrapped_upstream_error_with_raw_metadata(self):
+        exc = Exception("Provider returned error")
+        exc.status_code = 429
+        exc.body = {
+            "error": {
+                "message": "Provider returned error",
+                "metadata": {"raw": '{"error":"rate limited"}', "provider_name": "DeepSeek"},
+            }
+        }
+        assert _is_openrouter_upstream_rate_limit(exc) is True
+
+    def test_wrapped_upstream_error_with_provider_name_only(self):
+        exc = Exception("Provider returned error")
+        exc.body = {
+            "error": {
+                "message": "Provider returned error",
+                "metadata": {"provider_name": "Anthropic"},
+            }
+        }
+        assert _is_openrouter_upstream_rate_limit(exc) is True
+
+    def test_plain_account_rate_limit_is_not_upstream(self):
+        """A genuine account-level 429 has no 'Provider returned error' wrapper."""
+        exc = Exception("Rate limit exceeded, try again in 2 seconds")
+        exc.status_code = 429
+        exc.body = {"error": {"message": "Rate limit exceeded, try again in 2 seconds"}}
+        assert _is_openrouter_upstream_rate_limit(exc) is False
+
+    def test_no_body_is_not_upstream(self):
+        exc = Exception("Rate limit exceeded")
+        assert _is_openrouter_upstream_rate_limit(exc) is False
+
+    def test_wrapped_message_without_metadata_is_not_upstream(self):
+        """'Provider returned error' alone (no OpenRouter metadata shape)
+        is not enough — could be a different aggregator's wrapper."""
+        exc = Exception("Provider returned error")
+        exc.body = {"error": {"message": "Provider returned error"}}
+        assert _is_openrouter_upstream_rate_limit(exc) is False
+
+
+class TestRecoverProviderPoolUpstreamRateLimit:
+    """_recover_provider_pool must not burn a healthy OpenRouter key when the
+    429 actually came from an upstream provider OpenRouter aggregates."""
+
+    def _make_pool(self, calls):
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def mark_exhausted_and_rotate(self, **kw):
+                calls.append(kw)
+                return None
+
+            def try_refresh_current(self):
+                return None
+
+        return _Pool()
+
+    def test_upstream_429_does_not_rotate_credential(self):
+        calls = []
+        exc = Exception("Provider returned error")
+        exc.status_code = 429
+        exc.body = {
+            "error": {
+                "message": "Provider returned error",
+                "metadata": {"raw": "{}", "provider_name": "DeepSeek"},
+            }
+        }
+        with patch("agent.auxiliary_client.load_pool", return_value=self._make_pool(calls)):
+            result = _recover_provider_pool("openrouter", exc)
+        assert result is False
+        assert calls == [], "upstream 429 must not call mark_exhausted_and_rotate"
+
+    def test_account_429_still_rotates_credential(self):
+        """A genuine account-level 429 must still trigger pool rotation —
+        this guards against the upstream-check over-matching."""
+        calls = []
+        exc = Exception("Rate limit exceeded, try again in 2 seconds")
+        exc.status_code = 429
+        exc.body = {"error": {"message": "Rate limit exceeded, try again in 2 seconds"}}
+
+        class _PoolWithRotation:
+            def has_credentials(self):
+                return True
+
+            def mark_exhausted_and_rotate(self, **kw):
+                calls.append(kw)
+                return SimpleNamespace(api_key="next-key")
+
+        with patch("agent.auxiliary_client.load_pool", return_value=_PoolWithRotation()):
+            result = _recover_provider_pool("openrouter", exc)
+        assert result is True
+        assert len(calls) == 1, "genuine account 429 must still rotate the key"
 
 
 class TestGetProviderChain:


### PR DESCRIPTION
## Summary
- `agent/error_classifier.py` already distinguishes an OpenRouter aggregator-wrapped upstream provider 429 (`FailoverReason.upstream_rate_limit` — the user's key is healthy, an upstream model like DeepSeek is throttled) from a genuine account-level 429, and skips credential rotation for the former.
- The auxiliary client's `_recover_provider_pool()` never learned this distinction: `_is_rate_limit_error()` flags any 429-shaped error, and the rate-limit branch unconditionally calls `mark_exhausted_and_rotate()`.
- Any OpenRouter-backed auxiliary call (compression, title generation, vision routing, goal judging) that hits an upstream-wrapped 429 was exhausting `OPENROUTER_API_KEY` for ~24 minutes, silently disabling all auxiliary features on a perfectly healthy key.

## Fix
Add `_is_openrouter_upstream_rate_limit()`, mirroring `error_classifier`'s `_is_openrouter_upstream_error()` detection logic (kept local to avoid a cyclic import between the two modules — `error_classifier` isn't imported by `auxiliary_client` today). `_recover_provider_pool()` now checks it before the rate-limit rotation branch and returns `False` without touching the pool when the 429 is upstream-sourced. Genuine account 429s still rotate normally — verified with a dedicated regression test guarding against the upstream-check over-matching.

## Test plan
- `TestIsOpenRouterUpstreamRateLimit` (5 cases) — detection logic: wrapped errors with `raw`/`provider_name` metadata match, plain account 429s and bodies without the OpenRouter metadata shape don't.
- `TestRecoverProviderPoolUpstreamRateLimit` (2 cases) — `test_upstream_429_does_not_rotate_credential` confirms `mark_exhausted_and_rotate` is never called for an upstream 429; `test_account_429_still_rotates_credential` confirms a genuine account 429 still rotates (regression guard).

`pytest tests/agent/test_auxiliary_client.py` → 281 passed, 0 failed