### PR TITLE
fix(models): preserve Ollama model:tag colons in parse_model_input

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1855,16 +1855,45 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
         model_part = stripped[colon + 1:].strip()
         if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
             # Support custom:name:model triple syntax for named custom
-            # providers.  ``custom:local:qwen`` → ("custom:local", "qwen").
-            # Single colon ``custom:qwen`` → ("custom", "qwen") as before.
+            # providers.  `custom:local:qwen` → ("custom:local", "qwen").
+            # Single colon `custom:qwen` → ("custom", "qwen") as before.
+            #
+            # BUT: Ollama models use colons in their tags (e.g.
+            # `glm-5.2:cloud`, `nomic-embed-text:latest`).  When the
+            # middle part is NOT a registered custom provider name, we must
+            # treat everything after `custom:` as the model id to avoid
+            # truncating `glm-5.2:cloud` into just `cloud`.
             if provider_part == "custom" and ":" in model_part:
                 second_colon = model_part.find(":")
                 custom_name = model_part[:second_colon].strip()
                 actual_model = model_part[second_colon + 1:].strip()
-                if custom_name and actual_model:
+                if custom_name and actual_model and _is_registered_custom_provider(custom_name):
                     return (f"custom:{custom_name}", actual_model)
             return (normalize_provider(provider_part), model_part)
     return (current_provider, stripped)
+
+
+def _is_registered_custom_provider(name: str) -> bool:
+    """Check whether *name* matches a custom provider in config.yaml.
+
+    Used by :func:`parse_model_input` to distinguish ``custom:ollama:qwen``
+    (provider ``custom:ollama``, model ``qwen``) from ``custom:glm-5.2:cloud``
+    (provider ``custom``, model ``glm-5.2:cloud`` — an Ollama tag).
+    """
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+
+        providers = get_compatible_custom_providers()
+        normalized = name.strip().lower()
+        for entry in providers:
+            entry_name = str(entry.get("name", "") or "").strip().lower()
+            entry_key = str(entry.get("provider_key", "") or "").strip().lower()
+            if normalized and (normalized == entry_name or normalized == entry_key):
+                return True
+    except Exception:
+        import logging
+        logging.getLogger(__name__).debug("Failed to check custom provider registry", exc_info=True)
+    return False
 
 
 def _get_custom_base_url() -> str:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -163,6 +163,107 @@ class TestParseModelInput:
         assert model == "name:"
 
 
