### PR TITLE
fix(telegram): close reconnect races that leave adapter half-destroyed

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3644,6 +3644,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         If the error is retryable (e.g. network blip, DNS failure), queue the
         platform for background reconnection instead of giving up permanently.
         """
+        # Snapshot the current owner of this platform slot before doing
+        # anything else. If it's neither this adapter nor empty, a different
+        # adapter has already taken over (e.g. this is a delayed notification
+        # from a background retry chain that raced with, and lost to, a
+        # reconnect that already succeeded). Acting on a stale notification
+        # would overwrite an already-healthy platform's runtime status and
+        # incorrectly re-queue it for reconnection, so bail out before any of
+        # that happens.
+        existing = self.adapters.get(adapter.platform)
+        if existing is not None and existing is not adapter:
+            logger.debug(
+                "Ignoring stale fatal error from a superseded %s adapter instance: %s",
+                adapter.platform.value,
+                adapter.fatal_error_code or "unknown",
+            )
+            return
+
         logger.error(
             "Fatal %s adapter error (%s): %s",
             adapter.platform.value,
@@ -3667,7 +3684,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             error_message=adapter.fatal_error_message,
         )
 
-        existing = self.adapters.get(adapter.platform)
         if existing is adapter:
             # Claim this adapter for teardown before awaiting disconnect() —
             # a second fatal-error notification for the same adapter (e.g.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3669,11 +3669,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         existing = self.adapters.get(adapter.platform)
         if existing is adapter:
-            try:
-                await adapter.disconnect()
-            finally:
-                self.adapters.pop(adapter.platform, None)
-                self.delivery_router.adapters = self.adapters
+            # Claim this adapter for teardown before awaiting disconnect() —
+            # a second fatal-error notification for the same adapter (e.g.
+            # from a concurrent recovery path) would otherwise still see
+            # itself as "existing" during the await below and disconnect()
+            # the same object twice.
+            self.adapters.pop(adapter.platform, None)
+            self.delivery_router.adapters = self.adapters
+            await adapter.disconnect()
 
         # Queue retryable failures for background reconnection
         if adapter.fatal_error_retryable:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1751,16 +1751,24 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         await asyncio.sleep(delay)
 
+        # Capture a stable local reference: self._app can be reassigned to None
+        # by a concurrent disconnect() while we're suspended across the awaits
+        # below, and re-reading self._app after that point would silently swap
+        # in None mid-sequence instead of failing fast in one place.
+        app = self._app
+
         try:
-            if self._app and self._app.updater and self._app.updater.running:
-                await self._app.updater.stop()
+            if app and app.updater and app.updater.running:
+                await app.updater.stop()
         except Exception:
             pass
 
         await self._drain_polling_connections()
 
         try:
-            await self._app.updater.start_polling(
+            if not app:
+                raise RuntimeError("Telegram application was torn down during reconnect")
+            await app.updater.start_polling(
                 allowed_updates=Update.ALL_TYPES,
                 drop_pending_updates=False,
                 error_callback=self._polling_error_callback_ref,
@@ -1802,6 +1810,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
+                # This chained retry IS the in-flight recovery attempt — it
+                # must replace the reentrancy guard, otherwise the heartbeat
+                # loop, the pending-updates probe, and the PTB error callback
+                # all see _polling_error_task as "done" and can each start a
+                # second, concurrent recovery for the same outage.
+                self._polling_error_task = task
 
     async def _polling_heartbeat_loop(self) -> None:
         """Detect dead Telegram TCP sockets (CLOSE-WAIT) by periodic probing.

--- a/tests/gateway/test_runner_fatal_adapter.py
+++ b/tests/gateway/test_runner_fatal_adapter.py
@@ -153,3 +153,42 @@ async def test_concurrent_fatal_notifications_disconnect_same_adapter_once(monke
     )
 
     assert disconnect_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_fatal_notification_from_superseded_adapter_is_ignored(monkeypatch, tmp_path):
