### PR TITLE
fix(install): prefer active Hermes shim on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1940,6 +1940,44 @@ print(','.join(scripts))
     Write-Success "All dependencies installed"
 }
 
+function Merge-HermesPathEntries([string]$existingPath, [string]$hermesBin, [string]$installDir) {
+    # Rebuild PATH so the *current* managed install wins and any stale
+    # hermes launchers under the same install root are dropped. Native
+    # Windows users can accumulate dead ``...\hermes-agent\venv\Scripts``
+    # entries from interrupted reinstalls or relocated checkouts; if one of
+    # those stale shims resolves first, every `hermes <cmd>` aborts before
+    # Python starts with uv's "trampoline failed to spawn Python child
+    # process" error.
+    $hermesBinFull = [System.IO.Path]::GetFullPath($hermesBin).TrimEnd('\')
+    $installRootPrefix = [System.IO.Path]::GetFullPath($installDir).TrimEnd('\') + '\'
+    $kept = New-Object System.Collections.Generic.List[string]
+
+    if ($existingPath) {
+        foreach ($entry in $existingPath.Split(';')) {
+            if (-not $entry) { continue }
+            $trimmed = $entry.Trim()
+            if (-not $trimmed) { continue }
+
+            try {
+                $entryFull = [System.IO.Path]::GetFullPath($trimmed).TrimEnd('\')
+            } catch {
+                $entryFull = $trimmed.TrimEnd('\')
+            }
+
+            if ($entryFull -ieq $hermesBinFull) { continue }
+            if ($entryFull.StartsWith($installRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
+            $kept.Add($trimmed) | Out-Null
+        }
+    }
+
+    if ($kept.Count -gt 0) {
+        return "$hermesBinFull;$($kept -join ';')"
+    }
+    return $hermesBinFull
+}
+
 function Set-PathVariable {
     Write-Info "Setting up hermes command..."
     
@@ -1952,14 +1990,15 @@ function Set-PathVariable {
     # Add the venv Scripts dir to user PATH so hermes is globally available
     # On Windows, the hermes.exe in venv\Scripts\ has the venv Python baked in
     $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $newUserPath = Merge-HermesPathEntries $currentPath $hermesBin $InstallDir
     
-    if ($currentPath -notlike "*$hermesBin*") {
+    if ($newUserPath -ne $currentPath) {
         [Environment]::SetEnvironmentVariable(
             "Path",
-            "$hermesBin;$currentPath",
+            $newUserPath,
             "User"
         )
-        Write-Success "Added to user PATH: $hermesBin"
+        Write-Success "Added Hermes to the front of user PATH: $hermesBin"
     } else {
         Write-Info "PATH already configured"
     }
@@ -1975,7 +2014,24 @@ function Set-PathVariable {
     $env:HERMES_HOME = $HermesHome
     
     # Update current session
-    $env:Path = "$hermesBin;$env:Path"
+    $env:Path = Merge-HermesPathEntries $env:Path $hermesBin $InstallDir
+
+    if (-not $NoVenv) {
+        $expectedHermesExe = [System.IO.Path]::GetFullPath((Join-Path $hermesBin "hermes.exe"))
+        $resolvedHermes = Get-Command hermes -ErrorAction SilentlyContinue
+        if ($resolvedHermes -and $resolvedHermes.Source) {
+            try {
+                $resolvedHermesPath = [System.IO.Path]::GetFullPath($resolvedHermes.Source).TrimEnd('\')
+            } catch {
+                $resolvedHermesPath = $resolvedHermes.Source.TrimEnd('\')
+            }
+            if ($resolvedHermesPath -ne $expectedHermesExe) {
+                Write-Warn "hermes currently resolves to a different launcher: $resolvedHermesPath"
+                Write-Info "Expected: $expectedHermesExe"
+                Write-Info "Open a new terminal and retry. If it still resolves to the wrong path, remove the stale Hermes install from PATH and reinstall."
+            }
+        }
+    }
     
     Write-Success "hermes command ready"
 }

--- a/tests/test_install_ps1_windows_path_resolution.py
+++ b/tests/test_install_ps1_windows_path_resolution.py
@@ -1,0 +1,72 @@
+"""Regression: Windows installer must prefer the fresh managed hermes shim.
+
+Issue #54919 reported every ``hermes`` command failing immediately with uv's
+"trampoline failed to spawn Python child process" launcher error on native
+Windows. The installer already verified that ``venv\\Scripts\\hermes.exe``
+existed, but it only prepended the path if it was absent and never removed
+stale Hermes-owned entries or checked which launcher ``hermes`` actually
+resolved to afterwards.
+
+These source-level tests lock the installer contract:
+
+1. rebuild PATH so the current managed install wins over stale launchers under
+   the same install root; and
+2. verify which ``hermes`` shim resolves after the rewrite, surfacing a clear
+   warning if another launcher still wins.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def test_windows_installer_rebuilds_path_instead_of_append_if_missing() -> None:
+    text = _install_ps1()
+    assert "function Merge-HermesPathEntries" in text, (
+        "install.ps1 must rebuild PATH entries so the current managed Hermes "
+        "launcher wins over stale shims"
+    )
+    assert '$currentPath -notlike "*$hermesBin*"' not in text, (
+        "install.ps1 must not use the naive 'append if missing' PATH guard; "
+        "it leaves stale Hermes launchers ahead of the fresh install"
+    )
+    assert (
+        "StartsWith($installRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)"
+        in text
+    ), (
+        "PATH rebuild must drop stale entries under the managed install root "
+        "using a case-insensitive path-prefix check"
+    )
+
+
+def test_windows_installer_rewrites_both_user_and_session_path() -> None:
+    text = _install_ps1()
+    assert (
+        "$newUserPath = Merge-HermesPathEntries $currentPath $hermesBin $InstallDir"
+        in text
+    )
+    assert (
+        "$env:Path = Merge-HermesPathEntries $env:Path $hermesBin $InstallDir" in text
+    ), (
+        "install.ps1 must rewrite the current session PATH too, not just the "
+        "registry value for future shells"
+    )
+
+
+def test_windows_installer_verifies_resolved_hermes_launcher() -> None:
+    text = _install_ps1()
+    assert "Get-Command hermes" in text, (
+        "install.ps1 must verify which hermes launcher resolves after PATH setup"
+    )
+    assert "$expectedHermesExe" in text
+    assert "hermes currently resolves to a different launcher" in text, (
+        "installer should warn explicitly when another hermes shim still wins "
+        "after PATH normalization"
+    )


### PR DESCRIPTION
Fixes #54919

## What changed and why
- Reworked `scripts/install.ps1` PATH setup so the Windows installer rebuilds both the user PATH and the current session PATH instead of only prepending `venv\\Scripts` when it is missing.
- Dropped stale Hermes-owned PATH entries under the managed install root before prepending the fresh shim, which prevents old/broken `hermes.exe` launchers from winning command resolution and triggering uv's `trampoline failed to spawn Python child process` error.
- Added an installer warning when `Get-Command hermes` still resolves to a different launcher after PATH normalization, so users get an actionable diagnosis instead of a silent broken install.
- Added `tests/test_install_ps1_windows_path_resolution.py` to lock the new Windows PATH normalization and launcher-resolution checks into the installer source.

## How to test
- Run `pytest tests/test_install_ps1_windows_path_resolution.py -q`
- Run `pytest tests/test_install_ps1_uv_powershell_host.py tests/test_install_ps1_native_stderr_eap.py tests/test_install_unmerged_index.py tests/test_install_no_initial_commit.py tests/test_install_lockfile_churn.py tests/test_install_diverged_update.py tests/test_install_ps1_python_fallback_venv.py tests/test_install_ps1_windows_path_resolution.py -q`
- Run `python scripts/check-windows-footguns.py scripts/install.ps1 tests/test_install_ps1_windows_path_resolution.py`
- Run `git diff --check`
- Broad suite attempt: `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`
- Note: the broad suite stopped during collection in this local environment because `tests/hermes_cli/test_cron_fire_dashboard.py` imports `hermes_cli.web_server`, which exits when `fastapi`/`uvicorn` are unavailable under the externally managed Homebrew Python. The install.ps1 covering subset above passed green.

## What platforms tested on
- macOS on darwin-arm64 (local)

<!-- autocontrib:worker-id=issue-new-04f7a258 kind=pr-open -->