### PR TITLE
feat(desktop): add Algodyne Carbon theme

### DIFF
--- a/apps/desktop/src/themes/presets.test.ts
+++ b/apps/desktop/src/themes/presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BUILTIN_THEME_LIST, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK } from './presets'
+import { algodyneCarbonTheme, BUILTIN_THEME_LIST, BUILTIN_THEMES, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK } from './presets'
 
 // #40364: none of the UI text/mono fonts carry emoji glyphs, so every font
 // stack must end with a color-emoji fallback or emoji render as tofu on
@@ -29,5 +29,26 @@ describe('theme typography emoji fallback (#40364)', () => {
     expect(EMOJI_FALLBACK).toContain('Apple Color Emoji')
     expect(EMOJI_FALLBACK).toContain('Segoe UI Emoji')
     expect(EMOJI_FALLBACK).toContain('Noto Color Emoji')
+  })
+})
+
+describe('Algodyne Carbon desktop preset', () => {
+  it('is registered as a built-in desktop theme', () => {
+    expect(BUILTIN_THEMES['algodyne-carbon']).toBe(algodyneCarbonTheme)
+    expect(BUILTIN_THEME_LIST.map(theme => theme.name)).toContain('algodyne-carbon')
+  })
+
+  it('keeps red as the brand signal over carbon surfaces', () => {
+    expect(algodyneCarbonTheme.colors.background).toBe('#050505')
+    expect(algodyneCarbonTheme.colors.card).toBe('#0B0B0D')
+    expect(algodyneCarbonTheme.colors.primary).toBe('#FF4A4A')
+    expect(algodyneCarbonTheme.colors.ring).toBe('#FF4A4A')
+    expect(algodyneCarbonTheme.colors.destructive).toBe('#8F1F18')
+  })
+
+  it('reserves support colors for terminal status accents', () => {
+    expect(algodyneCarbonTheme.terminal?.cyan).toBe('#5BA7E4')
+    expect(algodyneCarbonTheme.terminal?.yellow).toBe('#F08A28')
+    expect(algodyneCarbonTheme.terminal?.green).toBe('#2F8F71')
   })
 })

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -241,6 +241,68 @@ export const cyberpunkTheme: DesktopTheme = {
   }
 }
 
+/** Carbon-black Algodyne operator console: red brand signal with functional status accents. */
+export const algodyneCarbonTheme: DesktopTheme = {
+  name: 'algodyne-carbon',
+  label: 'Algodyne Carbon',
+  description: 'Carbon-black Algodyne operator console with red brand signal and functional status accents',
+  colors: {
+    background: '#050505',
+    foreground: '#FAFAFA',
+    card: '#0B0B0D',
+    cardForeground: '#FAFAFA',
+    muted: '#121216',
+    mutedForeground: '#A1A1AA',
+    popover: '#101014',
+    popoverForeground: '#FAFAFA',
+    primary: '#FF4A4A',
+    primaryForeground: '#050505',
+    secondary: '#18181D',
+    secondaryForeground: '#D9D9DE',
+    accent: '#1A0E10',
+    accentForeground: '#FFB4B4',
+    border: '#2A2A2F',
+    input: '#202026',
+    ring: '#FF4A4A',
+    midground: '#FF4A4A',
+    midgroundForeground: '#050505',
+    composerRing: '#FF4A4A',
+    destructive: '#8F1F18',
+    destructiveForeground: '#FAFAFA',
+    sidebarBackground: '#080808',
+    sidebarBorder: '#222227',
+    userBubble: '#13090A',
+    userBubbleBorder: '#8F1F18'
+  },
+  terminal: {
+    foreground: '#FAFAFA',
+    cursor: '#FF4A4A',
+    selectionBackground: '#8F1F1880',
+    black: '#050505',
+    red: '#FF4A4A',
+    green: '#2F8F71',
+    yellow: '#F08A28',
+    blue: '#5BA7E4',
+    magenta: '#8F1F18',
+    cyan: '#5BA7E4',
+    white: '#FAFAFA',
+    brightBlack: '#2A2A2F',
+    brightRed: '#FF6B6B',
+    brightGreen: '#45B98F',
+    brightYellow: '#FFB05C',
+    brightBlue: '#7FC4FF',
+    brightMagenta: '#D14A43',
+    brightCyan: '#8DD4FF',
+    brightWhite: '#FFFFFF'
+  },
+  typography: {
+    fontSans: `Inter, Geist, "IBM Plex Sans", ${SYSTEM_SANS}`,
+    fontMono: `"IBM Plex Mono", "JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap'
+  }
+}
+
 /** Cool slate blue for developers. Matches the CLI slate skin. */
 export const slateTheme: DesktopTheme = {
   name: 'slate',
@@ -283,6 +345,7 @@ export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   ember: emberTheme,
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
+  'algodyne-carbon': algodyneCarbonTheme,
   slate: slateTheme
 }
 


### PR DESCRIPTION
## Summary

- Adds Algodyne Carbon as a built-in Hermes Desktop theme.
- Maps the Algodyne brand board palette into Desktop theme tokens and terminal ANSI accents.
- Adds preset tests for registration, carbon/red hierarchy, and functional cyan/amber/green status colors.

## Verification

- `cd apps/desktop && ../../node_modules/.bin/prettier --write src/themes/presets.ts src/themes/presets.test.ts`
- `cd apps/desktop && bunx eslint src/themes/presets.ts src/themes/presets.test.ts`
- `cd apps/desktop && bun run test:ui -- src/themes/presets.test.ts src/themes/user-themes.test.ts`
- `cd apps/desktop && bun run typecheck`
- `ubs apps/desktop/src/themes/presets.ts apps/desktop/src/themes/presets.test.ts`

## Notes

- Full `bun run lint` currently reports pre-existing findings outside this change (`electron/titlebar-overlay-width.cjs`, `src/store/projects.ts`, plus warnings in unrelated files). The changed files pass scoped ESLint.
- Full-repo `ubs .` exceeded the 300s local timeout after completing JS and Rust; scoped UBS for the changed files completed with 0 critical and 0 warning findings.
