### PR TITLE
fix(logging): stop Windows log lock contention from wedging Hermes

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -32,38 +32,9 @@ import logging
 import os
 import sys
 import threading
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional, Sequence
-
-# On Windows, stdlib ``RotatingFileHandler`` calls ``os.rename()`` in
-# ``doRollover()`` and fails with ``PermissionError [WinError 32]`` whenever
-# another process holds an append-mode handle on ``agent.log`` — which is
-# essentially always in Hermes (TUI, gateway, ``hy_memory`` server, MCP
-# servers, and on-demand CLI commands all log from separate processes),
-# pinning ``agent.log`` at the 5 MiB threshold and spamming stderr with
-# a traceback on every emit. ``concurrent-log-handler`` wraps the rename in a
-# cross-process file lock (via ``portalocker``: pywin32 on Windows) so only
-# one process rotates at a time and the others wait their turn.
-#
-# This swap is Windows-ONLY and deliberately so:
-#   * The bug (WinError 32 on rename-while-open) is specific to Windows file
-#     locking semantics — POSIX renames an open file fine, so stdlib already
-#     works correctly on Linux/macOS.
-#   * On POSIX, managed-mode (NixOS) relies on the exact ``_open()`` /
-#     ``doRollover()`` lifecycle of stdlib ``RotatingFileHandler`` (the
-#     ``_ManagedRotatingFileHandler`` subclass chmods 0660 after each). CLH
-#     opens lazily and rotates differently, which breaks the group-writable
-#     guarantee and the eager file-creation those paths depend on.
-# Aliasing keeps every existing ``RotatingFileHandler`` reference in this
-# module (class declaration, ``isinstance`` checks, docstring) working
-# unchanged. See #44873.
-if sys.platform == "win32":
-    from concurrent_log_handler import (  # noqa: E402
-        ConcurrentRotatingFileHandler as RotatingFileHandler,
-    )
-else:
-    from logging.handlers import RotatingFileHandler  # noqa: E402
-
 
 from hermes_constants import get_config_path, get_hermes_home
 
@@ -114,26 +85,6 @@ def _safe_stderr():  # type: ignore[return]
         pass
     # Best-effort: if wrapping fails, return the original stream.
     return stream
