### PR TITLE
fix(desktop): stop portaled submenu from drifting during scroll

### DIFF
--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -249,6 +249,12 @@ function DropdownMenuSubContent({
     // `overflow` clip. Without this, a submenu opening from a scrollable menu
     // gets visually cut off at the parent's edges. Radix Popper still anchors
     // it to the SubTrigger and handles collision/flip, so portaling is safe.
+    //
+    // `updatePositionStrategy="always"` makes Floating UI's autoUpdate use a
+    // continuous rAF loop instead of passive scroll listeners. Without this,
+    // portaled submenus visibly lag behind their trigger when the parent
+    // Content scrolls (the scroll → getBoundingClientRect → reposition pipeline
+    // can't keep pace with fast wheel events).
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.SubContent
         // `dt-portal-scrollbar` reproduces the themed scrollbar for portaled
@@ -266,6 +272,10 @@ function DropdownMenuSubContent({
         collisionPadding={collisionPadding}
         data-slot="dropdown-menu-sub-content"
         {...props}
+        // Placed after spread to prevent callers from overriding — the rAF
+        // loop is load-bearing for scroll-tracked submenus and must not revert
+        // to the default "optimized" passive-listener strategy.
+        updatePositionStrategy="always"
       />
     </DropdownMenuPrimitive.Portal>
   )


### PR DESCRIPTION
## What

Adds `updatePositionStrategy="always"` to `DropdownMenuSubContent` so the portaled submenu tracks its trigger via a continuous rAF loop instead of passive scroll listeners.

Fixes #55856

## Why

The model selector submenu (thinking/effort/fast) is portaled to `document.body` to escape the parent Content's `overflow-y-auto` clip (added in `bc9e33d66`). Floating UI's `autoUpdate` tracks the `SubTrigger` position through passive scroll listeners, but the reactive pipeline (`scroll event → getBoundingClientRect → reposition`) can't keep pace with fast wheel events — the submenu visibly drifts from its trigger.

Before today's re-render reduction (`00694b935`, `94d70dee5`), ChatBar re-rendered on every keystroke and status mutation. Each re-render cascaded through `ComposerControls → ModelPill → DropdownMenu`, which implicitly forced Radix to re-evaluate floating element positions as part of React reconciliation — masking the tracking lag. With those re-renders gone, the portaled SubContent depends entirely on `autoUpdate`'s scroll listeners, exposing the drift.

## How

One prop on `DropdownMenuSubContent` in `dropdown-menu.tsx`. The prop flows through Radix's chain:

```
DropdownMenuSubContent → MenuSubContent → MenuContentImpl → PopperContent
```

`PopperContent` passes `updatePositionStrategy` to `autoUpdate`:

```js
// @radix-ui/react-popper/dist/index.mjs:130-134
whileElementsMounted: (...args) => {
    const cleanup = autoUpdate(...args, {
        animationFrame: updatePositionStrategy === "always"
    });
    return cleanup;
},
```

When `animationFrame: true`, `autoUpdate` uses a `requestAnimationFrame` loop that checks the trigger's `getBoundingClientRect` every frame and repositions immediately on change — independent of scroll events and React renders.

## Verification

- `tsc --noEmit` — clean
- `eslint` — clean
- Type-verified through `MenuSubContentProps → MenuContentImplProps → Omit<PopperContentProps, 'dir' | 'onPlaced'>`
