### PR TITLE
fix(dashboard): allow forwarded websocket origins

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12118,6 +12118,17 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
     if not parsed.netloc:
         return f"origin_mismatch origin={origin} bound={bound_host}"
 
+    forwarded_host = (ws.headers.get("x-forwarded-host", "") or "").split(",", 1)[0].strip()
+    if forwarded_host and _is_accepted_host(parsed.netloc, forwarded_host):
+        # Reverse-proxy tunnels (Cloudflare Tunnel, Tailscale Funnel, ngrok,
+        # Caddy, etc.) commonly rewrite Host to the local bind address so the
+        # HTTP Host guard passes, but browsers keep the immutable public Origin
+        # (https://dashboard.example.com).  When the proxy tells us the public
+        # host it forwarded, accept that same host as the Origin target.  This
+        # preserves the DNS-rebinding check for arbitrary cross-site origins
+        # while allowing legitimate tunneled WebSocket upgrades.
+        return None
+
     if not _is_accepted_host(parsed.netloc, bound_host):
         return f"origin_mismatch origin={origin} bound={bound_host}"
     return None

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -465,9 +465,9 @@ class TestWsHostOriginGuardOrigins:
     match-checked against the bound host.
     """
 
-    def _ws(self, *, origin, host):
+    def _ws(self, *, origin, host, **headers):
         ws = _fake_ws(query={}, path="/api/ws")
-        ws.headers = {"host": host, "origin": origin}
+        ws.headers = {"host": host, "origin": origin, **headers}
         return ws
 
     def test_loopback_file_origin_allowed(self, loopback_app):
@@ -491,6 +491,26 @@ class TestWsHostOriginGuardOrigins:
         # DNS-rebinding / cross-site: a real web attacker can only present an
         # http(s) origin, and that must still be rejected.
         ws = self._ws(origin="http://evil.test", host="127.0.0.1:8080")
+        assert web_server._ws_host_origin_is_allowed(ws) is False
+
+    def test_loopback_tunnel_forwarded_origin_allowed(self, loopback_app):
+        # Reverse proxies/tunnels often rewrite Host to the local bind address
+        # while the browser keeps the immutable public Origin.  If the proxy
+        # supplies the forwarded public host, allow that exact Origin host so
+        # the dashboard PTY websocket works through Cloudflare/Tailscale/ngrok.
+        ws = self._ws(
+            origin="https://dashboard.example.com",
+            host="127.0.0.1:8080",
+            **{"x-forwarded-host": "dashboard.example.com"},
+        )
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+    def test_loopback_tunnel_unrelated_origin_rejected(self, loopback_app):
+        ws = self._ws(
+            origin="https://evil.test",
+            host="127.0.0.1:8080",
+            **{"x-forwarded-host": "dashboard.example.com"},
+        )
         assert web_server._ws_host_origin_is_allowed(ws) is False
 
     def test_explicit_non_loopback_file_origin_allowed(self, insecure_explicit_host_app):


### PR DESCRIPTION
Fixes #55917.\n\nAllows dashboard WebSocket Origin validation to accept an Origin host that exactly matches X-Forwarded-Host, preserving cross-site rejection while supporting reverse-proxy tunnels that rewrite Host to the local bind address.\n\nTests:\n- scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_ws_auth.py -q