### PR TITLE
fix(tui_gateway): add errno.EINVAL to PEER_GONE_ERRNOS for Windows

### DIFF
--- a/tests/tui_gateway/test_transport.py
+++ b/tests/tui_gateway/test_transport.py
@@ -1,0 +1,92 @@
+"""Tests for tui_gateway.transport — _PEER_GONE_ERRNOS and StdioTransport."""
+
+import errno
+import json
+import io
+import pytest
+
+from tui_gateway.transport import _PEER_GONE_ERRNOS, StdioTransport
+
+
+class TestPeerGoneErrnos:
+    """Verify that _PEER_GONE_ERRNOS contains the expected errno values."""
+
+    def test_einval_in_peer_gone_errnos(self):
+        """EINVAL (22) must be in the set for Windows detached-stdout."""
+        assert errno.EINVAL in _PEER_GONE_ERRNOS
+
+    def test_epipe_in_peer_gone_errnos(self):
+        """EPIPE must be in the set for POSIX closed-pipe."""
+        assert errno.EPIPE in _PEER_GONE_ERRNOS
+
+    def test_peer_gone_errnos_is_frozenset(self):
+        """_PEER_GONE_ERRNOS must be immutable."""
+        assert isinstance(_PEER_GONE_ERRNOS, frozenset)
+
+    def test_connreset_in_peer_gone_errnos(self):
+        """ECONNRESET must be in the set."""
+        assert errno.ECONNRESET in _PEER_GONE_ERRNOS
+
+    def test_ebadf_in_peer_gone_errnos(self):
+        """EBADF must be in the set."""
+        assert errno.EBADF in _PEER_GONE_ERRNOS
+
+    def test_eshutdown_in_peer_gone_errnos(self):
+        """ESHUTDOWN must be in the set."""
+        assert errno.ESHUTDOWN in _PEER_GONE_ERRNOS
+
+
+class TestStdioTransportWrite:
+    """Verify StdioTransport.write() handles peer-gone errnos correctly."""
+
+    def test_write_einval_returns_false(self):
+        """OSError(22) should return False (peer gone), not raise."""
+        import threading
+        stream = io.StringIO()
+        lock = threading.Lock()
+        transport = StdioTransport(lambda: stream, lock)
+
+        def raise_einval(line):
+            raise OSError(errno.EINVAL, "Invalid argument")
+
+        stream.write = raise_einval
+        result = transport.write({"test": "data"})
+        assert result is False
+
+    def test_write_epipe_returns_false(self):
+        """OSError(EPIPE) should return False (peer gone), not raise."""
+        import threading
+        stream = io.StringIO()
+        lock = threading.Lock()
+        transport = StdioTransport(lambda: stream, lock)
+
+        def raise_epipe(line):
+            raise OSError(errno.EPIPE, "Broken pipe")
+
+        stream.write = raise_epipe
+        result = transport.write({"test": "data"})
+        assert result is False
+
+    def test_write_enospc_raises(self):
+        """OSError(ENOSPC) should raise (real host problem), not return False."""
+        import threading
+        stream = io.StringIO()
+        lock = threading.Lock()
+        transport = StdioTransport(lambda: stream, lock)
+
+        def raise_enospc(line):
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+        stream.write = raise_enospc
+        with pytest.raises(OSError) as exc_info:
+            transport.write({"test": "data"})
+        assert exc_info.value.errno == errno.ENOSPC
+
+    def test_write_success_returns_true(self):
+        """Successful write should return True."""
+        import threading
+        stream = io.StringIO()
+        lock = threading.Lock()
+        transport = StdioTransport(lambda: stream, lock)
+        result = transport.write({"test": "data"})
+        assert result is True

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -38,6 +38,7 @@ _PEER_GONE_ERRNOS = frozenset({
     errno.ECONNRESET,   # peer reset the connection
     errno.EBADF,        # fd closed under us
     errno.ESHUTDOWN,    # transport endpoint shut down
+    errno.EINVAL,       # Windows: stdout detached → errno 22
     getattr(errno, "WSAECONNRESET", -1),  # win32 mapping (no-op on POSIX)
     getattr(errno, "WSAESHUTDOWN", -1),
 } - {-1})


### PR DESCRIPTION
## What does this PR do?

Adds `errno.EINVAL` (22) to `_PEER_GONE_ERRNOS` in `tui_gateway/transport.py`. On Windows, detached stdout raises `OSError(22, 'Invalid argument')` instead of POSIX `EPIPE`. Without `EINVAL` in the set, this was re-raised as a fatal error causing WebSocket 1011 crash loops with 28+ reconnections in 10 minutes.

## Related Issue

Fixes #55119

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/transport.py`: Add `errno.EINVAL` to `_PEER_GONE_ERRNOS` frozenset with comment explaining the Windows detached-stdout case
- `tests/tui_gateway/test_transport.py`: NEW — 10 tests covering:
  - EINVAL, EPIPE, ECONNRESET, EBADF, ESHUTDOWN presence in _PEER_GONE_ERRNOS
  - frozenset immutability
  - StdioTransport.write() behavior with EINVAL, EPIPE, ENOSPC, and success cases

## How to Test

1. Run `python -m pytest tests/tui_gateway/test_transport.py -v` — all 10 tests should pass
2. On Windows: launch TUI gateway, detach stdout (e.g. close terminal) — should see clean disconnect instead of WebSocket 1011 crash loop
3. On POSIX: no behavioral change (EINVAL was already not raised for pipe scenarios)

## Checklist

- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] I've added tests that prove my fix is effective
- [x] All new and existing tests passed