### PR TITLE
feat(stt): add Gemini transcription plugin

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -906,14 +906,20 @@ platform_toolsets:
 # Voice Transcription (Speech-to-Text)
 # =============================================================================
 # Automatically transcribe voice messages on messaging platforms.
-# Providers: local (free, faster-whisper) | groq (free tier) | openai (Whisper API) | mistral (Voxtral Transcribe)
-# Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
+# Providers: local (free, faster-whisper) | gemini (Google Gemini plugin; good for short voice clips) |
+# groq (free tier) | openai (Whisper API) | mistral (Voxtral Transcribe) |
+# xai (Grok STT) | elevenlabs (Scribe)
+# Set the corresponding API key in .env: GEMINI_API_KEY, GROQ_API_KEY,
+# OPENAI_API_KEY, MISTRAL_API_KEY, XAI_API_KEY, or ELEVENLABS_API_KEY.
 stt:
   enabled: true
   # provider: "local"          # auto-detected if omitted
   local:
     model: "base"              # tiny | base | small | medium | large-v3 | turbo
     # language: ""             # auto-detect; set to "en", "es", "fr", etc. to force
+  # gemini:
+  #   model: "gemini-3.1-flash-lite-preview"  # high-rate-limit default; override to gemini-3-flash-preview if desired
+  #   language: ""             # optional language hint; audio is sent to Google Gemini
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
   # mistral:

