### PR TITLE
Add delayed auto-resume for provider rate limits

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2772,12 +2772,31 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
             if value not in {None, ""}:
                 context["reset_at"] = value
                 break
-        retry_after = payload.get("retry_after")
-        if retry_after not in {None, ""} and "reset_at" not in context:
+        for key in ("resets_in_seconds", "reset_in_seconds", "retry_after"):
+            retry_after = payload.get(key)
+            if retry_after in {None, ""} or "reset_at" in context:
+                continue
             try:
                 context["reset_at"] = time.time() + float(retry_after)
             except (TypeError, ValueError):
                 pass
+        if "reset_at" not in context:
+            quota_reset_delay = (
+                payload.get("quotaResetDelay")
+                if "quotaResetDelay" in payload
+                else payload.get("quota_reset_delay")
+            )
+            if quota_reset_delay is not None and quota_reset_delay != "":
+                try:
+                    seconds = float(str(quota_reset_delay))
+                    # Codex-style quotaResetDelay values are commonly surfaced
+                    # as millisecond durations.  Keep small values as seconds so
+                    # plain JSON from other providers remains useful.
+                    if seconds > 10_000:
+                        seconds = seconds / 1000.0
+                    context["reset_at"] = time.time() + seconds
+                except (TypeError, ValueError):
+                    pass
 
     response = getattr(error, "response", None)
     headers = getattr(response, "headers", None)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3804,6 +3804,7 @@ def run_conversation(
                         # different exit code. ``rate_limit`` / ``billing`` here
                         # mean "quota wall, not a task error".
                         "failure_reason": classified.reason.value,
+                        "error_context": error_context,
                     }
 
                 # For rate limits, respect the Retry-After header if present

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -143,6 +143,11 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
     r"(rate\s+limit|rate-limited|\b429\b|quota|usage\s+limit)",
     re.IGNORECASE,
 )
+_RATE_LIMIT_RESUME_REASON = "rate_limit_reset"
+_RATE_LIMIT_RESUME_FAILURE_REASONS = frozenset(
+    {"rate_limit", "billing", "upstream_rate_limit"}
+)
+_RATE_LIMIT_RESUME_SAFETY_MARGIN_SECS = 15.0
 
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
@@ -612,6 +617,46 @@ def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
         except ValueError:
             return None
     return None
+
+
+def _rate_limit_resume_epoch_from_agent_result(
+    agent_result: Any,
+    *,
+    now: Optional[float] = None,
+    safety_margin: float = _RATE_LIMIT_RESUME_SAFETY_MARGIN_SECS,
+) -> Optional[float]:
+    """Return the epoch time when a provider-limit failed turn may resume.
+
+    The agent's normal retry loop handles short transient throttles. This path
+    is for quota/usage-limit walls that expose an authoritative reset timestamp
+    and should be durably resumed by the gateway after that time.
+    """
+    if not isinstance(agent_result, dict) or not agent_result.get("failed"):
+        return None
+
+    failure_reason = str(agent_result.get("failure_reason") or "").strip()
+    error_text = str(agent_result.get("error") or "")
+    if (
+        failure_reason not in _RATE_LIMIT_RESUME_FAILURE_REASONS
+        and not _GATEWAY_RATE_LIMIT_RE.search(error_text)
+    ):
+        return None
+
+    error_context = agent_result.get("error_context") or {}
+    if not isinstance(error_context, dict):
+        error_context = {}
+    reset_at = (
+        error_context.get("reset_at")
+        or error_context.get("resets_at")
+        or agent_result.get("reset_at")
+        or agent_result.get("resets_at")
+    )
+    reset_epoch = _coerce_gateway_timestamp(reset_at)
+    if reset_epoch is None:
+        return None
+
+    base_now = time.time() if now is None else float(now)
+    return max(reset_epoch, base_now) + max(float(safety_margin), 0.0)
 
 
 def _auto_continue_freshness_window() -> float:
