### PR TITLE
fix(desktop): preserve optimistic user message during post-turn hydration

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -476,10 +476,25 @@ export function DesktopController() {
           const messages = toChatMessages(latest.messages)
           updateSessionState(
             runtimeSessionId,
-            state => ({
-              ...state,
-              messages: preserveLocalAssistantErrors(messages, state.messages)
-            }),
+            state => {
+              // A queue drain (auto-drain after interrupt, or manual send-now)
+              // may have seeded an optimistic user message into the session
+              // between when hydration was triggered and when the fetch
+              // resolved. Overwriting with the backend snapshot would erase that
+              // message — the backend hasn't persisted it yet. Bail so the
+              // optimistic bubble survives until the next hydration cycle picks
+              // it up from the backend.
+              const lastVisible = [...state.messages].reverse().find(m => !m.hidden)
+
+              if (lastVisible?.role === 'user') {
+                return state
+              }
+
+              return {
+                ...state,
+                messages: preserveLocalAssistantErrors(messages, state.messages)
+              }
+            },
             storedSessionId
           )
 


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition where the user message bubble vanishes after pressing ESC to interrupt a running turn and auto-draining a queued message. The message IS sent to the gateway (model responds normally), but the user can't see their own message in the transcript.

## Related Issue

Fixes #56061

## Root Cause

`completeAssistantMessage` computes `shouldHydrate` synchronously BEFORE the queue auto-drain adds the optimistic user message. When `shouldHydrate` is true, `hydrateFromStoredSession` starts an async fetch (up to 3 retries × 250ms). The auto-drain fires during this window, seeding an optimistic user message. When the hydration fetch resolves, `preserveLocalAssistantErrors(backendMessages, state.messages)` replaces the entire messages array with the backend snapshot — which hasn't persisted the queued message yet. The optimistic bubble vanishes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/desktop-controller.tsx`: In `hydrateFromStoredSession`'s updater function, check if the current session state now has a user message at the tail. If so, bail — a queue drain raced the fetch and seeded an optimistic message that must not be overwritten.

## How to Test

1. Start a conversation, send a message that triggers a long generation
2. While generating, type another message → it gets queued
3. Press ESC to interrupt
4. The queued message's user bubble should remain visible (not vanish)
5. The model should respond normally to the queued message

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Typecheck passes (`tsc --noEmit` in `apps/desktop`)
- [x] Related tests pass (workspace-groups.test.ts, desktop-controller-utils.test.ts)
- [ ] I've added tests for my changes — the fix is a guard inside an async updater in a React callback; testing requires a full component + gateway mock harness
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] N/A — no documentation or config changes needed