### PR TITLE
fix(tui_gateway): respect display.streaming config for stream_callback

### DIFF
--- a/tests/tui_gateway/test_tui_streaming_config.py
+++ b/tests/tui_gateway/test_tui_streaming_config.py
@@ -1,0 +1,90 @@
+"""Tests for the TUI gateway respecting display.streaming config.
+
+When ``display.streaming`` is explicitly ``False`` in config.yaml, the TUI
+must NOT pass a ``stream_callback`` to ``run_conversation()``.  Otherwise the
+agent's ``_has_stream_consumers()`` returns True and forces the streaming API
+path, which crashes MoA + Codex aggregator (SimpleNamespace not iterable).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(
+                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_stream_cfg")
+            ),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
+        import importlib
+
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+
+
+def test_streaming_disabled_passes_none_callback(server, monkeypatch):
+    """When display.streaming is False, stream_callback must be None."""
+    cfg = {"display": {"streaming": False}}
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+
+    _display_cfg = (server._load_cfg().get("display") or {})
+    _streaming_enabled = _display_cfg.get("streaming", True)
+    assert _streaming_enabled is False
+
+    # Simulate what run() does
+    def _stream(delta):
+        pass
+
+    _stream_cb = _stream if _streaming_enabled else None
+    assert _stream_cb is None, (
+        "stream_callback should be None when display.streaming is False"
+    )
+
+
+def test_streaming_enabled_passes_callback(server, monkeypatch):
+    """When display.streaming is True (or unset), stream_callback is set."""
+    cfg = {"display": {"streaming": True}}
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+
+    _display_cfg = (server._load_cfg().get("display") or {})
+    _streaming_enabled = _display_cfg.get("streaming", True)
+    assert _streaming_enabled is True
+
+    def _stream(delta):
+        pass
+
+    _stream_cb = _stream if _streaming_enabled else None
+    assert _stream_cb is _stream, (
+        "stream_callback should be _stream when display.streaming is True"
+    )
+
+
+def test_streaming_default_enabled(server, monkeypatch):
+    """When display.streaming is not set, default to True (TUI is interactive)."""
+    cfg = {"display": {}}
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+
+    _display_cfg = (server._load_cfg().get("display") or {})
+    _streaming_enabled = _display_cfg.get("streaming", True)
+    assert _streaming_enabled is True
+
+
+def test_no_display_key_defaults_enabled(server, monkeypatch):
+    """When the display key is absent entirely, streaming defaults to True."""
+    cfg = {}
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+
+    _display_cfg = (server._load_cfg().get("display") or {})
+    _streaming_enabled = _display_cfg.get("streaming", True)
+    assert _streaming_enabled is True

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8558,9 +8558,19 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     payload["rendered"] = r
                 _emit("message.delta", sid, payload)
 
+            # Respect display.streaming config — when disabled, skip the
+            # streaming callback so run_conversation() uses the non-streaming
+            # API path.  Without this, the TUI always passes _stream which
+            # makes _has_stream_consumers() return True, forcing the streaming
+            # path even when the user explicitly disabled it.  This crashes
+            # MoA + Codex aggregator because it returns a SimpleNamespace
+            # instead of an iterable stream.
+            _display_cfg = (_load_cfg().get("display") or {})
+            _stream_cb = _stream if _display_cfg.get("streaming", True) else None
+
             run_kwargs = {
                 "conversation_history": list(history),
-                "stream_callback": _stream,
+                "stream_callback": _stream_cb,
             }
             try:
                 if "task_id" in inspect.signature(agent.run_conversation).parameters:


### PR DESCRIPTION
## What does this PR do?

The TUI gateway unconditionally passed `stream_callback` to `run_conversation()`, making `_has_stream_consumers()` always return `True`. This forced the streaming API path even when the user explicitly set `display.streaming: false` in config.yaml.

With MoA + `openai-codex` aggregator, the streaming path expects an iterable stream of chunks, but the Codex adapter returns a completed `SimpleNamespace` response object, causing:
```
TypeError: 'types.SimpleNamespace' object is not iterable
```

Fix: check `display.streaming` config before passing `stream_callback`. When disabled, pass `None` so `run_conversation()` uses the non-streaming API path. Default is `True` (TUI is interactive by default).

## Related Issue

Fixes #55933

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: Read `display.streaming` from config before constructing `stream_callback`. When `False`, pass `None` to `run_conversation()` so the agent uses the non-streaming API path.
- `tests/tui_gateway/test_tui_streaming_config.py`: 4 tests verifying the config-reading logic — disabled/enabled/default/unset cases.

## How to Test

1. Set `display.streaming: false` in a profile's config.yaml and configure MoA as the active model with an `openai-codex` / `gpt-5.5` aggregator.
2. Start the profile in TUI with `hermes -p PROFILE_NAME chat --tui`.
3. Send any prompt such as `ping`.
4. Observed result: the non-streaming path is used, the MoA aggregator returns a complete response, and the TUI displays it without the `SimpleNamespace` error.
5. Run `pytest tests/tui_gateway/test_tui_streaming_config.py -q` — should pass all 4 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
