### PR TITLE
fix: append assistant response on _handle_max_iterations failure

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1634,6 +1634,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     except Exception as e:
         logger.warning(f"Failed to get summary response: {e}")
         final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
+        # Append the error response as an assistant message to preserve
+        # role alternation. Without this, the synthetic user message at
+        # line 1420 is left orphaned — two consecutive user messages
+        # violate the alternation invariant and strict providers
+        # (Gemini, Claude) reject the session on resume.
+        messages.append({"role": "assistant", "content": final_response})
 
     return final_response
 


### PR DESCRIPTION
## What does this PR do?

When `_handle_max_iterations` fails (API call raises), the synthetic user message appended at line 1420 is left orphaned in `messages` without a corresponding assistant response. This violates the role alternation invariant — two consecutive user messages — which strict providers (Gemini, Claude) reject on session resume.

Fix: append the error response as an assistant message in the except block, matching the success path behavior.

## Related Issue

Fixes #56056

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: In the `except` block of `handle_max_iterations`, append `final_response` as an assistant message to `messages` to preserve role alternation.

## How to Test

1. Configure a provider that will fail (e.g. invalid API key)
2. Send a message that triggers max iterations
3. The summary call fails → the except block fires
4. Resume the session → model should see proper user/assistant alternation (not two consecutive user messages)

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `ruff check agent/chat_completion_helpers.py` and it passes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] I've considered cross-platform impact — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas — or N/A