### PR TITLE
fix(agent): add encoding="utf-8" to os.fdopen() calls for cross-platform safety

### DIFF
--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -117,7 +117,7 @@ def record_nous_rate_limit(
         # Atomic write: write to temp file + rename
         fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(state, f)
             atomic_replace(tmp_path, path)
         except Exception:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -642,7 +642,7 @@ def save_allowlist(data: Dict[str, Any]) -> None:
             prefix=f"{p.name}.", suffix=".tmp", dir=str(p.parent),
         )
         try:
-            with os.fdopen(fd, "w") as fh:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fh.write(json.dumps(data, indent=2, sort_keys=True))
             atomic_replace(tmp_path, p)
         except Exception:


### PR DESCRIPTION
## Problem

`os.fdopen(fd, "w")` without an explicit `encoding` parameter uses the platform default encoding. On Windows this is `cp1252` (or `mbcs`), which silently corrupts non-ASCII characters — emoji, CJK, accented characters — when written to JSON files. The corrupted data is then read back with `open(..., encoding="utf-8")`, producing garbled output or `UnicodeDecodeError`.

This is the same class of cross-platform corruption bug as the `write_text()` without encoding pattern (PR #54240).

## Affected locations

1. **`agent/nous_rate_guard.py:120`** — rate-limit state persistence via `json.dump(state, f)`. The state dict can contain model names, provider slugs, or error messages with non-ASCII characters.

2. **`agent/shell_hooks.py:645`** — shell hook metadata writes via `json.dumps(data, ...)`. The data dict can contain user-provided hook names, command outputs, or environment variable values with Unicode.

## Fix

Add `encoding="utf-8"` to both `os.fdopen()` calls, matching the pattern already used in `hermes_cli/config.py` (which passes `**write_kw` with `encoding="utf-8"`).

## Testing

- `python3 -m py_compile agent/nous_rate_guard.py` — OK
- `python3 -m py_compile agent/shell_hooks.py` — OK
- Both changes are single-line `os.fdopen(fd, "w")` → `os.fdopen(fd, "w", encoding="utf-8")`