### PR TITLE
fix: redact secrets in streaming path split-message chunks

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -471,7 +471,11 @@ def _mask_token(token: str) -> str:
     return mask_secret(token, head=6, tail=4, floor=18)
 
 
-def _redact_query_string(query: str) -> str:
+def _redact_query_string(
+    query: str,
+    *,
+    sensitive_keys: "frozenset[str] | set[str] | None" = None,
+) -> str:
     """Redact sensitive parameter values in a URL query string.
 
     Handles `k=v&k=v` format. Sensitive keys (case-insensitive) have values
@@ -480,13 +484,14 @@ def _redact_query_string(query: str) -> str:
     """
     if not query:
         return query
+    keys = _SENSITIVE_QUERY_PARAMS if sensitive_keys is None else sensitive_keys
     parts = []
     for pair in query.split("&"):
         if "=" not in pair:
             parts.append(pair)
             continue
         key, _, value = pair.partition("=")
-        if key.lower() in _SENSITIVE_QUERY_PARAMS:
+        if key.lower() in keys:
             parts.append(f"{key}=***")
         else:
             parts.append(pair)
@@ -603,7 +608,7 @@ def _redact_form_body(text: str) -> str:
     # The body-body form check is strict: only trigger on clean k=v&k=v.
     if not _FORM_BODY_RE.match(text.strip()):
         return text
