### PR TITLE
fix(agent): preserve alternation on max-iteration summary failure

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1647,6 +1647,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         logger.warning(f"Failed to get summary response: {e}")
         final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
 
+    if (
+        final_response
+        and messages
+        and messages[-1].get("role") == "user"
+        and messages[-1].get("content") == summary_request
+    ):
+        messages.append({"role": "assistant", "content": final_response})
+
     return final_response
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3452,6 +3452,7 @@ class TestHandleMaxIterations:
         assert isinstance(result, str)
         assert "error" in result.lower()
         assert "API down" in result
+        assert messages[-1] == {"role": "assistant", "content": result}
 
     def test_summary_skips_reasoning_for_unsupported_openrouter_model(self, agent):
         agent.base_url = "https://openrouter.ai/api/v1"


### PR DESCRIPTION
Fixes #56056.\n\nWhen the max-iteration summary call fails or otherwise falls back to a synthesized final response, append that response as an assistant turn after the synthetic summary request so persisted history keeps user/assistant role alternation intact.\n\nTests:\n- scripts/run_tests.sh tests/run_agent/test_run_agent.py -k TestHandleMaxIterations