--- a/plugins/transcription/__init__.py
+++ b/plugins/transcription/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled transcription provider plugins."""

--- a/plugins/transcription/gemini/__init__.py
+++ b/plugins/transcription/gemini/__init__.py
@@ -1,0 +1,186 @@
+"""Gemini speech-to-text plugin."""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from agent.transcription_provider import TranscriptionProvider
+from hermes_cli.config import get_env_value
+
+
+DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
+DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+INLINE_AUDIO_LIMIT_BYTES = 20 * 1024 * 1024
+
+
+def _api_key() -> str | None:
+    value = (
+        get_env_value("GEMINI_STT_API_KEY")
+        or get_env_value("GEMINI_API_KEY")
+        or get_env_value("GOOGLE_API_KEY")
+    )
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _base_url() -> str:
+    value = (
+        get_env_value("GEMINI_STT_BASE_URL")
+        or get_env_value("GEMINI_BASE_URL")
+        or DEFAULT_BASE_URL
+    )
+    return str(value).strip().rstrip("/") or DEFAULT_BASE_URL
+
+
+def _failure(message: str) -> dict[str, Any]:
+    return {
+        "success": False,
+        "transcript": "",
+        "provider": "gemini",
+        "error": message,
+    }
+
+
+def _extract_text(payload: dict[str, Any]) -> str:
+    texts: list[str] = []
+    for candidate in payload.get("candidates") or []:
+        content = candidate.get("content") or {}
+        for part in content.get("parts") or []:
+            text = part.get("text")
+            if isinstance(text, str):
+                texts.append(text)
+    return "".join(texts).strip()
+
+
+def _error_detail(response: requests.Response) -> str:
+    try:
+        payload = response.json()
+        error = payload.get("error") if isinstance(payload, dict) else None
+        if isinstance(error, dict) and error.get("message"):
+            return str(error["message"])
+    except Exception:
+        pass
+    return response.text[:300].strip() or f"HTTP {response.status_code}"
+
+
+class GeminiTranscriptionProvider(TranscriptionProvider):
+    @property
+    def name(self) -> str:
+        return "gemini"
+
+    @property
+    def display_name(self) -> str:
+        return "Gemini STT"
+
+    def is_available(self) -> bool:
+        return bool(_api_key())
+
+    def list_models(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": DEFAULT_MODEL,
+                "display": "Gemini 3.1 Flash Lite",
+            },
+            {
+                "id": "gemini-3-flash-preview",
+                "display": "Gemini 3 Flash",
+            },
+            {
+                "id": "gemini-2.5-flash",
+                "display": "Gemini 2.5 Flash",
+            },
+        ]
+
+    def default_model(self) -> str:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> dict[str, Any]:
+        return {
+            "name": self.display_name,
+            "badge": "cloud",
+            "tag": "Google Gemini audio transcription",
+            "env_vars": [
+                {
+                    "key": "GEMINI_API_KEY",
+                    "prompt": "Google AI Studio API key",
+                    "url": "https://aistudio.google.com/app/apikey",
+                }
+            ],
+        }
+
+    def transcribe(
+        self,
+        file_path: str,
+        *,
+        model: str | None = None,
+        language: str | None = None,
+        **extra: Any,
+    ) -> dict[str, Any]:
+        del extra
+        api_key = _api_key()
+        if not api_key:
+            return _failure("Gemini STT requires GEMINI_API_KEY or GOOGLE_API_KEY.")
+
+        audio_path = Path(file_path)
+        try:
+            audio_size = audio_path.stat().st_size
+        except OSError as exc:
+            return _failure(f"Gemini STT could not read audio file: {exc}")
+        if audio_size > INLINE_AUDIO_LIMIT_BYTES:
+            return _failure(
+                "Gemini STT inline audio is limited to 20 MB; use a shorter audio file."
+            )
+
+        mime_type = mimetypes.guess_type(audio_path.name)[0] or "audio/mpeg"
+        prompt = "Transcribe this audio. Return only the transcript text."
+        if language:
+            prompt += f" The expected language is {language}."
+
+        try:
+            audio_b64 = base64.b64encode(audio_path.read_bytes()).decode("utf-8")
+            selected_model = (model or DEFAULT_MODEL).strip() or DEFAULT_MODEL
+            response = requests.post(
+                f"{_base_url()}/models/{selected_model}:generateContent",
+                params={"key": api_key},
+                headers={"Content-Type": "application/json"},
+                json={
+                    "contents": [
+                        {
+                            "parts": [
+                                {"text": prompt},
+                                {
+                                    "inline_data": {
+                                        "mime_type": mime_type,
+                                        "data": audio_b64,
+                                    }
+                                },
+                            ],
+                        }
+                    ]
+                },
+                timeout=120,
+            )
+            if response.status_code != 200:
+                return _failure(
+                    f"Gemini STT API error (HTTP {response.status_code}): {_error_detail(response)}"
+                )
+            transcript = _extract_text(response.json())
+        except Exception as exc:
+            return _failure(f"Gemini STT failed: {exc}")
+
+        if not transcript:
+            return _failure("Gemini returned an empty transcript.")
+
+        return {
+            "success": True,
+            "transcript": transcript,
+            "provider": self.name,
+        }
+
+
+def register(ctx: Any) -> None:
+    ctx.register_transcription_provider(GeminiTranscriptionProvider())

--- a/plugins/transcription/gemini/plugin.yaml
+++ b/plugins/transcription/gemini/plugin.yaml
@@ -1,0 +1,7 @@
+name: transcription-gemini
+version: 0.1.0
+description: "Google Gemini speech-to-text provider"
+author: NousResearch
+kind: backend
+provides_transcription_providers:
+  - gemini

--- a/tests/hermes_cli/test_plugins_transcription_registration.py
+++ b/tests/hermes_cli/test_plugins_transcription_registration.py
@@ -108,7 +108,9 @@ class TestRegisterTranscriptionProvider:
 
         assert mgr._plugins["bad-stt-plugin"].enabled is True
         assert transcription_registry.get_provider("not a provider") is None
-        assert transcription_registry.list_providers() == []
+        assert "not a provider" not in {
+            provider.name for provider in transcription_registry.list_providers()
+        }
         assert "does not inherit from TranscriptionProvider" in caplog.text
 
         transcription_registry._reset_for_tests()

--- a/tests/plugins/transcription/test_gemini_stt_plugin.py
+++ b/tests/plugins/transcription/test_gemini_stt_plugin.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from plugins.transcription.gemini import GeminiTranscriptionProvider, register
+
+
+class _Response:
+    status_code = 200
+    text = ""
+
+    def __init__(self, payload, status_code=200, text=""):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def test_provider_metadata_and_availability(monkeypatch):
+    monkeypatch.delenv("GEMINI_STT_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    provider = GeminiTranscriptionProvider()
+    assert provider.name == "gemini"
+    assert provider.display_name == "Gemini STT"
+    assert provider.default_model() == "gemini-3.1-flash-lite-preview"
+    assert provider.is_available() is False
+
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    assert provider.is_available() is True
+
+
+def test_transcribe_success(monkeypatch, tmp_path):
+    import plugins.transcription.gemini as gemini
+
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    audio_path = tmp_path / "voice.mp3"
+    audio_path.write_bytes(b"fake audio")
+
+    post = Mock(
+        return_value=_Response(
+            {"candidates": [{"content": {"parts": [{"text": "hello world"}]}}]}
+        )
+    )
+    monkeypatch.setattr(gemini.requests, "post", post)
+
+    result = GeminiTranscriptionProvider().transcribe(
+        str(audio_path),
+        model="gemini-2.5-flash",
+        language="en",
+    )
+
+    assert result == {
+        "success": True,
+        "transcript": "hello world",
+        "provider": "gemini",
+    }
+
+    _, kwargs = post.call_args
+    assert kwargs["params"] == {"key": "test-key"}
+    assert kwargs["headers"] == {"Content-Type": "application/json"}
+    assert post.call_args.args[0].endswith("/models/gemini-2.5-flash:generateContent")
+    parts = kwargs["json"]["contents"][0]["parts"]
+    assert parts[0]["text"].endswith("The expected language is en.")
+    assert parts[1]["inline_data"]["data"]
+    assert parts[1]["inline_data"]["mime_type"] in {"audio/mp3", "audio/mpeg"}
+
+
+def test_transcribe_rejects_audio_over_inline_limit(monkeypatch, tmp_path):
+    import plugins.transcription.gemini as gemini
+
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    monkeypatch.setattr(gemini, "INLINE_AUDIO_LIMIT_BYTES", 8)
+
+    audio_path = tmp_path / "voice.wav"
+    audio_path.write_bytes(b"original audio larger than limit")
+
+    post = Mock()
+    monkeypatch.setattr(gemini.requests, "post", post)
+
+    result = GeminiTranscriptionProvider().transcribe(str(audio_path))
+
+    assert result["success"] is False
+    assert result["transcript"] == ""
+    assert result["provider"] == "gemini"
+    assert "inline audio is limited to 20 MB" in result["error"]
+    post.assert_not_called()
+
+
+def test_transcribe_returns_http_error_detail(monkeypatch, tmp_path):
+    import plugins.transcription.gemini as gemini
+
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    audio_path = tmp_path / "voice.wav"
+    audio_path.write_bytes(b"fake audio")
+
+    post = Mock(
+        return_value=_Response(
+            {"error": {"message": "bad request"}},
+            status_code=400,
+            text="fallback",
+        )
+    )
+    monkeypatch.setattr(gemini.requests, "post", post)
+
+    result = GeminiTranscriptionProvider().transcribe(str(audio_path))
+
+    assert result["success"] is False
+    assert result["transcript"] == ""
+    assert result["provider"] == "gemini"
+    assert result["error"] == "Gemini STT API error (HTTP 400): bad request"
+
+
+def test_transcribe_returns_error_envelope(monkeypatch, tmp_path):
+    import plugins.transcription.gemini as gemini
+
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    audio_path = tmp_path / "voice.wav"
+    audio_path.write_bytes(b"fake audio")
+
+    post = Mock(side_effect=RuntimeError("network down"))
+    monkeypatch.setattr(gemini.requests, "post", post)
+
+    result = GeminiTranscriptionProvider().transcribe(str(audio_path))
+
+    assert result["success"] is False
+    assert result["transcript"] == ""
+    assert result["provider"] == "gemini"
+    assert result["error"] == "Gemini STT failed: network down"
+
+
+def test_register_adds_provider():
+    ctx = Mock()
+
+    register(ctx)
+
+    ctx.register_transcription_provider.assert_called_once()
+    provider = ctx.register_transcription_provider.call_args.args[0]
+    assert isinstance(provider, GeminiTranscriptionProvider)


### PR DESCRIPTION
## Summary

Adds a bundled Gemini speech-to-text provider plugin that registers a `TranscriptionProvider` named `gemini`.

This uses the existing STT plugin extension point rather than adding another built-in branch to `tools/transcription_tools.py`. The provider targets normal short voice/audio clips, uses Gemini `generateContent` with inline audio, and keeps credentials in env via `GEMINI_STT_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY`.

## Details

- Adds `plugins/transcription/gemini` as a bundled backend plugin.
- Defaults to `gemini-3.1-flash-lite-preview` for the higher-rate-limit Flash Lite path.
- Allows opt-in model override via `stt.gemini.model`, including `gemini-3-flash-preview`.
- Returns the standard STT failure envelope for missing keys, Gemini API errors, empty transcripts, and audio over Gemini inline limits.
- Updates the example config with Gemini STT notes and the privacy hint that audio is sent to Google Gemini.

## Related

Builds on the current STT plugin/provider architecture from the #30398 pluggability work and follows the bundled backend plugin pattern used by other provider categories.

## Tests

```bash
venv/bin/ruff check plugins/transcription/gemini/__init__.py tests/plugins/transcription/test_gemini_stt_plugin.py tests/hermes_cli/test_plugins_transcription_registration.py
scripts/run_tests.sh tests/plugins/transcription/test_gemini_stt_plugin.py tests/tools/test_transcription_plugin_dispatch.py tests/hermes_cli/test_plugins_transcription_registration.py
```

Result: focused suite passes (`37 passed`).