### PR TITLE
fix(mcp): guard non-dict image source in attachment extraction

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -173,7 +173,16 @@ def _extract_attachments(msg: dict) -> List[dict]:
                 if url:
                     attachments.append({"type": "image", "url": url})
             elif ptype == "image":
-                url = part.get("url", part.get("source", {}).get("url", ""))
+                # ``source`` may be a dict (Anthropic-style block) or a bare
+                # string (e.g. a data: URI). Guard the ``.get`` so a non-dict
+                # source doesn't raise AttributeError — mirrors the
+                # ``image_url`` branch above. Note the previous default-arg
+                # form evaluated ``part.get("source", {}).get(...)``
+                # unconditionally, so a string source crashed even when a
+                # top-level ``url`` was present.
+                source = part.get("source")
+                source_url = source.get("url", "") if isinstance(source, dict) else ""
+                url = part.get("url") or source_url
                 if url:
                     attachments.append({"type": "image", "url": url})
             elif ptype not in {"text",}:

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -357,6 +357,36 @@ class TestAttachmentExtraction:
         att = _extract_attachments(msg)
         assert att[0]["type"] == "image"
 
+    def test_image_block_dict_source_url(self):
+        from mcp_serve import _extract_attachments
+        msg = {"content": [
+            {"type": "image", "source": {"url": "http://x.com/s.png"}},
+        ]}
+        att = _extract_attachments(msg)
+        assert att == [{"type": "image", "url": "http://x.com/s.png"}]
+
+    def test_image_block_string_source_does_not_crash(self):
+        """A non-dict ``source`` (e.g. a bare data: URI) must not raise.
+
+        Regression: ``source`` was read as ``part.get("source", {}).get("url")``,
+        an always-evaluated default arg that raised AttributeError when
+        ``source`` was a string instead of a dict.
+        """
+        from mcp_serve import _extract_attachments
+        msg = {"content": [
+            {"type": "image", "source": "data:image/png;base64,iVBORw0KGgo="},
+        ]}
+        att = _extract_attachments(msg)
+        assert att == []  # no usable url, but no crash
+
+    def test_image_block_url_wins_over_string_source(self):
+        from mcp_serve import _extract_attachments
+        msg = {"content": [
+            {"type": "image", "url": "http://x.com/top.png", "source": "data:xxx"},
+        ]}
+        att = _extract_attachments(msg)
+        assert att == [{"type": "image", "url": "http://x.com/top.png"}]
+
 
 # ---------------------------------------------------------------------------
 # 2. EVENT BRIDGE TESTS — queue, cursors, waiters, concurrency


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError` crash in `_extract_attachments` (used by the
`attachments_fetch` MCP tool) when an image content block has a **non-dict
`source`**.

The image branch read the URL as:

```python
url = part.get("url", part.get("source", {}).get("url", ""))
```

In Python the default argument is **always evaluated**, so
`part.get("source", {}).get("url", "")` runs unconditionally. When `source` is
a bare string (e.g. a `data:` URI) instead of an Anthropic-style dict, `.get`
raises `AttributeError: 'str' object has no attribute 'get'` — and it crashes
even when a usable top-level `url` is present. `attachments_fetch` calls the
helper without a guard, so one such stored message makes the MCP tool raise
instead of returning JSON.

The fix mirrors the `isinstance(..., dict)` guard already used by the
`image_url` branch immediately above: only index `source` when it is a dict,
and prefer a top-level `url` when present.

## Related Issue

No existing issue — found via a code audit of `mcp_serve._extract_attachments`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `mcp_serve.py` — guard non-dict `source` in the `image` block branch of
  `_extract_attachments`; prefer top-level `url`.
- `tests/test_mcp_serve.py` — add regression tests for dict-source,
  string-source (no crash), and url-wins-over-string-source.

## How to Test

1. `scripts/run_tests.sh tests/test_mcp_serve.py -q` → all pass.
2. Regression proof (pre-fix):
   ```python
   part = {"type": "image", "source": "data:image/png;base64,xx"}
   part.get("url", part.get("source", {}).get("url", ""))
   # AttributeError: 'str' object has no attribute 'get'
   ```
   With the fix, a string `source` yields no URL (and no crash); a top-level
   `url` is used when present.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(mcp):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] Affected test module passes — `tests/test_mcp_serve.py` (88 passed). The full 17k-test suite wasn't run locally.
- [x] I've added regression tests
- [x] I've tested on my platform: Ubuntu (WSL2)

### Documentation & Housekeeping

- [x] Behavior-only fix — N/A for docs
- [x] No config keys changed — N/A
- [x] No architecture/workflow change — N/A
- [x] No tool schema/description change — N/A
