### PR TITLE
fix(streaming): handle adapters that return final responses (salvage #11780)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1944,6 +1944,35 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         request_client_holder["diag"] = _diag
         stream = request_client.chat.completions.create(**stream_kwargs)
 
+        # Some OpenAI-compatible adapters (for example copilot-acp) accept
+        # stream=True but still return a completed response object rather than
+        # an iterator of chunks.  Treat that as "streaming unsupported" for the
+        # rest of this session instead of crashing on ``for chunk in stream``
+        # with ``'types.SimpleNamespace' object is not iterable`` (#11732).
+        response_choices = getattr(stream, "choices", None)
+        if isinstance(response_choices, list) and response_choices:
+            logger.info(
+                "Streaming request returned a final response object instead of "
+                "an iterator; switching %s/%s to non-streaming for this session.",
+                agent.provider or "unknown",
+                agent.model or "unknown",
+            )
+            agent._disable_streaming = True
+            message = getattr(response_choices[0], "message", None)
+            if message is not None:
+                reasoning_text = (
+                    getattr(message, "reasoning_content", None)
+                    or getattr(message, "reasoning", None)
+                )
+                if isinstance(reasoning_text, str) and reasoning_text:
+                    _fire_first_delta()
+                    agent._fire_reasoning_delta(reasoning_text)
+                content = getattr(message, "content", None)
+                if isinstance(content, str) and content:
+                    _fire_first_delta()
+                    agent._fire_stream_delta(content)
+            return stream
+
         # Capture rate limit headers from the initial HTTP response.
         # The OpenAI SDK Stream object exposes the underlying httpx
         # response via .response before any chunks are consumed.

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -626,6 +626,53 @@ class TestStreamingFallback:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_response_object_disables_streaming_and_returns_final_response(
+        self, mock_close, mock_create
+    ):
+        """Adapters that ignore stream=True should fall back cleanly."""
+        from run_agent import AIAgent
+
+        final_response = SimpleNamespace(
+            model="copilot-acp",
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content="Hello from ACP",
+                    tool_calls=None,
+                    reasoning_content=None,
+                    reasoning=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = final_response
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            model="claude-sonnet-4.6",
+            provider="copilot-acp",
+            api_key="test-key",
+            base_url="http://localhost:1234/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        deltas = []
+        agent._stream_callback = lambda text: deltas.append(text)
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response is final_response
+        assert agent._disable_streaming is True
+        assert deltas == ["Hello from ACP"]
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_stream_error_propagates_original(self, mock_close, mock_create):
         """The original streaming error propagates (not a fallback error)."""
         from run_agent import AIAgent


### PR DESCRIPTION
## Summary
ACP Copilot no longer crashes on the first message — adapters that accept `stream=True` but return a completed response object instead of a chunk iterator now fall back to non-streaming cleanly.

Root cause: `copilot-acp` ignores `stream=True` and returns a final response object. The streaming loop then hit `for chunk in stream` on a non-iterable `SimpleNamespace`, raising `'types.SimpleNamespace' object is not iterable`. Closes #11732.

## Changes
- `agent/chat_completion_helpers.py`: after `chat.completions.create(**stream_kwargs)`, detect a populated `choices` list (a final-response object). Log it, set `_disable_streaming` for the session, fire the content + reasoning deltas so output still reaches the user, and return the object instead of iterating it.
- `tests/run_agent/test_streaming.py`: focused test that a final-response object disables streaming and returns the response with deltas fired.

Salvaged from @LeonSGP43's #11780. The streaming loop was extracted out of `run_agent.py` into `agent/chat_completion_helpers.py` since the PR was authored, so the guard was ported to its new home (`self.` → `agent.`, local `_fire_first_delta()` helper). Logic and test are unchanged.

## Validation
| | Before | After |
|---|---|---|
| copilot-acp first message | `'SimpleNamespace' object is not iterable` | falls back to non-streaming, replies |
| content delta | — | fired via `stream_delta_callback` |
| reasoning delta | — | fired via `reasoning_callback` |
| streaming tests | — | 42/42 green |

E2E verified the real `interruptible_streaming_api_call` path returns the object, sets `_disable_streaming`, and fires both content and reasoning deltas.

## Infographic
![Streaming fallback guard](https://v3b.fal.media/files/b/0aa06db6/hVAxRgorWn-MENl52bWUt_Q6v4Mliz.png)
