### PR TITLE
fix(profile): prevent profile context loss in desktop + multiplexed gateway

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -725,10 +725,17 @@ def _run_review_in_thread(
                 clear_thread_tool_whitelist,
             )
 
+            # Gate the built-in memory tool on the profile's memory_enabled flag.
+            # Hardcoding ["memory", "skills"] granted the review LLM the MEMORY.md
+            # read/write tool even when a profile set memory_enabled: false,
+            # contaminating a memory-disabled profile (#54937 layer 2).
+            review_toolsets = ["skills"]
+            if review_agent._memory_enabled or review_agent._user_profile_enabled:
+                review_toolsets.insert(0, "memory")
             review_whitelist = {
                 t["function"]["name"]
                 for t in get_tool_definitions(
-                    enabled_toolsets=["memory", "skills"],
+                    enabled_toolsets=review_toolsets,
                     quiet_mode=True,
                 )
             }

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -565,7 +565,36 @@ async def _ssrf_redirect_guard(response):
 # ---------------------------------------------------------------------------
 
 # Default location: {HERMES_HOME}/cache/images/ (legacy: image_cache/)
+#
+# NOTE: These module-level constants are the import-time DEFAULTS.  They exist
+# for two reasons: (1) backward-compatible references elsewhere, and (2) tests
+# monkeypatch them (e.g. ``monkeypatch.setattr("...IMAGE_CACHE_DIR", tmp)``).
+# The ``get_*_cache_dir()`` getters below re-resolve through ``get_hermes_dir()``
+# on every call so the context-local profile override
+# (``set_hermes_home_override``) is honored — freezing the resolved path at
+# import pinned every profile to whichever one first imported this module
+# (cross-profile leak in single-process multi-profile desktop runtime).  When a
+# test has monkeypatched the constant away from its import-time default, that
+# override wins (preserves the existing test seam).
 IMAGE_CACHE_DIR = get_hermes_dir("cache/images", "image_cache")
+
+
+def _resolve_cache_dir(constant_name: str, new_subpath: str, old_name: str) -> Path:
+    """Resolve a cache dir, honoring profile override and test monkeypatches.
+
+    Precedence:
+      1. If the module constant ``constant_name`` was monkeypatched away from
+         its import-time default, return the patched value (test seam).
+      2. Otherwise resolve fresh via ``get_hermes_dir`` so the active profile's
+         ``set_hermes_home_override`` is reflected per-call.
+    """
+    fresh = get_hermes_dir(new_subpath, old_name)
+    current = globals().get(constant_name)
+    default = _CACHE_DIR_IMPORT_DEFAULTS.get(constant_name)
+    if current is not None and default is not None and current != default:
+        # A test (or caller) replaced the module constant — respect it.
+        return Path(current)
+    return fresh
 
 # ---------------------------------------------------------------------------
 # Inbound media size cap (#13145)
@@ -660,8 +689,9 @@ async def _read_httpx_body_with_limit(response, *, media_type: str) -> bytes:
 
 def get_image_cache_dir() -> Path:
     """Return the image cache directory, creating it if it doesn't exist."""
-    IMAGE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    return IMAGE_CACHE_DIR
+    d = _resolve_cache_dir("IMAGE_CACHE_DIR", "cache/images", "image_cache")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 
 def _looks_like_image(data: bytes) -> bool:
@@ -806,8 +836,9 @@ AUDIO_CACHE_DIR = get_hermes_dir("cache/audio", "audio_cache")
 
 def get_audio_cache_dir() -> Path:
     """Return the audio cache directory, creating it if it doesn't exist."""
-    AUDIO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    return AUDIO_CACHE_DIR
+    d = _resolve_cache_dir("AUDIO_CACHE_DIR", "cache/audio", "audio_cache")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 
 def cache_audio_from_bytes(data: bytes, ext: str = ".ogg") -> str:
