### PR TITLE
perf: pre-compute sorted reasoning timeout floors + thread-safe patterns

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -131,19 +131,16 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
 # so we accept that community forks inheriting the same prefix are
 # treated as reasoning models (a reasonable default — the upstream
 # gateway timing is the same).
-_PATTERN_CACHE: dict[str, re.Pattern[str]] = {}
-
-
-def _get_pattern(slug: str) -> re.Pattern[str]:
-    compiled = _PATTERN_CACHE.get(slug)
-    if compiled is None:
-        compiled = re.compile(
-            r"^"
-            + re.escape(slug)
-            + r"(?:$|[\-._])"
-        )
-        _PATTERN_CACHE[slug] = compiled
-    return compiled
+# Pre-compile all patterns at module load time to avoid per-call regex
+# compilation and thread-safety issues with the mutable _PATTERN_CACHE.
+# Tuples are immutable after creation, so this is safe for free-threaded
+# Python 3.13+ without any locking.
+_SORTED_REASONING_FLOORS: list[tuple[str, float, re.Pattern[str]]] = [
+    (slug, floor, re.compile(r"^" + re.escape(slug) + r"(?:$|[\-._])"))
+    for slug, floor in sorted(
+        _REASONING_STALE_TIMEOUT_FLOORS, key=lambda kv: -len(kv[0])
+    )
+]
 
 
 def _match_any(model_lower: str) -> Optional[float]:
@@ -154,13 +151,8 @@ def _match_any(model_lower: str) -> Optional[float]:
     order is irrelevant: longest slug wins (so ``o3-mini`` beats
     ``o3`` on a model like ``openai/o3-mini``).
     """
-    # Sort by slug length descending so longer / more-specific slugs
-    # win on shared prefixes (o3-mini beats o3).
-    sorted_floors = sorted(
-        _REASONING_STALE_TIMEOUT_FLOORS, key=lambda kv: -len(kv[0])
-    )
-    for slug, floor in sorted_floors:
-        if _get_pattern(slug).search(model_lower):
+    for _slug, floor, pattern in _SORTED_REASONING_FLOORS:
+        if pattern.search(model_lower):
             return float(floor)
     return None
 


### PR DESCRIPTION
## What does this PR do?

Two related optimizations in `agent/reasoning_timeouts.py`:

1. **Pre-compute sorted floors**: `_match_any()` was re-sorting `_REASONING_STALE_TIMEOUT_FLOORS` (21 elements) on every call. This function runs per API turn via `error_classifier`, `chat_completion_helpers`, and `thinking_timeout_guidance`. Moved the sort to module level.

2. **Thread-safe pattern cache**: The old `_PATTERN_CACHE` was a mutable `dict` accessed from multiple threads without locking. The get-check-set pattern was a classic TOCTOU race. Pre-compiled all 21 patterns at module load time into an immutable list. Safe for free-threaded Python 3.13+.

## Type of Change

- [x] ⚡ Performance improvement
- [x] 🐛 Bug fix (thread-safety)

## Changes Made

- `agent/reasoning_timeouts.py`: Removed `_PATTERN_CACHE` dict and `_get_pattern()` function. Added `_SORTED_REASONING_FLOORS` list comprehension that pre-compiles all patterns and sorts by slug length descending. Simplified `_match_any()` to iterate the pre-computed list.

## How to Test

```python
from agent.reasoning_timeouts import _match_any, get_reasoning_stale_timeout_floor, _SORTED_REASONING_FLOORS
assert len(_SORTED_REASONING_FLOORS) == 21
assert _match_any("o3-mini") is not None
assert get_reasoning_stale_timeout_floor("openai/o3-mini") == 300.0
assert get_reasoning_stale_timeout_floor("gpt-4o") is None
```

## Checklist

- [x] ruff check passes
- [x] Functional behavior preserved (same patterns, same sort order)
- [x] Thread-safe for free-threaded Python 3.13+
- [x] No new dependencies