-    return _redact_query_string(text.strip())
+    return _redact_query_string(text.strip(), sensitive_keys=_SENSITIVE_BODY_KEYS)
 
 
 def _mask_token_nonreusable(token: str) -> str:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -51,13 +51,11 @@ _TOOL_TRACE_RE = re.compile(
 # tail (``self._accumulated``) until either a delimiting character or
 # end-of-stream (got_done) proves it cannot grow into a credential.
 #
-# The seed list is derived from the same ``_PREFIX_SUBSTRINGS`` the redactor
-# itself uses, plus every proper prefix of those substrings ("sk-", "sk", "s"
-# would over-match — we deliberately start from real credential starts like
-# "sk-", "ghp_", "gAAAA", … and also keep their partial tails like "sk" only
-# when not already prefixed by a digit-or-letter continuation).  This keeps
-# the behavior crisp: " chairs" never triggers holdback; " ch AirSk" doesn't
-# either; " sk-" does.
+# The vendor seed list is derived from the same ``_PREFIX_SUBSTRINGS`` the
+# redactor itself uses, plus proper prefixes that could still grow into those
+# tokens.  Structural detector classes are handled by the companion patterns
+# below; all of them intentionally prefer a short delivery delay over sealing
+# a fragment that a later delta can turn into a secret.
 
 def _build_streaming_credential_prefix_tail_re() -> "re.Pattern[str]":
     """Compile a regex matching a trailing credential-prefix candidate.
@@ -114,7 +112,282 @@ def _build_streaming_credential_prefix_tail_re() -> "re.Pattern[str]":
 _CREDENTIAL_PREFIX_TAIL_RE = _build_streaming_credential_prefix_tail_re()
 
 
-def _hold_back_credential_prefix_tail(text: str, *, finalize: bool = False) -> "tuple[str, str]":
+# The prefix matcher above covers vendor-shaped tokens.  The authoritative
+# redactor also recognizes credentials whose beginning is structural rather
+# than vendor-specific (for example ``MY_API_KEY=...``, JSON fields,
+# authorization headers, JWTs, private-key blocks, and connection URLs).  A
+# stream can be split before those forms are complete, so keep a trailing
+# candidate mutable as well.  These patterns deliberately err on the side of
+# retaining a little extra text: delaying an edit is safe; sealing a fragment
+# that a later delta can turn into a secret is not.
+def _streaming_literal_prefixes(
+    values: tuple[str, ...], *, min_length: int = 1
+) -> tuple[str, ...]:
+    """Return distinct literal prefixes in longest-first order."""
+    prefixes: set[str] = set()
+    for value in values:
+        for index in range(min_length, len(value) + 1):
+            prefixes.add(value[:index])
+    ordered = list(prefixes)
+    ordered.sort(key=len, reverse=True)
+    return tuple(ordered)
+
+
+_STREAMING_SECRET_KEY_FORMS: tuple[str, ...] = (
+    "API_KEY",
+    "APIKEY",
+    "API.KEY",
+    "API-KEY",
+    "API KEY",
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "PASSWD",
+    "CREDENTIAL",
+    "AUTH",
+)
+_STREAMING_SECRET_KEY_PARTS = _streaming_literal_prefixes(
+    _STREAMING_SECRET_KEY_FORMS, min_length=2
+)
+_STREAMING_SECRET_KEY_PART_ALT = "|".join(
+    re.escape(part) for part in _STREAMING_SECRET_KEY_PARTS
+)
+_STREAMING_SECRET_KEY_PART_ALT_LOWER = "|".join(
+    re.escape(part.lower()) for part in _STREAMING_SECRET_KEY_PARTS if len(part) >= 2
+)
+_STREAMING_SECRET_KEY_FULL_RE = (
+    r"(?:API[ _.\-]?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
+)
+_STREAMING_ASSIGNMENT_SUFFIX = r"(?:[ \t]*(?:=|:)[ \t]*[^\s&]*)?"
+_STREAMING_COMPLETE_ASSIGNMENT_SUFFIX = r"[ \t]*(?:=|:)[ \t]*[^\s&]*"
+
+# Upper-case env assignments use the same key alphabet and 50-character
+# affix limits as agent.redact._ENV_ASSIGN_RE.  The lookbehind intentionally
+# excludes only upper-case token-continuation characters: that lets this
+# match ``...MY_API_KEY`` at the point where the authoritative regex would
+# begin a match, even when ordinary lower-case prose precedes it.
+_STREAMING_UPPER_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?<![A-Z0-9_])(?P<tail>[A-Z0-9_]{0,50}"
+    + _STREAMING_SECRET_KEY_FULL_RE
+    + r"[A-Z0-9_]{0,50}"
+    + _STREAMING_COMPLETE_ASSIGNMENT_SUFFIX
+    + r")\Z"
+)
+_STREAMING_UPPER_SECRET_KEY_TAIL_RE = re.compile(
+    r"(?<![A-Z0-9_])(?P<tail>[A-Z0-9_]*(?:"
+    + _STREAMING_SECRET_KEY_PART_ALT
+    + r")[A-Z0-9_]*"
+    + _STREAMING_ASSIGNMENT_SUFFIX
+    + r")\Z"
+)
+
+# Lower-case/dotted config forms are line-anchored or namespaced in the
+# authoritative redactor.  Keeping the complete forms separate lets them
+# remain protected even when a long value grows beyond the bounded partial
+# context used below.
+_STREAMING_LOWER_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?m)^[ \t]*(?:export[ \t]+)?(?P<tail>[a-z0-9_.-]*"
+    + _STREAMING_SECRET_KEY_FULL_RE.lower()
+    + r"[a-z0-9_.-]*"
+    + _STREAMING_COMPLETE_ASSIGNMENT_SUFFIX
+    + r")\Z"
+)
+_STREAMING_DOTTED_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])(?P<tail>[A-Za-z0-9_-]+"
+    r"(?:\.[A-Za-z0-9_-]+)*\.[A-Za-z0-9_.-]*"
+    + _STREAMING_SECRET_KEY_FULL_RE
+    + r"[A-Za-z0-9_.-]*"
+    + _STREAMING_COMPLETE_ASSIGNMENT_SUFFIX
+    + r")\Z",
+    re.IGNORECASE,
+)
+
+# Partial config keys are only inspected in a bounded suffix.  This prevents
+# an ordinary long prose line that happens to end in a short keyword prefix
+# from making the whole response immutable, while complete assignments above
+# continue to protect arbitrarily long secret values.
+_STREAMING_CONFIG_CONTEXT_WINDOW = 256
+_STREAMING_CONFIG_KEY_PARTIAL_RE = re.compile(
+    r"(?m)^[ \t]*(?:export[ \t]+)?(?P<tail>[A-Za-z0-9_.-]*"
+    + r"(?:"
+    + _STREAMING_SECRET_KEY_PART_ALT_LOWER
+    + r")[A-Za-z0-9_.-]*"
+    + _STREAMING_ASSIGNMENT_SUFFIX
+    + r")\Z",
+    re.IGNORECASE,
+)
+_STREAMING_DOTTED_CONFIG_KEY_PARTIAL_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])(?P<tail>[A-Za-z0-9_-]+"
+    r"(?:\.[A-Za-z0-9_-]+)*\.[A-Za-z0-9_.-]*"
+    + r"(?:"
+    + _STREAMING_SECRET_KEY_PART_ALT_LOWER
+    + r")[A-Za-z0-9_.-]*"
+    + _STREAMING_ASSIGNMENT_SUFFIX
+    + r")\Z",
+    re.IGNORECASE,
+)
+
+
+def _build_streaming_sensitive_form_key_tail_re() -> "re.Pattern[str]":
+    """Compile delimiter-aware tails from the authoritative form/query keys."""
+    try:
+        from agent.redact import _SENSITIVE_BODY_KEYS, _SENSITIVE_QUERY_PARAMS
+
+        sensitive_keys: set[str] = set()
+        for raw_key in (*_SENSITIVE_BODY_KEYS, *_SENSITIVE_QUERY_PARAMS):
+            if isinstance(raw_key, str) and raw_key:
+                sensitive_keys.add(raw_key.casefold())
+    except Exception:
+        # Keep the existing structural vocabulary as a last-resort fallback if
+        # the redactor module cannot be imported during partial installation.
+        sensitive_keys = {key.casefold() for key in _STREAMING_SECRET_KEY_FORMS}
+
+    prefixes: set[str] = set()
+    for key in sensitive_keys:
+        prefixes.update(key[:index] for index in range(1, len(key) + 1))
+    delimiter_prefixes: list[str] = list(prefixes)
+    delimiter_prefixes.sort(key=len, reverse=True)
+    delimiter_alternation = "|".join(re.escape(prefix) for prefix in delimiter_prefixes)
+    start_prefixes: list[str] = [prefix for prefix in prefixes if len(prefix) >= 2]
+    start_prefixes.sort(key=len, reverse=True)
+    start_alternation = "|".join(re.escape(prefix) for prefix in start_prefixes)
+    # The delimiter is part of the held tail.  This covers both query strings
+    # and form bodies while avoiding ordinary prose occurrences of a sensitive
+    # key.  Exact prefixes only are accepted, so a divergent key such as
+    # ``&access_log`` is not held merely because it starts with ``access_``.
+    # A one-character key prefix at absolute text start is intentionally not
+    # held: without a delimiter it is indistinguishable from ordinary prose
+    # (for example, a standalone ``C`` segment).
+    return re.compile(
+        r"(?P<tail>(?:[?&;](?:"
+        + delimiter_alternation
+        + r")|^(?:"
+        + start_alternation
+        + r")))\Z",
+        re.IGNORECASE,
+    )
+
+
+_STREAMING_SENSITIVE_FORM_KEY_TAIL_RE = _build_streaming_sensitive_form_key_tail_re()
+
+
+_STREAMING_JSON_FIELD_NAMES: tuple[str, ...] = (
+    "api_key",
+    "apikey",
+    "token",
+    "secret",
+    "password",
+    "access_token",
+    "refresh_token",
+    "auth_token",
+    "bearer",
+    "secret_value",
+    "raw_secret",
+    "secret_input",
+    "key_material",
+)
+_STREAMING_JSON_FIELD_PREFIX_ALT = "|".join(
+    re.escape(prefix)
+    for prefix in _streaming_literal_prefixes(_STREAMING_JSON_FIELD_NAMES)
+)
+_STREAMING_JSON_FIELD_TAIL_RE = re.compile(
+    r'(?P<tail>"(?:'
+    + _STREAMING_JSON_FIELD_PREFIX_ALT
+    + r')[^"]*(?:"[ \t]*:[ \t]*(?:"[^"]*)?)?)\Z',
+    re.IGNORECASE,
+)
+
+_STREAMING_HEADER_NAMES: tuple[str, ...] = (
+    "proxy-authorization",
+    "authorization",
+    "x-api-key",
+    "x-goog-api-key",
+    "api-key",
+    "apikey",
+    "x-api-token",
+    "x-auth-token",
+    "x-access-token",
+)
+_STREAMING_HEADER_PREFIX_ALT = "|".join(
+    re.escape(prefix)
+    for prefix in _streaming_literal_prefixes(_STREAMING_HEADER_NAMES, min_length=4)
+)
+_STREAMING_HEADER_TAIL_RE = re.compile(
+    r"(?P<tail>(?:" + _STREAMING_HEADER_PREFIX_ALT + r")[^\r\n]*)\Z",
+    re.IGNORECASE,
+)
+
+# URL userinfo, database connection strings, and JWTs all have a fixed
+# structural beginning but unbounded credential bodies.  Retain the complete
+# trailing structure until a delimiter or the end of the stream resolves it.
+_STREAMING_URL_TAIL_RE = re.compile(
+    r"(?P<tail>(?:https?|wss?|ftp|ftps|sftp|git|ssh|"
+    r"postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp)://[^\s]*)\Z",
+    re.IGNORECASE,
+)
+_STREAMING_JWT_TAIL_RE = re.compile(
+    r"(?P<tail>eyJ[A-Za-z0-9_=-]*(?:\.[A-Za-z0-9_=-]*){0,2})\Z"
+)
+_STREAMING_TELEGRAM_TAIL_RE = re.compile(r"(?P<tail>\d{8,}(?::[-A-Za-z0-9_]*)?)\Z")
+_STREAMING_PHONE_TAIL_RE = re.compile(r"(?P<tail>\+[1-9]\d{0,14})\Z")
+
+
+def _find_streaming_redaction_tail_start(text: str) -> Optional[int]:
+    """Return the earliest start of a trailing redaction-risk candidate.
+
+    The returned suffix must remain mutable until a later delta or stream end
+    resolves it.  Complete structural assignments are checked against the
+    full buffer so a long value cannot age out of the bounded partial window;
+    partial config-key candidates are bounded to avoid retaining arbitrary
+    prose forever.
+    """
+    starts: list[int] = []
+
+    prefix_match = _CREDENTIAL_PREFIX_TAIL_RE.search(text)
+    if prefix_match:
+        starts.append(prefix_match.start(1))
+
+    complete_patterns = (
+        _STREAMING_UPPER_SECRET_ASSIGNMENT_RE,
+        _STREAMING_LOWER_SECRET_ASSIGNMENT_RE,
+        _STREAMING_DOTTED_SECRET_ASSIGNMENT_RE,
+        _STREAMING_SENSITIVE_FORM_KEY_TAIL_RE,
+        _STREAMING_JSON_FIELD_TAIL_RE,
+        _STREAMING_HEADER_TAIL_RE,
+        _STREAMING_URL_TAIL_RE,
+        _STREAMING_JWT_TAIL_RE,
+        _STREAMING_TELEGRAM_TAIL_RE,
+        _STREAMING_PHONE_TAIL_RE,
+    )
+    for pattern in complete_patterns:
+        match = pattern.search(text)
+        if match:
+            starts.append(match.start("tail"))
+
+    context_start = max(0, len(text) - _STREAMING_CONFIG_CONTEXT_WINDOW)
+    context = text[context_start:]
+    for pattern in (
+        _STREAMING_UPPER_SECRET_KEY_TAIL_RE,
+        _STREAMING_CONFIG_KEY_PARTIAL_RE,
+        _STREAMING_DOTTED_CONFIG_KEY_PARTIAL_RE,
+    ):
+        match = pattern.search(context)
+        if match:
+            starts.append(context_start + match.start("tail"))
+
+    # Private-key blocks are multi-line and have no bounded body length.  Keep
+    # the block mutable from its BEGIN marker until the matching END marker
+    # appears; a false-positive hold is harmless and is released at finalize.
+    begin = text.rfind("-----BEGIN")
+    if begin >= 0 and "-----END" not in text[begin:]:
+        starts.append(begin)
+
+    return min(starts) if starts else None
+
+
+def _hold_back_credential_prefix_tail(
+    text: str, *, finalize: bool = False
+) -> "tuple[str, str]":
     """Split a sanitized display buffer into (sealable_head, holdback_tail).
 
     The holdback tail is the trailing substring of ``text`` that could still
@@ -129,30 +402,20 @@ def _hold_back_credential_prefix_tail(text: str, *, finalize: bool = False) -> "
     a fragment too short to be a real credential is not a credential).
 
     The split point is chosen so the head never ends mid-token inside a
