### PR TITLE
fix(agent): guard .get(key, "").method() None dereference in adapters

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2069,7 +2069,7 @@ def _convert_user_message(content: Any) -> Dict[str, Any]:
     if isinstance(content, list):
         converted_blocks = _convert_content_to_anthropic(content)
         if not converted_blocks or all(
-            b.get("text", "").strip() == ""
+            (b.get("text") or "").strip() == ""
             for b in converted_blocks
             if isinstance(b, dict) and b.get("type") == "text"
         ):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4187,8 +4187,8 @@ def resolve_provider_client(
         if custom_entry is None:
             custom_entry = _get_named_custom_provider(provider)
         if custom_entry:
-            custom_base = custom_entry.get("base_url", "").strip()
-            custom_key = custom_entry.get("api_key", "").strip()
+            custom_base = (custom_entry.get("base_url") or "").strip()
+            custom_key = (custom_entry.get("api_key") or "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
                 custom_key = os.getenv(custom_key_env, "").strip()


### PR DESCRIPTION
## Summary

Fix `dict.get(key, "").method()` pattern that crashes when the key exists with value `None`.

## Problem

`dict.get(key, default)` returns `None` (not the default) when the key **exists** with value `None`. The default only applies when the key is **absent**. Any chained method call (`.strip()`, `.upper()`, `.count()`) crashes with `AttributeError: 'NoneType' object has no attribute ...`.

## Fix

Two confirmed hits:

1. **`agent/auxiliary_client.py`** (lines 4190-4191): `custom_entry.get("base_url", "").strip()` and `custom_entry.get("api_key", "").strip()` crash when config has `base_url: null` or `api_key: null`.

2. **`agent/anthropic_adapter.py`** (line 2072): `b.get("text", "").strip()` crashes when a text block has `{"type": "text", "text": null}`.

Pattern: `.get(key, "").method()` → `(.get(key) or "").method()`