### PR TITLE
fix(tests): reset _SESSION_KEY contextvar after cron approval tests

### DIFF
--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -20,6 +20,19 @@ def _clear_approval_state():
     approval_module._permanent_approved.clear()
     approval_module.clear_session("default")
     approval_module.clear_session("test-session")
+    # Tests in TestCronWithGatewayOrigin call set_session_vars() which binds
+    # session contextvars to "" via clear_session_vars().  The empty-string
+    # sentinel prevents get_session_env() from falling back to os.environ,
+    # so subsequent tests that set HERMES_SESSION_KEY via monkeypatch (e.g.
+    # TestApprovalTimeoutIsNotConsent in test_approval.py) read the wrong
+    # session key ("default" instead of the expected value).
+    # Reset _SESSION_KEY to its _UNSET sentinel so the os.environ fallback
+    # works again for later tests in the same pytest process.
+    try:
+        from gateway.session_context import _SESSION_KEY, _UNSET
+        _SESSION_KEY.set(_UNSET)
+    except Exception:
+        pass
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes test isolation between `test_cron_approval_mode.py` and `test_approval.py` when run together in a single `pytest` process. The `TestCronWithGatewayOrigin` tests call `set_session_vars()` which binds the `_SESSION_KEY` contextvar to `""` via `clear_session_vars()`. The empty-string sentinel prevents `get_session_env("HERMES_SESSION_KEY")` from falling back to `os.environ`, so `TestApprovalTimeoutIsNotConsent` (which sets `HERMES_SESSION_KEY` via `os.environ`) reads the wrong session key (`"default"` instead of `"test-no-consent-session"`), causing the registered notify callback to not be found and the approval to return `approval_pending` instead of the expected timeout result.

## Related Issue

Fixes #55947

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/tools/test_cron_approval_mode.py`: Reset `_SESSION_KEY` contextvar to `_UNSET` sentinel in the `_clear_approval_state` fixture teardown, so that `get_session_env()` falls back to `os.environ` for subsequent tests in the same process.

## How to Test

1. Run both files together: `python -m pytest tests/tools/test_cron_approval_mode.py tests/tools/test_approval.py -q` — should pass (279 passed)
2. Run each file individually: `python -m pytest tests/tools/test_cron_approval_mode.py -q` (24 passed) and `python -m pytest tests/tools/test_approval.py -q` (255 passed) — no regressions
3. Previously, running both files together caused 3 failures in `TestApprovalTimeoutIsNotConsent` (assert `user_consent` is False, got None)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (test-only change)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
# Before fix:
FAILED tests/tools/test_approval.py::TestApprovalTimeoutIsNotConsent::test_timeout_returns_approved_false_with_no_consent
FAILED tests/tools/test_approval.py::TestApprovalTimeoutIsNotConsent::test_timeout_message_is_emphatic_against_retry_and_rephrase
FAILED tests/tools/test_approval.py::TestApprovalTimeoutIsNotConsent::test_timeout_emits_post_hook_with_timeout_outcome
3 failed, 276 passed in 3.34s

# After fix:
279 passed in 7.08s
```
