### PR TITLE
fix(agent): repair empty-name tool_calls in sanitizer to prevent Responses 400 (salvage #12807/#52893)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2257,6 +2257,39 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         filtered.append(msg)
     messages = filtered
 
+    # --- Strip tool_calls whose function.name is empty/missing ---
+    # Some providers (and partially-streamed responses) emit a tool_call with
+    # id="call_xxx" but function.name="". Downstream Responses-API adapters
+    # silently drop such function_call items while still emitting the matching
+    # function_call_output, producing the gateway's HTTP 400
+    # "No tool call found for function call output with call_id ...". Drop the
+    # malformed call here so the orphan-result logic below removes its (now
+    # unpaired) tool result.
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        tcs = msg.get("tool_calls") or []
+        if not tcs:
+            continue
+        cleaned = []
+        for tc in tcs:
+            if isinstance(tc, dict):
+                fn = tc.get("function") or {}
+                name = fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", None)
+            else:
+                fn = getattr(tc, "function", None)
+                name = getattr(fn, "name", None) if fn else None
+            if not isinstance(name, str) or not name.strip():
+                _ra().logger.warning(
+                    "Pre-call sanitizer: dropping tool_call with empty "
+                    "function.name (id=%s)",
+                    _ra().AIAgent._get_tool_call_id_static(tc),
+                )
+                continue
+            cleaned.append(tc)
+        if len(cleaned) != len(tcs):
+            msg["tool_calls"] = cleaned
+
     surviving_call_ids: set = set()
     for msg in messages:
         if msg.get("role") == "assistant":

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2257,38 +2257,53 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         filtered.append(msg)
     messages = filtered
 
-    # --- Strip tool_calls whose function.name is empty/missing ---
+    # --- Repair tool_calls whose function.name is empty/missing ---
     # Some providers (and partially-streamed responses) emit a tool_call with
     # id="call_xxx" but function.name="". Downstream Responses-API adapters
-    # silently drop such function_call items while still emitting the matching
+    # silently DROP such function_call items while still emitting the matching
     # function_call_output, producing the gateway's HTTP 400
-    # "No tool call found for function call output with call_id ...". Drop the
-    # malformed call here so the orphan-result logic below removes its (now
-    # unpaired) tool result.
+    # "No tool call found for function call output with call_id ...".
+    #
+    # We do NOT drop the call: hermes' own dispatch loop intentionally keeps an
+    # empty-name call paired with a synthesized anti-priming tool result
+    # ("tool name was empty", see #47967) so weak models self-correct instead of
+    # being fed the full tool catalog. Dropping the call here would (a) orphan
+    # that result and strip the anti-priming signal, and (b) still leave any
+    # provider-side orphan. Instead, rename the blank name to a non-empty
+    # sentinel so the call and its result stay PAIRED — the adapter no longer
+    # drops the function_call, so there is no orphaned output and no 400, while
+    # the result content the model needs is preserved.
+    _EMPTY_NAME_SENTINEL = "invalid_tool_call"
     for msg in messages:
         if msg.get("role") != "assistant":
             continue
         tcs = msg.get("tool_calls") or []
         if not tcs:
             continue
-        cleaned = []
         for tc in tcs:
             if isinstance(tc, dict):
-                fn = tc.get("function") or {}
+                fn = tc.get("function")
                 name = fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", None)
             else:
                 fn = getattr(tc, "function", None)
                 name = getattr(fn, "name", None) if fn else None
-            if not isinstance(name, str) or not name.strip():
-                _ra().logger.warning(
-                    "Pre-call sanitizer: dropping tool_call with empty "
-                    "function.name (id=%s)",
-                    _ra().AIAgent._get_tool_call_id_static(tc),
-                )
+            if isinstance(name, str) and name.strip():
                 continue
-            cleaned.append(tc)
-        if len(cleaned) != len(tcs):
-            msg["tool_calls"] = cleaned
+            _ra().logger.warning(
+                "Pre-call sanitizer: repairing tool_call with empty "
+                "function.name -> %r (id=%s)",
+                _EMPTY_NAME_SENTINEL,
+                _ra().AIAgent._get_tool_call_id_static(tc),
+            )
+            if isinstance(fn, dict):
+                fn["name"] = _EMPTY_NAME_SENTINEL
+            elif fn is not None and hasattr(fn, "name"):
+                try:
+                    fn.name = _EMPTY_NAME_SENTINEL
+                except Exception:
+                    pass
+            elif isinstance(tc, dict):
+                tc["function"] = {"name": _EMPTY_NAME_SENTINEL, "arguments": "{}"}
 
     surviving_call_ids: set = set()
     for msg in messages:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3659,12 +3659,15 @@ class TestHandleMaxIterations:
             "call_123"
         ]
 
