### PR TITLE
fix(weixin): clear stale sync_buf after platform lock contention recovery

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1158,6 +1158,7 @@ class WeixinAdapter(BasePlatformAdapter):
         self._send_session: Optional[aiohttp.ClientSession] = None
         self._poll_task: Optional[asyncio.Task] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
+        self._lock_contention_detected = False
 
         self._account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
         self._token = str(config.token or extra.get("token") or os.getenv("WEIXIN_TOKEN", "")).strip()
@@ -1280,6 +1281,7 @@ class WeixinAdapter(BasePlatformAdapter):
 
         try:
             if not self._acquire_platform_lock('weixin-bot-token', self._token, 'Weixin bot token'):
+                self._lock_contention_detected = True
                 return False
         except Exception as exc:
             logger.debug("[%s] Token lock unavailable (non-fatal): %s", self.name, exc)
@@ -1292,7 +1294,9 @@ class WeixinAdapter(BasePlatformAdapter):
         _no_aiohttp_timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)
         self._send_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector(), timeout=_no_aiohttp_timeout)
         self._token_store.restore(self._account_id)
-        self._poll_task = asyncio.create_task(self._poll_loop(), name="weixin-poll")
+        clear_sync_buf = self._lock_contention_detected
+        self._lock_contention_detected = False
+        self._poll_task = asyncio.create_task(self._poll_loop(clear_sync_buf=clear_sync_buf), name="weixin-poll")
         self._mark_connected()
         _LIVE_ADAPTERS[self._token] = self
         logger.info("[%s] Connected account=%s base=%s", self.name, _safe_id(self._account_id), self._base_url)
@@ -1334,9 +1338,14 @@ class WeixinAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[%s] Disconnected", self.name)
 
-    async def _poll_loop(self) -> None:
+    async def _poll_loop(self, *, clear_sync_buf: bool = False) -> None:
         assert self._poll_session is not None
-        sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
+        if clear_sync_buf:
+            _save_sync_buf(self._hermes_home, self._account_id, "")
+            sync_buf = ""
+            logger.info("[%s] Cleared stale sync_buf after lock contention recovery", self.name)
+        else:
+            sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
         timeout_ms = LONG_POLL_TIMEOUT_MS
         consecutive_failures = 0
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1205,3 +1205,84 @@ class TestWeixinApiTimeout:
             )
         )
         assert result == {"ret": 0, "msgs": [], "get_updates_buf": "buf-123"}
+
+
+class TestWeixinLockContentionSyncBuf:
+    """Regression: stale sync_buf must be cleared after lock contention recovery."""
+
+    def test_lock_contention_flag_set_on_acquire_failure(self):
+        """When platform lock fails, _lock_contention_detected is set."""
+        adapter = _make_adapter()
+        assert adapter._lock_contention_detected is False
+
+        # Simulate lock failure
+        adapter._acquire_platform_lock = lambda *a, **k: False
+        result = asyncio.run(adapter.connect())
+        assert result is False
+        assert adapter._lock_contention_detected is True
+
+    def test_poll_loop_clears_sync_buf_on_contention_flag(self, tmp_path):
+        """_poll_loop with clear_sync_buf=True clears the persisted file."""
+        adapter = _make_adapter()
+        adapter._hermes_home = str(tmp_path)
+
+        # Pre-populate sync_buf file
+        weixin._save_sync_buf(str(tmp_path), "test-account", "stale-buf-value")
+        assert weixin._load_sync_buf(str(tmp_path), "test-account") == "stale-buf-value"
+
+        # Set up a minimal poll_session mock so _poll_loop can start
+        mock_session = Mock()
+        mock_session.closed = False
+
+        # _poll_loop will call _get_updates which we mock to cancel immediately
+        async def _fake_get_updates(*a, **kw):
+            raise asyncio.CancelledError()
+
+        adapter._poll_session = mock_session
+        adapter._running = True
+
+        loop = asyncio.new_event_loop()
+        try:
+            with patch("gateway.platforms.weixin._get_updates", side_effect=_fake_get_updates):
+                loop.run_until_complete(adapter._poll_loop(clear_sync_buf=True))
+        except asyncio.CancelledError:
+            pass
+        finally:
+            loop.close()
+
+        # Verify sync_buf file was cleared
+        saved = weixin._load_sync_buf(str(tmp_path), "test-account")
+        assert saved == "", f"sync_buf should be empty after contention recovery, got: {saved!r}"
+
+    def test_poll_loop_preserves_sync_buf_without_contention(self, tmp_path):
+        """_poll_loop without clear_sync_buf loads existing sync_buf."""
+        adapter = _make_adapter()
+        adapter._hermes_home = str(tmp_path)
+
+        # Pre-populate sync_buf
+        weixin._save_sync_buf(str(tmp_path), "test-account", "valid-cursor")
+
+        mock_session = Mock()
+        mock_session.closed = False
+
+        captured_sync_buf = {}
+
+        async def _fake_get_updates(*a, **kw):
+            captured_sync_buf["value"] = kw.get("sync_buf") or a[3] if len(a) > 3 else kw.get("sync_buf")
+            raise asyncio.CancelledError()
+
+        adapter._poll_session = mock_session
+        adapter._running = True
+
+        loop = asyncio.new_event_loop()
+        try:
+            with patch("gateway.platforms.weixin._get_updates", side_effect=_fake_get_updates):
+                loop.run_until_complete(adapter._poll_loop(clear_sync_buf=False))
+        except asyncio.CancelledError:
+            pass
+        finally:
+            loop.close()
+
+        # sync_buf should still be the original value
+        saved = weixin._load_sync_buf(str(tmp_path), "test-account")
+        assert saved == "valid-cursor", f"sync_buf should be preserved, got: {saved!r}"


### PR DESCRIPTION
## What does this PR do?

Clears the persisted `sync_buf` cursor when the Weixin adapter recovers from a platform lock contention (e.g., after `docker compose up -d` without `down`). This prevents the iLink server from re-delivering old messages from previous sessions when it invalidates the stale cursor.

## Related Issue

Fixes #56026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py`: Added `_lock_contention_detected` flag to track when the platform lock was held by another process. When the lock is eventually acquired after contention, `_poll_loop` clears the persisted `sync_buf` file so the iLink server returns only new messages instead of replaying the entire message backlog.
- `tests/gateway/test_weixin.py`: Added 3 regression tests verifying the flag is set on lock failure, the sync_buf file is cleared after contention recovery, and normal connects preserve the existing sync_buf.

## How to Test

1. Run `pytest tests/gateway/test_weixin.py::TestWeixinLockContentionSyncBuf -xvs` — all 3 tests should pass.
2. Run `pytest tests/gateway/test_weixin.py -q` — all 72 tests should pass with no regressions.
3. The fix is automatically exercised on any container restart where the old gateway holds the platform lock during the overlap period.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
