### PR TITLE
fix(web): enforce website policy for all extract providers

### DIFF
--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -449,6 +449,98 @@ class TestWebToolPolicy:
         assert result["results"][0]["content"] == ""
         assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
 
+    @pytest.mark.asyncio
+    async def test_web_extract_blocks_policy_url_before_non_firecrawl_provider(self, monkeypatch):
+        from tools import web_tools
+        from plugins.web.tavily import provider as tavily_provider
+
+        async def _allow_ssrf(_url: str) -> bool:
+            return True
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                pytest.fail("tavily should not run for blocked URL")
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
+        monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "tavily")
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_provider",
+            lambda _name: tavily_provider.TavilyWebSearchProvider(),
+        )
+        monkeypatch.setattr(
+            "tools.website_policy.check_website_access",
+            lambda url: {
+                "host": "blocked.test",
+                "rule": "blocked.test",
+                "source": "config",
+                "message": "Blocked by website policy",
+            },
+        )
+        monkeypatch.setattr(tavily_provider.os, "getenv", lambda key, default=None: "fake-key")
+        monkeypatch.setattr("httpx.post", lambda *a, **k: FakeResponse())
+
+        result = json.loads(await web_tools.web_extract_tool(["https://blocked.test/private"]))
+
+        assert result["results"][0]["url"] == "https://blocked.test/private"
+        assert result["results"][0]["content"] == ""
+        assert "Blocked by website policy" in result["results"][0]["error"]
+        assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
+
+    @pytest.mark.asyncio
+    async def test_web_extract_blocks_policy_final_url_from_non_firecrawl_provider(self, monkeypatch):
+        from tools import web_tools
+        from plugins.web.tavily import provider as tavily_provider
+
+        async def _allow_ssrf(_url: str) -> bool:
+            return True
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "results": [
+                        {
+                            "url": "https://blocked.test/final",
+                            "title": "Blocked",
+                            "raw_content": "secret content",
+                        }
+                    ]
+                }
+
+        def fake_check(url):
+            if url == "https://allowed.test/start":
+                return None
+            if url == "https://blocked.test/final":
+                return {
+                    "host": "blocked.test",
+                    "rule": "blocked.test",
+                    "source": "config",
+                    "message": "Blocked by website policy",
+                }
+            pytest.fail(f"unexpected URL checked: {url}")
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
+        monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "tavily")
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_provider",
+            lambda _name: tavily_provider.TavilyWebSearchProvider(),
+        )
+        monkeypatch.setattr("tools.website_policy.check_website_access", fake_check)
+        monkeypatch.setattr(tavily_provider.os, "getenv", lambda key, default=None: "fake-key")
+        monkeypatch.setattr("httpx.post", lambda *a, **k: FakeResponse())
+
+        result = json.loads(await web_tools.web_extract_tool(["https://allowed.test/start"]))
+
+        assert result["results"][0]["url"] == "https://blocked.test/final"
+        assert result["results"][0]["content"] == ""
+        assert "Blocked by website policy" in result["results"][0]["error"]
+        assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
+
 
 def test_check_website_access_fails_open_on_malformed_config(tmp_path, monkeypatch):
     """Malformed config with default path should fail open (return None), not crash."""

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -682,14 +682,33 @@ async def web_extract_tool(
         # ── SSRF protection — filter out private/internal URLs before any backend ──
         safe_urls = []
         ssrf_blocked: List[Dict[str, Any]] = []
+        policy_blocked: List[Dict[str, Any]] = []
+        try:
+            from tools.website_policy import check_website_access
+        except Exception:
+            check_website_access = lambda _url: None  # noqa: E731
         for url in normalized_urls:
             if not await async_is_safe_url(url):
                 ssrf_blocked.append({
                     "url": url, "title": "", "content": "",
                     "error": "Blocked: URL targets a private or internal network address",
                 })
-            else:
-                safe_urls.append(url)
+                continue
+            blocked = check_website_access(url)
+            if blocked:
+                policy_blocked.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": blocked["message"],
+                    "blocked_by_policy": {
+                        "host": blocked["host"],
+                        "rule": blocked["rule"],
+                        "source": blocked["source"],
+                    },
+                })
+                continue
+            safe_urls.append(url)
 
         # Dispatch only safe URLs to the configured backend
         if not safe_urls:
@@ -761,9 +780,34 @@ async def web_extract_tool(
                     provider.extract, safe_urls, format=format
                 )
 
-        # Merge any SSRF-blocked results back in
-        if ssrf_blocked:
-            results = ssrf_blocked + results
+        # Re-check final provider URLs so redirects/canonicalization cannot
+        # bypass the central website policy on providers that do not enforce it
+        # internally.
+        if results:
+            filtered_results: List[Dict[str, Any]] = []
+            for result in results:
+                final_url = result.get("url", "")
+                blocked = check_website_access(final_url) if final_url else None
+                if blocked:
+                    filtered_results.append({
+                        "url": final_url,
+                        "title": result.get("title", ""),
+                        "content": "",
+                        "raw_content": "",
+                        "error": blocked["message"],
+                        "blocked_by_policy": {
+                            "host": blocked["host"],
+                            "rule": blocked["rule"],
+                            "source": blocked["source"],
+                        },
+                    })
+                else:
+                    filtered_results.append(result)
+            results = filtered_results
+
+        # Merge any blocked results back in
+        if ssrf_blocked or policy_blocked:
+            results = ssrf_blocked + policy_blocked + results
 
         response = {"results": results}
         


### PR DESCRIPTION
## Summary

This makes `web_extract` enforce the website blocklist policy centrally for every extract provider, not only Firecrawl.

## Why

The Firecrawl extract provider already checks `check_website_access()` before scraping and again after redirects. Other extract providers such as Tavily, Exa, and Parallel did not have the same policy gate.

That meant a URL blocked by `security.website_blocklist` could still be extracted when Hermes was configured to use a non-Firecrawl extract backend. A provider-returned final URL could also land on a blocked domain without a central post-provider check.

## Changes

- Add a central website-policy pre-check in `web_extract_tool()` after SSRF validation and before provider dispatch.
- Add a central post-provider final URL policy check before truncate-and-store processing.
- Preserve blocked result entries with `blocked_by_policy` metadata.
- Add regression coverage for a non-Firecrawl provider path:
  - blocked input URL never reaches Tavily
  - provider-returned blocked final URL returns an error and empty content

## Tests

```text
python -m pytest tests/tools/test_website_policy.py -q --timeout-method=thread
22 passed

python -m pytest tests/tools/test_web_tools_truncate.py -q --timeout-method=thread
12 passed

python -m pytest tests/tools/test_web_tools_tavily.py -q --timeout-method=thread
13 passed

python -m pytest tests/tools/test_web_providers.py -q --timeout-method=thread
15 passed