### PR TITLE
feat(browser): fall back from CDP to local engine

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -366,6 +366,10 @@ browser:
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
 
+  # Retry user-supplied external CDP transport/backend failures on the local
+  # browser engine. Semantic page/tool errors are never retried (default: false).
+  cdp_fallback_to_local: false
+
 # =============================================================================
 # Tool Loop Guardrails
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1286,6 +1286,7 @@ DEFAULT_CONFIG = {
         "auto_local_for_private_urls": True,  # When a cloud provider is set, auto-spawn local Chromium for LAN/localhost URLs instead of sending them to the cloud
         "cdp_url": "",  # Optional persistent CDP endpoint for attaching to an existing Chromium/Chrome
         "allow_unsafe_evaluate": False,  # Allow browser_console(expression=...) to use sensitive JS primitives (cookies/storage/clipboard/network/form values)
+        "cdp_fallback_to_local": False,  # If a user-supplied CDP endpoint fails, retry eligible commands with the configured local engine
         # CDP supervisor — dialog + frame detection via a persistent WebSocket.
         # Active only when a CDP-capable backend is attached (Browserbase or
         # local Chrome via /browser connect). See

--- a/tests/tools/test_browser_eval_ssrf.py
+++ b/tests/tools/test_browser_eval_ssrf.py
@@ -264,8 +264,8 @@ class TestPostEvalPageRecheck:
         assert result["success"] is True
         assert result["result"] == "public DOM text"
 
-    def test_fail_open_when_url_probe_fails(self, monkeypatch):
-        """If the window.location.href probe errors, don't block (fail-open)."""
+    def test_fail_closed_when_url_probe_fails(self, monkeypatch):
+        """If the window.location.href probe errors, withhold eval content."""
         self._guard_on(monkeypatch)
         monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
         monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda url: False)
@@ -273,13 +273,14 @@ class TestPostEvalPageRecheck:
         def _run(task_id, command, args=None, **k):
             if args == ["window.location.href"]:
                 return {"success": False, "error": "CDP probe failed"}
-            return {"success": True, "data": {"result": "dom text"}}
+            return {"success": True, "data": {"result": "METADATA_SECRET_CONTENT"}}
 
         monkeypatch.setattr(browser_tool, "_run_browser_command", _run)
 
         result = _eval("document.body.innerText")
-        assert result["success"] is True
-        assert result["result"] == "dom text"
+        assert result["success"] is False
+        assert "METADATA_SECRET_CONTENT" not in json.dumps(result)
+        assert "unable to verify" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_lightpanda.py
+++ b/tests/tools/test_browser_lightpanda.py
@@ -703,6 +703,33 @@ class TestCdpFallbackToLocalEngine:
         assert "--cdp" in captured_cmds[0]
         assert "--engine" not in captured_cmds[0]
 
+    def test_cdp_semantic_failure_does_not_retry_locally(self, tmp_path):
+        """Invalid refs/app-level command errors should not switch browsers."""
+        import tools.browser_tool as bt
+
+        captured_cmds = []
+        outputs = [json.dumps({"success": False, "error": "Element reference @e999 not found"})]
+
+        with patch("tools.browser_tool._get_session_info", return_value={
+                 "session_name": "cdp-sess",
+                 "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                 "features": {"cdp_override": True},
+             }), \
+             patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch("tools.browser_tool._requires_real_termux_browser_install", return_value=False), \
+             patch("tools.browser_tool._is_local_mode", return_value=False), \
+             patch("tools.browser_tool._get_browser_engine", return_value="lightpanda"), \
+             patch("tools.browser_tool._cdp_fallback_to_local", return_value=True), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._write_owner_pid"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("subprocess.Popen", side_effect=self._popen_writer(outputs, captured_cmds)):
+            result = bt._run_browser_command("cdp-task", "click", ["@e999"])
+
+        assert result == {"success": False, "error": "Element reference @e999 not found"}
+        assert len(captured_cmds) == 1
+        assert "--cdp" in captured_cmds[0]
+
     def test_cdp_failure_can_retry_on_local_lightpanda_session(self, tmp_path):
         """Opt-in CDP fallback retries the command through local Lightpanda."""
         import tools.browser_tool as bt
@@ -797,6 +824,52 @@ class TestCdpFallbackToLocalEngine:
         assert captured_cmds[1][-2:] == ["open", "https://example.com/"]
         assert captured_cmds[2][-2:] == ["snapshot", "-c"]
 
+    def test_cdp_snapshot_fallback_skips_unsafe_cached_warmup_url(self, tmp_path):
+        """Never reopen cached metadata/private URLs during CDP→local warm-up."""
+        import tools.browser_tool as bt
+
+        captured_cmds = []
+        outputs = [
+            json.dumps({"success": False, "error": "CDP socket closed"}),
+            json.dumps({
+                "success": True,
+                "data": {"snapshot": '- heading "Fallback OK" [ref=e1]', "refs": {"e1": {}}},
+            }),
+        ]
+        bt._last_browser_url_by_session_key["cdp-task"] = "http://169.254.169.254/latest/meta-data"
+
+        def fake_session_info(session_key):
+            if session_key.endswith("::local"):
+                return {"session_name": "local-sess", "cdp_url": None, "features": {"local": True}}
+            return {
+                "session_name": "cdp-sess",
+                "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                "features": {"cdp_override": True},
+            }
+
+        try:
+            with patch("tools.browser_tool._get_session_info", side_effect=fake_session_info), \
+                 patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+                 patch("tools.browser_tool._requires_real_termux_browser_install", return_value=False), \
+                 patch("tools.browser_tool._is_local_mode", return_value=False), \
+                 patch("tools.browser_tool._get_browser_engine", return_value="lightpanda"), \
+                 patch("tools.browser_tool._cdp_fallback_to_local", return_value=True), \
+                 patch("tools.browser_tool._allow_private_urls", return_value=False), \
+                 patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+                 patch("tools.browser_tool._write_owner_pid"), \
+                 patch("tools.interrupt.is_interrupted", return_value=False), \
+                 patch("subprocess.Popen", side_effect=self._popen_writer(outputs, captured_cmds)):
+                result = bt._run_browser_command("cdp-task", "snapshot", ["-c"])
+        finally:
+            bt._last_browser_url_by_session_key.pop("cdp-task", None)
+            bt._last_active_session_key.pop("cdp-task", None)
+
+        assert result["success"] is True
+        assert len(captured_cmds) == 2
+        assert captured_cmds[0][-2:] == ["snapshot", "-c"]
+        assert captured_cmds[1][-2:] == ["snapshot", "-c"]
+        assert "cdp-task" not in bt._last_browser_url_by_session_key
+
     def test_browser_navigate_uses_fallback_session_for_auto_snapshot(self):
         """After CDP→local fallback, follow-up snapshot uses the local session key."""
         import tools.browser_tool as bt
@@ -834,3 +907,38 @@ class TestCdpFallbackToLocalEngine:
         assert bt._last_active_session_key["nav-cdp"] == "nav-cdp::local"
         assert run_cmd.call_args_list[1].args[0] == "nav-cdp::local"
         bt._last_active_session_key.pop("nav-cdp", None)
+
+    def test_browser_navigate_blocked_redirect_is_not_cached_for_warmup(self):
+        """Blocked redirect URLs must not become future CDP→local warm-up targets."""
+        import tools.browser_tool as bt
+
+        bt._last_browser_url_by_session_key["nav-cdp"] = "https://previous.example/"
+        nav_result = {
+            "success": True,
+            "data": {
+                "title": "metadata",
+                "url": "http://169.254.169.254/latest/meta-data",
+            },
+        }
+        blank_result = {"success": True, "data": {}}
+
+        try:
+            with patch("tools.browser_tool._is_local_backend", return_value=False), \
+                 patch("tools.browser_tool._get_session_info", return_value={
+                     "session_name": "cdp-sess",
+                     "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                     "features": {"cdp_override": True},
+                     "_first_nav": False,
+                 }), \
+                 patch("tools.browser_tool._run_browser_command", side_effect=[nav_result, blank_result]) as run_cmd:
+                response = json.loads(bt.browser_navigate("https://example.com", task_id="nav-cdp"))
+        finally:
+            bt._last_active_session_key.pop("nav-cdp", None)
+            bt._last_browser_url_by_session_key.pop("nav-cdp", None)
+
+        assert response == {
+            "success": False,
+            "error": "Blocked: redirect landed on a cloud metadata endpoint",
+        }
+        assert "nav-cdp" not in bt._last_browser_url_by_session_key
+        assert run_cmd.call_args_list[1].args == ("nav-cdp", "open", ["about:blank"])

--- a/tests/tools/test_browser_lightpanda.py
+++ b/tests/tools/test_browser_lightpanda.py
@@ -241,6 +241,7 @@ class TestConfigIntegration:
         from hermes_cli.config import DEFAULT_CONFIG
         assert "engine" in DEFAULT_CONFIG["browser"]
         assert DEFAULT_CONFIG["browser"]["engine"] == "auto"
+        assert DEFAULT_CONFIG["browser"]["cdp_fallback_to_local"] is False
 
     def test_env_var_registered(self):
         from hermes_cli.config import OPTIONAL_ENV_VARS
@@ -634,3 +635,202 @@ class TestEngineOverride:
         assert len(captured_cmds) == 1
         assert "--engine" in captured_cmds[0]
         assert captured_cmds[0][captured_cmds[0].index("--engine") + 1] == "lightpanda"
+
+
+# ---------------------------------------------------------------------------
+# CDP override fallback to local engine chain
+# ---------------------------------------------------------------------------
+
+class TestCdpFallbackToLocalEngine:
+    """Verify external CDP failures can fall through to local engines."""
+
+    @staticmethod
+    def _popen_writer(outputs, captured_cmds):
+        import os
+
+        class FakeProc:
+            def __init__(self, stdout_fd, stderr_fd, output, returncode=0):
+                self._stdout_fd = stdout_fd
+                self._stderr_fd = stderr_fd
+                self._output = output
+                self.returncode = returncode
+
+            def wait(self, timeout=None):
+                if self._output:
+                    os.write(self._stdout_fd, self._output.encode("utf-8"))
+                os.close(self._stdout_fd)
+                os.close(self._stderr_fd)
+                return self.returncode
+
+            def kill(self):
+                self.returncode = -9
+
+        def fake_popen(cmd, stdout, stderr, **kwargs):
+            captured_cmds.append(cmd)
+            output = outputs.pop(0)
+            # subprocess.Popen gives the child its own descriptor. Duplicate here
+            # because _run_browser_command closes the parent fd immediately after
+            # Popen returns.
+            return FakeProc(os.dup(stdout), os.dup(stderr), output)
+
+        return fake_popen
+
+    def test_cdp_failure_does_not_trigger_lightpanda_chrome_fallback_when_disabled(self, tmp_path):
+        """A CDP backend failure is not misclassified as a Lightpanda failure."""
+        import tools.browser_tool as bt
+
+        captured_cmds = []
+        outputs = [json.dumps({"success": False, "error": "CDP socket closed"})]
+
+        with patch("tools.browser_tool._get_session_info", return_value={
+                 "session_name": "cdp-sess",
+                 "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                 "features": {"cdp_override": True},
+             }), \
+             patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch("tools.browser_tool._requires_real_termux_browser_install", return_value=False), \
+             patch("tools.browser_tool._is_local_mode", return_value=False), \
+             patch("tools.browser_tool._get_browser_engine", return_value="lightpanda"), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._write_owner_pid"), \
+             patch("tools.browser_tool._run_chrome_fallback_command", side_effect=AssertionError("wrong fallback")), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("subprocess.Popen", side_effect=self._popen_writer(outputs, captured_cmds)):
+            result = bt._run_browser_command("cdp-task", "snapshot", ["-c"])
+
+        assert result == {"success": False, "error": "CDP socket closed"}
+        assert len(captured_cmds) == 1
+        assert "--cdp" in captured_cmds[0]
+        assert "--engine" not in captured_cmds[0]
+
+    def test_cdp_failure_can_retry_on_local_lightpanda_session(self, tmp_path):
+        """Opt-in CDP fallback retries the command through local Lightpanda."""
+        import tools.browser_tool as bt
+
+        captured_cmds = []
+        outputs = [
+            json.dumps({"success": False, "error": "CDP socket closed"}),
+            json.dumps({
+                "success": True,
+                "data": {"snapshot": '- heading "Fallback OK" [ref=e1]', "refs": {"e1": {}}},
+            }),
+        ]
+
+        def fake_session_info(session_key):
+            if session_key.endswith("::local"):
+                return {"session_name": "local-sess", "cdp_url": None, "features": {"local": True}}
+            return {
+                "session_name": "cdp-sess",
+                "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                "features": {"cdp_override": True},
+            }
+
+        with patch("tools.browser_tool._get_session_info", side_effect=fake_session_info), \
+             patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch("tools.browser_tool._requires_real_termux_browser_install", return_value=False), \
+             patch("tools.browser_tool._is_local_mode", return_value=False), \
+             patch("tools.browser_tool._get_browser_engine", return_value="lightpanda"), \
+             patch("tools.browser_tool._cdp_fallback_to_local", return_value=True), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._write_owner_pid"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("subprocess.Popen", side_effect=self._popen_writer(outputs, captured_cmds)):
+            result = bt._run_browser_command("cdp-task", "snapshot", ["-c"])
+
+        assert result["success"] is True
+        assert result["browser_session_key"] == "cdp-task::local"
+        assert result["browser_backend_fallback"] == {
+            "from": "cdp",
+            "to": "local",
+            "reason": "CDP backend 'snapshot' failed (CDP socket closed); retried with local browser.",
+        }
+        assert "CDP fallback" in result["fallback_warning"]
+        assert len(captured_cmds) == 2
+        assert "--cdp" in captured_cmds[0]
+        assert "--session" in captured_cmds[1]
+        assert "--engine" in captured_cmds[1]
+        assert captured_cmds[1][captured_cmds[1].index("--engine") + 1] == "lightpanda"
+
+    def test_cdp_snapshot_fallback_warms_local_session_with_last_url(self, tmp_path):
+        """A later CDP snapshot fallback opens the last successful URL locally first."""
+        import tools.browser_tool as bt
+
+        captured_cmds = []
+        outputs = [
+            json.dumps({"success": False, "error": "CDP socket closed"}),
+            json.dumps({"success": True, "data": {"title": "Fallback OK", "url": "https://example.com/"}}),
+            json.dumps({
+                "success": True,
+                "data": {"snapshot": '- heading "Fallback OK" [ref=e1]', "refs": {"e1": {}}},
+            }),
+        ]
+        bt._last_browser_url_by_session_key["cdp-task"] = "https://example.com/"
+
+        def fake_session_info(session_key):
+            if session_key.endswith("::local"):
+                return {"session_name": "local-sess", "cdp_url": None, "features": {"local": True}}
+            return {
+                "session_name": "cdp-sess",
+                "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                "features": {"cdp_override": True},
+            }
+
+        try:
+            with patch("tools.browser_tool._get_session_info", side_effect=fake_session_info), \
+                 patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+                 patch("tools.browser_tool._requires_real_termux_browser_install", return_value=False), \
+                 patch("tools.browser_tool._is_local_mode", return_value=False), \
+                 patch("tools.browser_tool._get_browser_engine", return_value="lightpanda"), \
+                 patch("tools.browser_tool._cdp_fallback_to_local", return_value=True), \
+                 patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+                 patch("tools.browser_tool._write_owner_pid"), \
+                 patch("tools.interrupt.is_interrupted", return_value=False), \
+                 patch("subprocess.Popen", side_effect=self._popen_writer(outputs, captured_cmds)):
+                result = bt._run_browser_command("cdp-task", "snapshot", ["-c"])
+        finally:
+            bt._last_browser_url_by_session_key.pop("cdp-task", None)
+            bt._last_active_session_key.pop("cdp-task", None)
+
+        assert result["success"] is True
+        assert len(captured_cmds) == 3
+        assert captured_cmds[0][-2:] == ["snapshot", "-c"]
+        assert captured_cmds[1][-2:] == ["open", "https://example.com/"]
+        assert captured_cmds[2][-2:] == ["snapshot", "-c"]
+
+    def test_browser_navigate_uses_fallback_session_for_auto_snapshot(self):
+        """After CDP→local fallback, follow-up snapshot uses the local session key."""
+        import tools.browser_tool as bt
+
+        bt._last_active_session_key.pop("nav-cdp", None)
+        nav_result = {
+            "success": True,
+            "data": {"title": "Fallback OK", "url": "https://example.com/"},
+            "browser_session_key": "nav-cdp::local",
+            "fallback_warning": "⚠ CDP fallback: local browser was used.",
+            "browser_backend_fallback": {
+                "from": "cdp",
+                "to": "local",
+                "reason": "CDP backend 'open' failed (CDP socket closed); retried with local browser.",
+            },
+        }
+        snapshot_result = {
+            "success": True,
+            "data": {"snapshot": '- heading "Fallback OK" [ref=e1]', "refs": {"e1": {}}},
+        }
+
+        with patch("tools.browser_tool._is_local_backend", return_value=True), \
+             patch("tools.browser_tool._get_session_info", return_value={
+                 "session_name": "cdp-sess",
+                 "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                 "features": {"cdp_override": True},
+                 "_first_nav": False,
+             }), \
+             patch("tools.browser_tool._run_browser_command", side_effect=[nav_result, snapshot_result]) as run_cmd:
+            response = json.loads(bt.browser_navigate("https://example.com", task_id="nav-cdp"))
+
+        assert response["success"] is True
+        assert response["browser_backend_fallback"]["from"] == "cdp"
+        assert response["element_count"] == 1
+        assert bt._last_active_session_key["nav-cdp"] == "nav-cdp::local"
+        assert run_cmd.call_args_list[1].args[0] == "nav-cdp::local"
+        bt._last_active_session_key.pop("nav-cdp", None)

--- a/tests/tools/test_browser_lightpanda.py
+++ b/tests/tools/test_browser_lightpanda.py
@@ -18,12 +18,98 @@ def _reset_engine_cache():
     bt._browser_engine_resolved = False
 
 
+def _public_command_result(result):
+    """Strip internal dispatcher markers from a low-level command result."""
+    public = dict(result)
+    public.pop("_browser_session_key", None)
+    return public
+
+
 @pytest.fixture(autouse=True)
