### PR TITLE
fix(web): redact extracted content before truncate-store

### DIFF
--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -129,6 +129,43 @@ class TestEndToEnd:
         assert "para 0 " in content
         assert "para 2999 " in content
 
+    def test_web_extract_redacts_provider_content_before_return_and_store(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        secret = "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890"
+        body = (
+            "public heading\n"
+            f"OPENAI_API_KEY={secret}\n"
+            + "\n".join(f"row {i} " + "z" * 80 for i in range(3000))
+        )
+
+        class FakeProvider:
+            name = "fake"
+            display_name = "Fake"
+
+            def supports_extract(self):
+                return True
+
+            async def extract(self, urls, **kwargs):
+                return [{"url": urls[0], "title": "Leaky Page", "content": body}]
+
+        with patch("tools.web_tools._ensure_web_plugins_loaded"), \
+             patch("tools.web_tools._get_extract_backend", return_value="fake"), \
+             patch("tools.web_tools.async_is_safe_url", new=_AsyncTrue()), \
+             patch("agent.web_search_registry.get_provider", return_value=FakeProvider()):
+            result = json.loads(asyncio.new_event_loop().run_until_complete(
+                wt.web_extract_tool(["https://example.com/leaky"], char_limit=5000)
+            ))
+
+        content = result["results"][0]["content"]
+        assert secret not in content
+        assert "OPENAI_API_KEY=***" in content
+
+        path_line = next(ln for ln in content.splitlines() if "Full text saved to:" in ln)
+        stored_path = path_line.split("Full text saved to:", 1)[1].strip()
+        stored = open(stored_path, encoding="utf-8").read()
+        assert secret not in stored
+        assert "OPENAI_API_KEY=***" in stored
+
 
 def _make_awaitable(value):
     async def _coro(*a, **k):

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -792,6 +792,8 @@ async def web_extract_tool(
             if not raw_content:
                 continue
             clean = convert_base64_images_to_links(raw_content)
+            from agent.redact import redact_sensitive_text
+            clean = redact_sensitive_text(clean, force=True)
             model_text, truncated = _truncate_with_footer(clean, url, effective_char_limit)
             result["content"] = model_text
             if truncated:


### PR DESCRIPTION
## Summary

This redacts secrets from `web_extract` provider content before the new truncate-and-store path returns it to the model or writes the full page copy to `cache/web`.

## Why

After #54843, `web_extract` returns clean provider content directly instead of sending every page through an auxiliary LLM summarizer. That fast path still blocks secrets embedded in the URL, but it did not redact secrets present in the extracted page body.

As a result, if a backend returns page text containing values like `OPENAI_API_KEY=sk-...`, the raw secret can be included in the tool result sent to the model. For large pages, the same raw content can also be written into the stored full-text cache file used for paging.

## Changes

- Apply `redact_sensitive_text(..., force=True)` after base64 image cleanup and before truncate/store processing.
- This redacts both the inline model-visible content and the stored `cache/web` full-text copy.
- Add regression coverage proving raw provider-returned secrets do not appear in either the `web_extract` response or the stored full-text file.

## Tests

```text
python -m pytest tests/tools/test_web_tools_truncate.py -q --timeout-method=thread
13 passed

python -m pytest tests/tools/test_browser_secret_exfil.py -q --timeout-method=thread
12 passed