### PR TITLE
fix(agent): handle missing final_response on error paths

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5465,7 +5465,7 @@ class AIAgent:
             str: Final assistant response
         """
         result = self.run_conversation(message, stream_callback=stream_callback)
-        return result["final_response"]
+        return result.get("final_response") or result.get("error") or ""
 
     def _run_codex_app_server_turn(
         self,
@@ -5658,10 +5658,15 @@ def main(
     print(f"📞 API Calls: {result['api_calls']}")
     print(f"💬 Messages: {len(result['messages'])}")
     
-    if result['final_response']:
+    final_response = result.get('final_response')
+    if final_response:
         print("\n🎯 FINAL RESPONSE:")
         print("-" * 30)
-        print(result['final_response'])
+        print(final_response)
+    elif result.get('error'):
+        print("\n❌ ERROR:")
+        print("-" * 30)
+        print(result['error'])
     
     # Save sample trajectory to UUID-named file if requested
     if save_sample:

--- a/tests/run_agent/test_error_results.py
+++ b/tests/run_agent/test_error_results.py
@@ -1,0 +1,33 @@
+from unittest.mock import Mock
+
+from run_agent import AIAgent, main
+
+
+def test_chat_returns_error_when_run_conversation_has_no_final_response():
+    agent = AIAgent.__new__(AIAgent)
+    agent.run_conversation = Mock(return_value={"error": "provider failed"})
+
+    assert agent.chat("hello") == "provider failed"
+
+
+def test_direct_main_prints_error_result_without_final_response(monkeypatch, capsys):
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_conversation(self, user_query):
+            return {
+                "completed": False,
+                "api_calls": 3,
+                "messages": [],
+                "error": "payload too large",
+            }
+
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+
+    main(query="hello")
+
+    output = capsys.readouterr().out
+    assert "❌ ERROR:" in output
+    assert "payload too large" in output
+    assert "🎯 FINAL RESPONSE" not in output


### PR DESCRIPTION
Fixes #55822.\n\nAIAgent.chat() and the direct run_agent.py main() path now tolerate run_conversation error/exhaustion results that contain error without final_response. chat() returns the error string instead of raising KeyError, and main() prints the error summary.\n\nTests:\n- scripts/run_tests.sh tests/run_agent/test_error_results.py