### PR TITLE
fix(desktop): preserve popped-out pet on quit

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5753,6 +5753,7 @@ function createNewSessionWindow() {
 // pushes pet state over IPC (hermes:pet-overlay:state); the overlay just renders
 // it. Control flows back (pop-in, composer submit) via hermes:pet-overlay:control.
 let petOverlayWindow = null
+let closingPetOverlayForAppQuit = false
 
 function petOverlayUrl() {
   if (DEV_SERVER) {
@@ -5842,7 +5843,7 @@ function spawnPetOverlayWindow(bounds) {
     // If the overlay went away on its own (e.g. ⌘W), tell the main renderer to
     // pop the pet back in so it doesn't stay hidden. Harmless echo when we're
     // the ones who closed it (popInPet already cleared the active flag).
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    if (!closingPetOverlayForAppQuit && mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('hermes:pet-overlay:control', { type: 'pop-in' })
     }
   })
@@ -7574,7 +7575,11 @@ function configureSpellChecker() {
 
 app.on('before-quit', () => {
   // The always-on-top overlay isn't a "real" app window; close it so a stray
-  // pet can't keep the process alive or float over a quit app.
+  // pet can't keep the process alive or float over a quit app. Do not echo a
+  // pop-in control back to the renderer during app teardown: the renderer
+  // persists that state, and shutdown would otherwise erase the user's
+  // popped-out preference before the next launch can restore it.
+  closingPetOverlayForAppQuit = true
   closePetOverlay()
 
   // Quitting mid-install should stop the installer, not orphan it.

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -92,9 +92,28 @@ test('desktop backend teardown tree-kills Windows backend descendants', () => {
 
   const quitIndex = source.indexOf("app.on('before-quit'")
   assert.notEqual(quitIndex, -1, 'missing before-quit handler')
-  const quitSnippet = source.slice(quitIndex, quitIndex + 900)
+  const quitSnippet = source.slice(quitIndex, quitIndex + 1300)
   assert.match(quitSnippet, /stopBackendChild\(hermesProcess\)/)
   assert.doesNotMatch(quitSnippet, /hermesProcess\.kill\('SIGTERM'\)/)
+})
+
+test('pet overlay quit close preserves popped-out preference', () => {
+  const source = readElectronFile('main.cjs')
+
+  const overlayStartIndex = source.indexOf('function spawnPetOverlayWindow(bounds)')
+  assert.notEqual(overlayStartIndex, -1, 'missing pet overlay window factory')
+  const overlayCloseIndex = source.indexOf("win.on('closed', () => {", overlayStartIndex)
+  assert.notEqual(overlayCloseIndex, -1, 'missing pet overlay closed handler')
+  const overlayCloseSnippet = source.slice(overlayCloseIndex, overlayCloseIndex + 500)
+  assert.match(overlayCloseSnippet, /!closingPetOverlayForAppQuit/)
+  assert.match(overlayCloseSnippet, /hermes:pet-overlay:control/)
+  assert.match(overlayCloseSnippet, /type: 'pop-in'/)
+
+  const quitIndex = source.indexOf("app.on('before-quit'")
+  assert.notEqual(quitIndex, -1, 'missing before-quit handler')
+  const quitSnippet = source.slice(quitIndex, quitIndex + 500)
+  assert.match(quitSnippet, /closingPetOverlayForAppQuit = true/)
+  assert.match(quitSnippet, /closePetOverlay\(\)/)
 })
 
 test('intentional or interactive desktop child processes stay documented', () => {


### PR DESCRIPTION
Fixes #55920.\n\nPrevents the pet overlay close event during app quit from sending a pop-in control back to the renderer, preserving the persisted popped-out state for next launch.\n\nTests:\n- node --test apps/desktop/electron/windows-child-process.test.cjs