### PR TITLE
fix: suppress webhook [SILENT] responses

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -255,6 +255,15 @@ class WebhookAdapter(BasePlatformAdapter):
         delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
 
+        # Webhook monitors often receive high-volume ignored events (for example
+        # GitHub pull_request opened/synchronize/edited). Let route prompts
+        # suppress user-facing delivery by returning exactly [SILENT], matching
+        # the gateway-wide intentional-silence contract while still logging
+        # locally for auditability.
+        if content.strip() == "[SILENT]":
+            logger.info("[webhook] Suppressed [SILENT] response for %s", chat_id)
+            return SendResult(success=True)
+
         if deliver_type == "log":
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
             return SendResult(success=True)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -845,6 +845,51 @@ class TestDeliveryCleanup:
         assert chat_id in adapter._delivery_info
 
     @pytest.mark.asyncio
+    async def test_exact_silent_response_suppresses_all_webhook_delivery(self):
+        """Webhook [SILENT] must not leak to user-facing delivery targets."""
+        adapter = _make_adapter()
+        chat_id = "webhook:test:d-silent"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "github_comment",
+            "deliver_extra": {},
+            "payload": {"action": "synchronize"},
+        }
+        adapter._delivery_info_created[chat_id] = time.time()
+
+        with patch.object(
+            adapter,
+            "_deliver_github_comment",
+            new=AsyncMock(return_value=SendResult(success=True)),
+        ) as deliver_github_comment:
+            result = await adapter.send(chat_id, "  [SILENT]  ")
+
+        assert result.success is True
+        deliver_github_comment.assert_not_awaited()
+        assert chat_id in adapter._delivery_info
+
+    @pytest.mark.asyncio
+    async def test_prose_silent_token_still_delivers_webhook_response(self):
+        """Only an exact [SILENT] response is suppressed."""
+        adapter = _make_adapter()
+        chat_id = "webhook:test:d-prose"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "github_comment",
+            "deliver_extra": {},
+            "payload": {"action": "closed"},
+        }
+        adapter._delivery_info_created[chat_id] = time.time()
+
+        with patch.object(
+            adapter,
+            "_deliver_github_comment",
+            new=AsyncMock(return_value=SendResult(success=True)),
+        ) as deliver_github_comment:
+            result = await adapter.send(chat_id, "Use [SILENT] for ignored events.")
+
+        assert result.success is True
+        deliver_github_comment.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_delivery_info_pruned_via_ttl(self):
         """Stale delivery_info entries are dropped on the next POST."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- Suppress exact `[SILENT]` webhook agent responses before user-facing delivery targets
- Keep prose mentions of `[SILENT]` deliverable
- Add regression tests for exact silence vs prose mention behavior

## Tests
- `uv run --extra dev --extra messaging python -m pytest tests/gateway/test_webhook_adapter.py::TestDeliveryCleanup tests/gateway/test_gateway_silence_tokens.py -q`
- `git diff --check`

## Multica
- DC-212 / F5 webhook silent-noise control-plane cleanup
