### PR TITLE
fix(tools): support configurable terminal approval rules

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -16,6 +16,7 @@ from tools.approval import (
     _normalize_approval_mode,
     _smart_approve,
     approve_session,
+    check_all_command_guards,
     detect_dangerous_command,
     detect_hardline_command,
     is_approved,
@@ -567,6 +568,248 @@ class TestPatternKeyUniqueness:
             load_permanent({"find"})
             assert is_approved("legacy-find", key_exec) is True
             assert is_approved("legacy-find", key_delete) is True
+
+
+class TestConfigurableCommandPolicy:
+    def test_structured_allowlist_scopes_chmod_to_hermes_paths(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with (
+            mock_patch.object(approval_module, "_permanent_approved", set()),
+            mock_patch.object(approval_module, "_permanent_allowlist_rules", []),
+        ):
+            load_permanent([{"pattern": "chmod", "args_glob": ["$HERMES_HOME/**"]}])
+
+            assert approval_module._command_matches_permanent_allowlist(
+                f"chmod 777 {hermes_home}/skills/foo/run.sh"
+            ) is True
+            assert approval_module._command_matches_permanent_allowlist(
+                "chmod 777 /etc/passwd"
+            ) is False
+
+    def test_structured_allowlist_rejects_compound_commands(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with (
+            mock_patch.object(approval_module, "_permanent_approved", set()),
+            mock_patch.object(approval_module, "_permanent_allowlist_rules", []),
+        ):
+            load_permanent([{"pattern": "chmod", "args_glob": ["$HERMES_HOME/**"]}])
+
+            assert approval_module._command_matches_permanent_allowlist(
+                f"chmod 777 {hermes_home}/skills/foo/run.sh && ./run.sh"
+            ) is False
+
+    def test_path_scoped_allowlist_suppresses_matching_dangerous_prompt(
+        self, monkeypatch, tmp_path
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        target = hermes_home / "skills" / "foo" / "run.sh"
+        target.parent.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+
+        with (
+            mock_patch.object(approval_module, "_permanent_approved", set()),
+            mock_patch.object(approval_module, "_permanent_allowlist_rules", []),
+            mock_patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value={
+                    "approvals": {"mode": "manual"},
+                    "command_allowlist": [],
+                    "security": {"tirith_enabled": False},
+                },
+            ),
+        ):
+            load_permanent([{"pattern": "chmod", "args_glob": ["$HERMES_HOME/**"]}])
+            result = check_all_command_guards(f"chmod 777 {target}", "local")
+
+        assert result["approved"] is True
+
+    def test_configured_approval_required_overrides_broad_allowlist(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        session = "configured-required-test"
+        token = approval_module.set_current_session_key(session)
+        try:
+            _clear_session(session)
+            with (
+                mock_patch.object(approval_module, "_permanent_approved", set()),
+                mock_patch.object(approval_module, "_permanent_allowlist_rules", []),
+                mock_patch(
+                    "hermes_cli.config.load_config_readonly",
+                    return_value={
+                        "approvals": {
+                            "mode": "manual",
+                            "command_approval_required": [
+                                "systemctl --user restart openclaw-gateway*"
+                            ],
+                        },
+                        "command_allowlist": [],
+                        "security": {"tirith_enabled": False},
+                    },
+                ),
+            ):
+                load_permanent({"systemctl *"})
+                result = check_all_command_guards(
+                    "systemctl --user restart openclaw-gateway.service",
+                    "local",
+                )
+        finally:
+            approval_module.reset_current_session_key(token)
+            _clear_session(session)
+
+        assert result["approved"] is False
+        assert result["status"] == "pending_approval"
+        assert "configured approval-required command" in result["description"]
+
+    def test_configured_approval_required_bypasses_smart_approval(self, monkeypatch):
+        session = "configured-required-smart"
+        token = approval_module.set_current_session_key(session)
+        config = {
+            "approvals": {
+                "mode": "smart",
+                "command_approval_required": ["systemctl --user restart hermes-gateway*"],
+            },
+            "command_allowlist": [],
+            "security": {"tirith_enabled": False},
+        }
+        try:
+            _clear_session(session)
+            monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+            monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+            with (
+                mock_patch("hermes_cli.config.load_config_readonly", return_value=config),
+                mock_patch(
+                    "tools.tirith_security.check_command_security",
+                    return_value={"action": "allow", "findings": [], "summary": ""},
+                ),
+                mock_patch(
+                    "tools.approval.detect_dangerous_command",
+                    return_value=(False, None, None),
+                ),
+                mock_patch.object(
+                    approval_module, "_smart_approve", return_value="approve"
+                ) as smart_approve,
+            ):
+                result = check_all_command_guards(
+                    "systemctl --user restart hermes-gateway.service", "local"
+                )
+        finally:
+            approval_module.reset_current_session_key(token)
+            _clear_session(session)
+
+        assert result["approved"] is False
+        assert result["status"] == "pending_approval"
+        assert result["allow_permanent"] is False
+        smart_approve.assert_not_called()
+
+    def test_configured_approval_required_always_is_session_only(self, monkeypatch):
+        command = "systemctl --user restart hermes-gateway.service"
+        config = {
+            "approvals": {
+                "mode": "manual",
+                "command_approval_required": ["systemctl --user restart hermes-gateway*"],
+            },
+            "command_allowlist": [],
+            "security": {"tirith_enabled": False},
+        }
+        choices = iter(("always", "deny"))
+        callback_args = []
+
+        def approval_callback(_command, _description, **kwargs):
+            callback_args.append(kwargs)
+            return next(choices)
+
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+        with (
+            mock_patch.object(approval_module, "_permanent_approved", set()),
+            mock_patch("hermes_cli.config.load_config_readonly", return_value=config),
+            mock_patch(
+                "tools.tirith_security.check_command_security",
+                return_value={"action": "allow", "findings": [], "summary": ""},
+            ),
+            mock_patch(
+                "tools.approval.detect_dangerous_command",
+                return_value=(False, None, None),
+            ),
+        ):
+            first_token = approval_module.set_current_session_key("configured-required-first")
+            try:
+                first_result = check_all_command_guards(
+                    command, "local", approval_callback=approval_callback
+                )
+            finally:
+                approval_module.reset_current_session_key(first_token)
+                _clear_session("configured-required-first")
+
+            second_token = approval_module.set_current_session_key("configured-required-second")
+            try:
+                second_result = check_all_command_guards(
+                    command, "local", approval_callback=approval_callback
+                )
+            finally:
+                approval_module.reset_current_session_key(second_token)
+                _clear_session("configured-required-second")
+
+            assert approval_module._permanent_approved == set()
+
+        assert first_result["approved"] is True
+        assert second_result["approved"] is False
+        assert [kwargs["allow_permanent"] for kwargs in callback_args] == [False, False]
+
+    def test_configured_approval_required_hides_gateway_always(self, monkeypatch):
+        session = "configured-required-gateway"
+        token = approval_module.set_current_session_key(session)
+        config = {
+            "approvals": {
+                "mode": "manual",
+                "command_approval_required": ["systemctl --user restart hermes-gateway*"],
+            },
+            "command_allowlist": [],
+            "security": {"tirith_enabled": False},
+        }
+        notified = []
+
+        def notify(approval_data):
+            notified.append(approval_data)
+            approval_module.resolve_gateway_approval(session, "always")
+
+        try:
+            _clear_session(session)
+            monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+            monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+            monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+            with (
+                mock_patch.object(approval_module, "_permanent_approved", set()),
+                mock_patch("hermes_cli.config.load_config_readonly", return_value=config),
+                mock_patch(
+                    "tools.tirith_security.check_command_security",
+                    return_value={"action": "allow", "findings": [], "summary": ""},
+                ),
+                mock_patch(
+                    "tools.approval.detect_dangerous_command",
+                    return_value=(False, None, None),
+                ),
+            ):
+                approval_module.register_gateway_notify(session, notify)
+                result = check_all_command_guards(
+                    "systemctl --user restart hermes-gateway.service", "local"
+                )
+                assert approval_module._permanent_approved == set()
+        finally:
+            approval_module._gateway_notify_cbs.pop(session, None)
+            approval_module.reset_current_session_key(token)
+            _clear_session(session)
+
+        assert result["approved"] is True
+        assert notified[0]["allow_permanent"] is False
 
 
 class TestFullCommandAlwaysShown:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2350,6 +2350,7 @@ _pending: dict[str, dict] = {}
 _session_approved: dict[str, set] = {}
 _session_yolo: set[str] = set()
 _permanent_approved: set = set()
+_permanent_allowlist_rules: list[dict] = []
 
 
 # =========================================================================
@@ -2805,6 +2806,14 @@ def is_approved(session_key: str, pattern_key: str) -> bool:
         return any(alias in session_approvals for alias in aliases)
 
 
+def is_session_approved(session_key: str, pattern_key: str) -> bool:
+    """Check whether a pattern is approved in this session only."""
+    aliases = _approval_key_aliases(pattern_key)
+    with _lock:
+        session_approvals = _session_approved.get(session_key, set())
+        return any(alias in session_approvals for alias in aliases)
+
+
 def approve_permanent(pattern_key: str):
     """Add a pattern to the permanent allowlist."""
     with _lock:
@@ -2814,7 +2823,11 @@ def approve_permanent(pattern_key: str):
 def load_permanent(patterns: set):
     """Bulk-load permanent allowlist entries from config."""
     with _lock:
-        _permanent_approved.update(patterns)
+        for pattern in patterns:
+            if isinstance(pattern, str):
+                _permanent_approved.add(pattern)
+            elif isinstance(pattern, dict):
+                _permanent_allowlist_rules.append(pattern)
 
 
 # Shell control characters that make a command compound when they appear
@@ -2894,21 +2907,129 @@ def _has_allowlist_shell_operator(command: str) -> bool:
     return has_reinterpretable and bool(_REINTERPRETED_ARGUMENT_RE.search(command))
 
 
+def _split_simple_command(command: str) -> list[str] | None:
+    """Shell-split one non-compound command for policy matching."""
+    if _has_allowlist_shell_operator(command):
+        return None
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return None
+
+
+def _rule_command_matches(command: str, argv: list[str], pattern: str) -> bool:
+    """Match a policy rule's command pattern against a simple command."""
+    pattern = (pattern or "").strip()
+    if not pattern:
+        return False
+    verb = argv[0] if argv else ""
+    if command == pattern or verb == pattern:
+        return True
+    if any(ch in pattern for ch in "*?["):
+        return (
+            fnmatch.fnmatchcase(command, pattern)
+            or fnmatch.fnmatchcase(verb, pattern)
+        )
+    return False
+
+
+def _is_path_shaped_arg(arg: str) -> bool:
+    """Return True for shell args that are likely filesystem paths."""
+    if not arg or arg == "--":
+        return False
+    lowered = arg.lower()
+    if lowered.startswith((
+        "~/", "$home/", "${home}/", "$hermes_home/", "${hermes_home}/",
+        "/", "./", "../", "~\\", "$home\\", "${home}\\",
+        "$hermes_home\\", "${hermes_home}\\", "\\",
+    )):
+        return True
+    if re.match(r"^[a-z]:[/\\]", arg, re.IGNORECASE):
+        return True
+    return "/" in arg or "\\" in arg
+
+
+def _normalize_policy_path(value: str) -> str:
+    """Expand common roots and normalize separators for glob matching."""
+    value = value.strip()
+    try:
+        from hermes_constants import get_hermes_home
+        hermes_home = str(get_hermes_home().expanduser())
+    except Exception:
+        hermes_home = os.environ.get("HERMES_HOME", "")
+    for prefix in ("$HERMES_HOME", "${HERMES_HOME}", "$hermes_home", "${hermes_home}"):
+        if value.startswith(prefix):
+            value = hermes_home + value[len(prefix):]
+            break
+    value = os.path.expanduser(os.path.expandvars(value))
+    return value.replace("\\", "/").rstrip("/")
+
+
+def _path_glob_matches(path_arg: str, glob_pattern: str) -> bool:
+    path = _normalize_policy_path(path_arg)
+    pattern = _normalize_policy_path(glob_pattern)
+    if fnmatch.fnmatchcase(path, pattern):
+        return True
+    if pattern.endswith("/**"):
+        root = pattern[:-3].rstrip("/")
+        return path == root or path.startswith(root + "/")
+    return False
+
+
+def _entry_path_globs(entry: dict) -> list[str]:
+    raw = entry.get("args_glob", entry.get("path_glob", []))
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+    return [
+        item for item in raw
+        if isinstance(item, str) and _is_path_shaped_arg(item)
+    ]
+
+
+def _entry_path_args_allowed(entry: dict, argv: list[str]) -> bool:
+    """Verify every path-shaped arg is covered by a structured allowlist rule."""
+    globs = _entry_path_globs(entry)
+    if not globs:
+        return True
+    path_args = [arg for arg in argv[1:] if _is_path_shaped_arg(arg)]
+    if not path_args:
+        return False
+    return all(
+        any(_path_glob_matches(arg, glob_pattern) for glob_pattern in globs)
+        for arg in path_args
+    )
+
+
+def _structured_policy_entry_matches(command: str, argv: list[str], entry: dict) -> bool:
+    pattern = entry.get("pattern", entry.get("command", ""))
+    if not isinstance(pattern, str):
+        return False
+    if not _rule_command_matches(command, argv, pattern):
+        return False
+    return _entry_path_args_allowed(entry, argv)
+
+
 def _command_matches_permanent_allowlist(command: str) -> bool:
     """Return True when command_allowlist contains this command or a glob.
 
     Permanent approvals historically store dangerous-pattern keys such as
     ``recursive delete``. Manual entries in ``command_allowlist`` are command
-    text, and may include shell-style wildcards like ``podman *``.
+    text, and may include shell-style wildcards like ``podman *``. Structured
+    entries may additionally scope a verb to path-shaped arguments, e.g.
+    ``{"pattern": "chmod", "args_glob": ["~/.hermes/**"]}``.
     """
     command = (command or "").strip()
     if not command:
         return False
-    if _has_allowlist_shell_operator(command):
+    argv = _split_simple_command(command)
+    if argv is None:
         return False
 
     with _lock:
         patterns = tuple(_permanent_approved)
+        structured_rules = tuple(_permanent_allowlist_rules)
 
     for pattern in patterns:
         if not isinstance(pattern, str):
@@ -2920,7 +3041,58 @@ def _command_matches_permanent_allowlist(command: str) -> bool:
             return True
         if any(ch in pattern for ch in "*?[") and fnmatch.fnmatchcase(command, pattern):
             return True
+    for entry in structured_rules:
+        if isinstance(entry, dict) and _structured_policy_entry_matches(command, argv, entry):
+            return True
     return False
+
+
+def _configured_approval_required(command: str) -> tuple[bool, str | None, str | None]:
+    """Return a configured approval requirement match, if any.
+
+    Rules live in ``approvals.command_approval_required``. The legacy top-level
+    ``command_approval_required`` key is also accepted for simple deployments.
+    String entries match exact commands, command globs, or a bare verb. Dict
+    entries use the same ``pattern`` / ``args_glob`` shape as structured
+    allowlist entries.
+    """
+    command = (command or "").strip()
+    if not command:
+        return (False, None, None)
+    argv = _split_simple_command(command)
+    if argv is None:
+        return (False, None, None)
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly() or {}
+    except Exception as exc:
+        logger.warning("Failed to load approval-required command rules: %s", exc)
+        return (False, None, None)
+
+    approvals = config.get("approvals", {}) or {}
+    rules = approvals.get("command_approval_required")
+    if rules is None:
+        rules = config.get("command_approval_required", [])
+    if isinstance(rules, (str, dict)):
+        rules = [rules]
+    if not isinstance(rules, list):
+        return (False, None, None)
+
+    for entry in rules:
+        label = None
+        matched = False
+        if isinstance(entry, str):
+            label = entry.strip()
+            matched = _rule_command_matches(command, argv, label)
+        elif isinstance(entry, dict):
+            label_raw = entry.get("description") or entry.get("pattern") or entry.get("command")
+            label = str(label_raw).strip() if label_raw is not None else ""
+            matched = _structured_policy_entry_matches(command, argv, entry)
+        if matched:
+            label = label or "configured command policy"
+            description = f"configured approval-required command ({label})"
+            return (True, f"configured approval: {label}", description)
+    return (False, None, None)
 
 
 
@@ -2937,10 +3109,12 @@ def load_permanent_allowlist() -> set:
     try:
         from hermes_cli.config import load_config_readonly
         config = load_config_readonly()
-        patterns = set(config.get("command_allowlist", []) or [])
-        if patterns:
-            load_permanent(patterns)
-        return patterns
+        entries = config.get("command_allowlist", []) or []
+        if isinstance(entries, (str, dict)):
+            entries = [entries]
+        if isinstance(entries, list) and entries:
+            load_permanent(entries)
+        return {entry for entry in entries if isinstance(entry, str)}
     except Exception as e:
         logger.warning("Failed to load permanent allowlist: %s", e)
         return set()
@@ -2951,7 +3125,13 @@ def save_permanent_allowlist(patterns: set):
     try:
         from hermes_cli.config import load_config, save_config
         config = load_config()
-        config["command_allowlist"] = list(patterns)
+        existing = config.get("command_allowlist", []) or []
+        if isinstance(existing, (str, dict)):
+            existing = [existing]
+        structured = [entry for entry in existing if isinstance(entry, dict)]
+        config["command_allowlist"] = sorted(
+            pattern for pattern in patterns if isinstance(pattern, str)
+        ) + structured
         save_config(config)
     except Exception as e:
         logger.warning("Could not save allowlist: %s", e)
@@ -3421,6 +3601,7 @@ def _run_approval_gate(
     cron_deny_message: str,
     single_query_deny_message: str,
     autoapprove_log_prefix: str,
+    allow_permanent: bool = True,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
 ) -> dict:
@@ -3453,6 +3634,8 @@ def _run_approval_gate(
             (-q) session hits this gate under ``single_query_mode: deny``.
         autoapprove_log_prefix: Log line prefix for the non-interactive
             auto-approve warning (identifies command vs plugin origin).
+        allow_permanent: Whether the user can persist an approval beyond the
+            current session.
         fail_closed_when_no_human: When True, a non-interactive non-gateway
             context that is NOT a cron session (e.g. a bare script with
             HERMES_INTERACTIVE unset) BLOCKS instead of auto-approving. The
@@ -3473,7 +3656,8 @@ def _run_approval_gate(
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
-    if is_approved(session_key, pattern_key):
+    approved = is_approved if allow_permanent else is_session_approved
+    if approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
     approval_callback = _resolve_cli_approval_callback(approval_callback)
@@ -3564,7 +3748,7 @@ def _run_approval_gate(
                 "pattern_key": pattern_key,
                 "pattern_keys": [pattern_key],
                 "description": redact_sensitive_text(description),
-                "allow_permanent": True,
+                "allow_permanent": allow_permanent,
                 "allow_session": True,
             }
             decision = _await_gateway_decision(
@@ -3608,8 +3792,9 @@ def _run_approval_gate(
                 approve_session(session_key, pattern_key)
             elif choice == "always":
                 approve_session(session_key, pattern_key)
-                approve_permanent(pattern_key)
-                save_permanent_allowlist(_permanent_approved)
+                if allow_permanent:
+                    approve_permanent(pattern_key)
+                    save_permanent_allowlist(_permanent_approved)
             return {"approved": True, "message": None}
 
         # No notify callback: interactive CLI with a panel callback should
@@ -3626,6 +3811,7 @@ def _run_approval_gate(
                 "command": display_target,
                 "pattern_key": pattern_key,
                 "description": description,
+                "allow_permanent": allow_permanent,
             })
             return {
                 "approved": False,
@@ -3633,6 +3819,7 @@ def _run_approval_gate(
                 "status": "approval_required",
                 "command": display_target,
                 "description": description,
+                "allow_permanent": allow_permanent,
                 "message": (
                     f"⚠️ This action is potentially dangerous ({description}). "
                     f"Asking the user for approval.\n\n**Target:**\n```\n{display_target}\n```"
@@ -3648,8 +3835,12 @@ def _run_approval_gate(
         session_key=session_key,
         surface="cli",
     )
-    choice = prompt_dangerous_approval(display_target, description,
-                                       approval_callback=approval_callback)
+    choice = prompt_dangerous_approval(
+        display_target,
+        description,
+        allow_permanent=allow_permanent,
+        approval_callback=approval_callback,
+    )
     _fire_approval_hook(
         "post_approval_response",
         command=display_target,
@@ -3694,8 +3885,9 @@ def _run_approval_gate(
         approve_session(session_key, pattern_key)
     elif choice == "always":
         approve_session(session_key, pattern_key)
-        approve_permanent(pattern_key)
-        save_permanent_allowlist(_permanent_approved)
+        if allow_permanent:
+            approve_permanent(pattern_key)
+            save_permanent_allowlist(_permanent_approved)
 
     return {"approved": True, "message": None}
 
@@ -3759,10 +3951,14 @@ def check_dangerous_command(command: str, env_type: str,
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
         return {"approved": True, "message": None}
 
-    if _command_matches_permanent_allowlist(command):
+    required, required_key, required_desc = _configured_approval_required(command)
+    if not required and _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    if required:
+        is_dangerous, pattern_key, description = True, required_key, required_desc
+    else:
+        is_dangerous, pattern_key, description = detect_dangerous_command(command)
     if not is_dangerous:
         return {"approved": True, "message": None}
 
@@ -3788,6 +3984,7 @@ def check_dangerous_command(command: str, env_type: str,
         autoapprove_log_prefix=(
             "AUTO-APPROVED dangerous command in non-interactive non-gateway context"
         ),
+        allow_permanent=not required,
     )
 
 
@@ -4393,7 +4590,8 @@ def check_all_command_guards(command: str, env_type: str,
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
         return {"approved": True, "message": None}
 
-    if _command_matches_permanent_allowlist(command):
+    required, required_key, required_desc = _configured_approval_required(command)
+    if not required and _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
     approval_callback = _resolve_cli_approval_callback(approval_callback)
@@ -4488,7 +4686,8 @@ def check_all_command_guards(command: str, env_type: str,
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
-                if is_dangerous:
+                if required or is_dangerous:
+                    description = required_desc if required else description
                     return {
                         "approved": False,
                         "message": (
@@ -4598,7 +4797,9 @@ def check_all_command_guards(command: str, env_type: str,
     # --- Phase 2: Decide ---
 
     # Collect warnings that need approval
-    warnings = []  # list of (pattern_key, description, is_tirith)
+    # Entries retain their source so configured approval requirements cannot
+    # be smart-approved or converted into a permanent allowlist entry.
+    warnings = []  # list of (pattern_key, description, is_tirith, is_required)
 
     session_key = get_current_session_key()
 
@@ -4612,11 +4813,15 @@ def check_all_command_guards(command: str, env_type: str,
         tirith_key = f"tirith:{rule_id}"
         tirith_desc = _format_tirith_description(tirith_result)
         if not is_approved(session_key, tirith_key):
-            warnings.append((tirith_key, tirith_desc, True))
+            warnings.append((tirith_key, tirith_desc, True, False))
+
+    if required:
+        if not is_session_approved(session_key, required_key):
+            warnings.append((required_key, required_desc, False, True))
 
     if is_dangerous:
         if not is_approved(session_key, pattern_key):
-            warnings.append((pattern_key, description, False))
+            warnings.append((pattern_key, description, False, False))
 
     # Nothing to warn about
     if not warnings:
@@ -4627,13 +4832,16 @@ def check_all_command_guards(command: str, env_type: str,
     # Inspired by OpenAI Codex's Smart Approvals guardian subagent
     # (openai/codex#13860).
     smart_denied_for_owner = False
-    if approval_mode == "smart":
-        combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
+    if (
+        approval_mode == "smart"
+        and not any(is_required for *_, is_required in warnings)
+    ):
+        combined_desc_for_llm = "; ".join(desc for _, desc, _, _ in warnings)
         observer_payload = _prepare_smart_approval_observer(
             command=command,
             description=combined_desc_for_llm,
             pattern_key=warnings[0][0],
-            pattern_keys=[key for key, _, _ in warnings],
+            pattern_keys=[key for key, _, _, _ in warnings],
             session_key=session_key,
         )
         verdict = _smart_approve(command, combined_desc_for_llm)
@@ -4670,9 +4878,9 @@ def check_all_command_guards(command: str, env_type: str,
     # --- Phase 3: Approval ---
 
     # Combine descriptions for a single approval prompt
-    combined_desc = "; ".join(desc for _, desc, _ in warnings)
+    combined_desc = "; ".join(desc for _, desc, _, _ in warnings)
     primary_key = warnings[0][0]
-    all_keys = [key for key, _, _ in warnings]
+    all_keys = [key for key, _, _, _ in warnings]
     # "Always" is offered when at least one warning is a dangerous-pattern
     # key that the persistence layer would actually allowlist permanently.
     # Pure-tirith findings are session-max by design (no broad permanent
@@ -4681,7 +4889,10 @@ def check_all_command_guards(command: str, env_type: str,
     # tirith) previously hid Always too, even though choosing it would
     # correctly persist the pattern key and downgrade the tirith key to
     # session — the UI was stricter than the persistence layer.
-    has_permanent_capable = any(not is_t for _, _, is_t in warnings)
+    has_permanent_capable = any(
+        not is_tirith and not is_required
+        for _, _, is_tirith, is_required in warnings
+    )
 
     # An explicitly selected plugin transport replaces every built-in prompt
     # surface (CLI/TUI/gateway/ACP). Detection, allowed scopes, persistence,
@@ -4730,9 +4941,9 @@ def check_all_command_guards(command: str, env_type: str,
                     "user_consent": False,
                 }
             if not smart_denied_for_owner:
-                for key, _, is_tirith in warnings:
+                for key, _, is_tirith, is_required in warnings:
                     if transport_choice == "session" or (
-                        transport_choice == "always" and is_tirith
+                        transport_choice == "always" and (is_tirith or is_required)
                     ):
                         approve_session(session_key, key)
                     elif transport_choice == "always":
@@ -4844,8 +5055,10 @@ def check_all_command_guards(command: str, env_type: str,
             # older client returns "session" or "always". Manual and ESCALATE
             # choices retain their existing persistence semantics.
             if not smart_denied_for_owner:
-                for key, _, is_tirith in warnings:
-                    if choice == "session" or (choice == "always" and is_tirith):
+                for key, _, is_tirith, is_required in warnings:
+                    if choice == "session" or (
+                        choice == "always" and (is_tirith or is_required)
+                    ):
                         approve_session(session_key, key)
                     elif choice == "always":
                         approve_session(session_key, key)
@@ -4879,6 +5092,7 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_key": primary_key,
                 "pattern_keys": all_keys,
                 "description": _disp_combined_desc,
+                "allow_permanent": has_permanent_capable and not smart_denied_for_owner,
             }
             if smart_denied_for_owner:
                 pending_data.update(smart_denied=True, allow_permanent=False)
@@ -4890,6 +5104,7 @@ def check_all_command_guards(command: str, env_type: str,
                 "approval_pending": True,
                 "command": _disp_command,
                 "description": _disp_combined_desc,
+                "allow_permanent": has_permanent_capable and not smart_denied_for_owner,
                 "message": (
                     f"⚠️ {_disp_combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{_disp_command}\n```\n\n"
                     "STOP: do NOT re-run, rephrase, or re-issue this command — each "
@@ -4971,8 +5186,10 @@ def check_all_command_guards(command: str, env_type: str,
     # Smart-DENY owner overrides are one-operation scoped. Preserve existing
     # persistence for manual mode and smart ESCALATE.
     if not smart_denied_for_owner:
-        for key, _, is_tirith in warnings:
-            if choice == "session" or (choice == "always" and is_tirith):
+        for key, _, is_tirith, is_required in warnings:
+            if choice == "session" or (
+                choice == "always" and (is_tirith or is_required)
+            ):
                 # tirith: session only (no permanent broad allowlisting)
                 approve_session(session_key, key)
             elif choice == "always":

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2208,6 +2208,7 @@ _pending: dict[str, dict] = {}
 _session_approved: dict[str, set] = {}
 _session_yolo: set[str] = set()
 _permanent_approved: set = set()
+_permanent_allowlist_rules: list[dict] = []
 
 
 # =========================================================================
@@ -2623,6 +2624,14 @@ def is_approved(session_key: str, pattern_key: str) -> bool:
         return any(alias in session_approvals for alias in aliases)
 
 
+def is_session_approved(session_key: str, pattern_key: str) -> bool:
+    """Check whether a pattern is approved in this session only."""
+    aliases = _approval_key_aliases(pattern_key)
+    with _lock:
+        session_approvals = _session_approved.get(session_key, set())
+        return any(alias in session_approvals for alias in aliases)
+
+
 def approve_permanent(pattern_key: str):
     """Add a pattern to the permanent allowlist."""
     with _lock:
@@ -2632,7 +2641,11 @@ def approve_permanent(pattern_key: str):
 def load_permanent(patterns: set):
     """Bulk-load permanent allowlist entries from config."""
     with _lock:
-        _permanent_approved.update(patterns)
+        for pattern in patterns:
+            if isinstance(pattern, str):
+                _permanent_approved.add(pattern)
+            elif isinstance(pattern, dict):
+                _permanent_allowlist_rules.append(pattern)
 
 
 _ALLOWLIST_SHELL_OPERATOR_RE = re.compile(r"(?:\n|&&|\|\||[;&|<>`]|\$\()")
@@ -2643,21 +2656,129 @@ def _has_allowlist_shell_operator(command: str) -> bool:
     return bool(_ALLOWLIST_SHELL_OPERATOR_RE.search(command or ""))
 
 
+def _split_simple_command(command: str) -> list[str] | None:
+    """Shell-split one non-compound command for policy matching."""
+    if _has_allowlist_shell_operator(command):
+        return None
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return None
+
+
+def _rule_command_matches(command: str, argv: list[str], pattern: str) -> bool:
+    """Match a policy rule's command pattern against a simple command."""
+    pattern = (pattern or "").strip()
+    if not pattern:
+        return False
+    verb = argv[0] if argv else ""
+    if command == pattern or verb == pattern:
+        return True
+    if any(ch in pattern for ch in "*?["):
+        return (
+            fnmatch.fnmatchcase(command, pattern)
+            or fnmatch.fnmatchcase(verb, pattern)
+        )
+    return False
+
+
+def _is_path_shaped_arg(arg: str) -> bool:
+    """Return True for shell args that are likely filesystem paths."""
+    if not arg or arg == "--":
+        return False
+    lowered = arg.lower()
+    if lowered.startswith((
+        "~/", "$home/", "${home}/", "$hermes_home/", "${hermes_home}/",
+        "/", "./", "../", "~\\", "$home\\", "${home}\\",
+        "$hermes_home\\", "${hermes_home}\\", "\\",
+    )):
+        return True
+    if re.match(r"^[a-z]:[/\\]", arg, re.IGNORECASE):
+        return True
+    return "/" in arg or "\\" in arg
+
+
+def _normalize_policy_path(value: str) -> str:
+    """Expand common roots and normalize separators for glob matching."""
+    value = value.strip()
+    try:
+        from hermes_constants import get_hermes_home
+        hermes_home = str(get_hermes_home().expanduser())
+    except Exception:
+        hermes_home = os.environ.get("HERMES_HOME", "")
+    for prefix in ("$HERMES_HOME", "${HERMES_HOME}", "$hermes_home", "${hermes_home}"):
+        if value.startswith(prefix):
+            value = hermes_home + value[len(prefix):]
+            break
+    value = os.path.expanduser(os.path.expandvars(value))
+    return value.replace("\\", "/").rstrip("/")
+
+
+def _path_glob_matches(path_arg: str, glob_pattern: str) -> bool:
+    path = _normalize_policy_path(path_arg)
+    pattern = _normalize_policy_path(glob_pattern)
+    if fnmatch.fnmatchcase(path, pattern):
+        return True
+    if pattern.endswith("/**"):
+        root = pattern[:-3].rstrip("/")
+        return path == root or path.startswith(root + "/")
+    return False
+
+
+def _entry_path_globs(entry: dict) -> list[str]:
+    raw = entry.get("args_glob", entry.get("path_glob", []))
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+    return [
+        item for item in raw
+        if isinstance(item, str) and _is_path_shaped_arg(item)
+    ]
+
+
+def _entry_path_args_allowed(entry: dict, argv: list[str]) -> bool:
+    """Verify every path-shaped arg is covered by a structured allowlist rule."""
+    globs = _entry_path_globs(entry)
+    if not globs:
+        return True
+    path_args = [arg for arg in argv[1:] if _is_path_shaped_arg(arg)]
+    if not path_args:
+        return False
+    return all(
+        any(_path_glob_matches(arg, glob_pattern) for glob_pattern in globs)
+        for arg in path_args
+    )
+
+
+def _structured_policy_entry_matches(command: str, argv: list[str], entry: dict) -> bool:
+    pattern = entry.get("pattern", entry.get("command", ""))
+    if not isinstance(pattern, str):
+        return False
+    if not _rule_command_matches(command, argv, pattern):
+        return False
+    return _entry_path_args_allowed(entry, argv)
+
+
 def _command_matches_permanent_allowlist(command: str) -> bool:
     """Return True when command_allowlist contains this command or a glob.
 
     Permanent approvals historically store dangerous-pattern keys such as
     ``recursive delete``. Manual entries in ``command_allowlist`` are command
-    text, and may include shell-style wildcards like ``podman *``.
+    text, and may include shell-style wildcards like ``podman *``. Structured
+    entries may additionally scope a verb to path-shaped arguments, e.g.
+    ``{"pattern": "chmod", "args_glob": ["~/.hermes/**"]}``.
     """
     command = (command or "").strip()
     if not command:
         return False
-    if _has_allowlist_shell_operator(command):
+    argv = _split_simple_command(command)
+    if argv is None:
         return False
 
     with _lock:
         patterns = tuple(_permanent_approved)
+        structured_rules = tuple(_permanent_allowlist_rules)
 
     for pattern in patterns:
         if not isinstance(pattern, str):
@@ -2669,7 +2790,58 @@ def _command_matches_permanent_allowlist(command: str) -> bool:
             return True
         if any(ch in pattern for ch in "*?[") and fnmatch.fnmatchcase(command, pattern):
             return True
+    for entry in structured_rules:
+        if isinstance(entry, dict) and _structured_policy_entry_matches(command, argv, entry):
+            return True
     return False
+
+
+def _configured_approval_required(command: str) -> tuple[bool, str | None, str | None]:
+    """Return a configured approval requirement match, if any.
+
+    Rules live in ``approvals.command_approval_required``. The legacy top-level
+    ``command_approval_required`` key is also accepted for simple deployments.
+    String entries match exact commands, command globs, or a bare verb. Dict
+    entries use the same ``pattern`` / ``args_glob`` shape as structured
+    allowlist entries.
+    """
+    command = (command or "").strip()
+    if not command:
+        return (False, None, None)
+    argv = _split_simple_command(command)
+    if argv is None:
+        return (False, None, None)
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly() or {}
+    except Exception as exc:
+        logger.warning("Failed to load approval-required command rules: %s", exc)
+        return (False, None, None)
+
+    approvals = config.get("approvals", {}) or {}
+    rules = approvals.get("command_approval_required")
+    if rules is None:
+        rules = config.get("command_approval_required", [])
+    if isinstance(rules, (str, dict)):
+        rules = [rules]
+    if not isinstance(rules, list):
+        return (False, None, None)
+
+    for entry in rules:
+        label = None
+        matched = False
+        if isinstance(entry, str):
+            label = entry.strip()
+            matched = _rule_command_matches(command, argv, label)
+        elif isinstance(entry, dict):
+            label_raw = entry.get("description") or entry.get("pattern") or entry.get("command")
+            label = str(label_raw).strip() if label_raw is not None else ""
+            matched = _structured_policy_entry_matches(command, argv, entry)
+        if matched:
+            label = label or "configured command policy"
+            description = f"configured approval-required command ({label})"
+            return (True, f"configured approval: {label}", description)
+    return (False, None, None)
 
 
 
@@ -2686,10 +2858,12 @@ def load_permanent_allowlist() -> set:
     try:
         from hermes_cli.config import load_config_readonly
         config = load_config_readonly()
-        patterns = set(config.get("command_allowlist", []) or [])
-        if patterns:
-            load_permanent(patterns)
-        return patterns
+        entries = config.get("command_allowlist", []) or []
+        if isinstance(entries, (str, dict)):
+            entries = [entries]
+        if isinstance(entries, list) and entries:
+            load_permanent(entries)
+        return {entry for entry in entries if isinstance(entry, str)}
     except Exception as e:
         logger.warning("Failed to load permanent allowlist: %s", e)
         return set()
@@ -2700,7 +2874,13 @@ def save_permanent_allowlist(patterns: set):
     try:
         from hermes_cli.config import load_config, save_config
         config = load_config()
-        config["command_allowlist"] = list(patterns)
+        existing = config.get("command_allowlist", []) or []
+        if isinstance(existing, (str, dict)):
+            existing = [existing]
+        structured = [entry for entry in existing if isinstance(entry, dict)]
+        config["command_allowlist"] = sorted(
+            pattern for pattern in patterns if isinstance(pattern, str)
+        ) + structured
         save_config(config)
     except Exception as e:
         logger.warning("Could not save allowlist: %s", e)
@@ -3156,6 +3336,7 @@ def _run_approval_gate(
     approval_callback=None,
     cron_deny_message: str,
     autoapprove_log_prefix: str,
+    allow_permanent: bool = True,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
 ) -> dict:
@@ -3186,6 +3367,8 @@ def _run_approval_gate(
             under ``cron_mode: deny``.
         autoapprove_log_prefix: Log line prefix for the non-interactive
             auto-approve warning (identifies command vs plugin origin).
+        allow_permanent: Whether the user can persist an approval beyond the
+            current session.
         fail_closed_when_no_human: When True, a non-interactive non-gateway
             context that is NOT a cron session (e.g. a bare script with
             HERMES_INTERACTIVE unset) BLOCKS instead of auto-approving. The
@@ -3206,7 +3389,8 @@ def _run_approval_gate(
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
-    if is_approved(session_key, pattern_key):
+    approved = is_approved if allow_permanent else is_session_approved
+    if approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
     if approval_callback is None:
@@ -3275,7 +3459,7 @@ def _run_approval_gate(
                 "pattern_key": pattern_key,
                 "pattern_keys": [pattern_key],
                 "description": redact_sensitive_text(description),
-                "allow_permanent": True,
+                "allow_permanent": allow_permanent,
                 "allow_session": True,
             }
             decision = _await_gateway_decision(
@@ -3319,8 +3503,9 @@ def _run_approval_gate(
                 approve_session(session_key, pattern_key)
             elif choice == "always":
                 approve_session(session_key, pattern_key)
-                approve_permanent(pattern_key)
-                save_permanent_allowlist(_permanent_approved)
+                if allow_permanent:
+                    approve_permanent(pattern_key)
+                    save_permanent_allowlist(_permanent_approved)
             return {"approved": True, "message": None}
 
         # No notify callback (e.g. API server without an attached chat):
@@ -3329,6 +3514,7 @@ def _run_approval_gate(
             "command": display_target,
             "pattern_key": pattern_key,
             "description": description,
+            "allow_permanent": allow_permanent,
         })
         return {
             "approved": False,
@@ -3336,6 +3522,7 @@ def _run_approval_gate(
             "status": "approval_required",
             "command": display_target,
             "description": description,
+            "allow_permanent": allow_permanent,
             "message": (
                 f"⚠️ This action is potentially dangerous ({description}). "
                 f"Asking the user for approval.\n\n**Target:**\n```\n{display_target}\n```"
@@ -3397,8 +3584,9 @@ def _run_approval_gate(
         approve_session(session_key, pattern_key)
     elif choice == "always":
         approve_session(session_key, pattern_key)
-        approve_permanent(pattern_key)
-        save_permanent_allowlist(_permanent_approved)
+        if allow_permanent:
+            approve_permanent(pattern_key)
+            save_permanent_allowlist(_permanent_approved)
 
     return {"approved": True, "message": None}
 
@@ -3462,10 +3650,14 @@ def check_dangerous_command(command: str, env_type: str,
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
         return {"approved": True, "message": None}
 
-    if _command_matches_permanent_allowlist(command):
+    required, required_key, required_desc = _configured_approval_required(command)
+    if not required and _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    if required:
+        is_dangerous, pattern_key, description = True, required_key, required_desc
+    else:
+        is_dangerous, pattern_key, description = detect_dangerous_command(command)
     if not is_dangerous:
         return {"approved": True, "message": None}
 
@@ -3484,6 +3676,7 @@ def check_dangerous_command(command: str, env_type: str,
         autoapprove_log_prefix=(
             "AUTO-APPROVED dangerous command in non-interactive non-gateway context"
         ),
+        allow_permanent=not required,
     )
 
 
@@ -3789,7 +3982,8 @@ def check_all_command_guards(command: str, env_type: str,
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
         return {"approved": True, "message": None}
 
-    if _command_matches_permanent_allowlist(command):
+    required, required_key, required_desc = _configured_approval_required(command)
+    if not required and _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
     is_cli = _is_interactive_cli()
@@ -3804,7 +3998,8 @@ def check_all_command_guards(command: str, env_type: str,
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
-                if is_dangerous:
+                if required or is_dangerous:
+                    description = required_desc if required else description
                     return {
                         "approved": False,
                         "message": (
@@ -3914,7 +4109,9 @@ def check_all_command_guards(command: str, env_type: str,
     # --- Phase 2: Decide ---
 
     # Collect warnings that need approval
-    warnings = []  # list of (pattern_key, description, is_tirith)
+    # Entries retain their source so configured approval requirements cannot
+    # be smart-approved or converted into a permanent allowlist entry.
+    warnings = []  # list of (pattern_key, description, is_tirith, is_required)
 
     session_key = get_current_session_key()
 
@@ -3928,11 +4125,15 @@ def check_all_command_guards(command: str, env_type: str,
         tirith_key = f"tirith:{rule_id}"
         tirith_desc = _format_tirith_description(tirith_result)
         if not is_approved(session_key, tirith_key):
-            warnings.append((tirith_key, tirith_desc, True))
+            warnings.append((tirith_key, tirith_desc, True, False))
+
+    if required:
+        if not is_session_approved(session_key, required_key):
+            warnings.append((required_key, required_desc, False, True))
 
     if is_dangerous:
         if not is_approved(session_key, pattern_key):
-            warnings.append((pattern_key, description, False))
+            warnings.append((pattern_key, description, False, False))
 
     # Nothing to warn about
     if not warnings:
@@ -3943,13 +4144,16 @@ def check_all_command_guards(command: str, env_type: str,
     # Inspired by OpenAI Codex's Smart Approvals guardian subagent
     # (openai/codex#13860).
     smart_denied_for_owner = False
-    if approval_mode == "smart":
-        combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
+    if (
+        approval_mode == "smart"
+        and not any(is_required for *_, is_required in warnings)
+    ):
+        combined_desc_for_llm = "; ".join(desc for _, desc, _, _ in warnings)
         observer_payload = _prepare_smart_approval_observer(
             command=command,
             description=combined_desc_for_llm,
             pattern_key=warnings[0][0],
-            pattern_keys=[key for key, _, _ in warnings],
+            pattern_keys=[key for key, _, _, _ in warnings],
             session_key=session_key,
         )
         verdict = _smart_approve(command, combined_desc_for_llm)
@@ -3986,9 +4190,9 @@ def check_all_command_guards(command: str, env_type: str,
     # --- Phase 3: Approval ---
 
     # Combine descriptions for a single approval prompt
-    combined_desc = "; ".join(desc for _, desc, _ in warnings)
+    combined_desc = "; ".join(desc for _, desc, _, _ in warnings)
     primary_key = warnings[0][0]
-    all_keys = [key for key, _, _ in warnings]
+    all_keys = [key for key, _, _, _ in warnings]
     # "Always" is offered when at least one warning is a dangerous-pattern
     # key that the persistence layer would actually allowlist permanently.
     # Pure-tirith findings are session-max by design (no broad permanent
@@ -3997,7 +4201,10 @@ def check_all_command_guards(command: str, env_type: str,
     # tirith) previously hid Always too, even though choosing it would
     # correctly persist the pattern key and downgrade the tirith key to
     # session — the UI was stricter than the persistence layer.
-    has_permanent_capable = any(not is_t for _, _, is_t in warnings)
+    has_permanent_capable = any(
+        not is_tirith and not is_required
+        for _, _, is_tirith, is_required in warnings
+    )
 
     # Gateway/async approval — block the agent thread until the user
     # responds with /approve or /deny, mirroring the CLI's synchronous
@@ -4096,8 +4303,10 @@ def check_all_command_guards(command: str, env_type: str,
             # older client returns "session" or "always". Manual and ESCALATE
             # choices retain their existing persistence semantics.
             if not smart_denied_for_owner:
-                for key, _, is_tirith in warnings:
-                    if choice == "session" or (choice == "always" and is_tirith):
+                for key, _, is_tirith, is_required in warnings:
+                    if choice == "session" or (
+                        choice == "always" and (is_tirith or is_required)
+                    ):
                         approve_session(session_key, key)
                     elif choice == "always":
                         approve_session(session_key, key)
@@ -4122,6 +4331,7 @@ def check_all_command_guards(command: str, env_type: str,
             "pattern_key": primary_key,
             "pattern_keys": all_keys,
             "description": _disp_combined_desc,
+            "allow_permanent": has_permanent_capable and not smart_denied_for_owner,
         }
         if smart_denied_for_owner:
             pending_data.update(smart_denied=True, allow_permanent=False)
@@ -4133,6 +4343,7 @@ def check_all_command_guards(command: str, env_type: str,
             "approval_pending": True,
             "command": _disp_command,
             "description": _disp_combined_desc,
+            "allow_permanent": has_permanent_capable and not smart_denied_for_owner,
             "message": (
                 f"⚠️ {_disp_combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{_disp_command}\n```"
             ),
@@ -4210,8 +4421,10 @@ def check_all_command_guards(command: str, env_type: str,
     # Smart-DENY owner overrides are one-operation scoped. Preserve existing
     # persistence for manual mode and smart ESCALATE.
     if not smart_denied_for_owner:
-        for key, _, is_tirith in warnings:
-            if choice == "session" or (choice == "always" and is_tirith):
+        for key, _, is_tirith, is_required in warnings:
+            if choice == "session" or (
+                choice == "always" and (is_tirith or is_required)
+            ):
                 # tirith: session only (no permanent broad allowlisting)
                 approve_session(session_key, key)
             elif choice == "always":

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -231,9 +231,27 @@ Commands approved with "always" are saved to `~/.hermes/config.yaml`:
 command_allowlist:
   - rm
   - systemctl
+  - pattern: chmod
+    args_glob:
+      - ~/.hermes/**
 ```
 
-These patterns are loaded at startup and silently approved in all future sessions.
+String patterns are loaded at startup and silently approved in all future sessions. Structured entries can scope an allowed verb to path-shaped arguments. For example, the `chmod` rule above allows `chmod +x ~/.hermes/skills/foo/run.sh` without allowing `chmod` against `/etc` or `/usr`.
+
+Compound shell commands (`a && b`, `a | b`, `a ; b`, redirection, subshells, and heredocs) are not matched by the allowlist shortcut; each risky operation must be approved independently.
+
+### Deployment-Specific Approval Rules
+
+Admins can require approval for local commands that are operationally disruptive in their deployment even when the command is not universally dangerous:
+
+```yaml
+approvals:
+  command_approval_required:
+    - "systemctl --user restart hermes-gateway*"
+    - "systemctl --user restart openclaw-gateway*"
+```
+
+These rules use the same approval flow as built-in dangerous-command patterns. Entries may be exact commands, command globs, bare verbs, or structured rules with `pattern` and `args_glob`.
 
 :::tip
 Use `hermes config edit` to review or remove patterns from your permanent allowlist.

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -229,9 +229,27 @@ Commands approved with "always" are saved to `~/.hermes/config.yaml`:
 command_allowlist:
   - rm
   - systemctl
+  - pattern: chmod
+    args_glob:
+      - ~/.hermes/**
 ```
 
-These patterns are loaded at startup and silently approved in all future sessions.
+String patterns are loaded at startup and silently approved in all future sessions. Structured entries can scope an allowed verb to path-shaped arguments. For example, the `chmod` rule above allows `chmod +x ~/.hermes/skills/foo/run.sh` without allowing `chmod` against `/etc` or `/usr`.
+
+Compound shell commands (`a && b`, `a | b`, `a ; b`, redirection, subshells, and heredocs) are not matched by the allowlist shortcut; each risky operation must be approved independently.
+
+### Deployment-Specific Approval Rules
+
+Admins can require approval for local commands that are operationally disruptive in their deployment even when the command is not universally dangerous:
+
+```yaml
+approvals:
+  command_approval_required:
+    - "systemctl --user restart hermes-gateway*"
+    - "systemctl --user restart openclaw-gateway*"
+```
+
+These rules use the same approval flow as built-in dangerous-command patterns. Entries may be exact commands, command globs, bare verbs, or structured rules with `pattern` and `args_glob`.
 
 :::tip
 Use `hermes config edit` to review or remove patterns from your permanent allowlist.


### PR DESCRIPTION
## What does this PR do?

Adds config-driven terminal approval policy rules: `approvals.command_approval_required` can force commands through the existing approval flow, and structured `command_allowlist` entries can scope auto-approval to path-shaped arguments such as `$HERMES_HOME/**`.

## Related Issue

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Shared root cause

- Terminal approval policy had one flat matcher: built-in dangerous regexes plus a string-only permanent allowlist. That could not express deployment-local approval-required commands (#5528), nor safe path-scoped allowlist rules for risky verbs under operator-owned roots (#54155).
- The fix keeps the core tool surface unchanged and extends the existing approval policy layer in `tools/approval.py`.

## Changes Made

- Added `approvals.command_approval_required` support for exact commands, command globs, bare verbs, and structured rules.
- Added structured `command_allowlist` entries with `pattern` and `args_glob`, checked against shell-split path-shaped arguments.
- Kept legacy string allowlist semantics stable: exact command or explicit whole-command glob only, with compound commands rejected by the allowlist shortcut.
- Documented the new config shapes in `hermes_cli/config.py` defaults and the security guide.
- Added approval tests for path-scoped `chmod` under `$HERMES_HOME`, compound-command rejection, and configured approval-required service restarts overriding a broad allowlist.

## How this fixes each issue

- #5528: Admins can add deployment-specific rules such as `systemctl --user restart hermes-gateway*` or `systemctl --user restart openclaw-gateway*` under `approvals.command_approval_required`, causing those commands to use the normal CLI/gateway approval flow even when they are local operational policy rather than universally destructive commands.
- #54155: Admins can add structured allowlist entries such as `{pattern: chmod, args_glob: [$HERMES_HOME/**]}` so commands like `chmod 777 ~/.hermes/skills/foo/run.sh` can be auto-approved without approving `chmod` against unrelated system paths. Compound shell commands still do not match the allowlist shortcut.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`
   - Aborted during collection before changed tests because optional dashboard dependencies are missing in this environment: `fastapi`/`uvicorn` lazy install failed under externally managed Homebrew Python (PEP 668).
2. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/tools/test_approval.py -q --timeout=60' sh`
   - `262 passed`
3. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/tools/test_approval.py tests/tools/test_yolo_mode.py tests/tools/test_cron_approval_mode.py tests/tools/test_force_dangerous_override.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py -q --timeout=60' sh`
   - `464 passed`
4. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/tools/test_terminal_tool.py -q --timeout=60' sh`
   - `25 passed`
5. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'ruff check tools/approval.py tests/tools/test_approval.py hermes_cli/config.py' sh`
   - Passed
6. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'python scripts/check-windows-footguns.py tools/approval.py tests/tools/test_approval.py hermes_cli/config.py' sh`
   - Passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing source support before adding new behavior
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS on darwin-arm64 (local)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## What platforms tested on

- macOS on darwin-arm64 (local)

## Screenshots / Logs

N/A

Refs #5528
Refs #54155

<!-- autocontrib:worker-id=pr-spanning-2d081a34 kind=pr-open -->