### PR TITLE
fix(dashboard): guard auth_login against password-only providers to prevent NotImplementedError crash

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -192,6 +192,14 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             status_code=404,
             detail=f"Provider does not support interactive login: {provider!r}",
         )
+    if getattr(p, "supports_password", False):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Provider {provider!r} is password-only and does not support "
+                "OAuth redirect. Use /auth/password-login instead."
+            ),
+        )
 
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -325,6 +325,30 @@ def test_login_non_interactive_provider_returns_404_not_500(gated_app):
     assert "stub" in names
 
 
+def test_login_password_only_provider_returns_400_not_500(gated_app):
+    """Regression: a password-only provider (basic) must not crash on
+    /auth/login — it should return 400 instead of an unhandled
+    NotImplementedError that kills the ASGI server.
+    """
+    import plugins.dashboard_auth.basic as basic_plugin
+
+    register_provider(
+        basic_plugin.BasicAuthProvider(
+            username="admin",
+            password_hash=basic_plugin.hash_password("pw"),
+            secret=b"test-secret-at-least-16b",
+        )
+    )
+
+    r = gated_app.get(
+        "/auth/login?provider=basic&next=%2F", follow_redirects=False
+    )
+    assert r.status_code == 400, (
+        f"basic login should 400, not 500: {r.status_code} {r.text}"
+    )
+    assert "password-only" in r.json()["detail"].lower()
+
+
 def test_callback_without_pkce_cookie_returns_400(gated_app):
     # No prior /auth/login → no PKCE cookie.
     r = gated_app.get(


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in the dashboard auth login route when a password-only provider (BasicAuthProvider) is accessed via `/auth/login?provider=basic`. The route unconditionally calls `p.start_login()` which raises `NotImplementedError` for password-only providers, crashing the ASGI server and causing the container to enter a restart loop.

The fix adds a guard that rejects password-only providers with a 400 response before attempting the OAuth redirect flow.

## Related Issue

Fixes #55985

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/routes.py`: Added a `supports_password` guard in `auth_login()` that returns HTTP 400 for password-only providers, preventing the unhandled `NotImplementedError` from reaching the ASGI top level.
- `tests/hermes_cli/test_dashboard_auth_middleware.py`: Added `test_login_password_only_provider_returns_400_not_500` regression test that registers a BasicAuthProvider and verifies `/auth/login?provider=basic` returns 400 with a descriptive error message.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_dashboard_auth_middleware.py -v` — all 34 tests should pass, including the new `test_login_password_only_provider_returns_400_not_500`.
2. Manual: start the dashboard with basic auth, navigate to `/auth/login?provider=basic` — should return 400 JSON error instead of 500 crash.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