-def _clean_engine_cache():
-    """Reset engine cache before and after each test."""
-    _reset_engine_cache()
-    yield
-    _reset_engine_cache()
+def _isolate_browser_module_state():
+    """Keep browser ownership/session/config caches isolated between tests."""
+    import tools.browser_tool as bt
+
+    mapping_names = (
+        "_last_active_session_key",
+        "_last_active_session_generation",
+        "_last_browser_url_by_session_key",
+        "_active_sessions",
+        "_session_last_activity",
+    )
+    set_names = (
+        "_recording_sessions",
+        "_cdp_fallback_local_session_keys",
+    )
+    scalar_names = (
+        "_cached_browser_engine",
+        "_browser_engine_resolved",
+        "_cached_cdp_fallback_to_local",
+        "_cdp_fallback_to_local_resolved",
+        "_cached_cloud_provider",
+        "_cloud_provider_resolved",
+        "_cached_allow_private_urls",
+        "_allow_private_urls_resolved",
+        "_cached_auto_local_for_private_urls",
+        "_auto_local_for_private_urls_resolved",
+        "_cached_agent_browser",
+        "_agent_browser_resolved",
+        "_cached_chromium_installed",
+        "_chromium_autoinstall_attempted",
+    )
+    mapping_snapshots = {
+        name: dict(getattr(bt, name))
+        for name in mapping_names
+        if hasattr(bt, name)
+    }
+    set_snapshots = {
+        name: set(getattr(bt, name))
+        for name in set_names
+        if hasattr(bt, name)
+    }
+    scalar_snapshots = {
+        name: getattr(bt, name)
+        for name in scalar_names
+        if hasattr(bt, name)
+    }
+
+    def reset_for_test():
+        with bt._cleanup_lock:
+            for name in mapping_names:
+                if hasattr(bt, name):
+                    getattr(bt, name).clear()
+            for name in set_names:
+                if hasattr(bt, name):
+                    getattr(bt, name).clear()
+        _reset_engine_cache()
+        bt._cached_cdp_fallback_to_local = None
+        bt._cdp_fallback_to_local_resolved = False
+        bt._cached_cloud_provider = None
+        bt._cloud_provider_resolved = False
+        bt._cached_allow_private_urls = None
+        bt._allow_private_urls_resolved = False
+        bt._cached_auto_local_for_private_urls = True
+        bt._auto_local_for_private_urls_resolved = False
+        bt._cached_agent_browser = None
+        bt._agent_browser_resolved = False
+        bt._cached_chromium_installed = None
+        bt._chromium_autoinstall_attempted = False
+
+    reset_for_test()
+    try:
+        yield
+    finally:
+        with bt._cleanup_lock:
+            for name, snapshot in mapping_snapshots.items():
+                target = getattr(bt, name)
+                target.clear()
+                target.update(snapshot)
+            for name, snapshot in set_snapshots.items():
+                target = getattr(bt, name)
+                target.clear()
+                target.update(snapshot)
+        for name, value in scalar_snapshots.items():
+            setattr(bt, name, value)
 
 
 # ---------------------------------------------------------------------------
@@ -667,7 +753,7 @@ class TestCdpFallbackToLocalEngine:
 
         def fake_popen(cmd, stdout, stderr, **kwargs):
             captured_cmds.append(cmd)
-            output = outputs.pop(0)
+            output = outputs(cmd) if callable(outputs) else outputs.pop(0)
             # subprocess.Popen gives the child its own descriptor. Duplicate here
             # because _run_browser_command closes the parent fd immediately after
             # Popen returns.
@@ -698,7 +784,7 @@ class TestCdpFallbackToLocalEngine:
              patch("subprocess.Popen", side_effect=self._popen_writer(outputs, captured_cmds)):
             result = bt._run_browser_command("cdp-task", "snapshot", ["-c"])
 
-        assert result == {"success": False, "error": "CDP socket closed"}
+        assert _public_command_result(result) == {"success": False, "error": "CDP socket closed"}
         assert len(captured_cmds) == 1
         assert "--cdp" in captured_cmds[0]
         assert "--engine" not in captured_cmds[0]
@@ -726,9 +812,70 @@ class TestCdpFallbackToLocalEngine:
              patch("subprocess.Popen", side_effect=self._popen_writer(outputs, captured_cmds)):
             result = bt._run_browser_command("cdp-task", "click", ["@e999"])
 
-        assert result == {"success": False, "error": "Element reference @e999 not found"}
+        assert _public_command_result(result) == {
+            "success": False,
+            "error": "Element reference @e999 not found",
+        }
         assert len(captured_cmds) == 1
         assert "--cdp" in captured_cmds[0]
+
+    @pytest.mark.parametrize(
+        "semantic_error",
+        [
+            "JavaScript exception: application WebSocket is unavailable",
+            "Element text assertion failed: connection refused by upstream API",
+            "Evaluation returned app status: io error",
+            "Page reported: command timed out while importing data",
+            "DOM assertion failed: operation timed out after 5 seconds",
+        ],
+    )
+    def test_cdp_semantic_failure_containing_transport_words_does_not_retry_locally(
+        self, tmp_path, semantic_error
+    ):
+        """Transport-like words inside page semantics are not CDP failures."""
+        import tools.browser_tool as bt
+
+        captured_cmds = []
+        outputs = [json.dumps({"success": False, "error": semantic_error})]
+
+        with patch("tools.browser_tool._get_session_info", return_value={
+                 "session_name": "cdp-sess",
+                 "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                 "features": {"cdp_override": True},
+             }), \
+             patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch("tools.browser_tool._requires_real_termux_browser_install", return_value=False), \
+             patch("tools.browser_tool._is_local_mode", return_value=False), \
+             patch("tools.browser_tool._get_browser_engine", return_value="lightpanda"), \
+             patch("tools.browser_tool._cdp_fallback_to_local", return_value=True), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._write_owner_pid"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("subprocess.Popen", side_effect=self._popen_writer(outputs, captured_cmds)):
+            result = bt._run_browser_command("cdp-task", "eval", ["document.title"])
+
+        assert _public_command_result(result) == {"success": False, "error": semantic_error}
+        assert len(captured_cmds) == 1
+        assert "--cdp" in captured_cmds[0]
+
+    @pytest.mark.parametrize("snapshot", ["", "- none"])
+    def test_cdp_successful_empty_or_short_snapshot_does_not_retry_locally(
+        self, snapshot
+    ):
+        """Snapshot content length is page semantics, not backend health."""
+        import tools.browser_tool as bt
+
+        with patch("tools.browser_tool._cdp_fallback_to_local", return_value=True):
+            reason = bt._cdp_fallback_reason(
+                {
+                    "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                    "features": {"cdp_override": True},
+                },
+                "snapshot",
+                {"success": True, "data": {"snapshot": snapshot, "refs": {}}},
+            )
+
+        assert reason is None
 
     def test_cdp_failure_can_retry_on_local_lightpanda_session(self, tmp_path):
         """Opt-in CDP fallback retries the command through local Lightpanda."""
@@ -766,6 +913,7 @@ class TestCdpFallbackToLocalEngine:
 
         assert result["success"] is True
         assert result["browser_session_key"] == "cdp-task::local"
+        assert "cdp-task::local" in bt._cdp_fallback_local_session_keys
         assert result["browser_backend_fallback"] == {
             "from": "cdp",
             "to": "local",
@@ -786,6 +934,7 @@ class TestCdpFallbackToLocalEngine:
         outputs = [
             json.dumps({"success": False, "error": "CDP socket closed"}),
             json.dumps({"success": True, "data": {"title": "Fallback OK", "url": "https://example.com/"}}),
+            json.dumps({"success": True, "data": {"result": "https://example.com/"}}),
             json.dumps({
                 "success": True,
                 "data": {"snapshot": '- heading "Fallback OK" [ref=e1]', "refs": {"e1": {}}},
@@ -819,13 +968,14 @@ class TestCdpFallbackToLocalEngine:
             bt._last_active_session_key.pop("cdp-task", None)
 
         assert result["success"] is True
-        assert len(captured_cmds) == 3
+        assert len(captured_cmds) == 4
         assert captured_cmds[0][-2:] == ["snapshot", "-c"]
         assert captured_cmds[1][-2:] == ["open", "https://example.com/"]
-        assert captured_cmds[2][-2:] == ["snapshot", "-c"]
+        assert captured_cmds[2][-2:] == ["eval", "window.location.href"]
+        assert captured_cmds[3][-2:] == ["snapshot", "-c"]
 
-    def test_cdp_snapshot_fallback_skips_unsafe_cached_warmup_url(self, tmp_path):
-        """Never reopen cached metadata/private URLs during CDP→local warm-up."""
+    def test_cdp_snapshot_fallback_blocks_unsafe_cached_warmup_url(self, tmp_path):
+        """Never run the follow-up command after a cached metadata/private URL."""
         import tools.browser_tool as bt
 
         captured_cmds = []
@@ -864,10 +1014,10 @@ class TestCdpFallbackToLocalEngine:
             bt._last_browser_url_by_session_key.pop("cdp-task", None)
             bt._last_active_session_key.pop("cdp-task", None)
 
-        assert result["success"] is True
+        assert result["success"] is False
         assert len(captured_cmds) == 2
         assert captured_cmds[0][-2:] == ["snapshot", "-c"]
-        assert captured_cmds[1][-2:] == ["snapshot", "-c"]
+        assert captured_cmds[1][-2:] == ["open", "about:blank"]
         assert "cdp-task" not in bt._last_browser_url_by_session_key
 
     def test_browser_navigate_uses_fallback_session_for_auto_snapshot(self):
@@ -898,28 +1048,58 @@ class TestCdpFallbackToLocalEngine:
                  "features": {"cdp_override": True},
                  "_first_nav": False,
              }), \
-             patch("tools.browser_tool._run_browser_command", side_effect=[nav_result, snapshot_result]) as run_cmd:
+             patch(
+                 "tools.browser_tool._run_browser_command",
+                 side_effect=[
+                     nav_result,
+                     {"success": True, "data": {"result": "https://example.com/"}},
+                     snapshot_result,
+                     {"success": True, "data": {"result": "https://example.com/"}},
+                 ],
+             ) as run_cmd:
             response = json.loads(bt.browser_navigate("https://example.com", task_id="nav-cdp"))
 
         assert response["success"] is True
         assert response["browser_backend_fallback"]["from"] == "cdp"
         assert response["element_count"] == 1
         assert bt._last_active_session_key["nav-cdp"] == "nav-cdp::local"
-        assert run_cmd.call_args_list[1].args[0] == "nav-cdp::local"
+        assert run_cmd.call_args_list[2].args[0] == "nav-cdp::local"
+        assert run_cmd.call_args_list[2].args[1] == "snapshot"
         bt._last_active_session_key.pop("nav-cdp", None)
 
-    def test_browser_navigate_blocked_redirect_is_not_cached_for_warmup(self):
-        """Blocked redirect URLs must not become future CDP→local warm-up targets."""
+    @pytest.mark.parametrize(
+        ("redirect_url", "expected_error"),
+        [
+            (
+                "http://169.254.169.254/latest/meta-data",
+                "Blocked: page URL targets a cloud metadata endpoint "
+                "(http://169.254.169.254/latest/meta-data).",
+            ),
+            (
+                "http://127.0.0.1/admin",
+                "Blocked: page URL targets a private or internal address "
+                "(http://127.0.0.1/admin).",
+            ),
+        ],
+        ids=["metadata", "private"],
+    )
+    def test_browser_navigate_blocked_redirect_is_not_cached_for_warmup(
+        self, redirect_url, expected_error
+    ):
+        """Blocked fallback redirects are blanked on the serving session and not cached."""
         import tools.browser_tool as bt
 
+        bt._last_active_session_key["nav-cdp"] = "nav-cdp::local"
         bt._last_browser_url_by_session_key["nav-cdp"] = "https://previous.example/"
         nav_result = {
             "success": True,
             "data": {
-                "title": "metadata",
-                "url": "http://169.254.169.254/latest/meta-data",
+                "title": "blocked redirect",
+                "url": redirect_url,
             },
+            "browser_session_key": "nav-cdp::local",
         }
+        probe_result = {"success": True, "data": {"result": redirect_url}}
         blank_result = {"success": True, "data": {}}
 
         try:
@@ -930,15 +1110,1083 @@ class TestCdpFallbackToLocalEngine:
                      "features": {"cdp_override": True},
                      "_first_nav": False,
                  }), \
-                 patch("tools.browser_tool._run_browser_command", side_effect=[nav_result, blank_result]) as run_cmd:
+                 patch(
+                     "tools.browser_tool._run_browser_command",
+                     side_effect=[nav_result, probe_result, blank_result],
+                 ) as run_cmd:
                 response = json.loads(bt.browser_navigate("https://example.com", task_id="nav-cdp"))
+                binding_after_block = bt._last_active_session_key.get("nav-cdp")
         finally:
             bt._last_active_session_key.pop("nav-cdp", None)
             bt._last_browser_url_by_session_key.pop("nav-cdp", None)
 
         assert response == {
             "success": False,
-            "error": "Blocked: redirect landed on a cloud metadata endpoint",
+            "error": expected_error,
         }
         assert "nav-cdp" not in bt._last_browser_url_by_session_key
