### PR TITLE
fix(security): add URL safety check to image_ref fetch in openai image_gen (SSRF)

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -132,6 +132,12 @@ def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
     ref = ref.strip()
     lower = ref.lower()
     if lower.startswith(("http://", "https://")):
+        from tools.url_safety import is_safe_url
+
+        if not is_safe_url(ref):
+            raise ValueError(
+                f"Refusing to fetch image from unsafe URL: {ref}"
+            )
         import requests
 
         resp = requests.get(ref, timeout=60)


### PR DESCRIPTION
## Problem (P1 Security — SSRF)

The `_load_image_bytes()` function in `plugins/image_gen/openai/__init__.py` fetches arbitrary URLs passed via the `ref` parameter from model tool calls **without any URL safety validation**:

```python
resp = requests.get(ref, timeout=60)  # ref is model-supplied, no validation
```

A model-supplied URL can point to:
- **Cloud metadata endpoints** (`http://169.254.169.254/latest/meta-data/...`) — leaks AWS/GCP/Azure credentials
- **Internal network addresses** (`http://10.0.0.1:8080/admin`) — scans/exfiltrates internal services
- **Localhost services** (`http://127.0.0.1:6379/`) — accesses Redis, databases, etc.

This is a **server-side request forgery (SSRF)** vulnerability through the gateway process.

## Fix

Add `is_safe_url()` check from `tools.url_safety` before fetching, matching the pattern already used in:
- `tools/vision_tools.py:212` — image URL validation
- `tools/web_tools.py:100` — web search URL validation
- `tools/skills_hub.py:40` — skill URL validation
- `plugins/platforms/slack/adapter.py:1646` — Slack attachment validation
- `plugins/platforms/mattermost/adapter.py:500` — Mattermost attachment validation

## Scope

Only the openai image_gen plugin fetches user-supplied URLs via `ref`. Other image_gen plugins (krea, xai, openrouter) only call their respective API endpoints with server-controlled URLs — no SSRF risk.

## Testing

- `python3 -m py_compile plugins/image_gen/openai/__init__.py` — OK
- The `is_safe_url` function blocks private IPs (10.x, 172.16-31.x, 192.168.x), link-local (169.254.x), localhost, and metadata endpoints

Ref: #54553 (previous SSRF fix attempt, not merged)