### PR TITLE
feat(kanban): add kanban_dispatch_tick plugin hook

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -162,6 +162,59 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
         _log.debug("kanban lifecycle hook %s failed: %s", event, exc)
 
 
+def _fire_dispatch_tick_hook(
+    result: "DispatchResult",
+    *,
+    board: Optional[str] = None,
+    dry_run: bool = False,
+) -> None:
+    """Fire the ``kanban_dispatch_tick`` plugin hook after each dispatcher tick.
+
+    Board-scoped observability primitive: subscribers get a summary of what a
+    single dispatcher tick did (spawned, reclaimed, promoted, crashed, blocked,
+    per-profile-capped, etc.). Kept as a plugin hook — not a hardcoded
+    telemetry sink — so third-party observability backends stay out-of-tree
+    per the project's plugin policy.
+
+    Called AFTER the tick's write txn is done and the dispatch lock is
+    released, so subscribers never run inside the SQLite writer critical
+    section. Any exception from a subscriber is swallowed: a misbehaving
+    observer must never break the dispatcher.
+
+    Payload fields:
+        board:     resolved board slug (``None`` = default board)
+        dry_run:   whether this tick was a plan-only pass
+        outcome:   ``"ok"`` | ``"skipped_locked"`` | ``"idle"``
+        result:    the ``DispatchResult`` itself (subscribers can drill in)
+    """
+    try:
+        from hermes_cli.plugins import invoke_hook
+        outcome = "ok"
+        if getattr(result, "skipped_locked", False):
+            outcome = "skipped_locked"
+        elif not any((
+            result.spawned,
+            result.reclaimed,
+            result.promoted,
+            result.crashed,
+            result.stale,
+            result.timed_out,
+            result.auto_blocked,
+            result.skipped_per_profile_capped,
+            result.skipped_unassigned,
+        )):
+            outcome = "idle"
+        invoke_hook(
+            "kanban_dispatch_tick",
+            board=board,
+            dry_run=bool(dry_run),
+            outcome=outcome,
+            result=result,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        _log.debug("kanban dispatch tick hook failed: %s", exc)
+
+
 # A running task's claim is valid for 15 minutes by default; after that the
 # next dispatcher tick reclaims it. Workers that outlive this window should
 # call ``heartbeat_claim(task_id)`` periodically. In practice most kanban
@@ -6964,7 +7017,7 @@ def dispatch_once(
         # Path resolution should never fail, but if it somehow does we
         # must not lose the tick — fall through to an unguarded dispatch
         # rather than dropping work.
-        return _dispatch_once_locked(
+        result = _dispatch_once_locked(
             conn,
             spawn_fn=spawn_fn,
             ttl_seconds=ttl_seconds,
@@ -6977,22 +7030,27 @@ def dispatch_once(
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
+        _fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
+        return result
     with _dispatch_tick_lock(db_path) as held:
         if not held:
-            return DispatchResult(skipped_locked=True)
-        return _dispatch_once_locked(
-            conn,
-            spawn_fn=spawn_fn,
-            ttl_seconds=ttl_seconds,
-            dry_run=dry_run,
-            max_spawn=max_spawn,
-            max_in_progress=max_in_progress,
-            failure_limit=failure_limit,
-            stale_timeout_seconds=stale_timeout_seconds,
-            board=board,
-            default_assignee=default_assignee,
-            max_in_progress_per_profile=max_in_progress_per_profile,
-        )
+            result = DispatchResult(skipped_locked=True)
+        else:
+            result = _dispatch_once_locked(
+                conn,
+                spawn_fn=spawn_fn,
+                ttl_seconds=ttl_seconds,
+                dry_run=dry_run,
+                max_spawn=max_spawn,
+                max_in_progress=max_in_progress,
+                failure_limit=failure_limit,
+                stale_timeout_seconds=stale_timeout_seconds,
+                board=board,
+                default_assignee=default_assignee,
+                max_in_progress_per_profile=max_in_progress_per_profile,
+            )
+        _fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
+        return result
 
 
 def _dispatch_once_locked(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -210,6 +210,22 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Kanban dispatcher observability hook. Fired once per dispatcher tick,
+    # AFTER the tick's write txn is done and the board dispatch lock is
+    # released, so subscribers never run inside the SQLite writer critical
+    # section. Observers only: return values are ignored.
+    #
+    # Fires in the DISPATCHER process (gateway-embedded dispatcher or
+    # ``hermes kanban dispatch``). A plugin that wants to publish tick
+    # summaries to an external observability backend subscribes here — the
+    # core stays coupling-free.
+    #
+    # Kwargs: board: str | None, dry_run: bool,
+    #   outcome: "ok" | "skipped_locked" | "idle",
+    #   result: hermes_cli.kanban_db.DispatchResult (spawned, reclaimed,
+    #     promoted, crashed, stale, timed_out, auto_blocked,
+    #     skipped_per_profile_capped, skipped_unassigned, …).
+    "kanban_dispatch_tick",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/tests/hermes_cli/test_kanban_dispatch_tick_hook.py
+++ b/tests/hermes_cli/test_kanban_dispatch_tick_hook.py
@@ -1,0 +1,112 @@
+"""Tests for the ``kanban_dispatch_tick`` plugin hook.
+
+Verifies that ``kanban_db.dispatch_once`` fires the hook after each tick
+(including idle ticks and dry runs), that ``outcome`` classifies the tick
+correctly, and that a misbehaving subscriber never breaks the dispatcher.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def captured_ticks(monkeypatch):
+    """Register a capturing callback for the dispatch tick hook."""
+    mgr = get_plugin_manager()
+    events: list[dict] = []
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+    mgr._hooks.setdefault("kanban_dispatch_tick", []).append(
+        lambda **kw: events.append(kw)
+    )
+    try:
+        yield events
+    finally:
+        mgr._hooks = saved
+
+
+def test_dispatch_tick_hook_is_registered_as_valid():
+    """The dispatch tick hook name is part of VALID_HOOKS."""
+    assert "kanban_dispatch_tick" in VALID_HOOKS
+
+
+def test_idle_tick_fires_hook_with_outcome_idle(kanban_home, captured_ticks):
+    """An empty board produces one hook fire with outcome='idle'."""
+    conn = kb.connect()
+    try:
+        kb.dispatch_once(conn, spawn_fn=lambda *a, **k: 12345)
+    finally:
+        conn.close()
+    assert len(captured_ticks) == 1
+    kw = captured_ticks[0]
+    assert kw["outcome"] == "idle"
+    assert kw["dry_run"] is False
+    assert isinstance(kw["result"], kb.DispatchResult)
+
+
+def test_active_tick_fires_hook_with_outcome_ok(kanban_home, captured_ticks):
+    """A tick that spawns a worker fires the hook with outcome='ok'."""
+    conn = kb.connect()
+    try:
+        # 'default' is guaranteed to exist as a profile, so the dispatcher
+        # actually spawns it instead of skipping as non-spawnable.
+        tid = kb.create_task(conn, title="t", assignee="default")
+        kb.dispatch_once(conn, spawn_fn=lambda *a, **k: 4242)
+    finally:
+        conn.close()
+    ok_events = [kw for kw in captured_ticks if kw["outcome"] == "ok"]
+    assert ok_events, (
+        "expected an ok tick, got "
+        f"{[kw['outcome'] for kw in captured_ticks]}"
+    )
+    kw = ok_events[-1]
+    result = kw["result"]
+    assert any(row[0] == tid for row in result.spawned)
+
+
+def test_dry_run_tick_carries_dry_run_flag(kanban_home, captured_ticks):
+    """dry_run=True is propagated to the hook payload."""
+    conn = kb.connect()
+    try:
+        kb.dispatch_once(conn, dry_run=True, spawn_fn=lambda *a, **k: None)
+    finally:
+        conn.close()
+    assert captured_ticks
+    assert all(kw["dry_run"] is True for kw in captured_ticks)
+
+
+def test_misbehaving_subscriber_does_not_break_dispatcher(kanban_home, monkeypatch):
+    """A hook callback that raises must not break the dispatch tick."""
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+
+    def _boom(**kw):
+        raise RuntimeError("subscriber exploded")
+
+    mgr._hooks.setdefault("kanban_dispatch_tick", []).append(_boom)
+    try:
+        conn = kb.connect()
+        try:
+            # Idle tick — the dispatcher must return a DispatchResult cleanly
+            # despite the raising subscriber.
+            result = kb.dispatch_once(conn, spawn_fn=lambda *a, **k: 1)
+            assert isinstance(result, kb.DispatchResult)
+        finally:
+            conn.close()
+    finally:
+        mgr._hooks = saved


### PR DESCRIPTION
## Motivation

Fleet operators want per-tick dispatcher observability (spawned / reclaimed / promoted / crashed / per-profile-capped counts) without having to poll the board or scrape gateway logs. Following the existing `kanban_task_{claimed,completed,blocked}` pattern keeps the primitive in the plugin surface, so third-party observability backends (Prometheus exporters, custom SQLite telemetry sinks, dashboards) stay out-of-tree per the project's plugin policy (AGENTS.md: "Third-party products / other people's projects integrated into the core tree ... do NOT land under `plugins/` in this repo"). This PR adds the hook; a subscriber ships elsewhere.

## What it does

- Adds `_fire_dispatch_tick_hook(result, board, dry_run)` right next to the existing `_fire_kanban_lifecycle_hook` helper. Same defensive shape: swallows every exception, uses `_log.debug` on failure, no dispatcher side effects.
- Wires it into both `dispatch_once()` exit paths (path-resolution fallback + normal locked path, including `skipped_locked`). All three exit paths converge on `result -> fire-hook -> return result`.
- Classifies each tick as one of:
  - `"skipped_locked"` — another dispatcher held the board lock
  - `"idle"` — nothing to do this tick
  - `"ok"` — spawned / reclaimed / promoted / crashed / …
- Registers `'kanban_dispatch_tick'` in `plugins.VALID_HOOKS` with the same doc-comment style as the three existing lifecycle hooks.

## Hook payload

```
board:    str | None       resolved board slug (None = default board)
dry_run:  bool             whether this tick was a plan-only pass
outcome:  str              "ok" | "skipped_locked" | "idle"
result:   DispatchResult   the raw result (spawned, reclaimed, promoted,
                           crashed, stale, timed_out, auto_blocked,
                           skipped_per_profile_capped, ...)
```

## Non-goals

- **No hardcoded telemetry sink.** Core stays coupling-free; a backend ships as its own plugin.
- **No new `HERMES_*` env vars or `config.yaml` entries.** Zero user-facing configuration surface added.
- **No changes to `DispatchResult`, `dispatch_once()` signature, or `_dispatch_once_locked()` behavior.** Existing dispatch tests continue to see the same `DispatchResult` they always did.

## Tests

Adds `tests/hermes_cli/test_kanban_dispatch_tick_hook.py`:
- dispatch tick hook is registered in `VALID_HOOKS`
- idle tick fires with `outcome='idle'`
- active tick fires with `outcome='ok'` and `result.spawned` includes the spawned `task_id`
- `dry_run=True` is propagated to the hook payload
- misbehaving subscriber (raising callback) does not break the dispatch tick

Existing test suites verified green with this change applied:

| Suite | Result |
|---|---|
| `test_kanban_lifecycle_hooks.py` | 5 pass |
| `test_kanban_dispatch_lock.py` | 5 pass |
| `test_kanban_default_assignee.py` | all pass |
| `test_kanban_per_profile_cap.py` | all pass |
| `test_kanban_cli_dispatch_passthrough.py` | all pass |
| `test_kanban_dispatch_tick_hook.py` (new) | 5 pass |
| **Total (targeted)** | **35/35 pass** |

The broader `tests/hermes_cli/*kanban*` collection has ~40 pre-existing failures on `main` (test pollution across the full-suite runner, not the code under test); they reproduce identically **without** this patch applied.

## Backwards compatibility

- New hook name in `VALID_HOOKS` is additive.
- Existing subscribers to the three lifecycle hooks are unaffected.
- If a plugin registers a callback for `kanban_dispatch_tick` and raises, the dispatcher continues — matches the semantics of the other three hooks and is covered by `test_misbehaving_subscriber_does_not_break_dispatcher`.

## Design note (for reviewers who saw the earlier "telemetry emitter" variant)

An earlier internal draft of this change wrote directly into a plugin-owned SQLite file at every tick and gated it behind an env var. That approach was reworked into a plain plugin hook after re-reading AGENTS.md's "keep the core narrow / no HERMES_* env vars for non-secret config / third-party observability lives in the plugin surface" rubric. The result is this: one hook, one test file, no coupling.