-        assert run_cmd.call_args_list[1].args == ("nav-cdp", "open", ["about:blank"])
+        assert binding_after_block is None
+        assert run_cmd.call_args_list[2].args == ("nav-cdp::local", "open", ["about:blank"])
+
+    def test_browser_navigate_blocked_redirect_cleanup_failure_drops_fallback_binding(self):
+        """A failed blanking attempt cannot leave the unsafe fallback session active."""
+        import tools.browser_tool as bt
+
+        local_session_key = "nav-cdp::local"
+        bt._last_active_session_key["nav-cdp"] = local_session_key
+        bt._active_sessions[local_session_key] = {
+            "session_key": local_session_key,
+            "owner_task_id": "nav-cdp",
+            "session_name": "local-sess",
+        }
+        bt._last_browser_url_by_session_key["nav-cdp"] = "https://previous.example/"
+        bt._last_browser_url_by_session_key[local_session_key] = (
+            "http://169.254.169.254/latest/meta-data"
+        )
+        nav_result = {
+            "success": True,
+            "data": {
+                "title": "metadata",
+                "url": "http://169.254.169.254/latest/meta-data",
+            },
+            "browser_session_key": local_session_key,
+        }
+        probe_result = {
+            "success": True,
+            "data": {"result": "http://169.254.169.254/latest/meta-data"},
+        }
+        blank_failure = {"success": False, "error": "local sidecar unavailable"}
+        close_result = {"success": True, "data": {}}
+        snapshot_result = {
+            "success": True,
+            "data": {"snapshot": '- heading "Recovered CDP" [ref=e1]', "refs": {"e1": {}}},
+        }
+
+        try:
+            with patch("tools.browser_tool._is_local_backend", return_value=True), \
+                 patch("tools.browser_tool._get_session_info", return_value={
+                     "session_name": "cdp-sess",
+                     "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                     "features": {"cdp_override": True},
+                     "_first_nav": False,
+                 }), \
+                 patch(
+                     "tools.browser_tool._run_browser_command",
+                     side_effect=[
+                         nav_result,
+                         probe_result,
+                         blank_failure,
+                         close_result,
+                         snapshot_result,
+                     ],
+                 ) as run_cmd:
+                nav_response = json.loads(
+                    bt.browser_navigate("https://example.com", task_id="nav-cdp")
+                )
+                binding_after_nav = bt._last_active_session_key.get("nav-cdp")
+                snapshot_response = json.loads(bt.browser_snapshot(task_id="nav-cdp"))
+        finally:
+            bt._last_active_session_key.pop("nav-cdp", None)
+            bt._active_sessions.pop(local_session_key, None)
+            bt._last_browser_url_by_session_key.pop("nav-cdp", None)
+            bt._last_browser_url_by_session_key.pop(local_session_key, None)
+
+        assert nav_response == {
+            "success": False,
+            "error": (
+                "Blocked: page URL targets a cloud metadata endpoint "
+                "(http://169.254.169.254/latest/meta-data)."
+            ),
+        }
+        assert binding_after_nav is None
+        assert snapshot_response["success"] is True
+        assert run_cmd.call_args_list[2].args == (
+            local_session_key,
+            "open",
+            ["about:blank"],
+        )
+        assert run_cmd.call_args_list[3].args == (
+            local_session_key,
+            "close",
+            [],
+        )
+        assert run_cmd.call_args_list[4].args[0] == "nav-cdp"
+        assert local_session_key not in bt._active_sessions
+
+    def test_blocked_redirect_cleanup_does_not_mask_failure_with_temporary_chrome(
+        self, tmp_path
+    ):
+        """Blanking stays on the serving sidecar and destroys it on failure."""
+        import tools.browser_tool as bt
+
+        task_id = "cleanup-mask"
+        local_session_key = f"{task_id}::local"
+        bt._active_sessions.update({
+            task_id: {
+                "session_key": task_id,
+                "owner_task_id": task_id,
+                "session_name": "cdp-sess",
+                "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                "features": {"cdp_override": True},
+                "_first_nav": False,
+            },
+            local_session_key: {
+                "session_key": local_session_key,
+                "owner_task_id": task_id,
+                "session_name": "unsafe-local-sess",
+                "features": {"local": True},
+            },
+        })
+        captured_cmds = []
+        outputs = [
+            json.dumps({"success": False, "error": "CDP socket closed"}),
+            json.dumps({
+                "success": True,
+                "data": {
+                    "title": "metadata",
+                    "url": "http://169.254.169.254/latest/meta-data",
+                },
+            }),
+            json.dumps({
+                "success": True,
+                "data": {"result": "http://169.254.169.254/latest/meta-data"},
+            }),
+            json.dumps({"success": False, "error": "Lightpanda open failed"}),
+            json.dumps({"success": True, "data": {}}),
+        ]
+
+        with patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch("tools.browser_tool._requires_real_termux_browser_install", return_value=False), \
+             patch("tools.browser_tool._is_local_mode", return_value=False), \
+             patch("tools.browser_tool._is_local_backend", return_value=False), \
+             patch("tools.browser_tool._get_browser_engine", return_value="lightpanda"), \
+             patch("tools.browser_tool._cdp_fallback_to_local", return_value=True), \
+             patch("tools.browser_tool._navigation_session_key", return_value=task_id), \
+             patch("tools.browser_tool._allow_private_urls", return_value=False), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._write_owner_pid"), \
+             patch("tools.browser_tool._start_browser_cleanup_thread"), \
+             patch("tools.browser_tool._stop_cdp_supervisor"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("subprocess.Popen", side_effect=self._popen_writer(outputs, captured_cmds)), \
+             patch(
+                 "tools.browser_tool._run_chrome_fallback_command",
+                 return_value={"success": True, "data": {"url": "about:blank"}},
+             ) as chrome_fallback:
+            response = json.loads(bt.browser_navigate("https://example.com", task_id=task_id))
+
+        assert response == {
+            "success": False,
+            "error": (
+                "Blocked: page URL targets a cloud metadata endpoint "
+                "(http://169.254.169.254/latest/meta-data)."
+            ),
+        }
+        chrome_fallback.assert_not_called()
+        assert local_session_key not in bt._active_sessions
+        assert task_id not in bt._last_active_session_key
+        assert [cmd[-2:] for cmd in captured_cmds] == [
+            ["open", "https://example.com"],
+            ["open", "https://example.com"],
+            ["eval", "window.location.href"],
+            ["open", "about:blank"],
+            ["--json", "close"],
+        ]
+
+    def test_failed_cdp_fallback_does_not_change_last_active_owner(self):
+        """A failed local retry cannot retarget later tools to the local sidecar."""
+        import tools.browser_tool as bt
+
+        bt._last_active_session_key["owner-task"] = "owner-task"
+        with patch(
+            "tools.browser_tool._run_browser_command",
+            return_value={"success": False, "error": "local snapshot failed"},
+        ):
+            result = bt._run_cdp_local_fallback_command(
+                "owner-task",
+                "snapshot",
+                ["-c"],
+                30,
+                "CDP socket closed",
+            )
+
+        assert result["success"] is False
+        assert bt._last_active_session_key["owner-task"] == "owner-task"
+
+    def test_failed_cdp_fallback_warmup_aborts_followup_command(self):
+        """A failed local warm-up must not run a command against stale page state."""
+        import tools.browser_tool as bt
+
+        bt._last_active_session_key["warmup-task"] = "warmup-task"
+        bt._last_browser_url_by_session_key["warmup-task"] = "https://example.com/"
+        with patch(
+            "tools.browser_tool._run_browser_command",
+            side_effect=[
+                {"success": False, "error": "local open failed"},
+                {
+                    "success": True,
+                    "data": {"snapshot": "METADATA_SECRET_CONTENT"},
+                },
+            ],
+        ) as run_cmd:
+            result = bt._run_cdp_local_fallback_command(
+                "warmup-task",
+                "snapshot",
+                ["-c"],
+                30,
+                "CDP socket closed",
+            )
+
+        assert result["success"] is False
+        assert "local open failed" in result["error"]
+        assert run_cmd.call_count == 2
+        assert run_cmd.call_args_list[1].args[:3] == (
+            "warmup-task::local",
+            "open",
+            ["about:blank"],
+        )
+        assert all(call.args[1] != "snapshot" for call in run_cmd.call_args_list)
+        assert run_cmd.call_args_list[0].kwargs["_allow_fallback"] is False
+        assert bt._last_active_session_key["warmup-task"] == "warmup-task"
+
+    @pytest.mark.parametrize(
+        "probe_result",
+        [
+            {"success": False, "error": "probe failed"},
+            {"success": True, "data": {"result": ""}},
+            {
+                "success": True,
+                "data": {"result": "https://example.com/"},
+                "browser_session_key": "wrong-session",
+            },
+            {
+                "success": True,
+                "data": {"result": "https://example.com/"},
+                "browser_engine_fallback": {"from": "lightpanda", "to": "chrome"},
+            },
+            {"success": True, "data": {"result": "http://127.0.0.1/admin"}},
+            {
+                "success": True,
+                "data": {"result": "http://169.254.169.254/latest/meta-data"},
+            },
+        ],
+        ids=["failed", "empty", "session-mismatch", "fallback", "private", "imds"],
+    )
+    def test_cdp_warmup_probes_exact_serving_url_before_followup_and_quarantines(
+        self, probe_result
+    ):
+        """Warm-up proof failure withholds the command and discards all sidecar state."""
+        import tools.browser_tool as bt
+
+        task_id = "warmup-proof"
+        local_session_key = f"{task_id}::local"
+        bt._last_browser_url_by_session_key[task_id] = "https://example.com/"
+        bt._last_browser_url_by_session_key[local_session_key] = "https://stale.example/"
+        bt._active_sessions[local_session_key] = {
+            "session_key": local_session_key,
+            "owner_task_id": task_id,
+            "session_name": "warmup-local",
+            "bb_session_id": None,
+        }
+        bt._session_last_activity[local_session_key] = 123.0
+        bt._recording_sessions.add(local_session_key)
+        bt._cdp_fallback_local_session_keys.add(local_session_key)
+        bt._set_last_active_session_key(task_id, local_session_key)
+        commands = []
+
+        def run_command(session_key, command, args=None, timeout=None, **kwargs):
+            commands.append((session_key, command, args, kwargs))
+            assert session_key == local_session_key
+            if command == "open" and args == ["https://example.com/"]:
+                return {
+                    "success": True,
+                    "data": {"title": "redirected", "url": "https://example.com/"},
+                }
+            if command == "eval":
+                return probe_result
+            if command == "open" and args == ["about:blank"]:
+                return {"success": True, "data": {"url": "about:blank"}}
+            if command == "record":
+                return {"success": True, "data": {}}
+            if command == "close":
+                return {"success": True, "data": {}}
+            raise AssertionError((session_key, command, args, kwargs))
+
+        with patch("tools.browser_tool._run_browser_command", side_effect=run_command), \
+             patch("tools.browser_tool._stop_cdp_supervisor"), \
+             patch("tools.browser_tool._is_camofox_mode", return_value=False), \
+             patch("tools.browser_tool._allow_private_urls", return_value=False):
+            result = bt._run_cdp_local_fallback_command(
+                task_id,
+                "snapshot",
+                ["-c"],
+                30,
+                "CDP socket closed",
+            )
+
+        assert result["success"] is False
+        assert all(command != "snapshot" for _, command, _, _ in commands)
+        assert commands[1][1] == "eval"
+        assert commands[1][3]["_allow_fallback"] is False
+        assert local_session_key not in bt._active_sessions
+        assert local_session_key not in bt._session_last_activity
+        assert local_session_key not in bt._recording_sessions
+        assert local_session_key not in bt._cdp_fallback_local_session_keys
+        assert local_session_key not in bt._last_browser_url_by_session_key
+        assert task_id not in bt._last_active_session_key
+
+    @pytest.mark.parametrize("failed_phase", ["warmup", "followup"])
+    def test_failed_cdp_local_phase_quarantines_every_sidecar_tracker(
+        self, failed_phase
+    ):
+        """A failed warm-up or substantive retry never leaves a reusable daemon."""
+        import tools.browser_tool as bt
+
+        task_id = f"failed-{failed_phase}"
+        local_session_key = f"{task_id}::local"
+        if failed_phase == "warmup":
+            bt._last_browser_url_by_session_key[task_id] = "https://example.com/"
+        bt._last_browser_url_by_session_key[local_session_key] = "https://stale.example/"
+        bt._active_sessions[local_session_key] = {
+            "session_key": local_session_key,
+            "owner_task_id": task_id,
+            "session_name": "failed-local",
+            "bb_session_id": None,
+        }
+        bt._session_last_activity[local_session_key] = 123.0
+        bt._recording_sessions.add(local_session_key)
+        bt._cdp_fallback_local_session_keys.add(local_session_key)
+        bt._set_last_active_session_key(task_id, local_session_key)
+        commands = []
+
+        def run_command(session_key, command, args=None, timeout=None, **kwargs):
+            commands.append((session_key, command, args, kwargs))
+            assert session_key == local_session_key
+            if command in {"snapshot", "record", "close"}:
+                if command == "snapshot":
+                    return {"success": False, "error": "fallback command failed"}
+                return {"success": True, "data": {}}
+            if command == "open" and args == ["https://example.com/"]:
+                return {"success": False, "error": "warm-up open failed"}
+            if command == "open" and args == ["about:blank"]:
+                return {"success": True, "data": {"url": "about:blank"}}
+            raise AssertionError((session_key, command, args, kwargs))
+
+        with patch("tools.browser_tool._run_browser_command", side_effect=run_command), \
+             patch("tools.browser_tool._stop_cdp_supervisor"), \
+             patch("tools.browser_tool._is_camofox_mode", return_value=False):
+            result = bt._run_cdp_local_fallback_command(
+                task_id,
+                "snapshot",
+                ["-c"],
+                30,
+                "CDP socket closed",
+            )
+
+        assert result["success"] is False
+        assert local_session_key not in bt._active_sessions
+        assert local_session_key not in bt._session_last_activity
+        assert local_session_key not in bt._recording_sessions
+        assert local_session_key not in bt._cdp_fallback_local_session_keys
+        assert local_session_key not in bt._last_browser_url_by_session_key
+        assert task_id not in bt._last_active_session_key
+        assert [command for _, command, _, _ in commands][-1] == "close"
+
+    def test_slow_old_fallback_cannot_steal_owner_from_new_navigation(self):
+        """A fallback uses CAS so a newer successful navigation remains owner."""
+        import threading
+        import tools.browser_tool as bt
+
+        task_id = "stale-owner"
+        fallback_started = threading.Event()
+        release_fallback = threading.Event()
+        fallback_results = []
+
+        def fake_run(session_key, command, args=None, timeout=None, **kwargs):
+            if session_key.endswith("::local") and command == "snapshot":
+                fallback_started.set()
+                assert release_fallback.wait(timeout=5)
+                return {
+                    "success": True,
+                    "data": {
+                        "snapshot": '- heading "Old fallback" [ref=e1]',
+                        "refs": {"e1": {}},
+                    },
+                }
+            if session_key == task_id and command == "open":
+                return {
+                    "success": True,
+                    "data": {
+                        "title": "New navigation",
+                        "url": "https://new.example/",
+                    },
+                }
+            if session_key == task_id and command == "snapshot":
+                return {
+                    "success": True,
+                    "data": {
+                        "snapshot": '- heading "New navigation" [ref=e2]',
+                        "refs": {"e2": {}},
+                    },
+                }
+            raise AssertionError((session_key, command, args, timeout, kwargs))
+
+        def run_old_fallback():
+            fallback_results.append(bt._run_cdp_local_fallback_command(
+                task_id,
+                "snapshot",
+                ["-c"],
+                30,
+                "old CDP failure",
+            ))
+
+        with patch("tools.browser_tool._run_browser_command", side_effect=fake_run), \
+             patch("tools.browser_tool._navigation_session_key", return_value=task_id), \
+             patch("tools.browser_tool._is_local_backend", return_value=True), \
+             patch("tools.browser_tool._get_session_info", return_value={
+                 "session_name": "primary",
+                 "_first_nav": False,
+                 "features": {"local": True},
+             }):
+            thread = threading.Thread(target=run_old_fallback)
+            thread.start()
+            assert fallback_started.wait(timeout=5)
+            navigation = json.loads(
+                bt.browser_navigate("https://new.example/", task_id=task_id)
+            )
+            release_fallback.set()
+            thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert navigation["success"] is True
+        assert fallback_results[0]["success"] is True
+        assert bt._last_active_session_key[task_id] == task_id
+
+    def test_original_cdp_command_start_generation_blocks_stale_fallback_publish(
+        self, tmp_path
+    ):
+        """The CAS token predates the original CDP command, not only its retry."""
+        import threading
+        import tools.browser_tool as bt
+
+        task_id = "original-command-race"
+        original_cdp_started = threading.Event()
+        release_original_cdp = threading.Event()
+        captured_cmds = []
+        results = []
+
+        def output_for(cmd):
+            if "--cdp" in cmd:
+                original_cdp_started.set()
+                assert release_original_cdp.wait(timeout=5)
+                return json.dumps({"success": False, "error": "CDP socket closed"})
+            return json.dumps({
+                "success": True,
+                "data": {
+                    "snapshot": '- heading "stale fallback" [ref=e1]',
+                    "refs": {"e1": {}},
+                },
+            })
+
+        def session_info(session_key):
+            if session_key.endswith("::local"):
+                return {
+                    "session_name": "fallback-local",
+                    "cdp_url": None,
+                    "features": {"local": True},
+                }
+            return {
+                "session_name": "external-cdp",
+                "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                "features": {"cdp_override": True},
+            }
+
+        bt._set_last_active_session_key(task_id, task_id)
+        with patch("tools.browser_tool._get_session_info", side_effect=session_info), \
+             patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch("tools.browser_tool._requires_real_termux_browser_install", return_value=False), \
+             patch("tools.browser_tool._is_local_mode", return_value=False), \
+             patch("tools.browser_tool._get_browser_engine", return_value="lightpanda"), \
+             patch("tools.browser_tool._cdp_fallback_to_local", return_value=True), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._write_owner_pid"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("subprocess.Popen", side_effect=self._popen_writer(output_for, captured_cmds)):
+            worker = threading.Thread(target=lambda: results.append(
+                bt._run_browser_command(task_id, "snapshot", ["-c"])
+            ))
+            worker.start()
+            assert original_cdp_started.wait(timeout=5)
+            bt._set_last_active_session_key(task_id, task_id)
+            release_original_cdp.set()
+            worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        assert results[0]["success"] is True
+        assert bt._last_active_session_key[task_id] == task_id
+        assert f"{task_id}::local" not in bt._cdp_fallback_local_session_keys
+
+    def test_cdp_fallback_owner_and_provenance_publish_share_one_cas(self):
+        """A failed CAS changes neither owner nor fallback provenance."""
+        import tools.browser_tool as bt
+
+        task_id = "atomic-fallback-owner"
+        local_session_key = f"{task_id}::local"
+        generation = bt._set_last_active_session_key(task_id, task_id)
+        bt._cdp_fallback_local_session_keys.add("unrelated::local")
+
+        published = bt._compare_publish_cdp_fallback_owner(
+            task_id,
+            generation - 1,
+            local_session_key,
+        )
+
+        assert published is False
+        assert bt._last_active_session_key[task_id] == task_id
+        assert bt._last_active_session_generation[task_id] == generation
+        assert bt._cdp_fallback_local_session_keys == {"unrelated::local"}
+
+    def test_cleanup_compare_clear_preserves_new_same_binding_generation(self):
+        """Cleanup cannot clear a new navigation that reused the same session key."""
+        import tools.browser_tool as bt
+
+        task_id = "cleanup-same-key-race"
+        first_generation = bt._set_last_active_session_key(task_id, task_id)
+
+        def cleanup_then_new_navigation(session_key):
+            assert session_key == task_id
+            bt._set_last_active_session_key(task_id, task_id)
+
+        with patch(
+            "tools.browser_tool._cleanup_single_browser_session",
+            side_effect=cleanup_then_new_navigation,
+        ):
+            bt.cleanup_browser(task_id)
+
+        assert bt._last_active_session_key[task_id] == task_id
+        assert bt._last_active_session_generation[task_id] == first_generation + 1
+
+    def test_neutralize_compare_clear_preserves_new_same_binding_generation(self):
+        """A stale neutralizer cannot clear a same-key navigation completed meanwhile."""
+        import tools.browser_tool as bt
+
+        task_id = "neutralize-same-key-race"
+        first_generation = bt._set_last_active_session_key(task_id, task_id)
+
+        def blank_then_new_navigation(*args, **kwargs):
+            bt._set_last_active_session_key(task_id, task_id)
+            return {"success": True, "data": {"url": "about:blank"}}
+
+        with patch(
+            "tools.browser_tool._run_browser_command",
+            side_effect=blank_then_new_navigation,
+        ):
+            bt._neutralize_blocked_redirect(task_id, task_id, task_id)
+
+        assert bt._last_active_session_key[task_id] == task_id
+        assert bt._last_active_session_generation[task_id] == first_generation + 1
+
+    def test_cleanup_compare_clear_preserves_new_different_binding(self):
+        """All owner writes share the cleanup lock, making compare-clear atomic."""
+        import threading
+        import tools.browser_tool as bt
+
+        task_id = "owner-race"
+        stale_session_key = f"{task_id}::local"
+        owner_read = threading.Event()
+        new_owner_written = threading.Event()
+        original_bindings = bt._last_active_session_key
+        cleanup_thread_id = None
+
+        class InterleavingBindings(dict):
+            def get(self, key, default=None):
+                value = super().get(key, default)
+                if key == task_id and threading.get_ident() == cleanup_thread_id:
+                    owner_read.set()
+                    new_owner_written.wait(timeout=0.5)
+                return value
+
+            def __setitem__(self, key, value):
+                super().__setitem__(key, value)
+                if key == task_id and value == task_id:
+                    new_owner_written.set()
+
+        bindings = InterleavingBindings({task_id: stale_session_key})
+        bt._last_active_session_key = bindings
+
+        def fake_run(session_key, command, args=None, timeout=None, **kwargs):
+            if session_key == stale_session_key and command == "open":
+                assert new_owner_written.wait(timeout=5)
+                return {"success": True, "data": {"url": "about:blank"}}
+            if session_key == task_id and command == "open":
+                return {
+                    "success": True,
+                    "data": {"title": "new", "url": "https://new.example/"},
+                }
+            if session_key == task_id and command == "snapshot":
+                return {
+                    "success": True,
+                    "data": {
+                        "snapshot": '- heading "new" [ref=e1]',
+                        "refs": {"e1": {}},
+                    },
+                }
+            raise AssertionError((session_key, command, args, timeout, kwargs))
+
+        try:
+            with patch("tools.browser_tool._run_browser_command", side_effect=fake_run), \
+                 patch("tools.browser_tool._navigation_session_key", return_value=task_id), \
+                 patch("tools.browser_tool._is_local_backend", return_value=True), \
+                 patch("tools.browser_tool._get_session_info", return_value={
+                     "session_name": "primary",
+                     "_first_nav": False,
+                     "features": {"local": True},
+                 }):
+                def run_cleanup():
+                    nonlocal cleanup_thread_id
+                    cleanup_thread_id = threading.get_ident()
+                    bt._neutralize_blocked_redirect(
+                        task_id,
+                        task_id,
+                        stale_session_key,
+                    )
+
+                cleanup = threading.Thread(target=run_cleanup)
+                cleanup.start()
+                assert owner_read.wait(timeout=5)
+
+                navigation = {}
+
+                def run_navigation():
+                    navigation.update(json.loads(
+                        bt.browser_navigate("https://new.example/", task_id=task_id)
+                    ))
+
+                writer = threading.Thread(target=run_navigation)
+                writer.start()
+                cleanup.join(timeout=5)
+                writer.join(timeout=5)
+
+            assert not cleanup.is_alive()
+            assert not writer.is_alive()
+            assert navigation["success"] is True
+            assert bindings.get(task_id) == task_id
+        finally:
+            bt._last_active_session_key = original_bindings
+
+    @pytest.mark.parametrize(
+        ("unsafe_url", "expected_error"),
+        [
+            (
+                "http://169.254.169.254/latest/meta-data",
+                "cloud metadata endpoint",
+            ),
+            (
+                "http://127.0.0.1/admin",
+                "private or internal address",
+            ),
+        ],
+        ids=["metadata", "private"],
+    )
+    def test_snapshot_rechecks_actual_fallback_session_and_recreates_after_quarantine(
+        self, tmp_path, unsafe_url, expected_error
+    ):
+        """Never return an unsafe local snapshot based on a recovered public CDP probe."""
+        import tools.browser_tool as bt
+
+        task_id = "snapshot-guard"
+        local_session_key = f"{task_id}::local"
+        secret = "METADATA_SECRET_CONTENT"
+        bt._active_sessions.update({
+            task_id: {
+                "session_key": task_id,
+                "owner_task_id": task_id,
+                "session_name": "cdp-sess",
+                "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+                "features": {"cdp_override": True},
+            },
+            local_session_key: {
+                "session_key": local_session_key,
+                "owner_task_id": task_id,
+                "session_name": "unsafe-old-local",
+                "features": {"local": True},
+            },
+        })
+        captured_cmds = []
+
+        def output_for(cmd):
+            command_index = cmd.index("--json") + 1
+            command = cmd[command_index]
+            command_args = cmd[command_index + 1:]
+            if "--cdp" in cmd:
+                if command == "snapshot":
+                    return json.dumps({
+                        "success": False,
+                        "error": "CDP socket closed",
+                    })
+                if command == "eval":
+                    # The old implementation probes the recovered CDP session
+                    # and incorrectly treats this public URL as proof that the
+                    # local snapshot is safe.
+                    return json.dumps({
+                        "success": True,
+                        "data": {"result": "https://public.example/"},
+                    })
+            session_name = cmd[cmd.index("--session") + 1]
+            if session_name == "unsafe-old-local":
+                if command == "snapshot":
+                    return json.dumps({
+                        "success": True,
+                        "data": {
+                            "snapshot": f'- heading "{secret}" [ref=e1]',
+                            "refs": {"e1": {}},
+                        },
+                    })
+                if command == "eval":
+                    return json.dumps({
+                        "success": True,
+                        "data": {"result": unsafe_url},
+                    })
+                if command == "open" and command_args == ["about:blank"]:
+                    return json.dumps({
+                        "success": False,
+                        "error": "unsafe sidecar cannot blank",
+                    })
+                if command == "close":
+                    return json.dumps({"success": True, "data": {}})
+            if session_name == "fresh-local":
+                if command == "snapshot":
+                    return json.dumps({
+                        "success": True,
+                        "data": {
+                            "snapshot": '- heading "Public recovery" [ref=e2]',
+                            "refs": {"e2": {}},
+                        },
+                    })
+                if command == "eval":
+                    return json.dumps({
+                        "success": True,
+                        "data": {"result": "https://public.example/"},
+                    })
+            raise AssertionError(cmd)
+
+        with patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch("tools.browser_tool._requires_real_termux_browser_install", return_value=False), \
+             patch("tools.browser_tool._is_local_mode", return_value=False), \
+             patch("tools.browser_tool._is_local_backend", return_value=False), \
+             patch("tools.browser_tool._get_browser_engine", return_value="lightpanda"), \
+             patch("tools.browser_tool._cdp_fallback_to_local", return_value=True), \
+             patch("tools.browser_tool._allow_private_urls", return_value=False), \
+             patch(
+                 "tools.browser_tool._is_safe_url",
+                 side_effect=lambda url: not (
+                     url.startswith("http://127.0.0.1")
+                     or url.startswith("http://169.254.169.254")
+                 ),
+             ), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._write_owner_pid"), \
+             patch("tools.browser_tool._start_browser_cleanup_thread"), \
+             patch("tools.browser_tool._stop_cdp_supervisor"), \
+             patch("tools.browser_tool._create_local_session", return_value={
+                 "session_name": "fresh-local",
+                 "features": {"local": True},
+             }) as create_local, \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("subprocess.Popen", side_effect=self._popen_writer(output_for, captured_cmds)), \
+             patch(
+                 "tools.browser_tool._run_chrome_fallback_command",
+                 side_effect=AssertionError("safety cleanup must not fallback"),
+             ):
+            blocked = json.loads(bt.browser_snapshot(task_id=task_id))
+            recovered = json.loads(bt.browser_snapshot(task_id=task_id))
+
+        assert blocked["success"] is False
+        assert expected_error in blocked["error"]
+        assert secret not in json.dumps(blocked)
+        assert recovered["success"] is True
+        assert "Public recovery" in recovered["snapshot"]
+        assert secret not in json.dumps(recovered)
+        assert create_local.call_count == 1
+        assert bt._active_sessions[local_session_key]["session_name"] == "fresh-local"
+
+        local_commands = [
+            cmd[cmd.index("--json") + 1]
+            for cmd in captured_cmds
+            if "--session" in cmd
+        ]
+        assert local_commands == [
+            "snapshot",
+            "eval",
+            "open",
+            "close",
+            "snapshot",
+            "eval",
+        ]
+
+    def test_snapshot_url_probe_failure_is_fail_closed(self):
+        """A failed serving-session URL probe withholds snapshot content."""
+        import tools.browser_tool as bt
+
+        task_id = "snapshot-probe-failure"
+        bt._active_sessions[task_id] = {
+            "session_key": task_id,
+            "owner_task_id": task_id,
+            "session_name": "cdp-sess",
+            "cdp_url": "ws://127.0.0.1:9223/devtools/browser",
+            "features": {"cdp_override": True},
+        }
+        with patch("tools.browser_tool._is_local_backend", return_value=False), \
+             patch("tools.browser_tool._allow_private_urls", return_value=False), \
+             patch(
+                 "tools.browser_tool._run_browser_command",
+                 side_effect=[
+                     {
+                         "success": True,
+                         "data": {
+                             "snapshot": '- heading "METADATA_SECRET_CONTENT" [ref=e1]',
+                             "refs": {"e1": {}},
+                         },
+                     },
+                     {"success": False, "error": None},
+                     {"success": True, "data": {"url": "about:blank"}},
+                 ],
+             ) as run_cmd:
+            response = json.loads(bt.browser_snapshot(task_id=task_id))
+
+        assert response["success"] is False
+        assert "unable to verify" in response["error"]
+        assert "METADATA_SECRET_CONTENT" not in json.dumps(response)
+        assert run_cmd.call_args_list[1].kwargs["_allow_fallback"] is False
+        assert run_cmd.call_args_list[2].kwargs["_allow_fallback"] is False
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        ["snapshot", "eval", "get_images", "vision"],
+    )
+    def test_quarantined_sidecar_is_not_reused_by_followup_tools(
+        self, tmp_path, tool_name
+    ):
+        """Every non-navigation tool resolves away from a discarded unsafe sidecar."""
+        import tools.browser_tool as bt
+
+        task_id = "quarantine-followup"
+        local_session_key = f"{task_id}::local"
+        bt._active_sessions.update({
+            task_id: {
+                "session_key": task_id,
+                "owner_task_id": task_id,
+                "session_name": "primary",
+            },
+            local_session_key: {
+                "session_key": local_session_key,
+                "owner_task_id": task_id,
+                "session_name": "unsafe-local",
+            },
+        })
+        bt._last_active_session_key[task_id] = local_session_key
+        bt._cdp_fallback_local_session_keys.add(local_session_key)
+
+        with patch(
+            "tools.browser_tool._run_browser_command",
+            return_value={"success": False, "error": "cannot blank"},
+        ), patch("tools.browser_tool._cleanup_single_browser_session"):
+            bt._neutralize_blocked_redirect(
+                task_id,
+                task_id,
+                local_session_key,
+            )
+
+        served_sessions = []
+
+        def followup_run(session_key, command, args=None, timeout=None, **kwargs):
+            served_sessions.append(session_key)
+            if command == "snapshot":
+                return {
+                    "success": True,
+                    "data": {
+                        "snapshot": '- heading "safe primary" [ref=e1]',
+                        "refs": {"e1": {}},
+                    },
+                }
+            if command == "eval":
+                if tool_name == "get_images":
+                    return {"success": True, "data": {"result": "[]"}}
+                return {"success": True, "data": {"result": "1"}}
+            if command == "screenshot":
+                return {"success": False, "error": "stop after routing check"}
+            raise AssertionError((session_key, command, args, timeout, kwargs))
+
+        with patch("tools.browser_tool._run_browser_command", side_effect=followup_run), \
+             patch("tools.browser_tool._is_local_backend", return_value=True), \
+             patch("tools.browser_tool._is_camofox_mode", return_value=False), \
+             patch("tools.browser_tool._get_browser_engine", return_value="auto"), \
+             patch("tools.browser_tool._get_cloud_provider", return_value=None), \
+             patch("hermes_constants.get_hermes_dir", return_value=tmp_path):
+            if tool_name == "snapshot":
+                bt.browser_snapshot(task_id=task_id)
+            elif tool_name == "eval":
+                bt.browser_console(expression="1", task_id=task_id)
+            elif tool_name == "get_images":
+                bt.browser_get_images(task_id=task_id)
+            else:
+                bt.browser_vision("routing only", task_id=task_id)
+
+        assert local_session_key not in bt._active_sessions
+        assert local_session_key not in bt._cdp_fallback_local_session_keys
+        assert task_id not in bt._last_active_session_key
+        assert served_sessions
+        assert set(served_sessions) == {task_id}
+
+    def test_later_snapshot_from_cdp_fallback_sidecar_remains_ssrf_guarded(
+        self, monkeypatch
+    ):
+        """A persisted CDP fallback sidecar never inherits hybrid-private trust."""
+        import tools.browser_tool as bt
+
+        task_id = "persistent-fallback-guard"
+        local_session_key = f"{task_id}::local"
+        bt._active_sessions[local_session_key] = {
+            "session_key": local_session_key,
+            "owner_task_id": task_id,
+            "session_name": "fallback-local",
+            "features": {"local": True},
+        }
+        bt._last_active_session_key[task_id] = local_session_key
+        monkeypatch.setattr(
+            bt,
+            "_cdp_fallback_local_session_keys",
+            {local_session_key},
+            raising=False,
+        )
+        secret = "METADATA_SECRET_CONTENT"
+
+        def run_command(session_key, command, args=None, timeout=None, **kwargs):
+            assert session_key == local_session_key
+            if command == "snapshot":
+                return {
+                    "success": True,
+                    "data": {
+                        "snapshot": f'- heading "{secret}" [ref=e1]',
+                        "refs": {"e1": {}},
+                    },
+                }
+            if command == "eval":
+                return {
+                    "success": True,
+                    "data": {
+                        "result": "http://169.254.169.254/latest/meta-data"
+                    },
+                }
+            if command == "open":
+                return {"success": True, "data": {"url": "about:blank"}}
+            raise AssertionError((session_key, command, args, kwargs))
+
+        with patch("tools.browser_tool._run_browser_command", side_effect=run_command), \
+             patch("tools.browser_tool._is_local_backend", return_value=False), \
+             patch("tools.browser_tool._allow_private_urls", return_value=False):
+            response = json.loads(bt.browser_snapshot(task_id=task_id))
+
+        assert response["success"] is False
+        assert "metadata endpoint" in response["error"]
+        assert secret not in json.dumps(response)
+
+    def test_failed_explicit_hybrid_navigation_retains_fallback_provenance(self):
+        """Repurpose is committed only after the intentional hybrid open succeeds."""
+        import tools.browser_tool as bt
+
+        task_id = "hybrid-repurpose-failure"
+        local_session_key = f"{task_id}::local"
+        private_url = "http://127.0.0.1/admin"
+        bt._cdp_fallback_local_session_keys.add(local_session_key)
+        bt._set_last_active_session_key(task_id, task_id)
+
+        with patch(
+            "tools.browser_tool._navigation_session_key",
+            return_value=local_session_key,
+        ), patch("tools.browser_tool._is_local_backend", return_value=False), patch(
+            "tools.browser_tool._allow_private_urls", return_value=False
+        ), patch(
+            "tools.browser_tool.check_website_access", return_value=None
+        ), patch(
+            "tools.browser_tool._is_camofox_mode", return_value=False
+        ), patch(
+            "tools.browser_tool._get_cloud_provider", return_value=None
+        ), patch(
+            "tools.browser_tool._get_session_info",
+            return_value={
+                "session_key": local_session_key,
+                "owner_task_id": task_id,
+                "session_name": "hybrid-local",
+                "features": {"local": True},
+                "_first_nav": False,
+            },
+        ), patch(
+            "tools.browser_tool._run_browser_command",
+            return_value={"success": False, "error": "local open failed"},
+        ):
+            response = json.loads(bt.browser_navigate(private_url, task_id=task_id))
+
+        assert response["success"] is False
+        assert local_session_key in bt._cdp_fallback_local_session_keys
+        assert bt._last_active_session_key[task_id] == task_id
+
+    def test_explicit_hybrid_private_navigation_drops_fallback_provenance(self):
+        """Intentional hybrid-private routing may repurpose a fallback sidecar."""
+        import tools.browser_tool as bt
+
+        task_id = "hybrid-repurpose"
+        local_session_key = f"{task_id}::local"
+        private_url = "http://127.0.0.1/admin"
+        bt._cdp_fallback_local_session_keys.add(local_session_key)
+        nav_result = {
+            "success": True,
+            "data": {"title": "local admin", "url": private_url},
+        }
+        snapshot_result = {
+            "success": True,
+            "data": {"snapshot": '- heading "local admin" [ref=e1]', "refs": {"e1": {}}},
+        }
+
+        with patch(
+            "tools.browser_tool._navigation_session_key",
+            return_value=local_session_key,
+        ), patch("tools.browser_tool._is_local_backend", return_value=False), patch(
+            "tools.browser_tool._allow_private_urls", return_value=False
+        ), patch(
+            "tools.browser_tool.check_website_access", return_value=None
+        ), patch(
+            "tools.browser_tool._is_camofox_mode", return_value=False
+        ), patch(
+            "tools.browser_tool._get_cloud_provider", return_value=None
+        ), patch(
+            "tools.browser_tool._get_session_info",
+            return_value={
+                "session_key": local_session_key,
+                "owner_task_id": task_id,
+                "session_name": "hybrid-local",
+                "features": {"local": True},
+                "_first_nav": False,
+            },
+        ), patch(
+            "tools.browser_tool._run_browser_command",
+            side_effect=[nav_result, snapshot_result],
+        ):
+            response = json.loads(bt.browser_navigate(private_url, task_id=task_id))
+
+        assert response["success"] is True
+        assert local_session_key not in bt._cdp_fallback_local_session_keys
+
+    def test_fallback_sidecar_retains_shared_eval_guard(self):
+        """Eval/images/vision guard fallback sidecars but exempt hybrid sidecars."""
+        import tools.browser_tool as bt
+
+        fallback_key = "guard-provenance::local"
+        hybrid_key = "hybrid-only::local"
+        bt._cdp_fallback_local_session_keys.add(fallback_key)
+
+        with patch("tools.browser_tool._is_local_backend", return_value=True), patch(
+            "tools.browser_tool._allow_private_urls", return_value=False
+        ):
+            assert bt._eval_ssrf_guard_active(fallback_key) is True
+            assert bt._eval_ssrf_guard_active(hybrid_key) is False