@@ -1670,6 +1715,7 @@ from gateway.config import (
 from gateway.session import (
     SessionStore,
     SessionSource,
+    SessionEntry,
     SessionContext,
     build_session_context,
     build_session_context_prompt,
@@ -2664,6 +2710,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
+        self._delayed_resume_tasks: Dict[str, asyncio.Task] = {}
+        self._rate_limit_resume_lock = asyncio.Lock()
         self._active_session_leases: Dict[str, Any] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
         # Last successfully-resolved (non-empty) model, keyed by session. Used
@@ -5799,10 +5847,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # Drain-timeout reasons set by _stop_impl() when a still-running turn is
     # force-interrupted; "restart_interrupted" is set by
     # SessionStore.suspend_recently_active() on crash recovery (no
-    # .clean_shutdown marker).  All three mean "the agent was mid-turn and
-    # we killed it" — eligible for startup auto-resume.
+    # .clean_shutdown marker).  Provider-limit resumes are set when the agent
+    # exhausts short retries but exposes an authoritative reset timestamp.
     _AUTO_RESUME_REASONS = frozenset(
-        {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
+        {"restart_timeout", "shutdown_timeout", "restart_interrupted", _RATE_LIMIT_RESUME_REASON}
     )
 
     async def _run_startup_resume_event(
@@ -5833,6 +5881,115 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # otherwise the real run's normal cleanup owns the slot.
             if self._running_agents.get(session_key) is _AGENT_PENDING_SENTINEL:
                 self._release_running_agent_state(session_key)
+
+    def _resume_delay_seconds(self, entry: SessionEntry, *, now: Optional[float] = None) -> float:
+        if getattr(entry, "resume_reason", None) != _RATE_LIMIT_RESUME_REASON:
+            return 0.0
+        resume_epoch = _coerce_gateway_timestamp(getattr(entry, "resume_not_before", None))
+        if resume_epoch is None:
+            return 0.0
+        base_now = time.time() if now is None else float(now)
+        return max(0.0, resume_epoch - base_now)
+
+    def _claim_resume_session_slot(self, session_key: str) -> bool:
+        if session_key in self._running_agents:
+            return False
+        self._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+        self._running_agents_ts[session_key] = time.time()
+        self._persist_active_agents()
+        return True
+
+    def _build_resume_event(self, source: SessionSource) -> MessageEvent:
+        # Empty-text internal event — the _is_resume_pending branch in
+        # _handle_message_with_agent prepends the proper reason-aware system
+        # note before the turn runs.
+        return MessageEvent(
+            text="",
+            message_type=MessageType.TEXT,
+            source=source,
+            internal=True,
+        )
+
+    def _load_due_resume_entry(self, session_key: str) -> Optional[SessionEntry]:
+        try:
+            with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
+                self.session_store._ensure_loaded_locked()  # noqa: SLF001
+                entry = self.session_store._entries.get(session_key)  # noqa: SLF001
+        except Exception as exc:
+            logger.debug("Delayed resume lookup failed for %s: %s", session_key, exc)
+            return None
+        if entry is None or not entry.resume_pending or entry.suspended or entry.origin is None:
+            return None
+        if entry.resume_reason not in self._AUTO_RESUME_REASONS:
+            return None
+        if self._resume_delay_seconds(entry) > 0:
+            return None
+        return entry
+
+    async def _run_due_resume_entry(self, entry: SessionEntry) -> None:
+        session_key = entry.session_key
+        if not self._claim_resume_session_slot(session_key):
+            return
+        origin = entry.origin
+        if origin is None:
+            self._release_running_agent_state(session_key)
+            return
+        adapter = self.adapters.get(origin.platform)
+        if adapter is None:
+            self._release_running_agent_state(session_key)
+            logger.debug(
+                "Skipping delayed auto-resume for %s: adapter not ready for %s",
+                session_key,
+                getattr(origin, "platform", None),
+            )
+            return
+        await self._run_startup_resume_event(
+            adapter,
+            self._build_resume_event(origin),
+            session_key,
+        )
+
+    async def _run_delayed_resume_event(self, session_key: str, delay_seconds: float) -> None:
+        try:
+            if delay_seconds > 0:
+                await asyncio.sleep(delay_seconds)
+            if self._startup_should_abort():
+                return
+            entry = self._load_due_resume_entry(session_key)
+            if entry is None:
+                return
+            if entry.resume_reason == _RATE_LIMIT_RESUME_REASON:
+                # Provider quota resumes often share one account/license.  Hold
+                # a gateway-level drain lock while the resumed turn runs so due
+                # entries execute FIFO instead of stampeding at reset_at.
+                async with self._rate_limit_resume_lock:
+                    locked_entry = self._load_due_resume_entry(session_key)
+                    if locked_entry is None:
+                        return
+                    await self._run_due_resume_entry(locked_entry)
+                return
+            await self._run_due_resume_entry(entry)
+        finally:
+            tasks = getattr(self, "_delayed_resume_tasks", None)
+            if isinstance(tasks, dict) and tasks.get(session_key) is asyncio.current_task():
+                tasks.pop(session_key, None)
+
+    def _schedule_delayed_resume(self, entry: SessionEntry, delay_seconds: float) -> bool:
+        tasks = getattr(self, "_delayed_resume_tasks", None)
+        if tasks is None:
+            tasks = {}
+            self._delayed_resume_tasks = tasks
+        existing = tasks.get(entry.session_key)
+        current = asyncio.current_task()
+        if existing is not None and existing is not current and not existing.done():
+            existing.cancel()
+        task = asyncio.create_task(
+            self._run_delayed_resume_event(entry.session_key, delay_seconds)
+        )
+        tasks[entry.session_key] = task
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return True
 
     def _queue_startup_restore_event(self, event: MessageEvent) -> None:
         queue = getattr(self, "_startup_restore_queue", None)
@@ -5932,19 +6089,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Failed to enumerate resume-pending sessions: %s", exc)
             return 0
 
+        def _resume_order(entry: SessionEntry) -> tuple[float, float, str]:
+            marker_epoch = _coerce_gateway_timestamp(
+                entry.last_resume_marked_at or entry.updated_at or entry.created_at
+            )
+            resume_epoch = _coerce_gateway_timestamp(entry.resume_not_before)
+            return (
+                resume_epoch if resume_epoch is not None else 0.0,
+                marker_epoch if marker_epoch is not None else 0.0,
+                entry.session_key,
+            )
+
+        candidates.sort(key=_resume_order)
+
         now = datetime.now()
         scheduled = 0
         for entry in candidates:
-            marker = entry.last_resume_marked_at or entry.updated_at
-            if marker is not None and (now - marker).total_seconds() > window:
-                continue
-
-            # Already being resumed (e.g. scheduled at startup and still
-            # in-flight) — don't synthesize a second continuation turn.
-            if entry.session_key in self._running_agents:
-                continue
+            is_rate_limit_resume = entry.resume_reason == _RATE_LIMIT_RESUME_REASON
+            delay_seconds = self._resume_delay_seconds(entry)
+            if not is_rate_limit_resume:
+                marker = entry.last_resume_marked_at or entry.updated_at
+                if marker is not None and (now - marker).total_seconds() > window:
+                    continue
 
             source = entry.origin
+            if source is None:
+                continue
             adapter = self.adapters.get(source.platform)
             if adapter is None:
                 logger.debug(
@@ -5954,30 +6124,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 continue
 
-            # Claim the session slot *before* spawning the task so that an
-            # inbound message arriving between task creation and the task's
-            # first await (where _process_message_background sets the real
-            # sentinel) sees the slot as occupied and queues behind it
-            # instead of spinning up a duplicate AIAgent (#45456).
-            self._running_agents[entry.session_key] = _AGENT_PENDING_SENTINEL
-            self._running_agents_ts[entry.session_key] = time.time()
-            self._persist_active_agents()
+            # Provider-limit resumes always go through the delayed-resume
+            # worker, even when already due, so the account-level drain lock
+            # serializes FIFO execution across sessions.
+            if is_rate_limit_resume:
+                if self._schedule_delayed_resume(entry, delay_seconds):
+                    scheduled += 1
+                continue
 
-            # Empty-text internal event — the _is_resume_pending branch in
-            # _handle_message_with_agent prepends the proper reason-aware
-            # system note before the turn runs.
-            event = MessageEvent(
-                text="",
-                message_type=MessageType.TEXT,
-                source=source,
-                internal=True,
-            )
+            # Already being resumed (e.g. scheduled at startup and still
+            # in-flight) — don't synthesize a second continuation turn.
+            if entry.session_key in self._running_agents:
+                continue
+
+            if not self._claim_resume_session_slot(entry.session_key):
+                continue
+
             task = asyncio.create_task(
-                self._run_startup_resume_event(adapter, event, entry.session_key)
+                self._run_startup_resume_event(
+                    adapter,
+                    self._build_resume_event(source),
+                    entry.session_key,
+                )
             )
             self._background_tasks.add(task)
             task.add_done_callback(self._background_tasks.discard)
-            if getattr(self, "_startup_restore_in_progress", False):
+            if getattr(self, "_startup_restore_in_progress", False) and not is_rate_limit_resume:
                 tasks = getattr(self, "_startup_restore_tasks", None)
                 if tasks is None:
                     tasks = []
@@ -5986,10 +6158,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             scheduled += 1
         if scheduled:
             logger.info(
-                "Scheduled auto-resume for %d restart-interrupted session(s)",
+                "Scheduled auto-resume for %d pending session(s)",
                 scheduled,
             )
         return scheduled
+
+    def _format_rate_limit_resume_notice(self, resume_epoch: float) -> str:
+        resume_dt = datetime.fromtimestamp(resume_epoch)
+        reset_text = resume_dt.strftime("%Y-%m-%d %H:%M:%S")
+        wait_seconds = max(0, int(resume_epoch - time.time()))
+        if wait_seconds >= 3600:
+            wait_text = f"~{max(1, round(wait_seconds / 3600))}h"
+        elif wait_seconds >= 60:
+            wait_text = f"~{max(1, round(wait_seconds / 60))}m"
+        else:
+            wait_text = f"{wait_seconds}s"
+        return (
+            "⏱️ The model provider is rate-limiting requests. "
+            f"I'll automatically retry this session after the reset window "
+            f"({reset_text}, in {wait_text})."
+        )
+
+    def _maybe_schedule_provider_limit_resume(
+        self,
+        agent_result: Dict[str, Any],
+        *,
+        session_key: Optional[str],
+        source: SessionSource,
+    ) -> Optional[str]:
+        if not session_key:
+            return None
+        resume_epoch = _rate_limit_resume_epoch_from_agent_result(agent_result)
+        if resume_epoch is None:
+            return None
+        resume_not_before = datetime.fromtimestamp(resume_epoch)
+        try:
+            marked = self.session_store.mark_resume_pending(
+                session_key,
+                reason=_RATE_LIMIT_RESUME_REASON,
+                resume_not_before=resume_not_before,
+            )
+        except Exception as exc:
+            logger.debug("mark rate-limit resume pending failed for %s: %s", session_key, exc)
+            return None
+        if not marked:
+            return None
+        try:
+            self._schedule_resume_pending_sessions(platform=source.platform)
+        except Exception as exc:
+            logger.debug("schedule rate-limit resume failed for %s: %s", session_key, exc)
+        logger.info(
+            "Scheduled provider-limit auto-resume for %s at %s",
+            session_key,
+            resume_not_before.isoformat(),
+        )
+        return self._format_rate_limit_resume_notice(resume_epoch)
 
     def _startup_should_abort(self) -> bool:
         return (
@@ -10609,6 +10832,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     agent_result, response,
                 )
             except Exception:
+                _intentional_silence = False
+
+            _rate_limit_resume_notice = self._maybe_schedule_provider_limit_resume(
+                agent_result,
+                session_key=session_key,
+                source=source,
+            )
+            if _rate_limit_resume_notice:
+                response = _rate_limit_resume_notice
                 _intentional_silence = False
 
             # Convert the agent's internal "(empty)" sentinel into a
@@ -17065,10 +17297,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _resume_entry = self.session_store._entries.get(session_key)
                 except Exception:
                     _resume_entry = None
+            _resume_reason = (
+                getattr(_resume_entry, "resume_reason", None)
+                if _resume_entry is not None
+                else None
+            )
+            _is_rate_limit_resume = _resume_reason == _RATE_LIMIT_RESUME_REASON
+            _rate_limit_resume_due = (
+                not _is_rate_limit_resume
+                or (_resume_entry is not None and self._resume_delay_seconds(_resume_entry) <= 0)
+            )
             _is_resume_pending = bool(
                 _resume_entry is not None
                 and getattr(_resume_entry, "resume_pending", False)
-                and _interruption_is_fresh
+                and (_interruption_is_fresh or _is_rate_limit_resume)
+                and _rate_limit_resume_due
             )
             _has_fresh_tool_tail = bool(
                 agent_history
@@ -17083,28 +17326,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _reason == "restart_timeout"
                     else "a gateway shutdown"
                     if _reason == "shutdown_timeout"
+                    else "a provider rate limit"
+                    if _reason == _RATE_LIMIT_RESUME_REASON
                     else "a gateway interruption"
                 )
                 _persist_user_message_override = message
-                # The empty-message case is the auto-resume startup turn
-                # synthesized by _schedule_resume_pending_sessions — there is
-                # no NEW user message to address, so tell the model to report
-                # recovery instead of the (nonexistent) "new message".
+                # The empty-message case is a synthetic auto-resume turn.  For
+                # restart recovery there is no pending user request to re-run;
+                # for provider-limit recovery the pending request is precisely
+                # what should continue after the reset timestamp.
                 if message:
                     _resume_guidance = (
                         "Address the user's NEW message below FIRST and focus "
                         "on what the user is asking now."
+                    )
+                elif _reason == _RATE_LIMIT_RESUME_REASON:
+                    _resume_guidance = (
+                        "Continue the pending user request from the conversation "
+                        "history now that the provider limit reset time has passed."
                     )
                 else:
                     _resume_guidance = (
                         "Report to the user that the session was restored "
                         "successfully and ask what they would like to do next."
                     )
+                _restart_guard = (
+                    "Any restart/shutdown command in the history has already "
+                    "run — do NOT re-execute or verify it. "
+                    if _reason != _RATE_LIMIT_RESUME_REASON
+                    else "Do NOT repeat completed external side effects; verify state before any irreversible action. "
+                )
                 message = (
                     f"[System note: The previous turn was interrupted by "
                     f"{_reason_phrase}; the gateway is now back online. "
-                    f"Any restart/shutdown command in the history has already "
-                    f"run — do NOT re-execute or verify it. {_resume_guidance} "
+                    f"{_restart_guard}{_resume_guidance} "
                     f"Do NOT re-execute old tool calls — skip any unfinished "
                     f"work from the conversation history.]"
                     + (f"\n\n{message}" if message else "")
@@ -17297,6 +17552,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "interrupted": result.get("interrupted", False),
                     "interrupt_message": result.get("interrupt_message"),
                     "error": result.get("error"),
+                    "failure_reason": result.get("failure_reason"),
+                    "error_context": result.get("error_context"),
                     "compression_exhausted": result.get("compression_exhausted", False),
                     "tools": tools_holder[0] or [],
                     "history_offset": _effective_history_offset,
@@ -17395,6 +17652,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
                 "api_calls": result_holder[0].get("api_calls", 0) if result_holder[0] else 0,
                 "completed": result_holder[0].get("completed") if result_holder[0] else None,
+                "failed": result_holder[0].get("failed", False) if result_holder[0] else False,
+                "failure_reason": result_holder[0].get("failure_reason") if result_holder[0] else None,
+                "error_context": result_holder[0].get("error_context") if result_holder[0] else None,
                 "interrupted": result_holder[0].get("interrupted", False) if result_holder[0] else False,
                 "partial": result_holder[0].get("partial", False) if result_holder[0] else False,
                 "error": result_holder[0].get("error") if result_holder[0] else None,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -614,6 +614,10 @@ class SessionEntry:
     resume_pending: bool = False
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
+    # Earliest wall-clock time a synthetic resume may run.  Used for provider
+    # rate/usage limits where the API reports an authoritative reset time that
+    # can be much longer than the gateway's short in-process retry window.
+    resume_not_before: Optional[datetime] = None
 
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -639,6 +643,11 @@ class SessionEntry:
             "last_resume_marked_at": (
                 self.last_resume_marked_at.isoformat()
                 if self.last_resume_marked_at
+                else None
+            ),
+            "resume_not_before": (
+                self.resume_not_before.isoformat()
+                if self.resume_not_before
                 else None
             ),
             "is_fresh_reset": self.is_fresh_reset,
@@ -670,6 +679,14 @@ class SessionEntry:
                 last_resume_marked_at = datetime.fromisoformat(_lrma)
             except (TypeError, ValueError):
                 last_resume_marked_at = None
+
+        resume_not_before = None
+        _rnb = data.get("resume_not_before")
+        if _rnb:
+            try:
+                resume_not_before = datetime.fromisoformat(_rnb)
+            except (TypeError, ValueError):
+                resume_not_before = None
 
         session_key = data["session_key"]
         session_id = data["session_id"]
@@ -703,6 +720,7 @@ class SessionEntry:
             resume_pending=data.get("resume_pending", False),
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
+            resume_not_before=resume_not_before,
             is_fresh_reset=data.get("is_fresh_reset", False),
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
@@ -1451,6 +1469,7 @@ class SessionStore:
         self,
         session_key: str,
         reason: str = "restart_timeout",
+        resume_not_before: Optional[datetime] = None,
     ) -> bool:
         """Mark a session as resumable after a restart interruption.
 
@@ -1472,6 +1491,7 @@ class SessionStore:
                 entry.resume_pending = True
                 entry.resume_reason = reason
                 entry.last_resume_marked_at = _now()
+                entry.resume_not_before = resume_not_before
                 self._save()
                 return True
         return False
@@ -1493,6 +1513,7 @@ class SessionStore:
             entry.resume_pending = False
             entry.resume_reason = None
             entry.last_resume_marked_at = None
+            entry.resume_not_before = None
             self._save()
             return True
 

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -60,6 +60,8 @@ def make_restart_runner(
     runner._exit_code = None
     runner._running_agents = {}
     runner._running_agents_ts = {}
+    runner._delayed_resume_tasks = {}
+    runner._rate_limit_resume_lock = asyncio.Lock()
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._pending_model_notes = {}

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -40,6 +40,7 @@ from gateway.run import (
     _coerce_gateway_timestamp,
     _is_fresh_gateway_interruption,
     _last_transcript_timestamp,
+    _rate_limit_resume_epoch_from_agent_result,
     _should_clear_resume_pending_after_turn,
 )
 from gateway.session import SessionEntry, SessionSource, SessionStore
@@ -133,10 +134,23 @@ def _simulate_note_injection(
     )
 
     message = user_message
+    reason = getattr(resume_entry, "resume_reason", None) if resume_entry is not None else None
+    is_rate_limit_resume = reason == "rate_limit_reset"
+    resume_not_before = (
+        _coerce_gateway_timestamp(getattr(resume_entry, "resume_not_before", None))
+        if resume_entry is not None
+        else None
+    )
+    rate_limit_resume_due = (
+        not is_rate_limit_resume
+        or resume_not_before is None
+        or resume_not_before <= time.time()
+    )
     is_resume_pending = bool(
         resume_entry is not None
         and getattr(resume_entry, "resume_pending", False)
-        and interruption_is_fresh
+        and (interruption_is_fresh or is_rate_limit_resume)
+        and rate_limit_resume_due
     )
     has_fresh_tool_tail = bool(
         agent_history
@@ -151,6 +165,8 @@ def _simulate_note_injection(
             if reason == "restart_timeout"
             else "a gateway shutdown"
             if reason == "shutdown_timeout"
+            else "a provider rate limit"
+            if reason == "rate_limit_reset"
             else "a gateway interruption"
         )
         if message:
@@ -158,16 +174,26 @@ def _simulate_note_injection(
                 "Address the user's NEW message below FIRST and focus "
                 "on what the user is asking now."
             )
+        elif reason == "rate_limit_reset":
+            resume_guidance = (
+                "Continue the pending user request from the conversation "
+                "history now that the provider limit reset time has passed."
+            )
         else:
             resume_guidance = (
                 "Report to the user that the session was restored "
                 "successfully and ask what they would like to do next."
             )
+        restart_guard = (
+            "Any restart/shutdown command in the history has already "
+            "run — do NOT re-execute or verify it. "
+            if reason != "rate_limit_reset"
+            else "Do NOT repeat completed external side effects; verify state before any irreversible action. "
+        )
         message = (
             f"[System note: The previous turn was interrupted by "
             f"{reason_phrase}; the gateway is now back online. "
-            f"Any restart/shutdown command in the history has already "
-            f"run — do NOT re-execute or verify it. {resume_guidance} "
+            f"{restart_guard}{resume_guidance} "
             f"Do NOT re-execute old tool calls — skip any unfinished "
             f"work from the conversation history.]"
             + (f"\n\n{message}" if message else "")
@@ -200,9 +226,11 @@ class TestSessionEntryResumeFields:
         assert entry.resume_pending is False
         assert entry.resume_reason is None
         assert entry.last_resume_marked_at is None
+        assert entry.resume_not_before is None
 
     def test_roundtrip_with_resume_fields(self):
         now = datetime(2026, 4, 18, 12, 0, 0)
+        resume_not_before = now + timedelta(hours=6)
         entry = SessionEntry(
             session_key="agent:main:telegram:dm:1",
             session_id="sid",
@@ -211,11 +239,13 @@ class TestSessionEntryResumeFields:
             resume_pending=True,
             resume_reason="restart_timeout",
             last_resume_marked_at=now,
+            resume_not_before=resume_not_before,
         )
         restored = SessionEntry.from_dict(entry.to_dict())
         assert restored.resume_pending is True
         assert restored.resume_reason == "restart_timeout"
         assert restored.last_resume_marked_at == now
+        assert restored.resume_not_before == resume_not_before
 
     def test_from_dict_legacy_without_resume_fields(self):
         """Old sessions.json without the new fields deserialize cleanly."""
@@ -231,6 +261,7 @@ class TestSessionEntryResumeFields:
         assert restored.resume_pending is False
         assert restored.resume_reason is None
         assert restored.last_resume_marked_at is None
+        assert restored.resume_not_before is None
 
     def test_malformed_timestamp_is_tolerated(self):
         now = datetime.now()
@@ -242,12 +273,14 @@ class TestSessionEntryResumeFields:
             "resume_pending": True,
             "resume_reason": "restart_timeout",
             "last_resume_marked_at": "not-a-timestamp",
+            "resume_not_before": "also-not-a-timestamp",
         }
         restored = SessionEntry.from_dict(data)
-        # resume_pending still honoured, only the broken timestamp drops
+        # resume_pending still honoured, only the broken timestamps drop
         assert restored.resume_pending is True
         assert restored.resume_reason == "restart_timeout"
         assert restored.last_resume_marked_at is None
+        assert restored.resume_not_before is None
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +299,7 @@ class TestMarkResumePending:
         assert refreshed.resume_pending is True
         assert refreshed.resume_reason == "restart_timeout"
         assert refreshed.last_resume_marked_at is not None
+        assert refreshed.resume_not_before is None
 
     def test_custom_reason_persists(self, tmp_path):
         store = _make_store(tmp_path)
@@ -274,6 +308,23 @@ class TestMarkResumePending:
 
         store.mark_resume_pending(entry.session_key, reason="shutdown_timeout")
         assert store._entries[entry.session_key].resume_reason == "shutdown_timeout"
+
+    def test_resume_not_before_persists(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        resume_not_before = datetime.now() + timedelta(hours=6)
+
+        store.mark_resume_pending(
+            entry.session_key,
+            reason="rate_limit_reset",
+            resume_not_before=resume_not_before,
+        )
+
+        refreshed = store._entries[entry.session_key]
+        assert refreshed.resume_pending is True
+        assert refreshed.resume_reason == "rate_limit_reset"
+        assert refreshed.resume_not_before == resume_not_before
 
     def test_returns_false_for_unknown_key(self, tmp_path):
         store = _make_store(tmp_path)
@@ -317,6 +368,7 @@ class TestClearResumePending:
         assert e.resume_pending is False
         assert e.resume_reason is None
         assert e.last_resume_marked_at is None
+        assert e.resume_not_before is None
 
     def test_returns_false_when_not_pending(self, tmp_path):
         store = _make_store(tmp_path)
@@ -705,6 +757,43 @@ class TestResumePendingSystemNote:
         # Nothing appended after the closing bracket (no empty user text).
         assert result.rstrip().endswith("]")
 
+    def test_rate_limit_empty_message_continues_pending_request_after_stale_delay(self):
+        """Provider-limit delayed resumes may be hours old, so they bypass the
+        restart freshness window and tell the model to continue the pending user
+        request rather than merely report restart recovery.
+        """
+        entry = self._pending_entry(reason="rate_limit_reset")
+        entry.last_resume_marked_at = datetime.now() - timedelta(hours=6)
+        entry.resume_not_before = datetime.now() - timedelta(seconds=1)
+
+        result = _simulate_note_injection(
+            history=[
+                {"role": "user", "content": "finish the PR", "timestamp": time.time() - 6 * 3600},
+            ],
+            user_message="",
+            resume_entry=entry,
+            window_secs=1800,
+        )
+
+        assert "provider rate limit" in result
+        assert "Continue the pending user request" in result
+        assert "Do NOT repeat completed external side effects" in result
+        assert "ask what they would like to do next" not in result
+
+    def test_rate_limit_resume_not_before_blocks_early_note(self):
+        entry = self._pending_entry(reason="rate_limit_reset")
+        entry.resume_not_before = datetime.now() + timedelta(hours=1)
+
+        result = _simulate_note_injection(
+            history=[
+                {"role": "user", "content": "finish the PR", "timestamp": time.time()},
+            ],
+            user_message="",
+            resume_entry=entry,
+        )
+
+        assert result == ""
+
 
 # ---------------------------------------------------------------------------
 # Freshness helpers
@@ -812,6 +901,62 @@ class TestFreshnessHelpers:
     def test_auto_continue_freshness_window_empty_falls_back(self, monkeypatch):
         monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "")
         assert _auto_continue_freshness_window() == 3600.0
+
+
+class TestRateLimitResumeEpoch:
+    def test_uses_rate_limit_reset_at_with_fixed_safety_margin(self):
+        reset_at = datetime(2026, 4, 18, 12, 0, 0).timestamp()
+        result = _rate_limit_resume_epoch_from_agent_result(
+            {
+                "failed": True,
+                "failure_reason": "rate_limit",
+                "error_context": {"reset_at": reset_at},
+            },
+            now=reset_at - 60,
+        )
+
+        assert result == reset_at + 15.0
+
+    def test_parses_iso_reset_at(self):
+        expected = datetime.fromisoformat("2026-04-18T12:00:00+00:00").timestamp()
+        result = _rate_limit_resume_epoch_from_agent_result(
+            {
+                "failed": True,
+                "failure_reason": "upstream_rate_limit",
+                "error_context": {"reset_at": "2026-04-18T12:00:00Z"},
+            },
+            now=expected - 60,
+        )
+
+        assert result == expected + 15.0
+
+    def test_past_reset_at_clamps_to_now_plus_safety(self):
+        result = _rate_limit_resume_epoch_from_agent_result(
+            {
+                "failed": True,
+                "failure_reason": "billing",
+                "error_context": {"reset_at": 900.0},
+            },
+            now=1_000.0,
+        )
+
+        assert result == 1_015.0
+
+    def test_ignores_non_rate_limit_failures(self):
+        assert _rate_limit_resume_epoch_from_agent_result(
+            {
+                "failed": True,
+                "failure_reason": "context_length",
+                "error_context": {"reset_at": 2_000.0},
+            },
+            now=1_000.0,
+        ) is None
+
+    def test_ignores_rate_limit_without_reset_time(self):
+        assert _rate_limit_resume_epoch_from_agent_result(
+            {"failed": True, "failure_reason": "rate_limit", "error_context": {}},
+            now=1_000.0,
+        ) is None
 
 
 # ---------------------------------------------------------------------------
@@ -1018,6 +1163,141 @@ async def test_startup_auto_resume_skips_stale_entries():
 
     assert scheduled == 0
     adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_auto_resume_waits_until_resume_not_before_without_claiming():
+    """Future provider-limit resumes are durable timers, not active sessions.
+
+    The gateway must not occupy the session's running-agent slot for hours while
+    waiting for a Codex/Claude-Code quota reset.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="rate-limit-chat")
+    future = datetime.now() + timedelta(hours=6)
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:rate-limit-chat",
+        session_id="sid",
+        created_at=datetime.now() - timedelta(hours=1),
+        updated_at=datetime.now() - timedelta(hours=1),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="rate_limit_reset",
+        last_resume_marked_at=datetime.now(),
+        resume_not_before=future,
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner._delayed_resume_tasks = {}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    assert pending_entry.session_key not in runner._running_agents
+    adapter.handle_message.assert_not_called()
+    task = runner._delayed_resume_tasks.pop(pending_entry.session_key)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_auto_resume_due_entry_ignores_restart_freshness_window():
+    """Quota resets can be hours later; once due, they should resume even if
+    the normal restart-interruption freshness gate would treat them as stale.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="rate-limit-due-chat")
+    stale_marker = datetime.now() - timedelta(hours=6)
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:rate-limit-due-chat",
+        session_id="sid",
+        created_at=stale_marker,
+        updated_at=stale_marker,
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="rate_limit_reset",
+        last_resume_marked_at=stale_marker,
+        resume_not_before=datetime.now() - timedelta(seconds=1),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+    assert pending_entry.session_key not in runner._delayed_resume_tasks
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_auto_resume_serializes_due_entries_fifo():
+    """Due provider-limit resumes are drained one at a time in reset order."""
+    runner, _adapter = make_restart_runner()
+    now = datetime.now()
+    first_source = make_restart_source(chat_id="rate-limit-fifo-1")
+    second_source = make_restart_source(chat_id="rate-limit-fifo-2")
+    first = SessionEntry(
+        session_key="agent:main:telegram:dm:rate-limit-fifo-1",
+        session_id="sid-1",
+        created_at=now,
+        updated_at=now,
+        origin=first_source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="rate_limit_reset",
+        last_resume_marked_at=now,
+        resume_not_before=now - timedelta(seconds=10),
+    )
+    second = SessionEntry(
+        session_key="agent:main:telegram:dm:rate-limit-fifo-2",
+        session_id="sid-2",
+        created_at=now,
+        updated_at=now,
+        origin=second_source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="rate_limit_reset",
+        last_resume_marked_at=now,
+        resume_not_before=now - timedelta(seconds=5),
+    )
+    # Insert in reverse order to prove scheduler sorting, not dict order.
+    runner.session_store._entries = {
+        second.session_key: second,
+        first.session_key: first,
+    }
+
+    active = 0
+    max_active = 0
+    order: list[str] = []
+
+    async def fake_run_startup_resume_event(_adapter, _event, session_key):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        order.append(session_key)
+        await asyncio.sleep(0.01)
+        runner._release_running_agent_state(session_key)
+        active -= 1
+
+    setattr(runner, "_run_startup_resume_event", fake_run_startup_resume_event)
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    tasks = list(runner._delayed_resume_tasks.values())
+    await asyncio.gather(*tasks)
+
+    assert scheduled == 2
+    assert max_active == 1
+    assert order == [first.session_key, second.session_key]
+    assert runner._delayed_resume_tasks == {}
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5637,6 +5637,47 @@ class TestCredentialPoolRecovery:
         assert context["reason"] == "GoUsageLimitError"
         assert context["reset_at"] == 1_000.0 + (6 * 60 * 60) + (29 * 60)
 
+    def test_extract_api_error_context_uses_resets_in_seconds_payload(self, agent, monkeypatch):
+        from agent import agent_runtime_helpers
+
+        monkeypatch.setattr(agent_runtime_helpers.time, "time", lambda: 1_000.0)
+        error = SimpleNamespace(
+            body={
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "Plan usage limit reached.",
+                    "resets_in_seconds": 7_200,
+                }
+            },
+            response=SimpleNamespace(headers={}),
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reason"] == "usage_limit_reached"
+        assert context["reset_at"] == 8_200.0
+
+    def test_extract_api_error_context_uses_quota_reset_delay_payload(self, agent, monkeypatch):
+        from agent import agent_runtime_helpers
+
+        monkeypatch.setattr(agent_runtime_helpers.time, "time", lambda: 1_000.0)
+        error = SimpleNamespace(
+            body={
+                "error": {
+                    "code": "quota_exceeded",
+                    "message": "Quota reset delay provided in payload.",
+                    "quotaResetDelay": 90_000,
+                }
+            },
+            response=SimpleNamespace(headers={}),
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reason"] == "quota_exceeded"
+        # Large bare quotaResetDelay values are treated as milliseconds.
+        assert context["reset_at"] == 1_090.0
+
     def test_recover_with_pool_passes_error_context_on_rotated_429(self, agent):
         next_entry = SimpleNamespace(label="secondary")
         captured = {}


### PR DESCRIPTION
## Summary
- parse provider reset metadata from error payloads, including `resets_in_seconds` and `quotaResetDelay`, into normalized `reset_at` context
- persist provider-limit failed sessions as `resume_pending` with `resume_not_before = reset_at + 15s` instead of only returning the short retry exhausted message
- schedule gateway auto-resume after the reset window and serialize due provider-limit resumes through a gateway-level FIFO drain lock

## Tests
- `/Users/akitani/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_restart_resume_pending.py -q -o addopts=`
- `/Users/akitani/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery -q -o addopts=`
- `uv run --extra dev ruff check agent/agent_runtime_helpers.py agent/conversation_loop.py gateway/run.py gateway/session.py tests/gateway/restart_test_helpers.py tests/gateway/test_restart_resume_pending.py tests/run_agent/test_run_agent.py`
- `/Users/akitani/.hermes/hermes-agent/venv/bin/python -m py_compile agent/agent_runtime_helpers.py agent/conversation_loop.py gateway/run.py gateway/session.py tests/gateway/test_restart_resume_pending.py tests/gateway/restart_test_helpers.py tests/run_agent/test_run_agent.py`
- `git diff --check`
- `/Users/akitani/.hermes/hermes-agent/venv/bin/python scripts/check-windows-footguns.py agent/agent_runtime_helpers.py agent/conversation_loop.py gateway/run.py gateway/session.py tests/gateway/test_restart_resume_pending.py tests/gateway/restart_test_helpers.py tests/run_agent/test_run_agent.py`
- `uvx code-review-graph detect-changes --base origin/main --brief`

## Notes
- `uv run --extra dev ty check ...` was also tried, but the repository currently reports broad pre-existing diagnostics unrelated to this change (for example existing optional-parameter annotations and test mock attribute assignments).
