### PR TITLE
fix: dedupe headerless webhook retries by body hash

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -340,6 +340,36 @@ class WebhookAdapter(BasePlatformAdapter):
             self._prune_seen_deliveries(now)
         return True
 
+    def _delivery_id_from_request(
+        self,
+        request: Any,
+        raw_body: bytes,
+        route_name: str,
+    ) -> str:
+        """Return a stable idempotency key for this webhook delivery.
+
+        Providers with retry IDs get precedence.  Local fan-out helpers such
+        as ``gog gmail watch serve`` do not send those headers; previously we
+        fell back to the current millisecond timestamp, which made every retry
+        look unique and could dispatch repeated identical agent runs.  For
+        headerless webhooks, hash the exact raw body (namespaced by route) so
+        duplicate retries inside the TTL collapse without suppressing distinct
+        events.
+        """
+        for header_name in (
+            "X-GitHub-Delivery",
+            "svix-id",
+            "X-Request-ID",
+        ):
+            value = (request.headers.get(header_name) or "").strip()
+            if value:
+                return value
+
+        digest = hashlib.sha256(
+            route_name.encode("utf-8") + b"\0" + raw_body
+        ).hexdigest()[:32]
+        return f"body-sha256:{digest}"
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
 
@@ -584,13 +614,12 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
+        # Build a stable delivery ID.  Headerless local fan-outs use a body
+        # hash so retries of the exact same Gmail event do not drain quota.
+        delivery_id = self._delivery_id_from_request(
+            request,
+            raw_body,
+            route_name,
         )
 
         # ── Idempotency ─────────────────────────────────────────

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -630,6 +630,55 @@ class TestIdempotency:
             assert data["status"] == "duplicate"
             assert data["delivery_id"] == "msg_duplicate"
 
+    @pytest.mark.asyncio
+    async def test_headerless_identical_body_is_deduped_by_body_hash(self):
+        """Headerless local fan-out retries should not dispatch duplicate agents."""
+        routes = {"gmail-gonto": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        payload = {
+            "emailAddress": "m@gon.to",
+            "historyId": "48260355",
+            "messages": [{"id": "m1", "threadId": "t1", "labelIds": ["INBOX"]}],
+        }
+        async with TestClient(TestServer(app)) as cli:
+            resp1 = await cli.post("/webhooks/gmail-gonto", json=payload)
+            assert resp1.status == 202
+            data1 = await resp1.json()
+            assert data1["delivery_id"].startswith("body-sha256:")
+
+            resp2 = await cli.post("/webhooks/gmail-gonto", json=payload)
+            assert resp2.status == 200
+            data2 = await resp2.json()
+            assert data2["status"] == "duplicate"
+            assert data2["delivery_id"] == data1["delivery_id"]
+            assert adapter.handle_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_headerless_same_body_on_different_routes_has_distinct_delivery_id(self):
+        """Route names namespace body-hash fallback IDs."""
+        routes = {
+            "one": {"secret": _INSECURE_NO_AUTH, "prompt": "test"},
+            "two": {"secret": _INSECURE_NO_AUTH, "prompt": "test"},
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp1 = await cli.post("/webhooks/one", json={"a": 1})
+            assert resp1.status == 202
+            data1 = await resp1.json()
+
+            resp2 = await cli.post("/webhooks/two", json={"a": 1})
+            assert resp2.status == 202
+            data2 = await resp2.json()
+
+            assert data1["delivery_id"] != data2["delivery_id"]
+            assert adapter.handle_message.await_count == 2
+
 
 # ===================================================================
 # Rate limiting


### PR DESCRIPTION
## Summary
- derive a deterministic `body-sha256:<digest>` delivery id for webhook requests that lack provider delivery headers
- namespace the hash by route so identical payloads on different routes are distinct
- add idempotency regression coverage for headerless retries

## Tests
- `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py -v --tb=short`
- `git diff --check HEAD~1..HEAD`
