### PR TITLE
fix(approval): catch GNU long-flag abbreviations for chown --recursive and git push --force

### DIFF
--- a/tests/tools/test_gnu_long_option_abbreviation_bypass.py
+++ b/tests/tools/test_gnu_long_option_abbreviation_bypass.py
@@ -1,0 +1,109 @@
+"""Tests for GNU long-option abbreviation bypass in DANGEROUS_PATTERNS.
+
+GNU tools accept unique long-option prefix abbreviations at runtime
+(e.g. ``chown --recur`` resolves to ``chown --recursive``). Two approval
+patterns matched only the full flag name and could be evaded by passing a
+valid abbreviation:
+
+  chown    --recursive  →  --recur[a-z]*
+  git push --force      →  --forc[a-z]*
+
+The other long-flag patterns (rm/chmod/sed) were already covered on every
+abbreviation by sibling short-flag / target patterns, so this file only
+asserts the two gaps that were genuinely open plus the relevant regression
+guards.
+"""
+
+import pytest
+
+from tools.approval import detect_dangerous_command
+
+
+class TestChownRecursiveLongOptionAbbreviation:
+    """chown --recur* abbreviations targeting root must be caught.
+
+    On main the bare ``--recur root`` form is caught only by an accidental
+    case-insensitive ``r`` → ``R`` overlap with the short-flag pattern; longer
+    abbreviations like ``--recurs``/``--recursi`` break that overlap and
+    slipped through before the prefix change.
+    """
+
+    def test_chown_recursive_full_still_detected(self):
+        dangerous, _, desc = detect_dangerous_command("chown --recursive root /etc")
+        assert dangerous is True
+        assert "chown" in desc.lower() or "root" in desc.lower()
+
+    def test_chown_recur_root_detected(self):
+        dangerous, _, _ = detect_dangerous_command("chown --recur root /etc")
+        assert dangerous is True
+
+    def test_chown_recurs_root_detected(self):
+        dangerous, _, _ = detect_dangerous_command("chown --recurs root:root /var")
+        assert dangerous is True, "chown --recurs is a valid abbreviation of --recursive"
+
+    def test_chown_recursi_root_detected(self):
+        dangerous, _, _ = detect_dangerous_command("chown --recursi root /etc")
+        assert dangerous is True
+
+    def test_chown_recur_non_root_not_flagged(self):
+        """--recur* chown to a non-root user must not be flagged."""
+        dangerous, _, _ = detect_dangerous_command("chown --recur nobody /opt/app")
+        assert dangerous is False
+
+
+class TestGitPushForceLongOptionAbbreviation:
+    """git push --forc* abbreviations must be caught.
+
+    The short ``-f`` pattern does not catch ``--forc`` (the ``\\b`` after the
+    ``f`` does not match mid-word), so abbreviated long forms slipped through.
+    """
+
+    def test_git_push_force_full_still_detected(self):
+        dangerous, _, desc = detect_dangerous_command("git push --force origin main")
+        assert dangerous is True
+        assert "force" in desc.lower()
+
+    def test_git_push_forc_abbreviation_detected(self):
+        dangerous, _, _ = detect_dangerous_command("git push --forc origin main")
+        assert dangerous is True, "git push --forc is a valid abbreviation of --force"
+
+    def test_git_push_forced_variant_detected(self):
+        dangerous, _, _ = detect_dangerous_command("git push --forced origin main")
+        assert dangerous is True
+
+    def test_git_push_force_with_lease_detected(self):
+        dangerous, _, _ = detect_dangerous_command(
+            "git push --force-with-lease origin main"
+        )
+        assert dangerous is True
+
+    def test_git_push_short_f_still_detected(self):
+        """Existing -f pattern must not regress."""
+        dangerous, _, _ = detect_dangerous_command("git push -f origin main")
+        assert dangerous is True
+
+    def test_git_push_no_force_not_flagged(self):
+        dangerous, _, _ = detect_dangerous_command("git push origin main")
+        assert dangerous is False
+
+    def test_git_push_set_upstream_not_flagged(self):
+        dangerous, _, _ = detect_dangerous_command(
+            "git push --set-upstream origin feature"
+        )
+        assert dangerous is False
+
+
+class TestFullFormRegressions:
+    """The two changed long-flag patterns must still detect their full form."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "chown --recursive root /etc",
+            "git push --force origin main",
+        ],
+    )
+    def test_full_form_still_detected(self, cmd):
+        dangerous, key, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, f"Full-form long flag not detected in: {cmd!r}"
+        assert key is not None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -426,7 +426,7 @@ DANGEROUS_PATTERNS = [
     (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),
     (r'\bchmod\s+--recursive\b.*(777|666|o\+[rwx]*w|a\+[rwx]*w)', "recursive world/other-writable (long flag)"),
     (r'\bchown\s+(-[^\s]*)?R\s+root', "recursive chown to root"),
-    (r'\bchown\s+--recursive\b.*root', "recursive chown to root (long flag)"),
+    (r'\bchown\s+--recur[a-z]*\b.*root', "recursive chown to root (long flag)"),
     (r'\bmkfs\b', "format filesystem"),
     (r'\bdd\s+.*if=', "disk copy"),
     (r'>\s*/dev/sd', "write to block device"),
@@ -549,7 +549,7 @@ DANGEROUS_PATTERNS = [
     # Git destructive operations that can lose uncommitted work or rewrite
     # shared history. Not captured by rm/chmod/etc patterns.
     (r'\bgit\s+reset\s+--hard\b', "git reset --hard (destroys uncommitted changes)"),
-    (r'\bgit\s+push\b.*--force\b', "git force push (rewrites remote history)"),
+    (r'\bgit\s+push\b.*--forc[a-z]*\b', "git force push (rewrites remote history)"),
     (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
     (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
     (r'\bgit\s+branch\s+-D\b', "git branch force delete"),


### PR DESCRIPTION
## Summary

`chown --recurs root` and `git push --forc origin main` evaded the approval gate's exact-match `--recursive` / `--force` patterns, because GNU tools accept unique-prefix long-option abbreviations at runtime. Two `DANGEROUS_PATTERNS` entries now prefix-match (`--recur[a-z]*`, `--forc[a-z]*`) so abbreviated forms still trigger the approval prompt.

Salvages @Subway2023's #13941, narrowed to the two patterns with a genuine gap.

## Changes

- `tools/approval.py` — two `DANGEROUS_PATTERNS` long-flag entries switched from exact to prefix match:
  - `chown --recursive` → `--recur[a-z]*`
  - `git push --force` → `--forc[a-z]*`
- `tests/tools/test_gnu_long_option_abbreviation_bypass.py` — abbreviation-bypass + full-form-regression coverage for the two patterns.

## Why only two patterns (not the original five)

The original PR also rewrote the `rm`, `chmod`, and `sed` long-flag patterns. Verified empirically against current `main`: those three are **no-ops** — every abbreviation is already caught by sibling patterns (`rm -[^\s]*r`, the base `chmod 777` target match, `sed -[^\s]*i`). Only `chown` (beyond an accidental case-insensitive `r`→`R` overlap that breaks at `--recurs`) and `git push` had an actual gap, so the redundant three are dropped. The original test file asserted "bypass blocked" for 9 cases that were never open; the trimmed test file only covers the cases that prove a real gap.

This tightens the approval **gate** (`DANGEROUS_PATTERNS`, which `--yolo` passes through), not the unconditional `HARDLINE_PATTERNS` floor.

## Validation

| | Before | After |
|---|---|---|
| `chown --recurs root /var` | not flagged | flagged |
| `git push --forc origin main` | not flagged | flagged |
| `chown --recursive` / `git push --force` (full) | flagged | flagged |
| `chown --recur nobody` / `git push --set-upstream` (safe) | not flagged | not flagged |

- 14/14 new tests pass.
- 382/382 across `test_approval.py`, `test_hardline_blocklist.py`, `test_write_approval.py` — no regression.

## Infographic

![approval-gate-long-flag-abbreviation-hardening](https://v3b.fal.media/files/b/0aa06f13/YNX5QylfGYPCmU-YHqMH7_6PJkfRJG.png)
