### PR TITLE
[HERMES] fix: show Desktop message finish time

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -126,7 +126,7 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
       >
         <span
           className={cn(
-            'min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4',
+            'min-w-0 flex-1 truncate text-[0.73rem] leading-4',
             failed
               ? 'text-destructive/90'
               : item.todoStatus && item.todoStatus !== 'in_progress'

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -352,6 +352,7 @@ export function useMessageStream({
         }
 
         const streamId = state.streamId
+        const completedAt = Math.floor(Date.now() / 1000)
         const finalText = renderMediaTags(text).trim()
         const completionError = completionErrorText(finalText)
         const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
@@ -383,12 +384,14 @@ export function useMessageStream({
                 ...message,
                 error: completionError,
                 parts: message.parts.filter(part => part.type !== 'text'),
-                pending: false
+                pending: false,
+                timestamp: completedAt
               }
             : {
                 ...message,
                 parts: replaceTextPart(message.parts),
-                pending: false
+                pending: false,
+                timestamp: completedAt
               }
 
         const newAssistantFromCompletion = (): ChatMessage => ({
@@ -396,6 +399,7 @@ export function useMessageStream({
           role: 'assistant',
           parts: completionError ? [] : [assistantTextPart(finalText)],
           branchGroupId: state.pendingBranchGroup ?? undefined,
+          timestamp: completedAt,
           ...(completionError && { error: completionError })
         })
 
@@ -471,6 +475,7 @@ export function useMessageStream({
     (sessionId: string, errorMessage: string) => {
       updateSessionState(sessionId, state => {
         const streamId = state.streamId ?? `assistant-error-${Date.now()}`
+        const failedAt = Math.floor(Date.now() / 1000)
         const groupId = state.pendingBranchGroup ?? undefined
         const prev = state.messages
         const error = errorMessage.trim() || 'Hermes reported an error'
@@ -481,7 +486,8 @@ export function useMessageStream({
                 ? {
                     ...message,
                     error,
-                    pending: false
+                    pending: false,
+                    timestamp: failedAt
                   }
                 : message
             )
@@ -493,7 +499,8 @@ export function useMessageStream({
                 parts: [],
                 error,
                 pending: false,
-                branchGroupId: groupId
+                branchGroupId: groupId,
+                timestamp: failedAt
               }
             ]
 

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -1,0 +1,65 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Thread } from '.'
+
+const createdAt = new Date('2026-05-01T12:34:00.000Z')
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+function assistantMessage(): ThreadMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'done' }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+function Harness() {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [assistantMessage()],
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('assistant message footer', () => {
+  it('keeps the message timestamp visible without opening the more-actions menu', async () => {
+    const { container } = render(<Harness />)
+
+    await screen.findByText('done')
+
+    const timestamp = container.querySelector('[data-slot="aui_msg-timestamp"]')
+
+    expect(timestamp).toBeTruthy()
+    expect(timestamp?.textContent?.trim()).not.toBe('')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -143,7 +143,7 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
   const [menuOpen, setMenuOpen] = useState(false)
 
   return (
-    <div className="relative flex w-full shrink-0 justify-end">
+    <div className="relative flex shrink-0 justify-end">
       <ActionBarPrimitive.Root
         className={cn(
           // NOTE: intentionally NOT `hideWhenRunning`. That prop unmounts the
@@ -237,6 +237,26 @@ const MessageTimestamp: FC = () => {
   return <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">{label}</DropdownMenuLabel>
 }
 
+const VisibleMessageTimestamp: FC = () => {
+  const { t } = useI18n()
+  const createdAt = useAuiState(s => s.message.createdAt)
+  const label = formatMessageTimestamp(createdAt, t.assistant.thread)
+
+  if (!label) {
+    return null
+  }
+
+  return (
+    <span
+      className="shrink-0 whitespace-nowrap py-1.5 text-[0.68rem] leading-4 text-muted-foreground/70 tabular-nums"
+      data-slot="aui_msg-timestamp"
+      title={label}
+    >
+      {label}
+    </span>
+  )
+}
+
 const AssistantFooter: FC<MessageActionProps> = props => (
   <div className="flex min-h-6 flex-col items-end gap-1 pr-(--message-text-indent) pl-(--message-text-indent)">
     <BranchPickerPrimitive.Root
@@ -253,6 +273,9 @@ const AssistantFooter: FC<MessageActionProps> = props => (
         <Codicon name="chevron-right" size="0.875rem" />
       </BranchPickerPrimitive.Next>
     </BranchPickerPrimitive.Root>
-    <AssistantActionBar {...props} />
+    <div className="flex w-full items-center justify-end gap-2">
+      <AssistantActionBar {...props} />
+      <VisibleMessageTimestamp />
+    </div>
   </div>
 )


### PR DESCRIPTION
## Summary
- Show assistant message timestamps directly in the Desktop message footer, so the completion time is visible without opening the more-actions menu.
- Stamp streamed assistant completions/errors with the settle time so live messages display their finish time immediately.
- Let composer status/todo rows use the available width before truncating, instead of capping titles at 18rem.

## Test Plan
- `npm --workspace apps/desktop run test:ui -- src/components/assistant-ui/thread/assistant-message.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `npx eslint src/components/assistant-ui/thread/assistant-message.tsx src/components/assistant-ui/thread/assistant-message.test.tsx src/app/chat/composer/status-stack/status-row.tsx src/app/session/hooks/use-message-stream/index.ts`
- `npm --workspace apps/desktop run build`

Note: full `npm --workspace apps/desktop run lint` currently fails on pre-existing unrelated files (`electron/titlebar-overlay-width.cjs`, `src/store/projects.ts`, plus warnings in settings/context/starmap files).