### PR TITLE
[HERMES] fix(tui_gateway): do not use lifetime total as context-used after model switch

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8266,6 +8266,57 @@ def test_get_usage_safe_when_active_count_raises(monkeypatch):
     assert usage["model"] == "x"
 
 
+class _AgentWithCompressorAfterSwitch:
+    """Simulates an agent immediately after a model switch to a smaller context window.
+
+    The compressor has the new, smaller context_length but last_prompt_tokens is 0
+    because update_model() resets calibration state. The session's lifetime total is
+    still large from the previous model; the bug was that _get_usage used that total
+    as the "used" count, making the smaller window look full.
+    """
+
+    model = "smol-model"
+    session_total_tokens = 950_000
+    session_api_calls = 42
+
+    class _comp:
+        context_length = 200_000
+        last_prompt_tokens = 0
+        compression_count = 0
+
+    context_compressor = _comp()
+
+
+def test_get_usage_does_not_use_total_tokens_when_last_prompt_tokens_reset(monkeypatch):
+    """After a model switch, last_prompt_tokens is 0; the old fallback to session
+    total made the new smaller context window look instantly full."""
+    usage = server._get_usage(_AgentWithCompressorAfterSwitch())
+    assert usage["context_max"] == 200_000
+    assert "context_used" not in usage
+    assert "context_percent" not in usage
+
+
+class _AgentWithCompressorHasMeasured:
+    """Normal steady-state agent: the compressor has a real measured prompt size."""
+
+    model = "current-model"
+    session_total_tokens = 100_000
+
+    class _comp:
+        context_length = 200_000
+        last_prompt_tokens = 80_000
+        compression_count = 1
+
+    context_compressor = _comp()
+
+
+def test_get_usage_reports_percent_when_last_prompt_tokens_available(monkeypatch):
+    usage = server._get_usage(_AgentWithCompressorHasMeasured())
+    assert usage["context_max"] == 200_000
+    assert usage["context_used"] == 80_000
+    assert usage["context_percent"] == 40
+
+
 def test_persist_model_switch_preserves_sibling_model_keys(tmp_path, monkeypatch):
     """#48305: switching models from the TUI must NOT destroy sibling keys under
     `model:` (model_slots, model_fallback, etc.). _persist_model_switch now uses

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2964,12 +2964,19 @@ def _get_usage(agent) -> dict:
     }
     comp = getattr(agent, "context_compressor", None)
     if comp:
-        ctx_used = getattr(comp, "last_prompt_tokens", 0) or usage["total"] or 0
+        ctx_used = getattr(comp, "last_prompt_tokens", 0) or 0
         ctx_max = getattr(comp, "context_length", 0) or 0
         if ctx_max:
-            usage["context_used"] = ctx_used
             usage["context_max"] = ctx_max
-            usage["context_percent"] = max(0, min(100, round(ctx_used / ctx_max * 100)))
+            # Only report a "used" count when the compressor has measured the
+            # current model's prompt. After a model switch, update_model() resets
+            # last_prompt_tokens to 0; falling back to the session lifetime total
+            # made a smaller context window (e.g. 1M -> 200K) look instantly
+            # full because the old total far exceeded the new max. Wait for the
+            # next real response to repopulate usage.
+            if ctx_used > 0:
+                usage["context_used"] = ctx_used
+                usage["context_percent"] = max(0, min(100, round(ctx_used / ctx_max * 100)))
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status


### PR DESCRIPTION
## Bug
When switching from a 1M-context model to a 200K-context model, the desktop context-usage panel shows the new context window as instantly full.

## Root cause
After a model switch, `ContextCompressor.update_model()` resets `last_prompt_tokens` to 0. `tui_gateway/server.py::_get_usage()` was falling back to the session's lifetime `total` tokens when `last_prompt_tokens` was 0, so the used count for the new smaller window could exceed the new max.

## Fix
Only report `context_used`/`context_percent` when the compressor has a real measurement for the current model. `context_max` is still reported immediately, so the UI shows the correct new window size and waits for the next turn to show usage.

## Related / overlap
This touches the same `_get_usage()` fallback as:

- #50518 — narrow fix for #50421 / external-context-engine trigger; also removes the `last_prompt_tokens or usage["total"]` fallback and omits `context_used`/`context_percent` when no current occupancy is known.
- #55640 — broader session-recall/context PR that also removes the cumulative fallback, but reports `context_used = 0` / `context_percent = 0` when `last_prompt_tokens` is absent or reset.

This PR frames the same call-site bug from the model-switch trigger: `update_model()` resets `last_prompt_tokens` to 0 after changing the context window, so the old cumulative fallback made a newly smaller window look instantly full. A reviewer should reconcile these PRs at this single call site; #50518 is the most directly overlapping narrow fix.

## Tests
Adds two regression tests in `tests/test_tui_gateway_server.py` covering the post-switch and steady-state paths.

## Files changed
- `tui_gateway/server.py`
- `tests/test_tui_gateway_server.py`
