### PR TITLE
fix: respect explicit api server disable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1556,7 +1556,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     api_server_cors_origins = os.getenv("API_SERVER_CORS_ORIGINS", "")
     api_server_port = os.getenv("API_SERVER_PORT")
     api_server_host = os.getenv("API_SERVER_HOST")
-    if api_server_enabled or api_server_key:
+    api_server_config = config.platforms.get(Platform.API_SERVER)
+    api_server_explicitly_disabled = bool(
+        api_server_config is not None
+        and not api_server_config.enabled
+        and (api_server_config.extra or {}).get("_enabled_explicit")
+    )
+    if (api_server_enabled or api_server_key) and not api_server_explicitly_disabled:
         if Platform.API_SERVER not in config.platforms:
             config.platforms[Platform.API_SERVER] = PlatformConfig()
         config.platforms[Platform.API_SERVER].enabled = True

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -589,6 +589,28 @@ class TestLoadGatewayConfig:
         assert config.platforms[Platform.API_SERVER].enabled is False
         assert Platform.API_SERVER not in config.get_connected_platforms()
 
+    def test_explicit_api_server_disable_wins_over_env_key(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    api_server:\n"
+            "      enabled: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("API_SERVER_KEY", "test-key")
+        monkeypatch.setenv("API_SERVER_ENABLED", "false")
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.API_SERVER].enabled is False
+        assert "key" not in config.platforms[Platform.API_SERVER].extra
+        assert Platform.API_SERVER not in config.get_connected_platforms()
+
     def test_bridges_nested_gateway_platforms_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary\n- Keep api_server disabled when config explicitly sets gateway.platforms.api_server.enabled: false\n- Prevent API_SERVER_KEY from re-enabling the adapter in that explicit-disable case\n- Add gateway config regression coverage\n\n## Tests\n- uv run --with pytest --with pyyaml python -m pytest tests/gateway/test_config.py -q -o 'addopts='\n