### PR TITLE
fix: repair weak session project bindings

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -78,6 +78,58 @@ def _safe_which(cmd: str) -> str | None:
         return None
 
 
+def _tail_text(path: Path, *, max_bytes: int = 256_000) -> str:
+    """Return a UTF-8-ish tail of a log file without loading huge logs."""
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as f:
+            if size > max_bytes:
+                f.seek(size - max_bytes)
+                f.readline()  # drop partial first line
+            data = f.read()
+        return data.decode("utf-8", errors="replace")
+    except (OSError, UnicodeError):
+        return ""
+
+
+def _recent_runtime_log_hits(logs_dir: Path) -> list[str]:
+    """Lightweight recent-error scan for doctor runtime health.
+
+    This is intentionally heuristic: it points users at logs worth reading
+    without failing doctor for old/benign reconnect noise.
+    """
+    patterns = (
+        "traceback",
+        "uncaught exception",
+        "[gateway-crash]",
+        "cannot acquire lock after",
+        "database is locked",
+        "permissionerror",
+        "unicodeerror",
+        "unicodedecodeerror",
+    )
+    hits: list[str] = []
+    for name in ("error.log", "errors.log", "gateway.log", "desktop.log", "agent.log"):
+        path = logs_dir / name
+        if not path.exists():
+            continue
+        text = _tail_text(path)
+        if not text:
+            continue
+        lines = text.splitlines()[-800:]
+        count = 0
+        sample = ""
+        for line in lines:
+            low = line.lower()
+            if any(p in low for p in patterns):
+                count += 1
+                sample = line.strip()[:180] or sample
+        if count:
+            suffix = f" — latest: {sample}" if sample else ""
+            hits.append(f"{name}: {count} recent suspicious line(s){suffix}")
+    return hits
+
+
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps: list[str] = []
     step = 1
@@ -1317,6 +1369,55 @@ def run_doctor(args):
                 check_info(f"WAL file is {wal_size // (1024*1024)} MB (normal for active sessions)")
         except Exception:
             pass
+
+    _section("Runtime Health")
+    try:
+        log_hits = _recent_runtime_log_hits(hermes_home / "logs")
+        if log_hits:
+            for hit in log_hits[:5]:
+                check_warn(hit)
+            check_info("Review recent logs above if Hermes felt unstable; old reconnect noise may be benign.")
+        else:
+            check_ok("No recent suspicious runtime log patterns")
+    except Exception as e:
+        check_warn(f"Runtime log scan failed: {e}")
+
+    try:
+        from gateway.status import is_gateway_running, read_runtime_status
+
+        running = is_gateway_running(cleanup_stale=False)
+        runtime = read_runtime_status() or {}
+        state = runtime.get("gateway_state") or ("running" if running else "unknown")
+        pid = runtime.get("pid") or runtime.get("process", {}).get("pid") if isinstance(runtime, dict) else None
+        if running:
+            detail = f"(state={state}"
+            if pid:
+                detail += f", pid={pid}"
+            detail += ")"
+            check_ok("Gateway runtime is running", detail)
+        else:
+            check_info("Gateway runtime is not running or no live PID file was found")
+    except Exception as e:
+        check_warn(f"Gateway runtime status check failed: {e}")
+
+    try:
+        if state_db_path.exists():
+            from hermes_state import SessionDB
+
+            db = SessionDB(db_path=state_db_path, read_only=True)
+            try:
+                weak = db.find_weak_lineage_project_bindings()
+            finally:
+                db.close()
+            if weak:
+                check_warn(
+                    f"{len(weak)} compression continuation session(s) have weak project bindings",
+                    "(run `hermes sessions repair-project-binding --apply`)",
+                )
+            else:
+                check_ok("No weak compression project bindings")
+    except Exception as e:
+        check_warn(f"Session project-binding audit failed: {e}")
 
     _check_gateway_service_linger(issues)
     _check_s6_supervision(issues)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13171,6 +13171,26 @@ def main():
         help="Skip the timestamped backup copy (not recommended)",
     )
 
