### PR TITLE
fix(spotify): harden URI normalization and device guidance in tools

### DIFF
--- a/plugins/spotify/client.py
+++ b/plugins/spotify/client.py
@@ -139,6 +139,26 @@ def normalize_spotify_id(value: str, expected_type: Optional[str] = None) -> str
     return cleaned
 
 
+def spotify_uri_type(value: str) -> Optional[str]:
+    """Return the item type encoded in a Spotify URI/url, or None for bare ids.
+
+    Lets callers derive ``expected_type`` from the input instead of hardcoding a
+    single type, so ``normalize_spotify_uri`` can canonicalize whatever the user
+    passed without narrowing the accepted types.
+    """
+    cleaned = (value or "").strip()
+    if cleaned.startswith("spotify:"):
+        parts = cleaned.split(":")
+        if len(parts) >= 3 and parts[1]:
+            return parts[1]
+    elif "open.spotify.com" in cleaned:
+        path_parts = [part for part in urlparse(cleaned).path.split("/") if part]
+        if len(path_parts) >= 2:
+            return path_parts[0]
+    return None
+
+
+
 def normalize_spotify_uri(value: str, expected_type: Optional[str] = None) -> str:
     """Like normalize_spotify_id but returns a URI; bare ids need *expected_type* to become one."""
     cleaned = (value or "").strip()

--- a/plugins/spotify/tools.py
+++ b/plugins/spotify/tools.py
@@ -11,7 +11,8 @@ from typing import Any, Callable, Dict, List, Optional
 
 from hermes_cli.auth import get_auth_status
 from plugins.spotify.client import (
-    SpotifyClient, SpotifyError, normalize_spotify_id, normalize_spotify_uri, normalize_spotify_uris)
+    SpotifyClient, SpotifyError, normalize_spotify_id, normalize_spotify_uri, normalize_spotify_uris,
+    spotify_uri_type)
 from tools.registry import tool_error, tool_result
 
 _Handler = Callable[[SpotifyClient, dict, str], str]
@@ -22,6 +23,57 @@ def _check_spotify_available() -> bool:
         return bool(get_auth_status("spotify").get("logged_in"))
     except Exception:
         return False
+
+
+def _spotify_client() -> SpotifyClient:
+    return SpotifyClient()
+
+
+def _coerce_spotify_uri(value: str, expected_type: Optional[str] = None) -> str:
+    """Normalize a Spotify URI/URL/ID into a canonical ``spotify:<type>:<id>`` URI.
+
+    Delegates to ``normalize_spotify_uri`` from the Spotify client so behavior
+    stays in lock-step with the existing, tested normalizer. Accepts bare IDs
+    when ``expected_type`` is None (preserving the prior passthrough behavior
+    required by the queue handler for search-result IDs).
+    """
+    return normalize_spotify_uri(str(value or ""), expected_type)
+
+
+# Item types Spotify's queue endpoint accepts.
+_QUEUEABLE_TYPES = {"track", "episode"}
+
+
+def _coerce_queueable_spotify_uri(value: str) -> str:
+    """Normalize a queue target into ``spotify:track:<id>`` or ``spotify:episode:<id>``.
+
+    Spotify's ``POST /v1/me/player/queue`` accepts tracks *and* episodes, so the
+    type is inferred per input rather than forced to "track": typed URIs and
+    ``open.spotify.com/<type>/<id>`` urls keep their own type (and are still
+    canonicalized, never forwarded as a raw url), while a bare id — the
+    search-result case — defaults to a track. Types Spotify cannot queue are
+    rejected here instead of coming back as a "Bad URI" from the API.
+    """
+    item_type = spotify_uri_type(value) or "track"
+    if item_type.lower() not in _QUEUEABLE_TYPES:
+        raise SpotifyError(f"Spotify can only queue a track or an episode, got {item_type}.")
+    # Pass the canonical lower-case type on: Spotify's own types are lower-case, so
+    # an oddly-cased one has to fail here with a clear message rather than be
+    # forwarded as `spotify:EPISODE:<id>` for the API to reject as a Bad URI.
+    return _coerce_spotify_uri(value, item_type.lower())
+
+
+def _has_active_device(client: SpotifyClient) -> bool:
+    """Return True only when a device is currently *active* for playback.
+
+    Distinguishes the active device from merely-listed devices (Spotify's API
+    requires the currently active device when ``device_id`` is omitted). Lookup
+    failures are deliberately NOT swallowed here: the caller's top-level
+    ``except`` surfaces them via ``_spotify_tool_error`` instead of masking the
+    real cause behind a misleading "no active device" message.
+    """
+    devices = client.request("GET", "/me/player/devices") or {}
+    return any(bool(d.get("is_active")) for d in devices.get("devices") or [])
 
 
 def _spotify_tool_error(exc: Exception) -> str:
