### PR TITLE
fix(tui): coalesce drag-resize reflow + harden resize-burst heal coverage

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
@@ -46,7 +46,105 @@ describe('Ink resize healing', () => {
     ink.onRender()
     await tick()
 
-    expect(stdout.chunks.join('')).toContain(ERASE_SCREEN + CURSOR_HOME)
+    // The heal may also erase scrollback (CSI 3J interposed between 2J and H)
+    // depending on which recovery path runs, so assert the invariant — screen
+    // erased, then content repainted after — rather than an exact byte run.
+    const out = stdout.chunks.join('')
+    expect(out).toContain(ERASE_SCREEN)
+    expect(out).toContain(CURSOR_HOME)
+    expect(out.indexOf(ERASE_SCREEN)).toBeLessThan(out.lastIndexOf('hello'))
+
+    ink.unmount()
+  })
+
+  // Regression for issue #18449: dragging the terminal back and forth quickly
+  // emits a BURST of resize events (the single-event test above only covers one
+  // tick). Each tick resets the frame buffers and arms needsEraseBeforePaint, so
+  // the burst must still converge to a clean erase+repaint — a stacked event
+  // must never consume the erase and leave the final paint as a partial diff
+  // that lets stale glyphs survive.
+  it('converges to a clean erased frame after a rapid resize burst', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+
+    const ink = new Ink({
+      exitOnCtrlC: false,
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    ink.setAltScreenActive(true)
+    ink.render(React.createElement(Text, null, 'hello'))
+    ink.onRender()
+    stdout.chunks = []
+
+    // Wobble the dimensions like a drag — widen, shrink, grow rows — then
+    // settle back on the STARTING geometry. Even though the net dimensions are
+    // unchanged, a host reflow during the burst can have scattered glyphs, so
+    // the renderer must still heal rather than treat the end state as a no-op.
+    const wobble: Array<[number, number]> = [
+      [30, 5],
+      [12, 9],
+      [25, 4],
+      [20, 5]
+    ]
+
+    for (const [columns, rows] of wobble) {
+      stdout.columns = columns
+      stdout.rows = rows
+      stdout.emit('resize')
+    }
+
+    ink.onRender()
+    await tick()
+
+    // The heal can erase scrollback too (CSI 3J interposed), so assert the
+    // semantic invariant rather than an exact byte sequence: the screen was
+    // erased and the content was repainted AFTER the erase — i.e. the final
+    // frame is a clean repaint, not a partial diff over drifted cells.
+    const out = stdout.chunks.join('')
+    expect(out).toContain(ERASE_SCREEN)
+    expect(out).toContain(CURSOR_HOME)
+    expect(out.indexOf(ERASE_SCREEN)).toBeLessThan(out.lastIndexOf('hello'))
+
+    ink.unmount()
+  })
+
+  // The burst above ends on a same-dimension event; this isolates that worst
+  // case on its own — a resize event whose dims equal the last known geometry
+  // (the terminal restored the buffer / reflowed without a net size change)
+  // must still arm the erase, because the physical screen may carry drift the
+  // diff path cannot see (see log-update "drift repro").
+  it('heals a same-dimension resize even when no React commit changes the tree', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+
+    const ink = new Ink({
+      exitOnCtrlC: false,
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    ink.setAltScreenActive(true)
+    ink.render(React.createElement(Text, null, 'hello'))
+    ink.onRender()
+    stdout.chunks = []
+
+    // Dimensions are identical to the initial render — the tree never changes.
+    stdout.emit('resize')
+    ink.onRender()
+    await tick()
+
+    const out = stdout.chunks.join('')
+    expect(out).toContain(ERASE_SCREEN)
+    expect(out).toContain(CURSOR_HOME)
+    expect(out.indexOf(ERASE_SCREEN)).toBeLessThan(out.lastIndexOf('hello'))
 
     ink.unmount()
   })

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -24,6 +24,7 @@ import { useVirtualHistory } from '../hooks/useVirtualHistory.js'
 import { composerPromptWidth } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage } from '../lib/messages.js'
 import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
+import { createResizeCoalescer } from '../lib/resizeCoalescer.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
 import { buildToolTrailLine, formatAbandonedClarify, sameToolTrailGroup, toolTrailLabel } from '../lib/text.js'
@@ -149,29 +150,12 @@ export function useMainApp(gw: GatewayClient) {
     // A drag-resize emits a burst of 'resize' events; syncing `cols` on every
     // one remounts the visible transcript rows each tick (they're keyed on
     // cols so yoga re-measures), turning a smooth drag into a flickering
-    // remount storm. Throttle with a leading+trailing edge: the first event
-    // reflows immediately (the drag stays responsive), the rest collapse to at
-    // most one reflow per RESIZE_COALESCE_MS, and the trailing edge always
-    // applies the final width so the settled layout is exact.
-    let lastReflow = 0
-    let trailing: ReturnType<typeof setTimeout> | undefined
-
-    const apply = () => {
-      lastReflow = Date.now()
-      setCols(stdout.columns ?? 80)
-    }
-
-    const sync = () => {
-      const elapsed = Date.now() - lastReflow
-
-      clearTimeout(trailing)
-
-      if (elapsed >= RESIZE_COALESCE_MS) {
-        apply()
-      } else {
-        trailing = setTimeout(apply, RESIZE_COALESCE_MS - elapsed)
-      }
-    }
+    // remount storm. Coalesce the burst with a leading+trailing throttle: the
+    // first event reflows immediately (the drag stays responsive), the rest
+    // collapse to at most one reflow per RESIZE_COALESCE_MS, and the trailing
+    // edge always applies the final width so the settled layout is exact.
+    const coalescer = createResizeCoalescer(() => setCols(stdout.columns ?? 80), RESIZE_COALESCE_MS)
+    const sync = () => coalescer.schedule()
 
     stdout.on('resize', sync)
 
@@ -180,7 +164,7 @@ export function useMainApp(gw: GatewayClient) {
     }
 
     return () => {
-      clearTimeout(trailing)
+      coalescer.cancel()
       stdout.off('resize', sync)
 
       if (stdout.isTTY) {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { STARTUP_RESUME_ID } from '../config/env.js'
 import { MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
+import { RESIZE_COALESCE_MS } from '../config/timing.js'
 import { hasLeadGap, prevRenderedMsg } from '../domain/blockLayout.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { attachedImageNotice, imageTokenMeta } from '../domain/messages.js'
@@ -145,7 +146,32 @@ export function useMainApp(gw: GatewayClient) {
       return
     }
 
-    const sync = () => setCols(stdout.columns ?? 80)
+    // A drag-resize emits a burst of 'resize' events; syncing `cols` on every
+    // one remounts the visible transcript rows each tick (they're keyed on
+    // cols so yoga re-measures), turning a smooth drag into a flickering
+    // remount storm. Throttle with a leading+trailing edge: the first event
+    // reflows immediately (the drag stays responsive), the rest collapse to at
+    // most one reflow per RESIZE_COALESCE_MS, and the trailing edge always
+    // applies the final width so the settled layout is exact.
+    let lastReflow = 0
+    let trailing: ReturnType<typeof setTimeout> | undefined
+
+    const apply = () => {
+      lastReflow = Date.now()
+      setCols(stdout.columns ?? 80)
+    }
+
+    const sync = () => {
+      const elapsed = Date.now() - lastReflow
+
+      clearTimeout(trailing)
+
+      if (elapsed >= RESIZE_COALESCE_MS) {
+        apply()
+      } else {
+        trailing = setTimeout(apply, RESIZE_COALESCE_MS - elapsed)
+      }
+    }
 
     stdout.on('resize', sync)
 
@@ -154,6 +180,7 @@ export function useMainApp(gw: GatewayClient) {
     }
 
     return () => {
+      clearTimeout(trailing)
       stdout.off('resize', sync)
 
       if (stdout.isTTY) {

--- a/ui-tui/src/config/timing.ts
+++ b/ui-tui/src/config/timing.ts
@@ -4,3 +4,11 @@ export const STREAM_SCROLL_BATCH_MS = 96
 export const STREAM_TYPING_BATCH_MS = 80
 export const TYPING_IDLE_MS = 250
 export const REASONING_PULSE_MS = 700
+
+// A drag-resize fires a burst of SIGWINCH events (one per pixel step in some
+// hosts). Each distinct terminal width remounts the visible transcript rows so
+// yoga re-measures off live geometry, so reflowing on every tick stutters the
+// drag. Coalesce the burst to at most one reflow per this window (~30fps):
+// responsive enough to track the drag, cheap enough to stay smooth, and the
+// trailing edge always lands the final width so the settled layout is exact.
+export const RESIZE_COALESCE_MS = 32

--- a/ui-tui/src/lib/resizeCoalescer.test.ts
+++ b/ui-tui/src/lib/resizeCoalescer.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createResizeCoalescer } from './resizeCoalescer.js'
+
+describe('createResizeCoalescer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reflows immediately on the first event (leading edge)', () => {
+    const reflow = vi.fn()
+    const coalescer = createResizeCoalescer(reflow, 32)
+
+    coalescer.schedule()
+
+    expect(reflow).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapses a rapid burst into one leading + one trailing reflow', () => {
+    const reflow = vi.fn()
+    const coalescer = createResizeCoalescer(reflow, 32)
+
+    // A drag: five events inside one 32ms window.
+    coalescer.schedule()
+
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(5)
+      coalescer.schedule()
+    }
+
+    // Only the leading edge has fired mid-burst.
+    expect(reflow).toHaveBeenCalledTimes(1)
+
+    // The trailing edge lands the final width once the window settles.
+    vi.advanceTimersByTime(32)
+    expect(reflow).toHaveBeenCalledTimes(2)
+  })
+
+  it('reflows immediately again once the interval has elapsed', () => {
+    const reflow = vi.fn()
+    const coalescer = createResizeCoalescer(reflow, 32)
+
+    coalescer.schedule()
+    expect(reflow).toHaveBeenCalledTimes(1)
+
+    // Gap longer than the window — the next event is a fresh leading edge.
+    vi.advanceTimersByTime(40)
+    coalescer.schedule()
+
+    expect(reflow).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancel() drops a pending trailing reflow', () => {
+    const reflow = vi.fn()
+    const coalescer = createResizeCoalescer(reflow, 32)
+
+    coalescer.schedule() // leading
+    vi.advanceTimersByTime(5)
+    coalescer.schedule() // schedules a trailing reflow
+    coalescer.cancel()
+
+    vi.advanceTimersByTime(100)
+    expect(reflow).toHaveBeenCalledTimes(1)
+  })
+
+  it('continuous dragging reflows about once per interval, not per event', () => {
+    const reflow = vi.fn()
+    const coalescer = createResizeCoalescer(reflow, 30)
+
+    // 30 events over 300ms (one every 10ms) — a sustained drag.
+    for (let i = 0; i < 30; i++) {
+      coalescer.schedule()
+      vi.advanceTimersByTime(10)
+    }
+
+    // Flush the final trailing reflow.
+    vi.advanceTimersByTime(30)
+
+    // ~300ms / 30ms ≈ 10 reflows, not 30. Bound it loosely to stay robust.
+    expect(reflow.mock.calls.length).toBeLessThanOrEqual(12)
+    expect(reflow.mock.calls.length).toBeGreaterThanOrEqual(8)
+  })
+})

--- a/ui-tui/src/lib/resizeCoalescer.ts
+++ b/ui-tui/src/lib/resizeCoalescer.ts
@@ -1,0 +1,56 @@
+export interface ResizeCoalescer {
+  /** Call on each terminal 'resize' event. */
+  schedule: () => void
+  /** Drop any pending trailing reflow (effect cleanup). */
+  cancel: () => void
+}
+
+/**
+ * Leading + trailing throttle for terminal-resize bursts.
+ *
+ * A drag-resize emits a burst of 'resize' events; reflowing on every one
+ * remounts the visible transcript rows each tick (they're keyed on cols so
+ * yoga re-measures off live geometry), turning a smooth drag into a
+ * flickering remount storm.
+ *
+ * `schedule()` reflows immediately on the first event (the drag stays
+ * responsive), then collapses subsequent events to at most one `reflow()`
+ * per `intervalMs`, and always fires a trailing `reflow()` so the final
+ * width lands exactly. `cancel()` clears a pending trailing reflow.
+ *
+ * Uses `Date.now()` + `setTimeout` directly so it is deterministically
+ * testable under fake timers.
+ */
+export function createResizeCoalescer(reflow: () => void, intervalMs: number): ResizeCoalescer {
+  // -Infinity (not 0) so the first schedule() always satisfies the
+  // elapsed >= interval leading-edge check regardless of the wall clock.
+  let lastReflow = Number.NEGATIVE_INFINITY
+  let trailing: ReturnType<typeof setTimeout> | undefined
+
+  const run = () => {
+    lastReflow = Date.now()
+    reflow()
+  }
+
+  return {
+    schedule() {
+      const elapsed = Date.now() - lastReflow
+
+      clearTimeout(trailing)
+      trailing = undefined
+
+      if (elapsed >= intervalMs) {
+        run()
+      } else {
+        trailing = setTimeout(() => {
+          trailing = undefined
+          run()
+        }, intervalMs - elapsed)
+      }
+    },
+    cancel() {
+      clearTimeout(trailing)
+      trailing = undefined
+    }
+  }
+}


### PR DESCRIPTION
## What & why

Two focused fixes for steadier rendering under aggressive terminal resizing, plus unit coverage so the behavior can't silently regress.

### 1. Drag-resize flicker (`ui-tui/src/app/useMainApp.ts`)
`cols` was synced to `stdout.columns` **synchronously on every `'resize'` event**. Each distinct width remounts the visible transcript rows (they're keyed on `cols` so yoga re-measures off live geometry), so a drag — which emits a *burst* of resize events — became a per-tick remount storm that flickers and stutters.

The reflow is now coalesced with a **leading + trailing throttle** (`createResizeCoalescer`, `ui-tui/src/lib/resizeCoalescer.ts`):
- the first event reflows immediately (the drag stays responsive),
- the rest collapse to at most one reflow per `RESIZE_COALESCE_MS` (~30fps),
- the trailing edge always applies the final width, so the settled layout is exact.

New constant `RESIZE_COALESCE_MS = 32` in `ui-tui/src/config/timing.ts`. The helper is pure and **unit-tested with fake timers** (`resizeCoalescer.test.ts`): leading-edge immediacy, burst collapse, fresh leading edge after the window, `cancel()` dropping a pending reflow, and sustained-drag staying ~one reflow per interval.

### 2. Resize-burst heal coverage — refs #18449
The existing `ink-resize` test only drove a *single* same-dimension event. This adds two regressions that drive a rapid resize **burst** (wobbling dims that settle back to the start, and an isolated same-dimension event with no React tree change) and assert the renderer converges to a clean erased repaint — *screen erased, then content repainted after* — rather than a partial diff over drifted cells.

It also relaxes the pre-existing single-event assertion, which hard-coded the exact bytes `ESC[2J ESC[H`. The heal legitimately interposes `ESC[3J` (erase scrollback) on some recovery paths, so all three tests now assert the **semantic invariant** instead of an exact byte run.

## Testing
- `vitest`: `resizeCoalescer.test.ts` (5) + `ink-resize.test.ts` + `log-update.test.ts` all pass.
- Full `ui-tui` suite green (1098 passing) except 3 failures that pre-exist on `main` in unrelated, config-dependent files (`statusRule`, `virtualHeights`), confirmed by stashing this change.
- `tsc --noEmit`: 0 errors. `eslint` on changed files: clean.
- Manually verified in a real terminal: dragging the width in/out rapidly now reflows smoothly and settles cleanly. A/B'd by setting `RESIZE_COALESCE_MS = 0` (reproduces the original per-tick flicker) vs `32`.

## Scope notes
- The scroll-anchor-during-resize case is intentionally **not** touched here — it's already covered by #46492.
- Complementary to #30775 (this PR is additive test coverage + a brittle-test fix, not a competing renderer rewrite).

## Files
- `ui-tui/src/app/useMainApp.ts` — coalesce the resize→cols sync
- `ui-tui/src/lib/resizeCoalescer.ts` — new leading+trailing throttle helper
- `ui-tui/src/lib/resizeCoalescer.test.ts` — fake-timer unit tests for the helper
- `ui-tui/src/config/timing.ts` — add `RESIZE_COALESCE_MS`
- `ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts` — burst regressions + invariant assertions