### PR TITLE
fix(desktop): resolve unpacked release dir for non-x64 Linux arch

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2485,7 +2485,7 @@ async function applyUpdatesPosixInApp() {
   //       ("quit and never came back"). DO NOT quit into a dead app — keep the
   //       working window and surface the closeable manual-restart state.
   if (!IS_MAC) {
-    const unpackedDir = resolveUnpackedRelease(process.execPath, updateRoot, process.platform)
+    const unpackedDir = resolveUnpackedRelease(process.execPath, updateRoot, process.platform, process.arch)
     const underUnpacked = unpackedDir !== null
 
     const preflight = underUnpacked

--- a/apps/desktop/electron/update-relaunch.cjs
+++ b/apps/desktop/electron/update-relaunch.cjs
@@ -39,31 +39,42 @@
 
 const path = require('node:path')
 
-// Map process.platform → electron-builder's `release/<dir>-unpacked` name.
-function unpackedDirName(platform) {
-  if (platform === 'darwin') return 'mac-unpacked' // not used (mac swaps bundles)
-  if (platform === 'win32') return 'win-unpacked'
-  return 'linux-unpacked'
+// Map process.platform + arch → electron-builder's `release/<dir>-unpacked` name.
+// electron-builder 26+ suffixes -<arch> (e.g. linux-arm64-unpacked), but
+// older builds may use the bare platform name. Try arch-suffixed first,
+// falling back to the bare platform form for backward compatibility.
+function unpackedDirName(platform, arch) {
+  const os = platform === 'darwin' ? 'mac' : platform === 'win32' ? 'win' : 'linux'
+  const candidates = arch && arch !== 'x64'
+    ? [`${os}-${arch}-unpacked`, `${os}-unpacked`]
+    : [`${os}-unpacked`]
+  return candidates
 }
 
 /**
- * If `execPath` lives under `<updateRoot>/apps/desktop/release/<plat>-unpacked`,
+ * If `execPath` lives under `<updateRoot>/apps/desktop/release/<plat>[-<arch>]-unpacked`,
  * return that unpacked dir; otherwise null. A null result means the running
  * binary is NOT the thing we just rebuilt (AppImage/.deb/.rpm/dev), so we must
  * not claim a GUI relaunch.
  *
+ * Tries arch-suffixed names first (electron-builder 26+ convention), falling
+ * back to the bare platform form for backward compatibility.
+ *
  * Match is a path-segment-aware prefix check (not a bare string startsWith) so
  * `.../release/linux-unpacked-evil` can't masquerade as `.../release/linux-unpacked`.
  */
-function resolveUnpackedRelease(execPath, updateRoot, platform) {
+function resolveUnpackedRelease(execPath, updateRoot, platform, arch) {
   if (!execPath || !updateRoot) return null
   const releaseDir = path.join(updateRoot, 'apps', 'desktop', 'release')
-  const unpacked = path.join(releaseDir, unpackedDirName(platform))
   const normalizedExec = path.resolve(String(execPath))
-  // execPath must be the unpacked dir itself or a descendant of it.
-  const withSep = unpacked.endsWith(path.sep) ? unpacked : unpacked + path.sep
-  if (normalizedExec === unpacked || normalizedExec.startsWith(withSep)) {
-    return unpacked
+  const candidates = unpackedDirName(platform, arch)
+  for (const name of candidates) {
+    const unpacked = path.join(releaseDir, name)
+    // execPath must be the unpacked dir itself or a descendant of it.
+    const withSep = unpacked.endsWith(path.sep) ? unpacked : unpacked + path.sep
+    if (normalizedExec === unpacked || normalizedExec.startsWith(withSep)) {
+      return unpacked
+    }
   }
   return null
 }


### PR DESCRIPTION
## Problem

On arm64 Linux, the in-app self-update flow incorrectly reports "GUI skew" after a successful update and rebuild. The backend updates, the desktop rebuilds, but `resolveUnpackedRelease` returns null, so the app tells the user the GUI wasn't changed and blocks auto-relaunch.

## Root Cause

`update-relaunch.cjs:unpackedDirName()` hardcodes `linux-unpacked`, but electron-builder 26+ names the unpacked output directory as `<os>-<arch>-unpacked` (e.g. `linux-arm64-unpacked`). The running binary IS under the rebuilt directory, but the mismatch makes `resolveUnpackedRelease` return null, triggering the `guiSkew` terminal state.

## Fix

- `unpackedDirName(platform, arch)` — now returns arch-suffixed candidates first for non-x64 (e.g. `linux-arm64-unpacked`), falling back to `linux-unpacked` for x64 and backward compatibility
- `resolveUnpackedRelease(execPath, updateRoot, platform, arch)` — accepts `arch`, iterates candidates
- `main.cjs` — passes `process.arch`

## Verification

On arm64 Linux, after `hermes update` + `hermes desktop --build-only`:
- `execPath` = `<root>/apps/desktop/release/linux-arm64-unpacked/Hermes`
- Before fix: `resolveUnpackedRelease(...)` → null → guiSkew
- After fix: `resolveUnpackedRelease(...)` → the unpacked dir → relaunch