### PR TITLE
fix(image-gen): honor top-level image_gen.model and dispatch model kwarg in the xAI provider

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -100,8 +100,29 @@ def _load_xai_config() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
-    """Decide which model to use and return ``(model_id, meta)``."""
+def _load_image_gen_config() -> Dict[str, Any]:
+    """Read the top-level ``image_gen`` section from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen config: %s", exc)
+        return {}
+
+
+def _resolve_model(explicit: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
+    """Decide which model to use and return ``(model_id, meta)``.
+
+    Precedence: explicit caller override (e.g. the dispatched ``model`` kwarg)
+    → ``XAI_IMAGE_MODEL`` env → scoped ``image_gen.xai.model`` → top-level
+    ``image_gen.model`` (what ``hermes tools`` writes) → :data:`DEFAULT_MODEL`.
+    """
+    if isinstance(explicit, str) and explicit.strip() in _MODELS:
+        return explicit.strip(), _MODELS[explicit.strip()]
+
     env_override = os.environ.get("XAI_IMAGE_MODEL")
     if env_override and env_override in _MODELS:
         return env_override, _MODELS[env_override]
@@ -110,6 +131,10 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     candidate = cfg.get("model") if isinstance(cfg.get("model"), str) else None
     if candidate and candidate in _MODELS:
         return candidate, _MODELS[candidate]
+
+    top = _load_image_gen_config().get("model")
+    if isinstance(top, str) and top in _MODELS:
+        return top, _MODELS[top]
 
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
 
@@ -234,7 +259,7 @@ class XAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect_ratio,
             )
 
-        model_id, meta = _resolve_model()
+        model_id, meta = _resolve_model(kwargs.get("model"))
         aspect = resolve_aspect_ratio(aspect_ratio)
         xai_ar = _XAI_ASPECT_RATIOS.get(aspect, "1:1")
         resolution = _resolve_resolution()

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -120,6 +120,43 @@ class TestConfig:
         model_id, _ = _resolve_model()
         assert model_id == "grok-imagine-image"
 
+    def test_scoped_config_model(self, monkeypatch):
+        monkeypatch.delenv("XAI_IMAGE_MODEL", raising=False)
+        from plugins.image_gen.xai import _resolve_model
+
+        with patch(
+            "plugins.image_gen.xai._load_xai_config",
+            return_value={"model": "grok-imagine-image-quality"},
+        ):
+            model_id, _ = _resolve_model()
+        assert model_id == "grok-imagine-image-quality"
+
+    def test_top_level_config_model(self, monkeypatch):
+        """A model picked via ``hermes tools`` is persisted to top-level
+        ``image_gen.model``; the xAI provider must honor it, not only the
+        scoped ``image_gen.xai.model``.
+        """
+        monkeypatch.delenv("XAI_IMAGE_MODEL", raising=False)
+        from plugins.image_gen.xai import _resolve_model
+
+        with patch("plugins.image_gen.xai._load_xai_config", return_value={}), patch(
+            "plugins.image_gen.xai._load_image_gen_config",
+            return_value={"model": "grok-imagine-image-quality"},
+        ):
+            model_id, _ = _resolve_model()
+        assert model_id == "grok-imagine-image-quality"
+
+    def test_explicit_model_kwarg_wins_over_config(self, monkeypatch):
+        monkeypatch.delenv("XAI_IMAGE_MODEL", raising=False)
+        from plugins.image_gen.xai import _resolve_model
+
+        with patch("plugins.image_gen.xai._load_xai_config", return_value={}), patch(
+            "plugins.image_gen.xai._load_image_gen_config",
+            return_value={"model": "grok-imagine-image"},
+        ):
+            model_id, _ = _resolve_model("grok-imagine-image-quality")
+        assert model_id == "grok-imagine-image-quality"
+
 
 # ---------------------------------------------------------------------------
 # Generate tests


### PR DESCRIPTION
## What does this PR do?

Fixes a parity gap in image-gen model resolution. `hermes tools` persists the
selected image model to the top-level `image_gen.model`, and the
`image_generate` dispatcher forwards it to `provider.generate()` as a `model`
kwarg. The xAI provider read only the **scoped** `image_gen.xai.model` (plus
the `XAI_IMAGE_MODEL` env var) and called `_resolve_model()` with no arguments
— so a user's `hermes tools` selection was silently dropped and xAI always fell
back to its default `grok-imagine-image`.

This is the same gap recently fixed for the OpenRouter/Nous provider; openai,
openai-codex and krea already honor the top-level `image_gen.model`, so xAI was
the lone holdout. This brings xAI in line with the rest.

## Related Issue

N/A 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`plugins/image_gen/xai/__init__.py`**
  - Add `_load_image_gen_config()` — reads the top-level `image_gen` section.
  - `_resolve_model(explicit=None)` now follows the same precedence as the
    other providers: explicit dispatch `model` kwarg → `XAI_IMAGE_MODEL` env →
    scoped `image_gen.xai.model` → top-level `image_gen.model` → `DEFAULT_MODEL`.
  - `generate()` forwards the dispatched kwarg: `_resolve_model(kwargs.get("model"))`.
  - The scoped reader `_load_xai_config` and `_resolve_resolution` are left untouched.
- **`tests/plugins/image_gen/test_xai_provider.py`** — add scoped / top-level /
  explicit-kwarg model-resolution coverage.

## How to Test

Reproduction: set the image model in the top-level `image_gen.model` (what
`hermes tools` writes) without a scoped `image_gen.xai.model`, then resolve the
xAI model.

- Before: `plugins.image_gen.xai._resolve_model()` returns `grok-imagine-image`
  (the default) — the selection is ignored.
- After: it returns the selected model. The scoped key still works, and an
  explicit dispatched `model` kwarg wins over config.

Tests run and results:

```
pytest tests/plugins/image_gen/test_xai_provider.py::TestConfig -v

  TestConfig::test_default_model ........................... PASSED
  TestConfig::test_default_resolution ...................... PASSED
  TestConfig::test_custom_model ............................ PASSED
  TestConfig::test_scoped_config_model            (new) .... PASSED
  TestConfig::test_top_level_config_model         (new) .... PASSED
  TestConfig::test_explicit_model_kwarg_wins_over_config (new)  PASSED
  => 6 passed
```

The change is isolated to xAI model resolution; verified against an unmodified
baseline that it introduces no new failures in the full
`tests/plugins/image_gen/` suite (it adds the 3 passing tests above).

## Checklist

- [x] Read the Contributing Guide; commit follows Conventional Commits (`fix(image-gen): …`)
- [x] Searched existing PRs/issues to avoid a duplicate
- [x] PR contains only changes related to this fix
- [x] Ran the tests for the affected area — pass (results above)
- [x] Added tests for the change
- [x] Documentation / config / tool-schema — N/A (no new config keys; `image_gen.model` is already documented and honored by the other providers)