### PR TITLE
fix(desktop): return basename for native Windows paths in mediaName

### DIFF
--- a/apps/desktop/src/lib/media.test.ts
+++ b/apps/desktop/src/lib/media.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { mediaName } from './media'
+
+describe('mediaName', () => {
+  it('returns the basename of a native Windows path', () => {
+    expect(mediaName('C:\\Users\\foo\\image.png')).toBe('image.png')
+    expect(mediaName('C:\\a\\b\\c.png')).toBe('c.png')
+  })
+
+  it('keeps POSIX, file:// and http(s) paths working', () => {
+    expect(mediaName('/home/u/pic.png')).toBe('pic.png')
+    expect(mediaName('file:///tmp/image.png')).toBe('image.png')
+    expect(mediaName('https://a.com/b/c.png')).toBe('c.png')
+  })
+})

--- a/apps/desktop/src/lib/media.test.ts
+++ b/apps/desktop/src/lib/media.test.ts
@@ -8,6 +8,18 @@ describe('mediaName', () => {
     expect(mediaName('C:\\a\\b\\c.png')).toBe('c.png')
   })
 
+  it('returns the basename of a native forward-slash Windows path', () => {
+    // `C:/…` is a drive-letter path, not a `scheme://` URL — the split must
+    // still yield the trailing filename and not mistake `C:` for a URL scheme.
+    expect(mediaName('C:/Users/foo/image.png')).toBe('image.png')
+    expect(mediaName('C:/a/b/c.png')).toBe('c.png')
+  })
+
+  it('returns the basename of a UNC path', () => {
+    expect(mediaName('\\\\server\\share\\image.png')).toBe('image.png')
+    expect(mediaName('\\\\server\\share\\a\\b\\c.png')).toBe('c.png')
+  })
+
   it('keeps POSIX, file:// and http(s) paths working', () => {
     expect(mediaName('/home/u/pic.png')).toBe('pic.png')
     expect(mediaName('file:///tmp/image.png')).toBe('image.png')

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -43,13 +43,21 @@ export function mediaMime(path: string): string {
 }
 
 export function mediaName(path: string): string {
-  try {
-    const url = new URL(path)
+  // Only parse as a URL when there is a real `scheme://authority` form. A native
+  // filesystem path (incl. Windows `C:\…`) is not a URL even though
+  // `new URL('C:\\…')` succeeds — a drive letter parses as a URL scheme, leaving
+  // `url.pathname` backslash-separated so the '/'-only split returns the whole path.
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(path)) {
+    try {
+      const url = new URL(path)
 
-    return url.pathname.split('/').filter(Boolean).pop() || path
-  } catch {
-    return path.split(/[\\/]/).filter(Boolean).pop() || path
+      return url.pathname.split('/').filter(Boolean).pop() || path
+    } catch {
+      // fall through to the dual-separator path split below
+    }
   }
+
+  return path.split(/[\\/]/).filter(Boolean).pop() || path
 }
 
 export function mediaMarkdownHref(path: string): string {


### PR DESCRIPTION
## What does this PR do?

`mediaName()` extracts the display filename from a media path. It routed
every input through `new URL(path)`, only falling back to the
backslash-aware split inside the `catch` block. A native Windows path such
as `C:\Users\foo\image.png` does **not** throw — the drive letter `c:`
parses as a URL scheme, so `url.pathname` is `\Users\foo\image.png`, still
backslash-separated. The subsequent `.split('/')` finds no forward slashes,
so the whole path is returned as the "filename" and the entire `C:\…` path
is shown wherever a basename is expected.

The fix guards the URL branch behind a real `scheme://authority` match, so
native filesystem paths (including `C:\…` and `C:/…`) go through the
dual-separator `[\\/]` split. POSIX, `file://`, and `http(s)` inputs are
unchanged.

This corrects the filename shown by the `MediaAttachment` label
(`markdown-text.tsx`), the generated-image "Open image" label
(`generated-image-result.tsx`), and the `[Image: …]` link text via
`mediaDisplayLabel` (`chat-messages.ts`) for Windows desktop users.

## Related Issue

N/A — author-found regression while reading `apps/desktop/src/lib/media.ts`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/media.ts`: only parse the input with `new URL()`
  when it matches a real `scheme://authority` form; native paths fall
  through to the dual-separator basename split.
- `apps/desktop/src/lib/media.test.ts`: new vitest covering native Windows
  paths plus POSIX / `file://` / `http(s)` regression cases.

## How to Test

Before the fix, `mediaName('C:\\Users\\foo\\image.png')` returns
`'\\Users\\foo\\image.png'`; after, it returns `'image.png'`.

1. `cd apps/desktop`
2. `npx vitest run --environment jsdom src/lib/media.test.ts src/lib/media.remote.test.ts`
3. All 12 tests pass. The two native-Windows assertions fail before this
   change (return the full backslash path) and pass after; the POSIX /
   `file://` / `http(s)` assertions stay green throughout.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- N/A: TypeScript desktop change; verified with the desktop vitest suite -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (vitest; Windows path handling verified via the cross-platform string assertions)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this fix specifically targets Windows native-path handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A