### PR TITLE
fix: recognize cron legacy silence tokens

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -250,17 +250,35 @@ SILENT_MARKER = "[SILENT]"
 # a marker is the entire response OR appears as its own first/last line — but
 # NOT when a token merely appears mid-sentence in a genuine report (e.g.
 # "I considered staying [SILENT] but here is the summary…" must deliver).
-_CRON_SILENCE_TOKENS = frozenset({"[SILENT]", "SILENT", "NO_REPLY", "NO REPLY"})
+_CRON_SILENCE_TOKENS = frozenset({
+    "[SILENT]",
+    "SILENT",
+    "NO_REPLY",
+    "NO REPLY",
+    "NO_CHANGES",
+    "NO CHANGES",
+    "FIRST_RUN",
+    "FIRST RUN",
+    "HEARTBEAT_OK",
+    "HEARTBEAT OK",
+})
+
+
+def _canonical_cron_silence_candidate(text: str) -> str:
+    candidate = " ".join(text.strip().upper().split())
+    if candidate.startswith(">>>") and candidate.endswith("<<<"):
+        candidate = candidate[3:-3].strip()
+    return candidate
 
 
 def _is_cron_silence_response(text: str) -> bool:
     """Return True when a cron final response should suppress delivery.
 
     Recognizes the bracketed ``[SILENT]`` sentinel (whole-response, first line,
-    or last line) plus the bracketless ``SILENT`` / ``NO_REPLY`` / ``NO REPLY``
-    variants the model emits when it drops the brackets (#51438, #46917).
-    Whitespace-trimmed and case-insensitive.  A token buried mid-sentence is
-    treated as real content and delivered.
+    or last line) plus the bracketless/legacy no-op tokens cron agents may emit
+    when they have nothing to report (#51438, #46917). Whitespace-trimmed and
+    case-insensitive.  A token buried mid-sentence is treated as real content
+    and delivered.
     """
     if not isinstance(text, str):
         return False
@@ -269,7 +287,7 @@ def _is_cron_silence_response(text: str) -> bool:
         return False
 
     def _is_token(line: str) -> bool:
-        return " ".join(line.strip().upper().split()) in _CRON_SILENCE_TOKENS
+        return _canonical_cron_silence_candidate(line) in _CRON_SILENCE_TOKENS
 
     # Whole response is exactly a token.
     if _is_token(stripped):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -67,15 +67,40 @@ def test_run_one_job_success_sequence(monkeypatch):
 
 
 def test_run_one_job_silent_skips_delivery(monkeypatch):
-    """A [SILENT] final response saves output + marks the run but does NOT
-    deliver."""
-    calls = _patch_pipeline(monkeypatch, silent_marker_in="[SILENT]")
+    """Exact cron silence tokens save output + mark the run but do NOT deliver."""
+    for idx, token in enumerate(
+        (
+            "[SILENT]",
+            "SILENT",
+            "NO_REPLY",
+            "NO REPLY",
+            ">>>NO_REPLY<<<",
+            "NO_CHANGES",
+            "NO CHANGES",
+            ">>>NO_CHANGES<<<",
+            "FIRST_RUN",
+            "FIRST RUN",
+            "HEARTBEAT_OK",
+            "HEARTBEAT OK",
+        )
+    ):
+        calls = _patch_pipeline(monkeypatch, silent_marker_in=token)
 
-    s.run_one_job({"id": "j3", "name": "t"})
+        s.run_one_job({"id": f"j3-{idx}", "name": "t"})
+
+        kinds = [c[0] for c in calls]
+        assert "run_job" in kinds and "save" in kinds and "mark" in kinds
+        assert "deliver" not in kinds, token
+
+
+def test_run_one_job_prose_mentioning_legacy_token_still_delivers(monkeypatch):
+    """Legacy no-op tokens suppress only as whole/line-response markers."""
+    calls = _patch_pipeline(monkeypatch, final="Use NO_CHANGES when idle.")
+
+    s.run_one_job({"id": "j3-prose", "name": "t"})
 
     kinds = [c[0] for c in calls]