-    def test_api_sanitizer_drops_tool_call_with_empty_function_name(self, agent):
+    def test_api_sanitizer_repairs_tool_call_with_empty_function_name(self, agent):
         """A tool_call with id but empty function.name makes the Responses-API
         adapter drop the function_call while keeping its function_call_output,
         causing the gateway's HTTP 400 'No tool call found for function call
-        output ...'. The sanitizer must drop the malformed call AND its now-
-        orphaned tool result. (#12807)"""
+        output ...'. The sanitizer renames the blank name to a non-empty
+        sentinel so the call and its result stay PAIRED (no orphaned output,
+        no 400) while the result content is preserved — it must NOT drop the
+        call, because hermes' dispatch loop keeps empty-name calls paired with
+        an anti-priming result for self-correction (#47967). (#12807)"""
         messages = [
             {
                 "role": "assistant",
@@ -3688,13 +3691,15 @@ class TestHandleMaxIterations:
 
         sanitized = agent._sanitize_api_messages(messages)
 
-        # The malformed call is gone; the good one survives.
+        # The good call is untouched; the malformed call is repaired in place
+        # (renamed to a non-empty sentinel) rather than dropped.
         assistant = next(m for m in sanitized if m.get("role") == "assistant")
         names = [tc["function"]["name"] for tc in assistant["tool_calls"]]
-        assert names == ["web_search"]
-        # Its now-orphaned tool result is dropped; the good result remains.
+        assert names == ["web_search", "invalid_tool_call"]
+        # Both calls now have non-empty names, so neither output is orphaned
+        # and both tool results survive — this is what prevents the 400.
         tool_ids = [m.get("tool_call_id") for m in sanitized if m.get("role") == "tool"]
-        assert tool_ids == ["call_good"]
+        assert tool_ids == ["call_good", "call_bad"]
 
 
 class TestRunConversation:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3659,6 +3659,43 @@ class TestHandleMaxIterations:
             "call_123"
         ]
 
+    def test_api_sanitizer_drops_tool_call_with_empty_function_name(self, agent):
+        """A tool_call with id but empty function.name makes the Responses-API
+        adapter drop the function_call while keeping its function_call_output,
+        causing the gateway's HTTP 400 'No tool call found for function call
+        output ...'. The sanitizer must drop the malformed call AND its now-
+        orphaned tool result. (#12807)"""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_good",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {"name": "", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_good", "content": "ok"},
+            {"role": "tool", "tool_call_id": "call_bad", "content": "orphan"},
+        ]
+
+        sanitized = agent._sanitize_api_messages(messages)
+
+        # The malformed call is gone; the good one survives.
+        assistant = next(m for m in sanitized if m.get("role") == "assistant")
+        names = [tc["function"]["name"] for tc in assistant["tool_calls"]]
+        assert names == ["web_search"]
+        # Its now-orphaned tool result is dropped; the good result remains.
+        tool_ids = [m.get("tool_call_id") for m in sanitized if m.get("role") == "tool"]
+        assert tool_ids == ["call_good"]
+
 
 class TestRunConversation:
     """Tests for the main run_conversation method.


### PR DESCRIPTION
## Summary

Empty-name `tool_call`s in conversation history no longer brick a session with HTTP 400 — the pre-call sanitizer now repairs them instead of letting them produce an orphan output downstream.

Salvage of #12807 (idea by @melonboy312) via @Bartok9's rebased commits. Supersedes #11435 (@ygd58), which fixed the same 400 but in the wrong place and by dropping the orphan output — which would strip the intentional anti-priming signal (see below).

## Root cause

A stored `assistant` `tool_call` with an `id` but an empty/missing `function.name` (from partial streaming or certain providers) survives `sanitize_api_messages` untouched. The Responses-API serializer (`_chat_messages_to_responses_input`) then **drops** the nameless `function_call` while still emitting its paired `function_call_output`. The orphan output makes the provider reconstruct the name as an empty string and reject the whole request:

```
HTTP 400: Invalid 'input[n].name': empty string.
```

`sanitize_api_messages` already repaired orphan tool_call/result *pairs*, but never the empty-*name* case itself.

## Fix

Add a repair pass in `sanitize_api_messages` (runs unconditionally before **every** LLM call — chat-completions and Responses alike): rename any blank `function.name` to a non-empty sentinel (`invalid_tool_call`) so the call and its result stay **paired**. The serializer no longer drops the `function_call`, so there is no orphan output and no 400.

**Why rename, not drop:** hermes' dispatch loop intentionally keeps an empty-name call paired with a synthesized anti-priming `"tool name was empty"` result (#47967) so weak models self-correct instead of being fed the full tool catalog. Dropping the call (the #11435 approach) would orphan that result and strip the anti-priming signal. Renaming preserves it.

## Changes

- `agent/agent_runtime_helpers.py`: Pass-0 empty-name repair in `sanitize_api_messages` before the orphan-pairing logic.
- `tests/run_agent/test_run_agent.py`: regression test — empty-name call is renamed (not dropped), its result survives, no orphan.

## Validation

| | Before | After |
|---|---|---|
| Empty-name `tool_call` in history | orphan `function_call_output` → HTTP 400 | renamed → paired `function_call` emitted, no 400 |
| Anti-priming `"tool name was empty"` result | dropped by #11435 approach | preserved |
| Targeted tests | — | 8/8 pass |

E2E (real `sanitize_api_messages` → `_chat_messages_to_responses_input`): the standalone orphan that triggers the 400 is gone, the anti-priming result is preserved, and every emitted `function_call` has a non-empty name.

Fixes #11411.

## Infographic

![fix infographic](https://v3b.fal.media/files/b/0aa06d49/n9XxQilbr4ISgHPHzPf2j_WcmCCWzb.png)

---
Nous Research