+    """
+    A delayed fatal-error notification from an adapter instance that has
+    since been replaced by a different, already-installed adapter (e.g. a
+    background retry chain on the old instance finally giving up after a
+    reconnect on a new instance already succeeded) must be ignored: it must
+    not disconnect the new adapter, must not re-queue an already-healthy
+    platform for reconnection, and must not shut the gateway down.
+    """
+    config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(enabled=True, token="token")
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    old_adapter = _RuntimeRetryableAdapter()
+    old_adapter._set_fatal_error(
+        "whatsapp_bridge_exited",
+        "stale failure from a superseded adapter instance",
+        retryable=True,
+    )
+
+    new_adapter = _RuntimeRetryableAdapter()
+    new_adapter.disconnect = AsyncMock()
+    runner.adapters = {Platform.WHATSAPP: new_adapter}
+    runner.delivery_router.adapters = runner.adapters
+    runner.stop = AsyncMock()
+
+    await runner._handle_adapter_fatal_error(old_adapter)
+
+    new_adapter.disconnect.assert_not_awaited()
+    assert runner.adapters[Platform.WHATSAPP] is new_adapter
+    assert Platform.WHATSAPP not in runner._failed_platforms
+    runner.stop.assert_not_awaited()

--- a/tests/gateway/test_runner_fatal_adapter.py
+++ b/tests/gateway/test_runner_fatal_adapter.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -98,3 +99,57 @@ async def test_runner_queues_retryable_runtime_fatal_for_reconnection(monkeypatc
     assert runner._exit_with_failure is False
     assert Platform.WHATSAPP in runner._failed_platforms
     assert runner._failed_platforms[Platform.WHATSAPP]["attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_fatal_notifications_disconnect_same_adapter_once(monkeypatch, tmp_path):
+    """
+    Two fatal-error notifications for the same still-installed adapter (e.g.
+    from two concurrent recovery paths racing on the same underlying outage)
+    must result in exactly one disconnect() call.
+
+    Regression test for the TOCTOU race in _handle_adapter_fatal_error: the
+    old code only removed the adapter from self.adapters in a `finally` block
+    *after* awaiting disconnect(), so a second concurrent call could still see
+    itself as "existing" and disconnect() the same object twice — the
+    concrete origin of the "'NoneType' object has no attribute 'updater'"
+    crash when the adapter's own teardown code re-reads self._app afterwards.
+    """
+    config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(enabled=True, token="token")
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    adapter = _RuntimeRetryableAdapter()
+    adapter._set_fatal_error(
+        "whatsapp_bridge_exited",
+        "WhatsApp bridge process exited unexpectedly (code 1).",
+        retryable=True,
+    )
+
+    runner.adapters = {Platform.WHATSAPP: adapter}
+    runner.delivery_router.adapters = runner.adapters
+    runner.stop = AsyncMock()
+
+    disconnect_calls = 0
+    release_second_call = asyncio.Event()
+
+    async def slow_disconnect():
+        nonlocal disconnect_calls
+        disconnect_calls += 1
+        # Yield control so the second concurrent notification can run its
+        # "existing is adapter" check before this call finishes tearing down.
+        release_second_call.set()
+        await asyncio.sleep(0)
+        adapter._mark_disconnected()
+
+    monkeypatch.setattr(adapter, "disconnect", slow_disconnect)
+
+    await asyncio.gather(
+        runner._handle_adapter_fatal_error(adapter),
+        runner._handle_adapter_fatal_error(adapter),
+    )
+
+    assert disconnect_calls == 1

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -118,6 +118,43 @@ async def test_reconnect_does_not_self_schedule_when_fatal_error_set():
 
 
 @pytest.mark.asyncio
+async def test_reconnect_chained_retry_updates_polling_error_task():
+    """
+    When start_polling() fails and the handler self-schedules a retry, that
+    retry task must become the new `_polling_error_task` — otherwise the
+    reentrancy guard used by the heartbeat loop, the pending-updates probe,
+    and the PTB error callback goes stale while a recovery is still in
+    flight, letting a second concurrent recovery start for the same outage.
+
+    Regression test for the race behind the "half-destroyed adapter" bug
+    (gateway reports connected but silently stops processing messages).
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 1
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock(side_effect=Exception("Timed out"))
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(Exception("Bad Gateway"))
+
+    assert adapter._polling_error_task is not None
+    assert not adapter._polling_error_task.done()
+
+    adapter._polling_error_task.cancel()
+    try:
+        await adapter._polling_error_task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+@pytest.mark.asyncio
 async def test_reconnect_success_resets_error_count():
     """
     When start_polling() succeeds, _polling_network_error_count should reset to 0.


### PR DESCRIPTION
Fixes #55992

## Summary

After a network blip, the Telegram adapter self-restarts, logs `✓ telegram connected`, and then the gateway silently stops processing any further messages — while `gateway_state.json` keeps reporting `connected`/`running` and the process itself stays alive (or, on Windows, dies with a non-standard exit code). This PR fixes the root cause: a pair of concurrency bugs that let more than one recovery attempt run against the same Telegram adapter instance at once.

## Root cause

Three issues combine to produce the symptom:

**1. Stale reentrancy guard (`plugins/platforms/telegram/adapter.py`, `_handle_polling_network_error`)**

When `start_polling()` fails during a reconnect attempt, the handler self-schedules a follow-up retry via `asyncio.ensure_future(...)`, but that task was only tracked in `self._background_tasks` — it was never assigned to `self._polling_error_task`. That field is the *only* reentrancy guard checked by three independent trigger points: the PTB `error_callback`, `_polling_heartbeat_loop` (runs every 90s), and `_probe_pending_updates`. With the guard going stale while a retry was still in flight, any of those three could start a second, fully independent recovery attempt for the same underlying outage, sharing the same `self._app` with no synchronization.

**2. TOCTOU window in the fatal-error handler (`gateway/run.py`, `_handle_adapter_fatal_error`)**

```python
existing = self.adapters.get(adapter.platform)
if existing is adapter:
    try:
        await adapter.disconnect()
    finally:
        self.adapters.pop(adapter.platform, None)
```

The adapter was only removed from `self.adapters` in the `finally` block, *after* awaiting `disconnect()`. If issue #1 above caused a second concurrent fatal-error notification for the same adapter object, that second call would still see `existing is adapter == True` (because the first call hadn't reached its `finally` yet) and would call `disconnect()` a second time on the same object.

That double `disconnect()` is the concrete origin of the `'NoneType' object has no attribute 'updater'` exception reported in the issue: the first `disconnect()` call sets `self._app = None` at the end of its teardown, and the second concurrent call — already past its own `if self._app and self._app.updater...` check — re-reads `self._app` a few lines later and finds `None`.

Net effect: two live PTB `Application`/`Updater` objects (or one live + one half-torn-down) can end up racing for the same bot token's `getUpdates` long-poll. The `Updater` that loses that race sits in a healthy-looking `running=True` state, receiving empty long-poll responses forever, with no exception ever raised — which is why the log goes completely silent and `gateway_state.json` never updates again (it's written once, on the `connect()` that "won"). This also explains why the failure is intermittent rather than deterministic: it depends on the exact interleaving of the heartbeat loop, the pending-updates probe, and the network-error callback around the same outage.

**3. Stale notifications outliving their adapter (`gateway/run.py`, `_handle_adapter_fatal_error`)**

Even after closing #1 and #2, a delayed fatal-error notification can still arrive from an adapter instance that has *already been replaced* — e.g. its own background retry chain (started before the reconnect watcher successfully installed a fresh adapter) finally exhausts its retries and reports failure after the fact. The handler processed that notification unconditionally: it overwrote the platform's runtime status back to `retrying`/`fatal` even though a different, healthy adapter was already running, and could re-queue an already-connected platform into `_failed_platforms` for reconnection it didn't need.

## Fix

Three small, localized changes — no architectural changes, no behavior change to the retry/backoff strategy itself:

1. **`plugins/platforms/telegram/adapter.py`** — the chained retry task created in `_handle_polling_network_error`'s `except` block is now assigned to `self._polling_error_task`, so the shared reentrancy guard correctly reflects that a recovery is still in flight. Also captures `self._app` in a local variable at the top of the stop/start_polling sequence and reuses that reference across both `await` points, instead of re-reading `self._app` (which a concurrent `disconnect()` could have already cleared).
2. **`gateway/run.py`** — `_handle_adapter_fatal_error` now pops the adapter out of `self.adapters` (and updates `delivery_router.adapters`) *before* awaiting `disconnect()`, not after. A second concurrent notification for the same adapter now correctly sees it's already been claimed and skips the redundant `disconnect()` call.
3. **`gateway/run.py`** — `_handle_adapter_fatal_error` now snapshots the current owner of the platform slot as its very first step, before any log line or status write. If that owner is neither `None` nor the adapter reporting the error, the notification is stale (a different adapter already owns the slot) and the handler returns immediately, before touching runtime status or the reconnect queue.

## Steps to reproduce (from the issue)

1. Gateway is happily polling Telegram.
2. Network hiccup — `httpx.ConnectError` fires a few times in a row.
3. After 10 consecutive failures, the adapter logs `Fatal telegram adapter error → Restarting gateway`.
4. Reconnect happens, log says `✓ telegram connected`.
5. Gateway never processes another message. Log goes completely dead, but the process is still alive, still responds to SIGTERM, and `gateway_state.json` still says `running`/`connected`. On Docker this has been observed to last 6h9m+ of total silence; on Windows the process exits instead (non-standard exit code) with the state file stuck at `starting`.

This is a timing-dependent race, so it isn't reliably reproducible with a fixed manual recipe — the two regression tests below reproduce the exact interleavings that trigger it.

## Testing

Added three regression tests that fail against the pre-fix code and pass against this change:

- `tests/gateway/test_telegram_network_reconnect.py::test_reconnect_chained_retry_updates_polling_error_task` — asserts that after a failed `start_polling()` retry, `adapter._polling_error_task` points at the newly scheduled task (not stale/done), closing the reentrancy-guard gap described in root cause #1.
- `tests/gateway/test_runner_fatal_adapter.py::test_concurrent_fatal_notifications_disconnect_same_adapter_once` — drives two concurrent `_handle_adapter_fatal_error(adapter)` calls for the same adapter object (via `asyncio.gather`, with a mocked `disconnect()` that yields control mid-teardown) and asserts `disconnect()` is called exactly once. Without the fix, this test observes 2 calls.
- `tests/gateway/test_runner_fatal_adapter.py::test_stale_fatal_notification_from_superseded_adapter_is_ignored` — installs a healthy adapter, then feeds a fatal-error notification from a *different*, superseded adapter instance for the same platform, and asserts the healthy adapter is left untouched (`disconnect()` never called on it), the platform is not re-queued into `_failed_platforms`, and the gateway doesn't shut down. Without the fix, the stale notification is processed as if it came from the live adapter.

Ran:
```
pytest tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_runner_fatal_adapter.py \
       tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_pending_update_probe.py \
       tests/gateway/test_platform_reconnect.py -v
```
All 81 tests pass, including the 3 new regression tests. Also ran the full `tests/gateway/` suite; the only failures present are pre-existing and unrelated to this change (confirmed via `git stash` — they reproduce identically on `main`, e.g. Windows-vs-Unix path assumptions in `test_status.py`).

## Out of scope

- `gateway/status.py`'s one-shot (event-driven, not periodic) `connected` state write is a separate, larger design question (should there be a periodic "still healthy" re-validation?) and is intentionally not addressed here to keep this fix minimal and low-risk.
- `_handle_polling_conflict` (the 409-conflict retry ladder) has a structurally similar pattern to the network-error ladder and may warrant the same local-`self._app`-capture treatment, but wasn't implicated in the reported symptom and is left for a follow-up if confirmed necessary.
