### PR TITLE
fix(cli): prevent process_loop freeze from MCP reload join and voice flag leak (#16803)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10107,9 +10107,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             target=self._reload_mcp, daemon=True
         )
         _reload_thread.start()
-        _reload_thread.join(timeout=30)
-        if _reload_thread.is_alive():
-            print("  ⚠️  MCP reload timed out (30s). Some servers may not have reconnected.")
+        # Do NOT join here — process_loop calls this from its idle branch, so a
+        # blocking join would freeze input consumption for up to 30s (and a hung
+        # MCP server could block far longer). The reload runs purely in the
+        # background daemon thread, which reports its own progress/completion
+        # status via print() inside _reload_mcp().
 
     # Inline-skip tokens that bypass the destructive-slash confirmation modal.
     # A general escape hatch for non-interactive use (scripting/automation) and
@@ -10737,8 +10739,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             pass
 
+        # Recorder creation can fail (no input device, PortAudio init error).
+        # Reset the flag on failure or _voice_recording stays True forever and
+        # every future voice start is silently skipped by the guard above.
         if self._voice_recorder is None:
-            self._voice_recorder = create_audio_recorder()
+            try:
+                self._voice_recorder = create_audio_recorder()
+            except Exception:
+                with self._voice_lock:
+                    self._voice_recording = False
+                raise
 
         # Apply config-driven silence params (numeric-guarded so YAML
         # scalar corruption doesn't break recording start-up).


### PR DESCRIPTION
## Summary
Two narrow fixes that close paths to the "TUI input black hole" reported in #16803 — the CLI keeps rendering but stops consuming user input. Salvaged from @HiddenPuppy's PR #16931 (stale by ~7400 commits; the original branch also bundled CI-workflow deletions and an unrelated config line, both dropped here).

## Changes
- `cli.py` — **MCP reload no longer blocks `process_loop`.** `_check_config_mcp_changes()` runs in `process_loop`'s idle branch; the prior `_reload_thread.join(timeout=30)` froze input consumption for up to 30s (longer if an MCP server hung). The reload daemon already reports its own status via `print()`, so the join is removed and the reload runs purely in the background.
- `cli.py` — **Voice recording flag can no longer leak.** `_voice_recording` was set `True` before `create_audio_recorder()`, which ran outside any try/except. A recorder-creation failure (no input device, PortAudio init error) left the flag stuck `True`, so every future voice start was silently skipped by the double-start guard. Recorder creation is now wrapped to reset the flag and re-raise on failure, matching the existing `start()` handler.

## Validation
| | Before | After |
|---|---|---|
| MCP reload | blocks input up to 30s | runs in background, input stays live |
| Voice start fails (no device) | `_voice_recording` stuck True forever | flag reset, voice recovers on next start |
| Targeted tests | — | 49 pass (mcp_reload_confirm_gate + voice_wrapper) |
| E2E flag-reset sim | — | failure resets flag, second start succeeds |

Note: the `process_loop` exception handler itself is left as-is — current `main` already keeps the loop alive on `Exception` (via the `while` loop + `logger.warning`), so only the two upstream freeze sources needed fixing.

Closes #16803.

## Infographic
![process_loop freeze fixes](https://v3b.fal.media/files/b/0aa06f2b/usoA2cE3fFGyMVPosc5Db_7VDdckV1.png)
