### PR TITLE
fix(agent): detect CJK future-ack phrases in intent-ack continuation

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3219,6 +3219,12 @@ def looks_like_codex_intermediate_ack(
         re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
     )
     if not has_future_ack:
+        # CJK acks have no Latin future-ack phrase for the regex above to
+        # match, so check common Chinese future-ack phrases via substring
+        # containment instead (mirrors how action_markers below already work).
+        cjk_future_ack_markers = ("我先", "我來", "我会", "我會", "讓我", "让我", "我直接", "接下來我", "接下来我")
+        has_future_ack = any(marker in assistant_text for marker in cjk_future_ack_markers)
+    if not has_future_ack:
         return False
 
     action_markers = (
@@ -3241,6 +3247,20 @@ def looks_like_codex_intermediate_ack(
         "walkthrough",
         "report back",
         "summarize",
+        # CJK action verbs — already plain substring containment below, so
+        # these slot in directly without a separate word-boundary regex.
+        "載入",
+        "载入",
+        "查",
+        "執行",
+        "执行",
+        "掃描",
+        "扫描",
+        "檢查",
+        "检查",
+        "分析",
+        "讀取",
+        "读取",
     )
     workspace_markers = (
         "directory",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3222,8 +3222,13 @@ def looks_like_codex_intermediate_ack(
         # CJK acks have no Latin future-ack phrase for the regex above to
         # match, so check common Chinese future-ack phrases via substring
         # containment instead (mirrors how action_markers below already work).
-        cjk_future_ack_markers = ("我先", "我來", "我会", "我會", "讓我", "让我", "我直接", "接下來我", "接下来我")
-        has_future_ack = any(marker in assistant_text for marker in cjk_future_ack_markers)
+        # "我先" is checked with a lookahead instead of bare containment,
+        # which would also match "我先前" ("previously I..."), a past-tense
+        # report rather than a promise of future work.
+        cjk_future_ack_markers = ("我來", "我会", "我會", "讓我", "让我", "我直接", "接下來我", "接下来我")
+        has_future_ack = any(
+            marker in assistant_text for marker in cjk_future_ack_markers
+        ) or bool(re.search(r"我先(?!前)", assistant_text))
     if not has_future_ack:
         return False
 


### PR DESCRIPTION
## What

`looks_like_codex_intermediate_ack()` in `agent/agent_runtime_helpers.py` gates intent-ack continuation on an **English-only** future-ack regex (`\b(i'll|i will|let me|...)\b`) and an English-only `action_markers` substring list. When the acting model replies in Chinese ("我先載入 skill 確認用法…"), the regex never matches, the function returns `False` on its first guard, and the turn ends without executing a tool — the user has to manually type "please continue" every turn. This makes `intent_ack_continuation` a complete no-op for CJK users, most visible with MoA aggregators that tend to summarize the reference outputs and stop.

## Why

- The future-ack regex relies on Latin word-boundary phrases that simply don't exist in Chinese text — no amount of `\b` tuning fixes that, the fix needs CJK phrases.
- `action_markers` already matches via plain substring `in` containment (no regex), so CJK action verbs slot in directly with zero new matching logic.
- Scope is intentionally narrow: only the future-ack gate and `action_markers` are touched (the two markers the linked issue's repro actually exercises and the reporter validated locally). `workspace_markers` is untouched — it's only consulted on the `require_workspace=True` path, which this issue's repro doesn't reach, and guessing at unvalidated CJK workspace vocabulary isn't worth the risk in this PR.

## Change

- Added a parallel CJK substring check for future-ack phrases (我先, 我來/我来, 我會/我会, 讓我/让我, 我直接, 接下來我/接下来我) — only consulted when the English regex doesn't match, so the English path is untouched.
- Extended `action_markers` with CJK action verbs in both Traditional and Simplified script (載入/载入, 查, 執行/执行, 掃描/扫描, 檢查/检查, 分析, 讀取/读取).

## How to test

```bash
python -m pytest tests/agent/test_intent_ack_continuation.py -v
```

Repro before the fix (run on `main`, returns `False`):
```python
from types import SimpleNamespace
from agent.agent_runtime_helpers import looks_like_codex_intermediate_ack

a = SimpleNamespace(_intent_ack_continuation=True, api_mode="chat_completions",
                    model="copilot/claude-opus-4.8", _strip_think_blocks=lambda c: c)
user_msg = "幫我看一下伺服器狀態並抓最新的錯誤紀錄"
ack = "我先載入 skill 確認用法，然後幫你檢查伺服器狀態。"
looks_like_codex_intermediate_ack(a, user_msg, ack, [{"role": "user", "content": user_msg}], require_workspace=False)
# main: False (bug) — this branch: True
```

- All 14 pre-existing tests in `tests/agent/test_intent_ack_continuation.py` pass unchanged (English path is byte-stable).
- 2 new tests added: Traditional + Simplified Chinese ack fires under the opted-in (`require_workspace=False`) path, and a real Chinese final answer (no future-ack phrase) still does **not** fire — confirming the CJK addition only widens the future-ack gate, not the other guardrails (no-prior-tool, length cap, action-verb requirement).
- `scripts/check-windows-footguns.py` clean on the diff.

## Platforms tested

macOS (logic-only change, no OS-specific code paths — pure string/regex matching).

Fixes #55664