### PR TITLE
fix(config): keep kanban auto-subscribe default

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1375,21 +1375,6 @@ DEFAULT_CONFIG = {
                                       # after live validation.
     },
 
-    # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).
-    # See tools/kanban_tools.py and hermes_cli/kanban_db.py for the actual
-    # implementations. Per-platform notification opt-out is handled by the
-    # kanban dashboard (see ``hermes dashboard`` -> Notifications).
-    "kanban": {
-        # Auto-subscribe the originating gateway/TUI session to task
-        # completion + block events when ``kanban_create`` is called from
-        # inside a session that has a persistent delivery channel. The
-        # agent that dispatched the task will get notified automatically
-        # instead of having to poll. Disable to mirror pre-feature
-        # behaviour — e.g. for a profile that prefers explicit
-        # ``kanban_notify-subscribe`` calls per task.
-        "auto_subscribe_on_create": True,
-    },
-
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
     "prompt_caching": {
@@ -2546,6 +2531,14 @@ DEFAULT_CONFIG = {
     # each claimable ready task. One dispatcher per profile is sufficient;
     # running more than one on the same kanban.db will race for claims.
     "kanban": {
+        # Auto-subscribe the originating gateway/TUI session to task
+        # completion + block events when ``kanban_create`` is called from
+        # inside a session that has a persistent delivery channel. The
+        # agent that dispatched the task will get notified automatically
+        # instead of having to poll. Disable to mirror pre-feature
+        # behaviour — e.g. for a profile that prefers explicit
+        # ``kanban_notify-subscribe`` calls per task.
+        "auto_subscribe_on_create": True,
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3428,6 +3428,10 @@ def test_config_default_dispatch_in_gateway_is_true():
         "kanban.dispatch_in_gateway default should be True; got "
         f"{kanban.get('dispatch_in_gateway')!r}"
     )
+    assert kanban.get("auto_subscribe_on_create") is True, (
+        "kanban.auto_subscribe_on_create default should be True; got "
+        f"{kanban.get('auto_subscribe_on_create')!r}"
+    )
     interval = kanban.get("dispatch_interval_seconds")
     assert isinstance(interval, (int, float)) and interval >= 1, (
         f"dispatch_interval_seconds must be a positive number, got {interval!r}"


### PR DESCRIPTION
Fixes #55779.\n\nDEFAULT_CONFIG declared kanban twice, so the earlier auto_subscribe_on_create default was silently overwritten. This folds that default into the canonical kanban block and extends the existing kanban config regression test.\n\nTests: scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py