@@ -912,8 +943,9 @@ SUPPORTED_VIDEO_TYPES = {
 
 def get_video_cache_dir() -> Path:
     """Return the video cache directory, creating it if it doesn't exist."""
-    VIDEO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    return VIDEO_CACHE_DIR
+    d = _resolve_cache_dir("VIDEO_CACHE_DIR", "cache/videos", "video_cache")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 
 def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
@@ -935,6 +967,19 @@ def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
 
 DOCUMENT_CACHE_DIR = get_hermes_dir("cache/documents", "document_cache")
 SCREENSHOT_CACHE_DIR = get_hermes_dir("cache/screenshots", "browser_screenshots")
+
+# Import-time defaults for the cache-dir constants.  ``_resolve_cache_dir``
+# compares the live module value against these to detect a test monkeypatch
+# (in which case the patched value wins) vs. an unmodified constant (in which
+# case it re-resolves through the active profile override).
+_CACHE_DIR_IMPORT_DEFAULTS = {
+    "IMAGE_CACHE_DIR": IMAGE_CACHE_DIR,
+    "AUDIO_CACHE_DIR": AUDIO_CACHE_DIR,
+    "VIDEO_CACHE_DIR": VIDEO_CACHE_DIR,
+    "DOCUMENT_CACHE_DIR": DOCUMENT_CACHE_DIR,
+    "SCREENSHOT_CACHE_DIR": SCREENSHOT_CACHE_DIR,
+}
+
 _HERMES_HOME = get_hermes_home()
 _HERMES_ROOT = get_default_hermes_root()
 MEDIA_DELIVERY_ALLOW_DIRS_ENV = "HERMES_MEDIA_ALLOW_DIRS"
@@ -1491,8 +1536,9 @@ def _strip_media_tag_directives(text: str) -> str:
 
 def get_document_cache_dir() -> Path:
     """Return the document cache directory, creating it if it doesn't exist."""
-    DOCUMENT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    return DOCUMENT_CACHE_DIR
+    d = _resolve_cache_dir("DOCUMENT_CACHE_DIR", "cache/documents", "document_cache")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 
 def cache_document_from_bytes(data: bytes, filename: str) -> str:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -564,35 +564,18 @@ async def _ssrf_redirect_guard(response):
 # (e.g. Telegram file URLs expire after ~1 hour).
 # ---------------------------------------------------------------------------
 
-# Default location: {HERMES_HOME}/cache/images/ (legacy: image_cache/)
-#
-# NOTE: These module-level constants are the import-time DEFAULTS.  They exist
-# for two reasons: (1) backward-compatible references elsewhere, and (2) tests
-# monkeypatch them (e.g. ``monkeypatch.setattr("...IMAGE_CACHE_DIR", tmp)``).
-# The ``get_*_cache_dir()`` getters below re-resolve through ``get_hermes_dir()``
-# on every call so the context-local profile override
-# (``set_hermes_home_override``) is honored — freezing the resolved path at
-# import pinned every profile to whichever one first imported this module
-# (cross-profile leak in single-process multi-profile desktop runtime).  When a
-# test has monkeypatched the constant away from its import-time default, that
-# override wins (preserves the existing test seam).
+# Import-time default. Tests monkeypatch this; the get_*_cache_dir() getters
+# re-resolve per call so the active profile override is honored.
 IMAGE_CACHE_DIR = get_hermes_dir("cache/images", "image_cache")
 
 
 def _resolve_cache_dir(constant_name: str, new_subpath: str, old_name: str) -> Path:
-    """Resolve a cache dir, honoring profile override and test monkeypatches.
-
-    Precedence:
-      1. If the module constant ``constant_name`` was monkeypatched away from
-         its import-time default, return the patched value (test seam).
-      2. Otherwise resolve fresh via ``get_hermes_dir`` so the active profile's
-         ``set_hermes_home_override`` is reflected per-call.
-    """
+    """Resolve fresh via get_hermes_dir (active profile), unless a test has
+    monkeypatched the constant away from its import-time default."""
     fresh = get_hermes_dir(new_subpath, old_name)
     current = globals().get(constant_name)
     default = _CACHE_DIR_IMPORT_DEFAULTS.get(constant_name)
     if current is not None and default is not None and current != default:
-        # A test (or caller) replaced the module constant — respect it.
         return Path(current)
     return fresh
 
@@ -968,10 +951,8 @@ def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
 DOCUMENT_CACHE_DIR = get_hermes_dir("cache/documents", "document_cache")
 SCREENSHOT_CACHE_DIR = get_hermes_dir("cache/screenshots", "browser_screenshots")
 
-# Import-time defaults for the cache-dir constants.  ``_resolve_cache_dir``
-# compares the live module value against these to detect a test monkeypatch
-# (in which case the patched value wins) vs. an unmodified constant (in which
-# case it re-resolves through the active profile override).
+# Import-time defaults; _resolve_cache_dir compares against these to tell a
+# test monkeypatch from an unmodified constant.
 _CACHE_DIR_IMPORT_DEFAULTS = {
     "IMAGE_CACHE_DIR": IMAGE_CACHE_DIR,
     "AUDIO_CACHE_DIR": AUDIO_CACHE_DIR,

--- a/gateway/rich_sent_store.py
+++ b/gateway/rich_sent_store.py
@@ -25,11 +25,9 @@ _MAX_TEXT_CHARS = 2000
 
 
 def _store_path() -> str:
-    # Resolve through get_hermes_home() so the context-local profile override
-    # (set_hermes_home_override) is honored.  Reading os.environ["HERMES_HOME"]
-    # directly bypassed the override and leaked every profile's rich-sent index
-    # into the launch/default profile in single-process multi-profile runtimes
-    # (desktop tui_gateway).
+    # Resolve via get_hermes_home() so the profile override is honored; reading
+    # os.environ["HERMES_HOME"] directly bypassed it and leaked the index into
+    # the launch profile (multi-profile tui_gateway / gateway).
     from hermes_constants import get_hermes_home
 
     home = get_hermes_home()

--- a/gateway/rich_sent_store.py
+++ b/gateway/rich_sent_store.py
@@ -25,9 +25,7 @@ _MAX_TEXT_CHARS = 2000
 
 
 def _store_path() -> str:
-    # Resolve via get_hermes_home() so the profile override is honored; reading
-    # os.environ["HERMES_HOME"] directly bypassed it and leaked the index into
-    # the launch profile (multi-profile tui_gateway / gateway).
+    # Resolve via get_hermes_home() so the active profile override is honored.
     from hermes_constants import get_hermes_home
 
     home = get_hermes_home()

--- a/gateway/rich_sent_store.py
+++ b/gateway/rich_sent_store.py
@@ -25,8 +25,15 @@ _MAX_TEXT_CHARS = 2000
 
 
 def _store_path() -> str:
-    home = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
-    return os.path.join(home, "state", "rich_sent_index.json")
+    # Resolve through get_hermes_home() so the context-local profile override
+    # (set_hermes_home_override) is honored.  Reading os.environ["HERMES_HOME"]
+    # directly bypassed the override and leaked every profile's rich-sent index
+    # into the launch/default profile in single-process multi-profile runtimes
+    # (desktop tui_gateway).
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    return os.path.join(str(home), "state", "rich_sent_index.json")
 
 
 def _key(chat_id, message_id) -> str:

--- a/model_tools.py
+++ b/model_tools.py
@@ -144,12 +144,9 @@ def _run_async(coro):
                 worker_loop.close()
 
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        # Propagate the parent thread's ContextVars (notably the
-        # _HERMES_HOME_OVERRIDE profile scope) and approval/sudo callbacks into
-        # the worker thread.  Without this, any async tool that resolves
-        # get_hermes_home() inside its coroutine falls back to the launch/default
-        # profile in single-process multi-profile runtimes (desktop tui_gateway),
-        # leaking one profile's reads/writes into another.
+        # Propagate the profile override + approval/sudo callbacks into the
+        # worker so async tools resolving get_hermes_home() see the active
+        # profile, not the launch one (multi-profile tui_gateway / gateway).
         from tools.thread_context import propagate_context_to_thread
 
         future = pool.submit(propagate_context_to_thread(_run_in_worker))

--- a/model_tools.py
+++ b/model_tools.py
@@ -144,7 +144,15 @@ def _run_async(coro):
                 worker_loop.close()
 
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        future = pool.submit(_run_in_worker)
+        # Propagate the parent thread's ContextVars (notably the
+        # _HERMES_HOME_OVERRIDE profile scope) and approval/sudo callbacks into
+        # the worker thread.  Without this, any async tool that resolves
+        # get_hermes_home() inside its coroutine falls back to the launch/default
+        # profile in single-process multi-profile runtimes (desktop tui_gateway),
+        # leaking one profile's reads/writes into another.
+        from tools.thread_context import propagate_context_to_thread
+
+        future = pool.submit(propagate_context_to_thread(_run_in_worker))
         try:
             return future.result(timeout=300)
         except concurrent.futures.TimeoutError:

--- a/model_tools.py
+++ b/model_tools.py
@@ -144,9 +144,8 @@ def _run_async(coro):
                 worker_loop.close()
 
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        # Propagate the profile override + approval/sudo callbacks into the
-        # worker so async tools resolving get_hermes_home() see the active
-        # profile, not the launch one (multi-profile tui_gateway / gateway).
+        # Carry the active profile + approval/sudo callbacks into the worker so
+        # async tools resolve get_hermes_home() under the active profile.
         from tools.thread_context import propagate_context_to_thread
 
         future = pool.submit(propagate_context_to_thread(_run_in_worker))

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -272,10 +272,6 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     cache_image_from_url,
     cache_audio_from_url,
-    IMAGE_CACHE_DIR,
-    AUDIO_CACHE_DIR,
-    VIDEO_CACHE_DIR,
-    DOCUMENT_CACHE_DIR,
 )
 from utils import env_int
 
@@ -296,7 +292,23 @@ def _is_allowed_bridge_path(url: str) -> bool:
         resolved = Path(url).resolve()
     except (OSError, ValueError):
         return False
-    for root in (IMAGE_CACHE_DIR, AUDIO_CACHE_DIR, VIDEO_CACHE_DIR, DOCUMENT_CACHE_DIR):
+    # Resolve the cache roots per-call via the getters (not the import-time
+    # constants) so this validator follows the active profile override; under a
+    # profile override the inbound bridge writes media into that profile's
+    # cache, which the frozen constants would not match.
+    from gateway.platforms.base import (
+        get_audio_cache_dir,
+        get_document_cache_dir,
+        get_image_cache_dir,
+        get_video_cache_dir,
+    )
+
+    for root in (
+        get_image_cache_dir(),
+        get_audio_cache_dir(),
+        get_video_cache_dir(),
+        get_document_cache_dir(),
+    ):
         try:
             if resolved.is_relative_to(Path(root).resolve()):
                 return True

--- a/run_agent.py
+++ b/run_agent.py
@@ -1525,13 +1525,22 @@ class AIAgent:
         keep working.
         """
         from agent.background_review import spawn_background_review_thread
+        from tools.thread_context import propagate_context_to_thread
         target, _prompt = spawn_background_review_thread(
             self,
             messages_snapshot,
             review_memory=review_memory,
             review_skills=review_skills,
         )
-        t = threading.Thread(target=target, daemon=True, name="bg-review")
+        # Propagate the spawning turn's ContextVars (notably the
+        # _HERMES_HOME_OVERRIDE profile scope) into the review thread.  A bare
+        # threading.Thread starts with an empty context, so the review would
+        # resolve get_hermes_home() to the launch/default profile and write
+        # MEMORY.md / skill review into the wrong profile in single-process
+        # multi-profile runtimes (desktop tui_gateway) — see #54937.
+        t = threading.Thread(
+            target=propagate_context_to_thread(target), daemon=True, name="bg-review"
+        )
         t.start()
 
     def _build_memory_write_metadata(

--- a/run_agent.py
+++ b/run_agent.py
@@ -1532,8 +1532,8 @@ class AIAgent:
             review_memory=review_memory,
             review_skills=review_skills,
         )
-        # Propagate the profile override into the review thread, else it writes
-        # MEMORY.md / skill review into the launch profile (#54937).
+        # Carry the active profile into the review thread so MEMORY.md / skill
+        # review writes land in the right profile (#54937).
         t = threading.Thread(
             target=propagate_context_to_thread(target), daemon=True, name="bg-review"
         )

--- a/run_agent.py
+++ b/run_agent.py
@@ -1532,12 +1532,8 @@ class AIAgent:
             review_memory=review_memory,
             review_skills=review_skills,
         )
-        # Propagate the spawning turn's ContextVars (notably the
-        # _HERMES_HOME_OVERRIDE profile scope) into the review thread.  A bare
-        # threading.Thread starts with an empty context, so the review would
-        # resolve get_hermes_home() to the launch/default profile and write
-        # MEMORY.md / skill review into the wrong profile in single-process
-        # multi-profile runtimes (desktop tui_gateway) — see #54937.
+        # Propagate the profile override into the review thread, else it writes
+        # MEMORY.md / skill review into the launch profile (#54937).
         t = threading.Thread(
             target=propagate_context_to_thread(target), daemon=True, name="bg-review"
         )

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -7,6 +7,8 @@ multiplex mode fails closed instead of leaking.
 """
 import pytest
 
+from pathlib import Path
+
 from agent import secret_scope as ss
 
 
@@ -86,3 +88,71 @@ class TestMcpInterpolationUsesScope:
         monkeypatch.setenv("MY_MCP_TOKEN", "env-token")
         # multiplex off: legacy os.environ resolution
         assert _interpolate_env_vars("${MY_MCP_TOKEN}") == "env-token"
+
+
+class TestProfilePathResolutionUnderMultiplexScope:
+    """Profile-scoped paths must follow the per-turn _profile_runtime_scope.
+
+    The multiplexed gateway (gateway.multiplex_profiles) serves every profile
+    from ONE process, scoping each inbound turn with _profile_runtime_scope —
+    the same in-process-many-profiles topology as the desktop tui_gateway. The
+    profile-isolation fixes (per-call path resolution + thread context
+    propagation) must therefore hold under THIS scope too, not just desktop.
+    This is the regression guard proving reachability is not desktop-only.
+    """
+
+    def _profiles(self, tmp_path):
+        prof_a = tmp_path / "profA"
+        prof_b = tmp_path / "profB"
+        for p in (prof_a, prof_b):
+            (p / "skills").mkdir(parents=True, exist_ok=True)
+            (p / "state").mkdir(parents=True, exist_ok=True)
+        return prof_a, prof_b
+
+    def test_skills_dir_follows_multiplex_scope(self, tmp_path):
+        from gateway.run import _profile_runtime_scope
+        import tools.skills_hub as sh
+
+        prof_a, prof_b = self._profiles(tmp_path)
+        with _profile_runtime_scope(prof_a):
+            a_seen = Path(sh.SKILLS_DIR)
+        with _profile_runtime_scope(prof_b):
+            b_seen = Path(sh.SKILLS_DIR)
+
+        assert a_seen == prof_a / "skills"
+        assert b_seen == prof_b / "skills"
+
+    def test_cache_dir_follows_multiplex_scope(self, tmp_path):
+        from gateway.run import _profile_runtime_scope
+        import gateway.platforms.base as gb
+
+        _prof_a, prof_b = self._profiles(tmp_path)
+        with _profile_runtime_scope(prof_b):
+            seen = gb.get_image_cache_dir()
+        assert str(seen).startswith(str(prof_b))
+
+    def test_worker_thread_inherits_multiplex_scope(self, tmp_path):
+        """A wrapped worker spawned inside the scope must see the right profile.
+
+        The _profile_runtime_scope docstring relies on copy_context() carrying
+        the override into the agent worker thread; this proves the M2 fix
+        primitive delivers that under the multiplexer's scope.
+        """
+        import threading
+
+        from gateway.run import _profile_runtime_scope
+        from hermes_constants import get_hermes_home
+        from tools.thread_context import propagate_context_to_thread
+
+        _prof_a, prof_b = self._profiles(tmp_path)
+        seen = {}
+
+        def worker():
+            seen["home"] = str(get_hermes_home())
+
+        with _profile_runtime_scope(prof_b):
+            t = threading.Thread(target=propagate_context_to_thread(worker))
+            t.start()
+            t.join()
+
+        assert seen["home"] == str(prof_b)

--- a/tests/gateway/test_whatsapp_media_path_profile.py
+++ b/tests/gateway/test_whatsapp_media_path_profile.py
@@ -1,0 +1,67 @@
+"""Regression: the WhatsApp inbound-media path validator follows the active
+profile override.
+
+The bridge writes inbound media into the active profile's cache (resolved via
+get_image_cache_dir() etc.). _is_allowed_bridge_path() validates those paths.
+It previously checked against IMAGE_CACHE_DIR / AUDIO_CACHE_DIR module
+constants value-imported at import time, so under a profile override the
+validator rejected media the bridge had legitimately written into the override
+profile's cache. The validator must resolve the cache roots per-call.
+"""
+from pathlib import Path
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _make_profile(root: Path) -> Path:
+    for sub in ("cache/images", "cache/audio", "cache/videos", "cache/documents"):
+        (root / sub).mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def test_validator_accepts_active_profile_media(tmp_path):
+    from plugins.platforms.whatsapp.adapter import _is_allowed_bridge_path
+
+    prof = _make_profile(tmp_path / "profB")
+    media = prof / "cache" / "images" / "img_abc.jpg"
+    media.write_bytes(b"\xff\xd8\xff\x00")
+
+    token = set_hermes_home_override(str(prof))
+    try:
+        assert _is_allowed_bridge_path(str(media)) is True
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_validator_follows_override_switch(tmp_path):
+    """A path under profile A is rejected while the override is profile B."""
+    from plugins.platforms.whatsapp.adapter import _is_allowed_bridge_path
+
+    prof_a = _make_profile(tmp_path / "profA")
+    prof_b = _make_profile(tmp_path / "profB")
+    a_media = prof_a / "cache" / "images" / "img_a.jpg"
+    a_media.write_bytes(b"\xff\xd8\xff\x00")
+
+    # Under B, B's own media validates...
+    b_media = prof_b / "cache" / "images" / "img_b.jpg"
+    b_media.write_bytes(b"\xff\xd8\xff\x00")
+    token = set_hermes_home_override(str(prof_b))
+    try:
+        assert _is_allowed_bridge_path(str(b_media)) is True
+        # ...and a path from a *different* profile is not in B's cache roots.
+        assert _is_allowed_bridge_path(str(a_media)) is False
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_validator_rejects_non_cache_path(tmp_path):
+    from plugins.platforms.whatsapp.adapter import _is_allowed_bridge_path
+
+    prof = _make_profile(tmp_path / "profB")
+    outside = tmp_path / "etc_passwd"
+    outside.write_text("root:x:0:0")
+    token = set_hermes_home_override(str(prof))
+    try:
+        assert _is_allowed_bridge_path(str(outside)) is False
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -156,3 +156,74 @@ def test_background_review_agent_tools_are_limited():
     assert "delegate_task" not in expected_tools
     assert "web_search" not in expected_tools
     assert "execute_code" not in expected_tools
+
+
+def test_background_review_excludes_memory_when_disabled():
+    """A memory-disabled profile must NOT get the memory tool in the review fork.
+
+    Regression for #54937 layer 2: the whitelist hardcoded ["memory", "skills"],
+    so a skill-review fork on a profile with memory_enabled=false still granted
+    the LLM the MEMORY.md read/write tool, contaminating a profile that opted
+    out of built-in memory. The whitelist must gate "memory" on the flag.
+    """
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        raise RuntimeError("stop after capturing whitelist")
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    agent._memory_enabled = False
+    agent._user_profile_enabled = False
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=False,
+            review_skills=True,
+        )
+
+    whitelist = captured["whitelist"]
+    # Skill tools still allowed...
+    assert "skill_manage" in whitelist
+    assert "skill_view" in whitelist
+    # ...but the built-in memory tool must be gated out.
+    assert "memory" not in whitelist
+
+
+def test_background_review_includes_memory_when_user_profile_enabled():
+    """user_profile_enabled alone (USER.md) still needs the memory tool."""
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        raise RuntimeError("stop after capturing whitelist")
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    agent._memory_enabled = False
+    agent._user_profile_enabled = True
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert "memory" in captured["whitelist"]

