### PR TITLE
fix(agent): report concurrent heartbeat names by future

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -611,6 +611,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if block_result is None
         ]
         futures = []
+        future_tool_names = {}
         if runnable_calls:
             max_workers = min(len(runnable_calls), _MAX_TOOL_WORKERS)
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -649,6 +650,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                                 )
                         break
                     futures.append(f)
+                    future_tool_names[f] = name
 
                 # Wait for all to complete with periodic heartbeats so the
                 # gateway's inactivity monitor doesn't kill us during long
@@ -688,9 +690,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
                         _still_running = [
-                            parsed_calls[futures.index(f)][1]
+                            future_tool_names[f]
                             for f in not_done
-                            if f in futures
+                            if f in future_tool_names
                         ]
                         agent._touch_activity(
                             f"concurrent tools running ({_conc_elapsed}s, "

--- a/tests/run_agent/test_tool_executor_contextvar_propagation.py
+++ b/tests/run_agent/test_tool_executor_contextvar_propagation.py
@@ -227,6 +227,23 @@ def test_run_agent_concurrent_executor_wraps_submit_with_copy_context():
     )
 
 
+def test_concurrent_tool_heartbeat_names_are_keyed_by_future_not_parsed_index():
+    """Guard against blocked calls shifting heartbeat tool-name lookup.
+
+    The concurrent executor submits only runnable calls, while parsed_calls also
+    includes guardrail/plugin-blocked calls. Heartbeats must therefore map each
+    Future directly to its submitted tool name instead of reusing the Future's
+    position in the shorter futures list as an index into parsed_calls.
+    """
+    import inspect
+
+    from agent import tool_executor as tool_executor_module
+
+    source = inspect.getsource(tool_executor_module.execute_tool_calls_concurrent)
+    assert "future_tool_names" in source
+    assert "parsed_calls[futures.index" not in source
+
+
 def test_two_concurrent_tool_batches_keep_session_keys_isolated():
     """End-to-end guard: two callers each set a different session key
     and submit workers concurrently. Each worker must see its own


### PR DESCRIPTION
Fixes #55809.\n\nConcurrent tool heartbeats indexed parsed_calls with positions from the runnable-only futures list, so guardrail-blocked calls could shift the reported tool names. This records each submitted Future's tool name directly and uses that map for heartbeat status.\n\nTests: scripts/run_tests.sh tests/run_agent/test_tool_executor_contextvar_propagation.py tests/run_agent/test_tool_call_guardrail_runtime.py