### PR TITLE
kanban: persist model_override in task_runs.metadata for by-model analytics

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7829,6 +7829,22 @@ def _default_spawn(
     # handle is kept alive by the child's inheritance.  The parent's
     # reference goes out of scope and is GC'd, but the OS-level FD stays
     # open in the child until the child exits.
+    # Persist model_override into task_runs.metadata so by-model
+    # analytics work without parsing per-run log files.  Non-fatal —
+    # metadata write failure never blocks the worker spawn.
+    if task.model_override and task.current_run_id is not None:
+        try:
+            _meta_conn = sqlite3.connect(str(kanban_db_path(board=board)))
+            _meta_conn.execute(
+                "UPDATE task_runs SET metadata = json_set("
+                "COALESCE(metadata, '{}'), '$.resolved_model', ?"
+                ") WHERE id = ?",
+                (task.model_override, task.current_run_id),
+            )
+            _meta_conn.commit()
+            _meta_conn.close()
+        except Exception:
+            _log.warning("failed to persist resolved_model in task_runs metadata", exc_info=True)
     return proc.pid
 
 


### PR DESCRIPTION
**Problem:** When a kanban task has an explicit `model_override` set (e.g. via `--model` at creation or routing at dispatch), the resolved model is passed as `-m` to the worker CLI and recorded in the task row, but is never written into `task_runs.metadata`. This means by-model analytics — usage breakdown, failure-rate by model — require scraping per-run log files instead of a simple SQL query.

**Solution:** After spawning the worker subprocess inside `_default_spawn()`, write `task.model_override` into `task_runs.metadata.$.resolved_model` via a non-fatal `json_set` UPDATE. The write:

- Fires only when `task.model_override` is set and `task.current_run_id` exists
- Uses `COALESCE(metadata, '{}')` to handle null metadata columns gracefully
- Logs a warning on failure but never blocks the worker spawn
- Requires no schema migration — `task_runs.metadata` is already a nullable JSON column

**Query example after this change:**

```sql
SELECT
  json_extract(metadata, '$.resolved_model') AS model,
  status, outcome, COUNT(*) AS n
FROM task_runs
WHERE metadata IS NOT NULL
  AND json_extract(metadata, '$.resolved_model') IS NOT NULL
GROUP BY model, status, outcome
ORDER BY n DESC;
```

**Scope:** Single function, single file, +16 lines. No new dependencies. The auto-routing via `route_kanban_task()` (part of our local delegation-routing skill) is intentionally excluded — this PR is limited to persisting an already-resolved model.