### PR TITLE
[codex] Verify Google Calendar event creation

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -200,6 +200,12 @@ $GAPI gmail modify MESSAGE_ID --remove-labels UNREAD
 
 ### Calendar
 
+Calendar writes must be closed-loop verified. Do not tell the user an event is
+saved until the command output includes `"verified": true` or you have separately
+listed/read the event by ID and confirmed the title plus exact start/end time.
+If verification fails, say the save failed or is unverified, and show the user
+the exact follow-up needed instead of saying it was saved.
+
 ```bash
 # List events (defaults to next 7 days)
 $GAPI calendar list

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -300,7 +300,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 - **Gmail get**: `{id, threadId, from, to, subject, date, labels, body}`
 - **Gmail send/reply**: `{status: "sent", id, threadId}`
 - **Calendar list**: `[{id, summary, start, end, location, description, htmlLink}]`
-- **Calendar create**: `{status: "created", id, summary, htmlLink}`
+- **Calendar create**: `{status: "created", id, summary, htmlLink, verified}`
 - **Drive search**: `[{id, name, mimeType, modifiedTime, webViewLink}]`
 - **Drive get**: `{id, name, mimeType, modifiedTime, size, webViewLink, parents, owners}`
 - **Drive upload**: `{status: "uploaded", id, name, mimeType, webViewLink}`

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -27,6 +27,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from email.mime.text import MIMEText
 from pathlib import Path
@@ -534,22 +535,84 @@ def calendar_create(args):
             params={"calendarId": args.calendar},
             body=event,
         )
+        verified = _calendar_get_verified_gws(args.calendar, result["id"], event)
         print(json.dumps({
             "status": "created",
             "id": result["id"],
-            "summary": result.get("summary", ""),
-            "htmlLink": result.get("htmlLink", ""),
-        }, indent=2))
+            "summary": verified.get("summary", ""),
+            "htmlLink": verified.get("htmlLink", ""),
+            "verified": True,
+        }, indent=2, ensure_ascii=False))
         return
 
     service = build_service("calendar", "v3")
     result = service.events().insert(calendarId=args.calendar, body=event).execute()
+    verified = _calendar_get_verified_service(service, args.calendar, result["id"], event)
     print(json.dumps({
         "status": "created",
         "id": result["id"],
-        "summary": result.get("summary", ""),
-        "htmlLink": result.get("htmlLink", ""),
-    }, indent=2))
+        "summary": verified.get("summary", ""),
+        "htmlLink": verified.get("htmlLink", ""),
+        "verified": True,
+    }, indent=2, ensure_ascii=False))
+
+
+def _calendar_get_verified_gws(calendar_id: str, event_id: str, expected: dict) -> dict:
+    last_error = None
+    for _ in range(3):
+        try:
+            found = _run_gws(
+                ["calendar", "events", "get"],
+                params={"calendarId": calendar_id, "eventId": event_id},
+            )
+            if _calendar_event_matches(found, expected):
+                return found
+            last_error = "created event was readable but did not match requested fields"
+        except SystemExit:
+            raise
+        except Exception as exc:
+            last_error = str(exc)
+        time.sleep(1)
+
+    print(
+        f"ERROR: Calendar create returned id {event_id}, but verification failed: {last_error}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _calendar_get_verified_service(service, calendar_id: str, event_id: str, expected: dict) -> dict:
+    last_error = None
+    for _ in range(3):
+        try:
+            found = service.events().get(calendarId=calendar_id, eventId=event_id).execute()
+            if _calendar_event_matches(found, expected):
+                return found
+            last_error = "created event was readable but did not match requested fields"
+        except Exception as exc:
+            last_error = str(exc)
+        time.sleep(1)
+
+    print(
+        f"ERROR: Calendar create returned id {event_id}, but verification failed: {last_error}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _calendar_event_matches(found: dict, expected: dict) -> bool:
+    if found.get("status") == "cancelled":
+        return False
+    if found.get("summary", "") != expected.get("summary", ""):
+        return False
+
+    found_start = found.get("start", {}).get("dateTime", found.get("start", {}).get("date", ""))
+    found_end = found.get("end", {}).get("dateTime", found.get("end", {}).get("date", ""))
+    if found_start != expected.get("start", {}).get("dateTime", ""):
+        return False
+    if found_end != expected.get("end", {}).get("dateTime", ""):
+        return False
+    return True
 
 
 

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -608,11 +608,35 @@ def _calendar_event_matches(found: dict, expected: dict) -> bool:
 
     found_start = found.get("start", {}).get("dateTime", found.get("start", {}).get("date", ""))
     found_end = found.get("end", {}).get("dateTime", found.get("end", {}).get("date", ""))
-    if found_start != expected.get("start", {}).get("dateTime", ""):
+    if not _calendar_time_matches(found_start, expected.get("start", {}).get("dateTime", "")):
         return False
-    if found_end != expected.get("end", {}).get("dateTime", ""):
+    if not _calendar_time_matches(found_end, expected.get("end", {}).get("dateTime", "")):
         return False
     return True
+
+
+def _calendar_time_matches(found_value: str, expected_value: str) -> bool:
+    if found_value == expected_value:
+        return True
+    if not found_value or not expected_value:
+        return False
+    if "T" not in found_value or "T" not in expected_value:
+        return False
+
+    try:
+        found_dt = _parse_rfc3339_datetime(found_value)
+        expected_dt = _parse_rfc3339_datetime(expected_value)
+    except ValueError:
+        return False
+    return found_dt.astimezone(timezone.utc) == expected_dt.astimezone(timezone.utc)
+
+
+def _parse_rfc3339_datetime(value: str) -> datetime:
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -435,6 +435,85 @@ def test_api_gmail_reply_reads_headers_case_insensitively_and_uses_conventional_
     assert "\nreferences: " not in raw_text
 
 
+def test_api_calendar_create_verifies_inserted_event(api_module, capsys):
+    """calendar create must re-read the inserted event before reporting success."""
+    calls = []
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        calls.append({"parts": parts, "params": params, "body": body})
+        if parts == ["calendar", "events", "insert"]:
+            return {"id": "evt-123", "summary": body["summary"]}
+        if parts == ["calendar", "events", "get"]:
+            assert params == {"calendarId": "primary", "eventId": "evt-123"}
+            return {
+                "id": "evt-123",
+                "summary": "Team Standup",
+                "start": {"dateTime": "2026-04-01T10:00:00Z"},
+                "end": {"dateTime": "2026-04-01T10:30:00Z"},
+                "htmlLink": "https://calendar.google.com/event?eid=evt-123",
+            }
+        raise AssertionError(parts)
+
+    args = api_module.argparse.Namespace(
+        summary="Team Standup",
+        start="2026-04-01T10:00:00Z",
+        end="2026-04-01T10:30:00Z",
+        location="",
+        description="",
+        attendees="",
+        calendar="primary",
+        func=api_module.calendar_create,
+    )
+
+    with patch.object(api_module, "_run_gws", side_effect=fake_run_gws):
+        api_module.calendar_create(args)
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "created"
+    assert output["id"] == "evt-123"
+    assert output["verified"] is True
+    assert [call["parts"] for call in calls] == [
+        ["calendar", "events", "insert"],
+        ["calendar", "events", "get"],
+    ]
+
+
+def test_api_calendar_create_exits_when_verification_mismatches(api_module, capsys):
+    """calendar create must not emit success if the re-read event mismatches."""
+    args = api_module.argparse.Namespace(
+        summary="Team Standup",
+        start="2026-04-01T10:00:00Z",
+        end="2026-04-01T10:30:00Z",
+        location="",
+        description="",
+        attendees="",
+        calendar="primary",
+        func=api_module.calendar_create,
+    )
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        if parts == ["calendar", "events", "insert"]:
+            return {"id": "evt-123", "summary": body["summary"]}
+        if parts == ["calendar", "events", "get"]:
+            return {
+                "id": "evt-123",
+                "summary": "Different title",
+                "start": {"dateTime": "2026-04-01T10:00:00Z"},
+                "end": {"dateTime": "2026-04-01T10:30:00Z"},
+            }
+        raise AssertionError(parts)
+
+    monkey_sleep = patch.object(api_module.time, "sleep", lambda _seconds: None)
+    with patch.object(api_module, "_run_gws", side_effect=fake_run_gws), monkey_sleep:
+        with pytest.raises(SystemExit) as exc_info:
+            api_module.calendar_create(args)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "verification failed" in captured.err
+    assert captured.out == ""
+
+
 def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, monkeypatch):
     token_path = api_module.TOKEN_PATH
     _write_token(token_path, token="ya29.old")

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -448,8 +448,8 @@ def test_api_calendar_create_verifies_inserted_event(api_module, capsys):
             return {
                 "id": "evt-123",
                 "summary": "Team Standup",
-                "start": {"dateTime": "2026-04-01T10:00:00Z"},
-                "end": {"dateTime": "2026-04-01T10:30:00Z"},
+                "start": {"dateTime": "2026-04-01T12:00:00+02:00"},
+                "end": {"dateTime": "2026-04-01T12:30:00+02:00"},
                 "htmlLink": "https://calendar.google.com/event?eid=evt-123",
             }
         raise AssertionError(parts)
@@ -476,6 +476,44 @@ def test_api_calendar_create_verifies_inserted_event(api_module, capsys):
         ["calendar", "events", "insert"],
         ["calendar", "events", "get"],
     ]
+
+
+def test_api_calendar_create_verifies_python_client_event(api_module, capsys):
+    """The Python-client fallback must re-read the inserted event before success."""
+    api_module._gws_binary = lambda: None
+
+    events = MagicMock()
+    events.insert.return_value.execute.return_value = {"id": "evt-123"}
+    events.get.return_value.execute.return_value = {
+        "id": "evt-123",
+        "summary": "Team Standup",
+        "start": {"dateTime": "2026-04-01T12:00:00+02:00"},
+        "end": {"dateTime": "2026-04-01T12:30:00+02:00"},
+        "htmlLink": "https://calendar.google.com/event?eid=evt-123",
+    }
+    service = MagicMock()
+    service.events.return_value = events
+    api_module.build_service = lambda api, version: service
+
+    args = api_module.argparse.Namespace(
+        summary="Team Standup",
+        start="2026-04-01T10:00:00Z",
+        end="2026-04-01T10:30:00Z",
+        location="",
+        description="",
+        attendees="",
+        calendar="primary",
+        func=api_module.calendar_create,
+    )
+
+    api_module.calendar_create(args)
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "created"
+    assert output["id"] == "evt-123"
+    assert output["verified"] is True
+    events.insert.assert_called_once()
+    events.get.assert_called_once_with(calendarId="primary", eventId="evt-123")
 
 
 def test_api_calendar_create_exits_when_verification_mismatches(api_module, capsys):

--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -175,7 +175,7 @@ All commands return JSON. Key fields per service:
 | `gmail get` | `id`, `threadId`, `from`, `to`, `subject`, `date`, `labels`, `body` |
 | `gmail send/reply` | `status`, `id`, `threadId` |
 | `calendar list` | `id`, `summary`, `start`, `end`, `location`, `description`, `htmlLink` |
-| `calendar create` | `status`, `id`, `summary`, `htmlLink` |
+| `calendar create` | `status`, `id`, `summary`, `htmlLink`, `verified` |
 | `drive search` | `id`, `name`, `mimeType`, `modifiedTime`, `webViewLink` |
 | `contacts list` | `name`, `emails`, `phones` |
 | `sheets get` | 2D array of cell values |


### PR DESCRIPTION
## Summary

- Re-read newly inserted Google Calendar events before reporting calendar create success.
- Mark successful create responses with `verified: true` only after summary/start/end match the read-back event.
- Document the closed-loop calendar write requirement in the Google Workspace skill and add tests for verified and mismatched create flows.

## Why

A calendar write could previously be reported as saved without a closed-loop read-back check. This made it possible for the assistant to tell the user an event existed even when the actual Google Calendar state did not match.

## Validation

- `/home/yk/hermes-agent/venv/bin/python -m pytest tests/skills/test_google_workspace_api.py -q`
- Latest upstream PR worktree result: `18 passed in 0.22s`
- Live smoke on the home desktop created a temporary Google Calendar event, observed `verified: true`, and deleted the temporary event.