### PR TITLE
fix(cron): reject zero-duration intervals to prevent runaway jobs (#55727)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -339,6 +339,11 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     if schedule_lower.startswith("every "):
         duration_str = schedule[6:].strip()
         minutes = parse_duration(duration_str)
+        if minutes <= 0:
+            raise ValueError(
+                f"Interval must be at least 1 minute, got '{schedule}'. "
+                "Use 'every 1m' for the minimum recurring interval."
+            )
         return {
             "kind": "interval",
             "minutes": minutes,
@@ -395,6 +400,10 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     # Duration like "30m", "2h", "1d" → one-shot from now
     try:
         minutes = parse_duration(schedule)
+        if minutes <= 0:
+            raise ValueError(
+                f"Duration must be at least 1 minute, got '{schedule}'."
+            )
         run_at = _hermes_now() + timedelta(minutes=minutes)
         return {
             "kind": "once",


### PR DESCRIPTION
## Summary

Reject zero-duration intervals (`every 0m`, `every 0h`) in `parse_schedule()` to prevent runaway cron jobs that re-fire on every scheduler tick.

## Problem

`parse_schedule("every 0m")` returns `{"kind": "interval", "minutes": 0}`. Then `compute_next_run()` sets `next_run = last_run + timedelta(minutes=0)` — always equal to `last_run`, which is always in the past. The scheduler sees the job as overdue and re-fires it on every tick, creating an infinite agent invocation loop.

Similarly, bare `"0m"` accepted as a one-shot duration creates a job scheduled for `now + 0 minutes` = immediately.

## Fix

Add validation in both `parse_schedule` code paths:

1. **`every X` recurring interval**: `minutes <= 0` → raise `ValueError`
2. **`Xm` one-shot duration**: `minutes <= 0` → raise `ValueError`

Minimum interval is 1 minute. Error message guides the user to use `every 1m`.

## Reproduction

```python
from cron.jobs import parse_schedule, compute_next_run
sched = parse_schedule("every 0m")
# {'kind': 'interval', 'minutes': 0, 'display': 'every 0m'}
compute_next_run(sched, last_run_at="2020-01-01T00:00:00+00:00")
# → returns same time (always overdue → fires every tick)
```

Fixes #55727