### PR TITLE
fix(memory/holographic): sanitize FTS5 queries for natural-language recall

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -496,7 +496,11 @@ class FactRetriever:
         # We need to join facts_fts with facts to get all columns
         params: list = []
         where_clauses = ["facts_fts MATCH ?"]
-        params.append(query)
+        # FTS5 defaults to AND-between-tokens, which kills recall on
+        # natural-language queries ("what happened with the deployment
+        # rollback"). Sanitize: drop stopwords, OR-join content tokens, so
+        # any significant term can match.
+        params.append(self._sanitize_fts_query(query))
 
         if category:
             where_clauses.append("f.category = ?")
@@ -556,6 +560,63 @@ class FactRetriever:
             if cleaned:
                 tokens.add(cleaned)
         return tokens
+
+    # Stopwords dropped before FTS5 OR-expansion. Short English function
+    # words that carry no retrieval signal and force false-negative AND
+    # matches when left in the query.
+    _FTS_STOPWORDS = frozenset({
+        "a", "about", "above", "after", "again", "all", "am", "an", "and",
+        "any", "are", "as", "at", "be", "because", "been", "before", "being",
+        "between", "both", "but", "by", "can", "could", "did", "do", "does",
+        "doing", "don", "down", "during", "each", "few", "for", "from",
+        "further", "had", "has", "have", "having", "he", "her", "here",
+        "hers", "herself", "him", "himself", "his", "how", "i", "if", "in",
+        "into", "is", "it", "its", "itself", "just", "me", "more", "most",
+        "my", "myself", "no", "nor", "not", "now", "of", "off", "on", "once",
+        "only", "or", "other", "our", "ours", "ourselves", "out", "over",
+        "own", "same", "she", "should", "so", "some", "such", "than", "that",
+        "the", "their", "theirs", "them", "themselves", "then", "there",
+        "these", "they", "this", "those", "through", "to", "too", "under",
+        "until", "up", "very", "was", "we", "were", "what", "when", "where",
+        "which", "while", "who", "whom", "why", "will", "with", "would",
+        "you", "your", "yours", "yourself", "yourselves",
+    })
+
+    @classmethod
+    def _sanitize_fts_query(cls, query: str) -> str:
+        """Convert a natural-language query to an FTS5-safe OR expression.
+
+        FTS5 treats a multi-word MATCH argument as AND-joined by default,
+        which tanks recall on prose queries. This helper:
+          - tokenizes the query
+          - drops stopwords and short (<2 char) tokens
+          - strips FTS5 special characters from each token
+          - OR-joins the survivors
+
+        If nothing remains (pathological query), falls back to the raw
+        query so the caller sees zero results instead of a SQL error.
+        """
+        if not query:
+            return ""
+        # Strip FTS5 operator characters from EACH token to avoid
+        # accidentally creating a malformed query.
+        _FTS_SPECIAL = '"()*^:-+'
+        tokens: list[str] = []
+        for raw in query.lower().split():
+            cleaned = raw.strip(".,;:!?\"'()[]{}#@<>") .translate(
+                str.maketrans("", "", _FTS_SPECIAL)
+            )
+            if len(cleaned) < 2:
+                continue
+            if cleaned in cls._FTS_STOPWORDS:
+                continue
+            # FTS5 phrase-literal each token to ensure no special chars
+            # sneak through as operators.
+            tokens.append(f'"{cleaned}"')
+        if not tokens:
+            # Fallback: raw query (likely returns 0, but never crashes)
+            return query
+        return " OR ".join(tokens)
 
     @staticmethod
     def _jaccard_similarity(set_a: set, set_b: set) -> float:

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -205,7 +205,14 @@ class MemoryStore:
             if not query:
                 return []
 
