### PR TITLE
fix(tui): reject stale session model switches

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3620,6 +3620,43 @@ def test_config_set_model_uses_live_switch_path(monkeypatch):
     assert seen["args"] == ("sid", "session-key", "new/model")
 
 
+def test_config_set_rejects_unknown_session_id_before_key_dispatch(monkeypatch):
+    server._sessions.pop("missing", None)
+
+    def _unexpected_mutation(*_args, **_kwargs):
+        raise AssertionError("missing session must not fall through to config handlers")
+
+    monkeypatch.setattr(server, "_write_config_key", _unexpected_mutation)
+    monkeypatch.setattr(server, "_save_cfg", _unexpected_mutation)
+    monkeypatch.setattr(
+        server,
+        "_apply_model_switch",
+        _unexpected_mutation,
+    )
+    monkeypatch.setattr(server, "_apply_personality_to_session", _unexpected_mutation)
+
+    for key, value in (
+        ("model", "new/model"),
+        ("fast", "fast"),
+        ("verbose", "verbose"),
+        ("yolo", "1"),
+        ("reasoning", "low"),
+        ("personality", "helpful"),
+    ):
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "missing",
+                "key": key,
+                "value": value,
+            },
+        })
+
+        assert resp["error"]["code"] == 4001, key
+        assert resp["error"]["message"] == "session not found"
+
+
 def test_config_set_model_requires_confirmation_for_expensive_model(monkeypatch):
     class _Agent:
         provider = "openrouter"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10298,13 +10298,16 @@ def _(rid, params: dict) -> dict:
 @method("config.set")
 def _(rid, params: dict) -> dict:
     key, value = params.get("key", ""), params.get("value", "")
-    session = _sessions.get(params.get("session_id", ""))
+    session_id = str(params.get("session_id") or "")
+    session = _sessions.get(session_id) if session_id else None
+    if session_id and session is None:
+        return _err(rid, 4001, "session not found")
 
     if key == "model":
         try:
             if not value:
                 return _err(rid, 4002, "model value required")
-            if session:
+            if session is not None:
                 # Reject during an in-flight turn.  agent.switch_model()
                 # mutates self.model / self.provider / self.base_url /
                 # self.client in place; the worker thread running
@@ -10324,7 +10327,6 @@ def _(rid, params: dict) -> dict:
                 parsed_flags = parse_model_flags(value)
                 _model_input, explicit_provider, _persist_global, _force_refresh, _is_session = parsed_flags
                 if session.get("agent") is None and not explicit_provider.strip():
-                    session_id = params.get("session_id", "")
                     _start_agent_build(session_id, session)
                     init_err = _wait_agent(session, rid)
                     if init_err:
@@ -10332,7 +10334,7 @@ def _(rid, params: dict) -> dict:
                     if session.get("agent") is None:
                         return _err(rid, 5032, "agent initialization failed")
                 result = _apply_model_switch(
-                    params.get("session_id", ""),
+                    session_id,
                     session,
                     value,
                     confirm_expensive_model=bool(


### PR DESCRIPTION
## Summary
- reject `config.set` updates when a non-empty `session_id` no longer maps to a live gateway session
- keep no-session calls available for intentional global/default config updates
- add regression coverage so stale desktop/TUI session requests cannot fall through to key-specific global paths
- keep the fix scoped to the gateway guard while validating the existing desktop model controls path

Fixes #56058

## Tests
- `uv run --extra dev pytest tests/test_tui_gateway_server.py -k config_set -q`
- `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-model-controls.test.tsx`
- `uv run --extra dev ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check origin/main...HEAD`