### PR TITLE
fix(desktop): preserve pet overlay active state on app quit

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5753,6 +5753,7 @@ function createNewSessionWindow() {
 // pushes pet state over IPC (hermes:pet-overlay:state); the overlay just renders
 // it. Control flows back (pop-in, composer submit) via hermes:pet-overlay:control.
 let petOverlayWindow = null
+let appIsQuitting = false
 
 function petOverlayUrl() {
   if (DEV_SERVER) {
@@ -5840,9 +5841,9 @@ function spawnPetOverlayWindow(bounds) {
     }
 
     // If the overlay went away on its own (e.g. ⌘W), tell the main renderer to
-    // pop the pet back in so it doesn't stay hidden. Harmless echo when we're
-    // the ones who closed it (popInPet already cleared the active flag).
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    // pop the pet back in so it doesn't stay hidden. Skip during app quit so
+    // $petOverlayActive stays true and the overlay is restored on next launch.
+    if (!appIsQuitting && mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('hermes:pet-overlay:control', { type: 'pop-in' })
     }
   })
@@ -7573,6 +7574,10 @@ function configureSpellChecker() {
 }
 
 app.on('before-quit', () => {
+  // Prevent the overlay's 'closed' handler from clearing $petOverlayActive
+  // during a clean quit — we want the pet to reappear popped-out on next boot.
+  appIsQuitting = true
+
   // The always-on-top overlay isn't a "real" app window; close it so a stray
   // pet can't keep the process alive or float over a quit app.
   closePetOverlay()


### PR DESCRIPTION
## What does this PR do?

Preserves the pet overlay's popped-out state across app restarts. Currently, when the user quits Hermes while the pet is popped out into a desktop overlay, the quit sequence clears `$petOverlayActive` in the renderer's localStorage — so on the next launch, `restorePetOverlay()` sees `false` and skips restoration, forcing the pet back inside the main window.

The fix adds an `appIsQuitting` flag that guards the overlay window's `closed` handler against sending the `pop-in` IPC message during a clean shutdown.

## Related Issue

Fixes #55920

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.cjs`:
  - Added `let appIsQuitting = false` alongside `petOverlayWindow` module state.
  - Set `appIsQuitting = true` in the `before-quit` handler **before** `closePetOverlay()` is called.
  - Added `!appIsQuitting` guard to the overlay window's `closed` handler so the `pop-in` IPC is only sent when the overlay closes outside of a quit (e.g., user presses ⌘W on the overlay).

## How to Test

1. Enable a pet in Hermes (`display.pet.enabled: true` in config.yaml).
2. Shift-click the in-window pet to pop it out into the desktop overlay.
3. Observe the pet floating on the desktop outside the Hermes window.
4. Close Hermes completely (right-click tray → Quit, or Cmd+Q).
5. Reopen Hermes.
6. Expected result: the pet reappears at its previous desktop position, popped out in the overlay. Before the fix, Observed result: the pet was back inside the main window and the overlay was not restored.
7. Regression check: closing the overlay with ⌘W (not quitting the app) should still pop the pet back into the main window. The `appIsQuitting` flag only guards the quit path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes — N/A: this change is in Electron's main process lifecycle handlers (`before-quit` → `closed` event chain). The existing desktop test suite (`apps/desktop/electron/*.test.cjs`) tests isolated modules, not integrated main-process lifecycle flows. The fix is verified via manual reproduction steps above.
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
