### PR TITLE
fix(bedrock): guard against null url in image_url parts and lifecycle status (#55686)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -519,7 +519,7 @@ def _convert_content_to_converse(content) -> List[Dict]:
                 blocks.append({"text": text if text else " "})
             elif part_type == "image_url":
                 image_url = part.get("image_url", {})
-                url = image_url.get("url", "") if isinstance(image_url, dict) else ""
+                url = (image_url.get("url") or "") if isinstance(image_url, dict) else ""
                 if url.startswith("data:"):
                     # data:image/jpeg;base64,/9j/4AAQ...
                     header, _, data = url.partition(",")
@@ -1145,7 +1145,7 @@ def discover_bedrock_models(
 
             # Only include active, streaming-capable, text-output models
             lifecycle = summary.get("modelLifecycle", {})
-            if lifecycle.get("status", "").upper() != "ACTIVE":
+            if (lifecycle.get("status") or "").upper() != "ACTIVE":
                 continue
             if not summary.get("responseStreamingSupported", False):
                 continue


### PR DESCRIPTION
## Summary

Prevent `AttributeError` crash when Bedrock Converse encounters an `image_url` part with a null `url` field, or a model lifecycle entry with a null `status`.

## Problem

Two `.get(key, "")` patterns crash when the key exists with value `None`:

1. **`image_url.get("url", "")`** returns `None` (not `""`) when `url` is explicitly null → `url.startswith("data:")` raises `AttributeError: 'NoneType' object has no attribute 'startswith'`

2. **`lifecycle.get("status", "").upper()`** returns `None` when `status` is null → `.upper()` raises `AttributeError`

The `dict.get(key, default)` default only applies when the key is **absent**, not when it is present with value `None`.

## Fix

Use `(x.get("key") or "")` which coalesces both absent-key and None-value to empty string:
- `image_url.get("url") or ""` — null URL parts are safely skipped (empty string doesn't match `data:` prefix)
- `lifecycle.get("status") or ""` — null status is treated as non-ACTIVE (model skipped)

Fixes #55686