### PR TITLE
feat(tools): local OS toast on clarify() + approval blocking

### DIFF
--- a/tests/tools/test_approval_toast_hook.py
+++ b/tests/tools/test_approval_toast_hook.py
@@ -1,0 +1,94 @@
+"""Integration test: tools/approval.py fires notify_input_needed before blocking.
+
+Verifies that prompt_dangerous_approval() calls the local_toast module
+immediately before delegating to the approval_callback that owns the blocking
+wait. The toast call itself is patched to a no-op so we're purely asserting
+that the wire-up in approval.py is present and passes the command through.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.approval import prompt_dangerous_approval
+
+
+class TestApprovalToastHook:
+    def test_notify_input_needed_called_before_callback(self):
+        """The toast dispatch happens BEFORE the blocking approval callback."""
+        callback_mock = MagicMock(return_value="once")
+        with patch("tools.local_toast.notify_input_needed") as notify_mock:
+            result = prompt_dangerous_approval(
+                "rm -rf /tmp/x",
+                "Recursive delete",
+                approval_callback=callback_mock,
+            )
+
+        assert result == "once"
+        assert notify_mock.call_count == 1
+        args, kwargs = notify_mock.call_args
+        assert args[0] == "approval"
+        # detail is "<description>: <command>"
+        detail = kwargs.get("detail", "")
+        assert "Recursive delete" in detail
+        assert "rm -rf /tmp/x" in detail
+        assert kwargs.get("level") == "warn"
+
+    def test_notify_failure_does_not_break_approval(self):
+        """If notify_input_needed raises, prompt_dangerous_approval still runs."""
+        callback_mock = MagicMock(return_value="deny")
+
+        def _boom(*a, **kw):
+            raise RuntimeError("antenna is on fire")
+
+        with patch("tools.local_toast.notify_input_needed", side_effect=_boom):
+            result = prompt_dangerous_approval(
+                "docker system prune",
+                "Wipe unused images",
+                approval_callback=callback_mock,
+            )
+
+        assert result == "deny"
+        callback_mock.assert_called_once()
+
+    def test_command_newlines_stripped_in_detail(self):
+        """Multi-line commands (heredocs) are flattened in the toast detail."""
+        callback_mock = MagicMock(return_value="once")
+        with patch("tools.local_toast.notify_input_needed") as notify_mock:
+            prompt_dangerous_approval(
+                "bash <<EOF\nrm -rf /tmp/x\nEOF",
+                "Heredoc",
+                approval_callback=callback_mock,
+            )
+        _, kwargs = notify_mock.call_args
+        detail = kwargs.get("detail", "")
+        assert "\n" not in detail
+        assert "bash <<EOF" in detail
+        assert "rm -rf /tmp/x" in detail
+        assert "EOF" in detail
+
+    def test_toast_import_absent_is_fail_open(self):
+        """If local_toast cannot be imported, approval still proceeds."""
+        import sys
+        saved = sys.modules.pop("tools.local_toast", None)
+        with patch.dict(sys.modules, {"tools.local_toast": None}):
+            callback_mock = MagicMock(return_value="once")
+            result = prompt_dangerous_approval(
+                "echo hi", "test", approval_callback=callback_mock
+            )
+        if saved is not None:
+            sys.modules["tools.local_toast"] = saved
+        assert result == "once"
+
+    def test_description_missing_falls_back_to_command_only(self):
+        """Empty description should not produce a leading colon in the detail."""
+        callback_mock = MagicMock(return_value="once")
+        with patch("tools.local_toast.notify_input_needed") as notify_mock:
+            prompt_dangerous_approval(
+                "ls /", "", approval_callback=callback_mock
+            )
+        _, kwargs = notify_mock.call_args
+        detail = kwargs.get("detail", "")
+        assert not detail.startswith(":")
+        assert "ls /" in detail

--- a/tests/tools/test_clarify_toast_hook.py
+++ b/tests/tools/test_clarify_toast_hook.py
@@ -1,0 +1,81 @@
+"""Integration test: tools/clarify_tool.py fires notify_input_needed before blocking.
+
+Verifies that clarify_tool() calls the local_toast module immediately before
+handing off to the callback that actually blocks the agent thread. The toast
+call itself is patched to a no-op so we're purely asserting that the wire-up
+in clarify_tool.py is present and passes the question through.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.clarify_tool import clarify_tool
+
+
+class TestClarifyToastHook:
+    def test_notify_input_needed_called_before_callback(self):
+        """The toast dispatch happens BEFORE the blocking callback runs."""
+        callback_mock = MagicMock(return_value="answer")
+        with patch("tools.local_toast.notify_input_needed") as notify_mock:
+            result = json.loads(
+                clarify_tool("What color?", callback=callback_mock)
+            )
+
+        # Callback was invoked (clarify completed normally).
+        assert result["user_response"] == "answer"
+        # Notify was called exactly once with the right kind + detail.
+        assert notify_mock.call_count == 1
+        args, kwargs = notify_mock.call_args
+        assert args[0] == "clarify"
+        # detail=<question>, level="info"
+        assert kwargs.get("detail") == "What color?"
+        assert kwargs.get("level") == "info"
+
+    def test_notify_failure_does_not_break_clarify(self):
+        """If notify_input_needed raises, clarify_tool still proceeds."""
+        callback_mock = MagicMock(return_value="answer-anyway")
+
+        def _boom(*a, **kw):
+            raise RuntimeError("antenna is on fire")
+
+        with patch("tools.local_toast.notify_input_needed", side_effect=_boom):
+            result = json.loads(
+                clarify_tool("What color?", callback=callback_mock)
+            )
+
+        # Clarify completes even though the toast dispatcher raised.
+        assert result["user_response"] == "answer-anyway"
+        callback_mock.assert_called_once()
+
+    def test_no_notify_when_callback_missing(self):
+        """clarify_tool short-circuits with an error when no callback is
+        registered; the toast should NOT fire in that path because the
+        agent isn't actually blocking on user input."""
+        with patch("tools.local_toast.notify_input_needed") as notify_mock:
+            result = json.loads(clarify_tool("What?"))  # no callback
+        assert "error" in result
+        assert notify_mock.call_count == 0
+
+    def test_toast_import_absent_is_fail_open(self):
+        """Even if the local_toast module cannot be imported, clarify still runs.
+
+        Simulates the case where the module is missing entirely (e.g. an
+        older editable install without the patch applied). The try/except
+        around the import must swallow it.
+        """
+        import sys
+        # Temporarily remove tools.local_toast from sys.modules to force ImportError
+        saved = sys.modules.pop("tools.local_toast", None)
+        # Also block the fresh import attempt
+        with patch.dict(sys.modules, {"tools.local_toast": None}):
+            callback_mock = MagicMock(return_value="ok")
+            result = json.loads(
+                clarify_tool("still works?", callback=callback_mock)
+            )
+        # restore
+        if saved is not None:
+            sys.modules["tools.local_toast"] = saved
+        assert result["user_response"] == "ok"

