### PR TITLE
fix(gateway): await yuanbao forwarded-record heartbeat

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -2394,7 +2394,7 @@ class ForwardedRecordsParseMiddleware(InboundMiddleware):
     async def handle(self, ctx: InboundContext, next_fn) -> None:
         try:
             if ctx.forwarded_records:
-                self._send_loading_heartbeat(ctx)
+                await self._send_loading_heartbeat(ctx)
                 ctx.raw_text = self.build_forward_text(ctx.forwarded_records, ctx=ctx, is_dispatch=True)
         except Exception as exc:
             # Degrade gracefully: leave ctx.raw_text as-is.

--- a/tests/test_yuanbao_integration.py
+++ b/tests/test_yuanbao_integration.py
@@ -13,6 +13,7 @@ test_yuanbao_integration.py - Yuanbao 模块集成测试
 
 import sys
 import os
+import asyncio
 
 # 确保 hermes-agent 根目录在 sys.path 中
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -20,7 +21,7 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from gateway.config import Platform, PlatformConfig, GatewayConfig
 from gateway.platforms.yuanbao import YuanbaoAdapter
 
@@ -266,6 +267,41 @@ class TestManagerImports:
         assert isinstance(adapter._outbound.sender, MessageSender)
         assert isinstance(adapter._outbound.heartbeat, HeartbeatManager)
         assert isinstance(adapter._outbound.slow_notifier, SlowResponseNotifier)
+
+
+def test_forwarded_records_parse_awaits_loading_heartbeat():
+    from gateway.platforms.yuanbao import (
+        ForwardedRecordsParseMiddleware,
+        InboundContext,
+        WS_HEARTBEAT_RUNNING,
+    )
+
+    heartbeat = AsyncMock()
+    adapter = MagicMock()
+    adapter.name = "yuanbao"
+    adapter._outbound.heartbeat.send_heartbeat_once = heartbeat
+    ctx = InboundContext(
+        adapter=adapter,
+        chat_id="chat-1",
+        sender_nickname="Alice",
+        raw_text="please read",
+        forwarded_records={
+            "msg": [
+                {"sender": "Bob", "plainText": "hello", "msgContent": []},
+            ],
+        },
+    )
+    next_called = False
+
+    async def next_fn():
+        nonlocal next_called
+        next_called = True
+
+    asyncio.run(ForwardedRecordsParseMiddleware().handle(ctx, next_fn))
+
+    heartbeat.assert_awaited_once_with("chat-1", WS_HEARTBEAT_RUNNING)
+    assert next_called is True
+    assert "Bob：hello" in ctx.raw_text
 
 
 # ===========================================================


### PR DESCRIPTION
Fixes #55784.\n\nForwarded-record parsing created the loading heartbeat coroutine without awaiting it, so the heartbeat never ran and Python emitted a RuntimeWarning. Await the best-effort heartbeat before rendering forwarded records.\n\nTests: scripts/run_tests.sh tests/test_yuanbao_integration.py