### PR TITLE
fix(cron): honor workdir for no_agent job scripts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1545,7 +1545,7 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(script_path: str, cwd: Optional[str] = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -1571,6 +1571,14 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
             are also validated to ensure they stay within the scripts dir.
+        cwd: Optional working directory for the script subprocess (a job's
+            configured ``workdir``).  When set and it exists, the script runs
+            with this as its cwd so relative paths resolve against the job's
+            project dir; otherwise the script runs from its own directory
+            (``HERMES_HOME/scripts/``), the historical default.  Passing it here
+            is required because ``subprocess.run(cwd=...)`` sets the child's cwd
+            absolutely — a parent-process ``os.chdir()`` would be overridden and
+            silently ignored.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -1631,12 +1639,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         from tools.environments.local import _sanitize_subprocess_env
 
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
+        run_cwd = cwd if (cwd and Path(cwd).is_dir()) else str(path.parent)
         result = subprocess.run(
             argv,
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
+            cwd=run_cwd,
             env=_sanitize_subprocess_env(os.environ.copy()),
             **popen_kwargs,
         )
@@ -2004,25 +2013,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             return False, "", "", err
 
         # Apply workdir if configured — lets scripts use predictable relative
-        # paths. For no_agent jobs this is just the subprocess cwd (not an
-        # agent TERMINAL_CWD bridge).
+        # paths. For no_agent jobs this is the script's subprocess cwd (not an
+        # agent TERMINAL_CWD bridge). Pass it straight to _run_job_script: a
+        # parent-process os.chdir() would be overridden by the explicit cwd= in
+        # subprocess.run (so the workdir was silently ignored), and chdir is
+        # process-global — unsafe while other jobs run in parallel.
         _job_workdir = (job.get("workdir") or "").strip() or None
-        _prior_cwd = None
-        if _job_workdir and Path(_job_workdir).is_dir():
-            _prior_cwd = os.getcwd()
-            try:
-                os.chdir(_job_workdir)
-            except OSError:
-                _prior_cwd = None
+        if _job_workdir and not Path(_job_workdir).is_dir():
+            logger.warning(
+                "Job '%s': configured workdir %r no longer exists — "
+                "running script without it",
+                job_id, _job_workdir,
+            )
+            _job_workdir = None
 
-        try:
-            ok, output = _run_job_script(script_path)
-        finally:
-            if _prior_cwd is not None:
-                try:
-                    os.chdir(_prior_cwd)
-                except OSError:
-                    pass
+        ok, output = _run_job_script(script_path, cwd=_job_workdir)
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -390,3 +390,114 @@ class TestRunJobTerminalCwd:
         # And after run_job completes, it's still the sentinel (nothing
         # overwrote or cleared it).
         assert os.environ["TERMINAL_CWD"] == before
+
+
+# ---------------------------------------------------------------------------
+# scheduler._run_job_script: subprocess cwd (job workdir) + no_agent path
+# ---------------------------------------------------------------------------
+
+def _seed_probe_script(sched, tmp_path, monkeypatch,
+                       body="import os\nprint(os.getcwd())\n"):
+    """Point HERMES_HOME at a temp dir and drop a script that prints its cwd.
+
+    Returns the resolved scripts dir (the historical default cwd).
+    """
+    from pathlib import Path
+
+    home = tmp_path / "home"
+    scripts = home / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    (scripts / "probe.py").write_text(body, encoding="utf-8")
+    monkeypatch.setattr(sched, "_hermes_home", home)
+    return Path(scripts).resolve()
+
+
+class TestRunJobScriptCwd:
+    """_run_job_script must run the subprocess in the given cwd when provided.
+
+    Regression: the no_agent path used os.chdir(workdir) to set the script's
+    working directory, but subprocess.run() is invoked with an explicit cwd=
+    argument that overrides the parent process's cwd — so the configured
+    workdir was silently ignored and scripts always ran from HERMES_HOME/
+    scripts.  These tests fail before the fix (they'd land in the scripts dir)
+    and pass after it.
+    """
+
+    def test_honors_cwd_when_provided(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        import cron.scheduler as sched
+        _seed_probe_script(sched, tmp_path, monkeypatch)
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+
+        ok, output = sched._run_job_script("probe.py", cwd=str(workdir))
+        assert ok is True, output
+        assert Path(output.strip()).resolve() == workdir.resolve()
+
+    def test_defaults_to_scripts_dir_without_cwd(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        import cron.scheduler as sched
+        scripts = _seed_probe_script(sched, tmp_path, monkeypatch)
+
+        ok, output = sched._run_job_script("probe.py")
+        assert ok is True, output
+        assert Path(output.strip()).resolve() == scripts
+
+    def test_falls_back_when_cwd_missing(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        import cron.scheduler as sched
+        scripts = _seed_probe_script(sched, tmp_path, monkeypatch)
+        missing = tmp_path / "never-created"
+
+        ok, output = sched._run_job_script("probe.py", cwd=str(missing))
+        assert ok is True, output
+        # A non-existent cwd is ignored; the script still runs (scripts dir).
+        assert Path(output.strip()).resolve() == scripts
+
+
+class TestNoAgentScriptWorkdir:
+    """End-to-end: a no_agent job's script executes in the configured workdir."""
+
+    def test_no_agent_script_runs_in_workdir(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        import cron.scheduler as sched
+        scripts = _seed_probe_script(sched, tmp_path, monkeypatch)
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+
+        job = {
+            "id": "j1", "name": "wd", "no_agent": True,
+            "script": "probe.py", "workdir": str(workdir),
+        }
+        success, _doc, response, error = sched.run_job(job)
+        assert success is True, f"error={error!r}"
+        assert Path(response.strip()).resolve() == workdir.resolve()
+        assert Path(response.strip()).resolve() != scripts
+
+    def test_no_agent_without_workdir_uses_scripts_dir(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        import cron.scheduler as sched
+        scripts = _seed_probe_script(sched, tmp_path, monkeypatch)
+
+        job = {
+            "id": "j2", "name": "no-wd", "no_agent": True,
+            "script": "probe.py",
+        }
+        success, _doc, response, error = sched.run_job(job)
+        assert success is True, f"error={error!r}"
+        assert Path(response.strip()).resolve() == scripts
+
+    def test_no_agent_vanished_workdir_falls_back(self, tmp_path, monkeypatch):
+        """A workdir removed after job creation is skipped, not fatal."""
+        from pathlib import Path
+        import cron.scheduler as sched
+        scripts = _seed_probe_script(sched, tmp_path, monkeypatch)
+        gone = tmp_path / "removed"  # never created
+
+        job = {
+            "id": "j3", "name": "gone-wd", "no_agent": True,
+            "script": "probe.py", "workdir": str(gone),
+        }
+        success, _doc, response, error = sched.run_job(job)
+        assert success is True, f"error={error!r}"
+        assert Path(response.strip()).resolve() == scripts


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where a **`no_agent` cron job's configured `workdir` was silently ignored** — the job's script always ran from `HERMES_HOME/scripts/` instead of the configured working directory.

The `no_agent` path in `run_job()` called `os.chdir(workdir)` to set the script's working directory (its own comment: *"For no_agent jobs this is just the subprocess cwd"*). But `_run_job_script()` launches the subprocess with an explicit `cwd=str(path.parent)` (the scripts dir), and an explicit `cwd=` argument to `subprocess.run()` sets the child's working directory **absolutely** — it overrides the parent process's `os.chdir()`. So the `chdir` was a no-op for the subprocess and the workdir never took effect.

Impact: a `no_agent` watchdog/data-collection script that uses relative paths (`./state.json`, `python ./sub.py`, reading `./config`) resolved them against the scripts directory rather than the project directory the user configured — silent wrong reads/writes or "file not found".

The fix threads the workdir into `_run_job_script()` as an optional `cwd` argument and passes it straight to `subprocess.run()`. It also removes the `os.chdir()` dance, which was process-global and unsafe while other jobs run in parallel.

## Related Issue

_No existing issue — found via a code audit of the cron execution path._

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`cron/scheduler.py`**
  - `_run_job_script()` gains an optional `cwd` parameter. The subprocess now runs with `cwd` when it is an existing directory; otherwise it falls back to the historical default (the script's own dir under `HERMES_HOME/scripts/`). Backward compatible — the two callers that don't pass `cwd` are unchanged.
  - `run_job()` `no_agent` path: pass the job's validated `workdir` via `_run_job_script(script_path, cwd=_job_workdir)` and drop the ineffective (and process-global) `os.chdir()`/restore block. When the workdir no longer exists, log and fall back to running without it — mirroring the agent path's existing behavior.
- **`tests/cron/test_cron_workdir.py`**
  - `TestRunJobScriptCwd` — `cwd` honored when provided, default scripts-dir when omitted, and fallback when `cwd` doesn't exist.
  - `TestNoAgentScriptWorkdir` — end-to-end: a `no_agent` job's script runs in the configured workdir, defaults to the scripts dir without a workdir, and safely falls back when the workdir vanished after job creation.

## How to Test

**Reproduction (before the fix):**
1. Create a `no_agent` cron job with a `workdir` pointing at some project dir, and a script under `HERMES_HOME/scripts/` that prints its own cwd (`import os; print(os.getcwd())`).
2. Run the job. The delivered output is `HERMES_HOME/scripts` — **not** the configured workdir. Any relative path in the script resolves against the wrong directory.

**After the fix:** the same job's script prints (and runs from) the configured workdir.

**Automated regression tests** (added in this PR):

```
$ pytest tests/cron/test_cron_workdir.py::TestRunJobScriptCwd \
         tests/cron/test_cron_workdir.py::TestNoAgentScriptWorkdir -v

TestRunJobScriptCwd::test_honors_cwd_when_provided                   PASSED
TestRunJobScriptCwd::test_defaults_to_scripts_dir_without_cwd        PASSED
TestRunJobScriptCwd::test_falls_back_when_cwd_missing                PASSED
TestNoAgentScriptWorkdir::test_no_agent_script_runs_in_workdir       PASSED
TestNoAgentScriptWorkdir::test_no_agent_without_workdir_uses_scripts_dir  PASSED
TestNoAgentScriptWorkdir::test_no_agent_vanished_workdir_falls_back  PASSED

6 passed
```

**Before/after proof** — with the `scheduler.py` fix reverted (tests kept), the end-to-end test fails, demonstrating the bug:

```
>   assert Path(response.strip()).resolve() == workdir.resolve()
E   AssertionError: assert <tmp>/home/scripts == <tmp>/project
FAILED ...::test_no_agent_script_runs_in_workdir
```

With the fix applied, all 6 pass.

**Full cron suite:** `pytest tests/cron/` → `571 passed` (plus the 6 new). `ruff check` on the changed files passes clean; the Windows-footgun checker reports no findings on the diff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cron):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected test suite (`tests/cron/`) and it passes; added 6 regression tests that all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: local dev environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — `_run_job_script`'s docstring documents the new `cwd` argument
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — uses `subprocess.run(cwd=...)` + `Path.is_dir()`, both cross-platform; removes a process-global `os.chdir()`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A