### PR TITLE
feat: add Claude Code remote slash command

### DIFF
--- a/gateway/claude_code_command.py
+++ b/gateway/claude_code_command.py
@@ -1,0 +1,270 @@
+"""Helpers for the gateway /cc command.
+
+The command starts a detached Claude Code Remote Control session in a git repo,
+so users on messaging platforms can kick off a real interactive Claude Code TUI
+and then drive it from Anthropic's official app.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+_DEFAULT_WORKSPACE_ROOTS = (
+    "~/work",
+    "~/worktrees",
+    "~/projects",
+    "~/repos",
+    "~/src",
+    "~/.hermes/hermes-agent",
+)
+_SKIP_DIR_NAMES = {
+    ".cache",
+    ".claude",
+    ".git",
+    ".hermes",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "dist",
+    "node_modules",
+    "venv",
+}
+_MAX_SCAN_DEPTH = 4
+
+
+@dataclass(frozen=True)
+class ClaudeCodeLaunch:
+    """Result of launching a Claude Code Remote Control tmux session."""
+
+    repo_path: Path
+    tmux_session: str
+    remote_name: str
+    command: str
+
+
+def _slug(value: str, *, fallback: str = "repo", limit: int = 48) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-._")
+    if not slug:
+        slug = fallback
+    return slug[:limit].strip("-._") or fallback
+
+
+def _coerce_path_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part for part in value.split(os.pathsep) if part.strip()]
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray, dict)):
+        return [str(part) for part in value if str(part).strip()]
+    return []
+
+
+def _config_get(config: Any, dotted: str) -> Any:
+    cur = config
+    for part in dotted.split("."):
+        if isinstance(cur, dict):
+            cur = cur.get(part)
+        else:
+            cur = getattr(cur, part, None)
+        if cur is None:
+            return None
+    return cur
+
+
+def workspace_roots(config: Any | None = None) -> list[Path]:
+    """Return configured/default roots searched by /cc.
+
+    Operators can set ``gateway.claude_code.workspace_roots`` in config.yaml.
+    Defaults cover the common development directories without introducing a new
+    environment variable for non-secret behavior.
+    """
+
+    configured = _coerce_path_list(
+        _config_get(config, "gateway.claude_code.workspace_roots") if config is not None else None
+    )
+    terminal_cwd = _config_get(config, "terminal.cwd") if config is not None else None
+    candidates: list[str] = []
+    if terminal_cwd and str(terminal_cwd).strip() not in {"", "."}:
+        candidates.append(str(terminal_cwd))
+    candidates.extend(configured or list(_DEFAULT_WORKSPACE_ROOTS))
+
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for raw in candidates:
+        expanded = Path(os.path.expandvars(os.path.expanduser(str(raw)))).resolve()
+        if expanded in seen or not expanded.exists() or not expanded.is_dir():
+            continue
+        seen.add(expanded)
+        roots.append(expanded)
+    return roots
+
+
+def _git_root(path: Path) -> Path | None:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    root = proc.stdout.strip()
+    return Path(root).resolve() if root else None
+
+
+def _iter_candidate_dirs(root: Path) -> Iterable[Path]:
+    yield root
+    root_depth = len(root.parts)
+    for current, dirs, _files in os.walk(root):
+        cur_path = Path(current)
+        depth = len(cur_path.parts) - root_depth
+        if depth >= _MAX_SCAN_DEPTH:
+            dirs[:] = []
+            continue
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIR_NAMES]
+        for dirname in dirs:
+            yield cur_path / dirname
+
+
+def find_repo(repo_name: str, config: Any | None = None) -> tuple[Path | None, str | None]:
+    """Resolve a repo name/path to a git repository root.
+
+    Returns ``(path, None)`` on success, ``(None, message)`` on failure.
+    """
+
+    query = (repo_name or "").strip()
+    if not query:
+        return None, "Usage: /cc <repo-name>"
+
+    raw_path = Path(os.path.expandvars(os.path.expanduser(query)))
+    if raw_path.is_absolute() or any(sep in query for sep in ("/", os.sep)):
+        candidate = raw_path.resolve()
+        if not candidate.exists():
+            return None, f"No such path: `{candidate}`"
+        git_root = _git_root(candidate)
+        if git_root:
+            return git_root, None
+        return None, f"Path is not inside a git repository: `{candidate}`"
+
+    normalized = query.casefold()
+    matches: list[Path] = []
+    seen: set[Path] = set()
+    for root in workspace_roots(config):
+        for candidate in _iter_candidate_dirs(root):
+            if candidate.name.casefold() != normalized:
+                continue
+            git_root = _git_root(candidate)
+            if git_root and git_root not in seen:
+                seen.add(git_root)
+                matches.append(git_root)
+
+    if not matches:
+        roots_text = ", ".join(f"`{root}`" for root in workspace_roots(config)) or "no existing roots"
+        return None, f"Repo `{query}` not found under configured workspace roots ({roots_text})."
+    if len(matches) > 1:
+        choices = "\n".join(f"- `{path}`" for path in matches[:10])
+        return None, f"Repo name `{query}` is ambiguous. Use an absolute path:\n{choices}"
+    return matches[0], None
+
+
+def _require_command(name: str) -> str | None:
+    path = shutil.which(name)
+    if not path:
+        return f"`{name}` is not installed or not on PATH."
+    return None
+
+
+def _tmux_session_exists(session_name: str) -> bool:
+    proc = subprocess.run(
+        ["tmux", "has-session", "-t", session_name],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def _unique_tmux_session(base: str) -> str:
+    session = base
+    if not _tmux_session_exists(session):
+        return session
+    stamp = int(time.time())
+    for idx in range(1, 20):
+        session = f"{base}-{stamp}-{idx}"
+        if not _tmux_session_exists(session):
+            return session
+    raise RuntimeError("Could not allocate a unique tmux session name")
+
+
+def launch_claude_code(repo_path: Path, repo_name: str) -> ClaudeCodeLaunch:
+    """Start Claude Code Remote Control in a detached tmux session."""
+
+    for cmd in ("tmux", "claude"):
+        err = _require_command(cmd)
+        if err:
+            raise RuntimeError(err)
+
+    repo_path = repo_path.resolve()
+    if _git_root(repo_path) is None:
+        raise RuntimeError(f"Not a git repository: {repo_path}")
+
+    remote_name = _slug(repo_path.name or repo_name, fallback="repo")
+    tmux_session = _unique_tmux_session(f"cc-{remote_name}")
+    claude_command = (
+        "claude --dangerously-skip-permissions "
+        f"--remote-control {shlex_quote(remote_name)}"
+    )
+    proc = subprocess.run(
+        [
+            "tmux",
+            "new-session",
+            "-d",
+            "-s",
+            tmux_session,
+            "-c",
+            str(repo_path),
+            claude_command,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "tmux new-session failed").strip()
+        raise RuntimeError(detail)
+
+    return ClaudeCodeLaunch(
+        repo_path=repo_path,
+        tmux_session=tmux_session,
+        remote_name=remote_name,
+        command=claude_command,
+    )
+
+
+def shlex_quote(value: str) -> str:
+    """Small local quote helper to avoid importing shlex on hot paths elsewhere."""
+
+    if re.fullmatch(r"[A-Za-z0-9_@%+=:,./-]+", value):
+        return value
+    return "'" + value.replace("'", "'\"'\"'") + "'"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8581,6 +8581,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
+            # /cc launches an external Claude Code tmux session and must not
+            # interrupt or queue the active Hermes run.
+            if _cmd_def_inner and _cmd_def_inner.name == "cc":
+                return await self._handle_claude_code_command(event)
+
             # /kanban must bypass the guard. It writes to a profile-agnostic
             # DB (kanban.db), not to the running agent's state. In fact
             # /kanban unblock is often the only way to free a worker that
@@ -9096,6 +9101,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "background":
             return await self._handle_background_command(event)
+
+        if canonical == "cc":
+            return await self._handle_claude_code_command(event)
 
         if canonical == "steer":
             # No active agent — /steer has no tool call to inject into.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2311,6 +2311,37 @@ class GatewaySlashCommandsMixin:
         preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
         return t("gateway.background.started", preview=preview, task_id=task_id)
 
+    async def _handle_claude_code_command(self, event: MessageEvent) -> str:
+        """Handle /cc <repo> — launch Claude Code Remote Control in tmux."""
+        repo_query = event.get_command_args().strip()
+        if not repo_query:
+            return "Usage: /cc <repo-name-or-path>"
+
+        def _launch():
+            from gateway.claude_code_command import find_repo, launch_claude_code
+
+            repo_path, error = find_repo(repo_query, self.config)
+            if error or repo_path is None:
+                return None, error or "Repo not found."
+            try:
+                return launch_claude_code(repo_path, repo_query), None
+            except Exception as exc:
+                return None, str(exc)
+
+        result, error = await asyncio.to_thread(_launch)
+        if error or result is None:
+            return f"❌ Could not launch Claude Code: {error}"
+
+        return (
+            "✅ Claude Code Remote Control launched.\n"
+            f"Repo: `{result.repo_path}`\n"
+            f"Remote name: `{result.remote_name}`\n"
+            f"tmux: `{result.tmux_session}`\n\n"
+            "Open the Claude official app and connect to the remote-control "
+            "session. Server-side session command:\n"
+            f"`{result.command}`"
+        )
+
     async def _handle_reasoning_command(self, event: MessageEvent) -> str:
         """Handle /reasoning command — manage reasoning effort and display toggle.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -101,6 +101,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True),
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg", "btw"), args_hint="<prompt>"),
+    CommandDef("cc", "Launch a Claude Code Remote Control session for a repo", "Session",
+               gateway_only=True, args_hint="<repo-name-or-path>"),
     CommandDef("agents", "Show active agents and running tasks", "Session",
                aliases=("tasks",)),
     CommandDef("journey", "Open the learning journey timeline",
@@ -369,6 +371,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "agents",
         "approve",
         "background",
+        "cc",
         "commands",
         "deny",
         "help",
@@ -1163,7 +1166,8 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #   - moa: high-cost slash mode, available through /hermes moa to avoid
 #     displacing existing native Slack slash commands at the 50-command cap.
 #   - debug: the log/report upload surface; reached via /hermes debug on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug"})
+#   - cc: starts a host-side Claude Code tmux session; reached via /hermes cc on Slack.
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug", "cc"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2779,6 +2779,20 @@ DEFAULT_CONFIG = {
             # request flood. Set to 0 to disable the cap entirely.
             "max_concurrent_runs": 10,
         },
