### PR TITLE
fix(agent): append error response to messages on max-iteration summary failure (#56056)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1646,6 +1646,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     except Exception as e:
         logger.warning(f"Failed to get summary response: {e}")
         final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
+        # Append the error as an assistant response so the synthetic user
+        # message at the top of this function doesn't leave an orphaned
+        # consecutive-user pair in the conversation history.  Strict
+        # providers (Gemini, Claude) reject sessions with role alternation
+        # violations on resume.  (#56056)
+        messages.append({"role": "assistant", "content": final_response})
 
     return final_response
 


### PR DESCRIPTION
## Problem

When `handle_max_iterations()` exhausts the iteration budget:

1. **Line 1432**: Appends a synthetic user message: `"You've reached the maximum number of tool-calling iterations..."`
2. **Lines 1434-1644**: Makes API call(s) to get a summary
3. **Success path** (lines 1597, 1640): Appends assistant response to `messages` ✅
4. **Failure path** (line 1646-1648): Sets `final_response` to error string but does **NOT** append to `messages` ❌

The synthetic user message is left orphaned — no corresponding assistant response follows it. On session resume, the model sees two consecutive user messages, violating the role alternation invariant.

## Impact

- **Session permanently corrupted** with a role alternation violation
- Happens specifically when the model/provider is **already failing** (the worst time to corrupt state)
- Strict providers (Gemini, Claude) reject the session on resume with 400/422
- The synthetic message appears as a real user message to the model

## Fix

Append the error response as an assistant message in the except block, matching the success path behavior at lines 1597 and 1640. This ensures the synthetic user message always has a corresponding assistant response, maintaining the role alternation invariant.

```python
except Exception as e:
    logger.warning(f"Failed to get summary response: {e}")
    final_response = f"I reached the maximum iterations..."
+   messages.append({"role": "assistant", "content": final_response})
```

## Testing

- `python3 -m py_compile agent/chat_completion_helpers.py` — OK
- Single-line addition in except block

Fixes #56056