+
+# -- integration: real config --> parse_model_input -----------------------------
+#
+# The unit tests above mock _is_registered_custom_provider to isolate the
+# parser.  The sweeper review on PR #56089 asked for an integration test that
+# wires a real config.yaml with a named custom provider and asserts the full
+# code path: _is_registered_custom_provider -> get_compatible_custom_providers
+# -> config.yaml -> parse_model_input.
+
+
+class TestParseModelInputIntegration:
+    """Integration tests that use a real HERMES_HOME + config.yaml.
+
+    These exercise the full _is_registered_custom_provider ->
+    get_compatible_custom_providers -> load_config path, proving the named
+    custom provider syntax works end-to-end without mocks.
+    """
+
+    def test_named_custom_provider_resolves(self, tmp_path, monkeypatch):
+        """custom:<name>:<model> selects the named custom provider when it
+        exists in config.yaml's custom_providers list."""
+        import yaml
+
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        config = {
+            "model": "test-model",
+            "custom_providers": [
+                {
+                    "name": "ollama-local",
+                    "base_url": "http://127.0.0.1:11434/v1",
+                    "api_key": "ollama",
+                    "model": "qwen3",
+                }
+            ],
+        }
+        (home / "config.yaml").write_text(yaml.dump(config))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        # Clear any cached config for this new path.
+        from hermes_cli.config import _LOAD_CONFIG_CACHE
+        _LOAD_CONFIG_CACHE.pop(str(home / "config.yaml"), None)
+
+        provider, model = parse_model_input(
+            "custom:ollama-local:qwen3-coder", "openrouter"
+        )
+        assert provider == "custom:ollama-local"
+        assert model == "qwen3-coder"
+
+    def test_unregistered_name_keeps_full_model_id(self, tmp_path, monkeypatch):
+        """When the middle part is NOT a registered custom provider,
+        parse_model_input must keep everything after 'custom:' as the model
+        id -- including colons (Ollama tag syntax like glm-5.2:cloud)."""
+        import yaml
+
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        # config with NO custom_providers -- nothing registered
+        (home / "config.yaml").write_text(
+            yaml.dump({"model": "test-model", "custom_providers": []})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        from hermes_cli.config import _LOAD_CONFIG_CACHE
+        _LOAD_CONFIG_CACHE.pop(str(home / "config.yaml"), None)
+
+        provider, model = parse_model_input(
+            "custom:glm-5.2:cloud", "custom"
+        )
+        assert provider == "custom"
+        assert model == "glm-5.2:cloud"
+
+    def test_named_provider_via_providers_key(self, tmp_path, monkeypatch):
+        """The v12+ keyed 'providers' schema must also be discoverable by
+        _is_registered_custom_provider via get_compatible_custom_providers."""
+        import yaml
+
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        config = {
+            "model": "test-model",
+            "providers": {
+                "ollama-local": {
+                    "base_url": "http://127.0.0.1:11434/v1",
+                    "api_key": "ollama",
+                    "model": "qwen3",
+                }
+            },
+        }
+        (home / "config.yaml").write_text(yaml.dump(config))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        from hermes_cli.config import _LOAD_CONFIG_CACHE
+        _LOAD_CONFIG_CACHE.pop(str(home / "config.yaml"), None)
+
+        provider, model = parse_model_input(
+            "custom:ollama-local:qwen3-coder", "openrouter"
+        )
+        assert provider == "custom:ollama-local"
+        assert model == "qwen3-coder"
+
 # -- curated_models_for_provider ---------------------------------------------
 
 class TestCuratedModelsForProvider:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -108,14 +108,50 @@ class TestParseModelInput:
         assert model == "qwen-2.5"
 
     def test_custom_triple_syntax(self):
-        """custom:name:model → named custom provider."""
-        provider, model = parse_model_input("custom:local-server:qwen-2.5", "openrouter")
+        """custom:name:model → named custom provider (when name is registered)."""
+        with patch(
+            "hermes_cli.models._is_registered_custom_provider",
+            return_value=True,
+        ):
+            provider, model = parse_model_input("custom:local-server:qwen-2.5", "openrouter")
         assert provider == "custom:local-server"
         assert model == "qwen-2.5"
 
+    def test_custom_triple_unregistered_falls_back(self):
+        """custom:name:model → when name is NOT a registered custom provider,
+        treat everything after custom: as the model id.
+
+        Ollama models use colons in tags (e.g. glm-5.2:cloud).
+        Without this guard, parse_model_input truncates the model name
+        to just the part after the last colon (e.g. 'cloud' instead of
+        'glm-5.2:cloud'), causing HTTP 404 errors.
+        """
+        with patch(
+            "hermes_cli.models._is_registered_custom_provider",
+            return_value=False,
+        ):
+            provider, model = parse_model_input("custom:glm-5.2:cloud", "custom")
+        assert provider == "custom"
+        assert model == "glm-5.2:cloud"
+
+    def test_custom_ollama_tag_not_truncated(self):
+        """custom:glm-5.2:cloud must not be truncated to custom:glm-5.2 / cloud.
+
+        Regression test: Ollama cloud models have colons in their tags.
+        The triple-syntax parser must only split when the middle part is a
+        registered custom provider name.
+        """
+        provider, model = parse_model_input("custom:glm-5.2:cloud", "custom")
+        assert provider == "custom"
+        assert model == "glm-5.2:cloud"
+
     def test_custom_triple_spaces(self):
         """Triple syntax should handle whitespace."""
-        provider, model = parse_model_input("custom: my-server : my-model ", "openrouter")
+        with patch(
+            "hermes_cli.models._is_registered_custom_provider",
+            return_value=True,
+        ):
+            provider, model = parse_model_input("custom: my-server : my-model ", "openrouter")
         assert provider == "custom:my-server"
         assert model == "my-model"
 


### PR DESCRIPTION
## Problem

When ACP clients (like AionUI) send `custom:glm-5.2:cloud` to `set_session_model`, `parse_model_input` splits at the second colon, treating the middle part (`glm-5.2`) as a named custom provider name. For Ollama models that use colons in their tags (e.g. `glm-5.2:cloud`, `nomic-embed-text:latest`, `kimi-k2:1t-cloud`), this truncates the model id to just the tag suffix (`cloud` instead of `glm-5.2:cloud`), causing **HTTP 404 errors** from the inference endpoint.

The existing triple-syntax guard (`custom:name:model` → `("custom:name", "model")`) had no way to distinguish between:
- `custom:ollama:qwen3` — provider `custom:ollama`, model `qwen3` (intended triple syntax)
- `custom:glm-5.2:cloud` — provider `custom`, model `glm-5.2:cloud` (Ollama tag, NOT triple syntax)

## Solution

Add `_is_registered_custom_provider()` that checks whether the middle part matches a configured custom provider in `config.yaml` (via `get_compatible_custom_providers()`). The triple split only happens when the middle part is a **registered** custom provider name. Otherwise, the full string after `custom:` is treated as the model id.

```python
# Before (truncates Ollama tags):
if custom_name and actual_model:
    return (f"custom:{custom_name}", actual_model)

# After (only splits for registered custom providers):
if custom_name and actual_model and _is_registered_custom_provider(custom_name):
    return (f"custom:{custom_name}", actual_model)
```

## Testing

- Updated `test_custom_triple_syntax` and `test_custom_triple_spaces` to mock `_is_registered_custom_provider` (since `local-server`/`my-server` are not registered providers in the test env)
- Added `test_custom_triple_unregistered_falls_back` — verifies `custom:glm-5.2:cloud` with a mocked `False` returns the full model id
- Added `test_custom_ollama_tag_not_truncated` — regression test without mocks, verifies real-world Ollama model names pass through intact

Verified manually:
```
parse_model_input("custom:glm-5.2:cloud", "custom")    → ("custom", "glm-5.2:cloud") ✅
parse_model_input("custom:ollama:qwen3", "custom")      → ("custom:ollama", "qwen3")  ✅
parse_model_input("custom:nomic-embed-text:latest", ..) → ("custom", "nomic-embed-text:latest") ✅
parse_model_input("custom:gpt-4o", "custom")            → ("custom", "gpt-4o")         ✅
```

## Scope

- Only affects the triple-syntax path (`custom:name:model`). Single-colon path (`custom:model`) is unchanged.
- No new dependencies. `_is_registered_custom_provider` uses `get_compatible_custom_providers` which already exists in `hermes_cli/config.py`.
- Related: #53558 addresses a similar parsing issue for `/` (slash) syntax in ACP model names. This PR is complementary (different delimiter, same root concern).