### PR TITLE
docs(cli-commands): add missing -t/--toolsets row to hermes -z overrides table

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -152,6 +152,7 @@ Per-run overrides (no mutation to `~/.hermes/config.yaml`):
 |---|---|---|
 | `-m` / `--model <model>` | `HERMES_INFERENCE_MODEL` | Override the model for this run |
 | `--provider <provider>` | _(none)_ | Override the provider for this run |
+| `-t` / `--toolsets <csv>` | _(none)_ | Comma-separated toolsets to enable for this run |
 
 ```bash
 hermes -z "…" --provider openrouter --model openai/gpt-5.5


### PR DESCRIPTION
## Summary
The `hermes -z` per-run overrides table in `cli-commands.md` was missing the 
`-t/--toolsets` flag. The parser (`hermes_cli/_parser.py`) explicitly documents 
this flag with: *"Applies to -z/--oneshot and --tui"* - but the docs table only 
listed `-m/--model` and `--provider`.

This adds the missing row to match the parser's own help text.

## Validation
- Docs-only change - no runtime code touched
- Proof: direct comparison between `hermes_cli/_parser.py` help string and `cli-commands.md` table
- Checked open PRs: no overlap found on this specific table row