### PR TITLE
fix: skip auto-SSO redirect for password-only auth providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,14 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+
+    # Password-only providers (e.g. BasicAuthProvider) don't have an OAuth
+    # redirect flow — /auth/login calls start_login() which raises
+    # NotImplementedError → 500.  Fall through to /login which renders
+    # the credential form instead.  (#56067)
+    if getattr(provider, "supports_password", False):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
## What does this PR do?

`_auto_sso_response()` unconditionally redirects to `/auth/login` when there is exactly one session provider. For password-only providers (e.g. BasicAuthProvider), `/auth/login` calls `start_login()` which raises `NotImplementedError` → **500 Internal Server Error**.

Fix: check `provider.supports_password` before redirecting. If True, return `None` to let the `/login` interstitial render the credential form.

## Related Issue

Fixes #56067

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/middleware.py`: Added guard in `_auto_sso_response()` to skip auto-redirect when the sole provider is password-only.

## How to Test

1. Configure dashboard with only a basic auth provider
2. Visit `http://host:9119/` in browser
3. Should render `/login` with credential form (not 500)

## Checklist

- [x] ruff check passes
- [x] Fixes #56067
- [x] No new dependencies