### PR TITLE
fix(gateway): skip queued-follow-up re-send when stream consumer already delivered

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18057,6 +18057,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         first_response,
                         previewed=_previewed,
                     )
+                    # Fallback: the stream consumer may have already sent the
+                    # response (already_sent=True) but _final_response_sent was
+                    # never set because the stream task was cancelled after the
+                    # send completed (e.g. image delivery or cleanup exceeded
+                    # the 5-second wait).  Treat delivery as confirmed to
+                    # prevent re-sending the response that is already visible
+                    # on the chat platform.  (#55806)
+                    if (
+                        not _already_streamed
+                        and _sc is not None
+                        and getattr(_sc, "already_sent", False)
+                    ):
+                        _already_streamed = True
+                        logger.debug(
+                            "Queued follow-up for session %s: stream consumer already_sent=True but final_response_sent=False; skipping re-send.",
+                            session_key or "?",
+                        )
                     if first_response and not _already_streamed:
                         try:
                             logger.info(

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -376,6 +376,47 @@ class TestQueuedMessageAlreadyStreamed:
 
         assert _already_streamed is False
 
+    def test_queued_path_skips_resend_when_consumer_already_sent(self):
+        """When the stream consumer already sent content (already_sent=True)
+        but final_response_sent is False (e.g. stream task was cancelled
+        after the send), the queued follow-up must NOT re-send the response.
+
+        Regression test for #55806: image delivery or cleanup can exceed the
+        5-second stream-task wait, causing the task to be cancelled after the
+        message was already delivered to the user."""
+        _sc = self._make_mock_sc(already_sent=True, final_response_sent=False)
+
+        # Original check: only final_response_sent
+        _already_streamed = bool(
+            _sc and getattr(_sc, "final_response_sent", False)
+        )
+        # Fallback: consumer already sent content
+        if (
+            not _already_streamed
+            and _sc is not None
+            and getattr(_sc, "already_sent", False)
+        ):
+            _already_streamed = True
+
+        assert _already_streamed is True
+
+    def test_queued_path_sends_when_consumer_never_sent(self):
+        """When the stream consumer never sent anything (already_sent=False
+        and final_response_sent=False), the queued follow-up must re-send."""
+        _sc = self._make_mock_sc(already_sent=False, final_response_sent=False)
+
+        _already_streamed = bool(
+            _sc and getattr(_sc, "final_response_sent", False)
+        )
+        if (
+            not _already_streamed
+            and _sc is not None
+            and getattr(_sc, "already_sent", False)
+        ):
+            _already_streamed = True
+
+        assert _already_streamed is False
+
 
 # ===================================================================
 # Test 4: stream_consumer.py — cancellation handler delivery confirmation


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition where the gateway's queued-follow-up path re-sends a response that was already delivered to the user by the stream consumer.

When a response includes image attachments, the stream consumer sends the text, then `_deliver_media_from_response()` sends the images separately. If background processes finish around the same time and inject notifications, the queued-follow-up path checks `_stream_confirmed_final_delivery()` which only looks at `final_response_sent`. If the stream task was cancelled after the send (e.g. image delivery or cleanup exceeded the 5-second wait), `final_response_sent` stays `False` and the response is re-sent as a duplicate.

The fix adds a fallback check: if the stream consumer's `already_sent` property is `True`, treat delivery as confirmed. This only applies to the queued-follow-up path — the normal send path is unaffected.

## Related Issue

Fixes #55806

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Added fallback check in the queued-follow-up path — when `_stream_confirmed_final_delivery()` returns False but the stream consumer's `already_sent` is True, skip the re-send. This prevents duplicate responses when the stream task is cancelled after delivering the message.
- `tests/gateway/test_duplicate_reply_suppression.py`: Added 2 regression tests covering the new fallback (consumer already sent → skip, consumer never sent → re-send).

## How to Test

1. Run `pytest tests/gateway/test_duplicate_reply_suppression.py -q` — all 28 tests should pass (26 existing + 2 new).
2. The bug requires a specific timing scenario (stream consumer sends text, image delivery takes >5 seconds, background process notification arrives during the gap). The regression tests verify the logic without requiring the timing race.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (logic-only change, no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

From the issue reporter's gateway logs:
```
17:59:06  [Discord] Sending response (672 chars)    ← stream consumer sent the text
17:59:06  [Discord] Sending 1 image(s)              ← image delivered separately
17:59:11  Process finished — injecting agent notification
17:59:14  Queued follow-up: final stream delivery not confirmed; sending first response  ← BUG: duplicate
```

With the fix, the queued follow-up path sees `already_sent=True` on the stream consumer and skips the re-send.