+
+        # /cc <repo> launches a detached Claude Code Remote Control tmux session
+        # with --dangerously-skip-permissions. These are the roots searched when
+        # the user passes a repo name instead of an absolute path.
+        "claude_code": {
+            "workspace_roots": [
+                "~/work",
+                "~/worktrees",
+                "~/projects",
+                "~/repos",
+                "~/src",
+                "~/.hermes/hermes-agent",
+            ],
+        },
     },
 
     # Real-time token streaming to messaging platforms (Telegram, Discord,

--- a/tests/gateway/test_claude_code_slash.py
+++ b/tests/gateway/test_claude_code_slash.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+from unittest import mock
+
+from gateway.claude_code_command import find_repo, launch_claude_code, workspace_roots
+from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
+
+
+def test_cc_registered_as_gateway_only_command():
+    cmd = resolve_command("cc")
+
+    assert cmd is not None
+    assert cmd.name == "cc"
+    assert cmd.gateway_only is True
+    assert "cc" in GATEWAY_KNOWN_COMMANDS
+
+
+def test_workspace_roots_use_gateway_claude_code_config(tmp_path):
+    root = tmp_path / "workspace"
+    root.mkdir()
+    missing = tmp_path / "missing"
+    config = {
+        "gateway": {
+            "claude_code": {
+                "workspace_roots": [str(root), str(missing)],
+            }
+        }
+    }
+
+    assert workspace_roots(config) == [root.resolve()]
+
+
+def test_find_repo_by_name_under_configured_root(tmp_path, monkeypatch):
+    root = tmp_path / "workspace"
+    repo = root / "demo"
+    repo.mkdir(parents=True)
+    config = {"gateway": {"claude_code": {"workspace_roots": [str(root)]}}}
+
+    monkeypatch.setattr(
+        "gateway.claude_code_command._git_root",
+        lambda path: repo.resolve() if Path(path).name == "demo" else None,
+    )
+
+    found, error = find_repo("demo", config)
+
+    assert error is None
+    assert found == repo.resolve()
+
+
+def test_find_repo_reports_ambiguous_name(tmp_path, monkeypatch):
+    one = tmp_path / "one" / "demo"
+    two = tmp_path / "two" / "demo"
+    one.mkdir(parents=True)
+    two.mkdir(parents=True)
+    config = {"gateway": {"claude_code": {"workspace_roots": [str(tmp_path)]}}}
+
+    def fake_git_root(path):
+        path = Path(path)
+        if path == one:
+            return one.resolve()
+        if path == two:
+            return two.resolve()
+        return None
+
+    monkeypatch.setattr("gateway.claude_code_command._git_root", fake_git_root)
+
+    found, error = find_repo("demo", config)
+
+    assert found is None
+    assert error is not None
+    assert "ambiguous" in error
+    assert str(one.resolve()) in error
+    assert str(two.resolve()) in error
+
+
+def test_launch_claude_code_starts_tmux_with_remote_control(tmp_path, monkeypatch):
+    repo = tmp_path / "demo"
+    repo.mkdir()
+    monkeypatch.setattr("gateway.claude_code_command._git_root", lambda path: repo.resolve())
+    monkeypatch.setattr("gateway.claude_code_command.shutil.which", lambda name: f"/usr/bin/{name}")
+
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        if args[:2] == ["tmux", "has-session"]:
+            return mock.Mock(returncode=1, stdout="", stderr="")
+        if args[:3] == ["tmux", "new-session", "-d"]:
+            return mock.Mock(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.setattr("gateway.claude_code_command.subprocess.run", fake_run)
+
+    result = launch_claude_code(repo, "demo")
+
+    assert result.tmux_session == "cc-demo"
+    assert result.remote_name == "demo"
+    assert result.repo_path == repo.resolve()
+    new_session = calls[-1]
+    assert new_session[:3] == ["tmux", "new-session", "-d"]
+    assert "-c" in new_session
+    assert str(repo.resolve()) in new_session
+    assert new_session[-1] == "claude --dangerously-skip-permissions --remote-control demo"

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -227,6 +227,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | Control spoken replies in chat. `join`/`channel`/`leave` manage Discord voice-channel mode. |
 | `/rollback [number]` | List or restore filesystem checkpoints. |
 | `/background <prompt>` | Run a prompt in a separate background session. Results are delivered back to the same chat when the task finishes. See [Messaging Background Sessions](/user-guide/messaging/#background-sessions). |
+| `/cc <repo-name-or-path>` | Launch a detached Claude Code Remote Control session in the matching git repo using `claude --dangerously-skip-permissions --remote-control`. Configure searched roots with `gateway.claude_code.workspace_roots` in `config.yaml`. |
 | `/queue <prompt>` (alias: `/q`) | Queue a prompt for the next turn without interrupting the current one. |
 | `/steer <prompt>` | Inject a message after the next tool call without interrupting — the model picks it up on its next iteration rather than as a new turn. |
 | `/goal <text>` | Set a standing goal Hermes works toward across turns — our take on the Ralph loop. A judge model checks after each turn; if not done, Hermes auto-continues until it is, you pause/clear it, or the turn budget (default 20) is hit. Subcommands: `/goal status`, `/goal pause`, `/goal resume`, `/goal clear`. Safe to run mid-agent for status/pause/clear; setting a new goal requires `/stop` first. See [Persistent Goals](/user-guide/features/goals). |


### PR DESCRIPTION
## Summary
- Add gateway-only /cc <repo-name-or-path> command to locate a git repo under configured workspace roots and launch Claude Code in a detached tmux session
- Launches with `claude --dangerously-skip-permissions --remote-control <repo>` so the session can be controlled from the official Claude app
- Add configurable `gateway.claude_code.workspace_roots`, docs, Slack cap handling, and unit coverage

## Test Plan
- `scripts/run_tests.sh tests/hermes_cli/test_commands.py tests/gateway/test_claude_code_slash.py tests/gateway/test_slash_access.py -q`
- `python -m py_compile gateway/claude_code_command.py gateway/slash_commands.py gateway/run.py hermes_cli/commands.py hermes_cli/config.py`
