### PR TITLE
fix(gateway): guard NoneType in Telegram reconnect after network error (#55992)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1781,6 +1781,18 @@ class TelegramAdapter(BasePlatformAdapter):
 
         await self._drain_polling_connections()
 
+        # Guard against self._app being torn down by the supervisor while
+        # we were sleeping during the reconnect delay.  The stop() call
+        # above is already guarded but start_polling() was not — accessing
+        # self._app.updater when self._app is None raises AttributeError
+        # and silently kills the reconnect loop.  (#55992)
+        if not self._app or not self._app.updater:
+            logger.warning(
+                "[%s] Telegram app destroyed during reconnect delay (attempt %d) — aborting",
+                self.name, attempt,
+            )
+            return
+
         try:
             await self._app.updater.start_polling(
                 allowed_updates=Update.ALL_TYPES,


### PR DESCRIPTION
## Problem

After sustained network errors, the Telegram adapter's `_handle_polling_network_error` reconnect handler sleeps with exponential backoff (5s–60s) before calling `start_polling()`. During that sleep window the supervisor may tear down the adapter — `disconnect()` sets `self._app = None` (line 3028).

The existing `stop()` call at line 1777 was already guarded:
```python
if self._app and self._app.updater and self._app.updater.running:
    await self._app.updater.stop()
```

But `start_polling()` at line 1785 was **not** guarded:
```python
await self._app.updater.start_polling(...)  # AttributeError if self._app is None
```

This crashes with `'NoneType' object has no attribute 'updater'`, silently killing the reconnect loop. The gateway process stays alive (state file says "running" + "connected") but never processes another Telegram message.

## Fix

Add a `None` guard for both `self._app` and `self._app.updater` before the `start_polling()` call, matching the pattern already used for `stop()`. If the app was destroyed during the reconnect delay, log a warning and abort cleanly.

## Reproduction

1. Gateway happily polling Telegram
2. Network hiccup — `httpx.ConnectError` multiple times
3. After 10 consecutive failures, adapter enters reconnect loop
4. During the backoff sleep, supervisor restarts the adapter (`self._app = None`)
5. Reconnect handler wakes up and crashes on `self._app.updater.start_polling()`
6. Gateway appears healthy (state file says "running") but is completely silent

## Testing

- `python3 -m py_compile plugins/platforms/telegram/adapter.py` — syntax OK
- Verified the guard pattern matches the existing `stop()` guard at line 1777

Fixes #55992