### PR TITLE
fix(skills): coerce YAML date/time frontmatter to ISO strings

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -5,6 +5,7 @@ heavy dependency chain.  It is safe to import at module level without triggering
 tool registration or provider resolution.
 """
 
+import datetime
 import logging
 import os
 import re
@@ -171,6 +172,24 @@ def yaml_load(content: str):
 # ── Frontmatter parsing ──────────────────────────────────────────────────
 
 
+def _stringify_temporal(obj: Any) -> Any:
+    """Coerce YAML-parsed date/time values to ISO strings, recursively.
+
+    PyYAML's SafeLoader turns unquoted ``date:``/``updated:`` frontmatter values
+    into ``datetime.date``/``datetime.datetime`` objects, which are not JSON
+    serializable. Every ``json.dumps`` of skill metadata downstream then raises
+    ``TypeError: Object of type date is not JSON serializable``. Coerce them so
+    frontmatter stays JSON-safe. (``datetime`` subclasses ``date``.)
+    """
+    if isinstance(obj, dict):
+        return {k: _stringify_temporal(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_stringify_temporal(v) for v in obj]
+    if isinstance(obj, (datetime.date, datetime.time)):
+        return obj.isoformat()
+    return obj
+
+
 def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     """Parse YAML frontmatter from a markdown string.
 
@@ -208,7 +227,7 @@ def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     try:
         parsed = yaml_load(yaml_content)
         if isinstance(parsed, dict):
-            frontmatter = parsed
+            frontmatter = _stringify_temporal(parsed)
     except Exception:
         # Fallback: simple key:value parsing for malformed YAML
         for line in yaml_content.strip().split("\n"):

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,5 +1,7 @@
 """Tests for agent/skill_utils.py."""
 
+import json
+
 from unittest.mock import patch
 
 from agent.skill_utils import (
@@ -302,3 +304,44 @@ class TestBOMToleranceSiblingSites:
         assert fm is not None
         assert fm.get("name") == "bp"
 
+
+# parse_frontmatter — date/time coercion
+#
+# SafeLoader turns an unquoted ``date: 2025-12-01`` into a ``datetime.date``,
+# which is not JSON serializable. Since agentskills.io defines ``metadata:`` as
+# arbitrary key-value, a spec-valid SKILL.md can carry such a value, and every
+# downstream ``json.dumps`` of skill metadata (e.g. skill_view) then fails with
+# "Object of type date is not JSON serializable". Coerce temporal values to ISO
+# strings at parse time so frontmatter stays JSON-safe.
+
+
+def test_parse_frontmatter_coerces_top_level_date_to_iso_string():
+    fm, _ = parse_frontmatter("---\nname: demo\ndate: 2025-12-01\n---\nbody\n")
+    assert fm["date"] == "2025-12-01"
+    assert isinstance(fm["date"], str)
+    json.dumps(fm)  # must not raise
+
+
+def test_parse_frontmatter_coerces_nested_metadata_dates():
+    content = (
+        "---\n"
+        "name: demo\n"
+        "metadata:\n"
+        "  released: 2025-12-01\n"
+        "  when: 2025-12-01 09:30:00\n"
+        "---\nbody\n"
+    )
+    fm, _ = parse_frontmatter(content)
+    assert fm["metadata"]["released"] == "2025-12-01"
+    assert fm["metadata"]["when"] == "2025-12-01T09:30:00"
+    json.dumps(fm)  # must not raise
+
+
+def test_parse_frontmatter_preserves_non_temporal_values_and_body():
+    fm, body = parse_frontmatter(
+        "---\nname: demo\nversion: 1.0\ntags: [a, b]\n---\nhello body\n"
+    )
+    assert fm["name"] == "demo"
+    assert fm["version"] == 1.0
+    assert fm["tags"] == ["a", "b"]
+    assert body.strip() == "hello body"

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -334,6 +334,21 @@ class TestSkillView:
         assert by_name["success"] is True
         assert "Step 1" in by_name["content"]
 
+    def test_view_skill_with_date_metadata(self, tmp_path):
+        # Unquoted YAML dates under metadata: parse as datetime.date, which
+        # json.dumps cannot serialize — skill_view must still succeed and
+        # return the date as an ISO string.
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "dated-skill",
+                frontmatter_extra="metadata:\n  released: 2025-12-01\n",
+            )
+            raw = skill_view("dated-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["metadata"]["released"] == "2025-12-01"
+
 
     def test_view_reference_files(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):


### PR DESCRIPTION
## Problem

`parse_frontmatter` (`agent/skill_utils.py`) loads SKILL.md YAML with `CSafeLoader`, so an unquoted `date:`/`updated:` — or any date under the agentskills.io `metadata:` block, which the spec defines as arbitrary key-value — is parsed into a Python `datetime.date`. `skill_view` (`tools/skills_tool.py`) then serializes that metadata with `json.dumps`, which raises:

```
TypeError: Object of type date is not JSON serializable
```

The error is caught and returned as `{"success": false, ...}`, so a spec-valid skill silently fails to load via tier-2 disclosure.

### Reproduce

A stock skill:

```yaml
---
name: demo
metadata:
  released: 2025-12-01
---
```

`skill_view("demo")` → `{"error": "Object of type date is not JSON serializable", "success": false}`

## Fix

Coerce `date`/`datetime`/`time` values to ISO strings at parse time, recursively through nested dicts and lists, so frontmatter stays JSON-safe. Non-temporal values are unchanged.

## Tests

Adds regression tests in `tests/agent/test_skill_utils.py` for top-level and nested-`metadata` dates (both fail without the fix). Full `test_skill_utils.py` passes (23).
