### PR TITLE
feat(delegate): add per-call child timeout override

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6076,6 +6076,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            timeout_seconds=function_args.get("timeout_seconds"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -668,8 +668,11 @@ def test_run_agent_dispatch_forces_background():
 
     with patch("tools.delegate_tool.delegate_task", _fake_delegate):
         agent = _FakeAgent()
-        run_agent.AIAgent._dispatch_delegate_task(agent, {"goal": "x"})
+        run_agent.AIAgent._dispatch_delegate_task(
+            agent, {"goal": "x", "timeout_seconds": 900}
+        )
         assert captured["background"] is True
+        assert captured["timeout_seconds"] == 900
 
         run_agent.AIAgent._dispatch_delegate_task(
             agent, {"tasks": [{"goal": "a"}, {"goal": "b"}]}
@@ -871,5 +874,4 @@ def test_gateway_cli_origin_event_left_unrouted():
     evt = _make_async_evt(session_key="")
     runner._enrich_async_delegation_routing(evt)
     assert "platform" not in evt
-
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -348,6 +348,21 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIsNone(mock_run.call_args.kwargs["timeout_seconds"])
 
     @patch("tools.delegate_tool._run_single_child")
+    def test_timeout_override_floor_applied_before_forwarding(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done!",
+            "api_calls": 3,
+            "duration_seconds": 5.0,
+        }
+        parent = _make_mock_parent()
+
+        delegate_task(goal="Tiny cap", timeout_seconds=5, parent_agent=parent)
+
+        self.assertEqual(mock_run.call_args.kwargs["timeout_seconds"], 30.0)
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode_accepts_json_string_tasks(self, mock_run):
         mock_run.side_effect = [
             {
@@ -2205,6 +2220,74 @@ class TestDelegateHeartbeat(unittest.TestCase):
         time.sleep(0.15)
         self.assertEqual(len(touch_calls), count_after,
                          "Heartbeat continued firing after child error")
+
+    def test_timeout_override_hits_blocking_child_timeout_branch(self):
+        """A per-child timeout must reach Future.result(timeout=...) itself.
+
+        The forwarding tests above prove precedence. This regression proves the
+        applied value is the one that cuts off a blocked child and is reported
+        in the timeout result.
+        """
+        from tools.delegate_tool import _run_single_child
+
+        parent = _make_mock_parent()
+        released = threading.Event()
+        interrupted = threading.Event()
+
+        class BlockingChild:
+            tool_progress_callback = None
+            _credential_pool = None
+            _delegate_saved_tool_names = []
+            _delegate_role = "leaf"
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_estimated_cost_usd = 0.0
+            model = "test-model"
+
+            def run_conversation(self, **_kwargs):
+                released.wait(timeout=1.0)
+                return {
+                    "final_response": "late",
+                    "completed": True,
+                    "api_calls": 0,
+                    "messages": [],
+                }
+
+            def get_activity_summary(self):
+                return {
+                    "current_tool": None,
+                    "api_call_count": 0,
+                    "max_iterations": 50,
+                    "last_activity_desc": "blocked before first API call",
+                }
+
+            def interrupt(self):
+                interrupted.set()
+                released.set()
+
+        child = BlockingChild()
+
+        with patch(
+            "tools.delegate_tool._dump_subagent_timeout_diagnostic",
+            return_value="/tmp/subagent-timeout-test.log",
+        ):
+            started = time.monotonic()
+            result = _run_single_child(
+                task_index=0,
+                goal="Block until timeout",
+                child=child,
+                parent_agent=parent,
+                timeout_seconds=0.05,
+            )
+            elapsed = time.monotonic() - started
+
+        self.assertEqual(result["status"], "timeout")
+        self.assertEqual(result["exit_reason"], "timeout")
+        self.assertEqual(result["api_calls"], 0)
+        self.assertEqual(result["diagnostic_path"], "/tmp/subagent-timeout-test.log")
+        self.assertIn("0.05s", result["error"])
+        self.assertTrue(interrupted.wait(timeout=0.5))
+        self.assertLess(elapsed, 0.75)
 
     def test_heartbeat_includes_child_activity_desc_when_no_tool(self):
         """When child has no current_tool, heartbeat uses last_activity_desc."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -76,6 +76,10 @@ class TestDelegateRequirements(unittest.TestCase):
         # capability-selection surface the model should not control.
         self.assertNotIn("toolsets", props)
         self.assertNotIn("toolsets", props["tasks"]["items"]["properties"])
+        self.assertIn("timeout_seconds", props)
+        self.assertIn(
+            "timeout_seconds", props["tasks"]["items"]["properties"]
+        )
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -243,6 +247,25 @@ class TestDelegateTask(unittest.TestCase):
         mock_run.assert_called_once()
 
     @patch("tools.delegate_tool._run_single_child")
+    def test_single_task_timeout_override_forwarded(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done!",
+            "api_calls": 3,
+            "duration_seconds": 5.0,
+        }
+        parent = _make_mock_parent()
+
+        delegate_task(
+            goal="Fix tests",
+            timeout_seconds=1200,
+            parent_agent=parent,
+        )
+
+        self.assertEqual(mock_run.call_args.kwargs["timeout_seconds"], 1200.0)
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode(self, mock_run):
         mock_run.side_effect = [
             {"task_index": 0, "status": "completed", "summary": "Result A", "api_calls": 2, "duration_seconds": 3.0},
@@ -259,6 +282,70 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["summary"], "Result A")
         self.assertEqual(result["results"][1]["summary"], "Result B")
         self.assertIn("total_duration_seconds", result)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_per_task_timeout_overrides_top_level(self, mock_run):
+        mock_run.side_effect = [
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Result A",
+                "api_calls": 2,
+                "duration_seconds": 3.0,
+            },
+            {
+                "task_index": 1,
+                "status": "completed",
+                "summary": "Result B",
+                "api_calls": 4,
+                "duration_seconds": 6.0,
+            },
+        ]
+        parent = _make_mock_parent()
+        tasks = [
+            {"goal": "Research topic A"},
+            {"goal": "Build topic B", "timeout_seconds": 1800},
+        ]
+
+        delegate_task(tasks=tasks, timeout_seconds=600, parent_agent=parent)
+
+        by_index = {
+            call.kwargs["task_index"]: call.kwargs["timeout_seconds"]
+            for call in mock_run.call_args_list
+        }
+        self.assertEqual(by_index[0], 600.0)
+        self.assertEqual(by_index[1], 1800.0)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_invalid_timeout_override_rejected(self, mock_run):
+        parent = _make_mock_parent()
+
+        result = json.loads(
+            delegate_task(
+                goal="Fix tests",
+                timeout_seconds="later",
+                parent_agent=parent,
+            )
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("timeout_seconds must be a number", result["error"])
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_zero_timeout_override_disables_call_timeout(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done!",
+            "api_calls": 3,
+            "duration_seconds": 5.0,
+        }
+        parent = _make_mock_parent()
+
+        delegate_task(goal="Free local run", timeout_seconds=0, parent_agent=parent)
+
+        self.assertIsNone(mock_run.call_args.kwargs["timeout_seconds"])
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode_accepts_json_string_tasks(self, mock_run):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -465,6 +465,28 @@ def _get_child_timeout() -> Optional[float]:
     return DEFAULT_CHILD_TIMEOUT
 
 
+_CHILD_TIMEOUT_UNSET = object()
+
+
+def _parse_child_timeout_override(
+    value: Any, field_name: str = "timeout_seconds"
+) -> tuple[object, Optional[str]]:
+    """Parse a per-call child timeout override.
+
+    Returns ``_CHILD_TIMEOUT_UNSET`` when the caller omitted the override so the
+    global ``delegation.child_timeout_seconds`` value should still apply.
+    """
+    if value is _CHILD_TIMEOUT_UNSET:
+        return _CHILD_TIMEOUT_UNSET, None
+    if value is None or value == "":
+        return _CHILD_TIMEOUT_UNSET, None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return _CHILD_TIMEOUT_UNSET, f"{field_name} must be a number of seconds."
+    return (None if parsed <= 0 else max(30.0, parsed)), None
+
+
 def _get_max_spawn_depth() -> int:
     """Read delegation.max_spawn_depth from config, floored at 1 (no ceiling).
 
@@ -1749,6 +1771,7 @@ def _run_single_child(
     goal: str,
     child=None,
     parent_agent=None,
+    timeout_seconds: object = _CHILD_TIMEOUT_UNSET,
     **_kwargs,
 ) -> Dict[str, Any]:
     """
@@ -1927,7 +1950,11 @@ def _run_single_child(
         # Run child with an optional hard timeout (off by default —
         # result(timeout=None) blocks until the child finishes). Stuck-child
         # protection comes from the heartbeat staleness monitor instead.
-        child_timeout = _get_child_timeout()
+        child_timeout = (
+            _get_child_timeout()
+            if timeout_seconds is _CHILD_TIMEOUT_UNSET
+            else timeout_seconds
+        )
         # Daemon worker (tools.daemon_pool): a timed-out child is abandoned
         # below; a stdlib non-daemon worker would then block interpreter
         # exit at atexit-join time if the child never unwinds.
@@ -2385,6 +2412,7 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    timeout_seconds: Optional[float] = None,
     background: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
@@ -2459,6 +2487,12 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
+    top_timeout_override, timeout_error = _parse_child_timeout_override(
+        timeout_seconds, "timeout_seconds"
+    )
+    if timeout_error:
+        return tool_error(timeout_error)
+
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
     # bundle (base_url, api_key, api_mode) via the same runtime provider system
@@ -2504,6 +2538,18 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
+    task_timeout_overrides = []
+    for i, task in enumerate(task_list):
+        if "timeout_seconds" in task:
+            task_timeout_override, timeout_error = _parse_child_timeout_override(
+                task.get("timeout_seconds"), f"tasks[{i}].timeout_seconds"
+            )
+            if timeout_error:
+                return tool_error(timeout_error)
+        else:
+            task_timeout_override = top_timeout_override
+        task_timeout_overrides.append(task_timeout_override)
+
     overall_start = time.monotonic()
     results = []
 
@@ -2524,6 +2570,7 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            task_timeout_override = task_timeout_overrides[i]
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
@@ -2550,7 +2597,7 @@ def delegate_task(
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
-            children.append((i, t, child))
+            children.append((i, t, child, task_timeout_override))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
@@ -2567,8 +2614,14 @@ def delegate_task(
         """
         if n_tasks == 1:
             # Single task -- run directly (no thread pool overhead)
-            _i, _t, child = children[0]
-            result = _run_single_child(_i, _t["goal"], child, parent_agent)
+            _i, _t, child, child_timeout = children[0]
+            result = _run_single_child(
+                _i,
+                _t["goal"],
+                child,
+                parent_agent,
+                timeout_seconds=child_timeout,
+            )
             results.append(result)
         else:
             # Batch -- run in parallel with per-task progress lines
@@ -2581,13 +2634,14 @@ def delegate_task(
             from tools.daemon_pool import DaemonThreadPoolExecutor
             with DaemonThreadPoolExecutor(max_workers=max_children) as executor:
                 futures = {}
-                for i, t, child in children:
+                for i, t, child, child_timeout in children:
                     future = executor.submit(
                         _run_single_child,
                         task_index=i,
                         goal=t["goal"],
                         child=child,
                         parent_agent=parent_agent,
+                        timeout_seconds=child_timeout,
                     )
                     futures[future] = i
 
@@ -2598,7 +2652,7 @@ def delegate_task(
                 # when the parent is interrupted.
                 # Map task_index -> child agent, so fabricated entries for
                 # still-pending futures can carry the correct _delegate_role.
-                _child_by_index = {i: child for (i, _, child) in children}
+                _child_by_index = {i: child for (i, _, child, _) in children}
 
                 pending = set(futures.keys())
                 while pending:
@@ -2874,7 +2928,7 @@ def delegate_task(
             if _agent_session_id:
                 _session_key = _agent_session_id
         _parent_session_id = getattr(parent_agent, "session_id", None)
-        _child_agents = [c for (_, _, c) in children]
+        _child_agents = [c for (_, _, c, _) in children]
 
         # Detach every child from the parent's interrupt-propagation list — the
         # batch's lifecycle is owned by the async registry now, not the parent
@@ -3436,6 +3490,16 @@ DELEGATE_TASK_SCHEMA = {
                     "specific you are, the better the subagent performs."
                 ),
             },
+            "timeout_seconds": {
+                "type": "number",
+                "description": (
+                    "Optional per-call wall-clock cap for each child agent. "
+                    "Overrides delegation.child_timeout_seconds for this "
+                    "delegate_task call. Omit to use config; set 0 to disable "
+                    "the hard cap for this call. Positive values below 30 are "
+                    "floored to 30 seconds."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -3450,6 +3514,17 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
+                        },
+                        "timeout_seconds": {
+                            "type": "number",
+                            "description": (
+                                "Per-task wall-clock cap override for this "
+                                "child. Overrides the top-level "
+                                "timeout_seconds and "
+                                "delegation.child_timeout_seconds. Omit to "
+                                "inherit; set 0 to disable the hard cap for "
+                                "this child."
+                            ),
                         },
                     },
                     "required": ["goal"],
@@ -3535,6 +3610,7 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        timeout_seconds=args.get("timeout_seconds"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
     ),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3494,10 +3494,11 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "number",
                 "description": (
                     "Optional per-call wall-clock cap for each child agent. "
-                    "Overrides delegation.child_timeout_seconds for this "
-                    "delegate_task call. Omit to use config; set 0 to disable "
-                    "the hard cap for this call. Positive values below 30 are "
-                    "floored to 30 seconds."
+                    "Precedence is per-task timeout_seconds, then this "
+                    "top-level timeout_seconds, then "
+                    "delegation.child_timeout_seconds. Omit to use config; "
+                    "set 0 to disable the hard cap for this call. Positive "
+                    "values below 30 are floored to 30 seconds."
                 ),
             },
             "tasks": {
@@ -3523,7 +3524,8 @@ DELEGATE_TASK_SCHEMA = {
                                 "timeout_seconds and "
                                 "delegation.child_timeout_seconds. Omit to "
                                 "inherit; set 0 to disable the hard cap for "
-                                "this child."
+                                "this child. Positive values below 30 are "
+                                "floored to 30 seconds."
                             ),
                         },
                     },

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -191,6 +191,19 @@ delegation:
 
 A positive value enforces a hard wall-clock limit on each child; `0` or a negative value disables it.
 
+You can also set the cap on an individual `delegate_task` call with `timeout_seconds`, or on an individual task inside a batch. Precedence is **per-task `timeout_seconds` > top-level `timeout_seconds` > `delegation.child_timeout_seconds`**. Omit the field to inherit the next level. Set `timeout_seconds: 0` to disable the hard cap for that call or task, even when config has a positive cap. Positive values below 30 seconds are floored to 30 seconds.
+
+```python
+delegate_task(goal="Deep review", timeout_seconds=1800)
+delegate_task(
+    tasks=[
+        {"goal": "Quick lint", "timeout_seconds": 120},
+        {"goal": "Long research", "timeout_seconds": 0},
+    ],
+    timeout_seconds=600,
+)
+```
+
 :::tip Diagnostic dump on zero-call timeout
 With a hard cap configured, if a subagent times out having made **zero** API calls (usually: provider unreachable, auth failure, or tool-schema rejection), `delegate_task` writes a structured diagnostic to `~/.hermes/logs/subagent-timeout-<session>-<timestamp>.log` containing the subagent's config snapshot, credential-resolution trace, and any early error messages. Much easier to root-cause than the previous silent-timeout behavior.
 :::


### PR DESCRIPTION
## Summary
- add `timeout_seconds` to `delegate_task` top-level and per-task schema
- thread the effective override into single and batch child execution while preserving `delegation.child_timeout_seconds` fallback when omitted
- keep timeout diagnostics using the actual child timeout value that was applied

Fixes #54152.

## Tests
- `scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_async_delegation.py -q`
- `/Users/maxpetrusenko/.hermes/hermes-agent/venv/bin/python -m ruff check tools/delegate_tool.py run_agent.py tests/tools/test_delegate.py tests/tools/test_async_delegation.py`
- `scripts/run_tests.sh -q` (full suite completed: 36,754 passed, 24 failed across unrelated baseline/platform files; touched delegate tests passed in the full run)

Full-suite unrelated failures observed locally:
- `tests/agent/test_anthropic_adapter.py`
- `tests/gateway/test_background_command.py`
- `tests/gateway/test_gateway_shutdown.py`
- `tests/hermes_cli/test_gateway_wsl.py`
- `tests/hermes_cli/test_gateway_service.py`
- `tests/hermes_cli/test_service_manager.py`
- `tests/hermes_cli/test_signal_handler_kanban_worker.py`
- `tests/test_live_system_guard_self_test.py`
- `tests/test_tui_gateway_server.py`
- `tests/tools/test_file_tools.py`
- `tests/hermes_cli/test_doctor.py` timed out at 300s