-    assert "run_job" in kinds and "save" in kinds and "mark" in kinds
-    assert "deliver" not in kinds
+    assert "deliver" in kinds
 
 
 def test_run_one_job_empty_response_is_soft_failure(monkeypatch):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2324,7 +2324,7 @@ class TestRunJobSkillBacked:
 
 
 class TestSilentDelivery:
-    """Verify that [SILENT] responses suppress delivery while still saving output."""
+    """Verify that cron silence tokens suppress delivery while saving output."""
 
     def _make_job(self):
         return {
@@ -2379,10 +2379,22 @@ class TestSilentDelivery:
         deliver_mock.assert_not_called()
 
     def test_bracketless_silent_variants_suppress(self):
-        """Bracketless near-markers the model emits when it drops brackets
-        must still suppress delivery (#51438, #46917)."""
+        """Bracketless/legacy no-op markers suppress delivery as line tokens."""
         from cron.scheduler import tick
-        for marker in ("SILENT", "NO_REPLY", "NO REPLY", "no_reply"):
+        for marker in (
+            "SILENT",
+            "NO_REPLY",
+            "NO REPLY",
+            "no_reply",
+            ">>>NO_REPLY<<<",
+            "NO_CHANGES",
+            "NO CHANGES",
+            ">>>NO_CHANGES<<<",
+            "FIRST_RUN",
+            "FIRST RUN",
+            "HEARTBEAT_OK",
+            "HEARTBEAT OK",
+        ):
             with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
                  patch("cron.scheduler.run_job", return_value=(True, "# output", marker, None)), \
                  patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
@@ -2407,7 +2419,8 @@ class TestSilentDelivery:
     def test_is_cron_silence_response_contract(self):
         """Direct behavior contract for the cron silence matcher."""
         from cron.scheduler import _is_cron_silence_response as sil
-        # Suppress: bare/bracketed/bracketless tokens, prefix, trailing-line.
+        # Suppress: bare/bracketed/bracketless tokens, wrappers, prefix,
+        # trailing-line.
         assert sil("[SILENT]")
         assert sil("[silent] nothing new")
         assert sil("[SILENT] No changes detected")
@@ -2415,10 +2428,25 @@ class TestSilentDelivery:
         assert sil("SILENT")
         assert sil("NO_REPLY")
         assert sil("NO REPLY")
+        assert sil(">>>NO_REPLY<<<")
+        for token in (
+            "NO_CHANGES",
+            "NO CHANGES",
+            ">>>NO_CHANGES<<<",
+            "FIRST_RUN",
+            "FIRST RUN",
+            "HEARTBEAT_OK",
+            "HEARTBEAT OK",
+        ):
+            assert sil(token), token
+            assert sil(f"Summary.\n{token}"), token
         assert sil("Summary.\nSILENT")
         # Deliver: real content, mid-sentence quotes, bare words, junk.
         assert not sil("Daily report: 4 PRs merged.")
         assert not sil("I stayed [SILENT] but here is the report: 3 items.")
+        assert not sil("Use NO_CHANGES when idle.")
+        assert not sil("This monitor reports HEARTBEAT_OK for healthy services.")
+        assert not sil("Use >>>NO_CHANGES<<< when idle.")
         assert not sil("Silent retry succeeded after 2 attempts.")
         assert not sil("[SILENT")  # malformed open-bracket is not the sentinel
         assert not sil("")


### PR DESCRIPTION
## Summary
- extend cron silence detection to legacy no-op tokens: `NO_CHANGES`, `FIRST_RUN`, and `HEARTBEAT_OK` variants
- accept wrapper forms like `>>>NO_REPLY<<<` / `>>>NO_CHANGES<<<`
- preserve the safety rule that mid-sentence token mentions still deliver normally

## Tests
- `scripts/run_tests.sh tests/cron/test_run_one_job.py tests/cron/test_scheduler.py -v --tb=short`
- `git diff --check HEAD~1..HEAD`
