### PR TITLE
feat(gateway): add telegram group access notice

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -226,6 +226,7 @@ try:
         Application,
         CommandHandler,
         CallbackQueryHandler,
+        ChatMemberHandler,
         MessageHandler as TelegramMessageHandler,
         ContextTypes,
         filters,
@@ -244,6 +245,7 @@ except ImportError:
     Application = Any
     CommandHandler = Any
     CallbackQueryHandler = Any
+    ChatMemberHandler = Any
     TelegramMessageHandler = Any
     HTTPXRequest = Any
     filters = None
@@ -385,7 +387,7 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, ChatMemberHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -404,6 +406,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
+            ChatMemberHandler as _CMH,
             MessageHandler as _MH,
             ContextTypes as _CT, filters as _filters,
         )
@@ -420,6 +423,7 @@ def check_telegram_requirements() -> bool:
     Application = _App
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
+    ChatMemberHandler = _CMH
     TelegramMessageHandler = _MH
     ContextTypes = _CT
     filters = _filters
@@ -721,6 +725,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}
         self._media_group_tasks: Dict[str, asyncio.Task] = {}
+        self._group_access_notices_sent: Set[str] = set()
         # Buffer rapid text messages so Telegram client-side splits of long
         # messages are aggregated into a single MessageEvent.  Lower defaults
         # (0.3s / 1.0s instead of 0.6s / 2.0s) let short replies stream
