### PR TITLE
feat: add W&B (Weights & Biases) model-provider plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ images/
 __pycache__/
 hermes_agent.egg-info/
 wandb/
+!plugins/model-providers/wandb/
 testlogs
 
 # CLI config (may contain sensitive SSH paths)

--- a/plugins/model-providers/wandb/__init__.py
+++ b/plugins/model-providers/wandb/__init__.py
@@ -1,0 +1,89 @@
+"""W&B (Weights & Biases) inference provider profile.
+
+W&B hosts GLM-5.2 on a vLLM backend at api.inference.wandb.ai. The endpoint
+accepts:
+  - reasoning_effort as a top-level param ("high" or "max")
+  - chat_template_kwargs.enable_thinking as extra_body (false = no thinking)
+  - A browser User-Agent is required (Cloudflare blocks urllib default)
+
+GLM-5.2 only recognises "high" and "max" for reasoning_effort; other values
+(minimal/low/medium) are silently ignored and the model defaults to Think Max.
+The z.ai "thinking" parameter is also ignored by vLLM.
+
+This profile overrides build_api_kwargs_extras to emit the correct params.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+def _effort_to_glm(effort: str) -> str | None:
+    """Map Hermes reasoning effort levels to GLM-5.2's accepted values.
+
+    GLM-5.2 only supports "high" and "max". Unrecognised values silently
+    fall back to Think Max (the model default), so we explicitly map:
+      xhigh → "max" (GLM-5.2's deepest thinking)
+      high  → "high" (lighter, ~3× faster)
+      *     → None  (omit param — let GLM-5.2 use its default Think Max)
+    """
+    e = (effort or "").strip().lower()
+    if e in {"xhigh", "max"}:
+        return "max"
+    if e == "high":
+        return "high"
+    return None
+
+
+class WandbProfile(ProviderProfile):
+    """W&B inference — GLM-5.2 on vLLM with reasoning_effort + enable_thinking."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **ctx: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if not isinstance(reasoning_config, dict):
+            return extra_body, top_level
+
+        _enabled = reasoning_config.get("enabled", True)
+        _effort = (reasoning_config.get("effort") or "").strip().lower()
+
+        # Thinking disabled → chat_template_kwargs.enable_thinking=false
+        # This is the ONLY way to disable thinking on GLM-5.2 vLLM.
+        if _effort == "none" or _enabled is False:
+            extra_body["chat_template_kwargs"] = {"enable_thinking": False}
+            return extra_body, top_level
+
+        # Thinking enabled → emit reasoning_effort as top-level param
+        glm_effort = _effort_to_glm(_effort)
+        if glm_effort:
+            top_level["reasoning_effort"] = glm_effort
+
+        return extra_body, top_level
+
+
+wandb = WandbProfile(
+    name="wandb",
+    aliases=("wandb-ai", "weights-and-biases"),
+    env_vars=("WANDB_API_KEY",),
+    display_name="W&B Inference",
+    description="Weights & Biases inference API — GLM-5.2 on vLLM",
+    signup_url="https://wandb.ai",
+    base_url="https://api.inference.wandb.ai/v1",
+    fallback_models=("zai-org/GLM-5.2",),
+    default_max_tokens=65536,
+    # Cloudflare blocks the default urllib User-Agent; the transport
+    # adds a browser UA via default_headers.
+    default_headers={"User-Agent": "Mozilla/5.0"},
+)
+
+register_provider(wandb)

--- a/plugins/model-providers/wandb/__init__.py
+++ b/plugins/model-providers/wandb/__init__.py
@@ -7,8 +7,10 @@ accepts:
   - A browser User-Agent is required (Cloudflare blocks urllib default)
 
 GLM-5.2 only recognises "high" and "max" for reasoning_effort; other values
-(minimal/low/medium) are silently ignored and the model defaults to Think Max.
-The z.ai "thinking" parameter is also ignored by vLLM.
+(minimal/low/medium) are silently ignored and the model defaults to Think Max,
+so this profile maps unsupported lower efforts to the lightest supported value
+("high") instead of omitting the parameter. The z.ai "thinking" parameter is
+also ignored by vLLM.
 
 This profile overrides build_api_kwargs_extras to emit the correct params.
 """
@@ -26,14 +28,15 @@ def _effort_to_glm(effort: str) -> str | None:
 
     GLM-5.2 only supports "high" and "max". Unrecognised values silently
     fall back to Think Max (the model default), so we explicitly map:
-      xhigh → "max" (GLM-5.2's deepest thinking)
+      xhigh → "max"  (GLM-5.2's deepest thinking)
       high  → "high" (lighter, ~3× faster)
-      *     → None  (omit param — let GLM-5.2 use its default Think Max)
+      low/minimal/medium → "high" (lightest supported thinking)
+      unset/unknown → None (omit param — let GLM-5.2 use its default)
     """
     e = (effort or "").strip().lower()
     if e in {"xhigh", "max"}:
         return "max"
-    if e == "high":
+    if e in {"minimal", "low", "medium", "high"}:
         return "high"
     return None
 

--- a/plugins/model-providers/wandb/plugin.yaml
+++ b/plugins/model-providers/wandb/plugin.yaml
@@ -1,0 +1,5 @@
+name: wandb-provider
+kind: model-provider
+version: 1.0.0
+description: W&B Inference / GLM-5.2
+author: Nous Research

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -10,6 +10,13 @@ class TestRegistry:
         assert p is not None
         assert p.name == "nvidia"
 
+    def test_wandb_provider_discovered(self):
+        p = get_provider_profile("wandb")
+        assert p is not None
+        assert p.name == "wandb"
+        assert p.base_url == "https://api.inference.wandb.ai/v1"
+        assert p.default_headers["User-Agent"] == "Mozilla/5.0"
+
     def test_alias_lookup(self):
         assert get_provider_profile("kimi").name == "kimi-coding"
         assert get_provider_profile("moonshot").name == "kimi-coding"
@@ -44,6 +51,51 @@ class TestNvidiaProfile:
     def test_billing_header_not_profile_wide(self):
         p = get_provider_profile("nvidia")
         assert p.default_headers == {}
+
+
+class TestWandbProfile:
+    def test_none_disables_thinking_with_chat_template_kwargs(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "none"}
+        )
+        assert eb == {"chat_template_kwargs": {"enable_thinking": False}}
+        assert tl == {}
+
+    def test_high_maps_to_top_level_high(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}
+        )
+        assert eb == {}
+        assert tl["reasoning_effort"] == "high"
+
+    def test_xhigh_maps_to_top_level_max(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"}
+        )
+        assert eb == {}
+        assert tl["reasoning_effort"] == "max"
+
+    def test_lower_supported_efforts_map_to_lightest_glm_effort(self):
+        # W&B GLM-5.2 accepts only "high" and "max". Omitting the field for
+        # minimal/low/medium would silently select GLM's default Think Max,
+        # inverting the user's request for lighter reasoning.
+        p = get_provider_profile("wandb")
+        for effort in ("minimal", "low", "medium"):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort}
+            )
+            assert eb == {}
+            assert tl["reasoning_effort"] == "high"
+
+    def test_unset_or_unknown_effort_uses_provider_default(self):
+        p = get_provider_profile("wandb")
+        for cfg in ({"enabled": True}, {"enabled": True, "effort": "bogus"}):
+            eb, tl = p.build_api_kwargs_extras(reasoning_config=cfg)
+            assert eb == {}
+            assert tl == {}
 
 
 class TestKimiProfile:

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -155,6 +155,32 @@ def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():
     )
 
 
