### PR TITLE
fix(aux): handle dict/str message shape in extract_content_or_reasoning

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6269,7 +6269,21 @@ def extract_content_or_reasoning(response) -> str:
     import re
 
     msg = response.choices[0].message
-    content = (msg.content or "").strip()
+
+    # Some OpenAI-compatible proxies / local backends return a dict- or
+    # str-shaped message instead of a parsed object, so ``msg.content`` would
+    # raise AttributeError (mirrors the moa / context-compressor handling).
+    # Normalize field access before dereferencing anything off the message.
+    def _msg_field(name: str):
+        if isinstance(msg, dict):
+            return msg.get(name)
+        return getattr(msg, name, None)
+
+    raw_content = msg if isinstance(msg, str) else _msg_field("content")
+    if isinstance(raw_content, str):
+        content = raw_content.strip()
+    else:
+        content = str(raw_content).strip() if raw_content else ""
 
     if content:
         # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)
@@ -6285,11 +6299,11 @@ def extract_content_or_reasoning(response) -> str:
     # Content is empty or reasoning-only — try structured reasoning fields
     reasoning_parts: list[str] = []
     for field in ("reasoning", "reasoning_content"):
-        val = getattr(msg, field, None)
+        val = _msg_field(field)
         if val and isinstance(val, str) and val.strip() and val not in reasoning_parts:
             reasoning_parts.append(val.strip())
 
-    details = getattr(msg, "reasoning_details", None)
+    details = _msg_field("reasoning_details")
     if details and isinstance(details, list):
         for detail in details:
             if isinstance(detail, dict):

--- a/tests/tools/test_llm_content_none_guard.py
+++ b/tests/tools/test_llm_content_none_guard.py
@@ -31,6 +31,15 @@ def _make_response(content, **msg_attrs):
     return types.SimpleNamespace(choices=[choice])
 
 
+def _make_raw_response(message):
+    """Wrap a raw, possibly dict-/str-shaped message as the response.
+
+    Some OpenAI-compatible proxies / local backends hand back a dict- or
+    str-shaped ``choices[0].message`` rather than a parsed object.
+    """
+    return types.SimpleNamespace(choices=[types.SimpleNamespace(message=message)])
+
+
 def _run(coro):
     """Run an async coroutine synchronously."""
     return asyncio.get_event_loop().run_until_complete(coro)
@@ -121,7 +130,7 @@ class TestSourceLinesAreGuarded:
     def _read_file(rel_path: str) -> str:
         import os
         base = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        with open(os.path.join(base, rel_path)) as f:
+        with open(os.path.join(base, rel_path), encoding="utf-8") as f:
             return f.read()
 
     def test_web_tools_guarded(self):
@@ -212,3 +221,27 @@ class TestExtractContentOrReasoning:
         """When both content and reasoning exist, content wins."""
         response = _make_response("Actual answer", reasoning="Internal reasoning")
         assert extract_content_or_reasoning(response) == "Actual answer"
+
+    def test_dict_shaped_message_content(self):
+        """Some proxies/local backends return a dict-shaped message; ``.content``
+        must not be dereferenced on it (sibling of the moa / compressor fixes)."""
+        response = _make_raw_response({"role": "assistant", "content": "  Hello world  "})
+        assert extract_content_or_reasoning(response) == "Hello world"
+
+    def test_dict_shaped_message_reasoning_fallback(self):
+        """Reasoning fallback must work for a dict-shaped message too."""
+        response = _make_raw_response(
+            {"role": "assistant", "content": "", "reasoning": "Step 1: analyze..."}
+        )
+        assert extract_content_or_reasoning(response) == "Step 1: analyze..."
+
+    def test_str_shaped_message(self):
+        """A str-shaped message is treated as the content itself."""
+        response = _make_raw_response("  Hello world  ")
+        assert extract_content_or_reasoning(response) == "Hello world"
+
+    def test_non_string_content_coerced_not_crashed(self):
+        """Non-string content (e.g. a dict from some backends) is coerced, not crashed."""
+        response = _make_response({"unexpected": "shape"})
+        out = extract_content_or_reasoning(response)
+        assert isinstance(out, str) and out


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError` crash in the shared `extract_content_or_reasoning()`
helper. `response.choices[0].message` is not guaranteed to be a parsed object —
some OpenAI-compatible proxies / local backends return a **dict- or str-shaped
message**, the same shape the recent MoA and context-compressor fixes added
handling for. The helper dereferenced `msg.content` directly, so it raised
`AttributeError` on those backends, breaking every caller of this shared
helper: vision analysis (`tools/vision_tools.py`), oneshot (`agent/oneshot.py`),
and the teams pipeline.

## Related Issue

N/A — sibling of the recent MoA and context-compressor message-shape fixes;
this extends the same handling to the shared `extract_content_or_reasoning`
helper. Searched existing PRs/issues; none covers this helper.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/auxiliary_client.py`** — `extract_content_or_reasoning()`: normalize
  message-field access (dict / str / object) before reading `content`; make the
  reasoning-fallback reads dict-aware; coerce non-string content to `str`
  instead of crashing.
- **`tests/tools/test_llm_content_none_guard.py`** — add object/dict/str
  message-shape coverage to `TestExtractContentOrReasoning`; fix the
  `_read_file` test helper to open source files with `encoding="utf-8"` (it used
  the platform default, raising `UnicodeDecodeError` on non-UTF-8 locales).

## How to Test

Reproduction: call `extract_content_or_reasoning(response)` where
`response.choices[0].message` is a dict (`{"role":"assistant","content":"..."}`)
or a bare string.

- Before: `AttributeError: 'dict'/'str' object has no attribute 'content'`.
- After: returns the content, and falls back to structured `reasoning` for a
  dict-shaped message.

Tests run and results:

```
pytest tests/tools/test_llm_content_none_guard.py::TestExtractContentOrReasoning -v
  -> 15 passed
     (4 new: dict-content, dict reasoning-fallback, str-message, non-string-content coercion)

pytest tests/tools/test_llm_content_none_guard.py -q
  -> 26 passed
```

`ruff check` and `scripts/check-windows-footguns.py` on the changed files: both
clean. The change is isolated to the shared helper; verified against an
unmodified baseline that it adds the passing tests above and introduces no new
failures.

## Checklist

- [x] Read the Contributing Guide; commit follows Conventional Commits (`fix(aux): …`)
- [x] Searched existing PRs/issues to avoid a duplicate
- [x] PR contains only changes related to this fix
- [x] Ran the tests for the affected area — pass (results above)
- [x] Added tests for the change
- [x] Documentation / config / tool-schema — N/A (internal helper behavior fix; no API/config/schema change)