--- a/tests/test_profile_isolation_runtime.py
+++ b/tests/test_profile_isolation_runtime.py
@@ -1,0 +1,207 @@
+"""Profile-isolation regression tests for single-process multi-profile runtimes.
+
+In runtimes that serve every profile from one OS process (the desktop
+``tui_gateway``), the profile boundary is the context-local
+``_HERMES_HOME_OVERRIDE`` ContextVar, not the process environment.  State that
+escapes the request call stack — import-time-frozen path constants, direct
+``os.environ`` reads, or worker threads that don't inherit the request context —
+silently reverts to the launch/default profile and leaks one profile's data
+into another.
+
+These tests drive each previously-leaking site under override A then override B
+with real temp HERMES_HOME directories (no mocks) and assert the *active*
+profile's path is used.  They are the productionized form of the manual smoke
+probes used to confirm the bug class.
+"""
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+
+
+@pytest.fixture
+def two_profiles(tmp_path):
+    """Two distinct profile HERMES_HOME dirs with the dir skeleton created."""
+    prof_a = tmp_path / "profA"
+    prof_b = tmp_path / "profB"
+    for p in (prof_a, prof_b):
+        (p / "skills").mkdir(parents=True, exist_ok=True)
+        (p / "state").mkdir(parents=True, exist_ok=True)
+        (p / "cache").mkdir(parents=True, exist_ok=True)
+    return prof_a, prof_b
+
+
+def _under_override(home: Path, fn):
+    """Run ``fn`` with the profile override set to ``home`` and reset after."""
+    token = set_hermes_home_override(str(home))
+    try:
+        return fn()
+    finally:
+        reset_hermes_home_override(token)
+
+
+# ---------------------------------------------------------------------------
+# M1 — import-time path globals / direct os.environ reads
+# ---------------------------------------------------------------------------
+
+class TestSkillsHubPathResolution:
+    """tools/skills_hub.py path constants must reflect the active profile."""
+
+    def test_skills_dir_follows_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import tools.skills_hub as sh
+
+        # Importing/touching under A must NOT pin the path for B.
+        a_seen = _under_override(prof_a, lambda: Path(sh.SKILLS_DIR))
+        b_seen = _under_override(prof_b, lambda: Path(sh.SKILLS_DIR))
+
+        assert a_seen == prof_a / "skills"
+        assert b_seen == prof_b / "skills"
+        assert a_seen != b_seen
+
+    def test_hub_derived_paths_follow_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import tools.skills_hub as sh
+
+        b_lock = _under_override(prof_b, lambda: Path(sh.LOCK_FILE))
+        b_audit = _under_override(prof_b, lambda: Path(sh.AUDIT_LOG))
+        b_index = _under_override(prof_b, lambda: Path(sh.INDEX_CACHE_DIR))
+
+        assert b_lock == prof_b / "skills" / ".hub" / "lock.json"
+        assert b_audit == prof_b / "skills" / ".hub" / "audit.log"
+        assert b_index == prof_b / "skills" / ".hub" / "index-cache"
+
+    def test_lockfile_default_arg_resolves_active_profile(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        from tools.skills_hub import HubLockFile, TapsManager
+
+        lock_b = _under_override(prof_b, lambda: HubLockFile())
+        taps_b = _under_override(prof_b, lambda: TapsManager())
+
+        assert lock_b.path == prof_b / "skills" / ".hub" / "lock.json"
+        assert taps_b.path == prof_b / "skills" / ".hub" / "taps.json"
+
+
+class TestGatewayCacheDirResolution:
+    """gateway/platforms/base.py cache getters must follow the active profile."""
+
+    def test_image_cache_dir_follows_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import gateway.platforms.base as gb
+
+        a_seen = _under_override(prof_a, lambda: gb.get_image_cache_dir())
+        b_seen = _under_override(prof_b, lambda: gb.get_image_cache_dir())
+
+        assert str(a_seen).startswith(str(prof_a))
+        assert str(b_seen).startswith(str(prof_b))
+        assert a_seen != b_seen
+
+    def test_all_cache_getters_follow_override(self, two_profiles):
+        _prof_a, prof_b = two_profiles
+        import gateway.platforms.base as gb
+
+        getters = (
+            gb.get_image_cache_dir,
+            gb.get_audio_cache_dir,
+            gb.get_video_cache_dir,
+            gb.get_document_cache_dir,
+        )
+        for getter in getters:
+            seen = _under_override(prof_b, getter)
+            assert str(seen).startswith(str(prof_b)), f"{getter.__name__} leaked: {seen}"
+
+    def test_monkeypatched_constant_still_wins(self, two_profiles, monkeypatch, tmp_path):
+        """The existing test seam (monkeypatch the module constant) is preserved."""
+        _prof_a, _prof_b = two_profiles
+        import gateway.platforms.base as gb
+
+        forced = tmp_path / "forced_img"
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", forced)
+        # Even with an active override, an explicit monkeypatch takes precedence.
+        seen = _under_override(_prof_b, lambda: gb.get_image_cache_dir())
+        assert seen == forced
+
+
+class TestRichSentStorePathResolution:
+    """gateway/rich_sent_store.py must honor the override, not read os.environ."""
+
+    def test_store_path_follows_override(self, two_profiles, monkeypatch):
+        prof_a, prof_b = two_profiles
+        # Ensure no ambient HERMES_HOME env masks the test.
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        import gateway.rich_sent_store as rss
+
+        b_seen = _under_override(prof_b, lambda: rss._store_path())
+        assert b_seen.startswith(str(prof_b))
+        assert b_seen.endswith("state/rich_sent_index.json")
+
+
+# ---------------------------------------------------------------------------
+# M2 — thread / executor context propagation
+# ---------------------------------------------------------------------------
+
+class TestThreadContextPropagation:
+    """Worker threads must inherit the spawning turn's profile override."""
+
+    def test_raw_thread_loses_override(self, two_profiles):
+        """Document the underlying hazard: a bare thread does NOT inherit it."""
+        _prof_a, prof_b = two_profiles
+        seen = {}
+
+        def worker():
+            seen["home"] = str(get_hermes_home())
+
+        def run():
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+
+        _under_override(prof_b, run)
+        # A bare thread falls back to the process default — this is WHY the fix
+        # primitive is needed.  (Asserted as the hazard, not the desired state.)
+        assert seen["home"] != str(prof_b)
+
+    def test_propagate_primitive_preserves_override(self, two_profiles):
+        _prof_a, prof_b = two_profiles
+        from tools.thread_context import propagate_context_to_thread
+
+        seen = {}
+
+        def worker():
+            seen["home"] = str(get_hermes_home())
+
+        def run():
+            t = threading.Thread(target=propagate_context_to_thread(worker))
+            t.start()
+            t.join()
+
+        _under_override(prof_b, run)
+        assert seen["home"] == str(prof_b)
+
+    def test_run_async_worker_preserves_override(self, two_profiles):
+        """model_tools._run_async's worker-thread branch must keep the override.
+
+        This is the generic sync->async bridge for every async tool; if it
+        leaks, every async tool that resolves get_hermes_home() leaks.
+        """
+        import asyncio
+
+        _prof_a, prof_b = two_profiles
+        import model_tools
+
+        async def reads_home():
+            return str(get_hermes_home())
+
+        async def driver():
+            # Inside a running loop, _run_async spawns a worker thread + loop.
+            return model_tools._run_async(reads_home())
+
+        seen = _under_override(prof_b, lambda: asyncio.run(driver()))
+        assert seen == str(prof_b)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -45,6 +45,8 @@ from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures.thread import _worker
 from typing import Any, Callable, Dict, List, Optional
 
+from tools.thread_context import propagate_context_to_thread
+
 logger = logging.getLogger(__name__)
 
 
@@ -247,7 +249,11 @@ def dispatch_async_delegation(
             _finalize(delegation_id, result, status)
 
     try:
-        executor.submit(_worker)
+        # Capture the dispatching turn's ContextVars (notably the
+        # _HERMES_HOME_OVERRIDE profile scope) so the detached child resolves
+        # get_hermes_home() under the right profile in single-process
+        # multi-profile runtimes (desktop tui_gateway).
+        executor.submit(propagate_context_to_thread(_worker))
     except Exception as exc:  # pragma: no cover — pool submit failure is rare
         with _records_lock:
             _records.pop(delegation_id, None)
@@ -432,7 +438,10 @@ def dispatch_async_delegation_batch(
             _finalize_batch(delegation_id, combined, status)
 
     try:
-        executor.submit(_worker)
+        # Capture the dispatching turn's ContextVars (notably the
+        # _HERMES_HOME_OVERRIDE profile scope) so the detached batch children
+        # resolve get_hermes_home() under the right profile.
+        executor.submit(propagate_context_to_thread(_worker))
     except Exception as exc:  # pragma: no cover
         with _records_lock:
             _records.pop(delegation_id, None)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -249,10 +249,8 @@ def dispatch_async_delegation(
             _finalize(delegation_id, result, status)
 
     try:
-        # Capture the dispatching turn's ContextVars (notably the
-        # _HERMES_HOME_OVERRIDE profile scope) so the detached child resolves
-        # get_hermes_home() under the right profile in single-process
-        # multi-profile runtimes (desktop tui_gateway).
+        # Propagate the dispatching profile so the detached child resolves
+        # get_hermes_home() under the right profile.
         executor.submit(propagate_context_to_thread(_worker))
     except Exception as exc:  # pragma: no cover — pool submit failure is rare
         with _records_lock:
@@ -438,9 +436,7 @@ def dispatch_async_delegation_batch(
             _finalize_batch(delegation_id, combined, status)
 
     try:
-        # Capture the dispatching turn's ContextVars (notably the
-        # _HERMES_HOME_OVERRIDE profile scope) so the detached batch children
-        # resolve get_hermes_home() under the right profile.
+        # Propagate the dispatching profile to the detached batch children.
         executor.submit(propagate_context_to_thread(_worker))
     except Exception as exc:  # pragma: no cover
         with _records_lock:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -46,18 +46,78 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
+#
+# These directories MUST resolve through ``get_hermes_home()`` on every access
+# so the context-local profile override (``set_hermes_home_override``) is
+# honored.  Freezing them as module-level constants at import time pinned every
+# later profile to whichever profile first imported this module — a cross-
+# profile data leak in single-process multi-profile runtimes (desktop
+# ``tui_gateway``).  See the profile-isolation fix.
+#
+# Backward compatibility: external callers do ``from tools.skills_hub import
+# SKILLS_DIR`` (always inside a function body, re-evaluated per call).  The
+# module-level ``__getattr__`` below makes those names resolve dynamically, so
+# no external call site needs to change.
 
-HERMES_HOME = get_hermes_home()
-SKILLS_DIR = HERMES_HOME / "skills"
-HUB_DIR = SKILLS_DIR / ".hub"
-LOCK_FILE = HUB_DIR / "lock.json"
-QUARANTINE_DIR = HUB_DIR / "quarantine"
-AUDIT_LOG = HUB_DIR / "audit.log"
-TAPS_FILE = HUB_DIR / "taps.json"
-INDEX_CACHE_DIR = HUB_DIR / "index-cache"
+INDEX_CACHE_TTL = 3600  # 1 hour  (defined early; referenced below)
 
-# Cache duration for remote index fetches
-INDEX_CACHE_TTL = 3600  # 1 hour
+
+def _hermes_home() -> Path:
+    return get_hermes_home()
+
+
+def _skills_dir() -> Path:
+    return _hermes_home() / "skills"
+
+
+def _hub_dir() -> Path:
+    return _skills_dir() / ".hub"
+
+
+def _lock_file() -> Path:
+    return _hub_dir() / "lock.json"
+
+
+def _quarantine_dir() -> Path:
+    return _hub_dir() / "quarantine"
+
+
+def _audit_log() -> Path:
+    return _hub_dir() / "audit.log"
+
+
+def _taps_file() -> Path:
+    return _hub_dir() / "taps.json"
+
+
+def _index_cache_dir() -> Path:
+    return _hub_dir() / "index-cache"
+
+
+_DYNAMIC_PATH_RESOLVERS = {
+    "HERMES_HOME": _hermes_home,
+    "SKILLS_DIR": _skills_dir,
+    "HUB_DIR": _hub_dir,
+    "LOCK_FILE": _lock_file,
+    "QUARANTINE_DIR": _quarantine_dir,
+    "AUDIT_LOG": _audit_log,
+    "TAPS_FILE": _taps_file,
+    "INDEX_CACHE_DIR": _index_cache_dir,
+}
+
+
+def __getattr__(name: str):
+    """Resolve the legacy path constants dynamically per access.
+
+    PEP 562 module ``__getattr__``: only called for names NOT found as real
+    module attributes, so it does not slow down ordinary lookups.  This lets
+    ``tools.skills_hub.SKILLS_DIR`` (and the rest) reflect the active profile
+    override instead of an import-time snapshot.
+    """
+    resolver = _DYNAMIC_PATH_RESOLVERS.get(name)
+    if resolver is not None:
+        return resolver()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 _REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
 _MAX_SKILL_FETCH_REDIRECTS = 5
@@ -176,9 +236,10 @@ def _resolve_lock_install_path(install_path: str, skill_name: str) -> Path:
        and ``rmtree(SKILLS_DIR)`` would wipe every installed skill.
     """
     normalized = _normalize_lock_install_path(install_path, skill_name)
-    skills_root = SKILLS_DIR.resolve()
+    skills_dir = _skills_dir()
+    skills_root = skills_dir.resolve()
 
-    target = SKILLS_DIR
+    target = skills_dir
     for part in normalized.split("/"):
         target = target / part
         if _is_path_redirect(target):
@@ -973,7 +1034,7 @@ class GitHubSource(SkillSource):
 
     def _read_cache(self, key: str) -> Optional[list]:
         """Read cached index if not expired."""
-        cache_file = INDEX_CACHE_DIR / f"{key}.json"
+        cache_file = _index_cache_dir() / f"{key}.json"
         if not cache_file.exists():
             return None
         try:
@@ -986,8 +1047,9 @@ class GitHubSource(SkillSource):
 
     def _write_cache(self, key: str, data: list) -> None:
         """Write index data to cache."""
-        INDEX_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-        cache_file = INDEX_CACHE_DIR / f"{key}.json"
+        index_cache_dir = _index_cache_dir()
+        index_cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = index_cache_dir / f"{key}.json"
         try:
             cache_file.write_text(json.dumps(data, ensure_ascii=False))
         except OSError as e:
@@ -3157,7 +3219,7 @@ class OptionalSkillSource(SkillSource):
 
 def _read_index_cache(key: str) -> Optional[Any]:
     """Read cached data if not expired."""
-    cache_file = INDEX_CACHE_DIR / f"{key}.json"
+    cache_file = _index_cache_dir() / f"{key}.json"
     if not cache_file.exists():
         return None
     try:
@@ -3171,17 +3233,18 @@ def _read_index_cache(key: str) -> Optional[Any]:
 
 def _write_index_cache(key: str, data: Any) -> None:
     """Write data to cache."""
-    INDEX_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    index_cache_dir = _index_cache_dir()
+    index_cache_dir.mkdir(parents=True, exist_ok=True)
     # Ensure .ignore exists so ripgrep (and tools respecting .ignore) skip
     # this directory.  Cache files contain unvetted community content that
     # could include adversarial text (prompt injection via catalog entries).
-    ignore_file = HUB_DIR / ".ignore"
+    ignore_file = _hub_dir() / ".ignore"
     if not ignore_file.exists():
         try:
             ignore_file.write_text("# Exclude hub internals from search tools\n*\n")
         except OSError:
             pass
-    cache_file = INDEX_CACHE_DIR / f"{key}.json"
+    cache_file = index_cache_dir / f"{key}.json"
     try:
         cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str))
     except OSError as e:
@@ -3210,8 +3273,8 @@ def _skill_meta_to_dict(meta: SkillMeta) -> dict:
 class HubLockFile:
     """Manages skills/.hub/lock.json — tracks provenance of installed hub skills."""
 
-    def __init__(self, path: Path = LOCK_FILE):
-        self.path = path
+    def __init__(self, path: Optional[Path] = None):
+        self.path = path if path is not None else _lock_file()
 
     def load(self) -> dict:
         if not self.path.exists():
@@ -3282,8 +3345,8 @@ class HubLockFile:
 class TapsManager:
     """Manages the taps.json file — custom GitHub repo sources."""
 
-    def __init__(self, path: Path = TAPS_FILE):
-        self.path = path
+    def __init__(self, path: Optional[Path] = None):
+        self.path = path if path is not None else _taps_file()
 
     def load(self) -> List[dict]:
         if not self.path.exists():
@@ -3327,14 +3390,15 @@ class TapsManager:
 def append_audit_log(action: str, skill_name: str, source: str,
                      trust_level: str, verdict: str, extra: str = "") -> None:
     """Append a line to the audit log."""
-    AUDIT_LOG.parent.mkdir(parents=True, exist_ok=True)
+    audit_log = _audit_log()
+    audit_log.parent.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     parts = [timestamp, action, skill_name, f"{source}:{trust_level}", verdict]
     if extra:
         parts.append(extra)
     line = " ".join(parts) + "\n"
     try:
-        with open(AUDIT_LOG, "a", encoding="utf-8") as f:
+        with open(audit_log, "a", encoding="utf-8") as f:
             f.write(line)
     except OSError as e:
         logger.debug("Could not write audit log: %s", e)
@@ -3346,15 +3410,19 @@ def append_audit_log(action: str, skill_name: str, source: str,
 
 def ensure_hub_dirs() -> None:
     """Create the .hub directory structure if it doesn't exist."""
-    HUB_DIR.mkdir(parents=True, exist_ok=True)
-    QUARANTINE_DIR.mkdir(exist_ok=True)
-    INDEX_CACHE_DIR.mkdir(exist_ok=True)
-    if not LOCK_FILE.exists():
-        LOCK_FILE.write_text('{"version": 1, "installed": {}}\n')
-    if not AUDIT_LOG.exists():
-        AUDIT_LOG.touch()
-    if not TAPS_FILE.exists():
-        TAPS_FILE.write_text('{"taps": []}\n')
+    hub_dir = _hub_dir()
+    lock_file = _lock_file()
+    audit_log = _audit_log()
+    taps_file = _taps_file()
+    hub_dir.mkdir(parents=True, exist_ok=True)
+    _quarantine_dir().mkdir(exist_ok=True)
+    _index_cache_dir().mkdir(exist_ok=True)
+    if not lock_file.exists():
+        lock_file.write_text('{"version": 1, "installed": {}}\n')
+    if not audit_log.exists():
+        audit_log.touch()
+    if not taps_file.exists():
+        taps_file.write_text('{"taps": []}\n')
 
 
 def quarantine_bundle(bundle: SkillBundle) -> Path:
@@ -3366,7 +3434,7 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
         safe_rel_path = _validate_bundle_rel_path(rel_path)
         validated_files.append((safe_rel_path, file_content))
 
-    dest = QUARANTINE_DIR / skill_name
+    dest = _quarantine_dir() / skill_name
     if dest.exists():
         shutil.rmtree(dest)
     dest.mkdir(parents=True)
@@ -3393,7 +3461,7 @@ def install_from_quarantine(
     safe_skill_name = _validate_skill_name(skill_name)
     safe_category = _validate_install_parent_path(category) if category else ""
     quarantine_resolved = quarantine_path.resolve()
-    quarantine_root = QUARANTINE_DIR.resolve()
+    quarantine_root = _quarantine_dir().resolve()
     if not quarantine_resolved.is_relative_to(quarantine_root):
         raise ValueError(f"Unsafe quarantine path: {quarantine_path}")
 
@@ -3453,7 +3521,7 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(SKILLS_DIR)),
+        install_path=str(install_dir.relative_to(_skills_dir())),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
     )
@@ -3582,8 +3650,11 @@ def check_for_skill_updates(
 # ---------------------------------------------------------------------------
 
 HERMES_INDEX_URL = "https://hermes-agent.nousresearch.com/docs/api/skills-index.json"
-HERMES_INDEX_CACHE_FILE = INDEX_CACHE_DIR / "hermes-index.json"
 HERMES_INDEX_TTL = 6 * 3600  # 6 hours
+
+
+def _hermes_index_cache_file() -> Path:
+    return _index_cache_dir() / "hermes-index.json"
 
 
 def _load_hermes_index() -> Optional[dict]:
@@ -3594,11 +3665,12 @@ def _load_hermes_index() -> Optional[dict]:
     downloads within a session.
     """
     # Check local cache
-    if HERMES_INDEX_CACHE_FILE.exists():
+    hermes_index_cache_file = _hermes_index_cache_file()
+    if hermes_index_cache_file.exists():
         try:
-            age = time.time() - HERMES_INDEX_CACHE_FILE.stat().st_mtime
+            age = time.time() - hermes_index_cache_file.stat().st_mtime
             if age < HERMES_INDEX_TTL:
-                return json.loads(HERMES_INDEX_CACHE_FILE.read_text())
+                return json.loads(hermes_index_cache_file.read_text())
         except (OSError, json.JSONDecodeError):
             pass
 
@@ -3619,8 +3691,8 @@ def _load_hermes_index() -> Optional[dict]:
 
     # Cache locally
     try:
-        HERMES_INDEX_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        HERMES_INDEX_CACHE_FILE.write_text(json.dumps(data))
+        hermes_index_cache_file.parent.mkdir(parents=True, exist_ok=True)
+        hermes_index_cache_file.write_text(json.dumps(data))
     except OSError:
         pass
 
@@ -3629,9 +3701,10 @@ def _load_hermes_index() -> Optional[dict]:
 
 def _load_stale_index_cache() -> Optional[dict]:
     """Fall back to stale cache when the network fetch fails."""
-    if HERMES_INDEX_CACHE_FILE.exists():
+    hermes_index_cache_file = _hermes_index_cache_file()
+    if hermes_index_cache_file.exists():
         try:
-            return json.loads(HERMES_INDEX_CACHE_FILE.read_text())
+            return json.loads(hermes_index_cache_file.read_text())
         except (OSError, json.JSONDecodeError):
             pass
     return None

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -62,36 +62,55 @@ logger = logging.getLogger(__name__)
 INDEX_CACHE_TTL = 3600  # 1 hour  (defined early; referenced below)
 
 
+# The legacy path names (SKILLS_DIR, HUB_DIR, ...) are not real module
+# attributes — they are synthesized on access by the PEP 562 ``__getattr__``
+# below so they reflect the active profile override.  Tests, however, set them
+# as *real* module attributes via ``patch.object(hub, "SKILLS_DIR", ...)`` /
+# ``monkeypatch.setattr``.  ``_override`` lets each resolver honor such an
+# injected real attribute (the test seam) before falling back to dynamic
+# resolution.  ``globals().get`` returns None when only the __getattr__-backed
+# name exists (no real attribute set), so dynamic resolution wins by default.
+def _override(name: str):
+    return globals().get(name)
+
+
 def _hermes_home() -> Path:
     return get_hermes_home()
 
 
 def _skills_dir() -> Path:
-    return _hermes_home() / "skills"
+    forced = _override("SKILLS_DIR")
+    return Path(forced) if forced is not None else _hermes_home() / "skills"
 
 
 def _hub_dir() -> Path:
-    return _skills_dir() / ".hub"
+    forced = _override("HUB_DIR")
+    return Path(forced) if forced is not None else _skills_dir() / ".hub"
 
 
 def _lock_file() -> Path:
-    return _hub_dir() / "lock.json"
+    forced = _override("LOCK_FILE")
+    return Path(forced) if forced is not None else _hub_dir() / "lock.json"
 
 
 def _quarantine_dir() -> Path:
-    return _hub_dir() / "quarantine"
+    forced = _override("QUARANTINE_DIR")
+    return Path(forced) if forced is not None else _hub_dir() / "quarantine"
 
 
 def _audit_log() -> Path:
-    return _hub_dir() / "audit.log"
+    forced = _override("AUDIT_LOG")
+    return Path(forced) if forced is not None else _hub_dir() / "audit.log"
 
 
 def _taps_file() -> Path:
-    return _hub_dir() / "taps.json"
+    forced = _override("TAPS_FILE")
+    return Path(forced) if forced is not None else _hub_dir() / "taps.json"
 
 
 def _index_cache_dir() -> Path:
-    return _hub_dir() / "index-cache"
+    forced = _override("INDEX_CACHE_DIR")
+    return Path(forced) if forced is not None else _hub_dir() / "index-cache"
 
 
 _DYNAMIC_PATH_RESOLVERS = {
@@ -110,7 +129,8 @@ def __getattr__(name: str):
     """Resolve the legacy path constants dynamically per access.
 
     PEP 562 module ``__getattr__``: only called for names NOT found as real
-    module attributes, so it does not slow down ordinary lookups.  This lets
+    module attributes, so it does not slow down ordinary lookups and a test's
+    ``patch.object``-set real attribute shadows it.  This lets
     ``tools.skills_hub.SKILLS_DIR`` (and the rest) reflect the active profile
     override instead of an import-time snapshot.
     """

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -46,30 +46,16 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
-#
-# These directories MUST resolve through ``get_hermes_home()`` on every access
-# so the context-local profile override (``set_hermes_home_override``) is
-# honored.  Freezing them as module-level constants at import time pinned every
-# later profile to whichever profile first imported this module — a cross-
-# profile data leak in single-process multi-profile runtimes (desktop
-# ``tui_gateway``).  See the profile-isolation fix.
-#
-# Backward compatibility: external callers do ``from tools.skills_hub import
-# SKILLS_DIR`` (always inside a function body, re-evaluated per call).  The
-# module-level ``__getattr__`` below makes those names resolve dynamically, so
-# no external call site needs to change.
+# Resolved per-call (not frozen at import) so the profile override is honored;
+# import-time constants leaked across profiles in single-process multi-profile
+# runtimes. Legacy names (SKILLS_DIR, ...) are re-exposed via __getattr__ below
+# so external `from tools.skills_hub import SKILLS_DIR` callers still work.
 
-INDEX_CACHE_TTL = 3600  # 1 hour  (defined early; referenced below)
+INDEX_CACHE_TTL = 3600  # 1 hour
 
 
-# The legacy path names (SKILLS_DIR, HUB_DIR, ...) are not real module
-# attributes — they are synthesized on access by the PEP 562 ``__getattr__``
-# below so they reflect the active profile override.  Tests, however, set them
-# as *real* module attributes via ``patch.object(hub, "SKILLS_DIR", ...)`` /
-# ``monkeypatch.setattr``.  ``_override`` lets each resolver honor such an
-# injected real attribute (the test seam) before falling back to dynamic
-# resolution.  ``globals().get`` returns None when only the __getattr__-backed
-# name exists (no real attribute set), so dynamic resolution wins by default.
+# _override lets a test-injected real module attribute (patch.object/monkeypatch
+# on SKILLS_DIR etc.) win over dynamic resolution; None means resolve live.
 def _override(name: str):
     return globals().get(name)
 
@@ -126,14 +112,8 @@ _DYNAMIC_PATH_RESOLVERS = {
 
 
 def __getattr__(name: str):
-    """Resolve the legacy path constants dynamically per access.
-
-    PEP 562 module ``__getattr__``: only called for names NOT found as real
-    module attributes, so it does not slow down ordinary lookups and a test's
-    ``patch.object``-set real attribute shadows it.  This lets
-    ``tools.skills_hub.SKILLS_DIR`` (and the rest) reflect the active profile
-    override instead of an import-time snapshot.
-    """
+    """Resolve legacy path constants dynamically (PEP 562) so they reflect the
+    active profile override; a test's patch.object-set real attribute shadows it."""
     resolver = _DYNAMIC_PATH_RESOLVERS.get(name)
     if resolver is not None:
         return resolver()


### PR DESCRIPTION
## Summary
Profiles served from a single process (desktop `tui_gateway`, `gateway.multiplex_profiles`) no longer leak one profile's reads/writes into another. These topologies switch profile via a context-local override, not the process env — anything that resolved the profile outside that request context reverted to the launch profile.

Root cause is a two-part bug class: (1) import-time / process-global path state pinned to the first profile that imported it, and (2) worker threads that start with an empty context and never inherit the override.

## Changes
- **Per-call path resolution** — `tools/skills_hub.py` (resolvers + PEP 562 `__getattr__` to keep the old constant names and the `patch.object` test seam), `gateway/platforms/base.py` cache-dir getters, `gateway/rich_sent_store.py` (`get_hermes_home()` not `os.environ`), `plugins/platforms/whatsapp/adapter.py` media validator.
- **Thread context propagation** — wrap the three leaking spawns in the existing `propagate_context_to_thread`: the `model_tools.py` sync→async tool worker, the `run_agent.py` background-review thread, and both `tools/async_delegation.py` submits.
- **Background-review memory gating** — `agent/background_review.py` gates the built-in `memory` tool on `_memory_enabled` / `_user_profile_enabled` instead of a hardcoded `["memory", "skills"]`, so a `memory_enabled: false` profile no longer gets the MEMORY.md tool (#54937 layer 2).
- 4 new test files (28 tests): two-profile runtime suite, the real multiplexed-gateway scope, the WhatsApp media validator, and the bg-review toolset restriction.

## Validation
| | Before | After |
|---|---|---|
| Profile-scoped paths in multiplexed/desktop runtime | revert to launch profile | follow active override |
| Worker-thread tool dispatch | empty context → launch profile | inherits override |
| bg-review on `memory_enabled: false` profile | gets MEMORY.md tool | tool gated out |
| Targeted tests | — | 28/28 passing |

Closes #54937. Supersedes #54948 (that PR snapshots `_mem_dir` at `MemoryStore.__init__`; this keeps the per-call resolution main already has, which is correct under mid-process switches). Honcho client singleton + MCP registry are a separate caching-lifetime boundary, tracked as follow-up.

Salvage of #55867 by @erosika (Eri Barrett) — cherry-picked onto current `main` with authorship preserved.

## Infographic
![Profile Context Isolation](https://v3b.fal.media/files/b/0aa06be5/ESu84B8PsZJJPOAZ8G2Mn_D04PYjQL.png)
