### PR TITLE
feat(kanban): fire worker start lifecycle hook

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11641,6 +11641,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             except Exception:
                 pass
 
+    def _fire_kanban_worker_started_hook_once(self) -> None:
+        task_id = os.environ.get("HERMES_KANBAN_TASK")
+        if not task_id or getattr(self, "_kanban_worker_started_hook_fired", False):
+            return
+        self._kanban_worker_started_hook_fired = True
+        run_id = None
+        raw_run_id = os.environ.get("HERMES_KANBAN_RUN_ID")
+        if raw_run_id:
+            try:
+                run_id = int(raw_run_id)
+            except ValueError:
+                run_id = None
+        try:
+            from hermes_cli import kanban_db as _kb
+
+            _kb._fire_kanban_lifecycle_hook(
+                "kanban_worker_started",
+                task_id,
+                board=os.environ.get("HERMES_KANBAN_BOARD"),
+                assignee=os.environ.get("HERMES_PROFILE"),
+                run_id=run_id,
+                workspace=os.environ.get("HERMES_KANBAN_WORKSPACE"),
+            )
+        except Exception:
+            pass
+
     def chat(self, message, images: list = None) -> Optional[str]:
         """
         Send a message to the agent and get a response.
@@ -11687,6 +11713,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             request_overrides=turn_route.get("request_overrides"),
         ):
             return None
+
+        self._fire_kanban_worker_started_hook_once()
         
         # Route image attachments based on the active model's vision capability.
         # "native" → pass pixels as OpenAI-style content parts (adapters

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -195,6 +195,8 @@ VALID_HOOKS: Set[str] = {
     #   - kanban_task_claimed   -> the DISPATCHER process (gateway-embedded
     #                              dispatcher or `hermes kanban dispatch`),
     #                              right before the worker subprocess spawns.
+    #   - kanban_worker_started -> the WORKER process, before the first agent
+    #                              turn starts for a claimed task.
     #   - kanban_task_completed -> the WORKER process, when it calls
     #                              kanban_complete (or a CLI/manual complete).
     #   - kanban_task_blocked   -> the WORKER process (worker-initiated block)
@@ -208,6 +210,7 @@ VALID_HOOKS: Set[str] = {
     # kanban_task_completed adds: summary: str | None.
     # kanban_task_blocked adds:   reason: str | None.
     "kanban_task_claimed",
+    "kanban_worker_started",
     "kanban_task_completed",
     "kanban_task_blocked",
 }

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -36,7 +36,7 @@ def captured_hooks(monkeypatch):
     mgr = get_plugin_manager()
     events: list[tuple[str, dict]] = []
     saved = {k: list(v) for k, v in mgr._hooks.items()}
-    for hook in ("kanban_task_claimed", "kanban_task_completed", "kanban_task_blocked"):
+    for hook in ("kanban_task_claimed", "kanban_worker_started", "kanban_task_completed", "kanban_task_blocked"):
         mgr._hooks.setdefault(hook, []).append(
             lambda _h=hook, **kw: events.append((_h, kw))
         )
@@ -47,10 +47,65 @@ def captured_hooks(monkeypatch):
 
 
 def test_hooks_are_registered_as_valid():
-    """The three lifecycle hook names are part of VALID_HOOKS."""
+    """The lifecycle hook names are part of VALID_HOOKS."""
     assert "kanban_task_claimed" in VALID_HOOKS
+    assert "kanban_worker_started" in VALID_HOOKS
     assert "kanban_task_completed" in VALID_HOOKS
     assert "kanban_task_blocked" in VALID_HOOKS
+
+
+def test_worker_started_hook_carries_worker_context(kanban_home, captured_hooks, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "demo")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", "/tmp/demo-work")
+    monkeypatch.setenv("HERMES_PROFILE", "builder")
+    kb._fire_kanban_lifecycle_hook(
+        "kanban_worker_started",
+        "t_worker",
+        board="demo",
+        assignee="builder",
+        run_id=42,
+        workspace="/tmp/demo-work",
+    )
+    fired = [e for e in captured_hooks if e[0] == "kanban_worker_started"]
+    assert len(fired) == 1
+    kw = fired[0][1]
+    assert kw["task_id"] == "t_worker"
+    assert kw["board"] == "demo"
+    assert kw["assignee"] == "builder"
+    assert kw["run_id"] == 42
+    assert kw["workspace"] == "/tmp/demo-work"
+    assert "profile_name" in kw
+
+
+def test_cli_worker_started_hook_fires_once(monkeypatch):
+    from cli import HermesCLI
+
+    calls = []
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_cli")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "demo")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", "/tmp/demo-work")
+    monkeypatch.setenv("HERMES_PROFILE", "builder")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    monkeypatch.setattr(
+        kb,
+        "_fire_kanban_lifecycle_hook",
+        lambda event, task_id, **fields: calls.append((event, task_id, fields)),
+    )
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._fire_kanban_worker_started_hook_once()
+    cli._fire_kanban_worker_started_hook_once()
+
+    assert calls == [(
+        "kanban_worker_started",
+        "t_cli",
+        {
+            "board": "demo",
+            "assignee": "builder",
+            "run_id": 42,
+            "workspace": "/tmp/demo-work",
+        },
+    )]
 
 
 def test_claim_fires_hook(kanban_home, captured_hooks):


### PR DESCRIPTION
## What does this PR do?

Adds a `kanban_worker_started` plugin lifecycle hook that fires inside the worker subprocess before the first agent turn for a claimed Kanban task. This complements the existing dispatcher-side `kanban_task_claimed` hook for plugins that need worker-local context such as the active profile, board, run id, and workspace.

## Related Issue

Fixes #56008

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py`: registers `kanban_worker_started` as a valid hook and documents that it fires in the worker process.
- `cli.py`: emits the hook once per Kanban worker process after agent initialization and before the first `run_conversation()` call.
- `tests/hermes_cli/test_kanban_lifecycle_hooks.py`: covers hook registration, worker-context kwargs, and once-only CLI emission.

## How to Test

1. `python -m pytest tests/hermes_cli/test_kanban_lifecycle_hooks.py tests/hermes_cli/test_kanban_worker_spawn_toolsets.py -q`
2. `python -m ruff check cli.py hermes_cli/plugins.py tests/hermes_cli/test_kanban_lifecycle_hooks.py`
3. Configure a plugin callback for `kanban_worker_started`, dispatch a Kanban task, and verify the callback receives `task_id`, `board`, `assignee`, `run_id`, `workspace`, and `profile_name` from the worker process.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ python -m pytest tests/hermes_cli/test_kanban_lifecycle_hooks.py tests/hermes_cli/test_kanban_worker_spawn_toolsets.py -q
..........                                                               [100%]
10 passed in 0.91s

$ python -m ruff check cli.py hermes_cli/plugins.py tests/hermes_cli/test_kanban_lifecycle_hooks.py
All checks passed!
```
