### PR TITLE
docs(.env.example): align TERMINAL_TIMEOUT default with code (60 -> 180)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,8 +193,8 @@ TERMINAL_MODAL_IMAGE=nikolaik/python-nodejs:python3.11-nodejs20
 # Usually managed by config.yaml (terminal.cwd) — uncomment to override
 # TERMINAL_CWD=.
 
-# Default command timeout in seconds
-TERMINAL_TIMEOUT=60
+# Default command timeout in seconds (default: 180)
+TERMINAL_TIMEOUT=180
 
 # Cleanup inactive environments after this many seconds
 TERMINAL_LIFETIME_SECONDS=300


### PR DESCRIPTION
## Summary
`.env.example` shipped `TERMINAL_TIMEOUT=60`, but the actual built-in fallback used across the codebase is **180 seconds**:

- `tools/terminal_tool.py` -> `_parse_env_var("TERMINAL_TIMEOUT", "180")`
- `tools/process_registry.py` -> `os.getenv("TERMINAL_TIMEOUT", "180")`

Anyone who copied `.env.example` verbatim got a 60 s command timeout -- 3x shorter than the value the code falls back to when the variable is absent. The comment above the line called it the *Default command timeout*, making the mismatch more confusing.

`TERMINAL_LIFETIME_SECONDS=300` in the same file is correct and unchanged.

## Validation
- Config/example-only change -- no runtime code touched
- Proof: direct comparison between `.env.example` (60) and `tools/terminal_tool.py` / `tools/process_registry.py` (both default to 180)
- Checked open PRs: PR #45344 touches `.env.example` for Slack vars only -- no overlap
- No closed PR in last 30 days changed this value