### PR TITLE
chore(cron): add profile assignment migration tooling

### DIFF
--- a/docs/operations/cron-profile-assignment.md
+++ b/docs/operations/cron-profile-assignment.md
@@ -1,0 +1,139 @@
+# Cron Profile Assignment Runbook
+
+This runbook records the intended ownership model and the safe operating path for moving default-profile cron jobs into domain profiles.
+
+## Ownership Summary
+
+| Profile | Active jobs | Ownership |
+|---|---:|---|
+| `default` | 29 | Core Hermes runtime, backups, GBrain bridge, global diagnostics, default-owned `hermes-loop:*` checks. |
+| `rva-leads` | 13 | Lead intake, CRM lifecycle, consultation follow-up, quote suggestions, SMS opt-out handling. |
+| `rva-profit-pulse` | 10 | Content CMS, Square sales, topic discovery, weekly digest, profit/content loop checks. |
+| `rva-firm-ops` | 5 | Client email capture, TaxDome alerting, calendar nudges, Gmail watch refresh, meeting-note processing. |
+| `cpa-tax-researcher` | 2 | Tax research archive lint and tax research integrity. |
+| `personal` | 0 | No active cron jobs currently match this profile. |
+| `rva-dev` | 0 | No active cron jobs currently match this profile. |
+
+The paused `stale-draft-alert` job is not part of the active migration. Its candidate owner is `rva-firm-ops` after the existing shadow-readiness blocker is resolved.
+
+## Tools
+
+Read-only audit:
+
+```bash
+python3 scripts/cron_profile_assignment_audit.py --format markdown
+python3 scripts/cron_profile_assignment_audit.py --format json
+```
+
+Dry-run migration manifest:
+
+```bash
+python3 scripts/cron_profile_rebalance.py --format markdown
+python3 scripts/cron_profile_rebalance.py --format json
+```
+
+Use `--target-profile <profile>` to limit a dry-run or stage operation to one receiving profile. Repeat the flag to include multiple receiving profiles.
+
+Stage scripts and disabled target job copies:
+
+```bash
+python3 scripts/cron_profile_rebalance.py --apply-stage --format json
+```
+
+Do not combine `--apply-stage` with `--cutover-verified`; the CLI rejects that combination so profile-local verification cannot be skipped accidentally.
+
+Cut over verified script-only jobs:
+
+```bash
+python3 scripts/cron_profile_rebalance.py --cutover-verified <job-id> [<job-id> ...] --format json
+```
+
+Cut over accepted agent-driven shadow jobs:
+
+```bash
+python3 scripts/cron_profile_rebalance.py \
+  --cutover-verified <job-id> \
+  --accepted-agent <job-id> \
+  --format json
+```
+
+Use `--remove-source` only after you intentionally want the default-profile source records deleted instead of paused.
+
+## Required Profile Gateways
+
+Only profiles that receive active jobs need profile-scoped gateways for this migration:
+
+```bash
+hermes -p cpa-tax-researcher gateway start
+hermes -p rva-firm-ops gateway start
+hermes -p rva-leads gateway start
+hermes -p rva-profit-pulse gateway start
+```
+
+Use foreground debugging only when needed:
+
+```bash
+hermes -p <profile> gateway run
+```
+
+Before starting additional gateways, check multi-gateway dispatcher settings so only the intended profile owns singleton dispatcher behavior.
+
+## Migration Checklist
+
+1. Run the read-only audit and confirm the active counts match the Ownership Summary.
+2. Run the dry-run rebalance manifest and confirm there are no blockers.
+3. Review any `missing_target_skills`, `id_collision`, `output_history_collision`, `missing_source_script`, or `source_script_outside_profile_scripts` blockers before applying.
+4. Run `--apply-stage`. This copies required scripts into target profile `scripts/` directories and writes disabled target job copies.
+5. Start the required profile-scoped gateways.
+6. For each target profile, verify the target cron store and gateway status:
+
+   ```bash
+   hermes -p <profile> cron list
+   hermes -p <profile> cron status
+   hermes -p <profile> gateway status
+   ```
+
+7. Trigger or dry-run one migrated job per target profile and confirm output lands under that profile's cron output directory.
+8. For script-only jobs, cut over only after target execution is verified.
+9. For agent-driven jobs, compare the target-profile shadow output with the default-profile behavior and pass `--accepted-agent` only after the output quality is accepted.
+10. Re-run the audit and confirm default keeps only default-owned jobs plus any intentionally shadowing jobs.
+
+## Rollback
+
+Every apply-stage and cutover operation backs up existing target cron stores under each touched profile's cron backup directory.
+
+To roll back a failed profile batch:
+
+1. Stop or pause the target profile gateway if duplicate firing is possible.
+2. Restore that profile's latest pre-change `jobs.json` backup.
+3. Restore the default profile `jobs.json` backup if source jobs were paused or removed.
+4. Remove copied target scripts only if they were introduced by the failed batch and no other job references them.
+5. Run:
+
+   ```bash
+   hermes cron list
+   hermes -p <target-profile> cron list
+   ```
+
+6. Confirm the default copy is active before re-attempting migration.
+
+## Verification Evidence Format
+
+For each profile batch, record:
+
+- Target profile name.
+- Jobs staged.
+- Scripts copied.
+- Gateway command used.
+- `cron list` result.
+- `cron status` result.
+- Job IDs verified.
+- Agent-driven jobs accepted or left shadowing.
+- Cutover command run.
+- Rollback backup path if created.
+
+## Follow-up Items
+
+- Decide whether every profile should eventually get its own cloned `hermes-loop:*` diagnostic suite. This is a separate design change from moving domain-owned active jobs.
+- Resolve the `stale-draft-alert` paused blocker before migrating it to `rva-firm-ops`.
+- Add new assignments for `personal` and `rva-dev` only after cron jobs exist that match those domains.

