### PR TITLE
fix: authorize allowlisted WhatsApp group chats

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -195,6 +195,76 @@ class GatewayAuthorizationMixin:
             return any(str(item).strip() for item in sender_allow)
         return False
 
+    def _whatsapp_group_chat_authorized(self, source: SessionSource) -> bool:
+        """Authorize WhatsApp senders by an allowlisted group chat.
+
+        WhatsApp ``WHATSAPP_ALLOWED_USERS`` is the DM/user allowlist, while
+        ``group_policy`` / ``group_allow_from`` are chat-scoped. A participant
+        in an explicitly allowlisted group should not also need DM access.
+        """
+        if (
+            source.platform != Platform.WHATSAPP
+            or source.chat_type not in {"group", "forum"}
+            or not source.chat_id
+        ):
+            return False
+        if not self._adapter_enforces_own_access_policy(source.platform):
+            return False
+
+        adapters = getattr(self, "adapters", None) or {}
+        adapter = adapters.get(source.platform)
+
+        policy = getattr(adapter, "_group_policy", None) if adapter is not None else None
+        allowed = getattr(adapter, "_group_allow_from", None) if adapter is not None else None
+
+        config = getattr(self, "config", None)
+        platform_cfg = (
+            config.platforms.get(source.platform)
+            if config is not None and hasattr(config, "platforms")
+            else None
+        )
+        extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+        if isinstance(extra, dict):
+            if policy is None:
+                policy = extra.get("group_policy")
+            if allowed is None:
+                allowed = extra.get("group_allow_from")
+
+        if policy is None:
+            policy = os.getenv("WHATSAPP_GROUP_POLICY", "")
+        if allowed is None:
+            allowed = os.getenv("WHATSAPP_GROUP_ALLOWED_USERS", "")
+
+        if str(policy or "").strip().lower() != "allowlist":
+            return False
+
+        is_group_allowed = getattr(adapter, "_is_group_allowed", None)
+        if callable(is_group_allowed):
+            try:
+                return bool(is_group_allowed(source.chat_id))
+            except Exception:
+                pass
+
+        if isinstance(allowed, (set, list, tuple)):
+            allowed_ids = {str(value).strip() for value in allowed if str(value).strip()}
+        else:
+            allowed_ids = {
+                part.strip()
+                for part in str(allowed or "").split(",")
+                if part.strip()
+            }
+
+        if "*" in allowed_ids:
+            return True
+        chat_id = str(source.chat_id).strip()
+        if chat_id in allowed_ids:
+            return True
+        if chat_id.endswith("@g.us") and chat_id[:-5] in allowed_ids:
+            return True
+        if not chat_id.endswith("@g.us") and f"{chat_id}@g.us" in allowed_ids:
+            return True
+        return False
+
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.
@@ -274,6 +344,9 @@ class GatewayAuthorizationMixin:
                     }
                     if "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
                         return True
+
+        if self._whatsapp_group_chat_authorized(source):
+            return True
 
         if not user_id:
             return False

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -52,6 +52,8 @@ def _clear_auth_env(monkeypatch) -> None:
         "QQ_ALLOWED_USERS",
         "QQ_GROUP_ALLOWED_USERS",
         "WHATSAPP_ALLOWED_USERS",
+        "WHATSAPP_GROUP_ALLOWED_USERS",
+        "WHATSAPP_GROUP_POLICY",
         "TELEGRAM_ALLOWED_USERS",
         "GATEWAY_ALLOWED_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
@@ -285,6 +287,57 @@ def test_env_allowlist_still_takes_precedence_for_own_policy_platform(monkeypatc
     )
     assert runner._is_user_authorized(listed) is True
     assert runner._is_user_authorized(stranger) is False
+
+
+def test_whatsapp_group_allowlist_authorizes_group_sender_even_with_dm_allowlist(monkeypatch):
+    """WhatsApp group allowlist is chat-scoped and must not grant DM access."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "owner-user")
+
+    family_chat = "120363001234567890@g.us"
+    config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(
+                enabled=True,
+                extra={
+                    "dm_policy": "allowlist",
+                    "allow_from": ["owner-user"],
+                    "group_policy": "allowlist",
+                    "group_allow_from": [family_chat],
+                },
+            )
+        }
+    )
+    runner, adapter = _make_runner(Platform.WHATSAPP, config, enforces=True)
+    adapter._group_policy = "allowlist"
+    adapter._group_allow_from = {family_chat}
+    adapter._is_group_allowed = lambda chat_id: chat_id == family_chat
+
+    group_sender = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="other-member@lid",
+        chat_id=family_chat,
+        user_name="member",
+        chat_type="group",
+    )
+    other_group_sender = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="other-member@lid",
+        chat_id="120363999999999999@g.us",
+        user_name="member",
+        chat_type="group",
+    )
+    dm_sender = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="other-member@lid",
+        chat_id="other-member@lid",
+        user_name="member",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(group_sender) is True
+    assert runner._is_user_authorized(other_group_sender) is False
+    assert runner._is_user_authorized(dm_sender) is False
 
 
 def test_unknown_adapter_does_not_crash_trust_check(monkeypatch):


### PR DESCRIPTION
## Summary
- authorize WhatsApp group messages by chat-scoped `group_policy: allowlist` / `group_allow_from`
- keep DM allowlists scoped to DMs so `WHATSAPP_ALLOWED_USERS` no longer blocks members of an explicitly allowed group
- add regression coverage for group allowlists alongside DM allowlists

## Tests
- `scripts/run_tests.sh tests/gateway/test_config_driven_access_policy.py tests/gateway/test_relay_upstream_authz.py tests/gateway/test_whatsapp_group_gating.py -v --tb=short`
- `git diff --check HEAD~1..HEAD`