--- a/tests/tools/test_browser_snapshot_ssrf.py
+++ b/tests/tools/test_browser_snapshot_ssrf.py
@@ -63,14 +63,16 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
         monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
 
-        call_count = {"n": 0}
+        commands = []
 
         def mock_run_browser_command(task_id, command, args=None, **kwargs):
-            call_count["n"] += 1
+            commands.append((command, kwargs))
             if command == "snapshot":
                 return _make_snapshot_result()
-            elif command == "eval":
+            if command == "eval":
                 return _make_eval_result(self.PRIVATE_URL)
+            if command == "open":
+                return {"success": True, "data": {"url": "about:blank"}}
             return {"success": False, "error": "unknown command"}
 
         monkeypatch.setattr(
@@ -81,8 +83,9 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         assert result["success"] is False
         assert "private or internal address" in result["error"]
         assert self.PRIVATE_URL in result["error"]
-        # Must have called eval to check URL
-        assert call_count["n"] == 2  # snapshot + eval
+        assert [command for command, _ in commands] == ["snapshot", "eval", "open"]
+        assert commands[1][1]["_allow_fallback"] is False
+        assert commands[2][1]["_allow_fallback"] is False
 
     def test_allows_public_url_after_eval_navigation(self, monkeypatch):
         """Snapshot must succeed when current page URL is public."""
@@ -161,16 +164,19 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         assert result["success"] is True
         assert "snapshot" in result
 
-    def test_handles_eval_failure_gracefully(self, monkeypatch):
-        """If URL eval fails, snapshot should still succeed (fail-open)."""
+    def test_handles_eval_failure_fail_closed(self, monkeypatch):
+        """If URL eval fails, snapshot content is withheld."""
         monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
         monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        secret = "METADATA_SECRET_CONTENT"
 
         def mock_run_browser_command(task_id, command, args=None, **kwargs):
             if command == "snapshot":
-                return _make_snapshot_result()
-            elif command == "eval":
+                return _make_snapshot_result(snapshot=secret)
+            if command == "eval":
                 return {"success": False, "error": "eval failed"}
+            if command == "open":
+                return {"success": True, "data": {"url": "about:blank"}}
             return {"success": False, "error": "unknown"}
 
         monkeypatch.setattr(
@@ -178,19 +184,23 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         )
 
         result = json.loads(browser_browser_snapshot(task_id="test"))
-        # Should succeed — eval failure means we can't determine URL, fail-open
-        assert result["success"] is True
+        assert result["success"] is False
+        assert "unable to verify" in result["error"]
+        assert secret not in json.dumps(result)
 
-    def test_handles_empty_url_result(self, monkeypatch):
-        """If URL eval returns empty string, snapshot should succeed."""
+    def test_handles_empty_url_result_fail_closed(self, monkeypatch):
+        """An empty URL probe cannot release snapshot content."""
         monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
         monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        secret = "METADATA_SECRET_CONTENT"
 
         def mock_run_browser_command(task_id, command, args=None, **kwargs):
             if command == "snapshot":
-                return _make_snapshot_result()
-            elif command == "eval":
+                return _make_snapshot_result(snapshot=secret)
+            if command == "eval":
                 return _make_eval_result("")
+            if command == "open":
+                return {"success": True, "data": {"url": "about:blank"}}
             return {"success": False, "error": "unknown"}
 
         monkeypatch.setattr(
@@ -198,18 +208,23 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         )
 
         result = json.loads(browser_browser_snapshot(task_id="test"))
-        assert result["success"] is True
+        assert result["success"] is False
+        assert "unable to verify" in result["error"]
+        assert secret not in json.dumps(result)
 
-    def test_handles_eval_exception(self, monkeypatch):
-        """If URL eval raises an exception, snapshot should succeed."""
+    def test_handles_eval_exception_fail_closed(self, monkeypatch):
+        """An eval exception withholds snapshot content."""
         monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
         monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        secret = "METADATA_SECRET_CONTENT"
 
         def mock_run_browser_command(task_id, command, args=None, **kwargs):
             if command == "snapshot":
-                return _make_snapshot_result()
-            elif command == "eval":
+                return _make_snapshot_result(snapshot=secret)
+            if command == "eval":
                 raise RuntimeError("CDP connection lost")
+            if command == "open":
+                return {"success": True, "data": {"url": "about:blank"}}
             return {"success": False, "error": "unknown"}
 
         monkeypatch.setattr(
@@ -217,7 +232,9 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         )
 
         result = json.loads(browser_browser_snapshot(task_id="test"))
-        assert result["success"] is True
+        assert result["success"] is False
+        assert "unable to verify" in result["error"]
+        assert secret not in json.dumps(result)
 
     def test_blocks_loopback_url(self, monkeypatch):
         """Loopback URLs (localhost) must be blocked."""
@@ -436,3 +453,214 @@ class TestBrowserVisionPrivateNetworkGuard:
         result_raw = browser_browser_vision(question="what", task_id="test")
         result = json.loads(result_raw)
         assert "private or internal address" not in result.get("error", "")
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ["snapshot", "eval-cli", "images", "vision", "console"],
+)
+def test_actual_served_fallback_session_is_guarded_on_every_content_path(
+    monkeypatch, tmp_path, tool_name
+):
+    """Content is discarded when the exact fallback serving session is unsafe."""
+    task_id = f"served-guard-{tool_name}"
+    local_session_key = f"{task_id}::local"
+    secret = "METADATA_SECRET_CONTENT"
+    screenshot_path = tmp_path / f"{tool_name}.png"
+    events = []
+    href_probes = 0
+
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
+    monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+    monkeypatch.setattr(browser_tool, "_get_browser_engine", lambda: "auto")
+    monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
+    monkeypatch.setattr(
+        browser_tool,
+        "_get_session_info",
+        lambda session_key: {
+            "session_key": session_key,
+            "owner_task_id": task_id,
+            "session_name": f"s_{session_key}",
+            "features": {},
+            "_first_nav": False,
+        },
+    )
+
+    fallback_meta = {
+        "browser_session_key": local_session_key,
+        "browser_backend_fallback": {"from": "cdp", "to": "local"},
+    }
+
+    def run_command(session_key, command, args=None, timeout=None, **kwargs):
+        nonlocal href_probes
+        args = args or []
+        events.append((session_key, command, args, kwargs))
+        if command == "eval" and args == ["window.location.href"]:
+            href_probes += 1
+            url = (
+                "https://example.com/"
+                if session_key == task_id
+                else "http://169.254.169.254/latest/meta-data"
+            )
+            return {"success": True, "data": {"result": url}}
+        if command == "snapshot":
+            return {
+                "success": True,
+                "data": {"snapshot": secret, "refs": {"e1": {}}},
+                **fallback_meta,
+            }
+        if command == "eval":
+            payload = (
+                json.dumps([{"src": secret, "alt": secret}])
+                if tool_name == "images"
+                else secret
+            )
+            return {"success": True, "data": {"result": payload}, **fallback_meta}
+        if command == "console":
+            return {
+                "success": True,
+                "data": {"messages": [{"type": "log", "text": secret}]},
+                **fallback_meta,
+            }
+        if command == "errors":
+            return {"success": False, "error": "no error buffer"}
+        if command == "screenshot":
+            screenshot_path.write_bytes(secret.encode())
+            return {
+                "success": True,
+                "data": {"path": str(screenshot_path)},
+                **fallback_meta,
+            }
+        if command == "open" and args == ["about:blank"]:
+            return {"success": True, "data": {"url": "about:blank"}}
+        raise AssertionError((session_key, command, args, timeout, kwargs))
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", run_command)
+
+    if tool_name == "snapshot":
+        raw_response = browser_tool.browser_snapshot(task_id=task_id)
+    elif tool_name == "eval-cli":
+        raw_response = browser_tool.browser_console(
+            expression="document.body.innerText",
+            task_id=task_id,
+        )
+    elif tool_name == "images":
+        raw_response = browser_tool.browser_get_images(task_id=task_id)
+    elif tool_name == "vision":
+        raw_response = browser_tool.browser_vision("what is visible?", task_id=task_id)
+    else:
+        raw_response = browser_tool.browser_console(task_id=task_id)
+
+    response = raw_response if isinstance(raw_response, dict) else json.loads(raw_response)
+    assert response["success"] is False
+    assert "metadata endpoint" in response["error"]
+    assert secret not in json.dumps(response)
+    assert href_probes >= 1
+    if tool_name == "vision":
+        assert not screenshot_path.exists()
+
+
+def test_navigate_auto_snapshot_guards_the_actual_serving_session(monkeypatch):
+    """A safe open proof cannot authorize snapshot bytes from a later unsafe page."""
+    task_id = "served-guard-navigate"
+    local_session_key = f"{task_id}::local"
+    secret = "METADATA_SECRET_CONTENT"
+    probe_count = 0
+
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
+    monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda _url: None)
+    monkeypatch.setattr(
+        browser_tool,
+        "_get_session_info",
+        lambda session_key: {
+            "session_key": session_key,
+            "owner_task_id": task_id,
+            "session_name": f"s_{session_key}",
+            "features": {"cdp_override": True},
+            "_first_nav": False,
+        },
+    )
+
+    def run_command(session_key, command, args=None, **kwargs):
+        nonlocal probe_count
+        args = args or []
+        if command == "open" and args == ["https://example.com"]:
+            return {
+                "success": True,
+                "data": {"title": "safe", "url": "https://example.com/"},
+                "browser_session_key": local_session_key,
+                "browser_backend_fallback": {"from": "cdp", "to": "local"},
+            }
+        if command == "eval":
+            assert session_key == local_session_key
+            probe_count += 1
+            url = (
+                "https://example.com/"
+                if probe_count == 1
+                else "http://169.254.169.254/latest/meta-data"
+            )
+            return {"success": True, "data": {"result": url}}
+        if command == "snapshot":
+            assert session_key == local_session_key
+            return {
+                "success": True,
+                "data": {"snapshot": secret, "refs": {"e1": {}}},
+            }
+        if command == "open" and args == ["about:blank"]:
+            return {"success": True, "data": {"url": "about:blank"}}
+        raise AssertionError((session_key, command, args, kwargs))
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", run_command)
+    response = json.loads(
+        browser_tool.browser_navigate("https://example.com", task_id=task_id)
+    )
+
+    assert response["success"] is False
+    assert "metadata endpoint" in response["error"]
+    assert secret not in json.dumps(response)
+    assert probe_count == 2
+
+
+def test_supervisor_eval_result_uses_actual_served_url_guard(monkeypatch):
+    """The CDP-supervisor eval branch cannot bypass the common post-result guard."""
+    task_id = "served-guard-supervisor"
+    secret = "METADATA_SECRET_CONTENT"
+
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
+    monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+
+    from tools import browser_supervisor
+
+    class FakeSupervisor:
+        def evaluate_runtime(self, _expression):
+            return {"ok": True, "result": secret}
+
+    monkeypatch.setattr(
+        browser_supervisor,
+        "SUPERVISOR_REGISTRY",
+        {task_id: FakeSupervisor()},
+    )
+
+    def run_command(session_key, command, args=None, **kwargs):
+        assert session_key == task_id
+        if command == "eval":
+            return {
+                "success": True,
+                "data": {"result": "http://169.254.169.254/latest/meta-data"},
+            }
+        if command == "open":
+            return {"success": True, "data": {"url": "about:blank"}}
+        raise AssertionError((session_key, command, args, kwargs))
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", run_command)
+    response = json.loads(
+        browser_tool.browser_console(expression="document.body.innerText", task_id=task_id)
+    )
+
+    assert response["success"] is False
+    assert "metadata endpoint" in response["error"]
+    assert secret not in json.dumps(response)