+    sessions_project_repair = sessions_subparsers.add_parser(
+        "repair-project-binding",
+        help="Find or backfill compression continuation rows that lost project cwd metadata",
+        description=(
+            "Diagnose Desktop/TUI chats that disappeared from a Project after "
+            "compression because the continuation row lost cwd/git metadata. "
+            "Default is check-only; pass --apply to update affected rows."
+        ),
+    )
+    sessions_project_repair.add_argument(
+        "--apply",
+        action="store_true",
+        help="Backfill weak rows from their nearest compression-lineage project ancestor",
+    )
+    sessions_project_repair.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="When used with --apply, skip the timestamped state.db backup (not recommended)",
+    )
+
     sessions_subparsers.add_parser("stats", help="Show session store statistics")
 
     sessions_rename = sessions_subparsers.add_parser(
@@ -13258,6 +13278,38 @@ def main():
         # Hide third-party tool sessions by default, but honour explicit --source
         _source = getattr(args, "source", None)
         _exclude = None if _source else ["tool"]
+
+        if action == "repair-project-binding":
+            apply = bool(getattr(args, "apply", False))
+            if apply and not getattr(args, "no_backup", False):
+                from datetime import datetime
+                import shutil
+                from hermes_state import DEFAULT_DB_PATH
+
+                stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                backup_path = DEFAULT_DB_PATH.with_name(
+                    f"{DEFAULT_DB_PATH.name}.before-project-binding-repair-{stamp}.bak"
+                )
+                shutil.copy2(DEFAULT_DB_PATH, backup_path)
+                print(f"backup: {backup_path}")
+            result = db.repair_weak_lineage_project_bindings(apply=apply)
+            weak = result.get("weak") or []
+            print(
+                f"checked={result.get('checked', 0)} "
+                f"updated={result.get('updated', 0)} "
+                f"mode={'apply' if apply else 'check-only'}"
+            )
+            if weak:
+                for item in weak[:20]:
+                    print(
+                        f"- {item['id']} <- {item['ancestor_id']}: "
+                        f"{item.get('reason')} -> {item.get('target_cwd') or item.get('target_git_repo_root')}"
+                    )
+                if len(weak) > 20:
+                    print(f"… {len(weak) - 20} more")
+            else:
+                print("✓ no weak project bindings found")
+            return
 
         if action == "list":
             sessions = db.list_sessions_rich(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1152,6 +1152,13 @@ class SessionDB:
                 self._conn.close()
                 self._conn = None
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False
+
     @staticmethod
     def _parse_schema_columns(schema_sql: str) -> Dict[str, Dict[str, str]]:
         """Extract expected columns per table from SCHEMA_SQL.
@@ -1488,6 +1495,8 @@ class SessionDB:
         thread_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
+        git_branch: str = None,
+        git_repo_root: str = None,
     ) -> None:
         """Insert a session row, enriching NULL metadata on conflict.
 
@@ -1502,12 +1511,28 @@ class SessionDB:
         can't clobber a real source/model).
         """
         def _do(conn):
+            effective_cwd = cwd
+            effective_git_branch = git_branch
+            effective_git_repo_root = git_repo_root
+            if parent_session_id and (
+                not effective_cwd or not effective_git_branch or not effective_git_repo_root
+            ):
+                parent = conn.execute(
+                    "SELECT cwd, git_branch, git_repo_root FROM sessions WHERE id = ?",
+                    (parent_session_id,),
+                ).fetchone()
+                if parent is not None:
+                    effective_cwd = effective_cwd or parent["cwd"]
+                    effective_git_branch = effective_git_branch or parent["git_branch"]
+                    effective_git_repo_root = effective_git_repo_root or parent["git_repo_root"]
+
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
-                   model, model_config, system_prompt, parent_session_id, cwd, started_at
+                   model, model_config, system_prompt, parent_session_id, cwd,
+                   git_branch, git_repo_root, started_at
                 )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
                        model = COALESCE(sessions.model, excluded.model),
                        model_config = COALESCE(sessions.model_config, excluded.model_config),
@@ -1517,7 +1542,9 @@ class SessionDB:
                        chat_type = COALESCE(sessions.chat_type, excluded.chat_type),
                        thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
                        parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
-                       cwd = COALESCE(sessions.cwd, excluded.cwd)""",
+                       cwd = COALESCE(sessions.cwd, excluded.cwd),
+                       git_branch = COALESCE(sessions.git_branch, excluded.git_branch),
+                       git_repo_root = COALESCE(sessions.git_repo_root, excluded.git_repo_root)""",
                 (
                     session_id,
                     source,
@@ -1530,7 +1557,9 @@ class SessionDB:
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
                     parent_session_id,
-                    cwd,
+                    effective_cwd,
+                    effective_git_branch,
+                    effective_git_repo_root,
                     time.time(),
                 ),
             )
@@ -2576,6 +2605,136 @@ class SessionDB:
             current = child_id
         return current
 
+    @staticmethod
+    def _looks_like_home_cwd(cwd: Optional[str]) -> bool:
+        if not cwd:
+            return False
+        normalized = str(cwd).replace("\\", "/").rstrip("/").lower()
+        return bool(
+            re.match(r"^[a-z]:/users/[^/]+$", normalized)
+            or re.match(r"^/home/[^/]+$", normalized)
+            or re.match(r"^/users/[^/]+$", normalized)
+        )
+
+    def _nearest_lineage_workspace_ancestor(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Find the nearest compression-lineage ancestor with workspace metadata."""
+        current = session_id
+        seen = set()
+        with self._lock:
+            for _ in range(100):
+                if not current or current in seen:
+                    return None
+                seen.add(current)
+                row = self._conn.execute(
+                    """
+                    SELECT child.parent_session_id,
+                           parent.id AS ancestor_id,
+                           parent.end_reason AS ancestor_end_reason,
+                           parent.cwd AS target_cwd,
+                           parent.git_branch AS target_git_branch,
+                           parent.git_repo_root AS target_git_repo_root
+                    FROM sessions child
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE child.id = ?
+                    """,
+                    (current,),
+                ).fetchone()
+                if row is None:
+                    return None
+                target_cwd = row["target_cwd"]
+                target_repo = row["target_git_repo_root"]
+                target_is_project = bool(target_repo) or bool(
+                    target_cwd and not self._looks_like_home_cwd(target_cwd)
+                )
+                if row["ancestor_end_reason"] == "compression" and target_is_project:
+                    return dict(row)
+                current = row["parent_session_id"]
+        return None
+
+    def find_weak_lineage_project_bindings(self) -> List[Dict[str, Any]]:
+        """Report compression-continuation rows that lost project metadata.
+
+        Older Desktop/TUI continuations could be created with NULL or home cwd
+        even though their compression parent had a real project cwd/repo root.
+        Those rows make the same logical chat appear outside its Desktop Project.
+        """
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT s.id, s.cwd, s.git_branch, s.git_repo_root, s.parent_session_id
+                FROM sessions s
+                WHERE s.parent_session_id IS NOT NULL
+                  AND json_extract(COALESCE(s.model_config, '{}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(s.model_config, '{}'), '$._delegate_from') IS NULL
+                  AND COALESCE(s.source, '') != 'tool'
+                ORDER BY s.started_at ASC, s.id ASC
+                """
+            ).fetchall()
+
+        weak: List[Dict[str, Any]] = []
+        for row in rows:
+            child = dict(row)
+            ancestor = self._nearest_lineage_workspace_ancestor(child["id"])
+            if not ancestor:
+                continue
+            target_cwd = ancestor.get("target_cwd")
+            target_repo = ancestor.get("target_git_repo_root")
+            child_cwd = child.get("cwd")
+            child_repo = child.get("git_repo_root")
+
+            missing = not child_cwd and not child_repo
+            home_cwd = self._looks_like_home_cwd(child_cwd) and not child_repo
+            if not missing and not home_cwd:
+                continue
+
+            reason = "missing workspace metadata" if missing else "home cwd without git_repo_root"
+            weak.append({
+                "id": child["id"],
+                "ancestor_id": ancestor["ancestor_id"],
+                "parent_session_id": child.get("parent_session_id"),
+                "cwd": child_cwd,
+                "git_branch": child.get("git_branch"),
+                "git_repo_root": child_repo,
+                "target_cwd": target_cwd,
+                "target_git_branch": ancestor.get("target_git_branch"),
+                "target_git_repo_root": target_repo,
+                "reason": reason,
+            })
+        return weak
+
+    def repair_weak_lineage_project_bindings(self, apply: bool = False) -> Dict[str, Any]:
+        """Backfill weak compression-continuation project metadata.
+
+        ``apply=False`` is check-only. ``apply=True`` mutates only rows returned
+        by :meth:`find_weak_lineage_project_bindings`.
+        """
+        weak = self.find_weak_lineage_project_bindings()
+        result = {"checked": len(weak), "updated": 0, "weak": weak}
+        if not apply or not weak:
+            return result
+
+        def _do(conn):
+            updated = 0
+            for item in weak:
+                cursor = conn.execute(
+                    """
+                    UPDATE sessions
+                    SET cwd = ?, git_branch = ?, git_repo_root = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        item.get("target_cwd"),
+                        item.get("target_git_branch"),
+                        item.get("target_git_repo_root"),
+                        item["id"],
+                    ),
+                )
+                updated += cursor.rowcount or 0
+            return updated
+
+        result["updated"] = int(self._execute_write(_do) or 0)
+        return result
+
     def distinct_session_cwds(self, include_archived: bool = False) -> List[Dict[str, Any]]:
         """Distinct non-empty session cwds with usage stats, for repo discovery.
 
@@ -2839,10 +2998,15 @@ class SessionDB:
                 for key in (
                     "id", "ended_at", "end_reason", "message_count",
                     "tool_call_count", "title", "last_active", "preview",
-                    "model", "system_prompt", "cwd", "git_branch", "git_repo_root",
+                    "model", "system_prompt",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]
+                for key in ("cwd", "git_branch", "git_repo_root"):
+                    if tip_row.get(key):
+                        merged[key] = tip_row[key]
+                    elif s.get(key):
+                        merged[key] = s[key]
                 merged["_lineage_root_id"] = s["id"]
                 projected.append(merged)
             sessions = projected

--- a/tests/hermes_state/test_session_lineage_project_binding.py
+++ b/tests/hermes_state/test_session_lineage_project_binding.py
@@ -1,0 +1,314 @@
+"""Regression tests for compression lineage project binding.
+
+Physical continuation rows may rotate (`root -> mid -> tip`) when context is
+compacted.  The logical conversation must stay attached to its project even if
+one physical row is missing workspace metadata.
+"""
+
+import time
+from pathlib import Path
+
+from hermes_state import SessionDB
+
+
+def _make_db(tmp_path: Path) -> SessionDB:
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def _end_for_compression(db: SessionDB, session_id: str, ended_at: float) -> None:
+    db._conn.execute(
+        "UPDATE sessions SET ended_at=?, end_reason=? WHERE id=?",
+        (ended_at, "compression", session_id),
+    )
+    db._conn.commit()
+
+
+def _set_started(db: SessionDB, session_id: str, started_at: float) -> None:
+    db._conn.execute(
+        "UPDATE sessions SET started_at=? WHERE id=?",
+        (started_at, session_id),
+    )
+    db._conn.commit()
+
+
+def _make_broken_child(db: SessionDB, *, with_branch: bool = True) -> None:
+    t0 = time.time() - 3600
+    db.create_session("root", "cli")
+    _set_started(db, "root", t0)
+    db.update_session_cwd(
+        "root",
+        "N:/CodexProjects/example",
+        git_branch="feature/continuity" if with_branch else None,
+        git_repo_root="N:/CodexProjects/example",
+    )
+    _end_for_compression(db, "root", t0 + 100)
+    db.create_session("tip", "cli", parent_session_id="root")
+    _set_started(db, "tip", t0 + 101)
+    db._conn.execute(
+        "UPDATE sessions SET cwd=NULL, git_branch=NULL, git_repo_root=NULL WHERE id='tip'"
+    )
+    db._conn.commit()
+
+
+def test_child_session_inherits_parent_workspace_metadata(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        db.create_session("root", "cli")
+        db.update_session_cwd(
+            "root",
+            "N:/CodexProjects/example",
+            git_branch="feature/continuity",
+            git_repo_root="N:/CodexProjects/example",
+        )
+        _end_for_compression(db, "root", time.time())
+
+        db.create_session("tip", "cli", parent_session_id="root")
+
+        tip = db.get_session("tip")
+        assert tip["cwd"] == "N:/CodexProjects/example"
+        assert tip["git_branch"] == "feature/continuity"
+        assert tip["git_repo_root"] == "N:/CodexProjects/example"
+    finally:
+        db.close()
+
+
+def test_explicit_child_workspace_metadata_overrides_parent(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        db.create_session("root", "cli")
+        db.update_session_cwd(
+            "root",
+            "N:/CodexProjects/example",
+            git_branch="main",
+            git_repo_root="N:/CodexProjects/example",
+        )
+        _end_for_compression(db, "root", time.time())
+
+        db.create_session(
+            "tip",
+            "cli",
+            parent_session_id="root",
+            cwd="N:/CodexProjects/example-worktree",
+            git_branch="feature/worktree",
+            git_repo_root="N:/CodexProjects/example-worktree",
+        )
+
+        tip = db.get_session("tip")
+        assert tip["cwd"] == "N:/CodexProjects/example-worktree"
+        assert tip["git_branch"] == "feature/worktree"
+        assert tip["git_repo_root"] == "N:/CodexProjects/example-worktree"
+    finally:
+        db.close()
+
+
+def test_projection_falls_back_to_root_workspace_when_tip_is_legacy_broken(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        t0 = time.time() - 3600
+        db.create_session("root", "cli")
+        _set_started(db, "root", t0)
+        db.set_session_title("root", "Project chat")
+        db.update_session_cwd(
+            "root",
+            "N:/CodexProjects/example",
+            git_branch="feature/continuity",
+            git_repo_root="N:/CodexProjects/example",
+        )
+        db.append_message("root", "user", "root message")
+        _end_for_compression(db, "root", t0 + 100)
+
+        db.create_session("tip", "cli", parent_session_id="root")
+        _set_started(db, "tip", t0 + 101)
+        db.set_session_title("tip", "Project chat #2")
+        db.append_message("tip", "user", "tip message")
+        db._conn.execute(
+            "UPDATE sessions SET cwd=NULL, git_branch=NULL, git_repo_root=NULL WHERE id=?",
+            ("tip",),
+        )
+        db._conn.commit()
+
+        rows = db.list_sessions_rich(source="cli", limit=10)
+        projected = next(row for row in rows if row["id"] == "tip")
+
+        assert projected["_lineage_root_id"] == "root"
+        assert projected["cwd"] == "N:/CodexProjects/example"
+        assert projected["git_branch"] == "feature/continuity"
+        assert projected["git_repo_root"] == "N:/CodexProjects/example"
+    finally:
+        db.close()
+
+
+def test_projection_prefers_non_empty_tip_workspace_metadata(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        t0 = time.time() - 3600
+        db.create_session("root", "cli")
+        _set_started(db, "root", t0)
+        db.update_session_cwd(
+            "root",
+            "N:/CodexProjects/example",
+            git_branch="main",
+            git_repo_root="N:/CodexProjects/example",
+        )
+        _end_for_compression(db, "root", t0 + 100)
+
+        db.create_session("tip", "cli", parent_session_id="root")
+        _set_started(db, "tip", t0 + 101)
+        db.update_session_cwd(
+            "tip",
+            "N:/CodexProjects/example-worktree",
+            git_branch="feature/worktree",
+            git_repo_root="N:/CodexProjects/example-worktree",
+        )
+
+        rows = db.list_sessions_rich(source="cli", limit=10)
+        projected = next(row for row in rows if row["id"] == "tip")
+
+        assert projected["cwd"] == "N:/CodexProjects/example-worktree"
+        assert projected["git_branch"] == "feature/worktree"
+        assert projected["git_repo_root"] == "N:/CodexProjects/example-worktree"
+    finally:
+        db.close()
+
+
+def test_project_cwd_filter_includes_projected_logical_tip(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        _make_broken_child(db)
+
+        rows = db.list_sessions_rich(
+            source="cli",
+            cwd_prefix="N:/CodexProjects/example",
+            limit=10,
+        )
+
+        assert [row["id"] for row in rows] == ["tip"]
+        assert rows[0]["_lineage_root_id"] == "root"
+    finally:
+        db.close()
+
+
+def test_compression_tip_ignores_delegate_child_for_projected_lineage(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        t0 = time.time() - 3600
+        db.create_session("root", "cli")
+        _set_started(db, "root", t0)
+        db.update_session_cwd("root", "N:/CodexProjects/example")
+
+        db.create_session(
+            "delegate",
+            "cli",
+            parent_session_id="root",
+            model_config={"_delegate_from": "root"},
+        )
+        _set_started(db, "delegate", t0 + 50)
+        _end_for_compression(db, "root", t0 + 100)
+
+        db.create_session("tip", "cli", parent_session_id="root")
+        _set_started(db, "tip", t0 + 101)
+
+        assert db.get_compression_tip("root") == "tip"
+        rows = db.list_sessions_rich(source="cli", limit=10)
+        ids = [row["id"] for row in rows]
+        assert "tip" in ids
+        assert "delegate" not in ids
+    finally:
+        db.close()
+
+
+def test_find_weak_lineage_project_bindings_reports_repairable_child(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        _make_broken_child(db)
+
+        weak = db.find_weak_lineage_project_bindings()
+
+        assert len(weak) == 1
+        assert weak[0]["id"] == "tip"
+        assert weak[0]["ancestor_id"] == "root"
+        assert weak[0]["target_cwd"] == "N:/CodexProjects/example"
+        assert weak[0]["target_git_repo_root"] == "N:/CodexProjects/example"
+        assert weak[0]["target_git_branch"] == "feature/continuity"
+        assert "missing" in weak[0]["reason"]
+    finally:
+        db.close()
+
+
+def test_find_weak_lineage_project_bindings_ignores_real_different_cwd(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        t0 = time.time() - 3600
+        db.create_session("root", "cli")
+        _set_started(db, "root", t0)
+        db.update_session_cwd(
+            "root",
+            "N:/CodexProjects/example",
+            git_branch="main",
+            git_repo_root="N:/CodexProjects/example",
+        )
+        _end_for_compression(db, "root", t0 + 100)
+        db.create_session(
+            "tip",
+            "cli",
+            parent_session_id="root",
+            cwd="N:/CodexProjects/other",
+            git_branch="other",
+            git_repo_root="N:/CodexProjects/other",
+        )
+        _set_started(db, "tip", t0 + 101)
+
+        assert db.find_weak_lineage_project_bindings() == []
+    finally:
+        db.close()
+
+
+def test_find_weak_lineage_project_bindings_flags_home_cwd(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        _make_broken_child(db, with_branch=False)
+        db._conn.execute(
+            "UPDATE sessions SET cwd=?, git_repo_root=NULL WHERE id=?",
+            ("C:/Users/Alexander Semenov", "tip"),
+        )
+        db._conn.commit()
+
+        weak = db.find_weak_lineage_project_bindings()
+
+        assert len(weak) == 1
+        assert weak[0]["id"] == "tip"
+        assert weak[0]["target_cwd"] == "N:/CodexProjects/example"
+    finally:
+        db.close()
+
+
+def test_repair_weak_lineage_project_bindings_check_only_does_not_mutate(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        _make_broken_child(db)
+
+        result = db.repair_weak_lineage_project_bindings(apply=False)
+
+        assert result["checked"] == 1
+        assert result["updated"] == 0
+        assert db.get_session("tip")["cwd"] is None
+    finally:
+        db.close()
+
+
+def test_repair_weak_lineage_project_bindings_apply_backfills_metadata(tmp_path):
+    db = _make_db(tmp_path)
+    try:
+        _make_broken_child(db)
+
+        result = db.repair_weak_lineage_project_bindings(apply=True)
+
+        tip = db.get_session("tip")
+        assert result["checked"] == 1
+        assert result["updated"] == 1
+        assert tip["cwd"] == "N:/CodexProjects/example"
+        assert tip["git_branch"] == "feature/continuity"
+        assert tip["git_repo_root"] == "N:/CodexProjects/example"
+        assert db.find_weak_lineage_project_bindings() == []
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- preserve cwd/git metadata when creating compression continuation session rows
- project logical session lists from the compression tip without losing root workspace metadata
- add doctor runtime health audit and `hermes sessions repair-project-binding` check/apply repair command

## Verification
- `python -m pytest tests/hermes_state/test_session_lineage_project_binding.py tests/hermes_cli/test_doctor.py -q` → 75 passed, 1 warning
- `HERMES_HOME=$(mktemp -d) python -m hermes_cli.main sessions repair-project-binding` → checked=0 updated=0 mode=check-only

Replaces the runtime health / project-binding repair slice from the older broad PR #55980.