### PR TITLE
fix(agent): strip timestamp field from API messages (#55902)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1439,7 +1439,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         for msg in messages:
             api_msg = msg.copy()
             agent._copy_reasoning_content_for_api(msg, api_msg)
-            for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
+            for internal_field in ("reasoning", "finish_reason", "_thinking_prefill", "timestamp"):
                 api_msg.pop(internal_field, None)
             # Strict OpenAI-compatible gateways (Fireworks-backed OpenCode Go,
             # Mistral, Moonshot/Kimi) reject any message key outside the Chat

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -794,6 +794,10 @@ def run_conversation(
                 api_msg.pop("finish_reason")
             # Strip internal thinking-prefill marker
             api_msg.pop("_thinking_prefill", None)
+            # Strip internal wall-clock timestamp (SessionDB persistence metadata).
+            # Strict providers (Fireworks-backed OpenCode Go, Mistral, Kimi K2.5)
+            # reject unknown message keys with HTTP 400.
+            api_msg.pop("timestamp", None)
             # Strip Codex Responses API fields (call_id, response_item_id) for
             # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
             # Uses new dicts so the internal messages list retains the fields


### PR DESCRIPTION
## Summary

Strip the internal `timestamp` field from messages before sending to LLM APIs.

## Problem

The `timestamp` field is added internally by `run_agent.py` (line 1584) for SessionDB persistence of original event times. It is metadata, not part of the OpenAI Chat Completions protocol.

Strict providers like **Fireworks-backed OpenCode Go**, **Mistral**, and **Moonshot/Kimi K2.5** reject any unknown message key with HTTP 400, making these providers unusable after the first message.

## Fix

Strip `timestamp` in both sanitizer paths:
- **Main conversation loop** (`agent/conversation_loop.py`) — the per-API-call sanitizer
- **Summary path** (`agent/chat_completion_helpers.py`) — the compression/summary sanitizer

Both locations already strip `reasoning`, `finish_reason`, and `_thinking_prefill` for the same reason. `timestamp` was simply missed.

## Reproduction

1. Configure OpenCode Go provider with Kimi K2.5 model
2. Send any multi-turn conversation
3. Second API call fails with HTTP 400: `'messages[N].timestamp' is not permitted`

## Testing

- `python3 -m py_compile` passes on both changed files
- The `timestamp` field is still preserved in the conversation history (SessionDB) — only the API copy is stripped

Fixes #55902