### PR TITLE
fix: hide internal compaction todos from chats

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -646,7 +646,11 @@ def compress_context(
 
         todo_snapshot = agent._todo_store.format_for_injection()
         if todo_snapshot:
-            compressed.append({"role": "user", "content": todo_snapshot})
+            # Internal agent state, not a user turn. Store it as a system
+            # replay hint so compression does not create fake user messages
+            # in Desktop/TUI or make the model treat the task list as the
+            # operator's latest request on the next turn.
+            compressed.append({"role": "system", "content": todo_snapshot})
 
         agent._invalidate_system_prompt()
         new_system_prompt = agent._build_system_prompt(system_message)

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -82,6 +82,28 @@ describe('toChatMessages', () => {
     expect(chatMessageText(message)).toBe('@file:tsconfig.tsbuildinfo\n\nwhat is this file')
   })
 
+  it('hides internal todo snapshots injected by context compression', () => {
+    const messages = toChatMessages([
+      { role: 'user', content: 'real question', timestamp: 1 },
+      {
+        role: 'user',
+        content:
+          '[Your active task list was preserved across context compression]\n- [>] work. continue (in_progress)',
+        timestamp: 2
+      },
+      {
+        role: 'system',
+        content:
+          '[Your active task list was preserved across context compression]\n- [ ] hidden. not user content (pending)',
+        timestamp: 3
+      },
+      { role: 'assistant', content: 'real answer', timestamp: 4 }
+    ])
+
+    expect(messages).toHaveLength(2)
+    expect(messages.map(message => chatMessageText(message))).toEqual(['real question', 'real answer'])
+  })
+
   it('renders MEDIA tags as assistant attachment links', () => {
     const [message] = toChatMessages([
       {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -131,6 +131,7 @@ export function chatMessageText(message: ChatMessage): string {
 const ATTACHED_CONTEXT_MARKER_RE = /(?:^|\n)--- Attached Context ---\s*\n/
 const CONTEXT_WARNINGS_MARKER_RE = /(?:^|\n)--- Context Warnings ---[\s\S]*$/
 const CONTEXT_REF_RE = /@(file|folder|url|image|tool|terminal):(?:"[^"\n]+"|'[^'\n]+'|`[^`\n]+`|\S+)/g
+const TODO_INJECTION_PREFIX = '[Your active task list was preserved across context compression]'
 
 function textFromUnknown(value: unknown, depth = 0): string {
   if (typeof value === 'string') {
@@ -702,6 +703,12 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
   let pendingToolTimestamp: number | undefined
   let activeAssistantIndex: null | number = null
 
+  const isInternalTodoInjection = (message: SessionMessage): boolean => {
+    const content = textFromUnknown(message.content || message.text || message.context || message.name)
+
+    return content.startsWith(TODO_INJECTION_PREFIX)
+  }
+
   const clearPendingTools = () => {
     pendingToolParts = []
     pendingToolTimestamp = undefined
@@ -745,6 +752,13 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
   }
 
   messages.forEach((message, index) => {
+    if (isInternalTodoInjection(message)) {
+      // This is a hidden replay hint inserted after context compression. It is
+      // not a user-authored chat turn, and rendering it makes Desktop look like
+      // chats are mixing with internal state from earlier compactions.
+      return
+    }
+
     if (message.role === 'tool') {
       const updatedPendingToolParts = applyStoredToolResultToParts(pendingToolParts, message)
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3623,9 +3623,19 @@ class SessionDB:
         messages = []
         for row in rows:
             content = self._decode_content(row["content"])
-            if row["role"] in {"user", "assistant"} and isinstance(content, str):
+            role = row["role"]
+            try:
+                from tools.todo_tool import is_todo_injection_content
+            except Exception:
+                is_todo_injection_content = lambda _content: False
+            if is_todo_injection_content(content):
+                # Legacy rows were persisted as role='user'. Treat them as
+                # internal replay hints so a preserved todo list cannot become
+                # the active/latest user turn after resume or compression.
+                role = "system"
+            if role in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
-            msg = {"role": row["role"], "content": content}
+            msg = {"role": role, "content": content}
             if row["timestamp"]:
                 msg["timestamp"] = row["timestamp"]
             if row["tool_call_id"]:

--- a/tests/hermes_state/test_internal_todo_injection.py
+++ b/tests/hermes_state/test_internal_todo_injection.py
@@ -1,0 +1,27 @@
+from hermes_state import SessionDB
+from tools.todo_tool import TodoStore, is_todo_injection_content
+
+
+def test_todo_injection_is_internal_state_not_user_turn(tmp_path):
+    store = TodoStore()
+    store.write([
+        {"id": "work", "content": "continue implementation", "status": "in_progress"},
+    ])
+    snapshot = store.format_for_injection()
+    assert snapshot
+    assert is_todo_injection_content(snapshot)
+
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        db.create_session("s1", source="test")
+        # Legacy databases may already contain these snapshots as user rows.
+        db.append_message("s1", "user", snapshot)
+        db.append_message("s1", "user", "actual user message")
+
+        replay = db.get_messages_as_conversation("s1")
+
+        assert replay[0]["role"] == "system"
+        assert replay[0]["content"] == snapshot
+        assert replay[1] == {"role": "user", "content": "actual user message", "timestamp": replay[1]["timestamp"]}
+    finally:
+        db.close()

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -30,7 +30,18 @@ VALID_STATUSES = {"pending", "in_progress", "completed", "cancelled"}
 # task description, and active lists are a handful of items, not hundreds.
 MAX_TODO_CONTENT_CHARS = 4000
 MAX_TODO_ITEMS = 256
+_TODO_INJECTION_PREFIX = "[Your active task list was preserved across context compression]"
 _TRUNCATION_MARKER = "… [truncated]"
+
+
+def is_todo_injection_content(content: object) -> bool:
+    """Return True for Hermes' internal post-compression todo snapshot.
+
+    These snapshots are agent state, not user-authored chat content. They are
+    kept in model replay so long tasks survive compression, but UI/session
+    readers should never treat them as the user's latest message.
+    """
+    return isinstance(content, str) and content.startswith(_TODO_INJECTION_PREFIX)
 
 
 class TodoStore:
@@ -130,7 +141,7 @@ class TodoStore:
         if not active_items:
             return None
 
-        lines = ["[Your active task list was preserved across context compression]"]
+        lines = [_TODO_INJECTION_PREFIX]
         for item in active_items:
             marker = markers.get(item["status"], "[?]")
             lines.append(f"- {marker} {item['id']}. {item['content']} ({item['status']})")


### PR DESCRIPTION
## Summary
- Persist post-compression todo snapshots as internal `system` replay hints instead of fake `user` turns.
- Reclassify legacy todo snapshot rows during conversation replay so old databases do not treat them as the latest user message.
- Hide these internal snapshots in Desktop session rendering, including the legacy `role=user` shape.

## Verification
- `python -m pytest tests/hermes_state/test_internal_todo_injection.py tests/tools/test_todo_tool.py -q -n 0`
- `cd apps/desktop && npm run test:ui -- src/lib/chat-messages.test.ts`
- `cd apps/desktop && npm run typecheck`
- `git diff --cached --check`
