### PR TITLE
feat(delegation): add persona presets for subagents

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5679,6 +5679,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            persona=function_args.get("persona"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -32,6 +32,8 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _get_persona_registry,
+    _resolve_persona,
     _inherit_parent_base_url,
 )
 
@@ -70,10 +72,15 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         # toolsets is intentionally NOT exposed to the model — subagents always
-        # inherit the parent's toolsets. Letting the model name toolsets was a
+        # inherit the parent's toolsets unless operator-configured persona
+        # defaults narrow them internally. Letting the model name toolsets was a
         # capability-selection surface the model should not control.
         self.assertNotIn("toolsets", props)
         self.assertNotIn("toolsets", props["tasks"]["items"]["properties"])
+        self.assertIn("persona", props)
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("persona", task_props)
+        self.assertEqual(props["role"]["enum"], ["leaf", "orchestrator"])
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -135,6 +142,34 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn(f"up to {_get_max_concurrent_children()}", fn["description"])
         self.assertIn(f"max_spawn_depth={_get_max_spawn_depth()}", fn["description"])
 
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "personas": {
+                "reviewer": {
+                    "description": "Careful code reviewer",
+                    "system_prompt": "SECRET REVIEW PROMPT",
+                },
+                "cheap": {
+                    "description": "Cheap runtime preset",
+                    "model": "google/gemini-flash",
+                },
+            }
+        },
+    )
+    def test_dynamic_schema_lists_persona_keys_without_prompts(self, mock_cfg):
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        overrides = _build_dynamic_schema_overrides()
+        top_desc = overrides["parameters"]["properties"]["persona"]["description"]
+        task_desc = overrides["parameters"]["properties"]["tasks"]["items"]["properties"]["persona"]["description"]
+
+        self.assertIn("'reviewer'", top_desc)
+        self.assertIn("Careful code reviewer", top_desc)
+        self.assertIn("'cheap'", task_desc)
+        self.assertNotIn("SECRET REVIEW PROMPT", top_desc)
+        self.assertNotIn("SECRET REVIEW PROMPT", task_desc)
+
 
 class TestChildSystemPrompt(unittest.TestCase):
     def test_goal_only(self):
@@ -152,6 +187,16 @@ class TestChildSystemPrompt(unittest.TestCase):
     def test_empty_context_ignored(self):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
+
+    def test_persona_prompt_is_child_local_system_prompt(self):
+        prompt = _build_child_system_prompt(
+            "Review this patch",
+            persona="reviewer",
+            persona_system_prompt="Focus on correctness and security.",
+        )
+        self.assertIn("PERSONA (reviewer) INSTRUCTIONS", prompt)
+        self.assertIn("Focus on correctness and security.", prompt)
+        self.assertIn("Review this patch", prompt)
 
 
 class TestStripBlockedTools(unittest.TestCase):
@@ -568,6 +613,41 @@ class TestToolNamePreservation(unittest.TestCase):
         )
         self.assertIsNone(captured["acp_command"])
         self.assertEqual(captured["acp_args"], [])