-    potential credential: we find the LAST trailing credential-prefix
-    candidate in ``text`` and hold back from its first character.  Any
-    characters between that candidate and the end of ``text`` stay in the
-    tail; the next delta appends to the tail and the whole tail is re-tested
-    next iteration.
+    potential credential: the scan finds the earliest trailing redaction-risk
+    candidate and holds back from its first character.  Any characters between
+    that candidate and the end of ``text`` stay in the tail; the next delta
+    appends to the tail and the whole tail is re-tested next iteration.
     """
     if finalize or not text:
         return text, ""
-    # Find the start of the trailing credential-prefix candidate.  The regex
-    # above matches a trailing run starting at a non-token-continuation
-    # boundary.  m.start(1) is the index where the candidate seed itself
-    # begins inside the overall match; we hold back from there so any leading
-    # whitespace before the seed stays in the sealed head (it is safe to seal
-    # whitespace — it cannot be part of a credential).
-    m = _CREDENTIAL_PREFIX_TAIL_RE.search(text)
-    if not m:
+    # Keep the earliest candidate start returned by the authoritative-form
+    # holdback scan.  The prefix matcher remains one input to that scan, but
+    # structural detector classes (assignments, fields, headers, URLs, JWTs,
+    # and key blocks) are handled there too.
+    start = _find_streaming_redaction_tail_start(text)
+    if start is None:
         return text, ""
-    # m.start() is the start of the whole match (the candidate+trailing-run);
-    # the candidate seed starts at m.start(1).  Keep a small safety margin:
-    # also keep one character upstream of the seed so a sealed head never
-    # ends flush against the holdback when that character would visually
-    # "snap" the candidate into the prior token.  This is cosmetic — the
-    # security boundary is m.start(1).
-    start = m.start(1)
     return text[:start], text[start:]
 
 
@@ -1099,7 +1362,19 @@ class GatewayStreamConsumer:
                         self._message_id = None
                         self._last_sent_text = ""
 
-                    display_text = self._accumulated
+                    # When a trailing candidate is being held but the
+                    # sealable portion is still below the platform limit, do
+                    # not send the raw full buffer: it may contain the first
+                    # fragment of a structural secret.  Keep the full raw
+                    # buffer in ``_accumulated`` for the next delta, while
+                    # exposing only the sanitized, sealable head.  Overflow
+                    # branches above replace ``_accumulated`` with their
+                    # remainder, so they continue to use that remainder here.
+                    display_text = (
+                        _sealable_head
+                        if _len_fn(_sealable_head) <= _safe_limit
+                        else self._accumulated
+                    )
                     if not got_done and not got_segment_break and commentary_text is None:
                         display_text += self.cfg.cursor
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -19,9 +19,11 @@ import asyncio
 import inspect
 import logging
 import queue
+import re
 import threading
 import time
 from dataclasses import dataclass
+from typing import Any, Callable, Optional
 
 # Internal tool-trace banner lines — stripped from streaming output so
 # finalized split-message chunks don't permanently expose diagnostics.
@@ -29,7 +31,6 @@ _TOOL_TRACE_RE = re.compile(
     r"^[ \t]*(?:⚠️?\s*)?(?:🛠️?\s*)?`[^`]+`\s+failed\s*$",
     re.MULTILINE,
 )
-from typing import Any, Callable, Optional
 
 from gateway.platforms.base import BasePlatformAdapter as _BasePlatformAdapter
 from gateway.platforms.base import _custom_unit_to_cp
@@ -810,10 +811,17 @@ class GatewayStreamConsumer:
                 ):
                     should_edit = False
                 if should_edit and self._accumulated:
+                    # The complete display buffer must be sanitized BEFORE any
+                    # overflow split. Sanitizing each chunk later is unsafe: a
+                    # credential that crosses the boundary is unrecognizable in
+                    # either fragment but reconstructable by the recipient.
+                    # Keep the raw buffer for normal edits so _clean_for_display's
+                    # trailing-whitespace normalization cannot alter future deltas.
+                    display_accumulated = self._clean_for_display(self._accumulated)
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, split into properly sized chunks.
                     if (
-                        _len_fn(self._accumulated) > _safe_limit
+                        _len_fn(display_accumulated) > _safe_limit
                         and self._message_id is None
                     ):
                         # No existing message to edit (first message or after a
@@ -824,13 +832,13 @@ class GatewayStreamConsumer:
                         # updating in-place as later streamed deltas arrive
                         # instead of posting every split as an immutable message.
                         chunks = self._truncate_for_stream(
-                            self._accumulated, _safe_limit, _len_fn,
+                            display_accumulated, _safe_limit, _len_fn,
                         )
                         if len(chunks) <= 1:
                             # A malformed/legacy adapter result must not leave
                             # this overflow branch with an unsplittable payload.
                             chunks = self._split_text_chunks(
-                                self._accumulated, _safe_limit, _len_fn,
+                                display_accumulated, _safe_limit, _len_fn,
                             )
                         chunks_delivered = False
                         reply_to = self._initial_reply_to_id
@@ -899,17 +907,17 @@ class GatewayStreamConsumer:
                     # Existing message: edit it with the first chunk, then
                     # start a new message for the overflow remainder.
                     while (
-                        _len_fn(self._accumulated) > _safe_limit
+                        _len_fn(display_accumulated) > _safe_limit
                         and self._message_id is not None
                         and self._edit_supported
                     ):
                         _cp_budget = _custom_unit_to_cp(
-                            self._accumulated, _safe_limit, _len_fn,
+                            display_accumulated, _safe_limit, _len_fn,
                         )
-                        split_at = self._accumulated.rfind("\n", 0, _cp_budget)
+                        split_at = display_accumulated.rfind("\n", 0, _cp_budget)
                         if split_at < _cp_budget // 2:
                             split_at = _cp_budget
-                        chunk = self._accumulated[:split_at]
+                        chunk = display_accumulated[:split_at]
                         # finalize=True so the adapter applies platform-specific
                         # rich-text markup (e.g. Telegram MarkdownV2). This
                         # sealed chunk will never be edited again — _message_id
@@ -930,7 +938,7 @@ class GatewayStreamConsumer:
                             # fallback final-send path can deliver the remaining
                             # continuation without dropping content.
                             break
-                        self._accumulated = self._accumulated[split_at:].lstrip("\n")
+                        self._accumulated = display_accumulated[split_at:].lstrip("\n")
                         self._message_id = None
                         self._last_sent_text = ""
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -32,6 +32,130 @@ _TOOL_TRACE_RE = re.compile(
     re.MULTILINE,
 )
 
+# --- Streaming redaction holdback -----------------------------------------
+#
+# The Tirith redactor (`agent.redact.redact_sensitive_text`) is stateless:
+# it scans a finished string for whole credential-shaped tokens.  Its prefix
+# patterns require a minimum run of credential characters (e.g. ``sk-`` must
+# be followed by ``[A-Za-z0-9_-]{10,}`` to match).  During incremental
+# streaming, a delta that crosses the platform split boundary while ending
+# inside an unresolved credential prefix (" sk-" with <10 trailing chars,
+# " ghp_" alone, " gAA" beginning "gAAAA…", …) is sanitized and sealed into
+# an immutable, finalize=True message BEFORE a later delta supplies the suffix
+# that would have made the full token recognizable.  The recipient can then
+# reconstruct the raw credential across the sealed head and the next message.
+#
+# Holdback rule: BEFORE sealing any overflowing head, split the sanitized
+# display buffer so that the sealable head never ends with a suffix that could
+# still resolve to a credential prefix.  Any such suffix stays in the mutable
+# tail (``self._accumulated``) until either a delimiting character or
+# end-of-stream (got_done) proves it cannot grow into a credential.
+#
+# The seed list is derived from the same ``_PREFIX_SUBSTRINGS`` the redactor
+# itself uses, plus every proper prefix of those substrings ("sk-", "sk", "s"
+# would over-match — we deliberately start from real credential starts like
+# "sk-", "ghp_", "gAAAA", … and also keep their partial tails like "sk" only
+# when not already prefixed by a digit-or-letter continuation).  This keeps
+# the behavior crisp: " chairs" never triggers holdback; " ch AirSk" doesn't
+# either; " sk-" does.
+
+def _build_streaming_credential_prefix_tail_re() -> "re.Pattern[str]":
+    """Compile a regex matching a trailing credential-prefix candidate.
+
+    Matches any tail of ``text`` that (a) begins at a word boundary or right
+    after whitespace, and (b) is a non-empty proper prefix (or full prefix)
+    of one of the credential vocabulary seeds, NOT yet followed by a full
+    qualifying token.  Returns the longest such match's end position, or -1.
+    """
+    try:
+        from agent.redact import _PREFIX_SUBSTRINGS
+        seeds = list(_PREFIX_SUBSTRINGS)
+    except Exception:
+        # Fail-open to the documented common prefixes if the redactor is
+        # ever unavailable; production always imports it (see _clean_for_display
+        # try/except below).
+        seeds = [
+            "sk-", "ghp_", "github_pat_", "gho_", "ghu_", "ghs_", "ghr_",
+            "xapp-", "xox", "AIza", "pplx-", "fal_", "fc-", "bb_live_",
+            "gAAAA", "AKIA", "sk_live_", "sk_test_", "rk_live_", "SG.",
+            "hf_", "r8_", "npm_", "pypi-", "dop_v1_", "doo_v1_", "am_",
+            "sk_", "tvly-", "exa_", "gsk_", "syt_", "retaindb_", "hsk-",
+            "mem0_", "brv_", "xai-", "ntn_", "fw-", "fw_", "fpk_",
+        ]
+    # Build a set of distinct literal seeds plus their proper prefixes that
+    # could still extend into a full credential prefix.  Only keep partials
+    # that are at least 2 chars long so a lone "s" or "g" can't hold back
+    # ordinary text.
+    candidates: "set[str]" = set()
+    for seed in seeds:
+        if not seed:
+            continue
+        candidates.add(seed)
+        for i in range(2, len(seed)):
+            candidates.add(seed[:i])
+    # Escape each candidate and join as alternation, longest first so the
+    # longest viable prefix wins the match (greedy alternation already does,
+    # but explicit sort keeps it deterministic and doc-readable).
+    alt = "|".join(sorted((re.escape(c) for c in candidates), key=len, reverse=True))
+    # Anchor at start-of-tail: allow only whitespace or punctuation upstream
+    # — a letter/digit immediately before would mean the candidate is part of
+    # a longer token that already extends beyond it (e.g. "Xsk-" where the
+    # leading "X" means the credential prefix is not at a boundary).  Use a
+    # lookbehind for the common safe-left cases; the (?<!...) makes the
+    # candidate match only when not preceded by a token-continuation char.
+    # We accept the candidate ending anywhere (no lookahead): the caller
+    # decides whether to retain it based on whether subsequent text could
+    # extend it into a recognizable credential.
+    return re.compile(
+        r"(?<![A-Za-z0-9_])(" + alt + r")[A-Za-z0-9_=-]{0,40}\Z",
+    )
+
+
+_CREDENTIAL_PREFIX_TAIL_RE = _build_streaming_credential_prefix_tail_re()
+
+
+def _hold_back_credential_prefix_tail(text: str, *, finalize: bool = False) -> "tuple[str, str]":
+    """Split a sanitized display buffer into (sealable_head, holdback_tail).
+
+    The holdback tail is the trailing substring of ``text`` that could still
+    grow into a recognizable credential prefix once a future streaming delta
+    arrives.  The sealable head is everything before it and may be finalized
+    into an immutable split-message chunk without leaking a credential.
+
+    When ``finalize=True`` the stream is over (``got_done``), so there is no
+    future delta to grow the prefix — return ``(text, "")`` and let the caller
+    redact the still-partial prefix as part of the final buffer (the redactor
+    will leave a too-short fragment untouched, which is the safe outcome:
+    a fragment too short to be a real credential is not a credential).
+
+    The split point is chosen so the head never ends mid-token inside a
+    potential credential: we find the LAST trailing credential-prefix
+    candidate in ``text`` and hold back from its first character.  Any
+    characters between that candidate and the end of ``text`` stay in the
+    tail; the next delta appends to the tail and the whole tail is re-tested
+    next iteration.
+    """
+    if finalize or not text:
+        return text, ""
+    # Find the start of the trailing credential-prefix candidate.  The regex
+    # above matches a trailing run starting at a non-token-continuation
+    # boundary.  m.start(1) is the index where the candidate seed itself
+    # begins inside the overall match; we hold back from there so any leading
+    # whitespace before the seed stays in the sealed head (it is safe to seal
+    # whitespace — it cannot be part of a credential).
+    m = _CREDENTIAL_PREFIX_TAIL_RE.search(text)
+    if not m:
+        return text, ""
+    # m.start() is the start of the whole match (the candidate+trailing-run);
+    # the candidate seed starts at m.start(1).  Keep a small safety margin:
+    # also keep one character upstream of the seed so a sealed head never
+    # ends flush against the holdback when that character would visually
+    # "snap" the candidate into the prior token.  This is cosmetic — the
+    # security boundary is m.start(1).
+    start = m.start(1)
+    return text[:start], text[start:]
+
+
 from gateway.platforms.base import BasePlatformAdapter as _BasePlatformAdapter
 from gateway.platforms.base import _custom_unit_to_cp
 from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
@@ -818,10 +942,36 @@ class GatewayStreamConsumer:
                     # Keep the raw buffer for normal edits so _clean_for_display's
                     # trailing-whitespace normalization cannot alter future deltas.
                     display_accumulated = self._clean_for_display(self._accumulated)
+                    # Streaming redaction holdback: never seal a head chunk
+                    # whose tail could still resolve to a credential prefix
+                    # once the next delta arrives.  The Tirith redactor is
+                    # stateless and rejects short prefixes (e.g. ``sk-`` with
+                    # <10 trailing chars), so the overflow split would
+                    # otherwise seal ``" sk-"`` into an immutable
+                    # ``finalize=True`` message before the next delta supplies
+                    # the qualifying suffix — re-creating the raw credential
+                    # across the sealed head and the continuation.  We split
+                    # the sanitized buffer into a sealable head (everything up
+                    # to the trailing credential-prefix candidate) and a
+                    # holdback tail (the candidate itself); the tail stays
+                    # mutable in ``self._accumulated`` until a delimiter or
+                    # end-of-stream proves it cannot grow into a credential.
+                    # When ``got_done`` is set there is no future delta, so the
+                    # holdback is a no-op and the full sanitized buffer is
+                    # handled by the got_done path below (which redacts the
+                    # finished buffer as a whole).
+                    if not got_done:
+                        _sealable_head, _holdback_tail = _hold_back_credential_prefix_tail(
+                            display_accumulated, finalize=False,
+                        )
+                    else:
+                        _sealable_head, _holdback_tail = display_accumulated, ""
                     # Split overflow: if accumulated text exceeds the platform
-                    # limit, split into properly sized chunks.
+                    # limit, split into properly sized chunks.  Operate on the
+                    # sealable head so any sealed head chunk ends before the
+                    # trailing credential-prefix candidate.
                     if (
-                        _len_fn(display_accumulated) > _safe_limit
+                        _len_fn(_sealable_head) > _safe_limit
                         and self._message_id is None
                     ):
                         # No existing message to edit (first message or after a
@@ -832,13 +982,13 @@ class GatewayStreamConsumer:
                         # updating in-place as later streamed deltas arrive
                         # instead of posting every split as an immutable message.
                         chunks = self._truncate_for_stream(
-                            display_accumulated, _safe_limit, _len_fn,
+                            _sealable_head, _safe_limit, _len_fn,
                         )
                         if len(chunks) <= 1:
                             # A malformed/legacy adapter result must not leave
                             # this overflow branch with an unsplittable payload.
                             chunks = self._split_text_chunks(
-                                display_accumulated, _safe_limit, _len_fn,
+                                _sealable_head, _safe_limit, _len_fn,
                             )
                         chunks_delivered = False
                         reply_to = self._initial_reply_to_id
@@ -860,7 +1010,11 @@ class GatewayStreamConsumer:
                             reply_to = new_id
 
                         if all_heads_delivered:
-                            self._accumulated = chunks[-1]
+                            # Keep the trailing chunk plus the credential-prefix
+                            # holdback in _accumulated so the next delta can
+                            # grow the candidate into a recognizable (and thus
+                            # redactable) credential.
+                            self._accumulated = chunks[-1] + _holdback_tail
                             # The head chunks are sealed.  Clear the edit target
                             # so the remaining tail is sent as a fresh active
                             # chunk, then edited by subsequent deltas.
@@ -907,17 +1061,17 @@ class GatewayStreamConsumer:
                     # Existing message: edit it with the first chunk, then
                     # start a new message for the overflow remainder.
                     while (
-                        _len_fn(display_accumulated) > _safe_limit
+                        _len_fn(_sealable_head) > _safe_limit
                         and self._message_id is not None
                         and self._edit_supported
                     ):
                         _cp_budget = _custom_unit_to_cp(
-                            display_accumulated, _safe_limit, _len_fn,
+                            _sealable_head, _safe_limit, _len_fn,
                         )
-                        split_at = display_accumulated.rfind("\n", 0, _cp_budget)
+                        split_at = _sealable_head.rfind("\n", 0, _cp_budget)
                         if split_at < _cp_budget // 2:
                             split_at = _cp_budget
-                        chunk = display_accumulated[:split_at]
+                        chunk = _sealable_head[:split_at]
                         # finalize=True so the adapter applies platform-specific
                         # rich-text markup (e.g. Telegram MarkdownV2). This
                         # sealed chunk will never be edited again — _message_id
@@ -938,7 +1092,10 @@ class GatewayStreamConsumer:
                             # fallback final-send path can deliver the remaining
                             # continuation without dropping content.
                             break
-                        self._accumulated = display_accumulated[split_at:].lstrip("\n")
+                        # Preserve any credential-prefix holdback in the
+                        # mutable tail so the next delta can resolve it into
+                        # a recognizable (and thus redactable) credential.
+                        self._accumulated = _sealable_head[split_at:].lstrip("\n") + _holdback_tail
                         self._message_id = None
                         self._last_sent_text = ""
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -22,6 +22,13 @@ import queue
 import threading
 import time
 from dataclasses import dataclass
+
+# Internal tool-trace banner lines — stripped from streaming output so
+# finalized split-message chunks don't permanently expose diagnostics.
+_TOOL_TRACE_RE = re.compile(
+    r"^[ \t]*(?:⚠️?\s*)?(?:🛠️?\s*)?`[^`]+`\s+failed\s*$",
+    re.MULTILINE,
+)
 from typing import Any, Callable, Optional
 
 from gateway.platforms.base import BasePlatformAdapter as _BasePlatformAdapter
@@ -1123,8 +1130,28 @@ class GatewayStreamConsumer:
         delivered separately via ``_deliver_media_from_response()`` after the
         stream finishes — we just need to hide the raw directives from the
         user.
+
+        Also redacts secrets and strips tool-trace banners, matching the
+        sanitization that ``_sanitize_gateway_final_response`` applies to
+        non-streaming responses.  Without this, finalized split-message
+        chunks (``finalize=True``, never edited again) could permanently
+        expose secrets or internal diagnostics to chat users.
         """
