### PR TITLE
fix(desktop): wait for backend exit during bootstrap repair

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -6231,7 +6231,7 @@ ipcMain.handle('hermes:bootstrap:repair', async () => {
   }
   bootstrapFailure = null
   backendStartFailure = null
-  resetHermesConnection()
+  await teardownPrimaryBackendAndWait()
   return { ok: true }
 })
 ipcMain.handle('hermes:bootstrap:cancel', async () => {

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -97,6 +97,16 @@ test('desktop backend teardown tree-kills Windows backend descendants', () => {
   assert.doesNotMatch(quitSnippet, /hermesProcess\.kill\('SIGTERM'\)/)
 })
 
+test('bootstrap repair waits for backend teardown before renderer reloads', () => {
+  const source = readElectronFile('main.cjs')
+  const repairIndex = source.indexOf("ipcMain.handle('hermes:bootstrap:repair'")
+  assert.notEqual(repairIndex, -1, 'missing bootstrap repair handler')
+  const repairSnippet = source.slice(repairIndex, repairIndex + 900)
+
+  assert.match(repairSnippet, /await teardownPrimaryBackendAndWait\(\)/)
+  assert.doesNotMatch(repairSnippet, /resetHermesConnection\(\)/)
+})
+
 test('intentional or interactive desktop child processes stay documented', () => {
   const source = readElectronFile('main.cjs')
 


### PR DESCRIPTION
## Summary
- make the desktop bootstrap repair IPC path wait for the current backend process to exit before reporting success
- prevent the renderer reload from immediately racing a still-bound backend port
- add a focused Electron structural regression test

Fixes #55974

## Tests
- node --test apps/desktop/electron/windows-child-process.test.cjs