### PR TITLE
fix(gateway): fallback immediately on Telegram finalized edit flood control

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1592,6 +1592,22 @@ class GatewayStreamConsumer:
                                 self._MAX_FLOOD_STRIKES,
                                 self._current_edit_interval,
                             )
+                            if finalize:
+                                # A rate-limited finalize-d edit cannot wait for a
+                                # later streaming tick to recover: whether this is
+                                # the turn-final edit (is_turn_final=True) or the
+                                # overflow-split first-chunk edit
+                                # (is_turn_final=False), retrying wastes flood
+                                # budget — the content is already visible and the
+                                # gateway's normal final-send path would resend the
+                                # full response, duplicating the visible preview.
+                                # Preserve the already-visible prefix and let
+                                # got_done send only the missing tail.
+                                self._fallback_prefix = self._visible_prefix()
+                                self._fallback_final_send = True
+                                self._edit_supported = False
+                                self._already_sent = True
+                                return False
                             if self._flood_strikes < self._MAX_FLOOD_STRIKES:
                                 # Don't disable edits yet — just slow down.
                                 # Update _last_edit_time so the next edit

--- a/tests/gateway/test_stream_consumer_fresh_final.py
+++ b/tests/gateway/test_stream_consumer_fresh_final.py
@@ -568,10 +568,11 @@ class TestFinalCleanupEditFloodControl:
         consumer.finish()
         await task
 
-        # The final cosmetic edit failed, so final_response_sent stays false;
-        # the important signal is that content_delivered suppresses the
-        # gateway's normal full final send and prevents a duplicate answer.
-        assert consumer.final_response_sent is False
+        # The final cosmetic edit failed and immediately entered fallback;
+        # the fallback recognised the full answer is already visible and
+        # marked it delivered so the gateway suppresses its normal final
+        # send and prevents a duplicate answer.
+        assert consumer.final_response_sent is True
         assert consumer.final_content_delivered is True
         assert adapter.send.call_count == 1
         assert adapter.edit_message.call_count >= 1

--- a/tests/gateway/test_telegram_overflow_partial.py
+++ b/tests/gateway/test_telegram_overflow_partial.py
@@ -138,3 +138,77 @@ async def test_stream_consumer_fallback_sends_tail_after_partial_overflow():
     adapter.delete_message.assert_not_awaited()
     assert consumer.final_response_sent is True
     assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_flood_on_overflow_split_first_chunk_enters_fallback_immediately():
+    """Overflow split first-chunk edit hitting flood control enters fallback on
+    first strike (no wasteful retries) and preserves the visible prefix.
+
+    Acceptance criteria (#user-observed):
+      - streaming 中先成功显示 prefix ✓
+      - overflow split first edit 抛 RetryAfter ✓
+      - final response 到达 ✓
+      - 不发送完整 final duplicate ✓
+      - 只发送 missing tail 或 suppress final ✓
+      - final_content_delivered / already_sent 状态一致 ✓
+      - flood control 不导致重复刷屏 ✓
+    """
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    # first call is the preview send (step 1)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="preview-1"))
+    # overflow split first-chunk edit → flood
+    adapter.edit_message = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            message_id="preview-1",
+            error="Flood control exceeded. Retry in 130 seconds",
+        )
+    )
+    adapter.delete_message = AsyncMock()
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1", metadata={"thread_id": "77"})
+
+    # ── Step 1: Stream prefix "hello" → preview sent ──
+    ok = await consumer._send_or_edit("hello ", finalize=False)
+    assert ok is True
+    assert consumer._message_id == "preview-1"
+    assert consumer._last_sent_text == "hello "
+    assert consumer.already_sent is True
+    assert consumer.final_content_delivered is False
+    assert consumer.final_response_sent is False
+    adapter.send.assert_awaited_once()
+
+    # ── Step 2: Overflow split first-chunk edit → RetryAfter ──
+    ok = await consumer._send_or_edit(
+        "hello world", finalize=True, is_turn_final=False,
+    )
+    # Must enter fallback immediately (first strike) because finalize=True
+    # cannot afford 3 wasteful flood-strike retries.
+    assert ok is False
+    assert consumer._fallback_final_send is True
+    assert consumer._fallback_prefix == "hello "
+    assert consumer._edit_supported is False
+    assert consumer.already_sent is True
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+    # No full final re-sent via edit_message — only the flood error was returned
+    adapter.edit_message.assert_awaited_once()
+
+    # ── Step 3: Final response → fallback sends only missing tail ──
+    await consumer._send_fallback_final("hello world")
+
+    adapter.send.assert_awaited()  # = preview + fallback tail = 2 calls
+    assert adapter.send.await_args_list[-1].kwargs["content"] == "world"
+    assert adapter.send.await_args_list[-1].kwargs["metadata"] == {"thread_id": "77", "notify": True}
+    # Preview message preserved — not deleted
+    adapter.delete_message.assert_not_awaited()
+    # State flags consistent: content delivered, no false negatives
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+    assert consumer.already_sent is True
+
+    # ── Step 4: Flood control did NOT cause duplicate spam ──
+    # Only 2 calls: preview send + tail fallback.  Nothing else.
+    assert adapter.send.await_count == 2


### PR DESCRIPTION
## Summary
- Enter Telegram streaming fallback immediately when any finalized edit hits flood control, including overflow split first-chunk edits (`finalize=True, is_turn_final=False`).
- Preserve the already-visible prefix and send only the missing tail on final fallback, avoiding repeated full-response delivery.
- Adds regression coverage for the overflow split + RetryAfter path and updates the final cleanup edit expectation to match delivered-content state.

## Test plan
- `PYTHONPATH=. python3 -m pytest tests/gateway/test_telegram_overflow_partial.py tests/gateway/test_stream_consumer_fresh_final.py -q -o addopts=`

## Notes
This targets a Telegram duplicate-delivery bug where flood-controlled finalized edits previously went through the generic retry loop before fallback. Retrying finalized edits wastes Telegram flood budget and delays the tail message; fallback is already the safer path once visible content exists.
