### PR TITLE
fix(cli): clear OpenRouter catalog cache on model refresh

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2662,14 +2662,23 @@ def clear_provider_models_cache(provider: Optional[str] = None) -> None:
     entry is removed. Used by ``/model --refresh`` and
     ``hermes model --refresh``.
     """
+    global _openrouter_catalog_cache
+
     try:
+        normalized = normalize_provider(provider) if provider is not None else None
+        if provider is None or normalized == "openrouter":
+            # fetch_openrouter_models() keeps a process-local curated catalog cache
+            # in addition to the provider-id disk cache. A refresh must clear both
+            # so long-lived CLI/gateway processes see edited catalog overrides.
+            _openrouter_catalog_cache = None
+
         if provider is None:
             path = _provider_models_cache_path()
             if path.exists():
                 path.unlink()
             return
         cache = _load_provider_models_cache()
-        normalized = normalize_provider(provider) or provider or ""
+        normalized = normalized or provider or ""
         if normalized in cache:
             del cache[normalized]
             _save_provider_models_cache(cache)

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -86,6 +86,22 @@ class TestFetchOpenRouterModels:
 
         assert models == OPENROUTER_MODELS
 
+    def test_clear_provider_cache_resets_openrouter_catalog_cache(self, monkeypatch):
+        cached = [("cached/model", "recommended")]
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", cached)
+
+        _models_mod.clear_provider_models_cache("openrouter")
+
+        assert _models_mod._openrouter_catalog_cache is None
+
+    def test_clear_all_provider_caches_resets_openrouter_catalog_cache(self, monkeypatch):
+        cached = [("cached/model", "recommended")]
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", cached)
+
+        _models_mod.clear_provider_models_cache()
+
+        assert _models_mod._openrouter_catalog_cache is None
+
     def test_filters_out_models_without_tool_support(self, monkeypatch):
         """Models whose supported_parameters omits 'tools' must not appear in the picker.
 


### PR DESCRIPTION
## Summary
- clear the in-memory OpenRouter curated catalog cache when provider model caches are refreshed
- cover both OpenRouter-specific and all-provider refresh paths

Fixes #55994

## Tests
- scripts/run_tests.sh tests/hermes_cli/test_models.py