### PR TITLE
fix(models): clear in-memory OpenRouter catalog cache on `--refresh`

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2664,6 +2664,8 @@ def clear_provider_models_cache(provider: Optional[str] = None) -> None:
     """
     try:
         if provider is None:
+            global _openrouter_catalog_cache
+            _openrouter_catalog_cache = None
             path = _provider_models_cache_path()
             if path.exists():
                 path.unlink()


### PR DESCRIPTION
Fixes #55994

## Problem

`/model --refresh` and `hermes model --refresh` are no-ops for the OpenRouter model list. The in-memory `_openrouter_catalog_cache` global survives `clear_provider_models_cache()` untouched, so the stale cached list is returned on the next picker open.

## Fix

Added `global _openrouter_catalog_cache; _openrouter_catalog_cache = None` inside `clear_provider_models_cache()` when `provider is None` (the full-refresh path), so the in-memory cache is invalidated alongside the disk cache.

## Testing

- `python -m py_compile hermes_cli/models.py` — passes
- Existing test suite covers `clear_provider_models_cache` behavior; the change is additive (clearing a previously un-cleared global) so no existing tests should break.
