### PR TITLE
fix(agent): use .get() for final_response to prevent KeyError (#55822)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5475,7 +5475,7 @@ class AIAgent:
             str: Final assistant response
         """
         result = self.run_conversation(message, stream_callback=stream_callback)
-        return result["final_response"]
+        return result.get("final_response", "")
 
     def _run_codex_app_server_turn(
         self,
@@ -5668,7 +5668,7 @@ def main(
     print(f"📞 API Calls: {result['api_calls']}")
     print(f"💬 Messages: {len(result['messages'])}")
     
-    if result['final_response']:
+    if result.get('final_response'):
         print("\n🎯 FINAL RESPONSE:")
         print("-" * 30)
         print(result['final_response'])


### PR DESCRIPTION
## Summary

Prevent `KeyError('final_response')` crash when `run_conversation()` ends on an error/exhaustion path.

## Problem

`run_conversation()` (agent/conversation_loop.py) returns a result dict **without** `final_response` on error paths — it includes `error` instead. There are 8 such returns: invalid API response after max retries, payload-too-large (413), compaction disabled, context-overflow give-up, etc.

`chat()` and `main()` in `run_agent.py` were the only callers using direct dict subscript (`result["final_response"]`). Every other caller already uses `.get("final_response", ...)`.

## Fix

- `chat()`: `result["final_response"]` → `result.get("final_response", "")`
- `main()`: `result['final_response']` → `result.get('final_response')` (inside the existing `if` guard)

## Reproduction

```python
# Simulate error path
agent.run_conversation.return_value = {"messages": [], "completed": False, "error": "max retries exhausted"}
agent.chat("test")  # raises KeyError: 'final_response'
```

Fixes #55822