### PR TITLE
fix(tui_gateway): route setup.runtime_check and setup.status to RPC pool (#50005)

### DIFF
--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -64,9 +64,11 @@ def capture(server):
 # seconds when the GIL is contended by concurrent agent turns.
 
 FRONTEND_POLLED_RPCS = [
-    "session.list",   # loads session list — SQLite query
-    "pet.info",       # petdex poll — file/network read
-    "process.list",   # background process status — process registry scan
+    "session.list",          # loads session list — SQLite query
+    "pet.info",              # petdex poll — file/network read
+    "process.list",          # background process status — process registry scan
+    "setup.runtime_check",   # runtime readiness — resolve_runtime_provider() I/O
+    "setup.status",          # provider configured check — config/credential scan
 ]
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -212,6 +212,16 @@ _LONG_HANDLERS = frozenset(
         "projects.for_cwd",
         "projects.tree",
         "projects.project_sessions",
+        # Setup readiness RPCs are polled by the Desktop frontend on connect
+        # and periodically (use-status-snapshot → evaluateRuntimeReadiness).
+        # setup.runtime_check calls resolve_runtime_provider() which reads
+        # config, checks auth state, and may probe the provider endpoint;
+        # setup.status calls _has_any_provider_configured() which scans
+        # provider config + credential files. Under GIL pressure from
+        # concurrent agent turns, either can take seconds inline, blocking
+        # the WS read loop and causing false "needs setup" (#50005 family).
+        "setup.runtime_check",
+        "setup.status",
         "session.branch",
         "session.compress",
         "session.list",


### PR DESCRIPTION
## Summary

`setup.runtime_check` and `setup.status` are polled by the Desktop frontend on connect and periodically via `evaluateRuntimeReadiness()` (`use-status-snapshot.ts`). Both were missing from `_LONG_HANDLERS`, so they ran **inline on the WS reader thread**.

Under GIL pressure from concurrent agent turns (terminal I/O, large output processing, background process completions), either RPC can take seconds:

- `setup.runtime_check` calls `resolve_runtime_provider()` — reads config, checks auth state, may probe the provider endpoint
- `setup.status` calls `_has_any_provider_configured()` — scans provider config + credential files

While either blocks the reader thread, the WS read loop cannot service subsequent requests. The frontend's 120s RPC timeout fires, the client closes the WebSocket, and `setup.runtime_check`'s response is lost — `interpretRuntimeReadiness()` gets no signal, returns `ready=false`, and the status bar shows **"needs setup"** even though the provider is correctly configured.

This is the same failure mode described in #50005. PR #55545 added `session.list`, `pet.info`, and `process.list` to `_LONG_HANDLERS` but missed these two.

## Fix

Add `setup.runtime_check` and `setup.status` to `_LONG_HANDLERS` in `tui_gateway/server.py`. `dispatch()` now returns immediately (`_pool.submit` + `return None`) for both, keeping the WS read loop free under GIL pressure.

## Tests

Added both RPCs to `FRONTEND_POLLED_RPCS` in `tests/tui_gateway/test_inline_rpc_gil_starvation.py` — the parametrized `test_frontend_polled_rpc_is_pool_routed` now asserts all 5 frontend-polled RPCs are in `_LONG_HANDLERS`.

```
tests/tui_gateway/test_inline_rpc_gil_starvation.py::test_frontend_polled_rpc_is_pool_routed[setup.runtime_check] PASSED
tests/tui_gateway/test_inline_rpc_gil_starvation.py::test_frontend_polled_rpc_is_pool_routed[setup.status] PASSED
8 passed in 0.61s
```

## Relationship to other PRs

| PR | What it does | Status |
|---|---|---|
| #55545 | Added `session.list`/`pet.info`/`process.list` to `_LONG_HANDLERS` + WS ping relax + token coalescing | Merged |
| #55707 | Frontend: preserve `configured=true` when `checksDisagree=true` (transient outage mitigation) | Open |

This PR is the **backend root-cause fix** for the remaining gap. #55707 is a complementary frontend mitigation that handles transient provider outages where `setup.runtime_check` returns `ok: false` (not a transport failure). Both are useful; neither subsumes the other.