--- a/tests/tools/test_local_toast.py
+++ b/tests/tools/test_local_toast.py
@@ -1,0 +1,243 @@
+"""Tests for tools.local_toast — the loopback antenna toast dispatcher.
+
+Covers:
+- fires-once: mocked urllib captures the POST body when notify_input_needed is called
+- coalesces: repeat calls in the coalesce window collapse to a single dispatch
+- kill-switch: HERMES_LOCAL_TOAST_DISABLE=1 makes the call a no-op
+- fail-open: a broken antenna (URLError/timeout/etc.) never raises to caller
+- persona resolution: HERMES_ACTIVE_PROFILE wins, HERMES_PROFILE fallback, "hermes" last
+- endpoint override: HERMES_LOCAL_TOAST_URL is honored
+
+The dispatch runs on a daemon thread; tests join it via a short timeout on a
+threading.Event captured in the mocked _post_toast.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+import tools.local_toast as local_toast
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch):
+    """Clear coalesce state + env var overrides between tests."""
+    # Ensure kill-switch and URL override are clean unless the test sets them.
+    monkeypatch.delenv("HERMES_LOCAL_TOAST_DISABLE", raising=False)
+    monkeypatch.delenv("HERMES_LOCAL_TOAST_URL", raising=False)
+    monkeypatch.delenv("HERMES_ACTIVE_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    with local_toast._lock:
+        local_toast._last_fired.clear()
+    yield
+    with local_toast._lock:
+        local_toast._last_fired.clear()
+
+
+def _wait_for_dispatch(mock_post, expected: int = 1, timeout: float = 2.0) -> None:
+    """Poll until mock_post has been called `expected` times or timeout expires."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if mock_post.call_count >= expected:
+            return
+        time.sleep(0.02)
+    # let final call quiesce
+    time.sleep(0.05)
+
+
+class TestFiresOnce:
+    def test_notify_dispatches_post(self, monkeypatch):
+        """A single notify_input_needed call should invoke the POST helper once."""
+        monkeypatch.setenv("HERMES_ACTIVE_PROFILE", "test-persona")
+        with patch.object(local_toast, "_post_toast") as mock_post:
+            local_toast.notify_input_needed("clarify", detail="which color?")
+            _wait_for_dispatch(mock_post, expected=1)
+            assert mock_post.call_count == 1
+            title, message, level = mock_post.call_args.args
+            assert title == "test-persona: needs input"
+            assert "which color?" in message
+            assert level == "info"
+
+    def test_notify_carries_approval_level_warn(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACTIVE_PROFILE", "test-persona")
+        with patch.object(local_toast, "_post_toast") as mock_post:
+            local_toast.notify_input_needed(
+                "approval", detail="rm -rf /tmp/foo", level="warn"
+            )
+            _wait_for_dispatch(mock_post, expected=1)
+            title, message, level = mock_post.call_args.args
+            assert level == "warn"
+            assert "Command awaiting approval" in message
+            assert "rm -rf /tmp/foo" in message
+
+    def test_detail_truncated_at_200_chars(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACTIVE_PROFILE", "p")
+        with patch.object(local_toast, "_post_toast") as mock_post:
+            long_detail = "x" * 500
+            local_toast.notify_input_needed("clarify", detail=long_detail)
+            _wait_for_dispatch(mock_post, expected=1)
+            _, message, _ = mock_post.call_args.args
+            # The message contains prefix + colon + <=200 chars of detail
+            assert "x" * 200 in message
+            assert "x" * 201 not in message
+
+    def test_detail_newlines_stripped(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACTIVE_PROFILE", "p")
+        with patch.object(local_toast, "_post_toast") as mock_post:
+            local_toast.notify_input_needed("clarify", detail="line1\nline2\nline3")
+            _wait_for_dispatch(mock_post, expected=1)
+            _, message, _ = mock_post.call_args.args
+            assert "\n" not in message
+            assert "line1 line2 line3" in message
+
+
+class TestCoalesce:
+    def test_second_call_within_window_is_dropped(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACTIVE_PROFILE", "p")
+        with patch.object(local_toast, "_post_toast") as mock_post:
+            local_toast.notify_input_needed("clarify", detail="first")
+            local_toast.notify_input_needed("clarify", detail="second")
+            _wait_for_dispatch(mock_post, expected=1, timeout=0.5)
+            # Only ONE dispatch — the second was coalesced.
+            assert mock_post.call_count == 1
+            _, first_msg, _ = mock_post.call_args.args
+            assert "first" in first_msg
+
+    def test_different_kinds_do_not_coalesce(self, monkeypatch):
+        """Coalesce key is (persona, kind) — different kinds fire independently."""
+        monkeypatch.setenv("HERMES_ACTIVE_PROFILE", "p")
+        with patch.object(local_toast, "_post_toast") as mock_post:
+            local_toast.notify_input_needed("clarify", detail="q")
+            local_toast.notify_input_needed("approval", detail="rm -rf")
+            _wait_for_dispatch(mock_post, expected=2)
+            assert mock_post.call_count == 2
+
+    def test_call_after_window_expiry_fires_again(self, monkeypatch):
+        """After the coalesce window elapses the same key can fire again."""
+        monkeypatch.setenv("HERMES_ACTIVE_PROFILE", "p")
+        # Squash the window so we don't sleep in CI.
+        monkeypatch.setattr(local_toast, "_COALESCE_WINDOW_SEC", 0.05)
+        with patch.object(local_toast, "_post_toast") as mock_post:
+            local_toast.notify_input_needed("clarify", detail="first")
+            _wait_for_dispatch(mock_post, expected=1)
+            time.sleep(0.1)  # exceed window
+            local_toast.notify_input_needed("clarify", detail="second")
+            _wait_for_dispatch(mock_post, expected=2)
+            assert mock_post.call_count == 2
+
+
+class TestDisabled:
+    def test_env_kill_switch_prevents_dispatch(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LOCAL_TOAST_DISABLE", "1")
+        with patch.object(local_toast, "_post_toast") as mock_post:
+            local_toast.notify_input_needed("clarify", detail="quiet")
+            _wait_for_dispatch(mock_post, expected=1, timeout=0.3)
+            assert mock_post.call_count == 0
+
+    def test_blank_env_var_does_not_disable(self, monkeypatch):
+        """Only a non-empty value counts as a kill-switch."""
+        monkeypatch.setenv("HERMES_LOCAL_TOAST_DISABLE", "")
+        monkeypatch.setenv("HERMES_ACTIVE_PROFILE", "p")
+        with patch.object(local_toast, "_post_toast") as mock_post:
+            local_toast.notify_input_needed("clarify", detail="noisy")
+            _wait_for_dispatch(mock_post, expected=1)
+            assert mock_post.call_count == 1
+
+
+class TestFailOpen:
+    def test_urlopen_urlerror_never_raises(self, monkeypatch):
+        """A dead antenna must be swallowed inside _post_toast."""
+        monkeypatch.setenv("HERMES_ACTIVE_PROFILE", "p")
+
+        def _boom(*a, **kw):
+            raise urllib.error.URLError("connection refused")
+
+        with patch.object(local_toast.urllib.request, "urlopen", side_effect=_boom):
+            # Call the raw helper directly — must NOT raise.
+            local_toast._post_toast("title", "message", "info")
+
+    def test_notify_input_needed_swallows_persona_lookup_failure(self, monkeypatch):
+        """Even if _resolve_persona blows up, notify_input_needed returns None."""
+        def _boom():
+            raise RuntimeError("no profile")
+        monkeypatch.setattr(local_toast, "_resolve_persona", _boom)
+        # Must NOT raise
+        result = local_toast.notify_input_needed("clarify", detail="x")
+        assert result is None
+
+    def test_endpoint_override_env_var(self, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_LOCAL_TOAST_URL",
+            "http://127.0.0.1:9999/custom",
+        )
+        assert local_toast._endpoint() == "http://127.0.0.1:9999/custom"
+
+
+class TestPersonaResolution:
+    def test_active_profile_env_wins(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACTIVE_PROFILE", "daddy")
+        monkeypatch.setenv("HERMES_PROFILE", "legacy-value")
+        assert local_toast._resolve_persona() == "daddy"
+
+    def test_legacy_profile_env_fallback(self, monkeypatch):
+        monkeypatch.delenv("HERMES_ACTIVE_PROFILE", raising=False)
+        # Force the hermes_cli.profiles branch to fail cleanly.
+        import sys
+        # Even if the module exists, it won't return a value when nothing is set.
+        # If it does return something we still fall through to legacy env.
+        monkeypatch.setenv("HERMES_PROFILE", "legacy-persona")
+        # Patch the intermediate resolver to force fall-through.
+        try:
+            from hermes_cli import profiles as _p
+            monkeypatch.setattr(_p, "get_active_profile_name", lambda: "")
+        except Exception:
+            pass
+        assert local_toast._resolve_persona() == "legacy-persona"
+
+    def test_default_fallback_when_nothing_set(self, monkeypatch):
+        monkeypatch.delenv("HERMES_ACTIVE_PROFILE", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        try:
+            from hermes_cli import profiles as _p
+            monkeypatch.setattr(_p, "get_active_profile_name", lambda: "")
+        except Exception:
+            pass
+        assert local_toast._resolve_persona() == "hermes"
+
+
+class TestPostBodyShape:
+    def test_post_body_is_valid_json_with_expected_fields(self, monkeypatch):
+        """Capture the raw HTTP request payload built by _post_toast."""
+        captured = {}
+
+        class _FakeResp:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *a):
+                return False
+
+            def read(self_inner):
+                return b'{"ok":true}'
+
+        def _fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["method"] = req.get_method()
+            captured["body"] = req.data
+            captured["content_type"] = req.get_header("Content-type")
+            return _FakeResp()
+
+        monkeypatch.setattr(local_toast.urllib.request, "urlopen", _fake_urlopen)
+        local_toast._post_toast("t", "m", "info")
+
+        assert captured["url"] == local_toast._DEFAULT_URL
+        assert captured["method"] == "POST"
+        assert captured["content_type"] == "application/json"
+        body = json.loads(captured["body"].decode("utf-8"))
+        assert body == {"title": "t", "message": "m", "level": "info"}

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1044,6 +1044,25 @@ def prompt_dangerous_approval(command: str, description: str,
     if timeout_seconds is None:
         timeout_seconds = _get_approval_timeout()
 
+    # Best-effort local OS toast: notify the user that this persona is
+    # blocked waiting for command approval. Fire-and-forget on a daemon
+    # thread; the callback/input below still owns the actual blocking wait.
+    # A broken toast (no antenna, firewall block, etc.) MUST NOT prevent
+    # the approval prompt from proceeding.
+    try:
+        from tools.local_toast import notify_input_needed  # type: ignore
+        # Truncate the command to the toast-friendly window. approval.py
+        # is called for a huge range of commands (rm -rf, docker exec, etc.)
+        # so the detail is highly informative.
+        _cmd_short = (command or "").strip().replace("\n", " ")
+        notify_input_needed(
+            "approval",
+            detail=f"{description}: {_cmd_short}" if description else _cmd_short,
+            level="warn",
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
     # Redact secrets before any user-visible rendering. The original
     # `command` is still what executes after approval; only the displayed
     # copy is scrubbed. Reuses the same redaction module used for memory

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -98,6 +98,17 @@ def clarify_tool(
             ensure_ascii=False,
         )
 
+    # Best-effort local OS toast: notify the user that this persona is
+    # blocked waiting for a clarify reply. Fire-and-forget on a daemon
+    # thread; the callback below still owns the actual blocking wait.
+    # A broken toast (no antenna, firewall block, etc.) MUST NOT prevent
+    # the clarify from proceeding.
+    try:
+        from tools.local_toast import notify_input_needed  # type: ignore
+        notify_input_needed("clarify", detail=question, level="info")
+    except Exception:  # noqa: BLE001
+        pass
+
     try:
         user_response = callback(question, choices)
     except Exception as exc:

--- a/tools/local_toast.py
+++ b/tools/local_toast.py
@@ -1,0 +1,210 @@
+"""Local antenna toast — best-effort OS-native popup when an agent needs user input.
+
+Fires an HTTP POST to the loopback antenna's ``/peer/notify`` endpoint, which
+maps to ``prometheus_client.notify.notify()`` (Windows pystray toast + voice +
+tray icon fallback). Called from ``tools/clarify_tool.py`` and
+``tools/approval.py`` right before the agent thread blocks waiting for user
+input.
+
+**Design invariants:**
+
+1. **Fail open.** A broken antenna, network hiccup, or firewall block MUST NOT
+   prevent the underlying clarify/approval from proceeding. Every call is
+   wrapped in ``try/except Exception``; the caller never sees a raise.
+2. **Fire and forget.** The POST runs on a daemon thread with a short timeout.
+   The agent thread continues to the blocking input() immediately after
+   dispatch — the toast is a courtesy notification, not a synchronous barrier.
+3. **Rate-limited.** Repeat calls from the same session within 3s coalesce
+   into a single toast to avoid tray spam if an approval loop retries.
+4. **Zero deps.** stdlib ``urllib.request`` only. Same dependency surface as
+   the rest of ``tools/`` — no requests, no httpx.
+
+**Endpoint contract:**
+
+``POST http://127.0.0.1:7634/peer/notify``
+``Content-Type: application/json``
+``{"title": "<str>", "message": "<str>", "level": "info|success|warn|error"}``
+
+Antenna responds ``{"ok": true}`` on success. Any non-2xx response is
+logged and swallowed.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Loopback antenna endpoint. Antenna binds 127.0.0.1:7634 by default.
+# Override with HERMES_LOCAL_TOAST_URL for non-standard deployments.
+_DEFAULT_URL = "http://127.0.0.1:7634/peer/notify"
+_TIMEOUT_SEC = 1.5
+
+# Coalesce window — if the same (profile, kind) fires more than once within
+# this window, only the first toast dispatches. Prevents tray spam from an
+# approval loop or a clarify that gets retried.
+_COALESCE_WINDOW_SEC = 3.0
+
+# Kill-switch. If set (any non-empty value), local_toast becomes a no-op.
+# Useful for headless CI runs and for the antenna's OWN internal calls (which
+# would otherwise loop back through this module and infinite-recurse).
+_DISABLE_ENV = "HERMES_LOCAL_TOAST_DISABLE"
+
+# ---------------------------------------------------------------------------
+# State (module-level, thread-safe via lock)
+# ---------------------------------------------------------------------------
+
+_lock = threading.Lock()
+_last_fired: dict = {}  # key -> monotonic timestamp
+
+
+def _endpoint() -> str:
+    return os.environ.get("HERMES_LOCAL_TOAST_URL", _DEFAULT_URL)
+
+
+def _disabled() -> bool:
+    return bool(os.environ.get(_DISABLE_ENV, "").strip())
+
+
+def _should_fire(key: str) -> bool:
+    """Return True if this key hasn't fired recently.
+
+    Updates ``_last_fired`` when returning True — the caller is expected to
+    immediately dispatch, so we mark the timestamp here to close the race.
+    """
+    now = time.monotonic()
+    with _lock:
+        last = _last_fired.get(key, 0.0)
+        if (now - last) < _COALESCE_WINDOW_SEC:
+            return False
+        _last_fired[key] = now
+        # Prune stale entries so the dict doesn't grow unbounded across a
+        # long-lived agent session. Anything older than 10x the window is dead.
+        cutoff = now - (_COALESCE_WINDOW_SEC * 10.0)
+        for k, ts in list(_last_fired.items()):
+            if ts < cutoff:
+                _last_fired.pop(k, None)
+        return True
+
+
+def _resolve_persona() -> str:
+    """Best-effort discovery of the current profile / persona name.
+
+    Preference order:
+      1. HERMES_ACTIVE_PROFILE env var (set by cli.py when known)
+      2. hermes_cli.profiles.get_active_profile_name() (canonical)
+      3. HERMES_PROFILE env var (legacy)
+      4. "hermes" as generic fallback
+
+    Never raises. Any lookup failure returns the fallback.
+    """
+    try:
+        v = os.environ.get("HERMES_ACTIVE_PROFILE", "").strip()
+        if v:
+            return v
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from hermes_cli.profiles import get_active_profile_name  # type: ignore
+        v = (get_active_profile_name() or "").strip()
+        if v:
+            return v
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        v = os.environ.get("HERMES_PROFILE", "").strip()
+        if v:
+            return v
+    except Exception:  # noqa: BLE001
+        pass
+    return "hermes"
+
+
+def _post_toast(title: str, message: str, level: str) -> None:
+    """Fire the actual POST. Runs on a daemon thread. Any failure is swallowed."""
+    try:
+        body = json.dumps(
+            {"title": title, "message": message, "level": level},
+            ensure_ascii=False,
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            _endpoint(),
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_SEC) as resp:
+            # Drain body so the connection can be cleanly closed on Windows.
+            resp.read()
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError) as e:
+        # Antenna not running / not on this host / firewall blocked — expected in
+        # many environments. Log at debug so we don't spam the agent output.
+        logger.debug("local_toast: antenna unreachable (%s): %s", type(e).__name__, e)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("local_toast: unexpected error: %s", e)
+
+
+def notify_input_needed(
+    kind: str,
+    detail: str = "",
+    *,
+    persona: Optional[str] = None,
+    session_label: Optional[str] = None,
+    level: str = "info",
+) -> None:
+    """Fire a fire-and-forget local toast saying "<persona> needs input".
+
+    Never raises. Never blocks the caller (dispatches on a daemon thread).
+    Silently no-ops when ``HERMES_LOCAL_TOAST_DISABLE`` is set.
+
+    Args:
+        kind: Short tag for the kind of block ("clarify", "approval",
+            "sudo-approval"). Used both in the toast title and in the
+            coalescing key.
+        detail: Optional extra text (e.g. the first 80 chars of the question or
+            the command awaiting approval). Truncated at 200 chars.
+        persona: Override the persona-name resolution. Rarely used.
+        session_label: Optional session identifier for the toast body (e.g.
+            "chat", "sub-agent", "cron"). Falls back to "chat".
+        level: pystray toast level. Only "info" and "warn" render distinctly on
+            Windows; error is used for hard failures.
+    """
+    if _disabled():
+        return
+    try:
+        persona = persona or _resolve_persona()
+        session_label = session_label or "chat"
+        key = f"{persona}:{kind}"
+        if not _should_fire(key):
+            return
+        title = f"{persona}: needs input"
+        body_prefix = {
+            "clarify": "Question awaiting your reply",
+            "approval": "Command awaiting approval",
+            "sudo-approval": "Sudo command awaiting approval",
+        }.get(kind, "Input needed")
+        detail_trimmed = (detail or "").strip().replace("\n", " ")[:200]
+        if detail_trimmed:
+            message = f"{body_prefix} in {session_label}: {detail_trimmed}"
+        else:
+            message = f"{body_prefix} in {session_label}"
+        t = threading.Thread(
+            target=_post_toast,
+            args=(title, message, level),
+            daemon=True,
+            name="hermes-local-toast",
+        )
+        t.start()
+    except Exception as e:  # noqa: BLE001
+        # Absolute fail-open: no exception ever propagates from this module.
+        logger.debug("local_toast.notify_input_needed swallowed error: %s", e)


### PR DESCRIPTION
## Summary

Every Hermes persona now fires an OS-native toast on the same host's antenna tray icon when it blocks on `clarify()` or `prompt_dangerous_approval()`. Personas running in TUI windows across the desktop flash the notification center + tray icon when they're waiting on the user, so a clarify or sudo approval prompt doesn't sit for the full timeout while the user is looking at another window.

## What this PR adds

**New file — `tools/local_toast.py`** (208 lines)
- `notify_input_needed(kind, detail, *, persona=None, session_label=None, level="info")`
- Fire-and-forget POST to `http://127.0.0.1:7634/peer/notify` on a daemon thread
- Coalesces repeat calls per-`(persona, kind)` inside 3s to prevent tray spam
- `HERMES_LOCAL_TOAST_DISABLE=<any>` kill switch (headless / CI)
- `HERMES_LOCAL_TOAST_URL=<url>` endpoint override
- Persona name auto-resolved via `HERMES_ACTIVE_PROFILE` → `hermes_cli.profiles.get_active_profile_name()` → `HERMES_PROFILE` → `"hermes"`
- Zero deps (stdlib `urllib.request` only)

**Modified — `tools/clarify_tool.py`** (11-line addition at L102)
- Calls `notify_input_needed("clarify", detail=question, level="info")` immediately before the blocking `callback()`
- Wrapped in `try/except Exception` — a broken toast never breaks clarify

**Modified — `tools/approval.py`** (20-line addition at L1045)
- Calls `notify_input_needed("approval", detail=f"{description}: {command}", level="warn")` immediately before the blocking approval callback / input()
- Command is flattened (newlines stripped) so heredocs render as a single line in the toast
- Wrapped in `try/except Exception` — a broken toast never breaks approval

## Design invariants

1. **Fail-open at every layer.** A broken antenna, network hiccup, firewall block, or missing `local_toast` module MUST NOT prevent the underlying clarify/approval from proceeding. Every call site wraps the import + call in `try/except Exception`. Every dispatch failure inside `_post_toast` is caught and logged at `DEBUG`.
2. **Fire-and-forget.** The POST runs on a daemon thread with a 1.5s timeout. The agent thread continues to the blocking `input()` immediately after dispatch — the toast is a courtesy notification, not a synchronous barrier.
3. **Coalesced per `(persona, kind)`.** If a persona's approval loop retries three times in two seconds, the tray gets one toast, not three. Two personas both waiting for input at the same time each get their own toast — which is correct, they're different sessions.
4. **Zero new deps.** Same dependency surface as the rest of `tools/`. No `requests`, no `httpx`.

## Endpoint contract

```
POST http://127.0.0.1:7634/peer/notify
Content-Type: application/json
{"title": "<persona>: needs input", "message": "...", "level": "info|warn"}
```

Loopback-only enforcement (`client_address` check) lives on the antenna side; cross-host input signaling stays on the existing messaging gateway.

## Rollout note

This PR ships the **hermes-agent client half**. The antenna server-side `/peer/notify` route is a paired change to `prometheus-client` (dual-bind refactor + loopback-only enforcement). A hermes-agent install without that antenna change is safe — every call site fails open. The antenna change lives in a separate repo and is being tracked in the fleet substrate board.

## Tests — 25 new cases, all passing

```
$ pytest tests/tools/test_local_toast.py tests/tools/test_clarify_toast_hook.py tests/tools/test_approval_toast_hook.py -x -q
.........................                                                [100%]
25 passed in 1.60s
```

**`tests/tools/test_local_toast.py`** (14 cases)
- Fires-once: mocked `_post_toast` captures POST body when `notify_input_needed` is called
- Level propagation: `warn` for approval, `info` for clarify
- Detail truncation at 200 chars, newline stripping
- Coalesce: second call inside window dropped, different `kind` doesn't coalesce, post-window fires again
- Kill switch: `HERMES_LOCAL_TOAST_DISABLE=1` no-ops, blank env var doesn't disable
- Fail-open: `urllib.error.URLError` swallowed inside `_post_toast`, persona-resolver crash swallowed
- Endpoint override honored
- Persona resolution: `HERMES_ACTIVE_PROFILE` wins over `HERMES_PROFILE`; falls through to `"hermes"` when nothing set
- POST body shape: URL / method / content-type / JSON payload all asserted

**`tests/tools/test_clarify_toast_hook.py`** (4 cases)
- `clarify_tool()` calls `notify_input_needed` with `kind="clarify"` and `level="info"` before `callback()`
- Toast failure does NOT break clarify (callback still runs, user_response still returned)
- No notify when callback missing (no-callback error path is not a real "user blocking on input" case)
- `ImportError` on `tools.local_toast` is fail-open — clarify still runs

**`tests/tools/test_approval_toast_hook.py`** (5 cases)
- `prompt_dangerous_approval()` calls `notify_input_needed` with `kind="approval"` and `level="warn"` before the callback
- Toast failure does NOT break approval
- Multi-line commands (heredocs) are flattened in the toast detail — no `\n`
- `ImportError` on `tools.local_toast` is fail-open — approval still runs
- Empty description does not produce a leading colon in the toast detail

## Env knobs summary

| Env var | Effect |
|---|---|
| `HERMES_LOCAL_TOAST_DISABLE` | Any non-empty value silences all toasts (CI / headless / self-tests) |
| `HERMES_LOCAL_TOAST_URL` | Override the antenna endpoint (default `http://127.0.0.1:7634/peer/notify`) |
| `HERMES_ACTIVE_PROFILE` | Persona name shown in toast title; auto-resolved via `hermes_cli.profiles` if unset |
| `HERMES_PROFILE` | Legacy fallback for persona name |

## Cross-refs

- `tools/clarify_gateway.py` — event-based clarify path is unchanged. The toast fires before the gateway blocks, so the notification lands whether the reply comes back via CLI or via a gateway platform.
- `tools/terminal_tool.py::set_approval_callback` — approval CLI callback registration is unchanged.
- Antenna toast surface — `prometheus_client/notify.py` (existing, unchanged) handles the actual pystray toast dispatch on the antenna side.

## Manual verification

```bash
# From a hermes-agent install with the antenna running on 127.0.0.1:7634
python -c "from tools.local_toast import notify_input_needed; import time; notify_input_needed('clarify', 'test'); time.sleep(2)"
# -> Windows toast top-right: "<persona>: needs input — Question awaiting your reply in chat: test"

# Kill switch
HERMES_LOCAL_TOAST_DISABLE=1 python -c "from tools.local_toast import notify_input_needed; notify_input_needed('clarify', 'silent')"
# -> no toast

# Coalesce
python -c "from tools.local_toast import notify_input_needed; notify_input_needed('clarify','a'); notify_input_needed('clarify','b'); import time; time.sleep(2)"
# -> exactly one toast (second call inside the 3s window is coalesced)
```