-        return _BasePlatformAdapter.strip_media_directives_for_display(text)
+        text = _BasePlatformAdapter.strip_media_directives_for_display(text)
+
+        # Redact secrets (matches _sanitize_gateway_final_response path)
+        try:
+            from gateway.run import _redact_gateway_user_facing_secrets
+            text = _redact_gateway_user_facing_secrets(text)
+        except Exception:
+            pass
+
+        # Strip tool-trace banners (⚠️ 🛠️ `tool` failed)
+        text = _TOOL_TRACE_RE.sub("", text)
+
+        # Collapse excessive blank lines and strip trailing whitespace
+        text = re.sub(r'\n{3,}', '\n\n', text)
+        return text.rstrip()
 
     async def _send_new_chunk(
         self,

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -4,7 +4,12 @@ import logging
 
 import pytest
 
-from agent.redact import redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import (
+    _SENSITIVE_BODY_KEYS,
+    redact_cdp_url,
+    redact_sensitive_text,
+    RedactingFormatter,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -447,6 +452,12 @@ class TestBareTokenUserinfoRedaction:
 
 class TestFormBodyRedaction:
     """Form-urlencoded body redaction (k=v&k=v with no other text)."""
+
+    @pytest.mark.parametrize("key", tuple(sorted(_SENSITIVE_BODY_KEYS)))
+    def test_every_authoritative_body_key_is_redacted(self, key):
+        text = f"filler=public&{key}=body-secret-value-123456789"
+        result = redact_sensitive_text(text, force=True)
+        assert "body-secret-value-123456789" not in result
 
     def test_pure_form_body(self):
         text = "password=mysecret&username=bob&token=opaqueValue"

--- a/tests/gateway/test_stream_consumer_redaction.py
+++ b/tests/gateway/test_stream_consumer_redaction.py
@@ -1,0 +1,61 @@
+"""Tests for GatewayStreamConsumer._clean_for_display — secret redaction.
+
+Regression tests for the streaming-path secret redaction gap.
+The streaming path must redact secrets and strip tool-trace banners
+in every chunk, including finalized split-message chunks that are
+never edited again.
+"""
+
+from __future__ import annotations
+
+from gateway.stream_consumer import GatewayStreamConsumer
+
+
+class TestCleanForDisplaySecretRedaction:
+    """Verify _clean_for_display redacts secrets and strips banners."""
+
+    def test_media_tags_still_stripped(self):
+        """Existing behavior: MEDIA: tags are removed."""
+        text = "Hello MEDIA:/path/to/file.png world"
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert "MEDIA:" not in result
+        assert "Hello" in result
+        assert "world" in result
+
+    def test_audio_as_voice_still_stripped(self):
+        """Existing behavior: [[audio_as_voice]] directives are removed."""
+        text = "Hello [[audio_as_voice]] world"
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert "[[audio_as_voice]]" not in result
+
+    def test_normal_text_preserved(self):
+        """Normal text without secrets passes through unchanged."""
+        text = "Hello world, this is a normal response."
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert result == text
+
+    def test_api_key_redacted(self):
+        """API keys in streamed text must be redacted."""
+        text = "Here is your key: sk-abc123def456ghi789jkl012mno345pqr678stu"
+        result = GatewayStreamConsumer._clean_for_display(text)
+        # The redactor preserves first 6 + last 4 chars for long tokens
+        assert "sk-abc123def456" not in result
+        assert "sk-abc" in result  # prefix preserved
+        assert "8stu" in result  # suffix preserved
+
+    def test_tool_trace_banner_stripped(self):
+        """Tool-trace banners in streamed text must be stripped."""
+        text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed"
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert result == "Done."
+        assert "failed" not in result
+
+    def test_empty_text_returns_empty(self):
+        """Empty text returns empty string."""
+        result = GatewayStreamConsumer._clean_for_display("")
+        assert result == ""
+
+    def test_whitespace_only_returns_empty(self):
+        """Whitespace-only text returns empty string after rstrip."""
+        result = GatewayStreamConsumer._clean_for_display("   \n\n  ")
+        assert result == ""

--- a/tests/gateway/test_stream_consumer_redaction.py
+++ b/tests/gateway/test_stream_consumer_redaction.py
@@ -14,10 +14,34 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.redact import _SENSITIVE_BODY_KEYS, _SENSITIVE_QUERY_PARAMS
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig, _hold_back_credential_prefix_tail
 
 
 _BOUNDARY_SECRET = "sk-abc123def456ghi789jkl012mno345pqr678stu"
+
+
+_ASSIGNMENT_SECRET = "MY_API_KEY=supersecretvalue123456789"
+_SENSITIVE_FORM_KEYS = tuple(sorted(_SENSITIVE_BODY_KEYS))
+
+_STRUCTURAL_REDACTION_CASES = (
+    ("env assignment", "MY_AP", "I_KEY=supersecretvalue123456789"),
+    ("dotted config", "spring.datasource.passwo", "rd=supersecretvalue123456789"),
+    ("yaml assignment", "\npassword", ": supersecretvalue123456789"),
+    ("json field", '{"apiK', 'ey": "supersecretvalue123456789"}'),
+    ("authorization header", "Authorization: Bear", "er sk-abc123def456ghi789jkl"),
+    ("secret header", "\nx-api", "-key: supersecretvalue123456789"),
+    (
+        "private key",
+        "-----BEGIN RSA PRIVATE",
+        " KEY-----\nABCDEF\n-----END RSA PRIVATE KEY-----",
+    ),
+    ("database URL", "postgres://user:", "password@db.example/db"),
+    ("bare URL token", "https://", "secretvalue@example.com"),
+    ("JWT", "eyJ", "hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature"),
+    ("Telegram token", "12345678", ":ABCdefGHIjklMNOpqrSTUvwxYZ0123456789"),
+    ("phone number", "+123456", "789012"),
+)
 
 
 def _overflow_adapter() -> MagicMock:
@@ -136,12 +160,18 @@ class _RecordingSendAdapter:
     id, and a sealed finalize=True chunk is immutable.
     """
 
-    def __init__(self, max_len: int = 601):
+    def __init__(
+        self,
+        max_len: int = 601,
+        *,
+        first_delivery: asyncio.Event | None = None,
+    ):
         self.MAX_MESSAGE_LENGTH = max_len
         self.REQUIRES_EDIT_FINALIZE = False
         self._counter = 0
         self._editable: "dict[str, str]" = {}
         self._editable_order: "list[str]" = []
+        self._first_delivery = first_delivery
         self.send = AsyncMock(side_effect=self._send)
         self.edit_message = AsyncMock(side_effect=self._edit)
 
@@ -150,12 +180,16 @@ class _RecordingSendAdapter:
         mid = f"s{self._counter}"
         self._editable[mid] = kw["content"]
         self._editable_order.append(mid)
+        if self._first_delivery is not None:
+            self._first_delivery.set()
         return SimpleNamespace(success=True, message_id=mid)
 
     async def _edit(self, **kw):
         if self._editable_order:
             target = self._editable_order[-1]
             self._editable[target] = kw["content"]
+        if self._first_delivery is not None:
+            self._first_delivery.set()
         return SimpleNamespace(success=True, message_id=f"e{self._counter}")
 
     def final_visible_text(self) -> str:
@@ -238,6 +272,176 @@ class TestIncrementalStreamingHoldback:
         assert _BOUNDARY_SECRET not in visible, (
             "P1 bypass: incremental streaming reconstructed the raw credential "
             "across sealed messages (existing-message branch)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_incremental_assignment_split_fresh_message(self):
+        """Fresh-message branch: a generic secret assignment must remain
+        mutable when the split lands inside its key name."""
+        adapter = _RecordingSendAdapter()
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1",
+            StreamConsumerConfig(buffer_threshold=1, edit_interval=0.0),
+        )
+        delta1 = "x" * 495 + "MY_API_KEY"
+        suffix = _ASSIGNMENT_SECRET[len("MY_API_KEY"):]
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(delta1)
+        for _ in range(50):
+            await asyncio.sleep(0.005)
+            if consumer._queue.empty():
+                break
+        consumer.on_delta(suffix)
+        consumer.finish()
+        await task
+
+        visible = adapter.final_visible_text()
+        assert _ASSIGNMENT_SECRET not in visible, (
+            "P1 bypass: generic assignment reconstructed across fresh-message "
+            "overflow chunks"
+        )
+
+    @pytest.mark.asyncio
+    async def test_incremental_assignment_split_existing_message(self):
+        """Existing-message branch: the same generic assignment boundary
+        must not be reconstructable from the replacement-edit flow."""
+        adapter = _RecordingSendAdapter()
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1",
+            StreamConsumerConfig(buffer_threshold=1, edit_interval=0.0),
+        )
+        consumer._message_id = "preview"
+        consumer._already_sent = True
+
+        delta1 = "x" * 495 + "MY_API_KEY"
+        suffix = _ASSIGNMENT_SECRET[len("MY_API_KEY"):]
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(delta1)
+        for _ in range(50):
+            await asyncio.sleep(0.005)
+            if consumer._queue.empty():
+                break
+        consumer.on_delta(suffix)
+        consumer.finish()
+        await task
+
+        visible = adapter.final_visible_text()
+        assert _ASSIGNMENT_SECRET not in visible, (
+            "P1 bypass: generic assignment reconstructed across existing-message "
+            "overflow chunks"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "existing_message", [False, True], ids=["fresh", "existing"]
+    )
+    @pytest.mark.parametrize(
+        "key", _SENSITIVE_FORM_KEYS, ids=lambda key: str(key)
+    )
+    async def test_incremental_authoritative_form_key_split_offsets(
+        self, key, existing_message
+    ):
+        """Every authoritative form-body key stays mutable at every split offset.
+
+        The first delta ends exactly at the 500-character streaming boundary,
+        with the key preceded by a query/form delimiter.  The test waits until
+        the first send/edit has completed before supplying the value suffix, so
+        the assertion models immutable platform delivery rather than queue
+        ordering.
+        """
+        value = "form-secret-value-123456789"
+        for split_offset in range(1, len(key) + 1):
+            first_delivery = asyncio.Event()
+            adapter = _RecordingSendAdapter(first_delivery=first_delivery)
+            consumer = GatewayStreamConsumer(
+                adapter,
+                "chat_1",
+                StreamConsumerConfig(buffer_threshold=1, edit_interval=0.0),
+            )
+            if existing_message:
+                consumer._message_id = "preview"
+                consumer._already_sent = True
+
+            prefix = f"&{key[:split_offset]}"
+            delta1 = "filler=" + "x" * (500 - len("filler=") - len(prefix)) + prefix
+            suffix = f"{key[split_offset:]}={value}"
+
+            task = asyncio.create_task(consumer.run())
+            consumer.on_delta(delta1)
+            await asyncio.wait_for(first_delivery.wait(), timeout=1.0)
+            consumer.on_delta(suffix)
+            consumer.finish()
+            await task
+
+            raw_secret = f"&{key}={value}"
+            assert raw_secret not in adapter.final_visible_text(), (
+                f"{key!r} leaked across {('existing' if existing_message else 'fresh')} "
+                f"streaming boundary at split offset {split_offset}"
+            )
+
+    @pytest.mark.parametrize("delimiter", ["?", "&"], ids=["query", "form"])
+    @pytest.mark.parametrize(
+        "key", tuple(sorted(_SENSITIVE_QUERY_PARAMS)), ids=lambda key: str(key)
+    )
+    def test_authoritative_query_key_prefix_is_held_at_each_split_offset(
+        self, key, delimiter
+    ):
+        """Delimiter-aware query prefixes stay mutable until their key resolves."""
+        for split_offset in range(1, len(key) + 1):
+            text = f"safe{delimiter}{key[:split_offset]}"
+            head, tail = _hold_back_credential_prefix_tail(text)
+            assert head == "safe"
+            assert tail == f"{delimiter}{key[:split_offset]}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "existing_message", [False, True], ids=["fresh", "existing"]
+    )
+    @pytest.mark.parametrize(
+        "case",
+        _STRUCTURAL_REDACTION_CASES,
+        ids=[case[0] for case in _STRUCTURAL_REDACTION_CASES],
+    )
+    async def test_incremental_structural_detector_split_cannot_reconstruct_secret(
+        self, case, existing_message
+    ):
+        """Every authoritative detector keeps its incomplete form mutable.
+
+        The first delta is deliberately one overflowing chunk whose detector
+        prefix straddles the 500-character boundary.  The second delta makes
+        it a complete credential.  Both delivery branches must avoid exposing
+        the raw reconstructed value.
+        """
+        _, prefix, suffix = case
+        adapter = _RecordingSendAdapter()
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(buffer_threshold=1, edit_interval=0.0),
+        )
+        if existing_message:
+            consumer._message_id = "preview"
+            consumer._already_sent = True
+
+        split_start = 500 - max(1, len(prefix) // 2)
+        delta1 = "x" * split_start + prefix
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(delta1)
+        for _ in range(50):
+            await asyncio.sleep(0.005)
+            if consumer._queue.empty():
+                break
+        consumer.on_delta(suffix)
+        consumer.finish()
+        await task
+
+        raw_secret = prefix + suffix
+        assert raw_secret not in adapter.final_visible_text(), (
+            f"{case[0]} secret reconstructed across {('existing' if existing_message else 'fresh')} "
+            "streaming overflow branch"
         )
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_stream_consumer_redaction.py
+++ b/tests/gateway/test_stream_consumer_redaction.py
@@ -12,7 +12,9 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
-from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig, _hold_back_credential_prefix_tail
 
 
 _BOUNDARY_SECRET = "sk-abc123def456ghi789jkl012mno345pqr678stu"
@@ -124,3 +126,207 @@ class TestOverflowSecretRedaction:
         asyncio.run(consumer.run())
 
         assert _BOUNDARY_SECRET not in _delivered_text(adapter)
+
+
+class _RecordingSendAdapter:
+    """Adapter that records sends/edits with distinct message_ids.
+
+    Each send returns a unique message_id so the test can model replacement
+    edits properly: the platform keeps only the LAST text for each message
+    id, and a sealed finalize=True chunk is immutable.
+    """
+
+    def __init__(self, max_len: int = 601):
+        self.MAX_MESSAGE_LENGTH = max_len
+        self.REQUIRES_EDIT_FINALIZE = False
+        self._counter = 0
+        self._editable: "dict[str, str]" = {}
+        self._editable_order: "list[str]" = []
+        self.send = AsyncMock(side_effect=self._send)
+        self.edit_message = AsyncMock(side_effect=self._edit)
+
+    async def _send(self, **kw):
+        self._counter += 1
+        mid = f"s{self._counter}"
+        self._editable[mid] = kw["content"]
+        self._editable_order.append(mid)
+        return SimpleNamespace(success=True, message_id=mid)
+
+    async def _edit(self, **kw):
+        if self._editable_order:
+            target = self._editable_order[-1]
+            self._editable[target] = kw["content"]
+        return SimpleNamespace(success=True, message_id=f"e{self._counter}")
+
+    def final_visible_text(self) -> str:
+        """Reconstruct what a recipient sees: latest text per message id."""
+        return "".join(self._editable[mid] for mid in self._editable_order)
+
+
+class TestIncrementalStreamingHoldback:
+    """P1 regression: incremental deltas must not seal a credential prefix
+    before the suffix makes it recognizable.
+
+    See PR review comment #5139200976 — the PR's one-shot fix is bypassable
+    under real incremental streaming because the redactor is stateless and
+    requires a minimum token length (sk-[A-Za-z0-9_-]{10,}).  A first delta
+    ending at the platform split boundary in an unresolved credential prefix
+    (" sk-" with <10 trailing chars) was sealed into an immutable
+    finalize=True message before the next delta supplied the qualifying
+    suffix.
+
+    These tests drive the consumer concurrently: send delta 1, let it run,
+    then send delta 2, and reconstruct the final visible state by message
+    id (edits replace, sealed sends are immutable).
+    """
+
+    @pytest.mark.asyncio
+    async def test_incremental_prefix_split_fresh_message(self):
+        """Fresh-message branch: the first overflowing delta ending in ' sk-'
+        must not seal the prefix; the holdback keeps it in the mutable tail
+        until the suffix arrives, then redaction catches the complete token."""
+        adapter = _RecordingSendAdapter()
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1",
+            StreamConsumerConfig(buffer_threshold=1, edit_interval=0.0),
+        )
+        delta1 = "x" * 498 + " sk-"
+        suffix = _BOUNDARY_SECRET[len("sk-"):]
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(delta1)
+        for _ in range(50):
+            await asyncio.sleep(0.005)
+            if consumer._queue.empty():
+                break
+        consumer.on_delta(suffix)
+        consumer.finish()
+        await task
+
+        visible = adapter.final_visible_text()
+        assert _BOUNDARY_SECRET not in visible, (
+            "P1 bypass: incremental streaming reconstructed the raw credential "
+            "across sealed messages"
+        )
+
+    @pytest.mark.asyncio
+    async def test_incremental_prefix_split_existing_message(self):
+        """Existing-message branch: same adversarial delta pattern but the
+        consumer starts with an active preview message (_message_id set)."""
+        adapter = _RecordingSendAdapter()
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1",
+            StreamConsumerConfig(buffer_threshold=1, edit_interval=0.0),
+        )
+        consumer._message_id = "preview"
+        consumer._already_sent = True
+
+        delta1 = "x" * 498 + " sk-"
+        suffix = _BOUNDARY_SECRET[len("sk-"):]
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(delta1)
+        for _ in range(50):
+            await asyncio.sleep(0.005)
+            if consumer._queue.empty():
+                break
+        consumer.on_delta(suffix)
+        consumer.finish()
+        await task
+
+        visible = adapter.final_visible_text()
+        assert _BOUNDARY_SECRET not in visible, (
+            "P1 bypass: incremental streaming reconstructed the raw credential "
+            "across sealed messages (existing-message branch)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_incremental_prefix_split_499_fresh(self):
+        """Boundary at prefix_len=499: the split cuts inside ' sk-' leaving
+        'sk-' in the tail.  Without holdback the tail would be sealed raw;
+        with holdback it stays mutable until the suffix completes the token."""
+        adapter = _RecordingSendAdapter()
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1",
+            StreamConsumerConfig(buffer_threshold=1, edit_interval=0.0),
+        )
+        delta1 = "x" * 499 + " sk-"
+        suffix = _BOUNDARY_SECRET[len("sk-"):]
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(delta1)
+        for _ in range(50):
+            await asyncio.sleep(0.005)
+            if consumer._queue.empty():
+                break
+        consumer.on_delta(suffix)
+        consumer.finish()
+        await task
+
+        visible = adapter.final_visible_text()
+        assert _BOUNDARY_SECRET not in visible, (
+            "P1 bypass: incremental streaming reconstructed the raw credential "
+            "at prefix_len=499 (fresh message branch)"
+        )
+
+
+class TestHoldbackHelper:
+    """Unit tests for _hold_back_credential_prefix_tail."""
+
+    def test_no_credential_prefix_no_holdback(self):
+        """Normal text has no credential-prefix candidate -> full seal."""
+        head, tail = _hold_back_credential_prefix_tail("Hello world normal prose.")
+        assert tail == ""
+        assert head == "Hello world normal prose."
+
+    def test_trailing_sk_prefix_held_back(self):
+        """A trailing ' sk-' is the start of an OpenAI key -> held back."""
+        head, tail = _hold_back_credential_prefix_tail("x" * 498 + " sk-")
+        assert tail == "sk-"
+        assert head == "x" * 498 + " "
+
+    def test_trailing_short_sk_token_held_back(self):
+        """Short partial credential prefix (' sk-abc', 5 chars below the
+        {10,} minimum) is still held back because a future delta could
+        extend it into a recognizable credential."""
+        head, tail = _hold_back_credential_prefix_tail("filler sk-abc")
+        assert tail == "sk-abc"
+        assert head == "filler "
+
+    def test_finalize_releases_everything(self):
+        """On got_done (finalize=True) there's no future delta, so the
+        holdback is a no-op — the caller handles the complete buffer."""
+        head, tail = _hold_back_credential_prefix_tail("x" * 498 + " sk-", finalize=True)
+        assert tail == ""
+        assert head == "x" * 498 + " sk-"
+
+    def test_ghp_prefix_held_back(self):
+        """GitHub PAT prefix 'ghp_' is also a credential seed."""
+        head, tail = _hold_back_credential_prefix_tail("text ghp_")
+        assert tail == "ghp_"
+        assert head == "text "
+
+    def test_not_triggered_by_token_continuation(self):
+        """'Xsk-abc' (preceded by a letter) is part of a longer token,
+        not a credential boundary -> not held back."""
+        head, tail = _hold_back_credential_prefix_tail("Xsk-abc")
+        assert tail == ""
+        assert head == "Xsk-abc"
+
+    def test_codex_gaaaa_equals_sign_held_back(self):
+        """Codex tokens (gAAAA...) accept '=' inside their continuation.
+
+        The streaming holdback continuation alphabet must include '=' so that
+        a partial Codex token ending in '=' is not sealed into an immutable
+        message before a later delta completes it (review comment from
+        @egilewski on #56040).
+        """
+        head, tail = _hold_back_credential_prefix_tail("filler gAAAAabc=")
+        assert tail == "gAAAAabc="
+        assert head == "filler "
+
+    def test_empty_text(self):
+        """Empty text -> empty head and tail."""
+        head, tail = _hold_back_credential_prefix_tail("")
+        assert head == ""
+        assert tail == ""

--- a/tests/gateway/test_stream_consumer_redaction.py
+++ b/tests/gateway/test_stream_consumer_redaction.py
@@ -8,7 +8,36 @@ never edited again.
 
 from __future__ import annotations
 
-from gateway.stream_consumer import GatewayStreamConsumer
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+_BOUNDARY_SECRET = "sk-abc123def456ghi789jkl012mno345pqr678stu"
+
+
+def _overflow_adapter() -> MagicMock:
+    """Return an adapter that records the real streaming send/edit paths."""
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 601  # run() clamps its safe streaming limit to 500.
+    adapter.REQUIRES_EDIT_FINALIZE = False
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="sent"))
+    adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="edited"))
+    return adapter
+
+
+def _delivered_text(adapter: MagicMock) -> str:
+    """Reconstruct visible text in platform delivery order."""
+    sent = [call.kwargs["content"] for call in adapter.send.await_args_list]
+    edited = [call.kwargs["content"] for call in adapter.edit_message.await_args_list]
+    return "".join((*edited, *sent))
+
+
+def _boundary_crossing_response() -> str:
+    """Place a redactable token across the consumer's 500-character split."""
+    return "x" * 496 + " " + _BOUNDARY_SECRET + "\ncomplete"
 
 
 class TestCleanForDisplaySecretRedaction:
@@ -36,10 +65,10 @@ class TestCleanForDisplaySecretRedaction:
 
     def test_api_key_redacted(self):
         """API keys in streamed text must be redacted."""
-        text = "Here is your key: sk-abc123def456ghi789jkl012mno345pqr678stu"
+        text = f"Here is your key: {_BOUNDARY_SECRET}"
         result = GatewayStreamConsumer._clean_for_display(text)
         # The redactor preserves first 6 + last 4 chars for long tokens
-        assert "sk-abc123def456" not in result
+        assert _BOUNDARY_SECRET not in result
         assert "sk-abc" in result  # prefix preserved
         assert "8stu" in result  # suffix preserved
 
@@ -59,3 +88,39 @@ class TestCleanForDisplaySecretRedaction:
         """Whitespace-only text returns empty string after rstrip."""
         result = GatewayStreamConsumer._clean_for_display("   \n\n  ")
         assert result == ""
+
+
+class TestOverflowSecretRedaction:
+    """Overflow must sanitize the complete buffer before splitting it."""
+
+    def test_first_message_overflow_cannot_reconstruct_cross_boundary_secret(self):
+        """The no-message overflow branch never delivers reconstructable fragments."""
+        adapter = _overflow_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(buffer_threshold=1),
+        )
+        consumer.on_delta(_boundary_crossing_response())
+        consumer.finish()
+
+        asyncio.run(consumer.run())
+
+        assert _BOUNDARY_SECRET not in _delivered_text(adapter)
+
+    def test_existing_message_overflow_cannot_reconstruct_cross_boundary_secret(self):
+        """The existing-message overflow branch never delivers reconstructable fragments."""
+        adapter = _overflow_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(buffer_threshold=1),
+        )
+        consumer._message_id = "preview"
+        consumer._already_sent = True
+        consumer.on_delta(_boundary_crossing_response())
+        consumer.finish()
+
+        asyncio.run(consumer.run())
+
+        assert _BOUNDARY_SECRET not in _delivered_text(adapter)


### PR DESCRIPTION
## What does this PR do?

The streaming path (`_clean_for_display`) originally stripped MEDIA tags and `[[audio_as_voice]]` directives but did not redact secrets or strip tool-trace banners. When a long response is split into multiple platform messages, intermediate chunks are finalized (`finalize=True`, never edited again) and can permanently expose secrets or internal diagnostics to chat users.

The fix sanitizes the complete display buffer before splitting and adds a streaming holdback for unresolved credential candidates. A candidate remains in the mutable tail until a later delta resolves it or the stream ends, so neither overflow branch can seal fragments that a recipient could concatenate into a secret. The non-overflow path also sends only the sanitized sealable head when a tail is pending.

## Related Issue

Fixes #56039

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_consumer.py`: keep the existing vendor-token holdback aligned with the authoritative redactor and add structural candidates for generic assignments, dotted/YAML config keys, JSON fields, authorization/API-key headers, database and bare-token URLs, JWTs, Telegram tokens, phone numbers, and private-key blocks.
- `gateway/stream_consumer.py`: prevent the raw full buffer from being sent when a structural candidate is held but the sealable head is below the platform limit.
- `agent/redact.py`: make form-body redaction consume the declared `_SENSITIVE_BODY_KEYS` authority instead of reusing only query-string keys.
- `tests/gateway/test_stream_consumer_redaction.py`: add table-driven incremental regressions for every authoritative form-body key and split offset on both fresh-message and existing-message overflow branches, plus delimiter-aware `?`/`&` query-prefix coverage; the focused file now runs 106 tests.
- `tests/agent/test_redact.py`: verify every authoritative form-body key is masked.
- The PR branch is isolated to the four gateway/redactor implementation and regression-test files; unrelated desktop files are not included.

## How to Test

```text
bash scripts/run_tests.sh tests/gateway/test_stream_consumer_redaction.py -q
# 106 passed
bash scripts/run_tests.sh tests/gateway/test_stream_consumer.py -q
# 65 passed, 1 skipped
bash scripts/run_tests.sh tests/agent/test_redact.py -q
# 80 passed
uv run --extra dev ruff check agent/redact.py gateway/stream_consumer.py tests/agent/test_redact.py tests/gateway/test_stream_consumer_redaction.py
python -m compileall -q agent/redact.py gateway/stream_consumer.py tests/agent/test_redact.py tests/gateway/test_stream_consumer_redaction.py
git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run existing gateway tests and they pass
- [x] I've added tests for the streaming redaction changes (106 focused tests plus 80 redactor tests)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] I've considered cross-platform impact — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas — or N/A
