### PR TITLE
fix: cap MCP tool result size to prevent unbounded allocation

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4822,6 +4822,20 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     res_text = getattr(getattr(block, "resource", None), "text", None)
                     if res_text:
                         error_text += str(res_text)
+                # Cap error text size the same way success text is capped,
+                # so a buggy or malicious MCP error payload cannot blow the
+                # context window through an error branch (#56060).
+                if error_text:
+                    from tools.tool_output_limits import get_max_bytes as _mcp_get_max
+                    _mcp_max = _mcp_get_max()
+                    if len(error_text) > _mcp_max:
+                        _mcp_half = _mcp_max // 2
+                        _mcp_dropped = len(error_text) - _mcp_max
+                        error_text = (
+                            error_text[:_mcp_half]
+                            + f"\n...[\{_mcp_dropped:,} chars truncated]...\n"
+                            + error_text[-_mcp_half:]
+                        )
                 return tool_error(_sanitize_error(
                     error_text or "MCP tool returned an error"
                 ))
@@ -4875,11 +4889,39 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
             text_result = "\n".join(parts) if parts else ""
 
+            # Cap MCP tool result size to prevent unbounded allocation.
+            # Without this, a buggy or malicious MCP server can return
+            # multi-megabyte text that floods context, causes OOM on
+            # small VMs, or burns unbounded API costs.
+            from tools.tool_output_limits import get_max_bytes
+            _max = get_max_bytes()
+            if len(text_result) > _max:
+                _half = _max // 2
+                _dropped = len(text_result) - _max
+                text_result = text_result[:_half] + f"\n...[{_dropped:,} chars truncated]...\n" + text_result[-_half:]
+
             # Combine content + structuredContent when both are present.
             # MCP spec: content is model-oriented (text), structuredContent
             # is machine-oriented (JSON metadata).  For an AI agent, content
             # is the primary payload; structuredContent supplements it.
+            #
+            # Cap ``structuredContent`` the same way as ``text_result`` so a
+            # server returning a multi-megabyte structured payload cannot
+            # blow the context window (#56060). The shape is intentionally
+            # lossy: when truncated, we replace the value with a string
+            # describing the size so the model still has a hint, rather
+            # than reparse the partial JSON (which would raise).
             structured = getattr(result, "structuredContent", None)
+            from tools.tool_output_limits import get_max_bytes as _mcp_get_max_s
+            _mcp_max_s = _mcp_get_max_s()
+            if structured is not None:
+                _mcp_struct_dump = json.dumps(structured, ensure_ascii=False)
+                if len(_mcp_struct_dump) > _mcp_max_s:
+                    _mcp_dropped_s = len(_mcp_struct_dump) - _mcp_max_s
+                    structured = (
+                        f"<structuredContent of {len(_mcp_struct_dump):,} chars "
+                        f"truncated to {_mcp_max_s:,} (dropped {_mcp_dropped_s:,})>"
+                    )
             if structured is not None:
                 if text_result:
                     return json.dumps({


### PR DESCRIPTION
## What does this PR do?

MCP tool results were returned as raw strings with zero size enforcement. A buggy or malicious MCP server could return multi-megabyte text that floods context, causes OOM, or burns unbounded API costs. Apply the same `get_max_bytes()` truncation used by the terminal tool.

## Related Issue

Fixes #56059

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: After collecting MCP text result, cap at `get_max_bytes()` (default 50KB). Head/tail preserved so the agent still sees the beginning and end of large outputs.

## How to Test

1. Configure an MCP server that returns a large result
2. Call that tool via the agent
3. Observe: the result is truncated to ~50KB with head/tail preserved
4. Normal-sized MCP results pass through unchanged

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `ruff check tools/mcp_tool.py` and it passes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] I've considered cross-platform impact — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas — or N/A