### PR TITLE
fix(agent): replay preserved thinking for custom providers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -144,6 +144,107 @@ def _custom_provider_extra_body_for_agent(
     return fallback
 
 
+_REASONING_REPLAY_FIELDS = {"reasoning", "reasoning_content"}
+
+
+def _normalize_reasoning_replay_field(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    field = value.strip().lower()
+    if field in _REASONING_REPLAY_FIELDS:
+        return field
+    if field:
+        logger.warning(
+            "custom_providers: unsupported reasoning_replay_field %r ignored "
+            "(expected one of: reasoning, reasoning_content)",
+            value,
+        )
+    return None
+
+
+def _entry_preserves_thinking(entry: Dict[str, Any]) -> bool:
+    if is_truthy_value(entry.get("preserve_thinking")):
+        return True
+    extra_body = entry.get("extra_body")
+    if not isinstance(extra_body, dict):
+        return False
+    chat_template_kwargs = extra_body.get("chat_template_kwargs")
+    return (
+        isinstance(chat_template_kwargs, dict)
+        and is_truthy_value(chat_template_kwargs.get("preserve_thinking"))
+    )
+
+
+def _reasoning_replay_field_from_custom_provider_entry(
+    entry: Dict[str, Any],
+) -> Optional[str]:
+    explicit = _normalize_reasoning_replay_field(entry.get("reasoning_replay_field"))
+    if explicit:
+        return explicit
+    if _entry_preserves_thinking(entry):
+        return "reasoning"
+    return None
+
+
+def _custom_provider_reasoning_replay_field_for_agent(
+    *,
+    provider: str,
+    model: str,
+    base_url: str,
+    custom_providers: List[Dict[str, Any]],
+) -> Optional[str]:
+    provider_norm = (provider or "").strip().lower()
+    if provider_norm == "custom":
+        provider_key_filter = ""
+    elif provider_norm.startswith("custom:"):
+        provider_key_filter = provider_norm.split(":", 1)[1].strip()
+    else:
+        return None
+
+    target_url = _normalized_custom_base_url(base_url)
+    if not target_url:
+        return None
+
+    fallback: Optional[str] = None
+    for entry in custom_providers or []:
+        if not isinstance(entry, dict):
+            continue
+        if provider_key_filter:
+            entry_keys = {
+                str(entry.get("provider_key", "") or "").strip().lower(),
+                str(entry.get("name", "") or "").strip().lower(),
+            }
+            if provider_key_filter not in entry_keys:
+                continue
+        if _normalized_custom_base_url(entry.get("base_url")) != target_url:
+            continue
+
+        replay_field = _reasoning_replay_field_from_custom_provider_entry(entry)
+        if not replay_field:
+            continue
+
+        provider_model = str(entry.get("model", "") or "").strip()
+        if provider_model:
+            if _custom_provider_model_matches(model, entry):
+                return replay_field
+        elif fallback is None:
+            fallback = replay_field
+
+    return fallback
+
+
+def _configure_custom_provider_reasoning_replay(
+    agent,
+    custom_providers: List[Dict[str, Any]],
+) -> None:
+    agent._reasoning_replay_field = _custom_provider_reasoning_replay_field_for_agent(
+        provider=getattr(agent, "provider", ""),
+        model=getattr(agent, "model", ""),
+        base_url=getattr(agent, "base_url", ""),
+        custom_providers=custom_providers,
+    )
+
+
 def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
     extra_body = _custom_provider_extra_body_for_agent(
         provider=agent.provider,
@@ -1509,6 +1610,7 @@ def init_agent(
     # compression model context-length detection needs the same list).
     agent._custom_providers = _custom_providers
     _merge_custom_provider_extra_body(agent, _custom_providers)
+    _configure_custom_provider_reasoning_replay(agent, _custom_providers)
 
     # Check custom_providers per-model context_length
     if _config_context_length is None and _custom_providers:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -970,6 +970,14 @@ def try_recover_primary_transport(
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
+        try:
+            from agent.agent_init import _configure_custom_provider_reasoning_replay
+            _configure_custom_provider_reasoning_replay(
+                agent,
+                getattr(agent, "_custom_providers", None) or [],
+            )
+        except Exception:
+            agent._reasoning_replay_field = None
 
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -1134,6 +1142,14 @@ def restore_primary_runtime(agent) -> bool:
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._client_kwargs = dict(rt["client_kwargs"])
+        try:
+            from agent.agent_init import _configure_custom_provider_reasoning_replay
+            _configure_custom_provider_reasoning_replay(
+                agent,
+                getattr(agent, "_custom_providers", None) or [],
+            )
+        except Exception:
+            agent._reasoning_replay_field = None
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
         # native-vs-proxy split (older sessions saved before this PR).
@@ -1811,6 +1827,19 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             model=new_model,
         )
     )
+
+    try:
+        from hermes_cli.config import load_config, get_compatible_custom_providers
+        from agent.agent_init import _configure_custom_provider_reasoning_replay
+
+        _sm_cfg = load_config()
+        agent._custom_providers = get_compatible_custom_providers(_sm_cfg)
+        _configure_custom_provider_reasoning_replay(
+            agent,
+            getattr(agent, "_custom_providers", None) or [],
+        )
+    except Exception:
+        agent._reasoning_replay_field = None
 
     # ── LM Studio: preload before probing context length ──
     agent._ensure_lmstudio_runtime_loaded()
@@ -2501,12 +2530,57 @@ def intent_ack_continuation_enabled(agent) -> bool:
 
 
 
+def reasoning_replay_field_for_api(agent) -> Optional[str]:
+    """Return the configured provider-facing reasoning replay field, if any."""
+    field = getattr(agent, "_reasoning_replay_field", None)
+    if not isinstance(field, str):
+        return None
+    field = field.strip().lower()
+    if field in {"reasoning", "reasoning_content"}:
+        return field
+    return None
+
+
 def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> None:
     """Copy provider-facing reasoning fields onto an API replay message."""
     if source_msg.get("role") != "assistant":
         return
 
     needs_thinking_pad = agent._needs_thinking_reasoning_pad()
+    replay_field = reasoning_replay_field_for_api(agent)
+    normalized_reasoning = source_msg.get("reasoning")
+    existing = source_msg.get("reasoning_content")
+    replay_reasoning = (
+        normalized_reasoning
+        if isinstance(normalized_reasoning, str) and normalized_reasoning.strip()
+        else None
+    )
+    replay_existing = (
+        existing
+        if isinstance(existing, str) and existing.strip()
+        else None
+    )
+
+    if replay_field == "reasoning":
+        if replay_reasoning is not None:
+            api_msg["reasoning"] = replay_reasoning
+            api_msg.pop("reasoning_content", None)
+        elif replay_existing is not None:
+            api_msg["reasoning"] = replay_existing
+            api_msg.pop("reasoning_content", None)
+        else:
+            api_msg.pop("reasoning", None)
+            api_msg.pop("reasoning_content", None)
+        return
+
+    if replay_field == "reasoning_content":
+        if replay_existing is not None:
+            api_msg["reasoning_content"] = replay_existing
+        elif replay_reasoning is not None:
+            api_msg["reasoning_content"] = replay_reasoning
+        else:
+            api_msg.pop("reasoning_content", None)
+        return
 
     # 1. Explicit reasoning_content already set.
     #
@@ -2526,7 +2600,6 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     # fallback to a strict provider replays that pad and 422s. Stripping
     # here covers the rebuild path; reapply_reasoning_echo_for_provider()
     # covers the already-built api_messages path. Refs #45655.
-    existing = source_msg.get("reasoning_content")
     if isinstance(existing, str):
         if not needs_thinking_pad:
             api_msg.pop("reasoning_content", None)
@@ -2547,7 +2620,6 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     # provider's chain of thought to DeepSeek/Kimi. Space (not "")
     # because DeepSeek V4 Pro rejects empty-string reasoning_content
     # in thinking mode (refs #17341).
-    normalized_reasoning = source_msg.get("reasoning")
     if (
         needs_thinking_pad
         and source_msg.get("tool_calls")
@@ -2613,26 +2685,48 @@ def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
     fields against the *current* provider.  It is idempotent and safe to call
     every iteration; it covers every fallback path.
 
-    Returns the number of assistant turns whose reasoning_content was added or
-    removed.
+    Returns the number of assistant turns whose provider-facing reasoning
+    fields were added or removed.
     """
     needs_pad = agent._needs_thinking_reasoning_pad()
+    replay_field = reasoning_replay_field_for_api(agent)
     changed = 0
     for api_msg in api_messages:
         if api_msg.get("role") != "assistant":
             continue
-        if needs_pad:
-            if api_msg.get("reasoning_content"):
-                continue
+        before = dict(api_msg)
+        if replay_field:
             copy_reasoning_content_for_api(agent, api_msg, api_msg)
-            if api_msg.get("reasoning_content"):
+            if replay_field == "reasoning":
+                api_msg.pop("reasoning_content", None)
+            elif replay_field == "reasoning_content":
+                api_msg.pop("reasoning", None)
+            if api_msg != before:
+                changed += 1
+        elif needs_pad:
+            # api_messages may have been built under a provider that replays
+            # history under ``reasoning`` (for example Qwen/vLLM). Do not
+            # leak that provider's private trace into a DeepSeek/Kimi/MiMo
+            # fallback; their fallback-safe shape is the blank pad unless a
+            # reasoning_content field was already present.
+            if "reasoning" in api_msg:
+                api_msg.pop("reasoning", None)
+            if not api_msg.get("reasoning_content"):
+                copy_reasoning_content_for_api(agent, api_msg, api_msg)
+            if api_msg != before:
                 changed += 1
         else:
             # Strict provider — strip any stale reasoning_content pad left
             # over from a reasoning primary so the fallback request doesn't
             # 400/422 on it.
+            removed = False
             if "reasoning_content" in api_msg:
                 api_msg.pop("reasoning_content", None)
+                removed = True
+            if "reasoning" in api_msg:
+                api_msg.pop("reasoning", None)
+                removed = True
+            if removed:
                 changed += 1
     return changed
 
@@ -2969,6 +3063,7 @@ __all__ = [
     "repair_tool_call",
     "sanitize_api_messages",
     "looks_like_codex_intermediate_ack",
+    "reasoning_replay_field_for_api",
     "copy_reasoning_content_for_api",
     "cleanup_dead_connections",
     "extract_api_error_context",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1276,6 +1276,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
+        try:
+            from agent.agent_init import _configure_custom_provider_reasoning_replay
+            _configure_custom_provider_reasoning_replay(
+                agent,
+                getattr(agent, "_custom_providers", None) or [],
+            )
+        except Exception:
+            agent._reasoning_replay_field = None
 
         # Rebind the credential pool to the fallback provider when the provider
         # changes.  Keeping the primary pool attached would make downstream
@@ -1432,14 +1440,20 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     messages.append({"role": "user", "content": summary_request})
 
     try:
-        # Build API messages, stripping internal-only fields
-        # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
+        # Build API messages, stripping internal-only fields. Keep
+        # provider-facing reasoning when the active endpoint explicitly
+        # replays historical thinking through the ``reasoning`` field.
         _needs_sanitize = agent._should_sanitize_tool_calls()
         api_messages = []
         for msg in messages:
             api_msg = msg.copy()
             agent._copy_reasoning_content_for_api(msg, api_msg)
-            for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
+            if (
+                "reasoning" in api_msg
+                and agent._reasoning_replay_field_for_api() != "reasoning"
+            ):
+                api_msg.pop("reasoning", None)
+            for internal_field in ("finish_reason", "_thinking_prefill"):
                 api_msg.pop(internal_field, None)
             # Strict OpenAI-compatible gateways (Fireworks-backed OpenCode Go,
             # Mistral, Moonshot/Kimi) reject any message key outside the Chat

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -785,9 +785,12 @@ def run_conversation(
             # This ensures multi-turn reasoning context is preserved
             agent._copy_reasoning_content_for_api(msg, api_msg)
 
-            # Remove 'reasoning' field - it's for trajectory storage only
-            # We've copied it to 'reasoning_content' for the API above
-            if "reasoning" in api_msg:
+            # Remove 'reasoning' unless this provider explicitly replays
+            # historical thinking through that field (vLLM/Qwen preserve_thinking).
+            if (
+                "reasoning" in api_msg
+                and agent._reasoning_replay_field_for_api() != "reasoning"
+            ):
                 api_msg.pop("reasoning")
             # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
             if "finish_reason" in api_msg:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4411,6 +4411,8 @@ def _normalize_custom_provider_entry(
         "defaultModel": "default_model",
         "contextLength": "context_length",
         "rateLimitDelay": "rate_limit_delay",
+        "preserveThinking": "preserve_thinking",
+        "reasoningReplayField": "reasoning_replay_field",
     }
     # api_key_env is a documented snake_case alias for key_env (see
     # website/docs/guides/azure-foundry.md).  Normalize it up front so the
@@ -4423,6 +4425,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body",
+        "preserve_thinking", "reasoning_replay_field",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -4525,6 +4528,14 @@ def _normalize_custom_provider_entry(
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models
 
+    preserve_thinking = entry.get("preserve_thinking")
+    if isinstance(preserve_thinking, bool):
+        normalized["preserve_thinking"] = preserve_thinking
+
+    reasoning_replay_field = entry.get("reasoning_replay_field")
+    if isinstance(reasoning_replay_field, str) and reasoning_replay_field.strip():
+        normalized["reasoning_replay_field"] = reasoning_replay_field.strip()
+
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
@@ -4555,6 +4566,8 @@ def _custom_provider_entry_to_provider_config(
         "context_length",
         "rate_limit_delay",
         "discover_models",
+        "preserve_thinking",
+        "reasoning_replay_field",
         "extra_body",
     ):
         if field in normalized:
@@ -4757,6 +4770,7 @@ _KNOWN_ROOT_KEYS = {
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
+    "preserve_thinking", "reasoning_replay_field",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/run_agent.py
+++ b/run_agent.py
@@ -5205,6 +5205,11 @@ class AIAgent:
         from agent.agent_runtime_helpers import copy_reasoning_content_for_api
         return copy_reasoning_content_for_api(self, source_msg, api_msg)
 
+    def _reasoning_replay_field_for_api(self) -> Optional[str]:
+        """Forwarder — see ``agent.agent_runtime_helpers.reasoning_replay_field_for_api``."""
+        from agent.agent_runtime_helpers import reasoning_replay_field_for_api
+        return reasoning_replay_field_for_api(self)
+
     def _reapply_reasoning_echo_for_provider(self, api_messages: list) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.reapply_reasoning_echo_for_provider``."""
         from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -1,6 +1,9 @@
 from types import SimpleNamespace
 
-from agent.agent_init import _merge_custom_provider_extra_body
+from agent.agent_init import (
+    _configure_custom_provider_reasoning_replay,
+    _merge_custom_provider_extra_body,
+)
 
 
 def test_custom_provider_extra_body_merges_into_request_overrides():
@@ -122,3 +125,53 @@ def test_named_custom_provider_extra_body_matches_provider_key():
     )
 
     assert agent.request_overrides == {"extra_body": {"enable_thinking": False}}
+
+
+def test_custom_provider_preserve_thinking_enables_reasoning_replay():
+    agent = SimpleNamespace(
+        provider="custom:my-vllm",
+        model="Qwen/Qwen3.6-35B-A3B-FP8",
+        base_url="http://localhost:8000/v1",
+        request_overrides={},
+    )
+
+    _configure_custom_provider_reasoning_replay(
+        agent,
+        [
+            {
+                "provider_key": "my-vllm",
+                "name": "my-vllm",
+                "base_url": "http://localhost:8000/v1",
+                "model": "Qwen/Qwen3.6-35B-A3B-FP8",
+                "extra_body": {
+                    "chat_template_kwargs": {"preserve_thinking": True},
+                },
+            }
+        ],
+    )
+
+    assert agent._reasoning_replay_field == "reasoning"
+
+
+def test_custom_provider_explicit_reasoning_replay_field_wins():
+    agent = SimpleNamespace(
+        provider="custom",
+        model="qwen3.6-local",
+        base_url="http://localhost:8000/v1",
+        request_overrides={},
+    )
+
+    _configure_custom_provider_reasoning_replay(
+        agent,
+        [
+            {
+                "name": "vllm",
+                "base_url": "http://localhost:8000/v1",
+                "model": "qwen3.6-local",
+                "preserve_thinking": True,
+                "reasoning_replay_field": "reasoning_content",
+            }
+        ],
+    )
+
+    assert agent._reasoning_replay_field == "reasoning_content"

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -981,6 +981,35 @@ class TestCustomProviderCompatibility:
         assert compatible[0]["provider_key"] == "openai-direct"
         assert compatible[0]["api_mode"] == "codex_responses"
 
+    def test_compatible_custom_providers_preserves_reasoning_replay_config(self):
+        compatible = get_compatible_custom_providers(
+            {
+                "custom_providers": [
+                    {
+                        "name": "Legacy vLLM",
+                        "base_url": "http://legacy.example/v1",
+                        "reasoning_replay_field": "reasoning",
+                        "preserve_thinking": True,
+                    }
+                ],
+                "providers": {
+                    "my-vllm": {
+                        "name": "My vLLM",
+                        "api": "http://localhost:8000/v1",
+                        "reasoning_replay_field": "reasoning",
+                        "preserve_thinking": True,
+                    }
+                },
+            }
+        )
+
+        legacy, provider = compatible
+        assert legacy["reasoning_replay_field"] == "reasoning"
+        assert legacy["preserve_thinking"] is True
+        assert provider["provider_key"] == "my-vllm"
+        assert provider["reasoning_replay_field"] == "reasoning"
+        assert provider["preserve_thinking"] is True
+
     def test_compatible_custom_providers_prefers_base_url_then_url_then_api(self, tmp_path):
         """URL field precedence is base_url > url > api (PR #9332)."""
         config_path = tmp_path / "config.yaml"

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -533,6 +533,25 @@ class TestReapplyReasoningEchoForProviderSwitch:
         assert msgs[2]["reasoning_content"] == "summary from codex"
         assert msgs[4]["reasoning_content"] == " "
 
+    def test_switch_to_deepseek_strips_stale_reasoning_when_content_exists(self) -> None:
+        from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
+
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "done",
+                "reasoning": "stale provider-private trace",
+                "reasoning_content": "summary from codex",
+            }
+        ]
+
+        changed = reapply_reasoning_echo_for_provider(agent, msgs)
+
+        assert changed == 1
+        assert msgs[0]["reasoning_content"] == "summary from codex"
+        assert "reasoning" not in msgs[0]
+
     def test_strips_stale_pad_under_strict_provider(self) -> None:
         """Switching TO a strict provider (Codex/Mistral/Cerebras) must STRIP
         stale reasoning_content baked in under a reasoning primary, otherwise

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3550,6 +3550,31 @@ class TestHandleMaxIterations:
         assert messages[2]["tool_name"] == "execute_code"
         assert messages[1]["codex_reasoning_items"] == [{"id": "rs_1"}]
 
+    def test_summary_preserves_reasoning_for_reasoning_replay_provider(self, agent):
+        agent.provider = "custom:my-vllm"
+        agent.model = "Qwen/Qwen3.6-35B-A3B-FP8"
+        agent.base_url = "http://localhost:8000/v1"
+        agent._reasoning_replay_field = "reasoning"
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+        messages = [
+            {"role": "user", "content": "do stuff"},
+            {
+                "role": "assistant",
+                "content": "Visible result.",
+                "reasoning": "prior hidden reasoning",
+                "reasoning_content": "old provider scratchpad",
+            },
+        ]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        sent_msgs = agent.client.chat.completions.create.call_args.kwargs.get("messages", [])
+        replayed_assistant = next(m for m in sent_msgs if m.get("role") == "assistant")
+        assert replayed_assistant["reasoning"] == "prior hidden reasoning"
+        assert "reasoning_content" not in replayed_assistant
+
     def test_summary_omits_provider_preferences_for_non_openrouter(self, agent):
         agent.base_url = "https://api.openai.com/v1"
         agent._base_url_lower = agent.base_url.lower()
@@ -7072,6 +7097,50 @@ class TestReasoningReplayForStrictProviders:
         sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
         replayed_assistant = next(msg for msg in sent_messages if msg.get("role") == "assistant")
         assert "reasoning_content" not in replayed_assistant
+
+    def test_preserve_thinking_custom_provider_replays_reasoning_field(self, agent):
+        self._setup_agent(agent)
+        agent.provider = "custom:my-vllm"
+        agent.model = "Qwen/Qwen3.6-35B-A3B-FP8"
+        agent.base_url = "http://localhost:8000/v1"
+        agent._reasoning_replay_field = "reasoning"
+        prior_assistant = {
+            "role": "assistant",
+            "content": "The visible answer.",
+            "reasoning": "prior hidden reasoning",
+        }
+        final_resp = _mock_response(content="done", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = final_resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "next step",
+                conversation_history=[prior_assistant],
+            )
+
+        assert result["completed"] is True
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        replayed_assistant = next(msg for msg in sent_messages if msg.get("role") == "assistant")
+        assert replayed_assistant["reasoning"] == "prior hidden reasoning"
+        assert "reasoning_content" not in replayed_assistant
+
+    def test_strict_provider_strips_stale_reasoning_field_on_reapply(self, agent):
+        self._setup_agent(agent)
+        agent.provider = "mistral"
+        agent.base_url = "https://api.mistral.ai/v1"
+        agent._reasoning_replay_field = None
+        api_messages = [
+            {"role": "assistant", "content": "ok", "reasoning": "stale private reasoning"},
+        ]
+
+        changed = agent._reapply_reasoning_echo_for_provider(api_messages)
+
+        assert changed == 1
+        assert "reasoning" not in api_messages[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a custom-provider reasoning replay switch (`reasoning_replay_field`) and infer `reasoning` replay from `preserve_thinking` / `extra_body.chat_template_kwargs.preserve_thinking`
- keep outgoing assistant history `reasoning` for vLLM/Qwen preserve-thinking endpoints in both the normal conversation loop and max-iterations summary path, without adding DeepSeek-style blank `reasoning_content` pads
- strip stale `reasoning` / `reasoning_content` when the active provider does not opt into that field, while preserving existing DeepSeek/Kimi/MiMo echo-back behavior
- preserve the new replay config through legacy `custom_providers`, v12 `providers`, fallback activation, primary restore, primary transport recovery, and `/model` switches

Fixes #56004

## Tests
- `scripts/run_tests.sh tests/agent/test_custom_provider_extra_body.py tests/run_agent/test_deepseek_reasoning_content_echo.py tests/run_agent/test_run_agent.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py -q -k 'custom_provider or reasoning_replay or preserve_thinking or summary_preserves_reasoning or switch_to_deepseek_strips_stale_reasoning_when_content_exists or ReasoningReplayForStrictProviders or ReapplyReasoningEchoForProviderSwitch or ReasoningPrimaryToStrictFallback'` — 29 passed
- `scripts/run_tests.sh --file-timeout 900 tests/agent/test_custom_provider_extra_body.py tests/run_agent/test_deepseek_reasoning_content_echo.py tests/run_agent/test_run_agent.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py -q` — 612 passed
- `uv run ruff check agent/agent_init.py agent/agent_runtime_helpers.py agent/chat_completion_helpers.py agent/conversation_loop.py hermes_cli/config.py run_agent.py tests/agent/test_custom_provider_extra_body.py tests/hermes_cli/test_config.py tests/run_agent/test_run_agent.py tests/run_agent/test_deepseek_reasoning_content_echo.py` — All checks passed
- `git diff --check`