### PR TITLE
fix(mattermost): guard file-download URL against path-traversal fids

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -887,6 +887,14 @@ class MattermostAdapter(BasePlatformAdapter):
         media_types: List[str] = []
         for fid in file_ids:
             try:
+                # Guard: reject fids containing path-traversal sequences before
+                # building the download URL.  _api_get() already does this for
+                # the /files/{fid}/info call, but the direct session.get() below
+                # bypasses that helper — applying the same check here closes the
+                # gap (sibling of the guard added in commit d836b2bac).
+                if ".." in str(fid):
+                    logger.error("Mattermost: blocked download with path-traversal fid: %s", fid)
+                    continue
                 file_info = await self._api_get(f"files/{fid}/info")
                 fname = file_info.get("name", f"file_{fid}")
                 ext = Path(fname).suffix or ""

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -1034,3 +1034,81 @@ async def test_mattermost_dm_post_does_not_seed_thread_root():
     msg_event = adapter.handle_message.call_args[0][0]
     assert msg_event.source.thread_id is None
     assert msg_event.source.message_id == "dm_post_123"
+
+
+class TestMattermostFileDownloadGuard:
+    """file_ids from WebSocket events are server-controlled and must be
+    validated before being interpolated into the download URL.
+
+    _api_get() already blocks '..' in its path argument, but the direct
+    self._session.get(dl_url, ...) call below it bypasses that helper.
+    A crafted fid like '../../admin/config' would build a URL that makes
+    the bot's bearer token request an unintended Mattermost API endpoint,
+    with the response injected into the agent's prompt context.
+    Regression for commit d836b2bac / PR #54569 sibling gap.
+    """
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter.handle_message = AsyncMock()
+
+    def _make_event(self, file_ids):
+        post_data = {
+            "id": "post_guard_test",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id file attached",
+            "file_ids": file_ids,
+        }
+        return {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_traversal_fid_is_blocked(self):
+        """A file_id containing '..' must not reach the download request."""
+        self.adapter._api_get = AsyncMock(return_value={})
+        self.adapter._session = MagicMock()
+        self.adapter._session.get = MagicMock()
+
+        await self.adapter._handle_ws_event(self._make_event(["../../admin/config"]))
+
+        self.adapter._session.get.assert_not_called()
+        msg = self.adapter.handle_message.call_args[0][0]
+        assert not msg.media_urls  # None or [] — no files attached
+
+    @pytest.mark.asyncio
+    async def test_traversal_fid_skipped_legitimate_fid_still_downloaded(self):
+        """A legitimate fid following a malicious one must still be downloaded."""
+        file_info = {"name": "photo.png", "mime_type": "image/png"}
+
+        async def fake_api_get(path):
+            if "../../" in path:
+                return {}
+            return file_info
+
+        self.adapter._api_get = fake_api_get
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.read = AsyncMock(return_value=b"\x89PNG")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        self.adapter._session = MagicMock()
+        self.adapter._session.get = MagicMock(return_value=mock_resp)
+
+        with patch("gateway.platforms.base.cache_image_from_bytes", return_value="/tmp/p.png"):
+            await self.adapter._handle_ws_event(
+                self._make_event(["../../admin/config", "good_file_id"])
+            )
+
+        self.adapter._session.get.assert_called_once()
+        call_url = self.adapter._session.get.call_args[0][0]
+        assert "admin/config" not in call_url
+        assert "good_file_id" in call_url


### PR DESCRIPTION
## Summary
- Commit d836b2bac added a `'..'` traversal check to `_api_get()` so a crafted path like `files/../../admin/config` is blocked before it reaches the Mattermost server.
- The attachment download flow builds `dl_url` by interpolating `fid` directly into an f-string and calls `self._session.get(dl_url, headers={"Authorization": f"Bearer {self._token}"})` with **no equivalent guard**, completely bypassing `_api_get()`.
- `file_ids` come from `post.get("file_ids")` in the WebSocket event — fully server-controlled. A compromised or malicious Mattermost server could send a crafted `fid` (e.g. `../../admin/config`), causing the bot's bearer token to make an authenticated request to an unintended Mattermost API endpoint, with the response silently ingested into the agent's prompt context.

## Fix
Apply the same `".." in str(fid)` check before building `dl_url` — log an error and `continue` on match, matching `_api_get()`'s guard style. The `_api_get(f"files/{fid}/info")` call above already blocks the fid via `_api_get`'s guard, but this closes the second path that bypasses it.

## Test plan
- `test_traversal_fid_is_blocked` — fid `../../admin/config` must not reach `session.get`, no media attached to message
- `test_traversal_fid_skipped_legitimate_fid_still_downloaded` — malicious fid skipped, subsequent good fid still downloaded correctly; verified the download URL contains the good fid, not the traversal path

`pytest tests/gateway/test_mattermost.py::TestMattermostFileDownloadGuard tests/gateway/test_mattermost.py::TestMattermostMediaTypes` → 5 passed, 0 failed