### PR TITLE
fix(gateway): allow reply-only queue command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8477,7 +8477,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # (e.g. "/queue" as the caption of an image). Dropping these
                 # fields silently lost the attachment when the queued turn ran.
                 has_media = bool(getattr(event, "media_urls", None))
-                if not queued_text and not has_media:
+                has_reply = bool(
+                    getattr(event, "reply_to_message_id", None)
+                    or getattr(event, "reply_to_text", None)
+                )
+                if not queued_text and not has_media and not has_reply:
                     return "Usage: /queue <prompt>"
                 adapter = self.adapters.get(source.platform)
                 if adapter:

--- a/tests/gateway/test_queue_command.py
+++ b/tests/gateway/test_queue_command.py
@@ -176,6 +176,32 @@ async def test_queue_preserves_reply_context():
 
 
 @pytest.mark.asyncio
+async def test_queue_allows_reply_context_without_prompt_text():
+    runner, adapter = _make_runner(_session_entry())
+    sk = _running(runner)
+
+    event = MessageEvent(
+        text="/queue",
+        source=_make_source(),
+        message_id="q-reply-only",
+        reply_to_message_id="orig-7",
+        reply_to_text="the original message",
+        reply_to_author_id="a1",
+        reply_to_author_name="alice",
+    )
+    result = await runner._handle_message(event)
+
+    assert result is not None and "queued" in result.lower()
+    queued = adapter._pending_messages[sk]
+    assert queued.text == ""
+    assert queued.message_type == MessageType.TEXT
+    assert queued.reply_to_message_id == "orig-7"
+    assert queued.reply_to_text == "the original message"
+    assert queued.reply_to_author_id == "a1"
+    assert queued.reply_to_author_name == "alice"
+
+
+@pytest.mark.asyncio
 async def test_queue_no_text_no_media_returns_usage():
     runner, adapter = _make_runner(_session_entry())
     _running(runner)


### PR DESCRIPTION
## What does this PR do?

Allows a bare `/queue` command to enqueue reply context when it is sent as a reply to another message. The existing handler preserved `reply_to_*` fields after enqueueing, but its usage guard only allowed text or media payloads, so reply-only `/queue` returned `Usage: /queue <prompt>` before the queued event could be built.

## Related Issue

Follow-up to #55960

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: treats reply context as a valid `/queue` payload even when there is no prompt text or media attachment.
- `tests/gateway/test_queue_command.py`: adds a regression test for reply-only `/queue`, asserting the queued event keeps the reply metadata.

## How to Test

1. Start an active gateway session.
2. Reply to an existing message with `/queue` and no additional text.
3. Verify the message is queued instead of returning `Usage: /queue <prompt>`, and the follow-up turn retains the quoted message context.

Automated checks:

```bash
python -m pytest tests/gateway/test_queue_command.py -q
python -m ruff check gateway/run.py tests/gateway/test_queue_command.py
```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ python -m pytest tests/gateway/test_queue_command.py -q
......                                                                   [100%]
6 passed in 0.37s

$ python -m ruff check gateway/run.py tests/gateway/test_queue_command.py
All checks passed!
```
