### PR TITLE
fix(agent): resolve execute_code cwd from per-session override (#56047)

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1297,7 +1297,7 @@ def execute_code(
         # Env scrubbing and tool whitelist apply identically in both modes.
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir)
+        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id)
         _script_path = os.path.join(tmpdir, "script.py")
 
         proc = subprocess.Popen(
@@ -1703,17 +1703,29 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
+def _resolve_child_cwd(mode: str, staging_dir: str, task_id: Optional[str] = None) -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
-    - ``project``: the session's TERMINAL_CWD (same as the terminal tool), or
-      ``os.getcwd()`` if TERMINAL_CWD is unset or doesn't point at a real dir.
+    - ``project``: the session's registered cwd override (from
+      ``session.cwd.set``), then ``TERMINAL_CWD``, then ``os.getcwd()``.
       Falls back to the staging tmpdir as a last resort so we never invoke
       Popen with a nonexistent cwd.
     """
     if mode != "project":
         return staging_dir
+    # Check per-session cwd override first (registered via session.cwd.set
+    # → register_task_env_overrides).  This is the same lookup used by
+    # write_file/read_file/patch/terminal so all tool paths agree on the
+    # working directory within a session.  (#56047)
+    if task_id:
+        try:
+            from tools.file_tools import _registered_task_cwd_override
+            override = _registered_task_cwd_override(task_id)
+            if override and os.path.isdir(override):
+                return override
+        except Exception:
+            pass
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)


### PR DESCRIPTION
## Problem

`execute_code`'s `_resolve_child_cwd()` only checks the process-global `TERMINAL_CWD` env var and `os.getcwd()`. It never reads the per-session cwd override registered via `session.cwd.set` → `register_task_env_overrides`.

This means in a multi-session gateway (TUI/dashboard/ACP), `execute_code` writes to the **process launch directory** while sibling tools (`write_file`, `read_file`, `patch`, `terminal`) in the same turn correctly resolve the **session workspace** — the two file-writing paths silently disagree on the working directory.

### Reproduction (from issue)

```
Session A: session.cwd.set({session_id: "aaa", cwd: "/work/session-a"})
Session B: session.cwd.set({session_id: "bbb", cwd: "/work/session-b"})

In session A:
  write_file("flag.txt", "A")           → /work/session-a/flag.txt  ✅
  execute_code('open("flag.txt","w").write("A")') → <process launch dir>/flag.txt  ❌
```

## Fix

Pass `task_id` to `_resolve_child_cwd()` and check `_registered_task_cwd_override(task_id)` before falling back to `TERMINAL_CWD` and `os.getcwd()`. This matches the lookup order used by:
- `file_tools._resolve_base_dir` → `_registered_task_cwd_override(task_id)`
- `terminal_tool._resolve_command_cwd` → `register_task_env_overrides`

### Lookup order (after fix):

1. Per-session cwd override from `session.cwd.set` (via `task_id`)
2. Process-global `TERMINAL_CWD` env var
3. `os.getcwd()` (process launch directory)
4. Staging tmpdir (last resort, for `strict` mode)

## Testing

- `python3 -m py_compile tools/code_execution_tool.py` — OK
- Single-file change: function signature + call site

Fixes #56047