### PR TITLE
fix(gateway): redact secrets from finalized streaming chunks

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -804,7 +804,7 @@ class GatewayStreamConsumer:
 
     @staticmethod
     def _clean_for_display(text: str) -> str:
-        """Strip MEDIA: directives and internal markers from text before display.
+        """Strip MEDIA: directives and redact secrets from text before display.
 
         The streaming path delivers raw text chunks that may include
         ``MEDIA:<path>`` tags and ``[[audio_as_voice]]`` directives meant for
@@ -812,8 +812,16 @@ class GatewayStreamConsumer:
         delivered separately via ``_deliver_media_from_response()`` after the
         stream finishes — we just need to hide the raw directives from the
         user.
+
+        Secret redaction mirrors ``_sanitize_gateway_final_response`` so that
+        finalized intermediate chunks (sent with ``finalize=True`` and never
+        edited again) do not permanently expose credentials or tool-trace
+        diagnostics to chat participants.  (#56039)
         """
-        return _BasePlatformAdapter.strip_media_directives_for_display(text)
+        from gateway.run import _redact_gateway_user_facing_secrets
+
+        cleaned = _BasePlatformAdapter.strip_media_directives_for_display(text)
+        return _redact_gateway_user_facing_secrets(cleaned)
 
     async def _send_new_chunk(
         self,

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -84,6 +84,18 @@ class TestCleanForDisplay:
         # But "media:" is lowercase so won't match either
         assert result == text
 
+    def test_secrets_redacted_in_streaming_chunks(self):
+        """API keys and credentials must be redacted from streaming chunks.
+
+        Finalized intermediate chunks are never edited again, so secrets
+        must be stripped before the chunk is sent.  Regression guard for #56039.
+        """
+        fake_key = "sk-proj-" + "a" * 30
+        text = f"Here is the key: {fake_key}"
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert fake_key not in result
+        assert "Here is the key:" in result
+
 
 # ── Integration: _send_or_edit strips MEDIA: ─────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

The streaming path (`GatewayStreamConsumer._clean_for_display`) only stripped `MEDIA:` tags and `[[audio_as_voice]]` directives but never called `_redact_gateway_user_facing_secrets`. When a long response is split into multiple platform messages, intermediate chunks are finalized (`finalize=True`, never edited again) and permanently expose any secrets or tool-trace diagnostics to chat participants.

This fix adds `_redact_gateway_user_facing_secrets` to `_clean_for_display` with a lazy import (circular import guard — `run.py` imports from `stream_consumer.py`), so finalized intermediate chunks receive the same credential redaction as non-streaming final responses (`_sanitize_gateway_final_response`).

## Related Issue

Fixes #56039

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `gateway/stream_consumer.py`: Added `_redact_gateway_user_facing_secrets` call in `_clean_for_display` (lazy import to avoid circular dependency with `gateway.run`). Updated docstring to document the security behavior.
- `tests/gateway/test_stream_consumer.py`: Added `test_secrets_redacted_in_streaming_chunks` regression test verifying that `sk-proj-*` API keys are redacted from streaming display text.

## How to Test

1. Run `pytest tests/gateway/test_stream_consumer.py -q` — all 103 tests should pass (102 existing + 1 new regression test).
2. The new test verifies that a fake `sk-proj-*` key is redacted from `_clean_for_display` output, confirming the streaming path now applies the same redaction as the non-streaming path.
3. Manual verification: configure a chat gateway with streaming enabled, trigger a long response containing an API key pattern, and verify that finalized intermediate chunks do not contain the raw key.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (redaction logic is platform-independent)
