### PR TITLE
fix(plugins): preserve meet node import error message

### DIFF
--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -92,8 +92,9 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
         # If the node module fails to import for any reason (optional dep
         # missing at import time etc.), leave the subparser present but
         # flag it. The argparse dispatch will surface a clear error.
+        err_msg = str(e)
         def _node_unavailable(args):
-            print(f"hermes meet node: module unavailable ({e})")
+            print(f"hermes meet node: module unavailable ({err_msg})")
             return 1
         node_p.set_defaults(func=_node_unavailable)
 

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -584,6 +584,27 @@ def test_cli_register_includes_node_subcommand():
     assert ns.node_cmd == "list"
 
 
+def test_cli_node_unavailable_fallback_does_not_close_over_except_var(monkeypatch, capsys):
+    import argparse
+    import builtins
+    from plugins.google_meet.cli import register_cli
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "plugins.google_meet.node.cli":
+            raise RuntimeError("node deps missing")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    parser = argparse.ArgumentParser(prog="hermes meet")
+    register_cli(parser)
+    ns = parser.parse_args(["node"])
+
+    assert ns.func(ns) == 1
+    assert "module unavailable (node deps missing)" in capsys.readouterr().out
+
+
 def test_cli_join_accepts_mode_and_node_flags():
     import argparse
     from plugins.google_meet.cli import register_cli


### PR DESCRIPTION
Fixes #55774.\n\nThe meet node fallback captured the exception object from an except block, which Python clears after the block exits. Store the message string before installing the argparse fallback so dispatch prints the intended error instead of raising NameError.\n\nTests: scripts/run_tests.sh tests/plugins/test_google_meet_plugin.py