--- a/tests/tools/test_browser_ssrf_local.py
+++ b/tests/tools/test_browser_ssrf_local.py
@@ -17,8 +17,29 @@ from tools import browser_tool
 
 
 def _make_browser_result(url="https://example.com"):
-    """Return a mock successful browser command result."""
-    return {"success": True, "data": {"title": "OK", "url": url}}
+    """Return a mock successful browser command result for the given URL."""
+    return {"success": True, "data": {"title": "OK", "url": url, "result": url}}
+
+
+def _browser_command_mock(url="https://example.com"):
+    """Mock `_run_browser_command` that preserves post-nav URL proof probes."""
+
+    def _run(task_id, command, args=None, **kwargs):
+        if command == "eval" and args == ["window.location.href"]:
+            return {"success": True, "data": {"result": url}}
+        if command == "snapshot":
+            return {
+                "success": True,
+                "data": {
+                    "snapshot": f'- heading \"OK\" [ref=e1] ({url})',
+                    "refs": {"e1": {}},
+                },
+            }
+        if command == "open" and args == ["about:blank"]:
+            return {"success": True, "data": {"url": "about:blank"}}
+        return _make_browser_result(url)
+
+    return _run
 
 
 # ---------------------------------------------------------------------------
@@ -48,7 +69,7 @@ class TestPreNavigationSsrf:
         monkeypatch.setattr(
             browser_tool,
             "_run_browser_command",
-            lambda *a, **kw: _make_browser_result(),
+            _browser_command_mock(),
         )
 
     # -- Cloud mode: SSRF active -----------------------------------------------
@@ -262,13 +283,16 @@ class TestPostRedirectSsrf:
         monkeypatch.setattr(
             browser_tool,
             "_run_browser_command",
-            lambda *a, **kw: _make_browser_result(url=self.PRIVATE_FINAL_URL),
+            _browser_command_mock(url=self.PRIVATE_FINAL_URL),
         )
 
         result = json.loads(browser_tool.browser_navigate(self.PUBLIC_URL))
 
         assert result["success"] is False
-        assert "redirect landed on a private/internal address" in result["error"]
+        assert (
+            "redirect landed on a private/internal address" in result["error"]
+            or "private or internal address" in result["error"]
+        )
 
     def test_cloud_allows_redirect_to_private_when_setting_true(self, monkeypatch, _common_patches):
         """Redirects to private addresses pass in cloud mode with allow_private_urls."""
@@ -280,7 +304,7 @@ class TestPostRedirectSsrf:
         monkeypatch.setattr(
             browser_tool,
             "_run_browser_command",
-            lambda *a, **kw: _make_browser_result(url=self.PRIVATE_FINAL_URL),
+            _browser_command_mock(url=self.PRIVATE_FINAL_URL),
         )
 
         result = json.loads(browser_tool.browser_navigate(self.PUBLIC_URL))
@@ -300,7 +324,7 @@ class TestPostRedirectSsrf:
         monkeypatch.setattr(
             browser_tool,
             "_run_browser_command",
-            lambda *a, **kw: _make_browser_result(url=self.PRIVATE_FINAL_URL),
+            _browser_command_mock(url=self.PRIVATE_FINAL_URL),
         )
 
         result = json.loads(browser_tool.browser_navigate(self.PUBLIC_URL))
@@ -317,7 +341,7 @@ class TestPostRedirectSsrf:
         monkeypatch.setattr(
             browser_tool,
             "_run_browser_command",
-            lambda *a, **kw: _make_browser_result(url=final),
+            _browser_command_mock(url=final),
         )
 
         result = json.loads(browser_tool.browser_navigate(self.PUBLIC_URL))
@@ -343,7 +367,7 @@ class TestPostRedirectSsrf:
         monkeypatch.setattr(
             browser_tool,
             "_run_browser_command",
-            lambda *a, **kw: _make_browser_result(url=imds_final),
+            _browser_command_mock(url=imds_final),
         )
 
         result = json.loads(browser_tool.browser_navigate(self.PUBLIC_URL))

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -609,6 +609,11 @@ _agent_browser_resolved = False
 _cached_browser_engine: Optional[str] = None
 _browser_engine_resolved = False
 
+# External CDP fallback support.  When enabled, a user-supplied CDP endpoint
+# (for example Obscura) can fail over to the configured local engine chain.
+_cached_cdp_fallback_to_local: Optional[bool] = None
+_cdp_fallback_to_local_resolved = False
+
 
 def _is_legacy_provider_registry_overridden() -> bool:
     """Return True when a test has patched ``_PROVIDER_REGISTRY`` to a custom value.
@@ -894,6 +899,156 @@ def _using_lightpanda_engine() -> bool:
     return _get_browser_engine() == "lightpanda"
 
 
+def _cdp_fallback_to_local() -> bool:
+    """Return whether external CDP override failures should retry locally.
+
+    This is intentionally opt-in. A configured CDP endpoint usually means the
+    operator wants that specific browser (visible Chrome, Obscura, remote
+    Playwright, etc.); silently hiding a dead endpoint would make stale config
+    harder to notice.  When enabled, Hermes retries eligible failed CDP commands
+    through the normal local engine path, so ``browser.engine=lightpanda`` still
+    gets the existing Lightpanda→Chrome fallback chain.
+    """
+    global _cached_cdp_fallback_to_local, _cdp_fallback_to_local_resolved
+    if _cdp_fallback_to_local_resolved:
+        return bool(_cached_cdp_fallback_to_local)
+
+    _cdp_fallback_to_local_resolved = True
+    _cached_cdp_fallback_to_local = False
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {})
+        if isinstance(browser_cfg, dict):
+            _cached_cdp_fallback_to_local = is_truthy_value(
+                browser_cfg.get("cdp_fallback_to_local"), default=False
+            )
+    except Exception as e:
+        logger.debug("Could not read browser.cdp_fallback_to_local from config: %s", e)
+    return bool(_cached_cdp_fallback_to_local)
+
+
+_CDP_FALLBACK_ELIGIBLE: frozenset[str] = frozenset({
+    "open", "snapshot", "screenshot", "eval", "click", "fill",
+    "scroll", "back", "press", "console", "errors",
+})
+
+
+def _cdp_fallback_reason(
+    session_info: Dict[str, Any],
+    command: str,
+    result: Dict[str, Any],
+) -> Optional[str]:
+    """Return why a CDP command should fall back to local, or ``None``.
+
+    Only user-supplied CDP overrides participate. Cloud providers also expose
+    CDP URLs internally, but their fallback semantics are provider-specific and
+    should not be conflated with an operator-provided Obscura/Chrome endpoint.
+    """
+    if not session_info.get("cdp_url"):
+        return None
+    features = session_info.get("features") or {}
+    if not isinstance(features, dict) or not features.get("cdp_override"):
+        return None
+    if not _cdp_fallback_to_local():
+        return None
+    if command not in _CDP_FALLBACK_ELIGIBLE:
+        return None
+
+    if not result.get("success"):
+        error = str(result.get("error") or "command failed").strip()
+        return f"CDP backend {command!r} failed ({error}); retried with local browser."
+
+    data = result.get("data", {})
+    if command == "snapshot" and isinstance(data, dict):
+        snap = data.get("snapshot", "")
+        if not snap or len(str(snap).strip()) < 20:
+            return "CDP backend returned an empty/too-short snapshot; retried with local browser."
+
+    return None
+
+
+def _append_fallback_warning(result: Dict[str, Any], warning: str) -> Dict[str, Any]:
+    """Append a fallback warning without clobbering an inner fallback warning."""
+    current = result.get("fallback_warning")
+    if current:
+        result["fallback_warning"] = f"{warning}\n{current}"
+    else:
+        result["fallback_warning"] = warning
+    return result
+
+
+def _annotate_cdp_fallback(
+    result: Dict[str, Any],
+    reason: str,
+    local_session_key: str,
+) -> Dict[str, Any]:
+    """Add user-visible CDP→local fallback metadata to a browser result."""
+    warning = f"⚠ CDP fallback: local browser was used. {reason}"
+    annotated = dict(result)
+    _append_fallback_warning(annotated, warning)
+    annotated["browser_session_key"] = local_session_key
+    annotated["browser_backend_fallback"] = {
+        "from": "cdp",
+        "to": "local",
+        "reason": reason,
+    }
+    data = annotated.get("data")
+    if isinstance(data, dict):
+        data = dict(data)
+        existing_data_warning = data.get("fallback_warning")
+        if existing_data_warning:
+            data["fallback_warning"] = f"{warning}\n{existing_data_warning}"
+        else:
+            data["fallback_warning"] = annotated["fallback_warning"]
+        data["browser_session_key"] = local_session_key
+        data["browser_backend_fallback"] = annotated["browser_backend_fallback"]
+        annotated["data"] = data
+    return annotated
+
+
+def _run_cdp_local_fallback_command(
+    task_id: str,
+    command: str,
+    args: List[str],
+    timeout: int,
+    reason: str,
+) -> Dict[str, Any]:
+    """Retry a failed external-CDP command through the configured local engine."""
+    local_session_key = task_id if _is_local_sidecar_key(task_id) else f"{task_id}{_LOCAL_SUFFIX}"
+    logger.info(
+        "CDP fallback: retrying '%s' with local browser (task=%s local=%s): %s",
+        command,
+        task_id,
+        local_session_key,
+        reason,
+    )
+
+    if command != "open":
+        current_url = _last_browser_url_by_session_key.get(task_id)
+        if current_url:
+            warmup = _run_browser_command(
+                local_session_key,
+                "open",
+                [current_url],
+                timeout=_get_open_command_timeout(first_open=True),
+            )
+            if not warmup.get("success"):
+                logger.debug(
+                    "CDP fallback: local warm-up navigation to %s failed before %s: %s",
+                    current_url,
+                    command,
+                    warmup.get("error"),
+                )
+
+    fallback_result = _run_browser_command(local_session_key, command, args, timeout)
+    # Future non-nav calls for this task should follow the browser that actually
+    # served the fallback command. browser_navigate also reads browser_session_key
+    # and preserves it before running its automatic snapshot.
+    _last_active_session_key[task_id] = local_session_key
+    return _annotate_cdp_fallback(fallback_result, reason, local_session_key)
+
+
 def _lightpanda_fallback_reason(engine: str, command: str, result: Dict[str, Any]) -> Optional[str]:
     """Return the user-visible reason a Lightpanda result needs Chrome fallback.
 
