### PR TITLE
fix(mcp): cap tool result size

### DIFF
--- a/tests/tools/test_mcp_tool_result_limits.py
+++ b/tests/tools/test_mcp_tool_result_limits.py
@@ -1,0 +1,24 @@
+import json
+
+from tools import mcp_tool
+
+
+def test_mcp_tool_result_under_limit_is_unchanged(monkeypatch):
+    monkeypatch.setattr("tools.tool_output_limits.get_max_bytes", lambda: 100)
+    payload = json.dumps({"result": "short"})
+
+    assert mcp_tool._truncate_mcp_tool_result(payload) == payload
+
+
+def test_mcp_tool_result_over_limit_is_bounded_valid_json(monkeypatch):
+    monkeypatch.setattr("tools.tool_output_limits.get_max_bytes", lambda: 100)
+    payload = json.dumps({"result": "x" * 500})
+
+    truncated = mcp_tool._truncate_mcp_tool_result(payload)
+    parsed = json.loads(truncated)
+
+    assert set(parsed) == {"result"}
+    assert "MCP TOOL RESULT TRUNCATED" in parsed["result"]
+    assert len(parsed["result"]) < len(payload)
+    assert parsed["result"].startswith(payload[:40])
+    assert parsed["result"].endswith(payload[-60:])

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -101,6 +101,28 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
+
+def _truncate_mcp_tool_result(result: str) -> str:
+    """Bound MCP tool output before it enters conversation context."""
+    try:
+        from tools.tool_output_limits import get_max_bytes
+        max_chars = get_max_bytes()
+    except Exception:
+        max_chars = 50_000
+
+    if len(result) <= max_chars:
+        return result
+
+    head_chars = int(max_chars * 0.4)
+    tail_chars = max_chars - head_chars
+    omitted = len(result) - head_chars - tail_chars
+    truncated = (
+        result[:head_chars]
+        + f"\n\n... [MCP TOOL RESULT TRUNCATED - {omitted} chars omitted out of {len(result)} total] ...\n\n"
+        + result[-tail_chars:]
+    )
+    return json.dumps({"result": truncated}, ensure_ascii=False)
+
 # Upper bound for the OSV malware preflight during stdio MCP startup. The
 # check makes a blocking urllib HTTPS call whose own timeout can fail to
 # interrupt a stalled SSL handshake, which froze the asyncio event loop and
@@ -3385,7 +3407,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             return _run_on_mcp_loop(_call, timeout=tool_timeout)
 
         try:
-            result = _call_once()
+            result = _truncate_mcp_tool_result(_call_once())
             # Check if the MCP tool itself returned an error
             try:
                 parsed = json.loads(result)


### PR DESCRIPTION
Fixes #56059.\n\nMCP tool outputs are now bounded with the shared tool_output.max_bytes limit before returning into the agent tool-result pipeline, preventing oversized MCP responses from flooding context.\n\nTests:\n- scripts/run_tests.sh tests/tools/test_mcp_tool_result_limits.py