### PR TITLE
fix(gateway): stop raw `**` leaking in Telegram table/bold rendering

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -351,7 +351,15 @@ def _render_table_block(table_block: list[str]) -> str:
                 continue
             bullets.append(f"• {header}: {value}")
 
-        group_lines = [f"**{heading}**", *bullets]
+        # Strip any existing `*` bold/italic markers from the heading before
+        # wrapping it in `**...**`. LLMs often emit `**bold**` inside table
+        # cells; without this, `**{**bold**}**` becomes `****bold****`, which
+        # the MarkdownV2 bold converter downstream mangles into escaped `\*\*`
+        # that Telegram then renders as a literal `**`.
+        _heading = re.sub(r"\*+", "", heading).strip()
+        if not _heading:
+            _heading = f"Row {index}"
+        group_lines = [f"**{_heading}**", *bullets]
         rendered_groups.append("\n".join(group_lines))
 
     return "\n\n".join(rendered_groups)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5865,6 +5865,21 @@ class TelegramAdapter(BasePlatformAdapter):
         for key in reversed(list(placeholders.keys())):
             text = text.replace(key, placeholders[key])
 
+        # 11.5) Safety net: strip orphan escaped `\*\*` bold markers.
+        #       Step 5 converts well-formed `**bold**` to a placeholder, which
+        #       is restored above as clean `*bold*` (raw single `*`). Any
+        #       `\*\*` surviving to here therefore came from bold that step 5
+        #       could NOT match: bold spanning a newline, an unpaired/trailing
+        #       `**`, or residual `**` inside a table cell. In MarkdownV2 each
+        #       such escaped pair renders as a literal `**`, which is the leak
+        #       users see. Removing the escaped pair leaves the inner text as
+        #       plain (losing the bold) rather than showing raw `**`.
+        #       This is safe to run globally: correctly-converted `*bold*`
+        #       uses raw single `*` (no backslash), and fenced/inline code was
+        #       protected before step 10's escaping so it contains raw `**`,
+        #       never the escaped `\*\*` this strips.
+        text = re.sub(r'\\\*\\\*', '', text)
+
         # 12) Safety net: escape unescaped ( ) { } that slipped through
         #     placeholder processing.  Split the text into code/non-code
         #     segments so we never touch content inside ``` or ` spans.

--- a/tests/gateway/test_table_helpers.py
+++ b/tests/gateway/test_table_helpers.py
@@ -48,6 +48,38 @@ class TestConvertTableToBullets:
         assert "• Score: 120" in out
         assert "• Player: Alice" not in out
 