-            params: list = [query, min_trust]
+            # FTS5 AND-joins tokens by default, which zeroes out recall on
+            # natural-language queries. Reuse the retriever's sanitizer
+            # (stopword drop + OR-join content tokens). Imported lazily to
+            # avoid a store->retrieval import cycle.
+            from plugins.memory.holographic.retrieval import FactRetriever
+
+            match_query = FactRetriever._sanitize_fts_query(query)
+            params: list = [match_query, min_trust]
             category_clause = ""
             if category is not None:
                 category_clause = "AND f.category = ?"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "cyb3rwr3n@users.noreply.github.com": "cyb3rwr3n",  # PR #11333 salvage (sanitize FTS5 queries for natural-language recall in holographic memory)
     "186512915+lEWFkRAD@users.noreply.github.com": "lEWFkRAD",  # PR #53848 salvage (stream the MoA aggregator response to the user)
     "193368749+jimmyjohansson84@users.noreply.github.com": "jimmyjohansson84",  # PR #27123 salvage (Kanban unknown-skill warn-instead-of-crash; #27136)
     "gxalong@gmail.com": "Jeffgithub0029",  # PR #28558 salvage (chunk Telegram text *after* MarkdownV2/HTML formatting so escaping inflation can't push a send over the 4096 UTF-16 limit; #28557)

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -1,0 +1,129 @@
+"""Tests for FactRetriever FTS5 query sanitization.
+
+These tests cover the fix where raw natural-language queries passed to
+FTS5 MATCH were AND-joined by default, dropping recall to zero on any
+multi-word prose query. The sanitizer drops stopwords and OR-joins the
+remaining content tokens as phrase literals.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("numpy")  # retrieval module imports numpy indirectly
+
+from plugins.memory.holographic.retrieval import FactRetriever
+from plugins.memory.holographic.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_fts_query — unit tests (no DB required)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "query,expected_tokens",
+    [
+        # stopwords dropped
+        ("what happened with the deployment rollback", {"happened", "deployment", "rollback"}),
+        # single content word passes through
+        ("compaction", {"compaction"}),
+        # all stopwords → falls back to raw
+        ("the and of", None),  # None = sentinel for fallback-to-raw
+        # empty string → empty output
+        ("", ""),
+        # FTS5 operator characters stripped
+        ("context: length-probe", {"context", "lengthprobe"}),
+        # trailing punctuation stripped by tokenizer
+        ("hello, world!", {"hello", "world"}),
+    ],
+)
+def test_sanitize_fts_query_extracts_content_tokens(query, expected_tokens):
+    result = FactRetriever._sanitize_fts_query(query)
+
+    if expected_tokens == "":
+        assert result == ""
+        return
+
+    if expected_tokens is None:
+        # Pathological case: all stopwords — should fall back to raw query
+        assert result == query
+        return
+
+    # OR-joined phrase literals: `"tok1" OR "tok2" OR ...`
+    # Extract the tokens between quotes, order-independent.
+    import re
+    matches = re.findall(r'"([^"]+)"', result)
+    assert set(matches) == expected_tokens, f"got {result!r}"
+
+
+def test_sanitize_fts_query_never_crashes_on_fts5_specials():
+    """Queries with FTS5 operator characters must not produce malformed SQL."""
+    problematic = [
+        'test " query',
+        "test * query",
+        "test (a OR b) query",
+        "test^2 query",
+        "test:colon query",
+        "test-hyphen query",
+        "a" * 1000,  # long query
+    ]
+    for q in problematic:
+        result = FactRetriever._sanitize_fts_query(q)
+        # We just need it to return a string without raising
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Integration test — actually run _fts_candidates against an in-memory DB
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def retriever_with_facts(tmp_path):
+    """MemoryStore seeded with a few facts for retrieval tests."""
+    db_path = tmp_path / "test_facts.db"
+    store = MemoryStore(str(db_path))
+    store.add_fact(
+        content="The Thursday deployment rollback failed because of stale migration state.",
+        category="project",
+    )
+    store.add_fact(
+        content="Compaction settings tuned to 0.85 threshold.",
+        category="tool",
+    )
+    store.add_fact(
+        content="Venice.ai advertises availableContextTokens inside model_spec.",
+        category="tool",
+    )
+    retriever = FactRetriever(store=store)
+    yield retriever
+    store.close()
+
+
+def test_prefetch_recovers_prose_query(retriever_with_facts):
+    """A natural-language query should now match the relevant fact.
+
+    Before the sanitizer fix, 'what happened with the deployment rollback'
+    returned zero hits because FTS5 required every token to co-occur.
+    """
+    results = retriever_with_facts.search(
+        "what happened with the deployment rollback"
+    )
+    assert len(results) >= 1
+    # The top hit should be the deployment rollback fact
+    assert "deployment rollback" in results[0]["content"].lower()
+
+
+def test_prefetch_single_keyword_still_works(retriever_with_facts):
+    """Single-term queries (pre-fix working case) remain working."""
+    results = retriever_with_facts.search("compaction")
+    assert len(results) >= 1
+    assert "Compaction" in results[0]["content"] or "compaction" in results[0]["content"].lower()
+
+
+def test_prefetch_stopword_only_query_empty(retriever_with_facts):
+    """Pure stopword queries return zero results but don't crash."""
+    # Pass to _sanitize_fts_query directly first so we know what happens
+    assert FactRetriever._sanitize_fts_query("the and of") == "the and of"
+    # search() handles the likely-zero-hit case gracefully
+    results = retriever_with_facts.search("the and of")
+    # Either zero results or it errored-gracefully to [] — both are fine
+    assert isinstance(results, list)


### PR DESCRIPTION
## Summary
Natural-language prefetch queries now recover relevant facts from holographic memory instead of returning zero. FTS5's `MATCH` AND-joins tokens by default, so a prose query like "what happened with the deployment rollback" required all six tokens to co-occur and matched nothing.

Salvage of #11333 by @cyb3rwr3n (first-time contributor), cherry-picked onto current `main` with authorship preserved, plus a sibling-site fix on top.

## Changes
- `retrieval.py`: `_fts_candidates` routes the query through a new `_sanitize_fts_query()` — tokenize, lowercase, drop English stopwords + <2-char tokens, strip FTS5 operator chars, OR-join survivors as phrase literals; raw-query fallback on pathological input so it never SQL-errors. (contributor commit)
- `store.py`: `search_facts()` shared the same raw-`MATCH` bug class — routed through the same sanitizer via a lazy import to keep the store→retrieval layering acyclic. (follow-up)
- `scripts/release.py`: AUTHOR_MAP entry for @cyb3rwr3n.
- `tests/plugins/memory/test_holographic_retrieval.py`: 10 new tests (sanitizer units, FTS5 crash-safety, prose/keyword/stopword integration).

## Validation
| query | before | after |
|---|---|---|
| `"what happened with the deployment rollback"` (raw MATCH) | 0 hits | — |
| sanitized OR-expansion | — | 1 hit |
| `retriever.search()` prose | 0 results | 1 result |
| `store.search_facts()` prose (sibling) | 0 results | 1 result |
| keyword `compaction` | works | works |
| pure-stopword `"the and of"` | — | 0 hits, no crash |

Plugin-only — no core / API / config change. Regression reproduced live on `main` (prose → 0 hits) and confirmed fixed E2E. Targeted suite: 10/10 passed.

## Infographic
![FTS5 recall fix](https://v3b.fal.media/files/b/0aa06d41/JeI-Oq7wnr8PSl4HwnIWH_XGURqf3s.png)

---
Nous Research
