### PR TITLE
fix(desktop): lift memory-graph dark-mode line + outline alpha

### DIFF
--- a/apps/desktop/src/app/starmap/constants.ts
+++ b/apps/desktop/src/app/starmap/constants.ts
@@ -35,7 +35,7 @@ export const LIT_BAND_ALPHA = 0.04
 
 export const MODE_DEFAULTS: Record<'dark' | 'light', GraphParams> = {
   dark: {
-    lineAlpha: 0.12,
+    lineAlpha: 0.24,
     lineDash: 1.5,
     lineDashed: true,
     lineWidth: 0.5,
@@ -57,6 +57,6 @@ export const MODE_DEFAULTS: Record<'dark' | 'light', GraphParams> = {
 }
 
 export const RING_PARAMS: Record<'dark' | 'light', RingParams> = {
-  dark: { bandAlpha: 0.01, lightSize: 0.64, ringAlpha: 0.03, sheen: 0.12 },
+  dark: { bandAlpha: 0.01, lightSize: 0.64, ringAlpha: 0.06, sheen: 0.12 },
   light: { bandAlpha: 0.03, lightSize: 0.27, ringAlpha: 0.028, sheen: 0.1 }
 }


### PR DESCRIPTION
## Summary
- Dark-mode memory-graph connector lines and ring outlines read too faint.
- Double the two **live** alpha knobs in `apps/desktop/src/app/starmap/constants.ts`:
  - `MODE_DEFAULTS.dark.lineAlpha` 0.12 → 0.24 (graph connector lines, applied at `render.ts:434`)
  - `RING_PARAMS.dark.ringAlpha` 0.03 → 0.06 (ring outlines, applied at `render.ts:372,382`)

Note: `MODE_DEFAULTS.dark.ringAlpha` is **dead** — the outline is sourced from `RING_PARAMS`, not `GraphParams`. Left untouched to keep the diff tiny.

## Test plan
- [ ] Open the desktop Memory Graph in dark mode; connector lines + ring outlines are visibly stronger but still quiet.
- [ ] Light mode unchanged.