### PR TITLE
fix(aux): resolve provider keys via .env-preferring lookup so rotation isn't shadowed by a stale shell export

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1692,6 +1692,20 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 
 
+def _prefer_dotenv_env(key: str) -> Optional[str]:
+    """Resolve a credential env var, preferring ``~/.hermes/.env`` over a stale
+    value inherited from the parent shell.
+
+    Auxiliary tasks must honour a deliberate key rotation the same way the main
+    request path does — mirrors ``get_env_value_prefer_dotenv`` (see
+    #55528/#20591). Reading ``os.getenv`` directly serves the stale shell export
+    that shadows a freshly-rotated ``.env`` key, producing persistent 401s.
+    """
+    from hermes_cli.config import get_env_value_prefer_dotenv
+
+    return get_env_value_prefer_dotenv(key)
+
+
 def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
@@ -1705,7 +1719,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
         # the OPENROUTER_API_KEY env-var path rather than failing outright.
         logger.debug("Auxiliary client: OpenRouter pool exhausted, trying OPENROUTER_API_KEY")
 
-    or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
+    or_key = explicit_api_key or _prefer_dotenv_env("OPENROUTER_API_KEY")
     if not or_key:
         _mark_provider_unhealthy("openrouter", ttl=60)
         return None, None
@@ -1722,7 +1736,7 @@ def _describe_openrouter_unavailable() -> str:
             return "OpenRouter credential pool has no usable entries (credentials may be exhausted)"
         if not _pool_runtime_api_key(entry):
             return "OpenRouter credential pool entry is missing a runtime API key"
-    if not str(os.getenv("OPENROUTER_API_KEY") or "").strip():
+    if not str(_prefer_dotenv_env("OPENROUTER_API_KEY") or "").strip():
         return "OPENROUTER_API_KEY not set"
     return "no usable OpenRouter credentials found"
 
@@ -1972,7 +1986,7 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
 
     if not isinstance(runtime, dict):
         openai_base = os.getenv("OPENAI_BASE_URL", "").strip().rstrip("/")
-        openai_key = os.getenv("OPENAI_API_KEY", "").strip()
+        openai_key = (_prefer_dotenv_env("OPENAI_API_KEY") or "").strip()
         if not openai_base:
             return None, None, None
         runtime = {
@@ -4109,7 +4123,7 @@ def resolve_provider_client(
             custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
-                or os.getenv("OPENAI_API_KEY", "").strip()
+                or (_prefer_dotenv_env("OPENAI_API_KEY") or "").strip()
                 or "no-key-required"  # local servers don't need auth
             )
             if not custom_base:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
 
@@ -1022,6 +1023,27 @@ class TestExplicitProviderRouting:
         assert model is None
         mock_openai.assert_not_called()
         mock_mark.assert_called_once_with("openrouter", ttl=60)
+
+    def test_try_openrouter_prefers_rotated_dotenv_over_stale_shell_export(self, tmp_path, monkeypatch):
+        """#55528 parity: a key rotated in ~/.hermes/.env must beat a stale
+        shell export for the auxiliary OpenRouter path, as it now does for the
+        main request path — otherwise auxiliary tasks keep 401-ing on the old key.
+        """
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        # Stale value still exported in the parent shell (the OLD key):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-stale-shell")
+        # User rotated the key in ~/.hermes/.env (the NEW key):
+        (home / ".env").write_text("OPENROUTER_API_KEY=sk-or-fresh-rotated\n")
+
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock(name="openrouter_client")
+            _try_openrouter()
+
+        assert mock_openai.call_args.kwargs["api_key"] == "sk-or-fresh-rotated"
 
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""


### PR DESCRIPTION
## What does this PR do?

Extends the #55528 credential-rotation fix to the auxiliary client. #55528
established that Hermes-managed credential resolution must prefer
`~/.hermes/.env` over `os.environ`: Hermes loads `.env` **without** overriding
an existing process-env var, so a value exported in the parent shell (login
profile, Codex CLI, test runner) shadows a freshly-rotated `.env` key and
produces persistent 401s. That fix switched the main request path
(`_resolve_api_key_provider_secret`), `get_anthropic_key`, and the
Azure-Foundry status read to `get_env_value_prefer_dotenv`.

The **auxiliary client** — which authenticates every side-LLM task (title
generation, curator skill review, vision analysis, web-search summarization,
session search) — still resolved provider keys via `os.getenv(...)`. So after a
key rotation the main agent used the fresh key while auxiliary tasks kept
authenticating with the stale shell export and 401'd — a confusing split
failure ("my chat works but titles/vision are broken"). It's reachable on the
common single-key setup (no credential pool → the env-var path is taken
directly) and whenever the pool is exhausted.

## Related Issue

Sibling of #55528 / #20591 — extends the same `.env`-preferring resolution to
the auxiliary client. Searched existing PRs/issues; none covers the auxiliary
path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/auxiliary_client.py`** — add `_prefer_dotenv_env(key)` (wraps
  `get_env_value_prefer_dotenv`) and route the auxiliary credential reads
  through it, so a rotated `.env` key wins over a stale shell export:
  - `_try_openrouter` (OpenRouter key)
  - `_resolve_custom_runtime` and `resolve_provider_client` (OpenAI key)
  - `_describe_openrouter_unavailable` (the "not set" diagnostic, for consistency)
- **`tests/agent/test_auxiliary_client.py`** — regression test asserting the
  auxiliary OpenRouter path resolves a rotated `.env` key over a stale
  `os.environ` value.

## How to Test

Reproduction: export `OPENROUTER_API_KEY=old` in the shell, then rotate it to a
new value in `~/.hermes/.env`.

- Before: the auxiliary client resolves `old` (stale shell export) → auxiliary
  tasks 401, while the main agent (fixed by #55528) uses the new key.
- After: the auxiliary client resolves the new `.env` key, matching the main path.

Tests run and results:

```
pytest tests/agent/test_auxiliary_client.py -k try_openrouter -v
  test_try_openrouter_pool_exhausted_falls_back_to_env ................... PASSED
  test_try_openrouter_pool_exhausted_no_env_marks_unhealthy ............. PASSED
  test_try_openrouter_prefers_rotated_dotenv_over_stale_shell_export (new) PASSED
  -> 3 passed

pytest tests/agent/test_auxiliary_client.py -q
  -> 275 passed
```

`ruff check` and `scripts/check-windows-footguns.py` on the changed files: both
clean.

## Checklist

- [x] Read the Contributing Guide; commit follows Conventional Commits (`fix(aux): …`)
- [x] Searched existing PRs/issues to avoid a duplicate
- [x] PR contains only changes related to this fix
- [x] Ran the tests for the affected area — pass (results above)
- [x] Added tests for the change
- [x] Documentation / config / tool-schema — N/A (internal credential-resolution fix; no API/config/schema change)