### PR TITLE
fix(desktop): await backend exit before repair reload to prevent port race

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -6231,7 +6231,7 @@ ipcMain.handle('hermes:bootstrap:repair', async () => {
   }
   bootstrapFailure = null
   backendStartFailure = null
-  resetHermesConnection()
+  await teardownPrimaryBackendAndWait()
   return { ok: true }
 })
 ipcMain.handle('hermes:bootstrap:cancel', async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in the Desktop Electron bootstrap repair flow. When `BootFailureOverlay` triggers a Repair, the `hermes:bootstrap:repair` IPC handler called `resetHermesConnection()` which kills the backend process with SIGTERM but returns immediately without waiting for the process to exit. The renderer then reloads and spawns a new backend via `startHermes()`, but the old backend may still hold the port — causing a port conflict crash loop.

The sibling `hermes:bootstrap:reset` handler already does this correctly by using `await teardownPrimaryBackendAndWait()`, which waits for the process to exit (with a 5-second timeout + force-kill fallback). This PR aligns the repair handler with the same pattern.

## Related Issue

Fixes #55974

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.cjs`: Replace `resetHermesConnection()` with `await teardownPrimaryBackendAndWait()` in the `hermes:bootstrap:repair` IPC handler. This ensures the old backend process has fully exited and released its port before the renderer spawns a new one.

## How to Test

1. Launch Hermes Desktop and wait for backend to connect (`HERMES_DASHBOARD_READY` appears)
2. Force-kill the backend process (e.g., `taskkill /PID PID_HERE` on Windows or `kill -9 PID_HERE` on macOS/Linux)
3. `BootFailureOverlay` should appear
4. Click the "Repair" button
5. Before fix: The overlay reappears immediately in a crash loop (port conflict)
6. After fix: The app waits for the old backend to exit, then successfully restarts — no crash loop
7. Node syntax check should pass: `node --check apps/desktop/electron/main.cjs`
8. Desktop tests should pass: `node --test apps/desktop/electron/windows-child-process.test.cjs`
9. Bootstrap tests should pass: `node --test apps/desktop/electron/bootstrap-runner.test.cjs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — existing tests cover the affected code paths
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — applies to all Desktop platforms (Windows, macOS, Linux)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