+def test_bundled_model_provider_plugins_have_manifests():
+    """Bundled model-provider plugin dirs must be visible to PluginManager.
+
+    ``providers`` can import a provider profile directly from ``__init__.py``,
+    but the general plugin-management surface discovers directories by
+    manifest. Keep bundled model providers consistent with the rest of the
+    plugin tree so install/list/enable flows can see them.
+    """
+    missing = []
+    for provider_dir in sorted((REPO_ROOT / "plugins" / "model-providers").iterdir()):
+        if not provider_dir.is_dir():
+            continue
+        if not (provider_dir / "__init__.py").exists():
+            continue
+        if not (
+            (provider_dir / "plugin.yaml").exists()
+            or (provider_dir / "plugin.yml").exists()
+        ):
+            missing.append(provider_dir.relative_to(REPO_ROOT).as_posix())
+
+    assert not missing, (
+        "Bundled model-provider plugins with __init__.py must include "
+        f"plugin.yaml/plugin.yml manifests for PluginManager discovery: {missing}"
+    )
+
+
 # Minimum non-vulnerable Starlette: CVE-2026-48710 ("BadHost") was fixed in
 # 1.0.1. Anything below that lets a malformed Host header desync
 # ``request.url.path`` from the dispatched ASGI path, bypassing path-based


### PR DESCRIPTION
## What
Adds a W&B (Weights & Biases) model-provider plugin for Hermes Agent.

## Why
W&B hosts GLM-5.2 on a vLLM backend at `api.inference.wandb.ai/v1`. The endpoint has specific requirements:
- `reasoning_effort` must be sent as a **top-level** param (not in `extra_body`)
- Only `"high"` and `"max"` are recognized; other values are silently ignored
- Non-think mode requires `chat_template_kwargs.enable_thinking: false` in `extra_body`
- Cloudflare blocks the default urllib User-Agent

The existing `CustomProfile` sends Ollama-specific `think: False` params that GLM-5.2 ignores, making `provider: custom:wandb` non-functional for reasoning control.

## How
Adds `plugins/model-providers/wandb/__init__.py` with a `WandbProfile` class that overrides `build_api_kwargs_extras()` to emit the correct params. Follows the same pattern as the `zai`, `deepseek`, and `gmi` provider plugins.

### Effort mapping:
| Hermes effort | What gets sent |
|---|---|
| `xhigh` | top-level `reasoning_effort: "max"` |
| `high` | top-level `reasoning_effort: "high"` |
| `none` | extra_body `chat_template_kwargs: {"enable_thinking": false}` |
| `medium`/`low`/`minimal` | nothing (GLM-5.2 defaults to Think Max) |

### .gitignore
Adds `!plugins/model-providers/wandb/` negation so the plugin is tracked despite the `wandb/` exclusion (which prevents W&B SDK tracking dirs in the repo root).

## Config
```yaml
model: zai-org/GLM-5.2
provider: wandb
providers:
  wandb:
    base_url: https://api.inference.wandb.ai/v1
    key_env: WANDB_API_KEY
    reasoning_efforts:
      - none
      - high
      - xhigh
```