+
+    def test_build_child_agent_ignores_copilot_acp_provider_when_binary_missing(self):
+        """A resolved copilot-acp provider must fall back if its CLI is missing."""
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "openrouter"
+        parent.api_mode = "chat_completions"
+        parent.acp_command = None
+        parent.acp_args = []
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("shutil.which", return_value=None) as mock_which:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="copilot provider path",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_provider="copilot-acp",
+                override_acp_command="copilot",
+                override_acp_args=["--foo"],
+            )
+
+            _, kwargs = MockAgent.call_args
+
+        mock_which.assert_called_with("copilot")
+        self.assertEqual(kwargs.get("provider"), "openrouter")
+        self.assertIsNone(kwargs.get("acp_command"))
+        self.assertEqual(kwargs.get("acp_args"), [])
+        self.assertEqual(kwargs.get("api_mode"), "chat_completions")
 
     def test_build_child_agent_honors_acp_command_when_binary_present(self):
         """When the acp_command binary exists on PATH, behavior is unchanged:
@@ -1228,6 +1308,85 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             _resolve_delegation_credentials(cfg, parent)
         self.assertIn("no API key", str(ctx.exception))
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_configured_provider_honors_explicit_api_mode(self, mock_resolve):
+        """Explicit delegation/persona api_mode wins over provider defaults."""
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "runtime-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "anthropic/claude-sonnet-4",
+            "provider": "openrouter",
+            "api_mode": "anthropic_messages",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_configured_provider_invalid_api_mode_uses_runtime_default(self, mock_resolve):
+        """Invalid explicit api_mode must not override the provider runtime mode."""
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "runtime-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "anthropic/claude-sonnet-4",
+            "provider": "openrouter",
+            "api_mode": "garbage",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_mode"], "chat_completions")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_configured_provider_api_key_overrides_runtime_key(self, mock_resolve):
+        """Explicit delegation/persona api_key wins over provider-resolved credentials."""
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "runtime-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "anthropic/claude-sonnet-4",
+            "provider": "openrouter",
+            "api_key": "persona-key",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_key"], "persona-key")
+        mock_resolve.assert_called_once_with(
+            requested="openrouter", target_model="anthropic/claude-sonnet-4"
+        )
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_configured_provider_api_key_allows_runtime_without_key(self, mock_resolve):
+        """A persona/config api_key is sufficient even when runtime provider has none."""
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "anthropic/claude-sonnet-4",
+            "provider": "openrouter",
+            "api_key": "persona-key",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_key"], "persona-key")
+
     def test_missing_config_keys_inherit_parent(self):
         """When config dict has no model/provider keys at all, inherits parent."""
         parent = _make_mock_parent(depth=0)
@@ -1344,6 +1503,42 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         mock_resolve.assert_called_once()
         self.assertEqual(mock_resolve.call_args.kwargs.get("requested"), "bedrock")
 
+
+
+class TestPersonaRegistry(unittest.TestCase):
+    def test_registry_accepts_prompt_and_runtime_only_personas(self):
+        cfg = {
+            "personas": {
+                "reviewer": {
+                    "description": "Review code",
+                    "system_prompt": "Review carefully.",
+                    "toolsets": "file,terminal",
+                },
+                "cheap": {
+                    "description": "Cheap model preset",
+                    "model": "google/gemini-flash",
+                },
+                "empty": {"description": "No prompt or runtime"},
+            }
+        }
+        registry = _get_persona_registry(cfg)
+        self.assertIn("reviewer", registry)
+        self.assertIn("cheap", registry)
+        self.assertNotIn("empty", registry)
+        self.assertEqual(registry["reviewer"]["toolsets"], ["file", "terminal"])
+        self.assertEqual(registry["cheap"]["model"], "google/gemini-flash")
+
+    def test_resolve_persona_is_case_insensitive_and_unknown_fails_closed(self):
+        cfg = {"personas": {"Reviewer": {"system_prompt": "Review carefully."}}}
+        key, spec = _resolve_persona("reviewer", cfg)
+        self.assertEqual(key, "Reviewer")
+        assert spec is not None
+        self.assertEqual(spec["system_prompt"], "Review carefully.")
+
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_persona("missing", cfg)
+        self.assertIn("Unknown delegation persona", str(ctx.exception))
+        self.assertIn("'Reviewer'", str(ctx.exception))
 
 
 class TestDelegationProviderIntegration(unittest.TestCase):
@@ -1620,6 +1815,204 @@ class TestDelegationProviderIntegration(unittest.TestCase):
                 self.assertEqual(call.kwargs.get("override_base_url"), "https://openrouter.ai/api/v1")
                 self.assertEqual(call.kwargs.get("override_api_key"), "sk-or-batch")
                 self.assertEqual(call.kwargs.get("override_api_mode"), "chat_completions")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_mixed_persona_batch_resolves_runtime_per_child(self, mock_creds, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "personas": {
+                "reviewer": {
+                    "description": "Review code",
+                    "system_prompt": "Review carefully.",
+                    "model": "anthropic/claude-sonnet-4",
+                    "provider": "openrouter",
+                    "toolsets": ["file"],
+                },
+                "cheap": {
+                    "description": "Cheap model preset",
+                    "model": "google/gemini-flash",
+                    "toolsets": ["terminal"],
+                },
+            },
+        }
+
+        def resolve(cfg, parent):
+            return {
+                "model": cfg.get("model"),
+                "provider": cfg.get("provider"),
+                "base_url": None,
+                "api_key": None,
+                "api_mode": None,
+            }
+
+        mock_creds.side_effect = resolve
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            children = [MagicMock(), MagicMock()]
+            mock_build.side_effect = children
+            mock_run.side_effect = [
+                {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "Reviewed",
+                    "api_calls": 1,
+                    "duration_seconds": 1.0,
+                },
+                {
+                    "task_index": 1,
+                    "status": "completed",
+                    "summary": "Ran",
+                    "api_calls": 1,
+                    "duration_seconds": 1.0,
+                },
+            ]
+
+            result = json.loads(
+                delegate_task(
+                    tasks=[
+                        {"goal": "Review", "persona": "reviewer"},
+                        {"goal": "Run cheap", "persona": "cheap"},
+                    ],
+                    parent_agent=parent,
+                )
+            )
+
+        first = mock_build.call_args_list[0].kwargs
+        second = mock_build.call_args_list[1].kwargs
+        self.assertEqual(first["persona"], "reviewer")
+        self.assertEqual(first["model"], "anthropic/claude-sonnet-4")
+        self.assertEqual(first["override_provider"], "openrouter")
+        self.assertEqual(first["toolsets"], ["file"])
+        self.assertEqual(first["persona_system_prompt"], "Review carefully.")
+        self.assertEqual(second["persona"], "cheap")
+        self.assertEqual(second["model"], "google/gemini-flash")
+        self.assertEqual(second["toolsets"], ["terminal"])
+        self.assertEqual(result["results"][0]["persona"], "reviewer")
+        self.assertEqual(result["results"][1]["persona"], "cheap")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_persona_provider_api_key_reaches_child(self, mock_resolve, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "personas": {
+                "isolated": {
+                    "description": "Use an isolated provider credential.",
+                    "system_prompt": "Stay isolated.",
+                    "model": "anthropic/claude-sonnet-4",
+                    "provider": "openrouter",
+                    "api_key": "persona-key",
+                }
+            },
+        }
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "runtime-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Done",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+
+            delegate_task(goal="Use isolated credential", persona="isolated", parent_agent=parent)
+
+        kwargs = mock_build.call_args.kwargs
+        self.assertEqual(kwargs["persona"], "isolated")
+        self.assertEqual(kwargs["model"], "anthropic/claude-sonnet-4")
+        self.assertEqual(kwargs["override_provider"], "openrouter")
+        self.assertEqual(kwargs["override_base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(kwargs["override_api_key"], "persona-key")
+        self.assertEqual(kwargs["override_api_mode"], "chat_completions")
+
+    @patch("tools.delegate_tool._load_config")
+    def test_unknown_persona_fails_without_spawning(self, mock_cfg):
+        mock_cfg.return_value = {
+            "personas": {"reviewer": {"system_prompt": "Review carefully."}}
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            result = json.loads(
+                delegate_task(goal="Review", persona="missing", parent_agent=parent)
+            )
+
+        self.assertIn("error", result)
+        self.assertIn("Unknown delegation persona", result["error"])
+        mock_build.assert_not_called()
+
+    @patch("tools.delegate_tool._load_config")
+    def test_later_unknown_persona_fails_without_partial_child_build(self, mock_cfg):
+        mock_cfg.return_value = {
+            "personas": {"reviewer": {"system_prompt": "Review carefully."}}
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            result = json.loads(
+                delegate_task(
+                    tasks=[
+                        {"goal": "Valid first", "persona": "reviewer"},
+                        {"goal": "Invalid second", "persona": "missing"},
+                    ],
+                    parent_agent=parent,
+                )
+            )
+
+        self.assertIn("error", result)
+        self.assertIn("Unknown delegation persona", result["error"])
+        mock_build.assert_not_called()
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_later_credential_error_fails_without_partial_child_build(
+        self, mock_creds, mock_cfg
+    ):
+        mock_cfg.return_value = {
+            "personas": {
+                "valid": {"system_prompt": "First persona."},
+                "broken": {"system_prompt": "Second persona.", "provider": "missing"},
+            }
+        }
+        mock_creds.side_effect = [
+            {
+                "model": None,
+                "provider": None,
+                "base_url": None,
+                "api_key": None,
+                "api_mode": None,
+            },
+            ValueError("Cannot resolve delegation provider 'missing'"),
+        ]
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            result = json.loads(
+                delegate_task(
+                    tasks=[
+                        {"goal": "Valid first", "persona": "valid"},
+                        {"goal": "Broken second", "persona": "broken"},
+                    ],
+                    parent_agent=parent,
+                )
+            )
+
+        self.assertIn("error", result)
+        self.assertIn("Cannot resolve delegation provider", result["error"])
+        mock_build.assert_not_called()
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -113,7 +113,8 @@ def _get_subagent_approval_callback():
 
 # NOTE: nested delegation is granted by role='orchestrator' (which re-adds the
 # "delegation" toolset in _build_child_agent), NOT by the model naming toolsets
-# — the model has no toolsets argument. Subagents inherit the parent's toolsets.
+# — the model has no toolsets argument. Subagents inherit the parent's toolsets
+# unless an operator-configured persona narrows them internally.
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
 # One-shot guard: the high-concurrency cost advisory is emitted at most once
@@ -658,6 +659,230 @@ def check_delegate_requirements() -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# Persona registry (config-backed, model-facing only by key + description)
+# ---------------------------------------------------------------------------
+
+_PERSONA_RUNTIME_KEYS = frozenset(
+    {
+        "model",
+        "provider",
+        "base_url",
+        "api_key",  # supported for runtime parity with delegation.base_url; never advertised
+        "api_mode",
+        "toolsets",
+        "reasoning_effort",
+        "max_iterations",
+    }
+)
+_PERSONA_SCHEMA_MAX_ITEMS = 30
+_PERSONA_DESCRIPTION_MAX_CHARS = 180
+
+
+def _normalize_persona_key(value: Any) -> Optional[str]:
+    """Return a stripped persona key, or None for an empty/missing value."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_persona_toolsets(value: Any) -> Optional[List[str]]:
+    """Normalize persona.toolsets from config into a non-empty list of strings."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        # Accept both YAML list form and a forgiving comma-separated string.
+        raw_items = value.split(",") if "," in value else [value]
+    elif isinstance(value, (list, tuple, set)):
+        raw_items = list(value)
+    else:
+        return None
+    items = [str(item).strip() for item in raw_items if str(item).strip()]
+    return items or None
+
+
+def _coerce_positive_int(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _coerce_persona_entry(raw: Any) -> Optional[Dict[str, Any]]:
+    """Normalize one delegation.personas entry.
+
+    The public contract is a mapping with ``description`` and
+    ``system_prompt`` plus optional runtime defaults.  A plain string is
+    tolerated as shorthand for ``system_prompt`` for backwards-friendly config
+    ergonomics, but it is NEVER used as a schema description (to avoid leaking
+    prompts into model-facing tool definitions).
+    """
+    if isinstance(raw, str):
+        prompt = raw.strip()
+        if not prompt:
+            return None
+        return {"description": "", "system_prompt": prompt}
+
+    if not isinstance(raw, dict):
+        return None
+
+    prompt_value = raw.get("system_prompt")
+    # Accept "prompt" as a human-friendly alias, but keep system_prompt as the
+    # documented config key.
+    if prompt_value is None:
+        prompt_value = raw.get("prompt")
+    system_prompt = str(prompt_value or "").strip()
+
+    spec: Dict[str, Any] = {
+        "description": str(raw.get("description") or "").strip(),
+    }
+    if system_prompt:
+        spec["system_prompt"] = system_prompt
+
+    for key in _PERSONA_RUNTIME_KEYS:
+        if key not in raw:
+            continue
+        value = raw.get(key)
+        if value in (None, ""):
+            continue
+        if key == "toolsets":
+            normalized = _normalize_persona_toolsets(value)
+            if normalized:
+                spec[key] = normalized
+        elif key == "max_iterations":
+            parsed = _coerce_positive_int(value)
+            if parsed is not None:
+                spec[key] = parsed
+            else:
+                logger.warning(
+                    "Ignoring invalid delegation persona max_iterations=%r", value
+                )
+        elif key == "api_mode":
+            spec[key] = str(value).strip().lower()
+        else:
+            spec[key] = str(value).strip() if isinstance(value, str) else value
+
+    # A persona may be runtime-only (for example, a cheap model preset) without
+    # a prompt. Drop completely empty mappings so typos don't create phantom
+    # personas that do nothing.
+    return spec if any(key in spec for key in ("system_prompt", *_PERSONA_RUNTIME_KEYS)) else None
+
+
+def _get_persona_registry(cfg: Optional[dict] = None) -> Dict[str, Dict[str, Any]]:
+    """Return normalized ``delegation.personas`` entries keyed by persona name.
+
+    The returned specs contain full system prompts for runtime use.  Callers
+    that build model-facing schema text MUST use _build_persona_param_description
+    (keys/descriptions only) instead of serialising this registry directly.
+    """
+    if cfg is None:
+        cfg = _load_config()
+    raw_personas = (cfg or {}).get("personas")
+    if not isinstance(raw_personas, dict):
+        return {}
+
+    registry: Dict[str, Dict[str, Any]] = {}
+    for raw_key, raw_entry in raw_personas.items():
+        key = _normalize_persona_key(raw_key)
+        if not key:
+            continue
+        spec = _coerce_persona_entry(raw_entry)
+        if spec is not None:
+            registry[key] = spec
+    return registry
+
+
+def _truncate_schema_description(text: str) -> str:
+    compact = " ".join(str(text or "").split())
+    if len(compact) <= _PERSONA_DESCRIPTION_MAX_CHARS:
+        return compact
+    return compact[: _PERSONA_DESCRIPTION_MAX_CHARS - 1].rstrip() + "…"
+
+
+def _format_persona_options_for_schema(cfg: Optional[dict] = None) -> str:
+    """Model-facing persona list: keys + descriptions only, never prompts/secrets."""
+    registry = _get_persona_registry(cfg)
+    if not registry:
+        return "No delegation.personas are configured."
+
+    parts: List[str] = []
+    items = sorted(registry.items(), key=lambda kv: kv[0])
+    for key, spec in items[:_PERSONA_SCHEMA_MAX_ITEMS]:
+        desc = _truncate_schema_description(spec.get("description") or "")
+        if desc:
+            parts.append(f"'{key}' — {desc}")
+        else:
+            parts.append(f"'{key}'")
+    if len(items) > _PERSONA_SCHEMA_MAX_ITEMS:
+        parts.append(f"… +{len(items) - _PERSONA_SCHEMA_MAX_ITEMS} more")
+    return "; ".join(parts)
+
+
+def _build_persona_param_description() -> str:
+    return (
+        "Optional persona key from delegation.personas. Personas add a "
+        "child-local system prompt and may provide child-local defaults for "
+        "model/provider/base_url/api_mode/toolsets/reasoning/max_iterations. "
+        "Use the configured key only; do not invent personas. Available "
+        f"personas: {_format_persona_options_for_schema()}"
+    )
+
+
+def _resolve_persona(
+    persona: Any,
+    cfg: dict,
+) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Resolve a requested persona key to its normalized spec.
+
+    Returns (None, None) when no persona was requested. Raises ValueError with
+    a non-sensitive message for unknown keys.
+    """
+    key = _normalize_persona_key(persona)
+    if not key:
+        return None, None
+
+    registry = _get_persona_registry(cfg)
+    if key in registry:
+        return key, registry[key]
+
+    # Forgiving case-insensitive match when it is unambiguous. Keep the stored
+    # key in metadata so results match config exactly.
+    matches = [name for name in registry if name.lower() == key.lower()]
+    if len(matches) == 1:
+        actual = matches[0]
+        return actual, registry[actual]
+
+    available = ", ".join(f"'{name}'" for name in sorted(registry)) or "(none)"
+    raise ValueError(
+        f"Unknown delegation persona '{key}'. Available personas: {available}."
+    )
+
+
+def _merge_persona_runtime_config(
+    cfg: dict,
+    persona_spec: Optional[Dict[str, Any]],
+) -> dict:
+    """Overlay persona runtime defaults onto delegation config for one child."""
+    effective = dict(cfg or {})
+    if not persona_spec:
+        return effective
+    for key in ("model", "provider", "base_url", "api_key", "api_mode"):
+        if key in persona_spec and persona_spec[key] not in (None, ""):
+            effective[key] = persona_spec[key]
+    return effective
+
+
+def _persona_or_config_max_iterations(
+    default_max_iter: Any,
+    persona_spec: Optional[Dict[str, Any]],
+) -> Any:
+    if persona_spec and persona_spec.get("max_iterations") is not None:
+        return persona_spec["max_iterations"]
+    return default_max_iter
+
+
 def _build_child_system_prompt(
     goal: str,
     context: Optional[str] = None,
@@ -666,6 +891,8 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    persona: Optional[str] = None,
+    persona_system_prompt: Optional[str] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -680,6 +907,11 @@ def _build_child_system_prompt(
         "",
         f"YOUR TASK:\n{goal}",
     ]
+    if persona_system_prompt and str(persona_system_prompt).strip():
+        label = f"PERSONA ({persona})" if persona else "PERSONA"
+        parts.append(
+            f"\n{label} INSTRUCTIONS:\n{str(persona_system_prompt).strip()}"
+        )
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -812,6 +1044,7 @@ def _build_child_progress_callback(
     depth: Optional[int] = None,
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
+    persona: Optional[str] = None,
     session_ref: Optional[Dict[str, Any]] = None,
 ) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
@@ -821,7 +1054,7 @@ def _build_child_progress_callback(
       Gateway: batches tool names and relays to parent's progress callback
 
     The identity kwargs (``subagent_id``, ``parent_id``, ``depth``, ``model``,
-    ``toolsets``) are threaded into every relayed event so the TUI can
+    ``toolsets``, ``persona``) are threaded into every relayed event so the TUI can
     reconstruct the live spawn tree and route per-branch controls (kill,
     pause) back by ``subagent_id``.  All are optional for backward compat —
     older callers that ignore them still produce a flat list on the TUI.
@@ -860,6 +1093,8 @@ def _build_child_progress_callback(
             kw["model"] = model
         if toolsets is not None:
             kw["toolsets"] = list(toolsets)
+        if persona is not None:
+            kw["persona"] = persona
         # The child's own session id — filled into the shared ref once the
         # child agent exists (the callback is built first), so every relayed
         # event lets UIs open/inspect the subagent's session directly.
@@ -1062,6 +1297,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Optional config-backed persona resolved by delegate_task for this child.
+    persona: Optional[str] = None,
+    persona_system_prompt: Optional[str] = None,
+    persona_reasoning_effort: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1149,6 +1388,8 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        persona=persona,
+        persona_system_prompt=persona_system_prompt,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -1172,6 +1413,7 @@ def _build_child_agent(
         depth=tui_depth,
         model=effective_model_for_cb,
         toolsets=child_toolsets,
+        persona=persona,
         session_ref=child_session_ref,
     )
 
@@ -1200,12 +1442,12 @@ def _build_child_agent(
     if not override_base_url:
         effective_base_url = _inherit_parent_base_url(parent_agent, effective_base_url)
     effective_api_key = override_api_key or parent_api_key
+    _parent_provider = getattr(parent_agent, "provider", None) or ""
     # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
     # different provider than the parent — each provider has its own API surface
     # (e.g. MiniMax uses anthropic_messages, DeepSeek uses chat_completions).
     # Inheriting the parent's mode causes 404 errors when the child routes to the
     # wrong endpoint.  Derive the mode from the target provider when it differs.
-    _parent_provider = getattr(parent_agent, "provider", None) or ""
     if override_api_mode is not None:
         effective_api_mode = override_api_mode
     elif effective_provider != _parent_provider:
@@ -1226,6 +1468,19 @@ def _build_child_agent(
             )
             override_acp_command = None
             override_acp_args = None
+            if effective_provider == "copilot-acp":
+                # A stale/missing ACP CLI must not leave the child configured
+                # as copilot-acp without a command. Fall back to the parent's
+                # normal transport instead of constructing an invalid child.
+                effective_provider = _parent_provider or getattr(
+                    parent_agent, "provider", None
+                )
+                effective_base_url = _inherit_parent_base_url(
+                    parent_agent,
+                    getattr(parent_agent, "base_url", effective_base_url),
+                )
+                effective_api_key = parent_api_key
+                effective_api_mode = getattr(parent_agent, "api_mode", None)
     effective_acp_command = override_acp_command or getattr(
         parent_agent, "acp_command", None
     )
@@ -1249,14 +1504,19 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config: persona override > delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
         # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean
         # False (``reasoning_effort: false``) to "" and inherit the parent
-        # instead of disabling thinking for children.
-        delegation_effort = delegation_cfg.get("reasoning_effort")
+        # instead of disabling thinking for children. Personas may also set
+        # ``reasoning_effort: false`` to disable thinking for that lane.
+        delegation_effort = (
+            persona_reasoning_effort
+            if persona_reasoning_effort is not None
+            else delegation_cfg.get("reasoning_effort")
+        )
         if delegation_effort or delegation_effort is False:
             from hermes_constants import parse_reasoning_effort
 
@@ -1344,6 +1604,7 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    setattr(child, "_delegate_persona", persona)
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
     # Stable sidebar marker: delegate subagent sessions must stay out of
     # session pickers even when a parent delete orphans them (parent_session_id
@@ -1389,6 +1650,7 @@ def _build_child_agent(
             child_session_id=getattr(child, "session_id", None),
             child_subagent_id=subagent_id,
             child_role=effective_role,
+            child_persona=persona,
             child_goal=goal,
         )
     except Exception:
@@ -1841,6 +2103,8 @@ def _run_single_child(
     # hand us a MagicMock don't carry stable ids; skip registration then.
     _raw_sid = getattr(child, "_subagent_id", None)
     _subagent_id = _raw_sid if isinstance(_raw_sid, str) else None
+    _raw_persona = getattr(child, "_delegate_persona", None)
+    _persona = _raw_persona if isinstance(_raw_persona, str) and _raw_persona else None
     if _subagent_id:
         _raw_depth = getattr(child, "_delegate_depth", 1)
         _tui_depth = max(0, _raw_depth - 1) if isinstance(_raw_depth, int) else 0
@@ -1860,6 +2124,7 @@ def _run_single_child(
                 "status": "running",
                 "tool_count": 0,
                 "agent": child,
+                **({"persona": _persona} if _persona else {}),
             }
         )
 
@@ -2009,7 +2274,7 @@ def _run_single_child(
             else:
                 _err = str(_timeout_exc)
 
-            return {
+            error_entry = {
                 "task_index": task_index,
                 "status": "timeout" if is_timeout else "error",
                 "summary": None,
@@ -2020,6 +2285,9 @@ def _run_single_child(
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
             }
+            if _persona:
+                error_entry["persona"] = _persona
+            return error_entry
         finally:
             # Shut down executor without waiting — if the child thread
             # is stuck on blocking I/O, wait=True would hang forever.
@@ -2140,6 +2408,8 @@ def _run_single_child(
                 else 0.0
             ),
         }
+        if _persona:
+            entry["persona"] = _persona
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
@@ -2225,6 +2495,8 @@ def _run_single_child(
             "files_written": _files_written,
             "output_tail": _output_tail,
         }
+        if _persona:
+            complete_kwargs["persona"] = _persona
         if _cost_usd is not None:
             try:
                 complete_kwargs["cost_usd"] = float(_cost_usd)
@@ -2253,7 +2525,7 @@ def _run_single_child(
                 )
             except Exception as e:
                 logger.debug("Progress callback failure relay failed: %s", e)
-        return {
+        error_entry = {
             "task_index": task_index,
             "status": "error",
             "summary": None,
@@ -2262,6 +2534,9 @@ def _run_single_child(
             "duration_seconds": duration,
             "_child_role": getattr(child, "_delegate_role", None),
         }
+        if _persona:
+            error_entry["persona"] = _persona
+        return error_entry
 
     finally:
         # Stop the heartbeat thread so it doesn't keep touching parent activity
@@ -2345,6 +2620,7 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    persona: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
@@ -2352,13 +2628,15 @@ def delegate_task(
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, role, persona)
+      - Batch:  provide tasks array [{goal, context, role, persona}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+    The 'persona' parameter selects a config-backed child persona;
+    per-task persona beats the top-level persona.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2415,17 +2693,7 @@ def delegate_task(
             "using delegation.max_iterations=%s from config",
             max_iterations, default_max_iter,
         )
-    effective_max_iter = default_max_iter
-
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
+    top_persona = _normalize_persona_key(persona)
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2446,7 +2714,14 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "role": top_role}]
+        task_list = [
+            {
+                "goal": goal,
+                "context": context,
+                "role": top_role,
+                "persona": top_persona,
+            }
+        ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -2476,36 +2751,108 @@ def delegate_task(
 
     _parent_tool_names = list(_model_tools._last_resolved_tool_names)
 
+    # Resolve and validate every child spec before building any child agent.
+    # If a later task has an unknown persona or credential failure, returning
+    # after a partial build would leak already-registered children because
+    # _run_single_child() cleanup never runs. Keep planning side-effect free.
+    planned_children: List[Dict[str, Any]] = []
+    _credential_cache: Dict[Optional[str], Dict[str, Any]] = {}
+    for i, t in enumerate(task_list):
+        # Per-task role beats top-level; normalise again so unknown
+        # per-task values warn and degrade to leaf uniformly.
+        effective_role = _normalize_role(t.get("role") or top_role)
+
+        task_persona_raw = t.get("persona")
+        if _normalize_persona_key(task_persona_raw) is None:
+            task_persona_raw = top_persona
+        try:
+            persona_key, persona_spec = _resolve_persona(task_persona_raw, cfg)
+        except ValueError as exc:
+            return tool_error(str(exc))
+
+        if persona_key not in _credential_cache:
+            effective_cfg = _merge_persona_runtime_config(cfg, persona_spec)
+            try:
+                _credential_cache[persona_key] = _resolve_delegation_credentials(
+                    effective_cfg, parent_agent
+                )
+            except ValueError as exc:
+                return tool_error(str(exc))
+        creds = _credential_cache[persona_key]
+
+        persona_toolsets = (
+            persona_spec.get("toolsets")
+            if isinstance(persona_spec, dict)
+            else None
+        )
+        effective_toolsets = persona_toolsets
+        effective_max_iter = _persona_or_config_max_iterations(
+            default_max_iter, persona_spec
+        )
+        persona_prompt = (
+            persona_spec.get("system_prompt")
+            if isinstance(persona_spec, dict)
+            else None
+        )
+        persona_reasoning = (
+            persona_spec.get("reasoning_effort")
+            if isinstance(persona_spec, dict)
+            else None
+        )
+
+        planned_children.append(
+            {
+                "task_index": i,
+                "task": t,
+                "effective_role": effective_role,
+                "effective_toolsets": effective_toolsets,
+                "effective_max_iter": effective_max_iter,
+                "persona_key": persona_key,
+                "persona_prompt": persona_prompt,
+                "persona_reasoning": persona_reasoning,
+                "creds": creds,
+            }
+        )
+
     # Build all child agents on the main thread (thread-safe construction)
-    # Wrapped in try/finally so the global is always restored even if a
-    # child build raises (otherwise _last_resolved_tool_names stays corrupted).
+    # only after the whole batch is known-good. Wrapped in try/finally so the
+    # global is always restored even if a child build raises (otherwise
+    # _last_resolved_tool_names stays corrupted).
     children = []
     try:
-        for i, t in enumerate(task_list):
-            # Per-task role beats top-level; normalise again so unknown
-            # per-task values warn and degrade to leaf uniformly.
-            effective_role = _normalize_role(t.get("role") or top_role)
+        for spec in planned_children:
+            i = spec["task_index"]
+            t = spec["task"]
+            creds = spec["creds"]
+            persona_key = spec["persona_key"]
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                # Subagents always inherit the parent's toolsets; the model
-                # cannot choose or narrow them (no model-facing toolsets arg).
-                toolsets=None,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
+                # Model-facing schema does not expose toolsets. A configured
+                # persona may still narrow the child internally, and the child
+                # builder intersects that with the parent's available toolsets.
+                toolsets=spec["effective_toolsets"],
+                model=creds.get("model"),
+                max_iterations=spec["effective_max_iter"],
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=creds.get("provider"),
+                override_base_url=creds.get("base_url"),
+                override_api_key=creds.get("api_key"),
+                override_api_mode=creds.get("api_mode"),
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
-                role=effective_role,
+                role=spec["effective_role"],
+                persona=persona_key,
+                persona_system_prompt=spec["persona_prompt"],
+                persona_reasoning_effort=spec["persona_reasoning"],
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
+            # If tests/plugins wrap _build_child_agent, still stamp non-sensitive
+            # persona metadata so aggregation and hooks stay consistent.
+            setattr(child, "_delegate_persona", persona_key)
             children.append((i, t, child))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
@@ -2649,6 +2996,23 @@ def delegate_task(
             # Sort by task_index so results match input order
             results.sort(key=lambda r: r["task_index"])
 
+        # Ensure persona metadata is present even for mocked/fabricated result
+        # entries (interrupt branches, tests, plugin-wrapped child runners).
+        _child_by_index_all = {i: child for (i, _, child) in children}
+        for entry in results:
+            try:
+                idx = entry.get("task_index")
+                child = _child_by_index_all.get(idx)
+                raw_persona = getattr(child, "_delegate_persona", None)
+                if (
+                    isinstance(raw_persona, str)
+                    and raw_persona
+                    and not entry.get("persona")
+                ):
+                    entry["persona"] = raw_persona
+            except Exception:
+                pass
+
         # Cap subagent summaries against the parent's remaining context
         # headroom (split across the batch) before they enter the parent's
         # conversation. Full text is spilled to disk so nothing is lost.
@@ -2720,6 +3084,7 @@ def delegate_task(
                     parent_turn_id=getattr(parent_agent, "_current_turn_id", "") or "",
                     child_session_id=getattr(_child_agent, "session_id", None),
                     child_role=child_role,
+                    child_persona=entry.get("persona"),
                     child_summary=entry.get("summary"),
                     child_status=entry.get("status"),
                     duration_ms=int((entry.get("duration_seconds") or 0) * 1000),
@@ -2827,6 +3192,14 @@ def delegate_task(
                     pass
 
         _goals = [t["goal"] for t in task_list]
+        _models = [getattr(c, "model", None) for c in _child_agents]
+        _unique_models = {m for m in _models if m}
+        _dispatch_model = (
+            next(iter(_unique_models))
+            if len(_unique_models) == 1
+            else ("mixed" if len(_unique_models) > 1 else None)
+        )
+        _personas = [getattr(c, "_delegate_persona", None) for c in _child_agents]
         dispatch = dispatch_async_delegation_batch(
             goals=_goals,
             context=context,
@@ -2834,7 +3207,7 @@ def delegate_task(
             # parent's toolsets (no model-facing toolsets arg).
             toolsets=None,
             role=top_role,
-            model=creds["model"],
+            model=_dispatch_model,
             session_key=_session_key,
             runner=_batch_runner,
             interrupt_fn=_batch_interrupt,
@@ -2863,6 +3236,8 @@ def delegate_task(
                 "goals": _goals,
                 "note": note,
             }
+            if any(_personas):
+                payload["personas"] = _personas
             return json.dumps(payload, ensure_ascii=False)
 
         # Pool at capacity / schedule failure — children are still attached
@@ -2987,7 +3362,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     Otherwise, if ``delegation.provider`` is configured, the full credential
     bundle (base_url, api_key, api_mode, provider) is resolved via the runtime
     provider system — the same path used by CLI/gateway startup. This lets
-    subagents run on a completely different provider:model pair.
+    subagents run on a completely different provider:model pair. If
+    ``delegation.api_key`` (or a persona-overlaid api_key) is also set, that
+    explicit child-local key overrides the provider-resolved key.
 
     If neither base_url nor provider is configured, returns None values so the
     child inherits everything from the parent agent.
@@ -3079,19 +3456,26 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             f"Available providers: openrouter, nous, zai, kimi-coding, minimax."
         ) from exc
 
-    api_key = runtime.get("api_key", "")
+    runtime_api_key = runtime.get("api_key", "")
+    api_key = configured_api_key or runtime_api_key
     if not api_key:
         raise ValueError(
             f"Delegation provider '{configured_provider}' resolved but has no API key. "
             f"Set the appropriate environment variable or run 'hermes auth'."
         )
 
+    api_mode = runtime.get("api_mode")
+    if configured_api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        # Explicit delegation/persona api_mode wins over provider defaults, just
+        # like it does for direct base_url endpoints.
+        api_mode = configured_api_mode
+
     return {
         "model": configured_model or runtime.get("model") or None,
         "provider": configured_provider if runtime.get("provider") == _RUNTIME_PROVIDER_CUSTOM else runtime.get("provider"),
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
-        "api_mode": runtime.get("api_mode"),
+        "api_mode": api_mode,
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }
@@ -3224,7 +3608,7 @@ def _build_top_level_description() -> str:
         f"Orchestrators are bounded by max_spawn_depth={max_depth} for this "
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
-        "- Subagent model is NOT selectable per call: children inherit the parent model (plus its fallback chain) unless you pin all subagents to a model via delegation.provider / delegation.model in config.yaml.\n"
+        "- Subagent model defaults to the parent model (plus its fallback chain) unless delegation.provider / delegation.model or a configured delegation.personas entry selects a child-local runtime.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
         "- Results are always returned as an array, one entry per task."
     )
@@ -3288,15 +3672,18 @@ def _build_dynamic_schema_overrides() -> dict:
     get_definitions() pass rewrites the description fields to the user's
     actual limits.
     """
-    overrides_params = {
-        **DELEGATE_TASK_SCHEMA["parameters"],
-    }
-    # Deep-copy properties so we don't mutate the static schema dict.
-    overrides_params["properties"] = {
-        k: dict(v) for k, v in DELEGATE_TASK_SCHEMA["parameters"]["properties"].items()
-    }
+    import copy
+
+    overrides_params = copy.deepcopy(DELEGATE_TASK_SCHEMA["parameters"])
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
     overrides_params["properties"]["role"]["description"] = _build_role_param_description()
+    persona_desc = _build_persona_param_description()
+    if "persona" in overrides_params["properties"]:
+        overrides_params["properties"]["persona"]["description"] = persona_desc
+    try:
+        overrides_params["properties"]["tasks"]["items"]["properties"]["persona"]["description"] = persona_desc
+    except KeyError:
+        pass
 
     return {
         "description": _build_top_level_description(),
@@ -3353,6 +3740,10 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "persona": {
+                            "type": "string",
+                            "description": "Optional per-task persona override from delegation.personas.",
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3364,6 +3755,10 @@ DELEGATE_TASK_SCHEMA = {
             "role": {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
+                "description": "(rebuilt at get_definitions() time)",
+            },
+            "persona": {
+                "type": "string",
                 "description": "(rebuilt at get_definitions() time)",
             },
             "background": {
@@ -3436,6 +3831,7 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        persona=args.get("persona"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
     ),

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -636,6 +636,30 @@ delegation:
 
 Now when you tell Hermes "write me a Twitter thread about X" and it spawns a `delegate_task` subagent, that subagent runs on Gemini instead of your main model. Your primary conversation stays on GPT-5.4.
 
+For reusable specialist routing, configure `delegation.personas` instead. Personas let different tasks choose different child-local prompts, models, providers, and default toolsets without using full Hermes profiles:
+
+```yaml
+delegation:
+  personas:
+    social_writer:
+      description: "Drafts short-form social content"
+      system_prompt: "Write concise, platform-native social copy."
+      model: "google/gemini-3-flash-preview"
+      provider: "openrouter"
+
+    code_reviewer:
+      description: "Reviews code for correctness and regressions"
+      system_prompt: "Review code conservatively and cite concrete findings."
+      model: "anthropic/claude-sonnet-4"
+      provider: "openrouter"
+```
+
+Then ask Hermes to delegate with a persona, or let configured workflows choose one.
+
+Persona `description` values are shown to the active LLM in the `delegate_task` tool schema so it can choose the right persona. Keep descriptions short and non-sensitive; full `system_prompt` values and credential fields are not advertised in the schema.
+
+Personas are profile-scoped. A default-profile gateway reads `~/.hermes/config.yaml`; a `coder` session reads `~/.hermes/profiles/coder/config.yaml`. After editing personas, start a fresh chat and restart the long-running surface that serves it (Desktop app, gateway, or CLI/TUI process). If Hermes reports `Unknown delegation persona ... Available personas: (none)`, it is usually reading a profile/config that does not contain the persona or a process that has not been restarted since the config edit.
+
 You can also be explicit in your prompt: *"Delegate a task to write social media posts about our product launch. Use your subagent for the actual writing."* The agent will use `delegate_task`, which automatically picks up the delegation config.
 
 For one-off model switches without delegation, use `/model` in the CLI:

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -14,7 +14,6 @@ The `delegate_task` tool spawns child AIAgent instances with isolated context, r
 delegate_task(
     goal="Debug why tests fail",
     context="Error: assertion in test_foo.py line 42",
-    toolsets=["terminal", "file"]
 )
 ```
 
@@ -24,9 +23,9 @@ Up to 3 concurrent subagents by default (configurable, no hard ceiling):
 
 ```python
 delegate_task(tasks=[
-    {"goal": "Research topic A", "toolsets": ["web"]},
-    {"goal": "Research topic B", "toolsets": ["web"]},
-    {"goal": "Fix the build", "toolsets": ["terminal", "file"]}
+    {"goal": "Research topic A"},
+    {"goal": "Research topic B"},
+    {"goal": "Fix the build"}
 ])
 ```
 
@@ -65,18 +64,15 @@ Research multiple topics simultaneously and collect summaries:
 delegate_task(tasks=[
     {
         "goal": "Research the current state of WebAssembly in 2025",
-        "context": "Focus on: browser support, non-browser runtimes, language support",
-        "toolsets": ["web"]
+        "context": "Focus on: browser support, non-browser runtimes, language support"
     },
     {
         "goal": "Research the current state of RISC-V adoption in 2025",
-        "context": "Focus on: server chips, embedded systems, software ecosystem",
-        "toolsets": ["web"]
+        "context": "Focus on: server chips, embedded systems, software ecosystem"
     },
     {
         "goal": "Research quantum computing progress in 2025",
-        "context": "Focus on: error correction breakthroughs, practical applications, key players",
-        "toolsets": ["web"]
+        "context": "Focus on: error correction breakthroughs, practical applications, key players"
     }
 ])
 ```
@@ -93,7 +89,6 @@ delegate_task(
     The project uses Flask, PyJWT, and bcrypt.
     Focus on: SQL injection, JWT validation, password handling, session management.
     Fix any issues found and run the test suite (pytest tests/auth/).""",
-    toolsets=["terminal", "file"]
 )
 ```
 
@@ -113,7 +108,6 @@ delegate_task(
     - Other prints -> logger.info(...)
     Don't change print() in test files or CLI output.
     Run pytest after to verify nothing broke.""",
-    toolsets=["terminal", "file"]
 )
 ```
 
@@ -142,9 +136,69 @@ delegation:
 
 If omitted, subagents use the same model as the parent.
 
+## Persona Presets
+
+For reusable specialist subagents, configure `delegation.personas` in `config.yaml` and pass the persona key to `delegate_task`. A persona can add child-local instructions and optional runtime defaults without switching the parent conversation.
+
+```yaml
+# In ~/.hermes/config.yaml
+delegation:
+  personas:
+    code_reviewer:
+      description: "Security- and correctness-focused code reviewer"
+      system_prompt: |
+        You are a senior code reviewer. Focus on correctness, regressions,
+        security, and minimal safe changes.
+      model: "anthropic/claude-sonnet-4"
+      provider: "openrouter"
+      toolsets: ["file", "terminal"]
+
+    quick_researcher:
+      description: "Fast web/documentation researcher"
+      system_prompt: |
+        Gather evidence with sources and separate facts from speculation.
+      model: "google/gemini-flash-2.0"
+      provider: "openrouter"
+      toolsets: ["web", "file"]
+```
+
+Then select a persona for one child or per task:
+
+```python
+delegate_task(
+    goal="Review the current diff for correctness and security",
+    persona="code_reviewer",
+)
+
+delegate_task(tasks=[
+    {"goal": "Find relevant docs", "persona": "quick_researcher"},
+    {"goal": "Review the patch", "persona": "code_reviewer"},
+])
+```
+
+Personas are **not** full Hermes profiles (`hermes -p ...`). They do not load separate memory, skills, or profile config. They are child-local presets for delegation only. The existing `role` parameter remains topology-only (`leaf` or `orchestrator`); use `persona` for specialist behavior.
+
+Persona `toolsets` are defaults, not authority escalation: Hermes still intersects them with the parent's available toolsets and strips blocked child tools.
+
+Personas are scoped to the active Hermes profile. A persona configured in `~/.hermes/profiles/coder/config.yaml` is available only to sessions running with `--profile coder`; a default-profile gateway reads `~/.hermes/config.yaml` instead. If you want the same persona in multiple profiles, add it to each profile's `config.yaml`.
+
+Configuration is loaded when a Hermes process/session builds its tool schema. After adding or renaming personas, start a fresh chat session. For long-running surfaces, restart the process that serves that surface:
+
+- CLI/TUI: start a new session (or relaunch Hermes).
+- Desktop: quit and reopen the Desktop app so its local `serve` backend restarts.
+- Messaging gateway: restart the gateway for the profile that serves the chat.
+
+If a delegated call fails with `Unknown delegation persona 'name'. Available personas: (none)`, the process handling that conversation did not load a `delegation.personas` entry for its active profile. Check the active profile and restart the relevant surface after editing config.
+
+:::note
+Persona `description` values are included in the model-facing `delegate_task` tool schema so the active LLM can choose among configured personas. Keep descriptions short and non-sensitive. Full `system_prompt` values and credential fields are used at runtime only and are not advertised in the schema.
+:::
+
 ## Toolset Selection Tips
 
-The `toolsets` parameter controls what tools the subagent has access to. Choose based on the task:
+`delegate_task` no longer exposes a model-facing `toolsets` argument. Child agents inherit the parent's enabled toolsets by default, and operator-configured personas may narrow those tools internally. Persona toolsets are still intersected with the parent's available toolsets and the child blocklist, so they cannot grant new capabilities.
+
+Choose persona toolsets based on the task:
 
 | Toolset Pattern | Use Case |
 |----------------|----------|


### PR DESCRIPTION
## Summary
- Adds config-backed `delegation.personas` so subagents can use reusable child-local prompts and runtime defaults.
- Threads top-level and per-task `persona` through sync/async delegation, progress metadata, hooks, and result entries.
- Preserves explicit persona/config `api_key` precedence when a persona also selects a provider, so child-local credentials are not silently replaced by globally resolved provider credentials.
- Preserves upstream's delegation safety boundary: `toolsets` is not exposed as a direct model-facing `delegate_task` argument. Persona-configured toolsets can only narrow children internally and still intersect with the parent's available tools and the child blocklist.
- Documents persona setup, profile scope, restart requirements, unknown-persona troubleshooting, and the non-model-facing toolset policy.

## Validation
- Rebased PR branch onto `origin/main` `30e947e0a` after upstream advanced 50 commits beyond the previously carried local persona commit.
- Rebase completed without conflicts.
- `git diff --check origin/main...HEAD` → passed.
- Conflict-marker scan over changed files → passed.
- Persona code probes in `tools/delegate_tool.py`, `tests/tools/test_delegate.py`, and docs → passed.
- `python -m py_compile tools/delegate_tool.py run_agent.py tests/tools/test_delegate.py` → passed.
- `python -m pytest tests/tools/test_delegate.py::TestDelegateRequirements tests/tools/test_delegate.py::TestDelegationCredentialResolution tests/tools/test_delegate.py::TestDelegationProviderIntegration::test_persona_provider_api_key_reaches_child -q` → 25 passed in 1.07s.
- `python -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py tests/tools/test_delegate_composite_toolsets.py tests/tools/test_async_delegation.py tests/agent/test_subagent_stop_hook.py tests/cli/test_cli_delegate_background_notice.py tests/cli/test_cli_background_status_indicator.py tests/plugins/test_nemo_relay_plugin.py tests/tools/test_delegate_subagent_timeout_diagnostic.py tests/test_delegate_cascade_49148.py -q` → 284 passed in 15.76s.

<!-- PR-CONTEXT:START -->
```yaml
schema_version: 1
format: orchestra_pr_context
context_id: "ctx-delegation-persona-979a5709-20260702T150908Z"
context_revision: 5
anchor_head_sha: "979a570989aca827a3752f88449f047147ca5213"
base_sha: "30e947e0a05ef535e4b25a183d8bbe34fd68d1d5"
generated_at_utc: "2026-07-02T15:09:08Z"

system_context:
  system_type: "Hermes Agent delegation tool / subagent runtime"
  runtime_context: "CLI, Desktop/TUI, messaging gateway, and cron sessions that expose delegate_task"
  exposure_model: "local user config; model-facing schema exposes only persona keys/descriptions, not prompts, secrets, or direct toolset selection"
  user_visible_surface: "delegate_task tool schema, subagent behavior, docs"

intent:
  objective_real: "Allow users to define reusable delegation personas that select child-local prompts and optional runtime defaults per subagent."
  risk_to_avoid: "Do not turn personas into full profile switching, tool escalation, prompt-cache mutation, schema leakage of prompts/secrets, direct model-chosen child toolsets, or accidental credential routing through the parent/global provider key."
  acceptance_criteria:
    - id: "AC-01"
      text: "Existing delegate_task calls without persona keep current behavior."
      status: "verified"
    - id: "AC-02"
      text: "Top-level persona and tasks[].persona select configured delegation.personas entries."
      status: "verified"
    - id: "AC-03"
      text: "Mixed-persona batches resolve runtime/model/provider/toolset defaults per child."
      status: "verified"
    - id: "AC-04"
      text: "Unknown persona or later credential failures fail before any child is built."
      status: "verified"
    - id: "AC-05"
      text: "Schema-visible persona data is limited to keys/descriptions."
      status: "verified"
    - id: "AC-06"
      text: "Explicit persona/config api_key overrides provider-resolved credentials for that child."
      status: "verified"
    - id: "AC-07"
      text: "Direct model-facing toolsets argument remains absent while persona-configured toolsets can narrow internally under parent intersection/blocklist rules."
      status: "verified"
  restrictions:
    - "Do not load separate Hermes profiles, memory, skills, or homes for personas."
    - "Do not allow persona toolsets to grant access beyond the parent toolset or child blocklist."
    - "Do not expose full system_prompt or credential values in model-facing schema text."
    - "Do not reintroduce direct model-facing toolsets."
  non_goals:
    - "Full profile-backed subagents."
    - "Mutable pre-spawn hooks or arbitrary plugin lifecycle for persona selection."
    - "Changing role semantics; role remains leaf/orchestrator topology."

scope:
  touched_paths:
    - "run_agent.py"
    - "tools/delegate_tool.py"
    - "tests/tools/test_delegate.py"
    - "website/docs/user-guide/features/delegation.md"
    - "website/docs/reference/faq.md"

invariants:
  - id: "INV-01"
    rule: "Personas are child-local delegation presets, not Hermes profiles."
    rationale: "Keeps delegation lightweight and profile-safe."
    breakage_if_violated: "Subagents could unexpectedly load separate memory, skills, config, or homes."
  - id: "INV-02"
    rule: "Personas cannot grant tools unavailable to the parent or blocked for children."
    rationale: "Preserves delegation safety boundaries."
    breakage_if_violated: "A persona could escalate tool access."
  - id: "INV-03"
    rule: "Parent prompt cache remains stable; persona prompt is injected only into child ephemeral context."
    rationale: "Hermes treats prompt caching as a core invariant."
    breakage_if_violated: "Long-lived sessions could invalidate cache prefixes or leak child instructions upstream."
  - id: "INV-04"
    rule: "Credential fields and full persona prompts are never advertised in schema descriptions or summaries."
    rationale: "Tool schema is model-facing and persisted in session context."
    breakage_if_violated: "Private prompts/secrets could leak into model-visible context."
  - id: "INV-05"
    rule: "Explicit persona/config api_key takes precedence over provider-resolved api_key for that child."
    rationale: "A persona-specific credential must remain child-local and must not silently fall back to the host/global provider key."
    breakage_if_violated: "A subagent could bill/use the wrong account or fail isolation expectations."
  - id: "INV-06"
    rule: "The model cannot directly name arbitrary child toolsets through delegate_task."
    rationale: "Preserves upstream's delegation safety boundary."
    breakage_if_violated: "A model-facing capability-selection surface would be reintroduced."

validation_summary:
  automated:
    - command: "git diff --check origin/main...HEAD"
      result: "OK"
      scope: "patch whitespace/conflict markers"
    - command: "python -m py_compile tools/delegate_tool.py run_agent.py tests/tools/test_delegate.py"
      result: "OK"
      scope: "changed Python syntax"
    - command: "targeted delegate schema/credential pytest"
      result: "OK: 25 passed"
      scope: "schema and provider credential precedence"
    - command: "delegation suite pytest"
      result: "OK: 284 passed"
      scope: "delegation, async, hooks, CLI background, plugin, timeout, cascade paths"
  manual_pending:
    - "Full test suite was not run."
```
<!-- PR-CONTEXT:END -->
