### PR TITLE
fix(code-exec): honor session cwd override

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -45,6 +45,7 @@ from tools.code_execution_tool import (
     EXECUTE_CODE_SCHEMA,
     _TOOL_DOC_LINES,
     _execute_remote,
+    _resolve_child_cwd,
 )
 
 
@@ -914,6 +915,25 @@ class TestLoadConfig(unittest.TestCase):
              patch("hermes_cli.config.read_raw_config", return_value={}):
             result = _load_config()
         self.assertEqual(result, {})
+
+
+class TestResolveChildCwd(unittest.TestCase):
+    def test_project_mode_prefers_session_cwd_override(self):
+        from tools import terminal_tool
+
+        old = dict(terminal_tool._task_env_overrides)
+        try:
+            terminal_tool._task_env_overrides.clear()
+            session_cwd = os.getcwd()
+            terminal_tool.register_task_env_overrides("session-a", {"cwd": session_cwd})
+
+            self.assertEqual(
+                _resolve_child_cwd("project", "/tmp/staging", task_id="session-a"),
+                session_cwd,
+            )
+        finally:
+            terminal_tool._task_env_overrides.clear()
+            terminal_tool._task_env_overrides.update(old)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1297,7 +1297,7 @@ def execute_code(
         # Env scrubbing and tool whitelist apply identically in both modes.
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir)
+        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id)
         _script_path = os.path.join(tmpdir, "script.py")
 
         proc = subprocess.Popen(
@@ -1703,17 +1703,26 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
+def _resolve_child_cwd(mode: str, staging_dir: str, task_id: Optional[str] = None) -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
-    - ``project``: the session's TERMINAL_CWD (same as the terminal tool), or
-      ``os.getcwd()`` if TERMINAL_CWD is unset or doesn't point at a real dir.
+    - ``project``: the per-session cwd override registered by gateway/TUI/ACP,
+      then TERMINAL_CWD (same as the terminal/file tools), then ``os.getcwd()``.
       Falls back to the staging tmpdir as a last resort so we never invoke
       Popen with a nonexistent cwd.
     """
     if mode != "project":
         return staging_dir
+    try:
+        from tools.terminal_tool import resolve_task_overrides
+        override_cwd = (resolve_task_overrides(task_id) or {}).get("cwd")
+    except Exception:
+        override_cwd = None
+    if override_cwd:
+        expanded = os.path.expanduser(str(override_cwd).strip())
+        if os.path.isdir(expanded):
+            return expanded
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)


### PR DESCRIPTION
Fixes #56047.\n\nexecute_code now resolves project-mode subprocess cwd from the per-session task override registered by session.cwd.set before falling back to TERMINAL_CWD or process cwd, matching terminal and file tool behavior in multi-session gateways.\n\nTests:\n- scripts/run_tests.sh tests/tools/test_code_execution.py -k ResolveChildCwd