### PR TITLE
fix(dashboard): handle NotImplementedError on logout for password-only providers (#55985)

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -195,6 +195,14 @@ async def auth_login(request: Request, provider: str, next: str = ""):
 
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))
+    except NotImplementedError:
+        # Password-only providers (e.g. BasicAuthProvider) don't support
+        # OAuth redirect flow.  Redirect to the login form instead.
+        login_url = request.url_for("login_page")
+        resp = RedirectResponse(url=login_url, status_code=302)
+        if next:
+            resp.set_cookie("hermes_next", next, max_age=600, httponly=True, samesite="lax")
+        return resp
     except ProviderError as e:
         audit_log(
             AuditEvent.LOGIN_FAILURE,


### PR DESCRIPTION
## Summary

Prevent dashboard crash when logging out with a password-only auth provider (BasicAuthProvider).

## Problem

`BasicAuthProvider.start_login()` raises `NotImplementedError` because it has no OAuth redirect flow — it is password-only. The `auth_login` route (`/auth/login`) only catches `ProviderError`, so the `NotImplementedError` propagates through the ASGI stack, crashing the dashboard server (exit 0). With `restart: unless-stopped`, the container enters a restart loop.

The logout flow triggers this because it redirects to `/auth/login?provider=basic`, which unconditionally calls `p.start_login()`.

## Fix

Catch `NotImplementedError` separately in `auth_login` and redirect to the login form page (`/login`) instead of crashing. The `next` parameter is preserved via cookie so the user lands on the right page after re-authenticating.

## Reproduction

1. Start container with `restart: unless-stopped`
2. Log in to dashboard with basic auth
3. Click Log Out
4. Server crashes with `NotImplementedError: BasicAuthProvider is password-only`

Fixes #55985