### PR TITLE
fix(cron): keep WhatsApp cron replies anchored to the brief

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -399,15 +399,21 @@ def _cron_mirror_delivery_enabled(job: dict, cfg: Optional[dict] = None) -> bool
     """Whether a cron delivery should also be mirrored into the target chat's
     gateway session transcript.
 
-    Default OFF — preserves the historical isolation guarantee (cron deliveries
-    live only in the cron job's own session, never the target chat's history)
-    byte-for-byte for everyone who does not opt in.
+    Default OFF for most platforms — preserves the historical isolation
+    guarantee (cron deliveries live only in the cron job's own session, never
+    the target chat's history) byte-for-byte unless a job explicitly opts in.
+    WhatsApp / WhatsApp Cloud ``deliver=origin`` jobs are the one default-ON
+    exception: replies happen in the same DM lane and there is no thread handoff
+    escape hatch, so omitting the mirror leaves follow-up messages unanchored
+    (#55589).
 
     Precedence (first decisive value wins):
       1. Per-job ``attach_to_session`` (bool) — set via the ``cronjob`` tool,
          lets one briefing job opt in without flipping global behaviour.
       2. Global ``cron.mirror_delivery`` (bool) in config.yaml.
-      3. False.
+      3. Implicit True for ``deliver=origin`` jobs whose origin platform is
+         ``whatsapp`` or ``whatsapp_cloud``.
+      4. False.
 
     When enabled, the cron's final output is appended to the target session as
     an assistant turn via the existing ``gateway.mirror.mirror_to_session`` —
@@ -422,9 +428,19 @@ def _cron_mirror_delivery_enabled(job: dict, cfg: Optional[dict] = None) -> bool
     try:
         if cfg is None:
             cfg = load_config() or {}
-        return bool((cfg.get("cron", {}) or {}).get("mirror_delivery", False))
+        cron_cfg = (cfg.get("cron", {}) or {})
+        if cron_cfg.get("mirror_delivery"):
+            return True
     except Exception:
-        return False
+        pass
+
+    origin = _resolve_origin(job) or {}
+    deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
+    origin_platform = str(origin.get("platform", "")).lower()
+    return (
+        deliver_value == "origin"
+        and origin_platform in {"whatsapp", "whatsapp_cloud"}
+    )
 
 
 def _target_matches_origin(origin: dict, platform_name: str, chat_id: str,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3632,6 +3632,24 @@ class TestCronDeliveryMirror:
         assert _cron_mirror_delivery_enabled({}, {}) is False
         assert _cron_mirror_delivery_enabled({"id": "x"}, {"cron": {}}) is False
 
+    def test_gate_default_on_for_whatsapp_origin_delivery(self):
+        from cron.scheduler import _cron_mirror_delivery_enabled
+
+        assert _cron_mirror_delivery_enabled(
+            {
+                "deliver": "origin",
+                "origin": {"platform": "whatsapp", "chat_id": "12345"},
+            },
+            {},
+        ) is True
+        assert _cron_mirror_delivery_enabled(
+            {
+                "deliver": "origin",
+                "origin": {"platform": "whatsapp_cloud", "chat_id": "12345"},
+            },
+            {},
+        ) is True
+
     def test_gate_global_config_on(self):
         from cron.scheduler import _cron_mirror_delivery_enabled
 
@@ -3648,6 +3666,15 @@ class TestCronDeliveryMirror:
         assert _cron_mirror_delivery_enabled(
             {"attach_to_session": True}, {"cron": {"mirror_delivery": False}}
         ) is True
+        # Per-job False still disables the WhatsApp-origin default.
+        assert _cron_mirror_delivery_enabled(
+            {
+                "attach_to_session": False,
+                "deliver": "origin",
+                "origin": {"platform": "whatsapp_cloud", "chat_id": "12345"},
+            },
+            {},
+        ) is False
 
     def test_mirror_calls_mirror_to_session_when_enabled(self):
         from cron.scheduler import _maybe_mirror_cron_delivery
@@ -3774,6 +3801,31 @@ class TestCronDeliveryMirror:
             _deliver_result(job, "Here is today's summary.")
 
         mirror_mock.assert_not_called()
+
+    def test_delivery_mirrors_whatsapp_origin_by_default(self):
+        """WhatsApp-origin cron jobs should be continuable by default so a reply
+        lands in a session that already contains the brief (#55589)."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.WHATSAPP_CLOUD: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "whatsapp_cloud", "chat_id": "15551234567"},
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        mirror_mock.assert_called_once()
+        assert mirror_mock.call_args[0][0] == "whatsapp_cloud"
+        assert mirror_mock.call_args[0][1] == "15551234567"
 
     # --- origin-scoping (mirror only into the conversation that created the job) ---
 


### PR DESCRIPTION
## Summary
- default origin-delivered WhatsApp and WhatsApp Cloud cron jobs to continuable session mirroring
- keep per-job attach_to_session overrides and the global mirror_delivery opt-in path intact
- add scheduler regression coverage for the new default and override behavior

## Testing
- git diff --check
- uv run --python 3.11 python -m py_compile cron/scheduler.py tests/cron/test_scheduler.py
- uv run --python 3.11 --extra dev --extra messaging python -m pytest tests/cron/test_scheduler.py -k 'mirror or whatsapp_origin or gate_default or attach_to_session'\n\nFixes #55589