### PR TITLE
fix(tools): truncate oversized MCP tool results to prevent unbounded allocation (#56059)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3367,6 +3367,22 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     parts.append(image_tag)
             text_result = "\n".join(parts) if parts else ""
 
+            # Truncate oversized MCP results to prevent unbounded context
+            # allocation.  Uses the same byte cap as the terminal tool.
+            # (#56059)
+            from tools.tool_output_limits import get_max_bytes
+            _max = get_max_bytes()
+            if len(text_result) > _max:
+                _head = int(_max * 0.4)
+                _tail = _max - _head
+                _omitted = len(text_result) - _head - _tail
+                text_result = (
+                    text_result[:_head]
+                    + f"\n\n... [OUTPUT TRUNCATED - {_omitted} chars omitted "
+                    f"out of {len(text_result)} total] ...\n\n"
+                    + text_result[-_tail:]
+                )
+
             # Combine content + structuredContent when both are present.
             # MCP spec: content is model-oriented (text), structuredContent
             # is machine-oriented (JSON metadata).  For an AI agent, content


### PR DESCRIPTION
## Problem

MCP tool results are returned as raw strings with **zero size enforcement**. The result is collected from MCP content blocks, joined, and returned directly into the agent's tool-result pipeline — with no truncation, no byte cap, and no token estimate check.

Contrast this with:
- **Terminal tool**: truncates output at `get_max_bytes()` (default 50KB) with head/tail split
- **File read tool**: caps at `max_lines=2000`, `max_line_length=2000`
- **MCP tools**: none of these guards

## Impact

- A buggy or malicious MCP server can return a multi-megabyte text result
- This floods the conversation context window, triggering context overflow
- On memory-constrained deployments, can cause OOM
- Token costs are unbounded

## Fix

Apply the same `get_max_bytes()` truncation used by the terminal tool (tools/terminal_tool.py:2668-2678), with a 40/60 head/tail split so error messages at the start and recent output at the end are both preserved.

```python
text_result = "\n".join(parts) if parts else ""

+# Truncate oversized MCP results to prevent unbounded context allocation
+from tools.tool_output_limits import get_max_bytes
+_max = get_max_bytes()
+if len(text_result) > _max:
+    _head = int(_max * 0.4)
+    _tail = _max - _head
+    ...
```

## Testing

- `python3 -m py_compile tools/mcp_tool.py` — OK
- Matches terminal tool truncation pattern exactly

Fixes #56059