### PR TITLE
fix(desktop): add dark-mode text variant to auxiliary model warning

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -105,7 +105,7 @@ function StaleAuxWarning({ applying, onReset, slots, taskLabel }: StaleAuxWarnin
   const names = slots.map(slot => taskLabel(slot.task)).join(', ')
 
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-200">
       <AlertTriangle className="size-3.5 shrink-0" />
       <span className="grow">
         {slots.length} auxiliary task{slots.length === 1 ? '' : 's'} ({names}) still run on{' '}


### PR DESCRIPTION
The stale-aux-warning notice in the model settings panel (Nexus settings) used `text-amber-200` without a dark: variant, making it invisible on light backgrounds. Other warning elements in the app (PanelPill, badge, messaging status) already follow the `text-amber-600 dark:text-amber-300` pattern.

Reproduction:
1. Open Hermes desktop app
2. Go to Nexus → Model settings
3. If any auxiliary tasks are still running on the default model, the amber warning box appears with near-white text on a near-white background

Fix: `text-amber-200` → `text-amber-600 dark:text-amber-200`