### PR TITLE
fix(platforms): guard media redirects against SSRF

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3336,12 +3336,17 @@ class FeishuAdapter(BasePlatformAdapter):
         preferred_name: str,
     ) -> tuple[str, str]:
         from tools.url_safety import is_safe_url
+        from gateway.platforms.base import _ssrf_redirect_guard
         if not is_safe_url(file_url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {file_url[:80]}")
 
         import httpx
 
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(
+            timeout=30.0,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        ) as client:
             response = await client.get(
                 file_url,
                 headers={

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1072,13 +1072,18 @@ class WeComAdapter(BasePlatformAdapter):
         max_bytes: int,
     ) -> Tuple[bytes, Dict[str, str]]:
         from tools.url_safety import is_safe_url
+        from gateway.platforms.base import _ssrf_redirect_guard
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url[:80]}")
 
         if not HTTPX_AVAILABLE:
             raise RuntimeError("httpx is required for WeCom media download")
 
-        client = self._http_client or httpx.AsyncClient(timeout=30.0, follow_redirects=True)
+        client = self._http_client or httpx.AsyncClient(
+            timeout=30.0,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        )
         created_client = client is not self._http_client
         try:
             async with client.stream(
@@ -1090,6 +1095,8 @@ class WeComAdapter(BasePlatformAdapter):
                 },
             ) as response:
                 response.raise_for_status()
+                if not is_safe_url(str(response.url)):
+                    raise ValueError("Blocked unsafe redirect URL (SSRF protection)")
                 headers = {key.lower(): value for key, value in response.headers.items()}
                 content_length = headers.get("content-length")
                 if content_length and content_length.isdigit() and int(content_length) > max_bytes:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1825,8 +1825,12 @@ class TestAdapterBehavior(unittest.TestCase):
                 return b"doc-bytes"
 
         class _FakeAsyncClient:
-            def __init__(self, *_a: object, **_k: object) -> None:
-                pass
+            def __init__(self, *_a: object, **kwargs: object) -> None:
+                events.append(
+                    "has_redirect_guard"
+                    if kwargs.get("event_hooks", {}).get("response")
+                    else "missing_redirect_guard"
+                )
 
             async def __aenter__(self) -> "_FakeAsyncClient":
                 events.append("client_enter")
@@ -1860,6 +1864,7 @@ class TestAdapterBehavior(unittest.TestCase):
 
         self.assertEqual(path, "/tmp/cached-doc.bin")
         self.assertTrue(filename)
+        self.assertIn("has_redirect_guard", events)
         # content_read MUST happen before client_exit — otherwise we're
         # reading response body after the connection pool has been torn
         # down, which only works by accident (httpx's eager buffering).

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -443,6 +443,7 @@ class TestMediaUpload:
 
         class FakeResponse:
             headers = {"content-length": "10"}
+            url = "https://example.com/file.bin"
 
             async def __aenter__(self):
                 return self
@@ -465,6 +466,44 @@ class TestMediaUpload:
 
         with pytest.raises(ValueError, match="exceeds WeCom limit"):
             await adapter._download_remote_bytes("https://example.com/file.bin", max_bytes=4)
+
+    @pytest.mark.asyncio
+    async def test_download_remote_bytes_rejects_unsafe_redirect(self, monkeypatch):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        class FakeResponse:
+            headers = {}
+            url = "http://169.254.169.254/latest/meta-data"
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self):
+                yield b"secret"
+
+        class FakeClient:
+            def stream(self, method, url, headers=None):
+                return FakeResponse()
+
+        calls = []
+
+        def fake_safe(url):
+            calls.append(url)
+            return len(calls) == 1
+
+        monkeypatch.setattr("tools.url_safety.is_safe_url", fake_safe)
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = FakeClient()
+
+        with pytest.raises(ValueError, match="unsafe redirect"):
+            await adapter._download_remote_bytes("https://example.com/file.bin", max_bytes=100)
 
     @pytest.mark.asyncio
     async def test_cache_media_decrypts_url_payload_before_writing(self):


### PR DESCRIPTION
## Summary

This closes redirect-based SSRF gaps in Feishu and WeCom remote media/document downloads.

## Why

Both paths validated the initial URL with `is_safe_url()`, but then downloaded with `follow_redirects=True`.

That leaves a redirect gap: an attacker-controlled public URL can pass the initial safety check and then redirect to a private/internal address such as cloud metadata. The shared gateway redirect guard already exists for this exact class; these paths were not using it.

Affected paths:

- `plugins/platforms/feishu/adapter.py::_download_remote_document`
- `plugins/platforms/wecom/adapter.py::_download_remote_bytes`

## Changes

- Add `_ssrf_redirect_guard` to Feishu remote document download `httpx.AsyncClient`.
- Add `_ssrf_redirect_guard` to owned WeCom download clients.
- Add a final `response.url` safety check in WeCom so injected/shared clients that do not carry the event hook still cannot return redirected internal content.
- Add regression coverage for Feishu redirect hook wiring and WeCom unsafe final URL rejection.

## Tests

```text
python -m pytest tests/gateway/test_feishu.py -k "download_remote_document" -q --timeout-method=thread
1 passed, 204 deselected

python -m pytest tests/gateway/test_wecom.py -k "download_remote_bytes" -q --timeout-method=thread
2 passed, 45 deselected

python -m pytest tests/gateway/test_wecom.py -q --timeout-method=thread
47 passed