@@ -3787,6 +3792,10 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app.add_handler(TelegramMessageHandler(
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
+            ))
+            self._app.add_handler(ChatMemberHandler(
+                self._handle_my_chat_member,
+                ChatMemberHandler.MY_CHAT_MEMBER,
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
@@ -7706,6 +7715,18 @@ class TelegramAdapter(BasePlatformAdapter):
             return group_allowed & response_allowed
         return group_allowed
 
+    def _telegram_group_access_notice(self, chat_title: str | None = None) -> str:
+        title = chat_title or "this group"
+        return (
+            f"Hi, I'm Hermes.\n\n"
+            f"To reply in {title}, this chat must be allowlisted in the gateway "
+            f"configuration. For Telegram groups, the bot also needs enough "
+            f"group delivery permissions to see messages reliably, which usually "
+            f"means disabling privacy mode or promoting the bot to admin.\n\n"
+            f"If you've just changed those settings, remove and re-add the bot "
+            f"to refresh Telegram's cached group state."
+        )
+
     def _telegram_allowed_topics(self) -> set[str]:
         """Return the whitelist of Telegram forum topic IDs this bot handles.
 
@@ -7923,6 +7944,44 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         reply_user = getattr(message.reply_to_message, "from_user", None)
         return bool(reply_user and getattr(reply_user, "id", None) == getattr(self._bot, "id", None))
+
+    async def _handle_my_chat_member(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Surface a one-time onboarding notice when the bot is added to a group."""
+        member_update = getattr(update, "my_chat_member", None)
+        if not member_update:
+            return
+
+        chat = getattr(member_update, "chat", None)
+        if not chat:
+            return
+        chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
+        if chat_type not in {"group", "supergroup"}:
+            return
+
+        old_member = getattr(member_update, "old_chat_member", None)
+        new_member = getattr(member_update, "new_chat_member", None)
+        old_status = str(getattr(old_member, "status", "")).split(".")[-1].lower()
+        new_status = str(getattr(new_member, "status", "")).split(".")[-1].lower()
+
+        if old_status not in {"left", "kicked"}:
+            return
+        if new_status not in {"member", "administrator", "creator"}:
+            return
+
+        chat_id = str(getattr(chat, "id", "")).strip()
+        if not chat_id or chat_id in self._group_access_notices_sent:
+            return
+        self._group_access_notices_sent.add(chat_id)
+
+        notice = self._telegram_group_access_notice(getattr(chat, "title", None))
+        try:
+            await self.send(chat_id, notice)
+        except Exception:
+            logger.debug(
+                "[Telegram] Failed to send group access notice for chat %s",
+                chat_id,
+                exc_info=True,
+            )
 
     @classmethod
     def _extract_bot_mention_usernames(cls, message: Message, self_username: str = "") -> set[str]:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7719,12 +7719,13 @@ class TelegramAdapter(BasePlatformAdapter):
         title = chat_title or "this group"
         return (
             f"Hi, I'm Hermes.\n\n"
-            f"To reply in {title}, this chat must be allowlisted in the gateway "
-            f"configuration. For Telegram groups, the bot also needs enough "
-            f"group delivery permissions to see messages reliably, which usually "
-            f"means disabling privacy mode or promoting the bot to admin.\n\n"
-            f"If you've just changed those settings, remove and re-add the bot "
-            f"to refresh Telegram's cached group state."
+            f"To reply in {title}, authorize either the sender with "
+            f"TELEGRAM_ALLOWED_USERS or TELEGRAM_GROUP_ALLOWED_USERS, or this "
+            f"group with TELEGRAM_GROUP_ALLOWED_CHATS.\n\n"
+            f"Telegram must also deliver group messages to me. You can mention "
+            f"me directly, disable privacy mode, or grant suitable admin "
+            f"permissions. If you change BotFather privacy settings, remove and "
+            f"re-add me to refresh Telegram's cached group state."
         )
 
     def _telegram_allowed_topics(self) -> set[str]:

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -84,6 +84,67 @@ async def test_connect_rejects_same_host_token_lock(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_connect_registers_my_chat_member_handler(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    registered_handler = object()
+    captured = {}
+
+    class FakeChatMemberHandler:
+        MY_CHAT_MEMBER = "my_chat_member"
+
+        def __new__(cls, callback, chat_member_types):
+            captured["callback"] = callback
+            captured["chat_member_types"] = chat_member_types
+            return registered_handler
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock(), delete_webhook=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.ChatMemberHandler",
+        FakeChatMemberHandler,
+    )
+
+    try:
+        assert await adapter.connect() is True
+        app.add_handler.assert_any_call(registered_handler)
+        assert captured == {
+            "callback": adapter._handle_my_chat_member,
+            "chat_member_types": FakeChatMemberHandler.MY_CHAT_MEMBER,
+        }
+    finally:
+        await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
 async def test_polling_conflict_retries_before_fatal(monkeypatch):
     """A single 409 should trigger a retry, not an immediate fatal error."""
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -106,8 +106,12 @@ async def test_connect_registers_my_chat_member_handler(monkeypatch):
             captured["chat_member_types"] = chat_member_types
             return registered_handler
 
+    async def fake_start_polling(**_kwargs):
+        # Cold connects now wait for the first successful getUpdates response.
+        adapter._record_polling_progress(adapter._polling_generation)
+
     updater = SimpleNamespace(
-        start_polling=AsyncMock(),
+        start_polling=AsyncMock(side_effect=fake_start_polling),
         stop=AsyncMock(),
         running=True,
     )

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -80,6 +80,7 @@ def _make_adapter(
     adapter._forum_command_registered = set()
     adapter._active_sessions = {}
     adapter._pending_messages = {}
+    adapter._group_access_notices_sent = set()
     # Trigger-gating tests don't exercise the allowlist gate (added by
     # #23795 + #24468).  Force-authorize all senders so the trigger logic
     # under test runs.  Without this, every fake message hits the new
@@ -115,6 +116,16 @@ def _group_message(
         from_user=SimpleNamespace(id=from_user_id, full_name=from_user_name, first_name=from_user_name.split()[0]),
         reply_to_message=reply_to_message,
         date=None,
+    )
+
+
+def _my_chat_member_update(*, chat_id=-100, chat_title="Test Group", old_status="left", new_status="member"):
+    return SimpleNamespace(
+        my_chat_member=SimpleNamespace(
+            chat=SimpleNamespace(id=chat_id, type="group", title=chat_title, is_forum=False),
+            old_chat_member=SimpleNamespace(status=old_status),
+            new_chat_member=SimpleNamespace(status=new_status),
+        )
     )
 
 
@@ -157,6 +168,24 @@ def test_group_messages_can_be_opened_via_config():
     adapter = _make_adapter(require_mention=False)
 
     assert adapter._should_process_message(_group_message("hello everyone")) is True
+
+
+def test_bot_join_posts_one_time_group_access_notice():
+    async def _run():
+        adapter = _make_adapter()
+        adapter.send = AsyncMock()
+
+        await adapter._handle_my_chat_member(_my_chat_member_update(), SimpleNamespace())
+        await adapter._handle_my_chat_member(_my_chat_member_update(), SimpleNamespace())
+
+        adapter.send.assert_awaited_once()
+        chat_id, content = adapter.send.await_args.args[:2]
+        assert chat_id == "-100"
+        assert "allowlisted" in content
+        assert "admin" in content
+        assert "privacy mode" in content
+
+    asyncio.run(_run())
 
 
 def test_unmentioned_group_messages_can_be_observed_without_dispatching():

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -181,7 +181,10 @@ def test_bot_join_posts_one_time_group_access_notice():
         adapter.send.assert_awaited_once()
         chat_id, content = adapter.send.await_args.args[:2]
         assert chat_id == "-100"
-        assert "allowlisted" in content
+        assert "TELEGRAM_ALLOWED_USERS" in content
+        assert "TELEGRAM_GROUP_ALLOWED_USERS" in content
+        assert "TELEGRAM_GROUP_ALLOWED_CHATS" in content
+        assert "mention" in content
         assert "admin" in content
         assert "privacy mode" in content
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -542,7 +542,7 @@ Hermes Agent works in Telegram group chats with a few considerations:
 - Use `telegram.ignored_threads` to keep Hermes silent in specific Telegram forum topics, even when the group would otherwise allow free responses or mention-triggered replies
 - If `telegram.require_mention` is left unset or false, Hermes keeps the previous open-group behavior and responds to normal group messages it can see
 
-When Hermes is added to a new group, it now posts a one-time onboarding reminder explaining the group allowlist requirement and the Telegram delivery settings that affect whether the bot can see group messages. That keeps the failure mode visible instead of silently dropping the setup mistake.
+When Hermes is added to a new group, it posts a one-time onboarding reminder explaining that either the sender or the group must be authorized, plus the Telegram delivery settings that affect whether the bot can see group messages. The reminder points to sender authorization through `TELEGRAM_ALLOWED_USERS` or `TELEGRAM_GROUP_ALLOWED_USERS`, group authorization through `TELEGRAM_GROUP_ALLOWED_CHATS`, and delivery through a direct mention, disabled privacy mode, or suitable admin permissions. That keeps common setup failures visible instead of failing silently.
 
 ### Multiple Hermes bots in one group
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -542,6 +542,8 @@ Hermes Agent works in Telegram group chats with a few considerations:
 - Use `telegram.ignored_threads` to keep Hermes silent in specific Telegram forum topics, even when the group would otherwise allow free responses or mention-triggered replies
 - If `telegram.require_mention` is left unset or false, Hermes keeps the previous open-group behavior and responds to normal group messages it can see
 
+When Hermes is added to a new group, it now posts a one-time onboarding reminder explaining the group allowlist requirement and the Telegram delivery settings that affect whether the bot can see group messages. That keeps the failure mode visible instead of silently dropping the setup mistake.
+
 ### Multiple Hermes bots in one group
 
 If you run several Hermes profiles in the same Telegram group, create one Telegram bot token per profile and start one gateway per profile. Do not reuse the same bot token in multiple running gateways; Telegram will reject concurrent polling for the same token.


### PR DESCRIPTION
## Summary

Add a one-time onboarding notice for Telegram group and supergroup chats so operators get an immediate explanation when Hermes is added to a group but cannot yet reply.

The notice is intentionally generic: it explains the existing group-access requirements instead of introducing any enterprise-specific workflow.

## What Changed

- Added a `my_chat_member` Telegram handler that posts a one-time group access notice when Hermes is added to a group.
- The notice explains the existing setup requirements:
  - the chat must be allowlisted in gateway config
  - Telegram privacy mode may need to be disabled for group delivery
  - promoting the bot to admin is another valid way to receive group messages
  - re-add the bot after changing privacy settings so Telegram refreshes its state
- Added tests covering the one-time notice behavior.
- Updated the Telegram documentation to mention the onboarding reminder.

## Why This Belongs Upstream

- It reduces support burden by surfacing a common misconfiguration at the moment it occurs.
- It keeps the behavior scoped to the existing gateway adapter and message-delivery model.
- It improves operator clarity without changing core routing behavior.

## Verification

- `pytest tests/gateway/test_telegram_group_gating.py -q`
- Result: `56 passed`

## Commit

- `1e59723` `feat(gateway): add telegram group access notice`
