### PR TITLE
fix(mcp): keep rate limits from tripping circuit breaker

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -571,6 +571,35 @@ class TestToolHandler:
         finally:
             _servers.pop("test_srv", None)
 
+    def test_rate_limit_error_does_not_trip_circuit_breaker(self):
+        from tools.mcp_tool import (
+            _make_tool_handler,
+            _server_error_counts,
+            _servers,
+        )
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            return_value=_make_call_result(
+                "hmt notes get failed: HTTP 429 Too Many Requests: Rate limit exceeded (Retry-After: 1)",
+                is_error=True,
+            )
+        )
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+        _server_error_counts["test_srv"] = 0
+
+        try:
+            handler = _make_tool_handler("test_srv", "fail_tool", 120)
+            with self._patch_mcp_loop():
+                for _ in range(3):
+                    result = json.loads(handler({}))
+                    assert "error" in result
+            assert _server_error_counts["test_srv"] == 0
+        finally:
+            _servers.pop("test_srv", None)
+            _server_error_counts.pop("test_srv", None)
+
     def test_disconnected_server(self):
         from tools.mcp_tool import _make_tool_handler, _servers
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2848,6 +2848,27 @@ def _is_session_expired_error(exc: BaseException) -> bool:
     return any(marker in msg for marker in _SESSION_EXPIRED_MARKERS)
 
 
+_RATE_LIMIT_ERROR_MARKERS: tuple = (
+    "http 429",
+    "429 too many requests",
+    "rate limit exceeded",
+    "retry-after",
+)
+
+
+def _is_rate_limit_error_text(text: str) -> bool:
+    """Return True when a tool error is an upstream throttling response.
+
+    A 429 means the MCP server/session is reachable and correctly reporting
+    backpressure from its backing API. Treating that as a transport failure
+    trips the generic MCP circuit breaker and makes normal multi-call workflows
+    worse: after a few throttled calls Hermes announces the server is
+    "unreachable" even though waiting/retrying is the correct behavior.
+    """
+    msg = (text or "").lower()
+    return any(marker in msg for marker in _RATE_LIMIT_ERROR_MARKERS)
+
+
 def _handle_session_expired_and_retry(
     server_name: str,
     exc: BaseException,
@@ -3390,7 +3411,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    error_text = str(parsed.get("error", ""))
+                    if _is_rate_limit_error_text(error_text):
+                        # Upstream 429/backpressure is not an MCP transport
+                        # outage. Leave the breaker closed so callers can wait
+                        # and retry instead of being told the server is down.
+                        _reset_server_error(server_name)
+                    else:
+                        _bump_server_error(server_name)
                 else:
                     _reset_server_error(server_name)  # success — reset
             except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
## Summary
- classify MCP tool-level HTTP 429/rate-limit errors as upstream backpressure
- prevent repeated 429 tool errors from opening the generic MCP server-unreachable circuit breaker
- add regression coverage for repeated rate-limit errors

## Test plan
- venv/bin/python -m pytest tests/tools/test_mcp_tool.py::TestToolHandler::test_rate_limit_error_does_not_trip_circuit_breaker -q
- venv/bin/python -m pytest tests/tools/test_mcp_tool.py -q

## Context
This pairs with richardhapb/heramty#40. HeraMty MCP can surface API throttling as tool errors; those should not make Hermes report the MCP server itself as unreachable.