@@ -88,7 +140,7 @@ def _dispatcher(tool_name: str, default: str, table: Dict[str, _Handler], prepar
     """
     def handle(args: dict, **kw) -> str:
         action = str(args.get("action") or default).strip().lower()
-        client = SpotifyClient()
+        client = _spotify_client()
         try:
             if prepare is not None:
                 args = prepare(args)
@@ -122,7 +174,20 @@ def _pb_read(fetch: Callable[..., Any], args: dict, action: str) -> str:
 _CONTEXT_TYPES = (("album", "spotify:album:", "/album/"), ("playlist", "spotify:playlist:", "/playlist/"), ("artist", "spotify:artist:", "/artist/"))
 
 
+def _pb_device_guard(client: SpotifyClient, args: dict) -> Optional[str]:
+    """Active-device requirement for playback-changing commands: an error string, or None."""
+    if not args.get("device_id") and not _has_active_device(client):
+        return (
+            "No active Spotify playback device is available. Use `spotify_devices` to list devices, "
+            "then transfer playback before retrying."
+        )
+    return None
+
+
 def _pb_play(client: SpotifyClient, args: dict, action: str) -> str:
+    guard = _pb_device_guard(client, args)
+    if guard:
+        return tool_error(guard)
     offset = args.get("offset")
     payload_offset = {k: v for k, v in offset.items() if v is not None} if isinstance(offset, dict) else None
     uris = normalize_spotify_uris(_as_list(args.get("uris")), "track") if args.get("uris") else None
@@ -131,13 +196,16 @@ def _pb_play(client: SpotifyClient, args: dict, action: str) -> str:
         raw = str(args.get("context_uri"))
         # Infer the context type so mismatches raise; unknown kinds pass through unchecked.
         context_type = next((t for t, prefix, frag in _CONTEXT_TYPES if raw.startswith(prefix) or frag in raw), None)
-        context_uri = normalize_spotify_uri(raw, context_type)
+        context_uri = _coerce_spotify_uri(raw, context_type)
     body = {"context_uri": context_uri, "uris": uris, "offset": payload_offset, "position_ms": args.get("position_ms")}
     return _ok(action, client.request("PUT", "/me/player/play", params={"device_id": args.get("device_id")}, json_body=body))
 
 
 def _pb_cmd(client: SpotifyClient, args: dict, action: str, method: str, path: str, **extra: Any) -> str:
     """Player command whose only free argument is ``device_id`` (*extra* = fixed params)."""
+    guard = _pb_device_guard(client, args)
+    if guard:
+        return tool_error(guard)
     return _ok(action, client.request(method, path, params={**extra, "device_id": args.get("device_id")}))
 
 
@@ -190,7 +258,12 @@ _handle_spotify_devices = _dispatcher("spotify_devices", "list", {
 
 
 def _queue_add(client: SpotifyClient, args: dict, action: str) -> str:
-    uri = normalize_spotify_uri(str(args.get("uri") or ""), None)
+    if not args.get("device_id") and not _has_active_device(client):
+        return tool_error(
+            "No active Spotify playback device is available. Use `spotify_devices` to list devices, "
+            "then transfer playback before retrying."
+        )
+    uri = _coerce_queueable_spotify_uri(str(args.get("uri") or ""))
     return _ok(action, client.request("POST", "/me/player/queue", params={"uri": uri, "device_id": args.get("device_id")}), uri=uri)
 
 

--- a/tests/tools/test_spotify_client.py
+++ b/tests/tools/test_spotify_client.py
@@ -118,3 +118,310 @@ def test_client_wraps_invalid_grant_as_spotify_auth_required_error(
     )
     with pytest.raises(spotify_mod.SpotifyAuthRequiredError, match="expired or was revoked"):
         spotify_mod.SpotifyClient()
+
+
+# ── Regression tests for Spotify URI normalization & device guidance ─────────
+# Covers the normalizer contract used by the playback/queue tools, the
+# dedup + non-empty contract preserved by normalize_spotify_uris in the play
+# path, and the active-device guard that distinguishes the active device from
+# merely-listed devices.
+
+
+def test_normalize_spotify_uri_bare_id_prefixes_expected_type() -> None:
+    result = spotify_mod.normalize_spotify_uri("7ouMYWpwJ422jRcDASZB7P", "track")
+    assert result == "spotify:track:7ouMYWpwJ422jRcDASZB7P"
+
+
+def test_normalize_spotify_uri_returns_native_uri_unchanged() -> None:
+    uri = "spotify:album:0sNOF9WDwhWunNAHPD3Baj"
+    assert spotify_mod.normalize_spotify_uri(uri, "album") == uri
+
+
+def test_normalize_spotify_uri_open_url_canonicalizes() -> None:
+    url = "https://open.spotify.com/track/7ouMYWpwJ422jRcDASZB7P?si=abc"
+    assert spotify_mod.normalize_spotify_uri(url, "track") == "spotify:track:7ouMYWpwJ422jRcDASZB7P"
+
+
+def test_normalize_spotify_uri_rejects_type_mismatch() -> None:
+    with pytest.raises(spotify_mod.SpotifyError, match="Expected a Spotify track"):
+        spotify_mod.normalize_spotify_uri("spotify:album:abc", "track")
+
+
+def test_normalize_spotify_uri_empty_string_raises() -> None:
+    with pytest.raises(spotify_mod.SpotifyError, match="Spotify URI/url/id is required"):
+        spotify_mod.normalize_spotify_uri("", None)
+
+
+def test_normalize_spotify_uri_none_raises() -> None:
+    with pytest.raises(spotify_mod.SpotifyError, match="Spotify URI/url/id is required"):
+        spotify_mod.normalize_spotify_uri(None, None)  # type: ignore[arg-type]
+
+
+def test_normalize_spotify_uris_deduplicates_and_rejects_empty() -> None:
+    # Deduplicates repeated entries while preserving order.
+    result = spotify_mod.normalize_spotify_uris(
+        ["7ouMYWpwJ422jRcDASZB7P", "7ouMYWpwJ422jRcDASZB7P"], "track"
+    )
+    assert result == ["spotify:track:7ouMYWpwJ422jRcDASZB7P"]
+    # Rejects an empty collection instead of forwarding an empty list to the API.
+    with pytest.raises(spotify_mod.SpotifyError, match="At least one Spotify item is required"):
+        spotify_mod.normalize_spotify_uris([], "track")
+
+
+def _queue_stub(*, active_devices=True, devices_error=None):
+    """A request()-based SpotifyClient stub: records queued URIs, answers device lookups."""
+    seen_uris: list[str] = []
+
+    class _Stub:
+        def request(self, method, path, params=None, json_body=None):
+            if method == "GET" and path == "/me/player/devices":
+                if devices_error is not None:
+                    raise devices_error
+                return {"devices": [{"id": "dev-1", "is_active": active_devices}]}
+            if method == "POST" and path == "/me/player/queue":
+                seen_uris.append((params or {}).get("uri"))
+                return {"snapshot_id": "snap-1"}
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+    return _Stub(), seen_uris
+
+
+def test_handle_spotify_queue_add_canonicalizes_bare_id_to_track(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Queue add must promote a bare search-result ID to a full track URI,
+    since Spotify's POST /me/player/queue rejects anything other than a full
+    spotify:track:<id> URI."""
+    stub, seen_uris = _queue_stub()
+    monkeypatch.setattr(spotify_tool, "_spotify_client", lambda: stub)
+    response = json.loads(
+        spotify_tool._handle_spotify_queue(
+            {"action": "add", "uri": "7ouMYWpwJ422jRcDASZB7P", "device_id": "dev-1"}
+        )
+    )
+    assert response["success"] is True
+    assert response["uri"] == "spotify:track:7ouMYWpwJ422jRcDASZB7P"
+    assert seen_uris == ["spotify:track:7ouMYWpwJ422jRcDASZB7P"]
+
+
+def test_handle_spotify_queue_add_passes_native_track_uri_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub, seen_uris = _queue_stub()
+    monkeypatch.setattr(spotify_tool, "_spotify_client", lambda: stub)
+    response = json.loads(
+        spotify_tool._handle_spotify_queue(
+            {"action": "add", "uri": "spotify:track:7ouMYWpwJ422jRcDASZB7P", "device_id": "dev-1"}
+        )
+    )
+    assert response["uri"] == "spotify:track:7ouMYWpwJ422jRcDASZB7P"
+    assert seen_uris == ["spotify:track:7ouMYWpwJ422jRcDASZB7P"]
+
+
+def test_handle_spotify_queue_add_blocks_when_no_active_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No device_id and only inactive devices: must NOT reach the queue API."""
+    stub, seen_uris = _queue_stub(active_devices=False)
+    monkeypatch.setattr(spotify_tool, "_spotify_client", lambda: stub)
+    response = json.loads(
+        spotify_tool._handle_spotify_queue({"action": "add", "uri": "spotify:track:abc"})
+    )
+    assert "error" in response
+    assert "No active Spotify playback device" in response["error"]
+    assert seen_uris == []
+
+
+# ── Handler-level coverage requested by the cross-PR triage review ─────────
+# Covers the four gaps the consolidation review asked to confirm:
+#   1. empty playback input (uris=[""] must not reach start_playback as [])
+#   2. inactive-only device lists block playback, not just queue
+#   3. lookup failures propagate instead of being masked as "no active device"
+#   4. queue raw-ID coercion (covered above — listed here for completeness)
+
+
+def _play_stub(*, active_devices=True, devices_error=None):
+    """A request()-based playback stub: answers device lookups, records play bodies."""
+    plays: list[dict] = []
+
+    class _Stub:
+        def request(self, method, path, params=None, json_body=None):
+            if method == "GET" and path == "/me/player/devices":
+                if devices_error is not None:
+                    raise devices_error
+                return {"devices": [{"id": "dev-1", "is_active": active_devices}]}
+            if method == "PUT" and path == "/me/player/play":
+                plays.append({"params": params or {}, "body": json_body or {}})
+                return {}
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+    return _Stub(), plays
+
+
+def test_playback_play_rejects_empty_uris_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A truthy uris=[''] must NOT reach start_playback as an empty list.
+
+    The play path routes through normalize_spotify_uris (via _as_list, which
+    drops blank entries), so the batch normalizer's non-empty contract still
+    rejects it. Guards against the regression flagged at tools.py:134.
+    """
+    stub, plays = _play_stub()
+    monkeypatch.setattr(spotify_tool, "_spotify_client", lambda: stub)
+    response = json.loads(
+        spotify_tool._handle_spotify_playback({"action": "play", "uris": [""]})
+    )
+    assert "error" in response
+    assert "At least one Spotify item" in response["error"]
+    # Crucially, the API client was never called with an empty uris list.
+    assert plays == []
+
+
+def test_playback_play_blocks_when_only_inactive_devices_listed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """playback 'play' with no device_id and only inactive devices is blocked.
+
+    A nonempty device list does not establish the active device required when
+    device_id is omitted (docs contract at spotify.md:106).
+    """
+    stub, plays = _play_stub(active_devices=False)
+    monkeypatch.setattr(spotify_tool, "_spotify_client", lambda: stub)
+    response = json.loads(
+        spotify_tool._handle_spotify_playback(
+            {"action": "play", "uris": ["spotify:track:abc"]}
+        )
+    )
+    assert "error" in response
+    assert "No active Spotify playback device" in response["error"]
+    assert plays == []
+
+
+def test_playback_play_propagates_device_lookup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_devices() failures must surface, not be masked as 'no active device'.
+
+    _has_active_device deliberately does NOT swallow lookup errors; the
+    caller's top-level except surfaces them via _spotify_tool_error so the
+    real cause (e.g. a 401 / network failure) stays visible.
+    """
+    stub, plays = _play_stub(
+        devices_error=spotify_mod.SpotifyAPIError(
+            "Spotify rejected this playback request. "
+            "Playback control usually requires a Spotify Premium account "
+            "and an active Spotify Connect device.",
+            status_code=403,
+        )
+    )
+    monkeypatch.setattr(spotify_tool, "_spotify_client", lambda: stub)
+    response = json.loads(
+        spotify_tool._handle_spotify_playback(
+            {"action": "play", "uris": ["spotify:track:abc"]}
+        )
+    )
+    assert "error" in response
+    # The real cause is surfaced, NOT the misleading "no active device" message.
+    assert "No active Spotify playback device" not in response["error"]
+    assert plays == []
+
+
+def test_playback_play_proceeds_when_active_device_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity: playback 'play' proceeds when a device with is_active=True exists."""
+    stub, plays = _play_stub()
+    monkeypatch.setattr(spotify_tool, "_spotify_client", lambda: stub)
+    response = json.loads(
+        spotify_tool._handle_spotify_playback(
+            {"action": "play", "uris": ["spotify:track:abc"]}
+        )
+    )
+    assert response.get("success") is True
+    assert plays and plays[0]["body"]["uris"] == ["spotify:track:abc"]
+
+
+# ── Queue add must infer the item type instead of forcing "track" ────────────
+# Spotify's POST /v1/me/player/queue accepts tracks *and* episodes, so a typed
+# episode URI must survive the handler while unqueueable types still error and
+# bare search-result IDs still default to a track.
+
+
+@pytest.mark.parametrize(
+    ("raw_uri", "expected_uri"),
+    [
+        ("spotify:track:7ouMYWpwJ422jRcDASZB7P", "spotify:track:7ouMYWpwJ422jRcDASZB7P"),
+        ("spotify:episode:512ojhOuo1ktJprKbVcKyQ", "spotify:episode:512ojhOuo1ktJprKbVcKyQ"),
+        (
+            "https://open.spotify.com/episode/512ojhOuo1ktJprKbVcKyQ?si=abc",
+            "spotify:episode:512ojhOuo1ktJprKbVcKyQ",
+        ),
+        ("7ouMYWpwJ422jRcDASZB7P", "spotify:track:7ouMYWpwJ422jRcDASZB7P"),
+    ],
+)
+def test_handle_spotify_queue_add_infers_type_per_input(
+    monkeypatch: pytest.MonkeyPatch, raw_uri: str, expected_uri: str
+) -> None:
+    stub, seen_uris = _queue_stub()
+    monkeypatch.setattr(spotify_tool, "_spotify_client", lambda: stub)
+    response = json.loads(
+        spotify_tool._handle_spotify_queue(
+            {"action": "add", "uri": raw_uri, "device_id": "dev-1"}
+        )
+    )
+    assert response["success"] is True
+    assert response["uri"] == expected_uri
+    # A raw open.spotify.com URL is never handed to Spotify as-is (Bad URI).
+    assert seen_uris == [expected_uri]
+
+
+@pytest.mark.parametrize(
+    "raw_uri",
+    [
+        "spotify:album:0sNOF9WDwhWunNAHPD3Baj",
+        "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+    ],
+)
+def test_handle_spotify_queue_add_rejects_unqueueable_type(
+    monkeypatch: pytest.MonkeyPatch, raw_uri: str
+) -> None:
+    """Types Spotify cannot queue must fail before the API call."""
+    stub, seen_uris = _queue_stub()
+    monkeypatch.setattr(spotify_tool, "_spotify_client", lambda: stub)
+    response = json.loads(
+        spotify_tool._handle_spotify_queue(
+            {"action": "add", "uri": raw_uri, "device_id": "dev-1"}
+        )
+    )
+    assert "error" in response
+    assert "only queue a track or an episode" in response["error"]
+    assert seen_uris == []
+
+
+@pytest.mark.parametrize(
+    "raw_uri",
+    [
+        "spotify:EPISODE:512ojhOuo1ktJprKbVcKyQ",
+        "https://open.spotify.com/Track/7ouMYWpwJ422jRcDASZB7P",
+    ],
+)
+def test_handle_spotify_queue_add_rejects_miscased_type(
+    monkeypatch: pytest.MonkeyPatch, raw_uri: str
+) -> None:
+    """A queueable type in the wrong case fails locally, not as a Bad URI."""
+    stub, seen_uris = _queue_stub()
+    monkeypatch.setattr(spotify_tool, "_spotify_client", lambda: stub)
+    response = json.loads(
+        spotify_tool._handle_spotify_queue(
+            {"action": "add", "uri": raw_uri, "device_id": "dev-1"}
+        )
+    )
+    assert "error" in response
+    assert "Expected a Spotify" in response["error"]
+    assert seen_uris == []
+
+
+def test_spotify_uri_type_reads_type_from_uri_and_url() -> None:
+    assert spotify_mod.spotify_uri_type("spotify:episode:abc") == "episode"
+    assert spotify_mod.spotify_uri_type("https://open.spotify.com/track/abc?si=x") == "track"
+    # A bare id carries no type information.
+    assert spotify_mod.spotify_uri_type("7ouMYWpwJ422jRcDASZB7P") is None


### PR DESCRIPTION
Spotify tools now normalize URIs more carefully and require an active playback device before playback-changing and queue actions, so malformed IDs/URIs are never sent to Spotify as "Bad URI" and blind retries without a device stop.

Changes (`plugins/spotify/tools.py`, `plugins/spotify/client.py`):
- `_coerce_spotify_uri()` (tools) delegates to the existing `normalize_spotify_uri()` so `open.spotify.com/...`, `spotify:<type>:<id>` and bare IDs (when the type is known) all canonicalize to `spotify:<type>:<id>`.
- `spotify_uri_type()` (client) reads the item type out of a `spotify:<type>:<id>` URI or an `open.spotify.com/<type>/<id>` URL; returns `None` for a bare id.
- `_coerce_queueable_spotify_uri()` (tools) infers the queue target type per input (`spotify_uri_type(value) or "track"`), rejects anything outside `{track, episode}` locally with a clear message, and passes the lower-cased type on so `spotify:EPISODE:<id>` fails here rather than as a Spotify "Bad URI". A bare search-result id becomes `spotify:track:<id>` (the #56044 case).
- `_has_active_device()` (tools) checks `is_active` on `GET /me/player/devices`. Device-lookup failures are not swallowed; they surface through the handler's normal `_spotify_tool_error` path instead of being masked as "no active device".
- Playback-changing commands (play/pause/next/previous/seek/repeat/shuffle/volume) and queue `add` return an actionable "No active Spotify playback device is available..." error when `device_id` is omitted and no device is active.
- Playback `uris` keep going through `normalize_spotify_uris(_as_list(...), "track")`, so ordered de-duplication and empty-collection rejection are preserved (`uris=[""]` never reaches the API as `[]`).

Tests (`tests/tools/test_spotify_client.py`, 27 passing):
- Queue add: typed track, typed episode, `open.spotify.com/episode/<id>?si=...`, bare id -> asserted both the reported `uri` and the URI actually handed to the API; unqueueable types (`spotify:album:...`, `open.spotify.com/playlist/...`) rejected without an API call; mis-cased type pair; `spotify_uri_type` unit test.
- Device guard: inactive-only device lists block playback; lookup failures propagate; playback proceeds when an `is_active=True` device exists; queue add blocks with no active device.
- Batch normalizer: `test_normalize_spotify_uris_deduplicates_and_rejects_empty`, `test_playback_play_rejects_empty_uris_input`.
- Neighbour `tests/hermes_cli/test_spotify_auth.py` still passes.

Motivation:
Avoid sending malformed IDs/URIs to Spotify and reduce retries without an active device.

Related: #56044
