### PR TITLE
fix(agent): repair a tool name truncated to a leading-underscore fragment (Tool Search bridge)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2211,6 +2211,17 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     if normalized in agent.valid_tool_names:
         return normalized
 
+    # Some inference servers drop the leading "tool" token of the Tool Search bridge
+    # names (tool_search / tool_describe / tool_call) when streaming, because those
+    # names collide with the server's <tool_call> markup detection — so `tool_search`
+    # arrives as `_search`. Restore it deterministically BEFORE the fuzzy match, which
+    # otherwise mis-scores `_search` -> `web_search` (difflib 0.82) over `tool_search`
+    # (0.78). Unambiguous: no legitimate tool is named `_x`.
+    if tool_name.startswith("_"):
+        restored = "tool" + tool_name
+        if restored in agent.valid_tool_names:
+            return restored
+
     # Build the full candidate set for class-like emissions.
     cands: set[str] = {tool_name, lowered, normalized, _camel_snake(tool_name)}
     # Strip trailing tool-suffix up to twice — TodoTool_tool needs it.

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -186,3 +186,30 @@ class TestVolcEngineXmlPollution:
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+
+# ── Tool Search bridge: leading-"tool" token dropped when streaming ──────────
+# Some inference servers emit the bridge tool names one token short
+# (tool_search -> _search) because they collide with <tool_call> markup
+# detection. Repair must restore them before the fuzzy fallback, which would
+# otherwise mis-score `_search` to `web_search` over `tool_search`.
+_BRIDGE_VALID = {"tool_search", "tool_describe", "tool_call", "web_search", "session_search"}
+
+
+def _bridge_repair():
+    from run_agent import AIAgent
+    stub = SimpleNamespace(valid_tool_names=_BRIDGE_VALID)
+    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+
+@pytest.mark.parametrize(
+    "emitted,expected",
+    [("_search", "tool_search"), ("_describe", "tool_describe"), ("_call", "tool_call")],
+)
+def test_bridge_leading_underscore_restore(emitted, expected):
+    assert _bridge_repair()(emitted) == expected
+
+
+def test_bridge_underscore_fragment_without_tool_form_is_not_invented():
+    # `_nope` has no `tool_nope` — must not be force-mapped to a bridge tool.
+    assert _bridge_repair()("_nope") != "tool_search"


### PR DESCRIPTION
### Problem
Some inference servers truncate the leading `tool` token of tool names when **streaming** — observed with Avarok Atlas serving Qwen3.6 ([Avarok-Cybersecurity/atlas#222](https://github.com/Avarok-Cybersecurity/atlas/issues/222); streaming leak-marker family #204/#205/#206). Names that collide with `<tool_call>` markup are emitted one token short, so the **Tool Search bridge** control tools arrive mangled:

- `tool_search` → `_search`
- `tool_describe` → `_describe`
- `tool_call` → `_call`

`repair_tool_call`'s final fuzzy fallback then makes it worse:

```python
difflib.get_close_matches("_search", valid_tool_names, n=1, cutoff=0.7)
#  web_search 0.8235  >  tool_search 0.7778   → picks web_search
```

So the agent calls **the wrong tool** and concludes the deferred tools are unavailable — Tool Search breaks entirely on that serving stack. Only `tool_`-prefixed names are affected; ordinary MCP tool names stream fine.

### Fix
Before the fuzzy match, if the emitted name is a `_<x>` fragment whose `tool_<x>` form is a registered tool, restore it deterministically. Unambiguous (no legitimate tool is named `_x`) and only touches names that would otherwise fall through to fuzzy matching.

### Test
Adds parametrized cases to `tests/run_agent/test_repair_tool_call_name.py` covering the three bridge names and a negative case (`_nope` with no `tool_nope` isn't force-mapped).

### Notes
Root cause is server-side (tracked at Avarok-Cybersecurity/atlas#222), but hardening the repair here makes the Tool Search bridge robust to this truncation class regardless of serving engine. Verified live on a fleet of agents (Qwen3.6 + Atlas): with this change the agents drive `tool_search → tool_describe → tool_call` correctly. Related: #6841 (making tool-name repair conservative).