+    def test_bold_cell_heading_not_double_wrapped(self):
+        """Regression: a ``**bold**`` cell used to be wrapped again into
+        ``****bold****``, which the MarkdownV2 bold converter downstream
+        mangles into an escaped ``\\*\\*`` that Telegram renders as a literal
+        ``**``.  The heading's existing ``*`` markers must be stripped before
+        wrapping so each bold cell ends up wrapped exactly once.
+        """
+        text = (
+            "| 항목 | 설명 |\n"
+            "|------|------|\n"
+            "| **OCR** | 이미지에서 텍스트 |\n"
+            "| **LLM** | 대형 언어 모델 |"
+        )
+        out = convert_table_to_bullets(text)
+        # No double-wrap survives anywhere.
+        assert "****" not in out
+        # Each bold heading is wrapped exactly once.
+        assert out.count("**OCR**") == 1
+        assert out.count("**LLM**") == 1
+
+    def test_italic_marker_in_heading_stripped(self):
+        """A single-``*`` italic marker in a heading cell is stripped too,
+        so ``*foo*`` wraps to ``**foo**`` instead of ``***foo***``."""
+        text = (
+            "| Type | Count |\n"
+            "|------|-------|\n"
+            "| *foo* | 3 |"
+        )
+        out = convert_table_to_bullets(text)
+        assert "***" not in out
+        assert "**foo**" in out
+
     def test_three_column_table(self):
         text = (
             "| Name | Age | City |\n"

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -291,6 +291,28 @@ class TestFormatMessageBoldItalic:
         assert "tool\\[beta\\]" in result
         assert "alpha\\*prod" in result
 
+    def test_unpaired_trailing_bold_no_leak(self, adapter):
+        """Regression: a lone trailing ``**`` (no closing pair) cannot be
+        matched by the bold converter, so it used to be escaped to ``\\*\\*``
+        and render as a literal ``**``.  The safety net strips orphan escaped
+        ``\\*\\*`` so the raw marker never reaches Telegram.
+        """
+        result = adapter.format_message("Status: active **")
+        assert "**" not in result
+        assert "\\*\\*" not in result
+
+    def test_multiline_bold_no_leak(self, adapter):
+        """Regression: ``**bold\\nacross lines**`` spans a newline, which the
+        single-line bold regex cannot match, so both markers leaked as literal
+        ``**``.  The safety net now strips the orphan escaped pairs (the inner
+        text is left plain rather than showing raw ``**``).
+        """
+        result = adapter.format_message("**bold\ntext** end")
+        assert "**" not in result
+        assert "\\*\\*" not in result
+        assert "bold" in result
+        assert "text" in result
+
 
 # =========================================================================
 # format_message - headers
@@ -840,6 +862,27 @@ class TestFormatMessageTables:
         assert out.count("*1*") == 1
         assert out.count("*9*") == 1
         assert "• Y: 8" in out
+
+    def test_table_with_bold_cells_no_leak(self, adapter):
+        """Regression: when an LLM emits a GFM table whose first-column cells
+        already contain ``**bold**``, the heading used to be double-wrapped to
+        ``****bold****`` and then mangled into an escaped ``\\*\\*`` that
+        Telegram renders as a literal ``**``.  The heading ``*`` markers are
+        now stripped before wrapping, so no ``**`` leaks into the output.
+        """
+        text = (
+            "| 구분 | 설명 |\n"
+            "|------|------|\n"
+            "| **OCR** | 이미지에서 텍스트 |\n"
+            "| **LLM** | 대형 언어 모델 |"
+        )
+        out = adapter.format_message(text)
+        # No literal or escaped ** pair survives anywhere in the output.
+        assert "**" not in out
+        assert "\\*\\*" not in out
+        # The bold headings converted cleanly to MarkdownV2 single-* bold.
+        assert "*OCR*" in out
+        assert "*LLM*" in out
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

Telegram messages occasionally showed a raw literal `**` instead of bold. Root cause: when an LLM emits a GFM pipe table whose first-column cells already contain `**bold**`, the table→bullet renderer wrapped the heading a **second** time into `****bold****`. The MarkdownV2 bold converter downstream couldn't parse that and mangled it into escaped `\*\*`, which Telegram renders verbatim as `**`.

The same leak also appeared from:
- **bold spanning a newline** (`**bold\ntext**`) — the single-line bold regex can't match across `\n`
- **unpaired / trailing `**`** — no closing pair to match

## Changes

**1. `gateway/platforms/helpers.py` — `convert_table_to_bullets` (decisive fix)**
Strip existing `*` markers from the heading cell *before* wrapping it in `**...**`, so each bold heading ends up wrapped exactly once instead of `****bold****`.

**2. `plugins/platforms/telegram/adapter.py` — `format_message` safety net**
After placeholder restore, strip orphan escaped `\*\*` left over from bold the converter couldn't match (multiline / unpaired / table-cell residual). In MarkdownV2 each escaped pair renders as a literal `**`; removing it leaves the inner text plain rather than showing raw `**`.

This only touches escaped pairs:
- correctly-converted `*bold*` uses a raw single `*` (no backslash) → untouched
- fenced/inline code was protected before escaping, so it contains raw `**`, never `\*\*` → untouched

## How to test

```python
from gateway.platforms.helpers import convert_table_to_bullets
import re

table = "| 항목 | 설명 |\n|------|------|\n| **OCR** | 텍스트 추출 |\n"
out = convert_table_to_bullets(table)
# Before fix: '****OCR****'  →  mangled to literal ** downstream
# After fix:  '**OCR**'      →  converts cleanly to *OCR*
assert "****" not in out
```

Regression tests added (fail without the fix, pass with it):
- `tests/gateway/test_table_helpers.py` — `test_bold_cell_heading_not_double_wrapped`, `test_italic_marker_in_heading_stripped`
- `tests/gateway/test_telegram_format.py` — `test_table_with_bold_cells_no_leak` (end-to-end), `test_unpaired_trailing_bold_no_leak`, `test_multiline_bold_no_leak`

```
tests/gateway/test_table_helpers.py    20 passed (18 existing + 2 new)
tests/gateway/test_telegram_format.py 109 passed (106 existing + 3 new)
```

Full `tests/gateway/` run: the only failures are pre-existing and unrelated to this change (systemd/shutdown on non-Linux, wecom callback dependency, and a handful of order-dependent telegram-escaping tests that pass in isolation) — they fail identically on stock `main`.

## Platforms tested

macOS (Darwin 25.4), Python 3.12.13. The fix is pure Python with no platform-specific code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)