-
-
-_CONCURRENT_LOG_LOCK_TIMEOUT = "Cannot acquire lock after 20 attempts"
-
-
-def _is_windows_concurrent_log_lock_timeout(exc: BaseException | None) -> bool:
-    """Return True for concurrent-log-handler's Windows lock timeout.
-
-    On Windows Desktop, slash-command workers and the gateway can all write to
-    the same rotating log files. ``concurrent-log-handler`` serializes rollover
-    with a cross-process lock, but when another process holds that lock too
-    long it raises this RuntimeError. Logging failures should not escape into
-    Desktop chat output.
-    """
-    return (
-        sys.platform == "win32"
-        and isinstance(exc, RuntimeError)
-        and _CONCURRENT_LOG_LOCK_TIMEOUT in str(exc)
-    )
-
 
 # Third-party loggers that are noisy at DEBUG/INFO level.
 _NOISY_LOGGERS = (
@@ -514,33 +465,28 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
             self._reopen_if_externally_rotated()
         super().emit(record)
 
-    def handleError(self, record: logging.LogRecord) -> None:
-        """Suppress the known Windows ``concurrent-log-handler`` lock timeout
-        instead of printing a traceback.
-
-        CLH's own ``emit()`` wraps its body in ``try/except Exception:
-        self.handleError(record)``, so the ``"Cannot acquire lock after N
-        attempts"`` RuntimeError raised in ``_do_lock()`` is caught inside CLH
-        and routed here — it never propagates out of ``super().emit()``.  This
-        override is the single point where that timeout can be silenced before
-        the stdlib handler prints it to stderr (which, under the Desktop
-        slash-worker, is captured and surfaced into chat output)."""
-        exc = sys.exc_info()[1]
-        if _is_windows_concurrent_log_lock_timeout(exc):
-            return
-        super().handleError(record)
-
     def _open(self):
         stream = super()._open()
         self._chmod_if_managed()
         return stream
 
     def doRollover(self):
-        super().doRollover()
-        self._chmod_if_managed()
-        # Our own rollover writes a new baseFilename; refresh the snapshot
-        # so the next emit doesn't mistake it for external rotation.
-        self._record_stream_stat()
+        try:
+            super().doRollover()
+        except PermissionError:
+            # On Windows another Hermes process may still hold the active log
+            # file open during rotation. Skip this rollover and keep logging
+            # to the current file instead of wedging the caller on logging.
+            if self.stream is None and not self.delay:
+                try:
+                    self.stream = self._open()
+                except OSError:
+                    pass
+        else:
+            self._chmod_if_managed()
+            # Our own rollover writes a new baseFilename; refresh the snapshot
+            # so the next emit doesn't mistake it for external rotation.
+            self._record_stream_stat()
 
 
 def _add_rotating_handler(

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -13,10 +13,7 @@ import pytest
 import hermes_logging
 # Use whatever RotatingFileHandler class hermes_logging actually resolved so
 # the autouse fixture's isinstance checks (which strip rotating handlers
-# between tests) match the real handlers on every platform. hermes_logging
-# aliases concurrent-log-handler's ConcurrentRotatingFileHandler on Windows
-# (the #44873 fix) but keeps stdlib RotatingFileHandler on POSIX, so importing
-# the name from the module under test keeps the two in lockstep.
+# between tests) match the real handlers on every platform.
 from hermes_logging import RotatingFileHandler
 
 
@@ -817,85 +814,35 @@ class TestAddRotatingHandler:
                 logger.removeHandler(h)
                 h.close()
 
+    def test_rollover_permission_error_keeps_logging(self, tmp_path):
+        log_path = tmp_path / "rollover-permission.log"
+        logger = logging.getLogger("_test_rotating_rollover_permission")
+        formatter = logging.Formatter("%(message)s")
 
-class TestWindowsConcurrentLogLockTimeout:
-    """Windows concurrent-log-handler lock timeouts stay inside logging."""
-
-    def _make_logger_and_handler(self, log_path: Path):
-        logger = logging.getLogger(f"_test_concurrent_lock_timeout_{log_path.stem}")
-        logger.handlers.clear()
-        logger.propagate = False
-        logger.setLevel(logging.INFO)
-
-        handler = hermes_logging._ManagedRotatingFileHandler(
-            str(log_path), maxBytes=1, backupCount=1, encoding="utf-8",
+        hermes_logging._add_rotating_handler(
+            logger, log_path,
+            level=logging.INFO, max_bytes=1, backup_count=1,
+            formatter=formatter,
         )
-        handler.setFormatter(logging.Formatter("%(message)s"))
-        logger.addHandler(handler)
-        return logger, handler
-
-    def test_helper_only_matches_windows_concurrent_lock_timeout(self):
-        with patch.object(hermes_logging.sys, "platform", "win32"):
-            assert hermes_logging._is_windows_concurrent_log_lock_timeout(
-                RuntimeError("Cannot acquire lock after 20 attempts")
-            )
-            assert not hermes_logging._is_windows_concurrent_log_lock_timeout(
-                RuntimeError("some other logging failure")
-            )
-
-        with patch.object(hermes_logging.sys, "platform", "linux"):
-            assert not hermes_logging._is_windows_concurrent_log_lock_timeout(
-                RuntimeError("Cannot acquire lock after 20 attempts")
-            )
-
-    def test_lock_timeout_routed_to_handle_error_is_suppressed(self, tmp_path, capsys):
-        """Mirror CLH's real control flow.
-
-        ``concurrent-log-handler``'s ``emit()`` wraps its whole body in
-        ``try/except Exception: self.handleError(record)``, so the lock
-        RuntimeError raised in ``_do_lock()`` is caught *inside* CLH and routed
-        to ``handleError`` with the exception live in ``sys.exc_info()``.  We
-        invoke ``handleError`` the same way CLH would and assert no traceback
-        reaches stderr (the slash-worker surface)."""
-        logger, handler = self._make_logger_and_handler(tmp_path / "agent.log")
-        record = logger.makeRecord(
-            logger.name, logging.INFO, __file__, 0, "force rollover", (), None,
+        handler = next(
+            h for h in logger.handlers if isinstance(h, RotatingFileHandler)
         )
-        try:
-            with patch.object(hermes_logging.sys, "platform", "win32"):
-                try:
-                    raise RuntimeError("Cannot acquire lock after 20 attempts")
-                except RuntimeError:
-                    handler.handleError(record)
 
-            captured = capsys.readouterr()
-            assert "Cannot acquire lock after 20 attempts" not in captured.err
-            assert "--- Logging error ---" not in captured.err
-        finally:
-            logger.removeHandler(handler)
-            handler.close()
+        with patch.object(
+            RotatingFileHandler,
+            "doRollover",
+            side_effect=PermissionError("[WinError 32] file is busy"),
+        ):
+            logger.info("still writes after skipped rollover")
+            handler.flush()
 
-    def test_other_errors_routed_to_handle_error_still_print(self, tmp_path, capsys):
-        """An unrelated failure routed through ``handleError`` must still emit the
-        normal stdlib logging-error output — only the known CLH timeout is silent."""
-        logger, handler = self._make_logger_and_handler(tmp_path / "agent.log")
-        record = logger.makeRecord(
-            logger.name, logging.INFO, __file__, 0, "force rollover", (), None,
-        )
-        try:
-            with patch.object(hermes_logging.sys, "platform", "win32"):
-                try:
-                    raise RuntimeError("unexpected logging failure")
-                except RuntimeError:
-                    handler.handleError(record)
+        assert log_path.exists()
+        assert "still writes after skipped rollover" in log_path.read_text()
 
-            captured = capsys.readouterr()
-            assert "unexpected logging failure" in captured.err
-            assert "--- Logging error ---" in captured.err
-        finally:
-            logger.removeHandler(handler)
-            handler.close()
-
+        for h in list(logger.handlers):
+            if isinstance(h, RotatingFileHandler):
+                logger.removeHandler(h)
+                h.close()
 
 class TestReadLoggingConfig:
     """_read_logging_config() reads from config.yaml."""


### PR DESCRIPTION
## Summary\n- always use stdlib `RotatingFileHandler` on Windows instead of `concurrent-log-handler`\n- treat `PermissionError [WinError 32]` during rollover as a skipped rotation so logging continues\n- add regression coverage for skipped rollover logging and keep the logging suite green\n\n## Verification\n- `git diff --check`\n- `uv run --python 3.11 python -m py_compile hermes_logging.py tests/test_hermes_logging.py`\n- `uv run --python 3.11 --extra dev --extra messaging python -m pytest tests/test_hermes_logging.py`\n\nFixes #55953