@@ -982,8 +1137,14 @@ def _copy_fallback_warning(target: Dict[str, Any], result: Dict[str, Any]) -> Di
     """Copy browser fallback metadata from an internal result into a tool response."""
     if result.get("fallback_warning"):
         target["fallback_warning"] = result["fallback_warning"]
+    if result.get("browser_engine"):
         target["browser_engine"] = result.get("browser_engine")
+    if result.get("browser_engine_fallback"):
         target["browser_engine_fallback"] = result.get("browser_engine_fallback")
+    if result.get("browser_backend_fallback"):
+        target["browser_backend_fallback"] = result.get("browser_backend_fallback")
+    if result.get("browser_session_key"):
+        target["browser_session_key"] = result.get("browser_session_key")
     return target
 
 
@@ -1400,6 +1561,7 @@ _recording_sessions: set = set()  # session_keys with active recordings
 # navigation.  Without this, a task that navigated to localhost on the local
 # sidecar would fall back to the cloud session on its next snapshot call.
 _last_active_session_key: Dict[str, str] = {}  # task_id -> session_key
+_last_browser_url_by_session_key: Dict[str, str] = {}  # session_key -> last successful URL
 _LOCAL_SUFFIX = "::local"
 
 # Flag to track if cleanup has been done
@@ -2557,10 +2719,23 @@ def _run_browser_command(
         logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
         result = {"success": False, "error": str(e)}
 
+    # --- External CDP automatic local fallback ---
+    # CDP overrides (e.g. Obscura) are backend selections, not local engines. If
+    # they fail and the user opted in, retry through the normal local engine
+    # chain. This deliberately runs before Lightpanda fallback so a CDP failure
+    # is not misclassified as a Lightpanda failure when browser.engine=lightpanda.
+    cdp_fallback_reason = _cdp_fallback_reason(session_info, command, result)
+    if cdp_fallback_reason:
+        return _run_cdp_local_fallback_command(task_id, command, args, timeout, cdp_fallback_reason)
+
     # --- Lightpanda automatic Chrome fallback ---
-    # If engine is lightpanda and the result looks broken, retry with Chrome.
+    # If engine is lightpanda and the local result looks broken, retry with Chrome.
     # This runs for ALL exit paths (timeout, empty, non-JSON, nonzero rc, parsed).
-    fallback_reason = _lightpanda_fallback_reason(engine, command, result)
+    # Do not apply it to external CDP sessions — CDP failures are backend failures
+    # and may opt into the CDP→local fallback above.
+    fallback_reason = None
+    if not session_info.get("cdp_url"):
+        fallback_reason = _lightpanda_fallback_reason(engine, command, result)
     if fallback_reason:
         logger.info(
             "Lightpanda fallback: retrying '%s' with Chrome (task=%s): %s",
@@ -2814,10 +2989,23 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         timeout=_get_open_command_timeout(first_open=is_first_nav),
     )
 
+    # Remember which session served this nav so snapshot/click/fill/...
+    # on the same task_id hit it (critical when hybrid routing has both a
+    # cloud session and a local sidecar alive concurrently). Backend fallback
+    # can change the serving session inside _run_browser_command.
+    served_session_key = result.get("browser_session_key") or nav_session_key
+    _last_active_session_key[effective_task_id] = served_session_key
     if result.get("success"):
         data = result.get("data", {})
         title = data.get("title", "")
         final_url = data.get("url", url)
+        if final_url:
+            _last_browser_url_by_session_key[served_session_key] = final_url
+            # If a backend fallback served this navigation, keep the original
+            # session key's last URL too so a later fallback can warm up local
+            # state even before _last_active_session_key is consulted.
+            if served_session_key != nav_session_key:
+                _last_browser_url_by_session_key[nav_session_key] = final_url
 
         # Post-redirect SSRF check — if the browser followed a redirect to a
         # private/internal address, block the result so the model can't read
@@ -2895,7 +3083,7 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         # Auto-take a compact snapshot so the model can act immediately
         # without a separate browser_snapshot call.
         try:
-            snap_result = _run_browser_command(nav_session_key, "snapshot", ["-c"])
+            snap_result = _run_browser_command(served_session_key, "snapshot", ["-c"])
             if snap_result.get("success"):
                 snap_data = snap_result.get("data", {})
                 snapshot_text = snap_data.get("snapshot", "")
@@ -4326,6 +4514,7 @@ def _cleanup_single_browser_session(task_id: str) -> None:
         with _cleanup_lock:
             _active_sessions.pop(task_id, None)
             _session_last_activity.pop(task_id, None)
+            _last_browser_url_by_session_key.pop(task_id, None)
 
         # Cloud mode: close the cloud browser session via provider API.
         # Local sidecars have bb_session_id=None so this no-ops for them.
@@ -4382,6 +4571,7 @@ def cleanup_all_browsers() -> None:
     global _cached_command_timeout, _command_timeout_resolved
     global _cached_chromium_installed
     global _cached_browser_engine, _browser_engine_resolved
+    global _cached_cdp_fallback_to_local, _cdp_fallback_to_local_resolved
     _cached_agent_browser = None
     _agent_browser_resolved = False
     _discover_homebrew_node_dirs.cache_clear()
@@ -4394,6 +4584,8 @@ def cleanup_all_browsers() -> None:
     _chromium_autoinstall_attempted = False
     _cached_browser_engine = None
     _browser_engine_resolved = False
+    _cached_cdp_fallback_to_local = None
+    _cdp_fallback_to_local_resolved = False
 
 # ============================================================================
 # Requirements Check

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -933,6 +933,47 @@ _CDP_FALLBACK_ELIGIBLE: frozenset[str] = frozenset({
     "scroll", "back", "press", "console", "errors",
 })
 
+_CDP_BACKEND_FAILURE_MARKERS: tuple[str, ...] = (
+    "all cdp discovery methods failed",
+    "failed to resolve cdp",
+    "failed to connect to cdp",
+    "websocket connect failed",
+    "websocket",
+    "socket closed",
+    "socket hang up",
+    "connection refused",
+    "connection reset",
+    "connection closed",
+    "econnrefused",
+    "econnreset",
+    "etimedout",
+    "io error",
+    "target closed",
+    "browser has disconnected",
+    "browser closed",
+    "command timed out",
+    "timed out after",
+    "returned no output",
+    "non-json output from agent-browser",
+)
+
+
+def _is_cdp_backend_failure(result: Dict[str, Any]) -> bool:
+    """Return True for transport/backend failures, not page semantics.
+
+    A failed click because ``@e999`` no longer exists, a JS exception from
+    ``eval``, or an app-level navigation error should be reported as-is.  Only
+    failures that indicate the selected CDP backend itself is unreachable,
+    disconnected, or unable to speak the expected protocol are safe to retry in
+    a different local browser.
+    """
+    if result.get("success"):
+        return False
+    error = str(result.get("error") or "").strip().lower()
+    if not error:
+        return False
+    return any(marker in error for marker in _CDP_BACKEND_FAILURE_MARKERS)
+
 
 def _cdp_fallback_reason(
     session_info: Dict[str, Any],
@@ -956,6 +997,8 @@ def _cdp_fallback_reason(
         return None
 
     if not result.get("success"):
+        if not _is_cdp_backend_failure(result):
+            return None
         error = str(result.get("error") or "command failed").strip()
         return f"CDP backend {command!r} failed ({error}); retried with local browser."
 
@@ -1007,6 +1050,17 @@ def _annotate_cdp_fallback(
     return annotated
 
 
+def _cdp_fallback_warmup_url_safe(url: str) -> bool:
+    """Return whether a cached URL may be reopened during CDP→local fallback."""
+    if not url:
+        return False
+    if _is_always_blocked_url(url):
+        return False
+    if not _allow_private_urls() and not _is_safe_url(url):
+        return False
+    return True
+
+
 def _run_cdp_local_fallback_command(
     task_id: str,
     command: str,
@@ -1026,7 +1080,7 @@ def _run_cdp_local_fallback_command(
 
     if command != "open":
         current_url = _last_browser_url_by_session_key.get(task_id)
-        if current_url:
+        if current_url and _cdp_fallback_warmup_url_safe(current_url):
             warmup = _run_browser_command(
                 local_session_key,
                 "open",
@@ -1040,6 +1094,13 @@ def _run_cdp_local_fallback_command(
                     command,
                     warmup.get("error"),
                 )
+        elif current_url:
+            logger.warning(
+                "CDP fallback: skipped unsafe cached warm-up URL before %s: %s",
+                command,
+                _sanitize_url_for_logs(current_url),
+            )
+            _last_browser_url_by_session_key.pop(task_id, None)
 
     fallback_result = _run_browser_command(local_session_key, command, args, timeout)
     # Future non-nav calls for this task should follow the browser that actually
@@ -2994,18 +3055,10 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     # cloud session and a local sidecar alive concurrently). Backend fallback
     # can change the serving session inside _run_browser_command.
     served_session_key = result.get("browser_session_key") or nav_session_key
-    _last_active_session_key[effective_task_id] = served_session_key
     if result.get("success"):
         data = result.get("data", {})
         title = data.get("title", "")
         final_url = data.get("url", url)
-        if final_url:
-            _last_browser_url_by_session_key[served_session_key] = final_url
-            # If a backend fallback served this navigation, keep the original
-            # session key's last URL too so a later fallback can warm up local
-            # state even before _last_active_session_key is consulted.
-            if served_session_key != nav_session_key:
-                _last_browser_url_by_session_key[nav_session_key] = final_url
 
         # Post-redirect SSRF check — if the browser followed a redirect to a
         # private/internal address, block the result so the model can't read
@@ -3021,6 +3074,8 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             and final_url != url
             and _is_always_blocked_url(final_url)
         ):
+            _last_browser_url_by_session_key.pop(served_session_key, None)
+            _last_browser_url_by_session_key.pop(nav_session_key, None)
             _run_browser_command(nav_session_key, "open", ["about:blank"], timeout=10)
             return json.dumps({
                 "success": False,
@@ -3034,11 +3089,21 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             and final_url and final_url != url and not _is_safe_url(final_url)
         ):
             # Navigate away to a blank page to prevent snapshot leaks
+            _last_browser_url_by_session_key.pop(served_session_key, None)
+            _last_browser_url_by_session_key.pop(nav_session_key, None)
             _run_browser_command(nav_session_key, "open", ["about:blank"], timeout=10)
             return json.dumps({
                 "success": False,
                 "error": "Blocked: redirect landed on a private/internal address",
             })
+
+        if final_url:
+            _last_browser_url_by_session_key[served_session_key] = final_url
+            # If a backend fallback served this navigation, keep the original
+            # session key's last URL too so a later fallback can warm up local
+            # state even before _last_active_session_key is consulted.
+            if served_session_key != nav_session_key:
+                _last_browser_url_by_session_key[nav_session_key] = final_url
 
         response = {
             "success": True,
@@ -3048,7 +3113,7 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         # Remember only a successful, non-blocked navigation as the task owner.
         # Failed opens and blocked redirects must not retarget follow-up clicks
         # or snapshots to a newly-created but irrelevant session.
-        _last_active_session_key[effective_task_id] = nav_session_key
+        _last_active_session_key[effective_task_id] = served_session_key
         _copy_fallback_warning(response, result)
 
         # Detect common "blocked" page patterns from title/url

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -933,46 +933,42 @@ _CDP_FALLBACK_ELIGIBLE: frozenset[str] = frozenset({
     "scroll", "back", "press", "console", "errors",
 })
 
-_CDP_BACKEND_FAILURE_MARKERS: tuple[str, ...] = (
-    "all cdp discovery methods failed",
-    "failed to resolve cdp",
-    "failed to connect to cdp",
-    "websocket connect failed",
-    "websocket",
-    "socket closed",
-    "socket hang up",
-    "connection refused",
-    "connection reset",
-    "connection closed",
-    "econnrefused",
-    "econnreset",
-    "etimedout",
-    "io error",
-    "target closed",
-    "browser has disconnected",
-    "browser closed",
-    "command timed out",
-    "timed out after",
-    "returned no output",
-    "non-json output from agent-browser",
+_CDP_BACKEND_FAILURE_KINDS: frozenset[str] = frozenset({
+    "cdp_discovery",
+    "cdp_connect",
+    "cdp_transport",
+    "cdp_disconnect",
+})
+_CDP_BACKEND_FAILURE_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"^(?:error:\s*)?all cdp discovery methods failed(?:\s*[:.-]\s*.*)?$",
+        r"^(?:error:\s*)?failed to resolve cdp(?: endpoint)?(?:\s*[:.-]\s*.*)?$",
+        r"^(?:error:\s*)?failed to connect to cdp(?: endpoint)?(?:\s*[:.-]\s*.*)?$",
+        r"^(?:error:\s*)?(?:cdp )?websocket connect failed(?:\s*[:.-]\s*.*)?$",
+        r"^(?:error:\s*)?cdp (?:socket|connection) (?:closed|reset|refused)(?:\s*[:.-]\s*.*)?$",
+        r"^(?:error:\s*)?(?:browser has disconnected|browser closed|target closed)(?:\s*[:.-]\s*.*)?$",
+    )
 )
 
 
 def _is_cdp_backend_failure(result: Dict[str, Any]) -> bool:
-    """Return True for transport/backend failures, not page semantics.
+    """Return True for explicit CDP discovery/transport backend failures only.
 
-    A failed click because ``@e999`` no longer exists, a JS exception from
-    ``eval``, or an app-level navigation error should be reported as-is.  Only
-    failures that indicate the selected CDP backend itself is unreachable,
-    disconnected, or unable to speak the expected protocol are safe to retry in
-    a different local browser.
+    Error strings produced by page JavaScript and application semantics can
+    contain words such as ``WebSocket`` or ``connection refused``.  Those must
+    not move the command into another browser.  Prefer an internal typed kind;
+    legacy agent-browser output is accepted only when the whole message matches
+    a known CDP discovery/connect/disconnect shape.
     """
     if result.get("success"):
         return False
-    error = str(result.get("error") or "").strip().lower()
+    if result.get("_browser_failure_kind") in _CDP_BACKEND_FAILURE_KINDS:
+        return True
+    error = str(result.get("error") or "").strip()
     if not error:
         return False
-    return any(marker in error for marker in _CDP_BACKEND_FAILURE_MARKERS)
+    return any(pattern.fullmatch(error) for pattern in _CDP_BACKEND_FAILURE_PATTERNS)
 
 
 def _cdp_fallback_reason(
@@ -1001,12 +997,6 @@ def _cdp_fallback_reason(
             return None
         error = str(result.get("error") or "command failed").strip()
         return f"CDP backend {command!r} failed ({error}); retried with local browser."
-
-    data = result.get("data", {})
-    if command == "snapshot" and isinstance(data, dict):
-        snap = data.get("snapshot", "")
-        if not snap or len(str(snap).strip()) < 20:
-            return "CDP backend returned an empty/too-short snapshot; retried with local browser."
 
     return None
 
@@ -1061,15 +1051,190 @@ def _cdp_fallback_warmup_url_safe(url: str) -> bool:
     return True
 
 
+def _quarantine_browser_session(
+    task_id: str,
+    session_key: str,
+    *,
+    source_session_key: Optional[str] = None,
+) -> None:
+    """Blank, close, and forget a failed fallback session in every tracker."""
+    owner, generation = _last_active_session_state(task_id)
+    try:
+        _run_browser_command(
+            session_key,
+            "open",
+            ["about:blank"],
+            timeout=10,
+            _engine_override="auto",
+            _allow_fallback=False,
+        )
+    except Exception as exc:
+        logger.debug("Browser quarantine blank failed for %s: %s", session_key, exc)
+
+    try:
+        _cleanup_single_browser_session(session_key)
+    except Exception as exc:
+        logger.warning("Browser quarantine cleanup failed for %s: %s", session_key, exc)
+    finally:
+        with _cleanup_lock:
+            _active_sessions.pop(session_key, None)
+            _session_last_activity.pop(session_key, None)
+            _recording_sessions.discard(session_key)
+            _cdp_fallback_local_session_keys.discard(session_key)
+            _last_browser_url_by_session_key.pop(session_key, None)
+            if source_session_key:
+                _last_browser_url_by_session_key.pop(source_session_key, None)
+        if owner == session_key:
+            _compare_clear_last_active_session_key(
+                task_id,
+                session_key,
+                generation,
+            )
+
+
+def _result_has_serving_metadata(result: Dict[str, Any]) -> bool:
+    return bool(
+        result.get("browser_session_key")
+        or result.get("_browser_session_key")
+        or result.get("browser_backend_fallback")
+    )
+
+
+def _served_url_guard_active(
+    requested_session_key: str,
+    served_session_key: str,
+    result: Dict[str, Any],
+) -> bool:
+    """Return whether content from this serving context requires exact proof."""
+    if _allow_private_urls():
+        return False
+    if (
+        served_session_key != requested_session_key
+        or result.get("browser_backend_fallback")
+        or _is_cdp_fallback_local_session_key(served_session_key)
+    ):
+        return True
+    # An unmarked local sidecar is an intentional hybrid route and stays exempt.
+    if _is_local_backend() or _is_local_sidecar_key(served_session_key):
+        return False
+    # Non-local/cloud/CDP sessions always require an exact URL proof before any
+    # content is released. Missing serving metadata is not a fail-open signal.
+    return True
+
+
+def _actual_served_url_guard(
+    task_id: str,
+    requested_session_key: str,
+    result: Dict[str, Any],
+    content_kind: str,
+    *,
+    force: bool = False,
+    quarantine_on_failure: bool = False,
+    intentional_hybrid_local: bool = False,
+) -> tuple[str, Optional[str], Optional[Dict[str, Any]]]:
+    """Prove the exact serving session is on a non-empty safe URL.
+
+    The probe itself never falls back.  Any mismatch or fallback metadata means
+    it did not prove the session that produced the bytes about to be returned.
+    """
+    served_session_key = (
+        result.get("browser_session_key")
+        or result.get("_browser_session_key")
+        or requested_session_key
+    )
+    if intentional_hybrid_local and not result.get("browser_backend_fallback"):
+        return served_session_key, None, None
+    if not force and not _served_url_guard_active(
+        requested_session_key,
+        served_session_key,
+        result,
+    ):
+        return served_session_key, None, None
+
+    current_url: Optional[str] = None
+    probe_error: Optional[str] = None
+    try:
+        probe = _run_browser_command(
+            served_session_key,
+            "eval",
+            ["window.location.href"],
+            timeout=5,
+            _engine_override="auto",
+            _allow_fallback=False,
+        )
+        probe_session_key = (
+            probe.get("browser_session_key")
+            or probe.get("_browser_session_key")
+            or served_session_key
+        )
+        if not probe.get("success"):
+            probe_error = str(probe.get("error") or "URL probe failed")
+        elif probe_session_key != served_session_key:
+            probe_error = "URL probe ran on a different browser session"
+        elif probe.get("browser_backend_fallback") or probe.get("browser_engine_fallback"):
+            probe_error = "URL probe used browser fallback metadata"
+        else:
+            raw_url = probe.get("data", {}).get("result", "")
+            current_url = str(raw_url or "").strip().strip('\"').strip("'")
+            if not current_url:
+                probe_error = "URL probe returned an empty URL"
+    except Exception as exc:
+        probe_error = str(exc) or type(exc).__name__
+
+    unsafe_url = bool(
+        current_url
+        and (
+            _is_always_blocked_url(current_url)
+            or not _is_safe_url(current_url)
+        )
+    )
+    if not probe_error and not unsafe_url:
+        return served_session_key, current_url, None
+
+    if quarantine_on_failure:
+        _quarantine_browser_session(
+            task_id,
+            served_session_key,
+            source_session_key=requested_session_key,
+        )
+    else:
+        _neutralize_blocked_redirect(
+            task_id,
+            requested_session_key,
+            served_session_key,
+        )
+
+    if probe_error:
+        error = (
+            "Blocked: unable to verify the URL of the browser session that "
+            f"served this {content_kind} ({probe_error})."
+        )
+    elif current_url and _is_always_blocked_url(current_url):
+        error = (
+            "Blocked: page URL targets a cloud metadata endpoint "
+            f"({current_url})."
+        )
+    else:
+        error = (
+            "Blocked: page URL targets a private or internal address "
+            f"({current_url})."
+        )
+    return served_session_key, current_url, {"success": False, "error": error}
+
+
 def _run_cdp_local_fallback_command(
     task_id: str,
     command: str,
     args: List[str],
     timeout: int,
     reason: str,
+    expected_owner_generation: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Retry a failed external-CDP command through the configured local engine."""
     local_session_key = task_id if _is_local_sidecar_key(task_id) else f"{task_id}{_LOCAL_SUFFIX}"
+    owner_task_id = _bare_task_id_for_session_key(task_id)
+    if expected_owner_generation is None:
+        _, expected_owner_generation = _last_active_session_state(owner_task_id)
     logger.info(
         "CDP fallback: retrying '%s' with local browser (task=%s local=%s): %s",
         command,
@@ -1086,27 +1251,89 @@ def _run_cdp_local_fallback_command(
                 "open",
                 [current_url],
                 timeout=_get_open_command_timeout(first_open=True),
+                _allow_fallback=False,
             )
             if not warmup.get("success"):
-                logger.debug(
+                logger.warning(
                     "CDP fallback: local warm-up navigation to %s failed before %s: %s",
-                    current_url,
+                    _sanitize_url_for_logs(current_url),
                     command,
                     warmup.get("error"),
                 )
+                _quarantine_browser_session(
+                    owner_task_id,
+                    local_session_key,
+                    source_session_key=task_id,
+                )
+                warmup_failure = dict(warmup)
+                warmup_failure["error"] = (
+                    "CDP fallback local warm-up failed before "
+                    f"{command}: {warmup.get('error', 'unknown error')}"
+                )
+                return _annotate_cdp_fallback(
+                    warmup_failure,
+                    reason,
+                    local_session_key,
+                )
+            _, _, warmup_guard_failure = _actual_served_url_guard(
+                owner_task_id,
+                local_session_key,
+                warmup,
+                "CDP fallback warm-up",
+                force=True,
+                quarantine_on_failure=True,
+            )
+            if warmup_guard_failure:
+                return _annotate_cdp_fallback(
+                    warmup_guard_failure,
+                    reason,
+                    local_session_key,
+                )
         elif current_url:
             logger.warning(
-                "CDP fallback: skipped unsafe cached warm-up URL before %s: %s",
+                "CDP fallback: blocked unsafe cached warm-up URL before %s: %s",
                 command,
                 _sanitize_url_for_logs(current_url),
             )
-            _last_browser_url_by_session_key.pop(task_id, None)
+            _quarantine_browser_session(
+                owner_task_id,
+                local_session_key,
+                source_session_key=task_id,
+            )
+            return _annotate_cdp_fallback(
+                {
+                    "success": False,
+                    "error": (
+                        "CDP fallback refused an unsafe cached warm-up URL "
+                        f"before {command}."
+                    ),
+                },
+                reason,
+                local_session_key,
+            )
 
     fallback_result = _run_browser_command(local_session_key, command, args, timeout)
-    # Future non-nav calls for this task should follow the browser that actually
-    # served the fallback command. browser_navigate also reads browser_session_key
-    # and preserves it before running its automatic snapshot.
-    _last_active_session_key[task_id] = local_session_key
+    if not fallback_result.get("success"):
+        _quarantine_browser_session(
+            owner_task_id,
+            local_session_key,
+            source_session_key=task_id,
+        )
+    # The original CDP command captured this token before it started.  A local
+    # retry may publish only against that immutable generation.  Navigation is
+    # deferred to browser_navigate so redirect validation happens first.
+    if fallback_result.get("success"):
+        if command == "open":
+            fallback_result = dict(fallback_result)
+            fallback_result["_cdp_fallback_owner_generation"] = (
+                expected_owner_generation
+            )
+        else:
+            _compare_publish_cdp_fallback_owner(
+                owner_task_id,
+                expected_owner_generation,
+                local_session_key,
+            )
     return _annotate_cdp_fallback(fallback_result, reason, local_session_key)
 
 
@@ -1534,6 +1761,95 @@ def _session_info_owned_by_task(session_info: Dict[str, Any], task_id: str, sess
     return True
 
 
+def _last_active_session_state(task_id: str) -> tuple[Optional[str], int]:
+    """Read a task's owner and generation under the ownership lock."""
+    with _cleanup_lock:
+        return (
+            _last_active_session_key.get(task_id),
+            _last_active_session_generation.get(task_id, 0),
+        )
+
+
+def _is_cdp_fallback_local_session_key(session_key: str) -> bool:
+    """Return whether ``session_key`` is a local recovery for external CDP."""
+    with _cleanup_lock:
+        return session_key in _cdp_fallback_local_session_keys
+
+
+def _set_last_active_session_key(task_id: str, session_key: str) -> int:
+    """Publish a new task owner and advance its generation atomically."""
+    with _cleanup_lock:
+        generation = _last_active_session_generation.get(task_id, 0) + 1
+        _last_active_session_key[task_id] = session_key
+        _last_active_session_generation[task_id] = generation
+        return generation
+
+
+def _compare_set_last_active_session_key(
+    task_id: str,
+    expected_generation: int,
+    session_key: str,
+) -> bool:
+    """Publish ``session_key`` only if no newer owner decision was made."""
+    with _cleanup_lock:
+        if _last_active_session_generation.get(task_id, 0) != expected_generation:
+            return False
+        generation = expected_generation + 1
+        _last_active_session_key[task_id] = session_key
+        _last_active_session_generation[task_id] = generation
+        return True
+
+
+def _compare_publish_cdp_fallback_owner(
+    task_id: str,
+    expected_generation: int,
+    session_key: str,
+) -> bool:
+    """Atomically publish a CDP fallback owner and its guarded provenance."""
+    with _cleanup_lock:
+        if _last_active_session_generation.get(task_id, 0) != expected_generation:
+            return False
+        _last_active_session_key[task_id] = session_key
+        _last_active_session_generation[task_id] = expected_generation + 1
+        _cdp_fallback_local_session_keys.add(session_key)
+        return True
+
+
+def _compare_publish_navigation_owner(
+    task_id: str,
+    expected_generation: int,
+    session_key: str,
+    *,
+    explicit_hybrid_local: bool = False,
+) -> bool:
+    """Publish a normal navigation owner and commit hybrid repurpose atomically."""
+    with _cleanup_lock:
+        if _last_active_session_generation.get(task_id, 0) != expected_generation:
+            return False
+        _last_active_session_key[task_id] = session_key
+        _last_active_session_generation[task_id] = expected_generation + 1
+        if explicit_hybrid_local:
+            _cdp_fallback_local_session_keys.discard(session_key)
+        return True
+
+
+def _compare_clear_last_active_session_key(
+    task_id: str,
+    expected_session_key: str,
+    expected_generation: int,
+) -> bool:
+    """Clear an owner only when both its session key and generation are stale."""
+    with _cleanup_lock:
+        if (
+            _last_active_session_key.get(task_id) != expected_session_key
+            or _last_active_session_generation.get(task_id, 0) != expected_generation
+        ):
+            return False
+        _last_active_session_key.pop(task_id, None)
+        _last_active_session_generation[task_id] = expected_generation + 1
+        return True
+
+
 def _last_session_key(task_id: str) -> str:
     """Return the live session key to use for a non-nav browser tool call.
 
@@ -1546,14 +1862,17 @@ def _last_session_key(task_id: str) -> str:
     """
     if task_id is None:
         task_id = "default"
-    recorded_key = _last_active_session_key.get(task_id)
-    if not recorded_key:
-        return task_id
     with _cleanup_lock:
+        recorded_key = _last_active_session_key.get(task_id)
+        if not recorded_key:
+            return task_id
         session_info = _active_sessions.get(recorded_key)
         if session_info and _session_info_owned_by_task(session_info, task_id, recorded_key):
             return recorded_key
         _last_active_session_key.pop(task_id, None)
+        _last_active_session_generation[task_id] = (
+            _last_active_session_generation.get(task_id, 0) + 1
+        )
     logger.debug(
         "browser session ownership: dropping stale/mismatched last-active binding %s -> %s",
         task_id,
@@ -1622,6 +1941,14 @@ _recording_sessions: set = set()  # session_keys with active recordings
 # navigation.  Without this, a task that navigated to localhost on the local
 # sidecar would fall back to the cloud session on its next snapshot call.
 _last_active_session_key: Dict[str, str] = {}  # task_id -> session_key
+# Monotonic per-task generation used for compare-and-set ownership updates.
+# A slower fallback may only publish its local sidecar while the generation it
+# observed at start is still current.
+_last_active_session_generation: Dict[str, int] = {}
+# Local sidecars created as recovery for an external CDP session must retain the
+# external backend's SSRF policy. Plain hybrid sidecars intentionally used for
+# private URLs are not added here.
+_cdp_fallback_local_session_keys: set[str] = set()
 _last_browser_url_by_session_key: Dict[str, str] = {}  # session_key -> last successful URL
 _LOCAL_SUFFIX = "::local"
 
@@ -2483,6 +2810,7 @@ def _run_browser_command(
     args: List[str] = None,
     timeout: Optional[int] = None,
     _engine_override: Optional[str] = None,
+    _allow_fallback: bool = True,
 ) -> Dict[str, Any]:
     """
     Run an agent-browser CLI command using our pre-created Browserbase session.
@@ -2496,6 +2824,10 @@ def _run_browser_command(
         _engine_override: Force a specific engine for this call only.  Used
                           internally by the Lightpanda fallback to retry with
                           Chrome without touching global state.
+        _allow_fallback: Allow backend/engine fallback for this call. Internal
+                         safety probes and cleanup commands disable it so a
+                         different browser cannot mask failure of the session
+                         being checked or neutralized.
 
     Returns:
         Parsed JSON response from agent-browser
@@ -2550,6 +2882,19 @@ def _run_browser_command(
     except Exception as e:
         logger.warning("Failed to create browser session for task=%s: %s", task_id, e)
         return {"success": False, "error": f"Failed to create browser session: {str(e)}"}
+
+    # Capture fallback ownership before the original external command starts.
+    # A newer navigation completed while CDP is blocked must invalidate the
+    # local retry rather than become the retry's fresh publication token.
+    cdp_expected_owner_generation: Optional[int] = None
+    features = session_info.get("features") or {}
+    if (
+        session_info.get("cdp_url")
+        and isinstance(features, dict)
+        and features.get("cdp_override")
+    ):
+        owner_task_id = _bare_task_id_for_session_key(task_id)
+        _, cdp_expected_owner_generation = _last_active_session_state(owner_task_id)
 
     # Build the command with the appropriate backend flag.
     # Cloud mode: --cdp <websocket_url> connects to Browserbase.
@@ -2780,14 +3125,27 @@ def _run_browser_command(
         logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
         result = {"success": False, "error": str(e)}
 
+    # Internal only: downstream guards use the concrete dispatcher session even
+    # when a backend result does not expose public provenance. Tool responses
+    # selectively copy user-facing fields and never leak this marker.
+    result = dict(result)
+    result.setdefault("_browser_session_key", task_id)
+
     # --- External CDP automatic local fallback ---
     # CDP overrides (e.g. Obscura) are backend selections, not local engines. If
     # they fail and the user opted in, retry through the normal local engine
     # chain. This deliberately runs before Lightpanda fallback so a CDP failure
     # is not misclassified as a Lightpanda failure when browser.engine=lightpanda.
     cdp_fallback_reason = _cdp_fallback_reason(session_info, command, result)
-    if cdp_fallback_reason:
-        return _run_cdp_local_fallback_command(task_id, command, args, timeout, cdp_fallback_reason)
+    if _allow_fallback and cdp_fallback_reason:
+        return _run_cdp_local_fallback_command(
+            task_id,
+            command,
+            args,
+            timeout,
+            cdp_fallback_reason,
+            cdp_expected_owner_generation,
+        )
 
     # --- Lightpanda automatic Chrome fallback ---
     # If engine is lightpanda and the local result looks broken, retry with Chrome.
@@ -2797,7 +3155,7 @@ def _run_browser_command(
     fallback_reason = None
     if not session_info.get("cdp_url"):
         fallback_reason = _lightpanda_fallback_reason(engine, command, result)
-    if fallback_reason:
+    if _allow_fallback and fallback_reason:
         logger.info(
             "Lightpanda fallback: retrying '%s' with Chrome (task=%s): %s",
             command,
@@ -2927,6 +3285,61 @@ def _redact_browser_output(value: Any) -> Any:
 # Browser Tool Functions
 # ============================================================================
 
+def _neutralize_blocked_redirect(
+    task_id: str,
+    nav_session_key: str,
+    served_session_key: str,
+) -> None:
+    """Blank a blocked redirect on its serving session and drop unsafe ownership."""
+    _, neutralize_generation = _last_active_session_state(task_id)
+    _last_browser_url_by_session_key.pop(served_session_key, None)
+    _last_browser_url_by_session_key.pop(nav_session_key, None)
+    try:
+        blank_result = _run_browser_command(
+            served_session_key,
+            "open",
+            ["about:blank"],
+            timeout=10,
+            _engine_override="auto",
+            _allow_fallback=False,
+        )
+    except Exception as exc:
+        blank_result = {"success": False, "error": str(exc)}
+
+    _compare_clear_last_active_session_key(
+        task_id,
+        served_session_key,
+        neutralize_generation,
+    )
+
+    blanked_serving_session = (
+        blank_result.get("success")
+        and blank_result.get("browser_session_key", served_session_key)
+        == served_session_key
+        and not blank_result.get("browser_backend_fallback")
+        and not blank_result.get("browser_engine_fallback")
+    )
+    if blanked_serving_session:
+        return
+
+    try:
+        _cleanup_single_browser_session(served_session_key)
+    finally:
+        # Quarantine the session even if its close command or daemon teardown
+        # raises: no later browser tool may resolve back to unsafe page state.
+        with _cleanup_lock:
+            _active_sessions.pop(served_session_key, None)
+            _session_last_activity.pop(served_session_key, None)
+            _recording_sessions.discard(served_session_key)
+            _cdp_fallback_local_session_keys.discard(served_session_key)
+            _last_browser_url_by_session_key.pop(served_session_key, None)
+    logger.warning(
+        "Blocked redirect cleanup failed for serving session %s: %s",
+        served_session_key,
+        blank_result.get("error", "unknown error"),
+    )
+
+
 def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     """
     Navigate to a URL in the browser.
@@ -3025,6 +3438,9 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         return camofox_navigate(url, task_id)
 
     if auto_local_this_nav:
+        # Repurpose is committed only with the successful navigation's owner
+        # publication below.  Removing fallback provenance here would create a
+        # fail-open window when this open fails or loses a generation race.
         logger.info(
             "browser_navigate: auto-routing %s to local Chromium sidecar "
             "(cloud provider %s stays on cloud for public URLs; "
@@ -3032,6 +3448,10 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             url,
             type(_get_cloud_provider()).__name__ if _get_cloud_provider() else "none",
         )
+
+    # Capture before starting/opening the concrete session.  The command result
+    # may be stale by the time it returns if another navigation wins meanwhile.
+    _, navigation_generation = _last_active_session_state(effective_task_id)
 
     # Get session info to check if this is a new session
     # (will create one with features logged if not exists)
@@ -3056,9 +3476,21 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     # can change the serving session inside _run_browser_command.
     served_session_key = result.get("browser_session_key") or nav_session_key
     if result.get("success"):
+        served_session_key, actual_served_url, guard_failure = (
+            _actual_served_url_guard(
+                effective_task_id,
+                nav_session_key,
+                result,
+                "navigation",
+                intentional_hybrid_local=auto_local_this_nav,
+            )
+        )
+        if guard_failure:
+            return json.dumps(guard_failure, ensure_ascii=False)
+
         data = result.get("data", {})
         title = data.get("title", "")
-        final_url = data.get("url", url)
+        final_url = actual_served_url or data.get("url", url)
 
         # Post-redirect SSRF check — if the browser followed a redirect to a
         # private/internal address, block the result so the model can't read
@@ -3074,9 +3506,11 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             and final_url != url
             and _is_always_blocked_url(final_url)
         ):
-            _last_browser_url_by_session_key.pop(served_session_key, None)
-            _last_browser_url_by_session_key.pop(nav_session_key, None)
-            _run_browser_command(nav_session_key, "open", ["about:blank"], timeout=10)
+            _neutralize_blocked_redirect(
+                effective_task_id,
+                nav_session_key,
+                served_session_key,
+            )
             return json.dumps({
                 "success": False,
                 "error": "Blocked: redirect landed on a cloud metadata endpoint",
@@ -3089,13 +3523,38 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             and final_url and final_url != url and not _is_safe_url(final_url)
         ):
             # Navigate away to a blank page to prevent snapshot leaks
-            _last_browser_url_by_session_key.pop(served_session_key, None)
-            _last_browser_url_by_session_key.pop(nav_session_key, None)
-            _run_browser_command(nav_session_key, "open", ["about:blank"], timeout=10)
+            _neutralize_blocked_redirect(
+                effective_task_id,
+                nav_session_key,
+                served_session_key,
+            )
             return json.dumps({
                 "success": False,
                 "error": "Blocked: redirect landed on a private/internal address",
             })
+
+        fallback_owner_generation = result.get(
+            "_cdp_fallback_owner_generation",
+            navigation_generation,
+        )
+        if result.get("browser_backend_fallback"):
+            owner_published = _compare_publish_cdp_fallback_owner(
+                effective_task_id,
+                fallback_owner_generation,
+                served_session_key,
+            )
+        else:
+            owner_published = _compare_publish_navigation_owner(
+                effective_task_id,
+                navigation_generation,
+                served_session_key,
+                explicit_hybrid_local=auto_local_this_nav,
+            )
+        if not owner_published:
+            return json.dumps({
+                "success": False,
+                "error": "Navigation result was superseded by a newer browser navigation.",
+            }, ensure_ascii=False)
 
         if final_url:
             _last_browser_url_by_session_key[served_session_key] = final_url
@@ -3110,10 +3569,6 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             "url": final_url,
             "title": title
         }
-        # Remember only a successful, non-blocked navigation as the task owner.
-        # Failed opens and blocked redirects must not retarget follow-up clicks
-        # or snapshots to a newly-created but irrelevant session.
-        _last_active_session_key[effective_task_id] = served_session_key
         _copy_fallback_warning(response, result)
 
         # Detect common "blocked" page patterns from title/url
@@ -3150,6 +3605,14 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         try:
             snap_result = _run_browser_command(served_session_key, "snapshot", ["-c"])
             if snap_result.get("success"):
+                _, _, snapshot_guard_failure = _actual_served_url_guard(
+                    effective_task_id,
+                    served_session_key,
+                    snap_result,
+                    "navigation snapshot",
+                )
+                if snapshot_guard_failure:
+                    return json.dumps(snapshot_guard_failure, ensure_ascii=False)
                 snap_data = snap_result.get("data", {})
                 snapshot_text = snap_data.get("snapshot", "")
                 refs = snap_data.get("refs", {})
@@ -3204,36 +3667,14 @@ def browser_snapshot(
         snapshot_text = data.get("snapshot", "")
         refs = data.get("refs", {})
 
-        # ── Private-network guard: block snapshots from eval-navigated private pages ──
-        # After any eval (browser_console) that may have changed location.href to a
-        # private/internal address, the snapshot would expose private page content.
-        # Re-check the current URL before returning the snapshot.
-        if (
-            not _is_local_backend()
-            and not _is_local_sidecar_key(effective_task_id)
-            and not _allow_private_urls()
-        ):
-            try:
-                _url_result = _run_browser_command(
-                    effective_task_id, "eval", ["window.location.href"],
-                    timeout=5, _engine_override="auto",
-                )
-                if _url_result.get("success"):
-                    _current_url = (
-                        _url_result.get("data", {}).get("result", "")
-                        .strip().strip('"').strip("'")
-                    )
-                    if _current_url and not _is_safe_url(_current_url):
-                        return json.dumps({
-                            "success": False,
-                            "error": (
-                                "Blocked: page URL targets a private or internal address "
-                                f"({_current_url}). This may have been caused by a "
-                                "JavaScript navigation via browser_console."
-                            ),
-                        }, ensure_ascii=False)
-            except Exception as _url_exc:
-                logger.debug("browser_snapshot: URL safety check failed (%s)", _url_exc)
+        _, _, guard_failure = _actual_served_url_guard(
+            task_id or "default",
+            effective_task_id,
+            result,
+            "snapshot",
+        )
+        if guard_failure:
+            return json.dumps(guard_failure, ensure_ascii=False)
 
         # Check if snapshot needs summarization
         if len(snapshot_text) > SNAPSHOT_SUMMARIZE_THRESHOLD and user_task:
@@ -3567,6 +4008,21 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
     console_result = _run_browser_command(effective_task_id, "console", console_args)
     errors_result = _run_browser_command(effective_task_id, "errors", error_args)
 
+    for content_kind, content_result in (
+        ("console output", console_result),
+        ("JavaScript errors", errors_result),
+    ):
+        if not content_result.get("success"):
+            continue
+        _, _, guard_failure = _actual_served_url_guard(
+            task_id or "default",
+            effective_task_id,
+            content_result,
+            content_kind,
+        )
+        if guard_failure:
+            return json.dumps(guard_failure, ensure_ascii=False)
+
     messages = []
     if console_result.get("success"):
         for msg in console_result.get("data", {}).get("messages", []):
@@ -3600,16 +4056,19 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
 def _eval_ssrf_guard_active(effective_task_id: str) -> bool:
     """Return True when eval-driven private-network access must be guarded.
 
-    Matches the gating used by ``browser_navigate`` / ``browser_snapshot`` /
-    ``browser_vision``: the SSRF guard is only meaningful for non-local
-    backends (cloud browser, or a containerized terminal whose browser-on-host
-    can reach internal networks the terminal can't), and is skipped for local
-    sidecar sessions and when ``allow_private_urls`` is set.
+    Sidecars created intentionally for hybrid private-URL routing remain exempt,
+    but sidecars created as external-CDP recovery retain the external backend's
+    guard policy.
     """
     return (
-        not _is_local_backend()
-        and not _is_local_sidecar_key(effective_task_id)
-        and not _allow_private_urls()
+        not _allow_private_urls()
+        and (
+            _is_cdp_fallback_local_session_key(effective_task_id)
+            or (
+                not _is_local_backend()
+                and not _is_local_sidecar_key(effective_task_id)
+            )
+        )
     )
 
 
@@ -3829,6 +4288,17 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
         if supervisor is not None:
             sup_result = supervisor.evaluate_runtime(expression)
             if sup_result.get("ok"):
+                _, _, guard_failure = _actual_served_url_guard(
+                    task_id or "default",
+                    effective_task_id,
+                    {
+                        "success": True,
+                        "browser_session_key": effective_task_id,
+                    },
+                    "evaluation",
+                )
+                if guard_failure:
+                    return json.dumps(guard_failure, ensure_ascii=False)
                 raw_result = sup_result.get("result")
                 # Match the agent-browser path: if the value is a JSON string,
                 # parse it so the model gets structured data.
@@ -3838,20 +4308,6 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
                         parsed = json.loads(raw_result)
                     except (json.JSONDecodeError, ValueError):
                         pass  # keep as string
-                # Post-eval page-URL recheck: if this (or a prior) eval
-                # navigated the page to a private address, withhold the result.
-                if _eval_ssrf_guard_active(effective_task_id):
-                    _blocked_url = _current_page_private_url(effective_task_id)
-                    if _blocked_url:
-                        return json.dumps({
-                            "success": False,
-                            "error": (
-                                "Blocked: page URL targets a private or internal "
-                                f"address ({_blocked_url}). This may have been "
-                                "caused by a JavaScript navigation via "
-                                "browser_console."
-                            ),
-                        }, ensure_ascii=False)
                 response = {
                     "success": True,
                     "result": _redact_browser_output(parsed),
@@ -3910,6 +4366,33 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
         }
         return json.dumps(_copy_fallback_warning(response, result))
 
+    _, _, guard_failure = _actual_served_url_guard(
+        task_id or "default",
+        effective_task_id,
+        result,
+        "evaluation",
+    )
+    if guard_failure:
+        return json.dumps(guard_failure, ensure_ascii=False)
+
+    # Compatibility path for legacy/custom command adapters that do not yet
+    # identify their serving session. Real dispatcher results take the strict
+    # fail-closed path above.
+    if (
+        not _result_has_serving_metadata(result)
+        and _eval_ssrf_guard_active(effective_task_id)
+    ):
+        blocked_url = _current_page_private_url(effective_task_id)
+        if blocked_url:
+            return json.dumps({
+                "success": False,
+                "error": (
+                    "Blocked: page URL targets a private or internal address "
+                    f"({blocked_url}). This may have been caused by a "
+                    "JavaScript navigation via browser_console."
+                ),
+            }, ensure_ascii=False)
+
     data = result.get("data", {})
     raw_result = data.get("result")
 
@@ -3927,19 +4410,6 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
         "result": _redact_browser_output(parsed),
         "result_type": type(parsed).__name__,
     }
-    # Post-eval page-URL recheck: if this (or a prior) eval navigated the page
-    # to a private address, withhold the result (mirrors the supervisor path).
-    if _eval_ssrf_guard_active(effective_task_id):
-        _blocked_url = _current_page_private_url(effective_task_id)
-        if _blocked_url:
-            return json.dumps({
-                "success": False,
-                "error": (
-                    "Blocked: page URL targets a private or internal address "
-                    f"({_blocked_url}). This may have been caused by a "
-                    "JavaScript navigation via browser_console."
-                ),
-            }, ensure_ascii=False)
     return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False, default=str)
 
 
@@ -4093,15 +4563,26 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
     result = _run_browser_command(effective_task_id, "eval", [js_code])
 
     if result.get("success"):
-        # ── Private-network guard (sibling of snapshot/vision/eval guards) ──
-        if _eval_ssrf_guard_active(effective_task_id):
-            _blocked_url = _current_page_private_url(effective_task_id)
-            if _blocked_url:
+        _, _, guard_failure = _actual_served_url_guard(
+            task_id or "default",
+            effective_task_id,
+            result,
+            "image list",
+        )
+        if guard_failure:
+            return json.dumps(guard_failure, ensure_ascii=False)
+
+        if (
+            not _result_has_serving_metadata(result)
+            and _eval_ssrf_guard_active(effective_task_id)
+        ):
+            blocked_url = _current_page_private_url(effective_task_id)
+            if blocked_url:
                 return json.dumps({
                     "success": False,
                     "error": (
                         "Blocked: page URL targets a private or internal address "
-                        f"({_blocked_url}). This may have been caused by a "
+                        f"({blocked_url}). This may have been caused by a "
                         "JavaScript navigation via browser_console."
                     ),
                 }, ensure_ascii=False)
@@ -4176,11 +4657,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     # After any eval (browser_console) that may have changed location.href to a
     # private/internal address, the screenshot would expose private page content
     # to the vision model.  Re-check the current URL before capturing anything.
-    if (
-        not _is_local_backend()
-        and not _is_local_sidecar_key(effective_task_id)
-        and not _allow_private_urls()
-    ):
+    if _eval_ssrf_guard_active(effective_task_id):
         try:
             _url_result = _run_browser_command(
                 effective_task_id, "eval", ["window.location.href"],
@@ -4291,6 +4768,21 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
                 "error": f"Failed to take screenshot ({mode} mode): {error_detail}"
             }
             return json.dumps(_copy_fallback_warning(error_response, result), ensure_ascii=False)
+
+        _, _, guard_failure = _actual_served_url_guard(
+            task_id or "default",
+            effective_task_id,
+            result,
+            "screenshot",
+        )
+        if guard_failure:
+            captured_path = result.get("data", {}).get("path")
+            path_to_discard = Path(captured_path) if captured_path else screenshot_path
+            try:
+                path_to_discard.unlink(missing_ok=True)
+            except OSError:
+                logger.debug("Unable to remove blocked browser screenshot %s", path_to_discard)
+            return json.dumps(guard_failure, ensure_ascii=False)
 
         actual_screenshot_path = result.get("data", {}).get("path")
         if actual_screenshot_path:
@@ -4521,18 +5013,19 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
                 session_keys.append(sidecar_key)
         bare_task_id = task_id
 
+    cleanup_owner, cleanup_generation = _last_active_session_state(bare_task_id)
+
     for session_key in session_keys:
         _cleanup_single_browser_session(session_key)
 
-    # Drop stale last-active ownership. Cleaning a bare task drops its binding;
-    # cleaning a sidecar drops the binding only if that sidecar was still the
-    # recorded owner. This prevents a later click/snapshot from resurrecting a
-    # cleaned sidecar on about:blank while preserving a primary-session binding.
-    if _is_local_sidecar_key(task_id):
-        if _last_active_session_key.get(bare_task_id) == task_id:
-            _last_active_session_key.pop(bare_task_id, None)
-    else:
-        _last_active_session_key.pop(bare_task_id, None)
+    # Session keys may be reused.  A same-key navigation that advanced the
+    # generation while cleanup ran is a new owner and must survive.
+    if cleanup_owner in session_keys:
+        _compare_clear_last_active_session_key(
+            bare_task_id,
+            cleanup_owner,
+            cleanup_generation,
+        )
 
 
 def _cleanup_single_browser_session(task_id: str) -> None:
@@ -4579,6 +5072,7 @@ def _cleanup_single_browser_session(task_id: str) -> None:
         with _cleanup_lock:
             _active_sessions.pop(task_id, None)
             _session_last_activity.pop(task_id, None)
+            _cdp_fallback_local_session_keys.discard(task_id)
             _last_browser_url_by_session_key.pop(task_id, None)
 
         # Cloud mode: close the cloud browser session via provider API.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1838,8 +1838,10 @@ browser:
   command_timeout: 30             # Timeout in seconds for browser commands (screenshot, navigate, etc.)
   record_sessions: false         # Auto-record browser sessions as WebM videos to ~/.hermes/browser_recordings/
   # Optional CDP override — when set, Hermes attaches directly to your own
-  # Chromium-family browser (via /browser connect) rather than starting a headless browser.
+  # CDP endpoint (for example Chrome, Chromium-family browsers, or Obscura)
+  # rather than starting a headless browser.
   cdp_url: ""
+  cdp_fallback_to_local: false    # If that user-supplied CDP endpoint fails, retry eligible commands with the configured local engine
   # Dialog supervisor — controls how native JS dialogs (alert / confirm / prompt)
   # are handled when a CDP backend is attached (Browserbase, local Chromium-family
   # browser via /browser connect). Ignored on Camofox and default local agent-browser mode.

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -363,6 +363,18 @@ Then launch the Hermes CLI and run `/browser connect`.
 
 When connected via CDP, all browser tools (`browser_navigate`, `browser_click`, etc.) operate on your live browser instance instead of spinning up a cloud session.
 
+If you point `browser.cdp_url` at a non-Chromium CDP-compatible engine such as Obscura and want Hermes to keep working when that endpoint is down, enable the explicit local fallback:
+
+```yaml
+# ~/.hermes/config.yaml
+browser:
+  cdp_url: http://127.0.0.1:9223
+  cdp_fallback_to_local: true
+  engine: lightpanda   # optional: local fallback uses Lightpanda first, then Chrome when needed
+```
+
+This makes the chain `external CDP → configured local engine`. With `engine: lightpanda`, the existing local fallback continues to use Chrome for screenshots, vision, or broken Lightpanda results. The fallback is opt-in so stale `/browser connect` or `browser.cdp_url` settings do not get hidden accidentally. When a fallback happens, the tool result includes `fallback_warning`, `browser_backend_fallback`, and the local session key used for subsequent same-task browser actions.
+
 ### WSL2 + Windows Chrome: prefer MCP over `/browser connect`
 
 If Hermes runs inside WSL2 but the Chrome window you want to control runs on the Windows host, `/browser connect` is often not the best path.


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in recovery path for user-supplied external CDP endpoints: when `browser.cdp_fallback_to_local` is enabled and the external endpoint fails with a backend/transport-class failure, Hermes retries eligible browser commands through the normal local engine path (including the existing Lightpanda→Chrome chain when configured).

This revision also hardens post-fallback isolation and SSRF cleanup:

- CDP failure classification is typed/narrow (discovery/connect/disconnect shapes only). Semantic page errors that merely contain transport-like words do not trigger fallback.
- Fallback ownership is published with generation CAS. Tokens are captured before the original CDP command starts, so a newer navigation cannot be stolen by a stale local retry.
- Warm-up and content-serving paths prove the *actual served session* is on a non-empty safe URL with fallback disabled. Failures blank/quarantine the serving session and drop matching owner bindings generation-safely.
- Local sidecars created as external-CDP recovery retain the external backend SSRF policy on later snapshot/eval/images/vision/console paths. Intentional hybrid private-URL sidecars remain exempt.
- Probe/open failures and blocked redirects never release secrets and never leave an unsafe session reusable as the active binding.

## Why is this needed?

External CDP endpoints (Obscura, remote Chrome, local debugging ports) can become temporarily unreachable. Operators may prefer automatic local recovery for a single task rather than failing every browser tool call.

Separately, fallback must not weaken SSRF boundaries: a recovered local session is still serving content for a cloud/CDP task and must not become a silent path to private/metadata targets, and cleanup must target the session that actually served the navigation—not a recovered CDP handle.

## How to test

1. Configure an external CDP endpoint and set `browser.cdp_fallback_to_local: true`.
2. Stop or break the CDP endpoint.
3. Run a browser navigation / snapshot task.
4. Confirm Hermes continues on the local engine with a visible fallback warning, and that a later snapshot/eval remains SSRF-guarded.
5. Navigate to a redirect that lands on a blocked metadata/private URL and confirm:
   - the tool response is blocked
   - the serving local session is blanked/quarantined
   - later browser_snapshot does not reuse the contaminated session as active owner
6. Repeat with `browser.cdp_fallback_to_local: false` and confirm the original CDP failure is returned without local retry.
7. Unit coverage:
   - `scripts/run_tests.sh tests/tools/test_browser_lightpanda.py tests/tools/test_browser_snapshot_ssrf.py tests/tools/test_browser_eval_ssrf.py tests/tools/test_browser_ssrf_local.py -q -o addopts=`
   - browser-related suite (35 files) green after the security contract updates

## Pre-landing checklist

- [x] Linked related issue(s)
- [x] Linked related PR(s)
- [x] Added/updated unit tests for changed logic
- [x] Updated docs if user-facing behavior changed
- [x] Considered backwards compatibility for existing configs / integrations
- [x] Reviewed by Codex/Claude/Gemini or another model (or explain why not)
- [x] Self-review performed

## Related issue / PR

Implements the CDP failure recovery path requested for external browser endpoints and addresses hermes-sweeper review findings around actual-session SSRF cleanup, atomic ownership, and fail-closed content release.

## Notes for reviewers

- Opt-in only (`browser.cdp_fallback_to_local`, default false). Documented in `cli-config.yaml.example` and browser docs.
- Fallback is limited to backend/transport failures; page-level/auth/command errors stay on the CDP session.
- Content tools call a shared actual-served URL guard against `result.browser_session_key` / internal dispatcher session key with `_allow_fallback=False`.
- Owner publication uses pre-command generation tokens + CAS; compare-clear is generation-aware.
- Local verification: focused 153 PASS; browser-related 35 files / 552 PASS; ruff + Windows footguns + YAML readback PASS. Full suite previously showed only load-sensitive pre-existing flakes vs exact base (no candidate-only browser regressions).
