### PR TITLE
fix(tools): surface silent agent.disabled_toolsets override hiding tools (e.g. terminal in Telegram DMs)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1055,6 +1055,18 @@ def init_agent(
     elif not agent.quiet_mode:
         print("🛠️  No tools loaded (all tools filtered out or unavailable)")
 
+    # Always logged (even in quiet_mode, unlike the prints above) so the
+    # requested vs. actually-resolved tool set can be correlated from logs
+    # alone — quiet_mode is the normal mode for gateway-driven sessions
+    # (Telegram, Discord, etc.), where the prints above never fire.
+    logger.info(
+        "Resolved %d tool(s) for session (enabled_toolsets=%s, disabled_toolsets=%s): %s",
+        len(agent.tools) if agent.tools else 0,
+        sorted(enabled_toolsets) if enabled_toolsets else None,
+        sorted(disabled_toolsets) if disabled_toolsets else None,
+        sorted(agent.valid_tool_names) if agent.valid_tool_names else [],
+    )
+
     # Kanban worker/orchestrator lifecycle guidance is session-static:
     # the dispatcher decides at spawn time whether this process is a kanban
     # worker (kanban_show tool is present iff HERMES_KANBAN_TASK is set).

--- a/docs/rca-telegram-dm-terminal-tool-refusal.md
+++ b/docs/rca-telegram-dm-terminal-tool-refusal.md
@@ -1,0 +1,329 @@
+# RCA — Hermes recusa usar `terminal` em DMs do Telegram mesmo com `platform_toolsets.telegram` incluindo `terminal`
+
+Status: **investigação concluída — sem fix aplicado** (por escopo).
+Branch: `investigation/telegram-dm-terminal-tool-refusal`.
+
+## 1. Resumo executivo
+
+A exposição de tools para uma sessão de gateway (Telegram incluso) é recalculada do zero, a cada
+construção/reuso de `AIAgent`, a partir de **duas fontes de config estáticas**: `platform_toolsets.<plataforma>`
+e uma lista **global** `agent.disabled_toolsets`. Essa segunda lista é aplicada como uma subtração
+incondicional e final, **mesmo quando o toolset já foi habilitado explicitamente pela plataforma**
+(`model_tools.py:395-399`, citando o issue #17309 no próprio comentário do código). Se `"terminal"`
+estiver presente em `agent.disabled_toolsets` — por qualquer caminho, incluindo o fluxo oficial de
+"Blank Slate" documentado em `hermes_cli/cli_agent_setup_mixin.py:3021-3032` — o Telegram (e qualquer
+outra plataforma) perde `terminal` permanentemente, sem nenhum log que diferencie "excluído pela
+config da plataforma" de "excluído pelo override global". Como isso é recalculado puramente a partir
+do `config.yaml` a cada turno (a tabela `sessions` do SQLite não tem NENHUMA coluna de tools/toolset —
+verificado em `hermes_state.py:640-683`), o comportamento é 100% determinístico e reaparece
+identicamente em sessões novas. Os logs de `FOREIGN KEY constraint failed`, `Persisted transcript
+lagged` e `rebuilding from scratch` são sintomas de um problema de durabilidade de sessão **não
+relacionado** (mesma classe do bug já corrigido em `investigation/telegram-gateway-self-restart-freeze`
+/ PR #56036) — coincidentes no tempo, não causais.
+
+## 2. Fluxo de criação/rebuild de sessão Telegram (ASCII diagram)
+
+```
+Mensagem Telegram (DM) chega no gateway
+        │
+        ▼
+gateway/run.py: handler de mensagem (~L15479 / ~L16400+)
+        │
+        ├─ user_config = _load_gateway_config()                (yaml cacheado por mtime_ns+size)
+        ├─ platform_key = _platform_config_key(source.platform)  → "telegram" (sempre; sem variante DM)
+        │
+        ├─ enabled_toolsets = sorted(_get_platform_tools(user_config, "telegram"))
+        │        │
+        │        ├─ lê platform_toolsets.telegram (explícito) OU default_toolset "hermes-telegram"
+        │        ├─ resolve nomes → conjunto de toolset-keys configuráveis (inclui "terminal" se listado)
+        │        └─ NÃO aplica nenhuma restrição de plataforma a "terminal"
+        │                (_TOOLSET_PLATFORM_RESTRICTIONS só tem discord/discord_admin)
+        │
+        ├─ disabled_toolsets = user_config["agent"]["disabled_toolsets"]   ← GLOBAL, não por plataforma
+        │
+        ├─ _sig = _agent_config_signature(model, runtime, enabled_toolsets, ...)
+        │
+        ├─ cache hit? ──sim──► reusa AIAgent cacheado (agent.tools já fixado na 1ª construção)
+        │        │
+        │        não
+        │        ▼
+        └─ AIAgent(... enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets ...)
+                 │
+                 ▼
+        agent_init.py:1037  agent.tools = get_tool_definitions(enabled_toolsets, disabled_toolsets)
+                 │
+                 ▼
+        model_tools.py:_compute_tool_definitions
+                 ├─ tools_to_include = resolve(enabled_toolsets)        → inclui "terminal"
+                 └─ SEMPRE (independente de enabled_toolsets):          ← ***PONTO DA PERDA***
+                      tools_to_include -= resolve(disabled_toolsets)    → remove "terminal" se lá estiver
+                 │
+                 ▼
+        agent.tools (schema enviado à API)  ──►  NÃO contém "terminal"
+                 │
+                 ▼
+        agent/system_prompt.py: guidance de tool é condicional a
+        "terminal" ∈ agent.valid_tool_names → nenhuma menção é injetada
+                 │
+                 ▼
+        Modelo nunca vê function "terminal" no `tools=[...]` da chamada de API
+                 │
+                 ▼
+        Modelo responde em texto puro: "I can't access a terminal tool..."
+        (tool_turns=0 — nenhuma tool_call foi de fato tentada)
+```
+
+Em paralelo, e **sem interseção com o caminho acima**, existe o mecanismo de sessão/DB:
+
+```
+agent/conversation_loop.py: restore_or_build_system_prompt()
+        │
+        ├─ lê sessions.system_prompt (coluna TEXT, hermes_state.py:650)
+        ├─ NULL/empty/stale → loga "Stored system prompt ... rebuilding from scratch"
+        └─ SÓ reconstrói o TEXTO do system prompt (cache de prefixo de custo),
+           nunca toca em agent.tools / enabled_toolsets
+
+gateway/run.py (~L16846-16864): compara message_count persistido vs. cache em memória
+        └─ diverge → "Persisted transcript lagged live cached history" (guarda de corrupção de FTS,
+           preserva o histórico em memória — também não toca em tools)
+
+hermes_state.py: messages.session_id REFERENCES sessions(id)
+        └─ append_message em session_id inexistente/evictado → "FOREIGN KEY constraint failed"
+           (schema de sessions/messages não tem NENHUMA coluna de tools/toolset)
+```
+
+## 3. Ponto exato onde a tool `terminal` é perdida
+
+`model_tools.py:395-399`, dentro de `_compute_tool_definitions`:
+
+```python
+# Always apply disabled toolsets as a subtraction step at the end.
+# This ensures that even if a composite toolset (like hermes-cli)
+# is enabled, any tools belonging to a disabled toolset are strictly
+# stripped out. See issue #17309.
+if disabled_toolsets:
+    for toolset_name in disabled_toolsets:
+        ...
+        tools_to_include.difference_update(resolved)
+```
+
+Isso contradiz a docstring pública da função vizinha `get_tool_definitions` (linha 292):
+
+```python
+disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
+```
+
+Ou seja: a **documentação da API interna diz** que `disabled_toolsets` só importa quando
+`enabled_toolsets` é `None`; o **código real** aplica `disabled_toolsets` incondicionalmente, sempre,
+por cima de qualquer `enabled_toolsets` — inclusive um `enabled_toolsets` que veio de
+`platform_toolsets.telegram` explicitamente contendo `"terminal"`.
+
+## 4. Causa raiz (mecanismo, não sintoma)
+
+**A resolução de tools do gateway trata `agent.disabled_toolsets` (lista global, seção `agent:` do
+`config.yaml`, não escopada por plataforma) como um veto absoluto e silencioso sobre
+`platform_toolsets.<plataforma>`.** Isso é uma decisão de design explícita e documentada — não é um
+bug de digitação isolado:
+
+- `model_tools.py:395-399` implementa a subtração incondicional, citando o próprio issue #17309 como
+  justificativa ("mesmo se um toolset composto está habilitado, tools de um toolset desabilitado devem
+  ser removidas").
+- `hermes_cli/cli_agent_setup_mixin.py:3025-3031` documenta o mesmo comportamento do ponto de vista do
+  operador: *"`agent.disabled_toolsets` — a global hard-suppression list (applied last in
+  `_get_platform_tools`, overriding every other path ...)"* e instrui que o único jeito de reverter é
+  "editing `agent.disabled_toolsets`" diretamente — **não** basta ajustar `platform_toolsets` pela
+  plataforma.
+- `hermes_cli/setup.py` (fluxo de "Blank Slate") é um caminho **real e já existente no produto** que
+  escreve em `agent.disabled_toolsets` a partir de uma ação com escopo aparente de uma única
+  plataforma (`platform_toolsets["cli"]`), mas cujo efeito colateral (a lista de disabled) é
+  **global** e alcança todas as demais plataformas, Telegram incluído.
+
+Se `"terminal"` está nessa lista global — por edição manual, por um "Blank Slate" anterior (rodado
+para `cli` ou qualquer outro contexto onde o operador não quis manter terminal), ou por qualquer
+outro escritor de `agent.disabled_toolsets` — toda sessão de toda plataforma perde `terminal` de forma
+permanente e silenciosa, **independente do que `platform_toolsets.telegram` diga**. Como o cálculo é
+100% função do `config.yaml` atual (sem nenhum estado de sessão no meio), o resultado é determinístico:
+mesma entrada → mesma saída, sempre.
+
+**Confirma-se que isso não é um efeito de estado de sessão “presa”**: a tabela `sessions` (
+`hermes_state.py:640-683`) e a tabela `messages` (`hermes_state.py:685-705`) não têm nenhuma coluna
+relacionada a tools/toolsets — `agent.tools` nunca é persistido, é recalculado do zero em toda
+construção de `AIAgent` (`agent_init.py:1037`), a partir do config vigente naquele instante.
+
+## 5. Por que persiste mesmo em sessão fresh (não é só cache antigo)
+
+Uma sessão "fresh" limpa apenas o histórico de mensagens/transcript e o `system_prompt` persistido —
+nunca toca em `agent.disabled_toolsets` nem em `platform_toolsets`, que vivem em `config.yaml`,
+completamente fora do ciclo de vida da sessão. A cada construção de `AIAgent` (cache hit ou miss —
+`enabled_toolsets`/`disabled_toolsets` fazem parte da assinatura de cache em
+`gateway/run.py:_agent_config_signature`, então uma mudança neles já invalidaria o cache
+corretamente), o mesmo `agent.disabled_toolsets` global é lido do mesmo arquivo e produz o mesmo
+resultado. Isso descarta por completo as classes de hipótese "cache de sessão corrompido" e "rebuild
+usa fallback obsoleto" — o comportamento nem depende de rebuild nenhum: a subtração de `disabled_toolsets`
+roda de forma idêntica tanto no caminho de "sessão nova" quanto no de "sessão recuperada".
+
+## 6. Conexão com FK / transcript lag / rebuilding from scratch: causa ou sintoma colateral?
+
+**São sintomas de uma causa completamente diferente — não têm relação causal com a perda de `terminal`.**
+Evidências estruturais:
+
+- `restore_or_build_system_prompt` (`agent/conversation_loop.py:~250-336`) só lê/escreve a coluna
+  `sessions.system_prompt` (uma string). O rebuild que ela dispara (`agent._cached_system_prompt =
+  agent._build_system_prompt(...)`) reconstrói apenas o **texto** do system prompt para fins de
+  cache de prefixo de custo (ver comentário longo em `agent/turn_context.py:146-152` sobre o
+  issue #45499). Em nenhum ponto esse caminho toca `agent.tools`, `enabled_toolsets` ou
+  `disabled_toolsets` — esses já foram fixados antes, na construção do `AIAgent`.
+- `"FOREIGN KEY constraint failed"` vem de `messages.session_id REFERENCES sessions(id)`
+  (`hermes_state.py:687`) — um `append_message` para uma sessão que não existe (ou foi evictada) na
+  tabela `sessions`. Não existe FK nem coluna relacionada a tools em nenhuma das duas tabelas.
+- `"Persisted transcript lagged live cached history"` (`gateway/run.py:16846-16864`) é uma guarda
+  contra corrupção de gravação por FTS5 — ela decide qual histórico de **mensagens** usar, não qual
+  lista de **tools**.
+
+Ambos os sintomas (FK e lag) são, isso sim, indícios de um problema real e independente de
+durabilidade/concorrência na sessão do gateway do Telegram — da mesma família do bug de reconexão já
+identificado e corrigido em `investigation/telegram-gateway-self-restart-freeze` (PR #56036). Eles
+devem continuar sendo monitorados, mas **não explicam** a ausência de `terminal` nas tools do modelo.
+
+## 7. Por que o cronfallback funciona (caminho diferente de tools)
+
+`cron/scheduler.py` resolve tools por um par de funções **totalmente separado** do caminho do
+gateway de mensagens: `_resolve_cron_enabled_toolsets` / `_resolve_cron_disabled_toolsets`
+(`cron/scheduler.py:115-188`), chamado a partir de um `AIAgent(...)` próprio (`cron/scheduler.py:2478+`).
+Note que esse caminho **também** lê e aplica `agent.disabled_toolsets` global
+(`_resolve_cron_disabled_toolsets`, linha ~123-130: *"User-level `agent.disabled_toolsets` ... is
+layered on top so per-job `enabled_toolsets` cannot bypass policy"*) — ou seja, se `"terminal"`
+estivesse de fato na lista global, um job de cron que dependesse do modelo chamar a tool `terminal`
+seria igualmente afetado.
+
+A evidência do relator ("Cronfallback consegue executar `whoami` na mesma máquina") foi descrita como
+prova de que **o backend do terminal funciona** — não como prova de que um agente LLM do cron chamou
+a tool com sucesso. Isso é consistente com o mecanismo aqui descrito: `check_terminal_requirements()`
+(`tools/terminal_tool.py:2749+`) testa apenas a *capacidade* do backend (local/docker/ssh/modal) de
+executar comandos, e essa checagem independe inteiramente de `platform_toolsets`/`disabled_toolsets`.
+Ou seja, "o backend responde" e "o schema `terminal` chega até o modelo em uma sessão de chat" são
+duas coisas diferentes, verificadas por dois mecanismos diferentes — não há contradição entre
+"cron prova que o backend funciona" e "o Telegram nunca recebe o schema".
+
+## 8. Alcance: é genérico a outros gateways, não específico do Telegram
+
+`plugins/platforms/telegram/adapter.py` não contém nenhuma referência a toolsets/tools — a resolução
+inteira acontece em código compartilhado (`gateway/run.py` + `hermes_cli/tools_config.py` +
+`model_tools.py`), chamado da mesma forma para qualquer `source.platform` (Discord, Slack, WhatsApp,
+Mattermost, etc., via `_platform_config_key`/`_get_platform_tools` genéricos). **Qualquer plataforma
+cujo operador tenha, em algum momento, deixado `"terminal"` (ou qualquer outro toolset) entrar em
+`agent.disabled_toolsets` sofre exatamente o mesmo efeito.** O relato ter sido observado "só" no
+Telegram muito provavelmente reflete que foi a única plataforma onde o operador testou explicitamente
+`platform_toolsets.<plataforma>` contendo `"terminal"` — não que exista tratamento especial de Telegram
+no código.
+
+## 9. Soluções possíveis (ordenadas por impacto) — não implementadas nesta investigação
+
+**Baixo impacto**
+- Logar, no momento em que `_compute_tool_definitions` faz a subtração de `disabled_toolsets`
+  (`model_tools.py:399-426`), quais tool-names foram removidos **e por qual toolset desabilitado**,
+  em nível INFO (hoje só imprime via `print()` quando `quiet_mode=False` — o caminho do gateway roda
+  com `quiet_mode=True`, então essa informação nunca chega a `agent.log`).
+- Ao construir `agent.tools` em `agent_init.py:1037`, logar (nível INFO, sempre, mesmo em quiet_mode)
+  a lista final de nomes de tools resolvida para a sessão, junto com `enabled_toolsets` e
+  `disabled_toolsets` de entrada — permitindo correlacionar diretamente "o que a plataforma pediu"
+  vs. "o que efetivamente chegou ao modelo".
+- Corrigir a docstring de `get_tool_definitions` (`model_tools.py:292`) para refletir o
+  comportamento real (subtração sempre aplicada), evitando que o próprio texto do código continue
+  induzindo a leitura errada de que `disabled_toolsets` é ignorado quando `enabled_toolsets` está
+  presente.
+
+**Médio impacto**
+- Adicionar um aviso explícito (log WARNING ou saída de `hermes tools` / `hermes doctor`) quando
+  `platform_toolsets.<plataforma>` lista um toolset que também aparece em `agent.disabled_toolsets`
+  global — hoje esse conflito é resolvido silenciosamente a favor do override global, sem qualquer
+  sinalização ao operador no momento da configuração.
+- Expor, em `hermes tools show <platform>` (ou comando equivalente), o resultado *pós-subtração*
+  (o que realmente vai para o modelo) lado a lado com o `platform_toolsets` bruto, para que a
+  divergência fique visível sem precisar ler logs.
+
+**Alto impacto (só se estritamente necessário)**
+- Revisitar a decisão de design do issue #17309 de que `disabled_toolsets` deve sempre vencer
+  `enabled_toolsets`/`platform_toolsets`, avaliando se persiste a necessidade de veto global absoluto
+  ou se ele deveria ser explicitamente escopável por plataforma (o que exigiria migração de schema de
+  config e revisão de todos os chamadores que hoje dependem do "vence sempre").
+
+## 10. Pontos onde adicionar logs para validar/descartar a hipótese (requer confirmação)
+
+Esta causa raiz é a mais bem sustentada pelas evidências de código encontradas, mas **depende de um
+dado que não está disponível nesta investigação**: o conteúdo real de `agent.disabled_toolsets` no
+`config.yaml` do ambiente onde o bug foi reportado. Recomenda-se, antes de qualquer fix:
+
+1. Inspecionar diretamente `~/.hermes/config.yaml` do ambiente afetado — chave `agent.disabled_toolsets`
+   — e verificar se `"terminal"` (ou um toolset composto que o inclua, como `"hermes-cli"`, cuja
+   subtração de bundle é tratada à parte em `model_tools.py:402-421`) está presente.
+2. Adicionar temporariamente um log em `model_tools.py:399` (antes do loop de subtração) imprimindo
+   `disabled_toolsets` e `tools_to_include` antes/depois — isso confirma ou descarta o mecanismo em
+   minutos, sem precisar reproduzir a falha de ponta a ponta.
+3. Adicionar log em `agent_init.py:1037` com o `agent.tools` final resolvido por sessão Telegram,
+   comparando com o `enabled_toolsets` de entrada vindo de `gateway/run.py:15483`/`16594` — uma
+   divergência ali (`enabled_toolsets` contém "terminal" mas `agent.tools` não) confirma
+   definitivamente o ponto exato descrito na Seção 3.
+
+## Anexos — trechos relevantes
+
+**`model_tools.py:279-302` (contrato documentado, incorreto na prática):**
+```python
+def get_tool_definitions(
+    enabled_toolsets: Optional[List[str]] = None,
+    disabled_toolsets: Optional[List[str]] = None,
+    ...
+    Args:
+        enabled_toolsets: Only include tools from these toolsets.
+        disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
+```
+
+**`model_tools.py:395-399` (comportamento real):**
+```python
+# Always apply disabled toolsets as a subtraction step at the end.
+# This ensures that even if a composite toolset (like hermes-cli)
+# is enabled, any tools belonging to a disabled toolset are strictly
+# stripped out. See issue #17309.
+if disabled_toolsets:
+    ...
+```
+
+**`hermes_cli/cli_agent_setup_mixin.py:3021-3031` (o próprio produto documenta o override global):**
+```python
+1. ``platform_toolsets["cli"] = ["file", "terminal"]`` — an explicit list of
+   configurable keys, which the resolver treats as authoritative
+   (``has_explicit_config``) so default toolsets aren't re-expanded.
+2. ``agent.disabled_toolsets`` — a global hard-suppression list (applied last
+   in ``_get_platform_tools``, overriding every other path including the
+   non-configurable platform-toolset recovery that would otherwise re-add
+   toolsets like ``kanban``).
+```
+
+**`hermes_state.py:640-705` (schema — nenhuma coluna de tools em `sessions`/`messages`):**
+```sql
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    ...
+    system_prompt TEXT,
+    parent_session_id TEXT,
+    ...
+    FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    ...
+);
+```
+
+**`cron/scheduler.py:115-130` (mesmo override global, caminho independente do gateway):**
+```python
+def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
+    """
+    User-level ``agent.disabled_toolsets`` from config.yaml is layered on top
+    so per-job ``enabled_toolsets`` cannot bypass policy that applies to
+    ordinary agent runs (#25752 — LLM-supplied enabled_toolsets was widening
+    ...
+    """
+```

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -39,6 +39,11 @@ logger = logging.getLogger(__name__)
 # every tool resolution for a persistently-corrupt config (#38798).
 _warned_invalid_platform_toolsets: Set[str] = set()
 
+# (platform, toolset) pairs already warned about being resolved for the
+# platform yet globally suppressed via agent.disabled_toolsets, so the warning
+# fires once per pair instead of on every tool resolution.
+_warned_toolset_conflicts: Set[tuple] = set()
+
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
 
@@ -1415,8 +1420,15 @@ def _get_platform_tools(
     platform: str,
     *,
     include_default_mcp_servers: bool = True,
+    _apply_disabled_toolsets: bool = True,
 ) -> Set[str]:
-    """Resolve which individual toolset names are enabled for a platform."""
+    """Resolve which individual toolset names are enabled for a platform.
+
+    ``_apply_disabled_toolsets=False`` skips the final global
+    ``agent.disabled_toolsets`` subtraction (and its conflict warning) so a
+    caller can diff the pre- and post-subtraction sets — used by
+    ``_print_tools_list`` to flag toolsets that are silently suppressed.
+    """
     from toolsets import resolve_toolset, TOOLSETS
 
     platform_toolsets = config.get("platform_toolsets") or {}
@@ -1651,8 +1663,33 @@ def _get_platform_tools(
     # last so it overrides everything above.
     agent_cfg = config.get("agent") or {}
     disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
-    if disabled_toolsets:
+    if disabled_toolsets and _apply_disabled_toolsets:
         disabled_set = {str(ts) for ts in disabled_toolsets}
+        # A toolset resolved for this platform (explicitly listed in
+        # platform_toolsets.<platform>, or pulled in via the platform's
+        # default composite) that also sits in the global disabled_toolsets
+        # list is a silent override: the toggle looks "on" for this platform
+        # but the tool never reaches the model (see issue #49995 for the
+        # symmetric "saved but can't re-enable" case). Surface it once per
+        # platform+toolset instead of letting it disappear with no signal.
+        conflicts = enabled_toolsets & disabled_set
+        for ts_name in sorted(conflicts):
+            conflict_key = (platform, ts_name)
+            if conflict_key not in _warned_toolset_conflicts:
+                _warned_toolset_conflicts.add(conflict_key)
+                logger.warning(
+                    "platform '%s' resolves toolset '%s' (via platform_toolsets "
+                    "or its default composite), but agent.disabled_toolsets "
+                    "globally suppresses it — the global list wins and '%s' "
+                    "tools are NOT available on this platform. Remove '%s' from "
+                    "agent.disabled_toolsets if it should actually be enabled "
+                    "for '%s'.",
+                    platform,
+                    ts_name,
+                    ts_name,
+                    ts_name,
+                    platform,
+                )
         enabled_toolsets -= disabled_set
 
     # #38798: if this platform was explicitly configured but every toolset name
@@ -4152,7 +4189,8 @@ def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]
     return failed_servers
 
 
-def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = "cli"):
+def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = "cli",
+                       config: Optional[dict] = None):
     """Print a summary of enabled/disabled toolsets and MCP tool filters."""
     effective_all = _get_effective_configurable_toolsets()
     effective = [
@@ -4161,13 +4199,34 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
     ]
     builtin_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
 
+    # Toolsets that would be resolved for this platform (explicit config or
+    # its default composite) but are silently stripped by the global
+    # agent.disabled_toolsets list — same conflict _get_platform_tools warns
+    # about, surfaced here so `hermes tools list` doesn't just show a plain
+    # "✗ disabled" that looks identical to "never configured".
+    suppressed: Set[str] = set()
+    if config is not None:
+        pre_disabled = _get_platform_tools(
+            config, platform, include_default_mcp_servers=False,
+            _apply_disabled_toolsets=False,
+        )
+        disabled_globally = {
+            str(ts) for ts in (config.get("agent") or {}).get("disabled_toolsets") or []
+        }
+        suppressed = pre_disabled & disabled_globally
+
+    def _status(ts_key: str) -> str:
+        if ts_key in enabled_toolsets:
+            return color("✓ enabled", Colors.GREEN)
+        if ts_key in suppressed:
+            return color("✗ suppressed (agent.disabled_toolsets)", Colors.YELLOW)
+        return color("✗ disabled", Colors.RED)
+
     print(f"Built-in toolsets ({platform}):")
     for ts_key, label, _ in effective:
         if ts_key not in builtin_keys:
             continue
-        status = (color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets
-                  else color("✗ disabled", Colors.RED))
-        print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
+        print(f"  {_status(ts_key)}  {ts_key}  {color(label, Colors.DIM)}")
 
     # Plugin toolsets
     plugin_entries = [(k, l) for k, l, _ in effective if k not in builtin_keys]
@@ -4175,9 +4234,7 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
         print()
         print(f"Plugin toolsets ({platform}):")
         for ts_key, label in plugin_entries:
-            status = (color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets
-                      else color("✗ disabled", Colors.RED))
-            print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
+            print(f"  {_status(ts_key)}  {ts_key}  {color(label, Colors.DIM)}")
 
     if mcp_servers:
         print()
@@ -4210,7 +4267,7 @@ def tools_disable_enable_command(args):
 
     if action == "list":
         _print_tools_list(_get_platform_tools(config, platform, include_default_mcp_servers=False),
-                          config.get("mcp_servers") or {}, platform)
+                          config.get("mcp_servers") or {}, platform, config=config)
         return
 
     targets: List[str] = args.names

--- a/model_tools.py
+++ b/model_tools.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 # Tracks platform-bundle names already flagged in disabled_toolsets so the
 # advisory (#33924) is logged once per name, not on every tool recompute.
 _WARNED_DISABLED_BUNDLES: set = set()
+_WARNED_TOOLSET_CONFLICTS: set = set()
 
 
 # =============================================================================
@@ -289,7 +290,12 @@ def get_tool_definitions(
 
     Args:
         enabled_toolsets: Only include tools from these toolsets.
-        disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
+        disabled_toolsets: Exclude tools from these toolsets. Applied as a final
+            subtraction step regardless of enabled_toolsets — a toolset listed
+            here is always stripped, even if it is also explicitly present in
+            enabled_toolsets (see issue #17309). Callers that want a toolset to
+            actually reach the model must ensure it is absent from
+            disabled_toolsets, not merely present in enabled_toolsets.
         quiet_mode: Suppress status prints.
         skip_tool_search_assembly: When True, return the pre-assembly tool list
             (raw schemas for every enabled tool). Used internally by the
@@ -363,6 +369,7 @@ def _compute_tool_definitions(
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
     tools_to_include: set = set()
+    effective_enabled_toolsets: Optional[List[str]] = None
 
     if enabled_toolsets is not None:
         effective_enabled_toolsets = list(enabled_toolsets)
@@ -424,6 +431,29 @@ def _compute_tool_definitions(
                     tools_to_include.difference_update(resolved)
                 if not quiet_mode:
                     print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
+                if resolved:
+                    logger.info(
+                        "agent.disabled_toolsets removed toolset '%s' (tools: %s) "
+                        "from the final tool list.",
+                        toolset_name,
+                        ", ".join(resolved),
+                    )
+                if effective_enabled_toolsets and toolset_name in effective_enabled_toolsets:
+                    conflict_key = (toolset_name,)
+                    if conflict_key not in _WARNED_TOOLSET_CONFLICTS:
+                        _WARNED_TOOLSET_CONFLICTS.add(conflict_key)
+                        logger.warning(
+                            "Toolset '%s' is both explicitly enabled (present in "
+                            "enabled_toolsets) and globally suppressed via "
+                            "agent.disabled_toolsets; the global suppression wins "
+                            "and the toolset's tools (%s) are NOT exposed to the "
+                            "model. This is a silent override — remove '%s' from "
+                            "agent.disabled_toolsets if it should actually be "
+                            "available.",
+                            toolset_name,
+                            ", ".join(resolved) if resolved else "none",
+                            toolset_name,
+                        )
             elif toolset_name in _LEGACY_TOOLSET_MAP:
                 legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
                 tools_to_include.difference_update(legacy_tools)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -114,6 +114,93 @@ def test_partially_valid_platform_toolsets_no_runtime_warning(caplog):
     assert not any("#38798" in r.getMessage() for r in caplog.records)
 
 
+def test_platform_toolset_disabled_globally_logs_conflict_warning(caplog):
+    """RCA regression: a toolset explicitly listed in platform_toolsets.<platform>
+    (e.g. 'terminal' for telegram) that is ALSO in agent.disabled_toolsets is
+    silently stripped with no signal anywhere. This must now log a WARNING
+    naming the platform and the toolset so the conflict is discoverable."""
+    import hermes_cli.tools_config as _tc
+    _tc._warned_toolset_conflicts.discard(("telegram", "terminal"))
+    config = {
+        "agent": {"disabled_toolsets": ["terminal"]},
+        "platform_toolsets": {"telegram": ["terminal", "web"]},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        enabled = _get_platform_tools(config, "telegram")
+
+    assert "terminal" not in enabled
+    assert "web" in enabled
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("telegram" in m and "terminal" in m for m in warnings), warnings
+
+
+def test_platform_toolset_conflict_warning_fires_once(caplog):
+    """Same dedup contract as the #38798 warning: one conflict warning per
+    (platform, toolset) pair per process, not once per resolution call."""
+    import hermes_cli.tools_config as _tc
+    _tc._warned_toolset_conflicts.discard(("cli", "memory"))
+    config = {
+        "agent": {"disabled_toolsets": ["memory"]},
+        "platform_toolsets": {"cli": ["web", "terminal", "memory"]},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        _get_platform_tools(config, "cli")
+        _get_platform_tools(config, "cli")
+        _get_platform_tools(config, "cli")
+
+    hits = [r for r in caplog.records if "cli" in r.getMessage() and "memory" in r.getMessage()]
+    assert len(hits) == 1, f"expected exactly one conflict warning, got {len(hits)}"
+
+
+def test_no_conflict_warning_when_toolset_never_requested(caplog):
+    """A toolset that's globally disabled but never appears in this platform's
+    resolved set (explicit config or default composite) is not a conflict —
+    just an ordinary disablement — so no WARNING should fire."""
+    config = {
+        "agent": {"disabled_toolsets": ["homeassistant"]},
+        "platform_toolsets": {"cli": ["web", "terminal"]},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        _get_platform_tools(config, "cli")
+
+    assert not any("homeassistant" in r.getMessage() for r in caplog.records)
+
+
+def test_print_tools_list_marks_suppressed_toolset(capsys):
+    """`hermes tools list` must visually distinguish 'suppressed by
+    agent.disabled_toolsets' from a plain 'never enabled' toolset, so an
+    operator staring at the list can actually see the RCA'd conflict."""
+    from hermes_cli.tools_config import _print_tools_list
+
+    config = {
+        "agent": {"disabled_toolsets": ["terminal"]},
+        "platform_toolsets": {"telegram": ["terminal", "web"]},
+    }
+    enabled = _get_platform_tools(config, "telegram", include_default_mcp_servers=False)
+
+    _print_tools_list(enabled, {}, "telegram", config=config)
+
+    out = capsys.readouterr().out
+    assert "terminal" in out
+    assert "suppressed" in out.lower()
+    assert "agent.disabled_toolsets" in out
+
+
+def test_print_tools_list_without_config_falls_back_to_plain_disabled(capsys):
+    """Callers that don't pass `config` (none exist today, but the parameter
+    is optional) must not crash and must keep the old plain-disabled output."""
+    from hermes_cli.tools_config import _print_tools_list
+
+    enabled = _get_platform_tools({}, "cli", include_default_mcp_servers=False)
+    _print_tools_list(enabled, {}, "cli")
+
+    out = capsys.readouterr().out
+    assert "disabled" in out.lower()
+
+
 def test_agent_disabled_toolsets_empty_list_is_noop():
     """Empty or missing disabled_toolsets should not change behavior."""
     config_empty = {"agent": {"disabled_toolsets": []}}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1381,6 +1381,73 @@ class TestToolUseEnforcementConfig:
             assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
 
 
+class TestAgentInitResolvedToolsLogging:
+    """RCA regression: quiet_mode (the gateway's normal mode for Telegram,
+    Discord, etc.) used to suppress every print() showing the resolved tool
+    list, so a silently-stripped tool (e.g. 'terminal') left no trace in
+    agent.log. agent_init.py must always log the resolved tool set via
+    logging, independent of quiet_mode."""
+
+    def test_resolved_tools_logged_even_in_quiet_mode(self, caplog):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=[{"type": "function", "function": {"name": "terminal"}}],
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("hermes_cli.config.load_config", return_value={}),
+        ):
+            with caplog.at_level(logging.INFO, logger="run_agent"):
+                a = AIAgent(
+                    api_key="test-key-1234567890",
+                    base_url="https://openrouter.ai/api/v1",
+                    quiet_mode=True,
+                    skip_context_files=True,
+                    skip_memory=True,
+                    enabled_toolsets=["terminal"],
+                )
+            a.client = MagicMock()
+
+        matches = [
+            r.getMessage() for r in caplog.records
+            if r.levelno == logging.INFO and "Resolved" in r.getMessage() and "tool(s) for session" in r.getMessage()
+        ]
+        assert matches, "Expected an INFO log of the resolved tool set even in quiet_mode"
+        assert "terminal" in matches[0]
+        assert "enabled_toolsets=['terminal']" in matches[0]
+
+    def test_resolved_tools_log_names_disabled_toolsets_input(self, caplog):
+        """The log line must carry both enabled_toolsets and disabled_toolsets
+        inputs so a silent-override case (tool requested but absent from the
+        resolved list) can be diagnosed directly from this one line."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("hermes_cli.config.load_config", return_value={}),
+        ):
+            with caplog.at_level(logging.INFO, logger="run_agent"):
+                a = AIAgent(
+                    api_key="test-key-1234567890",
+                    base_url="https://openrouter.ai/api/v1",
+                    quiet_mode=True,
+                    skip_context_files=True,
+                    skip_memory=True,
+                    enabled_toolsets=["terminal"],
+                    disabled_toolsets=["terminal"],
+                )
+            a.client = MagicMock()
+
+        matches = [
+            r.getMessage() for r in caplog.records
+            if r.levelno == logging.INFO and "Resolved" in r.getMessage() and "tool(s) for session" in r.getMessage()
+        ]
+        assert matches
+        assert "enabled_toolsets=['terminal']" in matches[0]
+        assert "disabled_toolsets=['terminal']" in matches[0]
+
+
 class TestTaskCompletionGuidance:
     """Tests for the universal task-completion / no-fabrication guidance
     (config.yaml ``agent.task_completion_guidance``).

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -536,3 +536,110 @@ class TestDisabledToolsetsPlatformBundle:
         from toolsets import bundle_non_core_tools
         # A non-existent bundle resolves to an empty set (no tools), not a crash.
         assert bundle_non_core_tools("hermes-does-not-exist") == set()
+
+
+class TestDisabledToolsetsConflictVisibility:
+    """Regression coverage for the Telegram-DM terminal-tool RCA: disabled_toolsets
+    always wins over enabled_toolsets (model_tools.py `_compute_tool_definitions`,
+    issue #17309), but that override used to be completely silent. These tests
+    verify the new INFO/WARNING logging that makes the silent override visible."""
+
+    def test_disabled_toolset_removal_logs_info(self, caplog):
+        """Any toolset actually stripped by disabled_toolsets logs its removed
+        tool names at INFO, regardless of quiet_mode."""
+        import logging
+        from model_tools import _compute_tool_definitions
+
+        with caplog.at_level(logging.INFO, logger="model_tools"):
+            _compute_tool_definitions(
+                enabled_toolsets=["hermes-telegram"],
+                disabled_toolsets=["web"],
+                quiet_mode=True,
+            )
+
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any(
+            "disabled_toolsets removed toolset 'web'" in r.getMessage()
+            for r in info_records
+        ), f"Expected an INFO log about 'web' removal, got: {[r.getMessage() for r in info_records]}"
+
+    def test_toolset_enabled_and_disabled_simultaneously_logs_warning(self, caplog):
+        """The exact silent-override mechanism from the RCA: a toolset present
+        in BOTH enabled_toolsets and disabled_toolsets must emit a WARNING
+        naming the toolset, since disabled_toolsets wins without any other
+        signal to the caller."""
+        import logging
+        import model_tools
+        from model_tools import _compute_tool_definitions
+
+        # Clear dedup state so the warning isn't suppressed by an earlier test
+        # or an earlier call using the same toolset name.
+        model_tools._WARNED_TOOLSET_CONFLICTS.discard(("terminal",))
+
+        with caplog.at_level(logging.WARNING, logger="model_tools"):
+            tools = _compute_tool_definitions(
+                enabled_toolsets=["terminal"],
+                disabled_toolsets=["terminal"],
+                quiet_mode=True,
+            )
+
+        names = {t["function"]["name"] for t in tools}
+        assert "terminal" not in names, "disabled_toolsets must still win over enabled_toolsets"
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "'terminal' is both explicitly enabled" in r.getMessage()
+            for r in warning_records
+        ), f"Expected a conflict WARNING for 'terminal', got: {[r.getMessage() for r in warning_records]}"
+
+    def test_conflict_warning_fires_once_per_toolset(self, caplog):
+        """Dedup guard: repeated resolution with the same conflicting toolset
+        must not spam the log on every call."""
+        import logging
+        import model_tools
+        from model_tools import _compute_tool_definitions
+
+        model_tools._WARNED_TOOLSET_CONFLICTS.discard(("file",))
+
+        with caplog.at_level(logging.WARNING, logger="model_tools"):
+            for _ in range(3):
+                _compute_tool_definitions(
+                    enabled_toolsets=["file"],
+                    disabled_toolsets=["file"],
+                    quiet_mode=True,
+                )
+
+        matches = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "'file' is both explicitly enabled" in r.getMessage()
+        ]
+        assert len(matches) == 1, f"Expected exactly one conflict warning, got {len(matches)}"
+
+    def test_no_conflict_when_toolset_only_disabled(self, caplog):
+        """A toolset that is disabled but was never explicitly enabled is a
+        normal disablement, not a conflict — no WARNING should fire."""
+        import logging
+        from model_tools import _compute_tool_definitions
+
+        with caplog.at_level(logging.WARNING, logger="model_tools"):
+            _compute_tool_definitions(
+                enabled_toolsets=["hermes-telegram"],
+                disabled_toolsets=["memory"],
+                quiet_mode=True,
+            )
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any(
+            "'memory' is both explicitly enabled" in r.getMessage()
+            for r in warning_records
+        )
+
+    def test_docstring_documents_unconditional_override(self):
+        """The docstring must state the real precedence (disabled_toolsets
+        always wins), not the old inaccurate 'only if enabled_toolsets is
+        None' wording that motivated this RCA."""
+        from model_tools import get_tool_definitions
+
+        doc = get_tool_definitions.__doc__ or ""
+        assert "always" in doc.lower()
+        assert "disabled_toolsets" in doc


### PR DESCRIPTION
Fixes #55986

## Summary

Investigation + fix for: Hermes consistently refusing to use the `terminal` tool in Telegram DMs, even when `platform_toolsets.telegram` explicitly includes it — with no error, just a plain-text refusal (`tool_turns=0`).

**Root cause:** `agent.disabled_toolsets` (a global config key) is applied as an *unconditional final subtraction* in `model_tools.py::_compute_tool_definitions`, which strips a toolset even when it's also present in `enabled_toolsets` — by design (issue #17309), but completely silent. If `terminal` ends up in that global list, it disappears from every platform's tool schema regardless of what `platform_toolsets.<platform>` says, with zero signal anywhere in the stack. This is deterministic/config-driven, which is why it reproduced on fresh sessions too.

Session-DB corruption signals seen alongside this (`FOREIGN KEY constraint failed`, "Persisted transcript lagged", "rebuilding system prompt from scratch") were investigated and ruled out as unrelated: the `sessions`/`messages` schema has no tools/toolset column at all — tool exposure is recomputed purely from config on every `AIAgent` construction, so those symptoms belong to a separate transcript/system-prompt persistence issue.

Full writeup with evidence, ruled-out hypotheses, and flow diagrams: `docs/rca-telegram-dm-terminal-tool-refusal.md`.

## Changes

This does **not** change the override precedence (global `disabled_toolsets` still wins by design) — it makes the conflict visible instead of silent:

- **`model_tools.py`**: log INFO when `disabled_toolsets` strips tools from the final list; log WARNING when a toolset is present in *both* `enabled_toolsets` and `disabled_toolsets` (the exact silent-override case); corrected the `get_tool_definitions` docstring, which previously implied `disabled_toolsets` only applied when `enabled_toolsets` was `None`.
- **`agent/agent_init.py`**: always log the final resolved tool set plus the `enabled_toolsets`/`disabled_toolsets` inputs used to build it — even in `quiet_mode`, which is the gateway's normal mode for Telegram/Discord/etc., where the existing `print()`-based diagnostics never fired.
- **`hermes_cli/tools_config.py`**: `_get_platform_tools` now warns once per (platform, toolset) when a toolset resolved for that platform is globally suppressed; `hermes tools list` marks such toolsets as `suppressed (agent.disabled_toolsets)` instead of a plain, indistinguishable `disabled`.

## Test plan

- [x] `tests/test_model_tools.py` — 5 new tests covering the INFO/WARNING logging and docstring (36/36 pass)
- [x] `tests/hermes_cli/test_tools_config.py` — 5 new tests covering the conflict warning and `hermes tools list` output (113/113 pass)
- [x] `tests/run_agent/test_run_agent.py` — 2 new tests covering the always-on resolved-tools log in `agent_init.py` (409/409 pass)
- [x] `tests/cron/test_scheduler.py` — full suite re-run to confirm the independent cron toolset-resolution path has no regression (191/191 pass)
