### PR TITLE
fix(security): constrain persisted tool-result filenames to their storage dir (#10097)

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -16,6 +16,7 @@ from tools.tool_result_storage import (
     _build_persisted_message,
     _heredoc_marker,
     _resolve_storage_dir,
+    _safe_result_filename,
     _write_to_sandbox,
     enforce_turn_budget,
     generate_preview,
@@ -163,6 +164,19 @@ class TestResolveStorageDir:
         env = MagicMock()
         env.get_temp_dir.return_value = "/data/data/com.termux/files/usr/tmp"
         assert _resolve_storage_dir(env) == "/data/data/com.termux/files/usr/tmp/hermes-results"
+
+
+class TestSafeResultFilename:
+    def test_preserves_normal_tool_call_id(self):
+        assert _safe_result_filename("tc_456") == "tc_456.txt"
+
+    def test_replaces_path_and_shell_metacharacters(self):
+        filename = _safe_result_filename("../outside/$(whoami);x")
+        assert filename.startswith("outside_whoami_x_")
+        assert filename.endswith(".txt")
+        assert "/" not in filename
+        assert "$" not in filename
+        assert ";" not in filename
 
 
 # ── _build_persisted_message ──────────────────────────────────────────
@@ -375,6 +389,28 @@ class TestMaybePersistToolResult:
             threshold=30_000,
         )
         assert "unique_id_abc.txt" in result
+
+    def test_tool_use_id_cannot_escape_storage_dir(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        env.get_temp_dir.return_value = ""
+        content = "x" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="../outside/$(whoami);x",
+            env=env,
+            threshold=30_000,
+        )
+        cmd = env.execute.call_args[0][0]
+        target = cmd.split("cat > ", 1)[1].split(" <<", 1)[0]
+
+        assert "Full output saved to: /tmp/hermes-results/outside_whoami_x_" in result
+        assert "/tmp/hermes-results/../" not in result
+        assert target.startswith("/tmp/hermes-results/outside_whoami_x_")
+        assert "/../" not in target
+        assert "$(whoami)" not in target
+        assert ";" not in target
 
     def test_preview_included_in_persisted_output(self):
         env = MagicMock()

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -22,8 +22,10 @@ Defense against context-window overflow operates at three levels:
    where many medium-sized results combine to overflow context.
 """
 
+import hashlib
 import logging
 import os
+import re
 import shlex
 import uuid
 
@@ -39,6 +41,8 @@ PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
+_UNSAFE_RESULT_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
+_MAX_RESULT_FILENAME_STEM = 120
 
 
 def _resolve_storage_dir(env) -> str:
@@ -55,6 +59,24 @@ def _resolve_storage_dir(env) -> str:
                     temp_dir = temp_dir.rstrip("/") or "/"
                     return f"{temp_dir}/hermes-results"
     return STORAGE_DIR
+
+
+def _safe_result_filename(tool_use_id: str) -> str:
+    """Return a single safe filename for a tool result id."""
+    raw_id = str(tool_use_id or "tool_result")
+    safe_stem = _UNSAFE_RESULT_FILENAME_CHARS.sub("_", raw_id).strip("._-")
+    changed = safe_stem != raw_id
+
+    if not safe_stem:
+        safe_stem = "tool_result"
+        changed = True
+
+    if changed or len(safe_stem) > _MAX_RESULT_FILENAME_STEM:
+        digest = hashlib.sha256(raw_id.encode("utf-8")).hexdigest()[:12]
+        safe_stem = safe_stem[:_MAX_RESULT_FILENAME_STEM].rstrip("._-") or "tool_result"
+        safe_stem = f"{safe_stem}_{digest}"
+
+    return f"{safe_stem}.txt"
 
 
 def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) -> tuple[str, bool]:
@@ -153,7 +175,7 @@ def maybe_persist_tool_result(
         return content
 
     storage_dir = _resolve_storage_dir(env)
-    remote_path = f"{storage_dir}/{tool_use_id}.txt"
+    remote_path = f"{storage_dir}/{_safe_result_filename(tool_use_id)}"
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
 
     if env is not None:


### PR DESCRIPTION
## Summary
A model/provider-supplied tool-call id can no longer escape the persisted-result storage directory — the id is normalized to a single safe filename segment before the path is built.

Root cause: `agent/tool_executor.py` passes `tool_call.id` (model/provider-controlled) straight into `f"{storage_dir}/{tool_use_id}.txt"`. The existing `shlex.quote` (PR #7912) blocks shell metacharacters but is orthogonal to path-segment containment — a quoted `/tmp/hermes-results/../../etc/cron.d/x.txt` is still a valid path that resolves outside the storage dir, so an id like `../../etc/cron.d/x` writes attacker content to an arbitrary location.

## Changes
- `tools/tool_result_storage.py`: add `_safe_result_filename()` (collapse unsafe chars → `_`, strip leading/trailing dots, hash-suffix when changed or over length) and route the persisted path through it. Single chokepoint — the budget-enforcement path feeds back through `maybe_persist_tool_result`, so it's covered transitively.
- `tests/tools/test_tool_result_storage.py`: regression coverage for normal-id preservation and traversal/metacharacter containment.

## Validation
| input | before | after |
|---|---|---|
| `tc_456` | `tc_456.txt` | `tc_456.txt` (unchanged) |
| `../../etc/cron.d/x` | escapes `/tmp/hermes-results` | `etc_cron.d_x_<hash>.txt` (contained) |
| `..` / empty / `None` | traversal / odd paths | `tool_result(_<hash>).txt` |

`scripts/run_tests.sh tests/tools/test_tool_result_storage.py` → 52 passed. E2E'd all attack vectors: every output is a contained single segment; legit ids unchanged.

Salvaged from #10097 (@WuKongAI-CMU), cherry-picked onto current main with authorship preserved. An earlier equivalent fix — #6121 by @Junass1 — was self-closed by its author before landing; credit to both for spotting the same gap.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa06d71/upt3P_duyDw2Cv_aNYOBV_SMVDnpDi.png)