--- a/docs/plans/2026-06-30-003-chore-cron-profile-assignment-plan.md
+++ b/docs/plans/2026-06-30-003-chore-cron-profile-assignment-plan.md
@@ -1,0 +1,354 @@
+---
+title: Cron Profile Assignment - Plan
+type: chore
+date: 2026-06-30
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Cron Profile Assignment - Plan
+
+## Goal Capsule
+
+Create a safe, reversible migration path that reviews all active Hermes cron jobs, assigns each job to the agent profile that owns its business function, and moves each job only after the target profile can execute it with its own scripts, config, credentials, and gateway.
+
+Target repository: `hermes-agent`.
+
+Authority order:
+
+1. Cron profile isolation contract in `cron/jobs.py`, `cron/scheduler.py`, and `tests/cron/test_cron_profile_isolation.py`.
+2. Existing profile and gateway behavior documented in `website/docs/user-guide/profiles.md` and `website/docs/developer-guide/gateway-internals.md`.
+3. Current live cron inventory from the active default profile.
+4. This plan.
+
+Stop conditions:
+
+- Do not centralize all jobs in one shared `cron/jobs.json` with a new `profile` field.
+- Do not move a script-backed job before its script exists under the target profile's `scripts/` directory.
+- Do not move an agent-driven job until the target profile's provider/model is accepted for that job's output quality.
+- Do not delete jobs from default until a profile-scoped gateway has fired or dry-run-executed the migrated copy successfully.
+- Do not migrate paused jobs as part of the active-job pass.
+
+---
+
+## Product Contract
+
+### Summary
+
+Hermes cron is intentionally profile-local: a job stored under one profile runs with that profile's `HERMES_HOME`, `.env`, `config.yaml`, skills, scripts, locks, and output directory. Today all 60 jobs are stored in the default profile, but only 59 are active. The desired behavior is to turn that flat default-profile schedule into a profile-owned schedule: CRM lead workflows under `rva-leads`, firm operations under `rva-firm-ops`, tax research under `cpa-tax-researcher`, profit and content workflows under `rva-profit-pulse`, and core Hermes/GBrain/runtime diagnostics under `default`.
+
+### Problem Frame
+
+The current default profile is overloaded. It owns business workflows, client communication watches, content automation, GBrain health checks, backups, infrastructure self-healing, and Hermes loop diagnostics. That makes ownership hard to reason about and makes profile-specific agents ineffective because their cron work does not live with their memories, skills, or model configuration.
+
+The migration is risky because cron isolation is a security boundary. Moving a job is not just editing a label. It means copying any referenced script into the target profile, writing the job record into the target profile's `cron/jobs.json`, running the job under the target profile's gateway, and only then removing or disabling the default-profile copy.
+
+### Requirements
+
+**Inventory and assignment**
+
+- R1. Review every currently enabled cron job in the default profile and produce a deterministic assignment to `default`, `cpa-tax-researcher`, `personal`, `rva-dev`, `rva-firm-ops`, `rva-leads`, or `rva-profit-pulse`.
+- R2. Keep paused jobs out of the active migration plan while still reporting them as follow-up candidates.
+- R3. Classify jobs by the business function they perform, not by the channel they deliver to.
+
+**Cron isolation and migration safety**
+
+- R4. Preserve Hermes's per-profile cron model: each moved job must live under the target profile's `cron/jobs.json`, not a shared default store.
+- R5. Copy script dependencies into the target profile's `scripts/` directory before the moved job is eligible to run.
+- R6. Preserve job identity and behavior during migration: schedule, prompt, script, `no_agent`, delivery target, toolsets, model override, context links, workdir, paused state, repeat counters, and recent output metadata.
+- R7. Back up every affected profile's cron store and script target before writing migrations.
+- R8. Migrate in batches by target profile so one failed profile does not block unrelated profiles.
+
+**Runtime readiness and verification**
+
+- R9. Start or configure a profile-scoped gateway only for profiles that receive active jobs.
+- R10. Verify that each migrated profile can list, dry-run, or fire at least one migrated job under its own `HERMES_HOME`.
+- R11. Treat agent-driven jobs as model-sensitive: the target profile's provider/model must be accepted or overridden before the default copy is removed.
+- R12. Document the final assignment ledger, skipped jobs, gateway requirements, rollback steps, and follow-up work.
+
+### Recommended Active Assignment Ledger
+
+| Target profile | Active jobs | Rationale |
+|---|---:|---|
+| `default` | 29 | Core Hermes runtime, GBrain bridge, backups, global diagnostics, and self-referential loop jobs. |
+| `rva-leads` | 13 | Lead intake, CRM pipeline, consultation follow-up, quote suggestions, SMS opt-out handling, and lead lifecycle checks. |
+| `rva-profit-pulse` | 10 | Content CMS, Square sales, weekly digest, topic discovery, and revenue/content loop checks. |
+| `rva-firm-ops` | 5 | Client email capture, TaxDome alerting, calendar nudges, Gmail watch refresh, and meeting-note processing. |
+| `cpa-tax-researcher` | 2 | Tax research archive lint and tax research integrity checks. |
+| `personal` | 0 | No active cron job currently performs personal-profile work. |
+| `rva-dev` | 0 | No active cron job currently performs RVA development-profile work distinct from default runtime operations. |
+
+#### Job-level target map
+
+| Job | Target profile | Execution type | Notes |
+|---|---|---|---|
+| `backup-daily` | `default` | script-only | Global backup coverage should remain with the runtime owner profile. |
+| `crm-daily-scan` | `rva-leads` | agent | CRM pipeline summary belongs with lead operations; verify target model quality before cutover. |
+| `crm-lead-check` | `rva-leads` | script-only | Squarespace lead check belongs with lead operations. |
+| `crm-weekly-scores` | `rva-leads` | agent | Relationship scoring belongs with CRM/lead ownership; verify target model quality. |
+| `taxdome-client-alert` | `rva-firm-ops` | script-only | Client-service alerting is firm operations, not research. |
+| `cron-integrity-selfcheck` | `default` | script-only | It checks the live default cron runtime and should remain self-referential. |
+| `calendar-aware-nudges` | `rva-firm-ops` | agent | Workday operational nudges belong with firm operations; verify target model quality. |
+| `client-email-capture` | `rva-firm-ops` | script-only | Direct client email capture is firm operations. |
+| `crm-lead-reconcile` | `rva-leads` | script-only | Late lead conversion reconciliation belongs with lead operations. |
+| `gbrain-live-sync` | `default` | script-only | GBrain bridge is shared runtime infrastructure. |
+| `gbrain-daily-check` | `default` | agent | GBrain health is shared runtime infrastructure. |
+| `gbrain-weekly-health` | `default` | agent | GBrain health is shared runtime infrastructure. |
+| `tax-research-archive-lint` | `cpa-tax-researcher` | script-only | Tax research archive quality belongs with the tax researcher profile. |
+| `critical-repo-git-sync` | `default` | script-only | Cross-repo backup/sync is global runtime infrastructure. |
+| `crm-gbrain-client-export` | `rva-leads` | script-only | CRM client export belongs with CRM ownership even though it writes to GBrain. |
+| `content-squarespace-sync` | `rva-profit-pulse` | agent | Content CMS sync belongs with the profit/content profile; verify target model quality. |
+| `content-topic-miner` | `rva-profit-pulse` | script-only | Content topic mining belongs with the profit/content profile. |
+| `content-distribution-audit` | `rva-profit-pulse` | agent | Content distribution audit belongs with the profit/content profile. |
+| `content-weekly-strategy-report` | `rva-profit-pulse` | agent | Weekly content strategy belongs with the profit/content profile. |
+| `gmail-watch-refresh` | `rva-firm-ops` | script-only | Gmail push-watch maintenance supports client communication capture. |
+| `crm-meeting-notes-sync` | `rva-leads` | script-only | CRM meeting note sync feeds lead/client follow-up workflows. |
+| `content-idea-proposer` | `rva-profit-pulse` | agent | Content ideation belongs with the profit/content profile; verify target model quality. |
+| `process-meeting-notes` | `rva-firm-ops` | script-only | Meeting-note processing is general firm operations. |
+| `squarespace-hourly-intake` | `rva-leads` | agent with script context | Lead intake review belongs with lead operations; verify target model quality. |
+| `lead-no-response-watchdog` | `rva-leads` | script-only | Lead nonresponse monitoring belongs with lead operations. |
+| `crm-funnel-digest` | `rva-leads` | script-only | CRM funnel reporting belongs with lead operations. |
+| `stall-followup-draft` | `rva-leads` | script-only | Follow-up draft generation belongs with lead operations. |
+| `crm-quote-suggestions` | `rva-leads` | script-only | Quote suggestions belong with lead operations. |
+| `square-daily-sales-capture` | `rva-profit-pulse` | script-only | Square sales capture belongs with the profit profile. |
+| `infra-self-heal-loop` | `default` | agent with script context | Shared infra self-healing should stay with the default runtime owner. |
+| `hermes-backend-update-canary` | `default` | script-only | Backend canary is default runtime infrastructure. |
+| `hermes-loop:contract-registry` | `default` | script-only | Core loop governance should stay self-referential unless cloned per profile later. |
+| `hermes-loop:semantic-audit` | `default` | script-only | Core semantic audit should stay with default. |
+| `hermes-loop:loop-truth-maintenance` | `default` | script-only | Core loop truth maintenance should stay with default. |
+| `hermes-loop:delivery-integrity` | `default` | script-only | Delivery integrity is global runtime infrastructure. |
+| `hermes-loop:cron-wrapper-truth` | `default` | script-only | Cron wrapper truth checks the default cron system. |
+| `hermes-loop:high-risk-gates` | `default` | script-only | Global high-risk gate checks should stay with default. |
+| `hermes-loop:observability-reconciliation` | `default` | script-only | Observability reconciliation should stay with default. |
+| `hermes-loop:dashboard-loop-health` | `default` | script-only | Dashboard loop health is default runtime infrastructure. |
+| `hermes-loop:gateway-plugin-readiness` | `default` | script-only | Gateway/plugin readiness is default runtime infrastructure. |
+| `hermes-loop:model-provider-readiness` | `default` | script-only | Model-provider readiness is global runtime infrastructure. |
+| `hermes-loop:cost-no-progress-guard` | `default` | script-only | Cost/no-progress guard remains global. |
+| `hermes-loop:crm-lead-lifecycle` | `rva-leads` | script-only | CRM lifecycle loop belongs with lead ownership. |
+| `hermes-loop:meeting-to-action` | `default` | script-only | Current loop is global until a profile-specific clone is designed. |
+| `hermes-loop:tax-research-integrity` | `cpa-tax-researcher` | script-only | Tax integrity loop belongs with tax research. |
+| `hermes-loop:content-production-quality` | `rva-profit-pulse` | script-only | Content production quality belongs with profit/content ownership. |
+| `hermes-loop:square-sales-pipeline-verification` | `rva-profit-pulse` | script-only | Square sales verification belongs with profit ownership. |
+| `hermes-loop:gbrain-bridge-health` | `default` | script-only | GBrain bridge health is shared runtime infrastructure. |
+| `hermes-loop:credential-security-drift` | `default` | script-only | Credential drift is shared security infrastructure. |
+| `hermes-loop:backup-restore-verification` | `default` | script-only | Backup/restore verification is shared runtime infrastructure. |
+| `hermes-loop:skill-promotion-upgrade` | `default` | script-only | Skill promotion/upgrade checks are default profile infrastructure. |
+| `hermes-loop:test-suite-truth-targeted` | `default` | script-only | Test-suite truth checks the Hermes runtime repo. |
+| `hermes-loop:skill-promotions` | `default` | script-only | Skill promotion checks remain with default. |
+| `hermes-loop:ingest-observability` | `default` | script-only | Ingest observability remains global. |
+| `hermes-loop:orphan-metric-cleanup` | `default` | script-only | Orphan metric cleanup remains global. |
+| `rva-profit-pulse-topic-discovery-weekly` | `rva-profit-pulse` | script-only | Already names the profit pulse domain. |
+| `square-weekly-digest` | `rva-profit-pulse` | script-only | Square reporting belongs with profit ownership. |
+| `ringcentral-sms-opt-out-watchdog` | `rva-leads` | script-only | Lead/client SMS opt-out handling belongs with lead operations. |
+| `notcrawl-nightly-sync` | `default` | script-only | Nightly sync wrapper is shared runtime infrastructure. |
+
+### Paused Job Handling
+
+`stale-draft-alert` is paused with reason `blocked_pending_profile_shadow_readiness_approval`. It should not be migrated during the active-job pass. The assignment candidate is `rva-firm-ops`, but only after the shadow-readiness blocker is resolved and delivery configuration is verified.
+
+### Scope Boundaries
+
+#### In scope
+
+- Inventorying the active default-profile jobs.
+- Producing and documenting a target profile assignment for each active job.
+- Creating a dry-run migration tool that stages job records and scripts into target profiles.
+- Starting or documenting profile-scoped gateway requirements for profiles that receive jobs.
+- Verifying moved jobs under target profile homes.
+
+#### Deferred to Follow-Up Work
+
+- Cloning the full `hermes-loop:*` diagnostic suite into every profile. This may be valuable later, but it changes the loop design from one default-owned monitor set to many profile-owned monitor sets.
+- Moving the paused `stale-draft-alert` job after its shadow-readiness blocker is resolved.
+- Assigning any jobs to `personal` or `rva-dev` after new jobs exist that actually match those domains.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Use profile-local cron stores, not a central assignment field. `cron/jobs.py` and `tests/cron/test_cron_profile_isolation.py` make profile locality a security boundary, so the migration writes target jobs into each target profile's own `cron/jobs.json`.
+- KTD2. Keep default-owned runtime diagnostics self-referential. Most `hermes-loop:*` jobs monitor default's gateway, skills, model providers, delivery, cron wrappers, and backup posture. Moving those jobs would make them observe a different profile without redesigning their semantics.
+- KTD3. Move business-domain script-only jobs first. Script-only jobs avoid model-quality changes; they mainly need script staging, config parity, delivery validation, and profile gateway readiness.
+- KTD4. Treat agent-driven jobs as shadow migrations. Agent-driven CRM and content jobs may change behavior when moved from default's `gpt-5.5` runtime to the target profile's provider/model, so the target copy should run in shadow mode before default is disabled.
+- KTD5. Start only needed profile gateways. This pass needs gateways for `cpa-tax-researcher`, `rva-firm-ops`, `rva-leads`, and `rva-profit-pulse`; `personal` and `rva-dev` receive no active jobs and should not get new gateway process burden.
+- KTD6. Use backups plus idempotent migration state. Job moves should be replayable: a second run should detect already-staged scripts, already-copied jobs, and already-disabled default copies without duplicating records.
+- KTD7. Prefer profile-scoped subprocesses for live profile operations. `cron/jobs.py` binds its store globals at import time, so live migration and verification should use `hermes -p <profile> ...` subprocesses rather than retargeting already-imported module globals in a long-running process.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[Read default cron/jobs.json] --> B[Filter enabled jobs]
+  B --> C[Classify by business function]
+  C --> D[Generate assignment ledger]
+  D --> E[Backup default and target cron stores]
+  E --> F[Copy required scripts into target profile scripts]
+  F --> G[Write target profile job records]
+  G --> H[Start or verify target profile gateway]
+  H --> I[Dry-run or fire migrated job under target HERMES_HOME]
+  I --> J{Verification passed?}
+  J -->|yes| K[Disable or remove default copy]
+  J -->|no| L[Leave default copy active and report blocker]
+```
+
+### Implementation Constraints
+
+- Script validation must respect the existing constraint from `cron/scheduler.py`: cron scripts execute only from the active profile's `scripts/` directory.
+- The dashboard profile-routing helpers in `hermes_cli/web_server.py` are useful reference behavior, but the migration should not rely on mutating imported module globals in a long-running process.
+- Job IDs are immutable and are also output-directory keys, so target profile stores must be checked for ID and output-history collisions before copying records.
+- Jobs that reference `skills` or profile-specific tool availability must verify those skills and tools exist in the target profile before cutover.
+- There is no built-in selective cron migration command today; `--clone-all` copies an entire `cron/` and `scripts/` tree, but this plan needs selective per-job movement.
+- Live path references in reports should use profile names and symbolic profile homes, not absolute machine paths.
+- The migration tool should default to dry-run and require an explicit apply flag.
+
+### Sources and Research
+
+- `cron/jobs.py` defines cron storage under the active profile home and warns not to anchor jobs at the shared root.
+- `cron/scheduler.py` resolves `HERMES_HOME` dynamically for execution and lock paths.
+- `tests/cron/test_cron_profile_isolation.py` pins storage, execution, and lock paths to the profile home.
+- `tests/hermes_cli/test_web_server_cron_profiles.py` shows dashboard-side profile routing and script path normalization for profile cron jobs.
+- `hermes_cli/profiles.py` provides the nearest precedent: `--clone-all` copies `cron/` and `scripts/`, but only as a whole-profile clone.
+- `hermes_cli/gateway.py` builds profile gateway commands; service-mode startup is `hermes -p <profile> gateway start`, while foreground debugging can use `hermes -p <profile> gateway run`.
+- `hermes_cli/cron.py` exposes list/create/edit/pause/resume/run/remove/status/tick operations but no selective move or migrate command.
+- `website/docs/developer-guide/cron-internals.md` and `website/docs/guides/cron-troubleshooting.md` document cron execution, locks, status, and script-path failure modes.
+- `docs/design/profile-builder.md` documents the module-global import seam and why profile-scoped subprocesses are safer than mutating globals in a live process.
+- `docs/kanban/multi-gateway.md` documents multi-gateway deployment concerns, including single-owner dispatcher settings that should not be accidentally duplicated across profiles.
+- `website/docs/user-guide/profiles.md` explains that each profile has separate config, `.env`, memory, sessions, skills, cron jobs, and state.
+- `website/docs/developer-guide/gateway-internals.md` identifies `gateway/status.py` as token-lock management for profile-scoped gateway instances.
+
+---
+
+## Implementation Units
+
+### U1. Build the active cron inventory and assignment report
+
+- **Goal:** Create a read-only tool that inventories enabled jobs, reports paused jobs separately, and emits the assignment ledger in machine-readable and human-readable forms.
+- **Requirements:** R1, R2, R3, R12
+- **Dependencies:** None
+- **Files:** `scripts/cron_profile_assignment_audit.py`, `tests/cron/test_cron_profile_assignment_audit.py`
+- **Approach:** Load the default profile's `cron/jobs.json`, support both wrapped `{"jobs": [...]}` and legacy list shapes, filter enabled jobs by default, preserve disabled jobs under a paused section, and classify each enabled job using explicit rules keyed on job name, script name, workdir domain, and prompt keywords. Output a summary by target profile plus a full job-level ledger.
+- **Patterns to follow:** Use profile-home resolution conventions from `hermes_constants.py`; mirror JSON-store compatibility expectations from `cron/jobs.py`.
+- **Test scenarios:**
+  - Given a wrapped jobs store with two enabled jobs and one disabled job, the report counts only the enabled jobs as active and lists the disabled job under paused follow-up.
+  - Given a CRM job with a lead-check script, the classifier assigns it to `rva-leads`.
+  - Given a GBrain health job, the classifier assigns it to `default`.
+  - Given a tax research lint job, the classifier assigns it to `cpa-tax-researcher`.
+  - Given an unknown job, the classifier assigns `default` and marks the decision as review-needed rather than silently inventing a business owner.
+  - Given a legacy list-form jobs store, the report still produces the same active and paused counts.
+- **Verification:** The tool reports 59 active jobs and one paused job against the current default store, with target counts matching the ledger in this plan.
+
+### U2. Add a dry-run migration planner with backups and rollback metadata
+
+- **Goal:** Produce a safe migration manifest that describes every script copy, job copy, default-profile disable/remove action, profile gateway requirement, and rollback operation before any live write occurs.
+- **Requirements:** R4, R6, R7, R8, R11
+- **Dependencies:** U1
+- **Files:** `scripts/cron_profile_rebalance.py`, `tests/cron/test_cron_profile_rebalance.py`
+- **Approach:** Accept the U1 assignment ledger as input, resolve each target profile home, plan backups for default plus every target profile, and emit a dry-run manifest. The manifest should include source job ID, target profile, required script files, ID/output collision status, skill requirements, whether the job is script-only or agent-driven, whether a profile gateway is needed, and rollback instructions.
+- **Patterns to follow:** Preserve `jobs.json` structure used by `cron/jobs.py`; preserve profile isolation verified by `tests/cron/test_cron_profile_isolation.py`.
+- **Test scenarios:**
+  - Given an assignment that moves a script-backed job, the dry-run includes a script copy into the target profile's `scripts/` directory before the job write.
+  - Given an agent-driven job, the dry-run marks it as shadow-required and does not schedule default-copy removal in the same step.
+  - Given a target profile without `cron/jobs.json`, the dry-run plans directory creation and a wrapped jobs store.
+  - Given an existing target job with the same ID, the dry-run treats it as already staged and does not duplicate it.
+  - Given an existing unrelated target job with the same ID, the dry-run blocks the move and reports the immutable-ID/output-history collision.
+  - Given a job with a `skills` reference missing from the target profile, the dry-run blocks cutover and reports the missing skill.
+  - Given a missing source script, the dry-run blocks that job and leaves the default copy untouched.
+  - Given an apply request, the tool writes timestamped backups before modifying any cron store.
+- **Verification:** A dry-run against the current default store produces no live changes and names every target profile that would receive jobs.
+
+### U3. Stage scripts and profile cron stores safely
+
+- **Goal:** Copy required scripts to target profiles and create target `cron/` directories without enabling migrated jobs prematurely.
+- **Requirements:** R4, R5, R7, R8
+- **Dependencies:** U2
+- **Files:** `scripts/cron_profile_rebalance.py`, `tests/cron/test_cron_profile_rebalance.py`
+- **Approach:** Add an apply phase that can stage scripts and target job stores while leaving default jobs active. Script staging should preserve executable bits for shell scripts, avoid copying cache files or backups, and skip scripts for jobs that stay on default.
+- **Patterns to follow:** Follow script validation behavior tested in `tests/hermes_cli/test_web_server_cron_profiles.py`, where profile cron APIs normalize scripts to profile-local paths and reject scripts outside the profile scripts directory.
+- **Test scenarios:**
+  - Given a shell script source, the staged target script preserves executable permissions.
+  - Given a Python script source, the staged target script is copied once and is not duplicated on a second run.
+  - Given a job that stays on default, no target script copy is planned.
+  - Given a script path that points outside the source profile's scripts directory, the staging phase blocks the job.
+  - Given four target profiles, the staging phase creates each required `cron/` and `scripts/` directory without modifying profiles that receive no jobs.
+- **Verification:** Target profiles that receive jobs have the required scripts present before any migrated job is enabled there.
+
+### U4. Migrate jobs by target profile and verify profile-scoped execution
+
+- **Goal:** Move jobs in batches by profile, verify target execution, and only then disable or remove default copies.
+- **Requirements:** R6, R8, R9, R10, R11
+- **Dependencies:** U2, U3
+- **Files:** `scripts/cron_profile_rebalance.py`, `tests/cron/test_cron_profile_rebalance.py`, `tests/cron/test_cron_profile_isolation.py`
+- **Approach:** Add per-profile apply steps: write target job records through profile-scoped subprocesses, start or confirm the profile-scoped gateway outside the migration tool, and run a verification command or scheduled dry run under the target profile. Script-only jobs can cut over after target output is verified. Agent-driven jobs should remain in shadow mode until a reviewer accepts target-profile model output.
+- **Execution note:** Use characterization-first verification for agent-driven jobs: capture current default-profile output shape before comparing target-profile output.
+- **Patterns to follow:** Use `hermes -p <profile> gateway start` for service-mode profile gateways and `hermes -p <profile> gateway run` for foreground debugging; use `tests/cron/test_cron_profile_isolation.py` as the invariant that target execution follows target profile home.
+- **Test scenarios:**
+  - Given a target job copy, the tool can verify it exists only in the target profile store after cutover.
+  - Given a script-only job with successful target verification, the default copy is disabled or removed according to the chosen cutover mode.
+  - Given an agent-driven job, the default copy remains active until shadow verification is accepted.
+  - Given a failed target verification, the default copy remains active and the target job is marked blocked.
+  - Given two target profiles, a failure in one profile does not prevent migration of an unrelated profile batch.
+  - Given a target profile with kanban dispatcher settings, gateway startup verification confirms only the intended profile owns dispatcher behavior.
+- **Verification:** At least one migrated job per target profile is proven to execute or dry-run under that profile's `HERMES_HOME` before any default copy from that profile's batch is removed.
+
+### U5. Document final ownership, gateway operations, and rollback
+
+- **Goal:** Leave an operator-facing record of the final state, including assignment rationale, gateway process requirements, rollback steps, and follow-up jobs.
+- **Requirements:** R9, R10, R12
+- **Dependencies:** U1, U2, U3, U4
+- **Files:** `docs/operations/cron-profile-assignment.md`, `tests/cron/test_cron_profile_assignment_audit.py`
+- **Approach:** Generate or maintain a runbook that includes the assignment ledger, target profile counts, active gateway expectations, verification evidence format, and rollback procedure. Include `stale-draft-alert` as a paused follow-up rather than an active assignment.
+- **Patterns to follow:** Keep operational docs concise and path-safe; reference profile names and symbolic profile homes instead of absolute paths.
+- **Test scenarios:**
+  - Given a completed migration manifest, the generated runbook includes target profile counts and all migrated job IDs.
+  - Given a paused job, the generated runbook lists it under follow-up and not in active counts.
+  - Given a blocked job, the generated runbook includes the blocker and rollback action.
+- **Verification:** A reader can identify which profile owns each active job, which gateways must run, and how to roll back a failed profile batch without reading the migration tool source.
+
+---
+
+## Verification Contract
+
+| Gate | Applies to | Done signal |
+|---|---|---|
+| Unit tests | U1-U5 | `scripts/run_tests.sh tests/cron/test_cron_profile_isolation.py tests/hermes_cli/test_web_server_cron_profiles.py tests/cron/test_cron_profile_assignment_audit.py tests/cron/test_cron_profile_rebalance.py` passes. |
+| Read-only audit | U1 | The audit report shows 59 active jobs, one paused job, and target counts `default=29`, `rva-leads=13`, `rva-profit-pulse=10`, `rva-firm-ops=5`, `cpa-tax-researcher=2`. |
+| Dry-run manifest | U2 | The dry-run prints every planned script copy, job copy, gateway requirement, and default-copy action without modifying live files. |
+| Staging verification | U3 | Every moved script-backed job has its script present in the target profile's `scripts/` directory before target job enablement. |
+| Profile gateway status | U4 | `hermes -p <profile> cron status` and `hermes -p <profile> gateway status` show a live profile-scoped gateway for every target profile that receives jobs. |
+| Profile execution verification | U4 | Each target profile that receives jobs has at least one migrated job verified under its own `HERMES_HOME`. |
+| Shadow output review | U4 | Agent-driven jobs are accepted under the target profile's provider/model before their default copies are disabled. |
+| Runbook review | U5 | `docs/operations/cron-profile-assignment.md` matches the final migration manifest and names all deferred items. |
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Profile-scoped gateways are not running for target profiles. | Stage jobs first, then start gateways only for `cpa-tax-researcher`, `rva-firm-ops`, `rva-leads`, and `rva-profit-pulse`. |
+| A script-backed job fails after migration because the target profile lacks the script. | Block target job enablement until script staging verifies the target profile `scripts/` file. |
+| Agent-driven jobs change tone or reasoning because target profiles use different providers/models. | Shadow-run target copies and compare output before disabling default copies. |
+| Discord or Telegram delivery behaves differently from a non-default profile. | Verify one delivered message per target profile before cutover. |
+| Job IDs or output histories collide in a target profile. | Block the move unless the target record is the same staged job; never rename an existing job ID in place. |
+| A migrated job references a skill missing from the target profile. | Verify `skills` references before cutover and install/copy the missing skill or keep the job on default. |
+| Multi-gateway startup duplicates dispatcher ownership. | Check profile gateway config before start and preserve single-owner dispatcher behavior. |
+| Duplicate jobs fire during shadow migration. | Mark shadow copies clearly and keep destructive/default-disable actions separate from staging. |
+| A stale branch or future fix re-centralizes cron storage. | Keep `tests/cron/test_cron_profile_isolation.py` in the verification gate. |
+
+---
+
+## Definition of Done
+
+- U1-U5 are complete and verified.
+- The active cron inventory has been reviewed and every active job has an explicit target profile.
+- The migration plan is reversible, with backups for every touched profile cron store.
+- Script-backed jobs have target-profile script copies before execution.
+- Target profile gateways are running or explicitly scheduled for only the profiles that receive active jobs.
+- Agent-driven jobs have accepted target-profile output before default copies are removed.
+- The paused `stale-draft-alert` job remains out of the active migration and is documented as follow-up.
+- The final runbook records the completed ownership ledger and rollback path.
+- Abandoned experimental scripts, temp manifests, and dead-end migration artifacts are removed before declaring the work complete.

--- a/scripts/cron_profile_assignment_audit.py
+++ b/scripts/cron_profile_assignment_audit.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Audit Hermes cron jobs and recommend profile ownership.
+
+This script is intentionally standalone. It reads cron JSON stores directly so
+operators can inspect a profile's jobs without importing ``cron.jobs`` into a
+long-running process whose module globals may already point at another profile.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+TARGET_PROFILES = (
+    "default",
+    "cpa-tax-researcher",
+    "personal",
+    "rva-dev",
+    "rva-firm-ops",
+    "rva-leads",
+    "rva-profit-pulse",
+)
+
+EXACT_JOB_TARGETS = {
+    "backup-daily": "default",
+    "crm-daily-scan": "rva-leads",
+    "crm-lead-check": "rva-leads",
+    "crm-weekly-scores": "rva-leads",
+    "taxdome-client-alert": "rva-firm-ops",
+    "cron-integrity-selfcheck": "default",
+    "calendar-aware-nudges": "rva-firm-ops",
+    "client-email-capture": "rva-firm-ops",
+    "crm-lead-reconcile": "rva-leads",
+    "gbrain-live-sync": "default",
+    "gbrain-daily-check": "default",
+    "gbrain-weekly-health": "default",
+    "tax-research-archive-lint": "cpa-tax-researcher",
+    "critical-repo-git-sync": "default",
+    "crm-gbrain-client-export": "rva-leads",
+    "content-squarespace-sync": "rva-profit-pulse",
+    "content-topic-miner": "rva-profit-pulse",
+    "content-distribution-audit": "rva-profit-pulse",
+    "content-weekly-strategy-report": "rva-profit-pulse",
+    "gmail-watch-refresh": "rva-firm-ops",
+    "crm-meeting-notes-sync": "rva-leads",
+    "content-idea-proposer": "rva-profit-pulse",
+    "process-meeting-notes": "rva-firm-ops",
+    "squarespace-hourly-intake": "rva-leads",
+    "lead-no-response-watchdog": "rva-leads",
+    "crm-funnel-digest": "rva-leads",
+    "stall-followup-draft": "rva-leads",
+    "crm-quote-suggestions": "rva-leads",
+    "square-daily-sales-capture": "rva-profit-pulse",
+    "infra-self-heal-loop": "default",
+    "hermes-backend-update-canary": "default",
+    "hermes-loop:contract-registry": "default",
+    "hermes-loop:semantic-audit": "default",
+    "hermes-loop:loop-truth-maintenance": "default",
+    "hermes-loop:delivery-integrity": "default",
+    "hermes-loop:cron-wrapper-truth": "default",
+    "hermes-loop:high-risk-gates": "default",
+    "hermes-loop:observability-reconciliation": "default",
+    "hermes-loop:dashboard-loop-health": "default",
+    "hermes-loop:gateway-plugin-readiness": "default",
+    "hermes-loop:model-provider-readiness": "default",
+    "hermes-loop:cost-no-progress-guard": "default",
+    "hermes-loop:crm-lead-lifecycle": "rva-leads",
+    "hermes-loop:meeting-to-action": "default",
+    "hermes-loop:tax-research-integrity": "cpa-tax-researcher",
+    "hermes-loop:content-production-quality": "rva-profit-pulse",
+    "hermes-loop:square-sales-pipeline-verification": "rva-profit-pulse",
+    "hermes-loop:gbrain-bridge-health": "default",
+    "hermes-loop:credential-security-drift": "default",
+    "hermes-loop:backup-restore-verification": "default",
+    "hermes-loop:skill-promotion-upgrade": "default",
+    "hermes-loop:test-suite-truth-targeted": "default",
+    "hermes-loop:skill-promotions": "default",
+    "hermes-loop:ingest-observability": "default",
+    "hermes-loop:orphan-metric-cleanup": "default",
+    "rva-profit-pulse-topic-discovery-weekly": "rva-profit-pulse",
+    "square-weekly-digest": "rva-profit-pulse",
+    "ringcentral-sms-opt-out-watchdog": "rva-leads",
+    "notcrawl-nightly-sync": "default",
+    "stale-draft-alert": "rva-firm-ops",
+}
+
+
+@dataclass(frozen=True)
+class Assignment:
+    job_id: str
+    name: str
+    target_profile: str
+    execution_type: str
+    reason: str
+    review_needed: bool = False
+    script: str | None = None
+    workdir: str | None = None
+    enabled: bool = True
+
+
+def default_jobs_file() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "cron" / "jobs.json"
+    except Exception:
+        return Path.home() / ".hermes" / "cron" / "jobs.json"
+
+
+def load_job_store(path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Load cron jobs from wrapped or legacy list-form JSON stores."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(raw, list):
+        return [dict(job) for job in raw], {"shape": "list"}
+    if isinstance(raw, dict) and isinstance(raw.get("jobs"), list):
+        metadata = {k: v for k, v in raw.items() if k != "jobs"}
+        metadata["shape"] = "wrapped"
+        return [dict(job) for job in raw["jobs"]], metadata
+    raise ValueError(f"Unsupported cron jobs store shape in {path}")
+
+
+def job_enabled(job: dict[str, Any]) -> bool:
+    return bool(job.get("enabled", True))
+
+
+def execution_type(job: dict[str, Any]) -> str:
+    if job.get("no_agent"):
+        return "script-only"
+    if job.get("script"):
+        return "agent-with-script"
+    return "agent"
+
+
+def _job_text(job: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for key in ("name", "script", "workdir", "prompt"):
+        value = job.get(key)
+        if value:
+            parts.append(str(value).lower())
+    return " ".join(parts)
+
+
+def classify_job(job: dict[str, Any]) -> tuple[str, str, bool]:
+    """Return ``(target_profile, reason, review_needed)`` for a cron job."""
+    name = str(job.get("name") or job.get("id") or "").strip()
+    if name in EXACT_JOB_TARGETS:
+        target = EXACT_JOB_TARGETS[name]
+        return target, f"exact match: {name} -> {target}", False
+
+    text = _job_text(job)
+    if name.startswith("hermes-loop:"):
+        if "crm" in text or "lead" in text:
+            return "rva-leads", "Hermes loop monitors CRM/lead lifecycle", False
+        if "tax-research" in text or "tax_research" in text:
+            return "cpa-tax-researcher", "Hermes loop monitors tax research integrity", False
+        if "content" in text or "square" in text or "sales" in text:
+            return "rva-profit-pulse", "Hermes loop monitors content/profit workflows", False
+        return "default", "Hermes runtime diagnostic loop stays self-referential", False
+
+    if name.startswith("crm-") or any(
+        token in text
+        for token in (
+            "crm",
+            "lead",
+            "squarespace",
+            "quote",
+            "ringcentral",
+            "sms opt",
+        )
+    ):
+        return "rva-leads", "CRM/lead workflow", False
+    if any(token in text for token in ("taxdome", "gmail", "calendar", "meeting-notes", "client_email")):
+        return "rva-firm-ops", "Firm operations/client communications workflow", False
+    if any(token in text for token in ("content", "square", "profit-pulse", "sales")):
+        return "rva-profit-pulse", "Content/profit workflow", False
+    if "tax-research" in text or "tax_research" in text:
+        return "cpa-tax-researcher", "Tax research workflow", False
+    if "gbrain" in text or "backup" in text or "infra" in text or "repo" in text:
+        return "default", "Shared runtime infrastructure", False
+    return "default", "unknown job shape; default is safest pending review", True
+
+
+def assignment_for_job(job: dict[str, Any]) -> Assignment:
+    target, reason, review_needed = classify_job(job)
+    return Assignment(
+        job_id=str(job.get("id") or ""),
+        name=str(job.get("name") or job.get("id") or ""),
+        target_profile=target,
+        execution_type=execution_type(job),
+        reason=reason,
+        review_needed=review_needed,
+        script=str(job["script"]) if job.get("script") else None,
+        workdir=str(job["workdir"]) if job.get("workdir") else None,
+        enabled=job_enabled(job),
+    )
+
+
+def build_report(jobs: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    active: list[dict[str, Any]] = []
+    paused: list[dict[str, Any]] = []
+    target_counts = {profile: 0 for profile in TARGET_PROFILES}
+
+    for job in jobs:
+        assignment = assignment_for_job(job)
+        row = asdict(assignment)
+        if assignment.enabled:
+            active.append(row)
+            target_counts[assignment.target_profile] += 1
+        else:
+            paused.append(row)
+
+    target_counts = {k: v for k, v in target_counts.items() if v or k in {"personal", "rva-dev"}}
+    return {
+        "summary": {
+            "active_total": len(active),
+            "paused_total": len(paused),
+            "target_counts": target_counts,
+            "review_needed": sum(1 for row in active if row["review_needed"]),
+        },
+        "active": active,
+        "paused": paused,
+    }
+
+
+def report_as_markdown(report: dict[str, Any]) -> str:
+    lines = ["# Cron Profile Assignment Audit", ""]
+    summary = report["summary"]
+    lines.append(f"Active jobs: {summary['active_total']}")
+    lines.append(f"Paused jobs: {summary['paused_total']}")
+    lines.append("")
+    lines.append("## Target Counts")
+    lines.append("")
+    for profile, count in summary["target_counts"].items():
+        lines.append(f"- `{profile}`: {count}")
+    lines.append("")
+    lines.append("## Active Jobs")
+    lines.append("")
+    lines.append("| Job | Target | Execution | Review | Reason |")
+    lines.append("|---|---|---|---|---|")
+    for row in report["active"]:
+        review = "yes" if row["review_needed"] else "no"
+        lines.append(
+            f"| `{row['name']}` | `{row['target_profile']}` | {row['execution_type']} | {review} | {row['reason']} |"
+        )
+    if report["paused"]:
+        lines.append("")
+        lines.append("## Paused Follow-up")
+        lines.append("")
+        lines.append("| Job | Candidate Target | Reason |")
+        lines.append("|---|---|---|")
+        for row in report["paused"]:
+            lines.append(f"| `{row['name']}` | `{row['target_profile']}` | {row['reason']} |")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jobs-file", type=Path, default=default_jobs_file())
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    args = parser.parse_args(argv)
+
+    jobs, _metadata = load_job_store(args.jobs_file)
+    report = build_report(jobs)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(report_as_markdown(report), end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/cron_profile_rebalance.py
+++ b/scripts/cron_profile_rebalance.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Plan and safely stage Hermes cron jobs into profile-local stores.
+
+The default mode is dry-run. Apply modes write only profile-local cron stores and
+scripts after creating backups. The script never starts gateways or executes
+jobs; it reports the profile-scoped commands operators should run next.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shutil
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from cron_profile_assignment_audit import assignment_for_job, load_job_store
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-Unix
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - non-Windows
+    msvcrt = None
+
+MIGRATION_KEY = "profile_migration"
+SOURCE_PROFILE = "default"
+MIGRATION_TARGET_PROFILES = ("cpa-tax-researcher", "rva-firm-ops", "rva-leads", "rva-profit-pulse")
+
+
+@dataclass
+class MovePlan:
+    job_id: str
+    name: str
+    source_profile: str
+    target_profile: str
+    action: str
+    execution_type: str
+    shadow_required: bool
+    gateway_required: bool
+    default_action: str
+    blockers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    script_copy: dict[str, str] | None = None
+    skills: list[str] = field(default_factory=list)
+    missing_skills: list[str] = field(default_factory=list)
+    already_staged: bool = False
+
+
+@dataclass
+class Manifest:
+    generated_at: str
+    source_profile: str
+    source_home: str
+    moves: list[MovePlan]
+    gateway_profiles: list[str]
+    summary: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        moves: list[dict[str, Any]] = []
+        for move in self.moves:
+            row = asdict(move)
+            if move.script_copy:
+                relative = move.script_copy["relative"]
+                row["script_copy"] = {
+                    "relative": relative,
+                    "source": f"<{self.source_profile}:scripts/{relative}>",
+                    "target": f"<{move.target_profile}:scripts/{relative}>",
+                }
+            moves.append(row)
+        return {
+            "generated_at": self.generated_at,
+            "source_profile": self.source_profile,
+            "source_home": f"<profile:{self.source_profile}>",
+            "gateway_profiles": self.gateway_profiles,
+            "summary": self.summary,
+            "moves": moves,
+        }
+
+
+def default_source_home() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home()
+    except Exception:
+        return Path.home() / ".hermes"
+
+
+def profile_home(default_home: Path, profile: str) -> Path:
+    if profile == "default":
+        return default_home
+    return default_home / "profiles" / profile
+
+
+def jobs_file_for(home: Path) -> Path:
+    return home / "cron" / "jobs.json"
+
+
+@contextlib.contextmanager
+def jobs_store_lock(home: Path):
+    cron_dir = home / "cron"
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = cron_dir / ".jobs.lock"
+    handle = lock_file.open("a+", encoding="utf-8")
+    try:
+        if fcntl is not None:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+        elif msvcrt is not None:
+            getattr(msvcrt, "locking")(handle.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+        yield
+    finally:
+        try:
+            if fcntl is not None:
+                fcntl.flock(handle, fcntl.LOCK_UN)
+            elif msvcrt is not None:
+                getattr(msvcrt, "locking")(handle.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
+        finally:
+            handle.close()
+
+
+def load_jobs_for_home(home: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    jobs_file = jobs_file_for(home)
+    if not jobs_file.exists():
+        return [], {"shape": "wrapped"}
+    return load_job_store(jobs_file)
+
+
+def _now_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _atomic_write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        with tmp.open("w", encoding="utf-8") as handle:
+            handle.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def save_jobs_for_home(
+    home: Path,
+    jobs: list[dict[str, Any]],
+    metadata: dict[str, Any] | None = None,
+    *,
+    lock: bool = True,
+) -> None:
+    if lock:
+        with jobs_store_lock(home):
+            save_jobs_for_home(home, jobs, metadata, lock=False)
+        return
+    metadata = dict(metadata or {})
+    shape = metadata.pop("shape", "wrapped")
+    jobs_file = jobs_file_for(home)
+    if shape == "list":
+        _atomic_write_json(jobs_file, jobs)
+        return
+    payload = {"jobs": jobs, **metadata, "updated_at": datetime.now(timezone.utc).isoformat()}
+    _atomic_write_json(jobs_file, payload)
+
+
+def backup_jobs_file(home: Path) -> Path | None:
+    jobs_file = jobs_file_for(home)
+    if not jobs_file.exists():
+        return None
+    backup_dir = home / "cron" / "backups"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_path = backup_dir / f"jobs-{_now_stamp()}.json"
+    shutil.copy2(jobs_file, backup_path)
+    return backup_path
+
+
+def backup_existing_file(path: Path) -> Path | None:
+    if not path.exists():
+        return None
+    backup_path = path.with_name(f"{path.name}.bak-{_now_stamp()}")
+    shutil.copy2(path, backup_path)
+    return backup_path
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_source_script(source_home: Path, script: str) -> tuple[Path | None, str | None]:
+    """Resolve and sandbox a source script path under source_home/scripts."""
+    scripts_dir = (source_home / "scripts").resolve()
+    raw = Path(script).expanduser()
+    candidate = raw if raw.is_absolute() else scripts_dir / raw
+    try:
+        resolved = candidate.resolve(strict=False)
+    except OSError:
+        return None, "source_script_unresolvable"
+    if not _is_relative_to(resolved, scripts_dir):
+        return None, "source_script_outside_profile_scripts"
+    return resolved, None
+
+
+def script_copy_plan(source_home: Path, target_home: Path, script: str) -> tuple[dict[str, str] | None, str | None]:
+    source_script, error = resolve_source_script(source_home, script)
+    if error:
+        return None, error
+    assert source_script is not None
+    if not source_script.exists():
+        return None, "missing_source_script"
+    rel = source_script.relative_to((source_home / "scripts").resolve())
+    target_script = target_home / "scripts" / rel
+    return {"source": str(source_script), "target": str(target_script), "relative": str(rel)}, None
+
+
+def job_skills(job: dict[str, Any]) -> list[str]:
+    raw = job.get("skills")
+    if raw is None:
+        raw = [job.get("skill")] if job.get("skill") else []
+    elif isinstance(raw, str):
+        raw = [raw]
+    result: list[str] = []
+    for value in raw:
+        text = str(value or "").strip()
+        if text and text not in result:
+            result.append(text)
+    return result
+
+
+def available_skills(profile: Path) -> set[str]:
+    skills_dir = profile / "skills"
+    found: set[str] = set()
+    if not skills_dir.exists():
+        return found
+    for child in skills_dir.iterdir():
+        if child.is_dir():
+            found.add(child.name)
+    for skill_md in skills_dir.rglob("SKILL.md"):
+        found.add(skill_md.parent.name)
+        try:
+            lines = skill_md.read_text(encoding="utf-8", errors="ignore").splitlines()
+        except OSError:
+            continue
+        if lines[:1] != ["---"]:
+            continue
+        for line in lines[1:40]:
+            if line.strip() == "---":
+                break
+            if line.startswith("name:"):
+                found.add(line.split(":", 1)[1].strip().strip('"\''))
+                break
+    return found
+
+
+def is_same_staged_job(existing: dict[str, Any], source_job: dict[str, Any]) -> bool:
+    meta = existing.get(MIGRATION_KEY)
+    return isinstance(meta, dict) and meta.get("source_job_id") == source_job.get("id") and meta.get("source_profile") == SOURCE_PROFILE
+
+
+def make_target_job(job: dict[str, Any], target_profile: str, *, shadow_required: bool) -> dict[str, Any]:
+    copied = dict(job)
+    now = datetime.now(timezone.utc).isoformat()
+    copied["enabled"] = False
+    copied["state"] = "paused"
+    copied["paused_reason"] = "profile_migration_staged_shadow" if shadow_required else "profile_migration_staged"
+    copied["paused_at"] = now
+    copied["next_run_at"] = None
+    copied[MIGRATION_KEY] = {
+        "source_profile": SOURCE_PROFILE,
+        "source_job_id": job.get("id"),
+        "target_profile": target_profile,
+        "source_enabled": bool(job.get("enabled", True)),
+        "shadow_required": shadow_required,
+        "staged_at": now,
+    }
+    return copied
+
+
+def build_manifest(
+    source_home: Path,
+    *,
+    default_home: Path | None = None,
+    target_profiles: set[str] | None = None,
+) -> Manifest:
+    source_home = source_home.resolve()
+    default_home = (default_home or source_home).resolve()
+    source_jobs, _source_metadata = load_jobs_for_home(source_home)
+    target_cache: dict[str, tuple[Path, list[dict[str, Any]], set[str]]] = {}
+    moves: list[MovePlan] = []
+
+    for job in source_jobs:
+        if not bool(job.get("enabled", True)):
+            continue
+        assignment = assignment_for_job(job)
+        target_profile = assignment.target_profile
+        if target_profiles is not None and target_profile not in target_profiles:
+            continue
+        execution_type = assignment.execution_type
+        shadow_required = not bool(job.get("no_agent"))
+        job_id = str(job.get("id") or "")
+        if not job_id:
+            moves.append(
+                MovePlan(
+                    job_id="",
+                    name=assignment.name,
+                    source_profile=SOURCE_PROFILE,
+                    target_profile=target_profile,
+                    action="blocked",
+                    execution_type=execution_type,
+                    shadow_required=shadow_required,
+                    gateway_required=target_profile != SOURCE_PROFILE,
+                    default_action="leave_active_blocked",
+                    blockers=["missing_job_id"],
+                )
+            )
+            continue
+        if target_profile == SOURCE_PROFILE:
+            moves.append(
+                MovePlan(
+                    job_id=job_id,
+                    name=assignment.name,
+                    source_profile=SOURCE_PROFILE,
+                    target_profile=target_profile,
+                    action="keep",
+                    execution_type=execution_type,
+                    shadow_required=False,
+                    gateway_required=False,
+                    default_action="keep_active",
+                )
+            )
+            continue
+
+        target_home = profile_home(default_home, target_profile).resolve()
+        if target_profile not in target_cache:
+            target_jobs, _target_metadata = load_jobs_for_home(target_home)
+            target_cache[target_profile] = (target_home, target_jobs, available_skills(target_home))
+        _home, target_jobs, skill_names = target_cache[target_profile]
+        blockers: list[str] = []
+        warnings: list[str] = []
+        script_plan = None
+        already_staged = False
+
+        existing = next((candidate for candidate in target_jobs if candidate.get("id") == job.get("id")), None)
+        if existing:
+            if is_same_staged_job(existing, job):
+                already_staged = True
+            else:
+                blockers.append("id_collision")
+        output_dir = target_home / "cron" / "output" / job_id
+        if output_dir.exists() and not already_staged:
+            blockers.append("output_history_collision")
+
+        if job.get("script"):
+            script_plan, error = script_copy_plan(source_home, target_home, str(job["script"]))
+            if error:
+                blockers.append(error)
+
+        skills = job_skills(job)
+        missing = [skill for skill in skills if skill not in skill_names]
+        if missing:
+            blockers.append("missing_target_skills")
+            warnings.append("missing skills: " + ", ".join(missing))
+
+        action = "blocked" if blockers else ("already_staged" if already_staged else "stage")
+        default_action = "leave_active_blocked" if blockers else ("leave_active_shadow" if shadow_required else "disable_after_verification")
+        moves.append(
+            MovePlan(
+                job_id=job_id,
+                name=assignment.name,
+                source_profile=SOURCE_PROFILE,
+                target_profile=target_profile,
+                action=action,
+                execution_type=execution_type,
+                shadow_required=shadow_required,
+                gateway_required=True,
+                default_action=default_action,
+                blockers=blockers,
+                warnings=warnings,
+                script_copy=script_plan,
+                skills=skills,
+                missing_skills=missing,
+                already_staged=already_staged,
+            )
+        )
+
+    gateway_profiles = sorted({move.target_profile for move in moves if move.gateway_required and not move.blockers})
+    summary = {
+        "total_active": len(moves),
+        "kept": sum(1 for move in moves if move.action == "keep"),
+        "to_stage": sum(1 for move in moves if move.action == "stage"),
+        "blocked": sum(1 for move in moves if move.action == "blocked"),
+        "already_staged": sum(1 for move in moves if move.action == "already_staged"),
+        "shadow_required": sum(1 for move in moves if move.shadow_required and move.action in {"stage", "already_staged"}),
+    }
+    return Manifest(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        source_profile=SOURCE_PROFILE,
+        source_home=str(source_home),
+        moves=moves,
+        gateway_profiles=gateway_profiles,
+        summary=summary,
+    )
+
+
+def _index_jobs(jobs: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    indexed: dict[str, dict[str, Any]] = {}
+    for job in jobs:
+        job_id = str(job.get("id") or "")
+        if job_id:
+            indexed[job_id] = job
+    return indexed
+
+
+def apply_stage(manifest: Manifest, *, default_home: Path) -> dict[str, Any]:
+    source_home = Path(manifest.source_home)
+    backups: dict[str, str | None] = {}
+    script_backups: dict[str, str] = {}
+    copied_scripts: list[str] = []
+    staged_jobs: list[str] = []
+    skipped: dict[str, str] = {}
+
+    with jobs_store_lock(source_home):
+        source_jobs, _source_metadata = load_jobs_for_home(source_home)
+    source_by_id = _index_jobs(source_jobs)
+
+    for move in manifest.moves:
+        if move.action != "stage":
+            continue
+        source_job = source_by_id.get(move.job_id)
+        if source_job is None:
+            skipped[move.job_id] = "source_job_missing"
+            continue
+        target_home = profile_home(default_home, move.target_profile)
+        target_home.joinpath("cron").mkdir(parents=True, exist_ok=True)
+        target_home.joinpath("scripts").mkdir(parents=True, exist_ok=True)
+        if move.script_copy:
+            source = Path(move.script_copy["source"])
+            target = Path(move.script_copy["target"])
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if not target.exists() or source.read_bytes() != target.read_bytes():
+                script_backup = backup_existing_file(target)
+                if script_backup is not None:
+                    script_backups[str(target)] = str(script_backup)
+                shutil.copy2(source, target)
+                copied_scripts.append(str(target))
+        with jobs_store_lock(target_home):
+            if move.target_profile not in backups:
+                backup = backup_jobs_file(target_home)
+                backups[move.target_profile] = str(backup) if backup else None
+            target_jobs, metadata = load_jobs_for_home(target_home)
+            if any(is_same_staged_job(job, source_job) for job in target_jobs):
+                continue
+            target_jobs.append(make_target_job(source_job, move.target_profile, shadow_required=move.shadow_required))
+            save_jobs_for_home(target_home, target_jobs, metadata, lock=False)
+        staged_jobs.append(move.job_id)
+
+    return {
+        "backups": backups,
+        "script_backups": script_backups,
+        "copied_scripts": copied_scripts,
+        "staged_jobs": staged_jobs,
+        "skipped": skipped,
+    }
+
+
+def apply_cutover(
+    manifest: Manifest,
+    *,
+    default_home: Path,
+    verified_job_ids: set[str],
+    accepted_agent_job_ids: set[str] | None = None,
+    remove_source: bool = False,
+) -> dict[str, Any]:
+    accepted_agent_job_ids = accepted_agent_job_ids or set()
+    source_home = Path(manifest.source_home)
+    changed_profiles: set[str] = set()
+    cutover: list[str] = []
+    skipped: dict[str, str] = {}
+    backups: dict[str, str | None] = {}
+    source_backup: Path | None = None
+
+    with jobs_store_lock(source_home):
+        source_jobs, source_metadata = load_jobs_for_home(source_home)
+        source_by_id = _index_jobs(source_jobs)
+
+        for move in manifest.moves:
+            if move.action not in {"stage", "already_staged"}:
+                continue
+            if move.job_id not in verified_job_ids:
+                skipped[move.job_id] = "not_verified"
+                continue
+            source_job = source_by_id.get(move.job_id)
+            if source_job is None:
+                skipped[move.job_id] = "source_job_missing"
+                continue
+            if move.shadow_required and move.job_id not in accepted_agent_job_ids:
+                skipped[move.job_id] = "agent_shadow_not_accepted"
+                continue
+            target_home = profile_home(default_home, move.target_profile)
+            with jobs_store_lock(target_home):
+                target_jobs, target_metadata = load_jobs_for_home(target_home)
+                if move.target_profile not in backups:
+                    backup = backup_jobs_file(target_home)
+                    backups[move.target_profile] = str(backup) if backup else None
+                updated = False
+                for target_job in target_jobs:
+                    if is_same_staged_job(target_job, source_job):
+                        now = datetime.now(timezone.utc).isoformat()
+                        target_job["enabled"] = True
+                        target_job["state"] = "scheduled"
+                        target_job["next_run_at"] = None
+                        target_job.pop("paused_reason", None)
+                        target_job.pop("paused_at", None)
+                        meta = dict(target_job.get(MIGRATION_KEY) or {})
+                        meta["cutover_at"] = now
+                        target_job[MIGRATION_KEY] = meta
+                        updated = True
+                        break
+                if not updated:
+                    skipped[move.job_id] = "target_job_not_staged"
+                    continue
+                if source_backup is None:
+                    source_backup = backup_jobs_file(source_home)
+                save_jobs_for_home(target_home, target_jobs, target_metadata, lock=False)
+            changed_profiles.add(move.target_profile)
+
+            if remove_source:
+                source_jobs = [job for job in source_jobs if str(job.get("id") or "") != move.job_id]
+            else:
+                source_job["enabled"] = False
+                source_job["state"] = "paused"
+                source_job["paused_reason"] = "profile_migration_cutover"
+                source_job["paused_at"] = datetime.now(timezone.utc).isoformat()
+            cutover.append(move.job_id)
+
+        if cutover:
+            backups[SOURCE_PROFILE] = str(source_backup) if source_backup else None
+            if remove_source:
+                save_jobs_for_home(source_home, source_jobs, source_metadata, lock=False)
+            else:
+                save_jobs_for_home(source_home, list(source_by_id.values()), source_metadata, lock=False)
+    return {
+        "cutover": cutover,
+        "skipped": skipped,
+        "changed_profiles": sorted(changed_profiles),
+        "backups": backups if cutover else {},
+    }
+
+
+def manifest_as_markdown(manifest: Manifest) -> str:
+    data = manifest.to_dict()
+    lines = ["# Cron Profile Rebalance Dry Run", ""]
+    lines.append("## Summary")
+    for key, value in data["summary"].items():
+        lines.append(f"- `{key}`: {value}")
+    lines.append("")
+    lines.append("## Gateway Profiles")
+    if data["gateway_profiles"]:
+        for profile in data["gateway_profiles"]:
+            lines.append(f"- `{profile}`: run `hermes -p {profile} gateway start`")
+    else:
+        lines.append("- none")
+    lines.append("")
+    lines.append("## Moves")
+    lines.append("")
+    lines.append("| Job | Target | Action | Default action | Blockers |")
+    lines.append("|---|---|---|---|---|")
+    for move in manifest.moves:
+        blockers = ", ".join(move.blockers) if move.blockers else ""
+        lines.append(f"| `{move.name}` | `{move.target_profile}` | {move.action} | {move.default_action} | {blockers} |")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-home", type=Path, default=default_source_home())
+    parser.add_argument("--default-home", type=Path)
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    parser.add_argument("--apply-stage", action="store_true")
+    parser.add_argument("--cutover-verified", nargs="*", default=[])
+    parser.add_argument("--accepted-agent", nargs="*", default=[])
+    parser.add_argument("--remove-source", action="store_true")
+    parser.add_argument("--target-profile", action="append", choices=MIGRATION_TARGET_PROFILES)
+    args = parser.parse_args(argv)
+
+    if args.apply_stage and args.cutover_verified:
+        parser.error("run --apply-stage and --cutover-verified as separate invocations after verification")
+    if args.accepted_agent and not args.cutover_verified:
+        parser.error("--accepted-agent requires --cutover-verified")
+
+    default_home = (args.default_home or args.source_home).resolve()
+    target_profiles = set(args.target_profile) if args.target_profile else None
+    manifest = build_manifest(args.source_home, default_home=default_home, target_profiles=target_profiles)
+    result: dict[str, Any] | None = None
+    if args.apply_stage:
+        result = apply_stage(manifest, default_home=default_home)
+    if args.cutover_verified:
+        result = apply_cutover(
+            manifest,
+            default_home=default_home,
+            verified_job_ids=set(args.cutover_verified),
+            accepted_agent_job_ids=set(args.accepted_agent),
+            remove_source=args.remove_source,
+        )
+
+    if args.format == "json":
+        payload = manifest.to_dict()
+        if result is not None:
+            payload["apply_result"] = result
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(manifest_as_markdown(manifest), end="")
+        if result is not None:
+            print("\n## Apply Result")
+            print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/cron_profile_rebalance.py
+++ b/scripts/cron_profile_rebalance.py
@@ -9,10 +9,12 @@ jobs; it reports the profile-scoped commands operators should run next.
 from __future__ import annotations
 
 import argparse
+import copy
 import contextlib
 import json
 import os
 import shutil
+import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -104,10 +106,34 @@ def jobs_file_for(home: Path) -> Path:
     return home / "cron" / "jobs.json"
 
 
+def _secure_dir(path: Path) -> None:
+    try:
+        os.chmod(path, 0o700)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def _secure_file(path: Path) -> None:
+    try:
+        if path.exists():
+            os.chmod(path, 0o600)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def ensure_cron_store(home: Path) -> None:
+    cron_dir = home / "cron"
+    output_dir = cron_dir / "output"
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _secure_dir(cron_dir)
+    _secure_dir(output_dir)
+
+
 @contextlib.contextmanager
 def jobs_store_lock(home: Path):
+    ensure_cron_store(home)
     cron_dir = home / "cron"
-    cron_dir.mkdir(parents=True, exist_ok=True)
     lock_file = cron_dir / ".jobs.lock"
     handle = lock_file.open("a+", encoding="utf-8")
     try:
@@ -139,13 +165,16 @@ def _now_stamp() -> str:
 
 def _atomic_write_json(path: Path, data: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    _secure_dir(path.parent)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    tmp = Path(tmp_name)
     try:
-        with tmp.open("w", encoding="utf-8") as handle:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(tmp, path)
+        _secure_file(path)
     finally:
         if tmp.exists():
             tmp.unlink()
@@ -443,7 +472,7 @@ def apply_stage(manifest: Manifest, *, default_home: Path) -> dict[str, Any]:
             skipped[move.job_id] = "source_job_missing"
             continue
         target_home = profile_home(default_home, move.target_profile)
-        target_home.joinpath("cron").mkdir(parents=True, exist_ok=True)
+        ensure_cron_store(target_home)
         target_home.joinpath("scripts").mkdir(parents=True, exist_ok=True)
         if move.script_copy:
             source = Path(move.script_copy["source"])
@@ -511,46 +540,58 @@ def apply_cutover(
             target_home = profile_home(default_home, move.target_profile)
             with jobs_store_lock(target_home):
                 target_jobs, target_metadata = load_jobs_for_home(target_home)
+                staged_target_job = next(
+                    (target_job for target_job in target_jobs if is_same_staged_job(target_job, source_job)),
+                    None,
+                )
+                if staged_target_job is None:
+                    skipped[move.job_id] = "target_job_not_staged"
+                    continue
                 if move.target_profile not in backups:
                     backup = backup_jobs_file(target_home)
                     backups[move.target_profile] = str(backup) if backup else None
-                updated = False
-                for target_job in target_jobs:
-                    if is_same_staged_job(target_job, source_job):
-                        now = datetime.now(timezone.utc).isoformat()
-                        target_job["enabled"] = True
-                        target_job["state"] = "scheduled"
-                        target_job["next_run_at"] = None
-                        target_job.pop("paused_reason", None)
-                        target_job.pop("paused_at", None)
-                        meta = dict(target_job.get(MIGRATION_KEY) or {})
-                        meta["cutover_at"] = now
-                        target_job[MIGRATION_KEY] = meta
-                        updated = True
-                        break
-                if not updated:
-                    skipped[move.job_id] = "target_job_not_staged"
-                    continue
                 if source_backup is None:
                     source_backup = backup_jobs_file(source_home)
-                save_jobs_for_home(target_home, target_jobs, target_metadata, lock=False)
-            changed_profiles.add(move.target_profile)
 
-            if remove_source:
-                source_jobs = [job for job in source_jobs if str(job.get("id") or "") != move.job_id]
-            else:
-                source_job["enabled"] = False
-                source_job["state"] = "paused"
-                source_job["paused_reason"] = "profile_migration_cutover"
-                source_job["paused_at"] = datetime.now(timezone.utc).isoformat()
+                source_snapshot = copy.deepcopy(source_jobs)
+                if remove_source:
+                    source_jobs = [job for job in source_jobs if str(job.get("id") or "") != move.job_id]
+                else:
+                    source_job["enabled"] = False
+                    source_job["state"] = "paused"
+                    source_job["paused_reason"] = "profile_migration_cutover"
+                    source_job["paused_at"] = datetime.now(timezone.utc).isoformat()
+
+                now = datetime.now(timezone.utc).isoformat()
+                staged_target_job["enabled"] = True
+                staged_target_job["state"] = "scheduled"
+                staged_target_job["next_run_at"] = None
+                staged_target_job.pop("paused_reason", None)
+                staged_target_job.pop("paused_at", None)
+                meta = dict(staged_target_job.get(MIGRATION_KEY) or {})
+                meta["cutover_at"] = now
+                staged_target_job[MIGRATION_KEY] = meta
+
+                try:
+                    save_jobs_for_home(source_home, source_jobs, source_metadata, lock=False)
+                    save_jobs_for_home(target_home, target_jobs, target_metadata, lock=False)
+                except Exception as exc:
+                    source_jobs = source_snapshot
+                    source_by_id = _index_jobs(source_jobs)
+                    try:
+                        save_jobs_for_home(source_home, source_jobs, source_metadata, lock=False)
+                    except Exception as rollback_exc:
+                        raise RuntimeError(
+                            f"failed to roll back source cutover after target write error: {rollback_exc}"
+                        ) from exc
+                    raise
+
+            changed_profiles.add(move.target_profile)
+            source_by_id = _index_jobs(source_jobs)
             cutover.append(move.job_id)
 
         if cutover:
             backups[SOURCE_PROFILE] = str(source_backup) if source_backup else None
-            if remove_source:
-                save_jobs_for_home(source_home, source_jobs, source_metadata, lock=False)
-            else:
-                save_jobs_for_home(source_home, list(source_by_id.values()), source_metadata, lock=False)
     return {
         "cutover": cutover,
         "skipped": skipped,

--- a/tests/cron/test_cron_profile_assignment_audit.py
+++ b/tests/cron/test_cron_profile_assignment_audit.py
@@ -1,0 +1,93 @@
+import json
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+spec = importlib.util.spec_from_file_location(
+    "cron_profile_assignment_audit", SCRIPTS_DIR / "cron_profile_assignment_audit.py"
+)
+assert spec and spec.loader
+audit = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = audit
+spec.loader.exec_module(audit)
+assignment_for_job = audit.assignment_for_job
+build_report = audit.build_report
+load_job_store = audit.load_job_store
+
+
+def write_jobs(path: Path, jobs, *, wrapped: bool = True):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"jobs": jobs, "updated_at": "2026-06-30T00:00:00Z"} if wrapped else jobs
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_report_counts_wrapped_active_jobs_and_paused_followup(tmp_path):
+    jobs_file = tmp_path / "cron" / "jobs.json"
+    write_jobs(
+        jobs_file,
+        [
+            {"id": "j1", "name": "crm-lead-check", "script": "lead.py", "no_agent": True},
+            {"id": "j2", "name": "gbrain-daily-check", "prompt": "check gbrain"},
+            {"id": "j3", "name": "stale-draft-alert", "enabled": False},
+        ],
+    )
+
+    jobs, metadata = load_job_store(jobs_file)
+    report = build_report(jobs)
+
+    assert metadata["shape"] == "wrapped"
+    assert report["summary"]["active_total"] == 2
+    assert report["summary"]["paused_total"] == 1
+    assert report["summary"]["target_counts"]["rva-leads"] == 1
+    assert report["summary"]["target_counts"]["default"] == 1
+    assert report["paused"][0]["target_profile"] == "rva-firm-ops"
+
+
+def test_legacy_list_form_jobs_are_supported(tmp_path):
+    jobs_file = tmp_path / "cron" / "jobs.json"
+    write_jobs(
+        jobs_file,
+        [
+            {"id": "tax", "name": "tax-research-archive-lint", "script": "tax.py", "no_agent": True},
+            {"id": "old", "name": "old-paused", "enabled": False},
+        ],
+        wrapped=False,
+    )
+
+    jobs, metadata = load_job_store(jobs_file)
+    report = build_report(jobs)
+
+    assert metadata["shape"] == "list"
+    assert report["summary"]["active_total"] == 1
+    assert report["active"][0]["target_profile"] == "cpa-tax-researcher"
+    assert report["summary"]["paused_total"] == 1
+
+
+def test_unknown_job_defaults_to_default_with_review_needed():
+    assignment = assignment_for_job({"id": "mystery", "name": "mystery-job"})
+
+    assert assignment.target_profile == "default"
+    assert assignment.review_needed is True
+    assert "unknown" in assignment.reason
+
+
+def test_rule_based_classification_covers_business_domains():
+    assert assignment_for_job({"id": "1", "name": "crm-new-thing"}).target_profile == "rva-leads"
+    assert assignment_for_job({"id": "2", "name": "square-metrics"}).target_profile == "rva-profit-pulse"
+    assert assignment_for_job({"id": "3", "name": "tax_research_extra"}).target_profile == "cpa-tax-researcher"
+    assert assignment_for_job({"id": "4", "name": "gmail-maintenance"}).target_profile == "rva-firm-ops"
+
+
+def test_audit_main_json_smoke(tmp_path, capsys):
+    jobs_file = tmp_path / "cron" / "jobs.json"
+    write_jobs(jobs_file, [{"id": "j1", "name": "crm-lead-check", "script": "lead.py", "no_agent": True}])
+
+    assert audit.main(["--jobs-file", str(jobs_file), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["summary"]["active_total"] == 1
+    assert payload["active"][0]["target_profile"] == "rva-leads"

--- a/tests/cron/test_cron_profile_rebalance.py
+++ b/tests/cron/test_cron_profile_rebalance.py
@@ -1,0 +1,252 @@
+import importlib.util
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+for module_name in ("cron_profile_assignment_audit", "cron_profile_rebalance"):
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPTS_DIR / f"{module_name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+rebalance = sys.modules["cron_profile_rebalance"]
+
+
+def write_jobs(home: Path, jobs):
+    jobs_file = home / "cron" / "jobs.json"
+    jobs_file.parent.mkdir(parents=True, exist_ok=True)
+    jobs_file.write_text(json.dumps({"jobs": jobs, "updated_at": "old"}), encoding="utf-8")
+
+
+def read_jobs(home: Path):
+    return json.loads((home / "cron" / "jobs.json").read_text(encoding="utf-8"))["jobs"]
+
+
+def make_script(home: Path, name: str, content: str = "print('ok')\n", mode: int | None = None) -> Path:
+    path = home / "scripts" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    if mode is not None:
+        path.chmod(mode)
+    return path
+
+
+def test_manifest_marks_script_copies_shadow_jobs_gateways_and_default_keeps(tmp_path):
+    default_home = tmp_path / ".hermes"
+    make_script(default_home, "lead_check.py")
+    write_jobs(
+        default_home,
+        [
+            {"id": "j1", "name": "crm-lead-check", "script": "lead_check.py", "no_agent": True},
+            {"id": "j2", "name": "crm-daily-scan", "prompt": "scan crm"},
+            {"id": "j3", "name": "backup-daily", "script": "backup.sh", "no_agent": True},
+        ],
+    )
+
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+    by_id = {move.job_id: move for move in manifest.moves}
+
+    assert by_id["j1"].action == "stage"
+    assert by_id["j1"].script_copy["relative"] == "lead_check.py"
+    assert by_id["j1"].default_action == "disable_after_verification"
+    assert by_id["j2"].shadow_required is True
+    assert by_id["j2"].default_action == "leave_active_shadow"
+    assert by_id["j3"].action == "keep"
+    assert manifest.gateway_profiles == ["rva-leads"]
+
+
+def test_manifest_blocks_missing_skills_unsafe_scripts_and_collisions(tmp_path):
+    default_home = tmp_path / ".hermes"
+    make_script(default_home, "lead_check.py")
+    write_jobs(
+        default_home,
+        [
+            {"id": "lead", "name": "crm-lead-check", "script": "lead_check.py", "no_agent": True},
+            {"id": "tax", "name": "tax-research-archive-lint", "script": "../escape.py", "no_agent": True, "skills": ["tax-skill"]},
+            {"id": "sms", "name": "ringcentral-sms-opt-out-watchdog", "script": "lead_check.py", "no_agent": True},
+        ],
+    )
+    target = default_home / "profiles" / "rva-leads"
+    write_jobs(target, [{"id": "lead", "name": "unrelated-existing"}])
+    (target / "cron" / "output" / "sms").mkdir(parents=True)
+
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+    by_id = {move.job_id: move for move in manifest.moves}
+
+    assert "id_collision" in by_id["lead"].blockers
+    assert "source_script_outside_profile_scripts" in by_id["tax"].blockers
+    assert "missing_target_skills" in by_id["tax"].blockers
+    assert "output_history_collision" in by_id["sms"].blockers
+
+
+def test_apply_stage_copies_scripts_preserves_mode_and_leaves_source_active(tmp_path):
+    default_home = tmp_path / ".hermes"
+    script = make_script(default_home, "lead_check.sh", "#!/usr/bin/env bash\necho ok\n", 0o755)
+    write_jobs(default_home, [{"id": "j1", "name": "crm-lead-check", "script": "lead_check.sh", "no_agent": True}])
+
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+    result = rebalance.apply_stage(manifest, default_home=default_home)
+    second_result = rebalance.apply_stage(manifest, default_home=default_home)
+
+    target_script = default_home / "profiles" / "rva-leads" / "scripts" / "lead_check.sh"
+    assert target_script.exists()
+    assert target_script.read_text(encoding="utf-8") == script.read_text(encoding="utf-8")
+    assert target_script.stat().st_mode & stat.S_IXUSR
+    assert result["staged_jobs"] == ["j1"]
+    assert second_result["staged_jobs"] == []
+    target_jobs = read_jobs(default_home / "profiles" / "rva-leads")
+    assert len(target_jobs) == 1
+    assert target_jobs[0]["enabled"] is False
+    assert target_jobs[0]["paused_at"]
+    assert target_jobs[0]["next_run_at"] is None
+    assert target_jobs[0]["profile_migration"]["source_job_id"] == "j1"
+    assert read_jobs(default_home)[0]["enabled"] is True
+
+
+def test_apply_stage_skips_source_job_removed_after_manifest(tmp_path):
+    default_home = tmp_path / ".hermes"
+    make_script(default_home, "lead_check.py")
+    write_jobs(default_home, [{"id": "j1", "name": "crm-lead-check", "script": "lead_check.py", "no_agent": True}])
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+    write_jobs(default_home, [])
+
+    result = rebalance.apply_stage(manifest, default_home=default_home)
+
+    assert result["staged_jobs"] == []
+    assert result["skipped"] == {"j1": "source_job_missing"}
+
+
+def test_cutover_enables_verified_script_job_and_removes_source_when_requested(tmp_path):
+    default_home = tmp_path / ".hermes"
+    make_script(default_home, "lead_check.py")
+    write_jobs(default_home, [{"id": "j1", "name": "crm-lead-check", "script": "lead_check.py", "no_agent": True}])
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+    rebalance.apply_stage(manifest, default_home=default_home)
+
+    result = rebalance.apply_cutover(
+        manifest,
+        default_home=default_home,
+        verified_job_ids={"j1"},
+        remove_source=True,
+    )
+
+    assert result["cutover"] == ["j1"]
+    assert result["backups"]["default"] is not None
+    assert result["backups"]["rva-leads"] is not None
+    assert read_jobs(default_home) == []
+    target_job = read_jobs(default_home / "profiles" / "rva-leads")[0]
+    assert target_job["enabled"] is True
+    assert target_job["state"] == "scheduled"
+    assert target_job["next_run_at"] is None
+    assert "paused_at" not in target_job
+    assert "cutover_at" in target_job["profile_migration"]
+
+
+def test_cutover_keeps_agent_shadow_until_accepted(tmp_path):
+    default_home = tmp_path / ".hermes"
+    write_jobs(default_home, [{"id": "agent", "name": "crm-daily-scan", "prompt": "scan crm"}])
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+    rebalance.apply_stage(manifest, default_home=default_home)
+
+    blocked = rebalance.apply_cutover(manifest, default_home=default_home, verified_job_ids={"agent"})
+    assert blocked["cutover"] == []
+    assert blocked["skipped"] == {"agent": "agent_shadow_not_accepted"}
+    assert read_jobs(default_home)[0]["enabled"] is True
+
+    accepted = rebalance.apply_cutover(
+        manifest,
+        default_home=default_home,
+        verified_job_ids={"agent"},
+        accepted_agent_job_ids={"agent"},
+    )
+    assert accepted["cutover"] == ["agent"]
+    assert accepted["backups"]["default"] is not None
+    assert read_jobs(default_home)[0]["enabled"] is False
+    assert read_jobs(default_home)[0]["paused_at"]
+    assert read_jobs(default_home / "profiles" / "rva-leads")[0]["enabled"] is True
+
+
+def test_stage_creates_only_receiving_profile_dirs(tmp_path):
+    default_home = tmp_path / ".hermes"
+    make_script(default_home, "lead.py")
+    make_script(default_home, "content.py")
+    write_jobs(
+        default_home,
+        [
+            {"id": "lead", "name": "crm-lead-check", "script": "lead.py", "no_agent": True},
+            {"id": "content", "name": "content-topic-miner", "script": "content.py", "no_agent": True},
+            {"id": "default", "name": "backup-daily", "script": "backup.sh", "no_agent": True},
+        ],
+    )
+
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+    rebalance.apply_stage(manifest, default_home=default_home)
+
+    assert (default_home / "profiles" / "rva-leads" / "cron").exists()
+    assert (default_home / "profiles" / "rva-profit-pulse" / "cron").exists()
+    assert not (default_home / "profiles" / "cpa-tax-researcher").exists()
+    assert not (default_home / "profiles" / "rva-firm-ops").exists()
+    assert not (default_home / "profiles" / "personal").exists()
+    assert not (default_home / "profiles" / "rva-dev").exists()
+
+
+def test_manifest_blocks_jobs_without_ids(tmp_path):
+    default_home = tmp_path / ".hermes"
+    write_jobs(default_home, [{"name": "crm-lead-check", "no_agent": True}])
+
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+
+    assert manifest.moves[0].action == "blocked"
+    assert manifest.moves[0].blockers == ["missing_job_id"]
+
+
+def test_target_profile_filter_limits_manifest_and_stage(tmp_path):
+    default_home = tmp_path / ".hermes"
+    make_script(default_home, "lead.py")
+    make_script(default_home, "content.py")
+    write_jobs(
+        default_home,
+        [
+            {"id": "lead", "name": "crm-lead-check", "script": "lead.py", "no_agent": True},
+            {"id": "content", "name": "content-topic-miner", "script": "content.py", "no_agent": True},
+        ],
+    )
+
+    manifest = rebalance.build_manifest(default_home, default_home=default_home, target_profiles={"rva-leads"})
+    result = rebalance.apply_stage(manifest, default_home=default_home)
+
+    assert [move.target_profile for move in manifest.moves] == ["rva-leads"]
+    assert result["staged_jobs"] == ["lead"]
+    assert (default_home / "profiles" / "rva-leads" / "cron").exists()
+    assert not (default_home / "profiles" / "rva-profit-pulse").exists()
+
+
+def test_rebalance_main_json_smoke_and_rejects_stage_cutover_combo(tmp_path, capsys):
+    default_home = tmp_path / ".hermes"
+    make_script(default_home, "lead.py")
+    write_jobs(default_home, [{"id": "lead", "name": "crm-lead-check", "script": "lead.py", "no_agent": True}])
+
+    assert rebalance.main(["--source-home", str(default_home), "--default-home", str(default_home), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["source_home"] == "<profile:default>"
+    assert payload["moves"][0]["script_copy"]["source"] == "<default:scripts/lead.py>"
+
+    with pytest.raises(SystemExit):
+        rebalance.main([
+            "--source-home",
+            str(default_home),
+            "--default-home",
+            str(default_home),
+            "--apply-stage",
+            "--cutover-verified",
+            "lead",
+        ])

--- a/tests/cron/test_cron_profile_rebalance.py
+++ b/tests/cron/test_cron_profile_rebalance.py
@@ -40,6 +40,10 @@ def make_script(home: Path, name: str, content: str = "print('ok')\n", mode: int
     return path
 
 
+def mode_bits(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
 def test_manifest_marks_script_copies_shadow_jobs_gateways_and_default_keeps(tmp_path):
     default_home = tmp_path / ".hermes"
     make_script(default_home, "lead_check.py")
@@ -91,7 +95,10 @@ def test_manifest_blocks_missing_skills_unsafe_scripts_and_collisions(tmp_path):
 def test_apply_stage_copies_scripts_preserves_mode_and_leaves_source_active(tmp_path):
     default_home = tmp_path / ".hermes"
     script = make_script(default_home, "lead_check.sh", "#!/usr/bin/env bash\necho ok\n", 0o755)
-    write_jobs(default_home, [{"id": "j1", "name": "crm-lead-check", "script": "lead_check.sh", "no_agent": True}])
+    write_jobs(
+        default_home,
+        [{"id": "j1", "name": "crm-lead-check", "script": "lead_check.sh", "no_agent": True, "enabled": True}],
+    )
 
     manifest = rebalance.build_manifest(default_home, default_home=default_home)
     result = rebalance.apply_stage(manifest, default_home=default_home)
@@ -110,6 +117,37 @@ def test_apply_stage_copies_scripts_preserves_mode_and_leaves_source_active(tmp_
     assert target_jobs[0]["next_run_at"] is None
     assert target_jobs[0]["profile_migration"]["source_job_id"] == "j1"
     assert read_jobs(default_home)[0]["enabled"] is True
+
+
+def test_apply_stage_secures_new_target_cron_store(tmp_path):
+    default_home = tmp_path / ".hermes"
+    make_script(default_home, "lead_check.py")
+    write_jobs(default_home, [{"id": "j1", "name": "crm-lead-check", "script": "lead_check.py", "no_agent": True}])
+
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+    rebalance.apply_stage(manifest, default_home=default_home)
+
+    target_home = default_home / "profiles" / "rva-leads"
+    assert mode_bits(target_home / "cron") == 0o700
+    assert mode_bits(target_home / "cron" / "output") == 0o700
+    assert mode_bits(target_home / "cron" / "jobs.json") == 0o600
+
+
+def test_atomic_write_creates_temp_file_owner_only(tmp_path, monkeypatch):
+    jobs_file = tmp_path / "cron" / "jobs.json"
+    original_replace = rebalance.os.replace
+    observed: dict[str, int] = {}
+
+    def inspect_temp_mode(source, target):
+        observed["temp_mode"] = mode_bits(Path(source))
+        original_replace(source, target)
+
+    monkeypatch.setattr(rebalance.os, "replace", inspect_temp_mode)
+
+    rebalance._atomic_write_json(jobs_file, {"jobs": []})
+
+    assert observed == {"temp_mode": 0o600}
+    assert mode_bits(jobs_file) == 0o600
 
 
 def test_apply_stage_skips_source_job_removed_after_manifest(tmp_path):
@@ -151,9 +189,85 @@ def test_cutover_enables_verified_script_job_and_removes_source_when_requested(t
     assert "cutover_at" in target_job["profile_migration"]
 
 
+@pytest.mark.parametrize("remove_source", [False, True])
+def test_cutover_makes_source_non_runnable_before_enabling_target(tmp_path, monkeypatch, remove_source):
+    default_home = tmp_path / ".hermes"
+    make_script(default_home, "lead_check.py")
+    write_jobs(
+        default_home,
+        [{"id": "j1", "name": "crm-lead-check", "script": "lead_check.py", "no_agent": True, "enabled": True}],
+    )
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+    rebalance.apply_stage(manifest, default_home=default_home)
+
+    target_home = (default_home / "profiles" / "rva-leads").resolve()
+    original_save = rebalance.save_jobs_for_home
+    observed: dict[str, bool] = {}
+
+    def observing_save(home: Path, jobs, metadata=None, *, lock=True):
+        resolved_home = home.resolve()
+        if resolved_home == target_home:
+            source_jobs = read_jobs(default_home)
+            observed["source_runnable_before_target_save"] = any(
+                job.get("enabled", True) for job in source_jobs if job.get("id") == "j1"
+            )
+            observed["target_runnable_before_target_save"] = read_jobs(target_home)[0]["enabled"]
+        return original_save(home, jobs, metadata, lock=lock)
+
+    monkeypatch.setattr(rebalance, "save_jobs_for_home", observing_save)
+
+    result = rebalance.apply_cutover(
+        manifest,
+        default_home=default_home,
+        verified_job_ids={"j1"},
+        remove_source=remove_source,
+    )
+
+    assert result["cutover"] == ["j1"]
+    assert observed == {
+        "source_runnable_before_target_save": False,
+        "target_runnable_before_target_save": False,
+    }
+
+
+def test_cutover_rolls_source_back_if_target_save_fails(tmp_path, monkeypatch):
+    default_home = tmp_path / ".hermes"
+    make_script(default_home, "lead_check.py")
+    write_jobs(
+        default_home,
+        [{"id": "j1", "name": "crm-lead-check", "script": "lead_check.py", "no_agent": True, "enabled": True}],
+    )
+    manifest = rebalance.build_manifest(default_home, default_home=default_home)
+    rebalance.apply_stage(manifest, default_home=default_home)
+
+    target_home = (default_home / "profiles" / "rva-leads").resolve()
+    original_save = rebalance.save_jobs_for_home
+
+    def failing_save(home: Path, jobs, metadata=None, *, lock=True):
+        if home.resolve() == target_home:
+            raise OSError("target write failed")
+        return original_save(home, jobs, metadata, lock=lock)
+
+    monkeypatch.setattr(rebalance, "save_jobs_for_home", failing_save)
+
+    with pytest.raises(OSError, match="target write failed"):
+        rebalance.apply_cutover(
+            manifest,
+            default_home=default_home,
+            verified_job_ids={"j1"},
+            remove_source=True,
+        )
+
+    assert read_jobs(default_home)[0]["enabled"] is True
+    assert read_jobs(target_home)[0]["enabled"] is False
+
+
 def test_cutover_keeps_agent_shadow_until_accepted(tmp_path):
     default_home = tmp_path / ".hermes"
-    write_jobs(default_home, [{"id": "agent", "name": "crm-daily-scan", "prompt": "scan crm"}])
+    write_jobs(
+        default_home,
+        [{"id": "agent", "name": "crm-daily-scan", "prompt": "scan crm", "enabled": True}],
+    )
     manifest = rebalance.build_manifest(default_home, default_home=default_home)
     rebalance.apply_stage(manifest, default_home=default_home)
 


### PR DESCRIPTION
## Summary

Cron jobs can now be safely redistributed from the `default` profile into domain profiles (`rva-leads`, `rva-profit-pulse`, `rva-firm-ops`, `cpa-tax-researcher`) without risking duplicate execution, data loss, or verification-gate bypass. Two standalone operator scripts and a runbook cover the full audit to dry-run to stage to verify to cutover lifecycle, keeping all writes profile-local with backups and cross-process locking.

## What changed

- **Read-only audit** (`scripts/cron_profile_assignment_audit.py`): classifies every active/paused cron job into a target profile, reports counts, and flags unknown jobs for review. Supports both wrapped `{"jobs": [...]}` and legacy list-form stores.
- **Rebalance planner** (`scripts/cron_profile_rebalance.py`): dry-run manifest, stage scripts and disabled target job copies, cutover after per-profile verification. Blocks on ID collisions, output-history collisions, missing source scripts, unsafe script paths, and missing target skills. Keeps agent-driven jobs in shadow until explicitly accepted via `--accepted-agent`.
- **Tests**: inventory classification, collision/blocker detection, staging idempotency, cutover with source removal vs pause, shadow-acceptance gate, missing-ID blocking, per-profile filtering, CLI smoke tests, and backup assertions.
- **Runbook** (`docs/operations/cron-profile-assignment.md`): ownership summary, tool commands, gateway requirements, migration checklist, and rollback steps.

## Safety guarantees

- Default mode is dry-run; apply modes create backups before any write
- `--apply-stage` and `--cutover-verified` cannot be combined in one invocation
- Cross-process fcntl/msvcrt locking on every jobs.json read-modify-write
- fsync before atomic os.replace
- Manifest JSON uses symbolic profile paths (no absolute filesystem paths)
- Source jobs disabled (not deleted) by default; --remove-source is opt-in

## Testing

- `scripts/run_tests.sh tests/cron/test_cron_profile_isolation.py tests/hermes_cli/test_web_server_cron_profiles.py tests/cron/test_cron_profile_assignment_audit.py tests/cron/test_cron_profile_rebalance.py` — all pass
- `python3 -m py_compile` on both scripts — pass
- Live audit against default profile: 59 active, 1 paused, target counts match plan (default=29, rva-leads=13, rva-profit-pulse=10, rva-firm-ops=5, cpa-tax-researcher=2)
- Live dry-run manifest: 30 to stage, 0 blocked, 8 shadow-required agent jobs
- --target-profile rva-leads filter correctly scopes to 13 jobs

## Post-Deploy Monitoring and Validation

No runtime impact — these are standalone operator scripts not imported by the cron ticker or gateway. After staging a migration batch, operators should monitor:
- **Log queries**: `hermes -p <profile> cron list` and `hermes -p <profile> cron status` on target profiles
- **Healthy signals**: staged jobs appear as `enabled: false` with `paused_reason: profile_migration_staged` in target stores
- **Failure signals**: `source_job_missing` in apply results, `id_collision` or `output_history_collision` blockers in manifest
- **Rollback**: restore from `cron/backups/jobs-*.json` in the affected profile home
- **Validation window**: per-batch, 1-2 ticks after gateway start before cutover

## Known Residuals

None — all review findings were addressed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/gpt-5.5-black)
