### PR TITLE
fix(doctor): accept local provider aliases

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -787,10 +787,14 @@ def run_doctor(args):
                 if catalog_provider is not None:
                     provider_ids_to_accept.add(catalog_provider)
 
+            provider_is_known = bool(provider_ids_to_accept & valid_provider_ids)
             if provider and provider != "auto":
-                if catalog_provider is None or (
-                    known_providers
-                    and not (provider_ids_to_accept & valid_provider_ids)
+                # Local runtime aliases such as ollama/vllm/llamacpp resolve
+                # through hermes_cli.auth to "custom" without a catalog
+                # ProviderDef. Treat that runtime match as valid so doctor
+                # stays consistent with actual agent routing.
+                if (known_providers and not provider_is_known) or (
+                    not known_providers and catalog_provider is None
                 ):
                     known_list = ", ".join(sorted(known_providers)) if known_providers else "(unavailable)"
                     _fail_and_issue(

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -445,6 +445,61 @@ def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
     assert "model.provider 'custom' is not a recognised provider" not in out
 
 
+@pytest.mark.parametrize("provider", ["ollama", "vllm", "llamacpp", "llama-cpp"])
+def test_run_doctor_accepts_local_custom_provider_aliases(monkeypatch, tmp_path, provider):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("OPENROUTER_API_KEY=sk-or-test\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "model:\n"
+        f"  provider: {provider}\n"
+        "  default: qwen3.5\n"
+        "  base_url: http://192.168.0.103:11434/v1\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    import httpx
+
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        lambda *a, **kw: types.SimpleNamespace(
+            status_code=200,
+            text="",
+            ok=True,
+            json=lambda: {"data": []},
+        ),
+    )
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert f"model.provider '{provider}' is not a recognised provider" not in out
+    assert f"model.provider '{provider}' is unknown" not in out
+
+
 def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- allow `hermes doctor` provider validation to accept local runtime aliases that resolve to `custom`, such as `ollama`, `vllm`, `llamacpp`, and `llama-cpp`
- add regression coverage for those aliases with a LAN/local `base_url` and an `OPENROUTER_API_KEY` present

## Why
Runtime provider resolution already treats these aliases as local/custom providers, including the regression covered by #27132/#27133. `hermes doctor` still required a catalog provider match, so it reported valid local configs like `model.provider: ollama` as an unknown provider even though the agent runtime would route them correctly.

This keeps doctor diagnostics aligned with actual runtime routing and avoids telling local-model users to change a working provider config.

## Tests
- `python3 -m pytest tests/hermes_cli/test_doctor.py::test_run_doctor_accepts_local_custom_provider_aliases -q`
- `python3 -m pytest tests/hermes_cli/test_doctor.py -q`
- `python3 -m pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_custom_aliases_with_lan_base_url_route_to_custom_not_openrouter tests/hermes_cli/test_runtime_provider_resolution.py::test_custom_alias_with_loopback_base_url_routes_to_custom tests/hermes_cli/test_runtime_provider_resolution.py::test_trustworthy_check_accepts_custom_aliases -q`
- `python3 -m ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`