### PR TITLE
feat(acp): add evidence no-tools mode

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -143,6 +143,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Accept all prompts (currently used by --setup-browser to skip the "
              "~400 MB Chromium download confirmation).",
     )
+    parser.add_argument(
+        "--evidence-no-tools",
+        action="store_true",
+        help=(
+            "Start ACP in no-tool/no-MCP evidence mode for reviewed "
+            "governance preflights. This does not authorize a provider run."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -246,18 +254,21 @@ def main(argv: list[str] | None = None) -> None:
     import acp
     from .server import HermesACPAgent
 
-    # MCP tool discovery from config.yaml — run before asyncio.run() so
-    # it's safe to use blocking waits.  (ACP also registers per-session
-    # MCP servers dynamically via asyncio.to_thread inside the event
-    # loop; that path is unaffected.)  Moved from model_tools.py module
-    # scope to avoid freezing the gateway's loop on lazy import (#16856).
-    try:
-        from tools.mcp_tool import discover_mcp_tools
-        discover_mcp_tools()
-    except Exception:
-        logger.debug("MCP tool discovery failed at ACP startup", exc_info=True)
+    if not args.evidence_no_tools:
+        # MCP tool discovery from config.yaml — run before asyncio.run() so
+        # it's safe to use blocking waits.  (ACP also registers per-session
+        # MCP servers dynamically via asyncio.to_thread inside the event
+        # loop; that path is unaffected.)  Moved from model_tools.py module
+        # scope to avoid freezing the gateway's loop on lazy import (#16856).
+        try:
+            from tools.mcp_tool import discover_mcp_tools
+            discover_mcp_tools()
+        except Exception:
+            logger.debug("MCP tool discovery failed at ACP startup", exc_info=True)
+    else:
+        logger.info("Starting ACP evidence no-tool/no-MCP mode")
 
-    agent = HermesACPAgent()
+    agent = HermesACPAgent(evidence_no_tools=args.evidence_no_tools)
     try:
         asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))
     except KeyboardInterrupt:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -514,9 +514,20 @@ class HermesACPAgent(acp.Agent):
         value: key for key, value in _MODE_TO_EDIT_APPROVAL_POLICY.items()
     }
 
-    def __init__(self, session_manager: SessionManager | None = None):
+    def __init__(
+        self,
+        session_manager: SessionManager | None = None,
+        evidence_no_tools: bool = False,
+    ):
         super().__init__()
-        self.session_manager = session_manager or SessionManager()
+        self.evidence_no_tools = bool(
+            evidence_no_tools or getattr(session_manager, "evidence_no_tools", False)
+        )
+        self.session_manager = session_manager or SessionManager(
+            evidence_no_tools=self.evidence_no_tools
+        )
+        if self.evidence_no_tools:
+            self.session_manager.evidence_no_tools = True
         self._conn: Optional[acp.Client] = None
 
     # ---- Connection lifecycle -----------------------------------------------
@@ -793,6 +804,10 @@ class HermesACPAgent(acp.Agent):
         """Register ACP-provided MCP servers and refresh the agent tool surface."""
         if not mcp_servers:
             return
+        if self.evidence_no_tools:
+            raise RuntimeError(
+                "ACP evidence no-tool/no-MCP mode rejects session MCP servers"
+            )
 
         try:
             from tools.mcp_tool import register_mcp_servers
@@ -1779,6 +1794,8 @@ class HermesACPAgent(acp.Agent):
         return f"Model switched to: {new_model}\nProvider: {provider_label}"
 
     def _cmd_tools(self, args: str, state: SessionState) -> str:
+        if self.evidence_no_tools or getattr(state.agent, "acp_evidence_no_tools", False):
+            return "No tools available."
         try:
             from model_tools import get_tool_definitions
             from types import SimpleNamespace

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -74,6 +74,7 @@ from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
 from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
 from acp_adapter.tools import build_tool_complete, build_tool_start
+from tools.approval import reset_hermes_interactive_context, set_hermes_interactive_context
 
 logger = logging.getLogger(__name__)
 
@@ -1461,20 +1462,19 @@ class HermesACPAgent(acp.Agent):
         # Approval callback is per-thread (thread-local, GHSA-qg5c-hvr5-hjgr).
         # Set it INSIDE _run_agent so the TLS write happens in the executor
         # thread — setting it here would write to the event-loop thread's TLS,
-        # not the executor's. Also set HERMES_INTERACTIVE so approval.py
-        # takes the CLI-interactive path (which calls the registered
-        # callback via prompt_dangerous_approval) instead of the
+        # not the executor's. Also bind interactive approval mode through a
+        # ContextVar so approval.py takes the CLI-interactive path, which calls
+        # the registered callback via prompt_dangerous_approval instead of the
         # non-interactive auto-approve branch (GHSA-96vc-wcxf-jjff).
         # ACP's conn.request_permission maps cleanly to the interactive
         # callback shape — not the gateway-queue HERMES_EXEC_ASK path,
         # which requires a notify_cb registered in _gateway_notify_cbs.
         previous_approval_cb = None
-        previous_interactive = None
         edit_approval_token = None
         previous_session_id = None
 
         def _run_agent() -> dict:
-            nonlocal previous_approval_cb, previous_interactive, edit_approval_token, previous_session_id
+            nonlocal previous_approval_cb, edit_approval_token, previous_session_id
             # Bind HERMES_SESSION_KEY for this session so per-session caches
             # (e.g. the interactive sudo password cache in tools.terminal_tool)
             # scope to the ACP session rather than leaking across sessions
@@ -1506,9 +1506,11 @@ class HermesACPAgent(acp.Agent):
                 except Exception:
                     logger.debug("Could not set ACP edit approval requester", exc_info=True)
             # Signal to tools.approval that we have an interactive callback
-            # and the non-interactive auto-approve path must not fire.
-            previous_interactive = os.environ.get("HERMES_INTERACTIVE")
-            os.environ["HERMES_INTERACTIVE"] = "1"
+            # and the non-interactive auto-approve path must not fire. This
+            # must be context-local, not os.environ-based: concurrent ACP
+            # sessions share executor threads and process-global env mutation
+            # can race across sessions.
+            interactive_token = set_hermes_interactive_context(True)
             # Propagate the originating ACP session id to tools that want to
             # tag side-effects with it (e.g. ``kanban_create`` stamps it on
             # the new task so clients can render a per-session board). Save
@@ -1528,11 +1530,7 @@ class HermesACPAgent(acp.Agent):
                 logger.exception("Agent error in session %s", session_id)
                 return {"final_response": f"Error: {e}", "messages": state.history}
             finally:
-                # Restore HERMES_INTERACTIVE.
-                if previous_interactive is None:
-                    os.environ.pop("HERMES_INTERACTIVE", None)
-                else:
-                    os.environ["HERMES_INTERACTIVE"] = previous_interactive
+                reset_hermes_interactive_context(interactive_token)
                 # Restore HERMES_SESSION_ID symmetrically.
                 if previous_session_id is None:
                     os.environ.pop("HERMES_SESSION_ID", None)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -191,7 +191,7 @@ class SessionManager:
     via ``session_search``.
     """
 
-    def __init__(self, agent_factory=None, db=None):
+    def __init__(self, agent_factory=None, db=None, evidence_no_tools: bool = False):
         """
         Args:
             agent_factory: Optional callable that creates an AIAgent-like object.
@@ -199,11 +199,14 @@ class SessionManager:
                            using the current Hermes runtime provider configuration.
             db:            Optional SessionDB instance. When omitted, the default
                            SessionDB (``~/.hermes/state.db``) is lazily created.
+            evidence_no_tools: Create ACP sessions with an empty tool surface
+                           for reviewed governance evidence preflights.
         """
         self._sessions: Dict[str, SessionState] = {}
         self._lock = Lock()
         self._agent_factory = agent_factory
         self._db_instance = db  # None → lazy-init on first use
+        self.evidence_no_tools = bool(evidence_no_tools)
 
     # ---- public API ---------------------------------------------------------
 
@@ -566,7 +569,7 @@ class SessionManager:
         api_mode: str | None = None,
     ):
         if self._agent_factory is not None:
-            return self._agent_factory()
+            return self._prepare_agent_for_session(self._agent_factory())
 
         from run_agent import AIAgent
         from hermes_cli.config import load_config
@@ -582,18 +585,23 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
-        configured_mcp_servers = [
-            name
-            for name, cfg in (config.get("mcp_servers") or {}).items()
-            if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
-        ]
+        if self.evidence_no_tools:
+            configured_mcp_servers = []
+            enabled_toolsets: list[str] = []
+        else:
+            configured_mcp_servers = [
+                name
+                for name, cfg in (config.get("mcp_servers") or {}).items()
+                if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
+            ]
+            enabled_toolsets = _expand_acp_enabled_toolsets(
+                ["hermes-acp"],
+                mcp_server_names=configured_mcp_servers,
+            )
 
         kwargs = {
             "platform": "acp",
-            "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
-                mcp_server_names=configured_mcp_servers,
-            ),
+            "enabled_toolsets": enabled_toolsets,
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),
@@ -624,4 +632,14 @@ class SessionManager:
         # ACP stdio transport requires stdout to remain protocol-only JSON-RPC.
         # Route any incidental human-readable agent output to stderr instead.
         agent._print_fn = _acp_stderr_print
+        self._prepare_agent_for_session(agent)
+        return agent
+
+    def _prepare_agent_for_session(self, agent):
+        if self.evidence_no_tools:
+            agent.acp_evidence_no_tools = True
+            agent._skip_mcp_refresh = True
+            agent.enabled_toolsets = []
+            agent.tools = []
+            agent.valid_tool_names = set()
         return agent

--- a/docs/design/acp-no-tool-no-mcp-evidence-mode.md
+++ b/docs/design/acp-no-tool-no-mcp-evidence-mode.md
@@ -1,0 +1,177 @@
+# ACP No-Tool / No-MCP Evidence Mode
+
+Status: design proposal (not yet implemented)
+Author: drafted for AI Governance evidence planning
+
+## Why this exists
+
+AI Governance wants to run one future Hermes model/provider evidence attempt
+without treating a normal Hermes session as governed runtime proof.
+
+The evidence run needs a stronger boundary than prompt wording. A prompt such
+as "do not use tools" is model guidance, not an execution constraint. If the
+runtime still exposes tool schemas, MCP servers, edit approvals, terminal
+tools, browser tools, memory tools, or plugin tools, the run cannot be used as
+no-tool governance evidence.
+
+This design defines the smallest Hermes-side shape that could support a future
+real provider evidence run:
+
+- no tools exposed to the model;
+- no MCP discovery or MCP server toolsets added;
+- final response capture still available;
+- no provider run authorized by this proposal;
+- no change to normal ACP or Hermes user experience.
+
+## Current blocker
+
+`hermes-acp` is a useful final-response capture candidate, but it is not
+currently a reviewed no-tool/no-MCP execution path.
+
+The current ACP startup and session path has these blocker properties:
+
+- `acp_adapter/entry.py` loads environment/config surfaces before starting the
+  server.
+- `acp_adapter/entry.py` performs MCP tool discovery during ACP startup.
+- `acp_adapter/session.py` constructs ACP agents with
+  `enabled_toolsets=["hermes-acp"]`.
+- `acp_adapter/session.py` also adds enabled MCP servers from config as
+  toolsets.
+- `hermes tools disable ...` is config-mutating and is not a no-write preflight
+  mechanism.
+- The shared platform registry does not currently expose an `acp` platform that
+  can be targeted by the existing tools configuration UX.
+
+Therefore a future governance evidence run is blocked until Hermes exposes a
+reviewed no-tool/no-MCP execution constraint.
+
+## Design goals
+
+1. Provide a real runtime constraint, not prompt-only policy.
+2. Preserve ACP final-response capture so the evidence runner can review the
+   model's final text.
+3. Avoid normal UX regression for ACP users.
+4. Avoid prompt-cache churn during ordinary conversations.
+5. Avoid adding a new core model tool.
+6. Avoid writing or mutating user config as part of the evidence preflight.
+7. Make the active tool surface inspectable in the evidence packet.
+
+## Non-goals
+
+- Do not run a provider or model.
+- Do not read or store credential values.
+- Do not add a new provider integration.
+- Do not change normal ACP startup behavior by default.
+- Do not mutate `config.yaml`, `.env`, profile files, or MCP config for the
+  evidence mode.
+- Do not add a new core model tool.
+- Do not implement a governance hook, CI gate, or enforcement layer.
+- Do not claim that no-tool evidence proves truth, reliability, safety, or
+  non-bypassable governance.
+
+## Proposed shape
+
+Add an ACP evidence-mode path that can construct a session with:
+
+```text
+enabled_toolsets=[]
+disabled_toolsets=None
+mcp_server_names=[]
+discover_mcp_tools_on_startup=false
+```
+
+The mode should be selected by an explicit ACP startup/session option, not by a
+prompt, not by editing global config, and not by relying on an environment
+variable as user-facing configuration.
+
+Possible implementation surfaces, in preference order:
+
+1. An ACP-specific command-line flag, for example `hermes-acp --evidence-no-tools`.
+2. An ACP protocol/session initialization option if the client can pass one.
+3. A local wrapper used only by the evidence harness that calls ACP session
+   construction with the no-tool parameters.
+
+The design should prefer a narrow ACP-specific option over widening global
+Hermes tool configuration.
+
+## Required behavior
+
+When evidence mode is enabled:
+
+1. ACP server startup must not discover MCP tools.
+2. ACP session construction must not add `hermes-acp`.
+3. ACP session construction must not add config-defined MCP server toolsets.
+4. The model API request must receive no tool schemas.
+5. Tool dispatch callbacks should remain inert or unreachable for the run.
+6. Final response capture must remain available.
+7. The evidence packet must record the effective tool surface as empty.
+
+If any of these cannot be met, the evidence mode must fail closed before a
+provider call.
+
+## Prompt-cache boundary
+
+This mode is intended for a dedicated evidence session, not for changing an
+existing conversation mid-stream.
+
+It must not mutate toolsets in a live conversation. The no-tool state must be
+fixed at session creation time. This keeps the normal prompt-cache invariant:
+toolsets are part of the cached prompt surface and must not change
+mid-conversation.
+
+## Config boundary
+
+Behavioral settings should not be introduced as new user-facing `HERMES_*`
+environment variables. If this becomes a persistent user-facing feature, it
+should be represented in `config.yaml` or an ACP session option.
+
+For the governance evidence run, prefer an explicit per-run option over writing
+to `config.yaml`. The evidence run should not require changing the user's
+normal ACP tools setup.
+
+## Evidence packet fields
+
+A future evidence packet should include:
+
+```yaml
+entrypoint: hermes-acp
+evidence_mode: no_tools_no_mcp
+effective_enabled_toolsets: []
+effective_mcp_servers: []
+mcp_discovery_on_startup: false
+tool_schema_count: 0
+final_response_capture: present
+provider_run_authorized: false
+not_claimed:
+  - provider_safety
+  - model_reliability
+  - semantic_truth
+  - non_bypassable_governance
+  - general_acp_behavior_changed
+```
+
+`provider_run_authorized` remains false until a separate operator instruction
+authorizes credential use and model execution.
+
+## Test expectations for a future implementation
+
+The implementation should include focused tests that prove:
+
+1. Default ACP behavior still enables its normal ACP tool surface.
+2. Evidence mode constructs the agent with an empty enabled toolset list.
+3. Evidence mode does not add config-defined MCP servers.
+4. Evidence mode does not call MCP discovery during startup.
+5. Evidence mode leaves final-response capture intact.
+6. Evidence mode fails closed if a tool schema would be sent to the model.
+
+These tests should use a temp `HERMES_HOME` and the existing Hermes test
+wrapper conventions. They should not touch the user's real `~/.hermes`.
+
+## Review boundary
+
+This proposal only defines the design target. It does not make real provider
+evidence runnable.
+
+Before any provider run, the implementation must be reviewed separately and a
+preflight packet must show that the effective tool surface is empty for the
+selected entrypoint, provider, model, prompt, and artifact paths.

--- a/tests/acp/test_approval_isolation.py
+++ b/tests/acp/test_approval_isolation.py
@@ -13,6 +13,7 @@ Both fixed together by:
    threads don't collide.
 """
 
+import os
 import threading
 
 
@@ -193,19 +194,10 @@ class TestThreadLocalApprovalCallback:
 
 
 class TestAcpExecAskGate:
-    """GHSA-96vc-wcxf-jjff: ACP's _run_agent must set HERMES_INTERACTIVE so
-    that tools.approval.check_all_command_guards takes the CLI-interactive
-    path (consults the registered callback via prompt_dangerous_approval)
-    instead of the non-interactive auto-approve shortcut.
-
-    (HERMES_EXEC_ASK takes the gateway-queue path which requires a
-    notify_cb registered in _gateway_notify_cbs — not applicable to ACP,
-    which uses a direct callback shape.)"""
+    """GHSA-96vc-wcxf-jjff: ACP must route dangerous commands to callbacks."""
 
     def test_interactive_env_var_routes_to_callback(self, monkeypatch):
-        """When HERMES_INTERACTIVE is set and an approval callback is
-        registered, a dangerous command must route through the callback."""
-        # Clean env
+        """The legacy HERMES_INTERACTIVE env fallback still works."""
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
@@ -219,7 +211,6 @@ class TestAcpExecAskGate:
             called_with.append((command, description))
             return "once"
 
-        # Without HERMES_INTERACTIVE: takes auto-approve path, callback NOT called
         result = check_all_command_guards(
             "rm -rf /tmp/test-exec-ask", "local", approval_callback=fake_cb,
         )
@@ -229,7 +220,6 @@ class TestAcpExecAskGate:
             "path should fire without consulting the callback"
         )
 
-        # With HERMES_INTERACTIVE: callback IS called, approval flows through it
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         called_with.clear()
         result = check_all_command_guards(
@@ -237,7 +227,42 @@ class TestAcpExecAskGate:
         )
         assert called_with, (
             "with HERMES_INTERACTIVE the approval path should consult the "
-            "registered callback — this was the ACP bypass in "
-            "GHSA-96vc-wcxf-jjff"
+            "registered callback"
+        )
+        assert result["approved"] is True
+
+    def test_interactive_contextvar_routes_to_callback_without_env(self, monkeypatch):
+        """ACP should not need process-global HERMES_INTERACTIVE for approvals."""
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from tools.approval import (
+            check_all_command_guards,
+            reset_hermes_interactive_context,
+            set_hermes_interactive_context,
+        )
+
+        called_with = []
+
+        def fake_cb(command, description, *, allow_permanent=True):
+            called_with.append((command, description))
+            return "once"
+
+        token = set_hermes_interactive_context(True)
+        try:
+            result = check_all_command_guards(
+                "rm -rf /tmp/test-contextvar-approval",
+                "local",
+                approval_callback=fake_cb,
+            )
+        finally:
+            reset_hermes_interactive_context(token)
+
+        assert os.environ.get("HERMES_INTERACTIVE") is None
+        assert called_with, (
+            "context-local interactive approval should consult the registered "
+            "callback without mutating process-global HERMES_INTERACTIVE"
         )
         assert result["approved"] is True

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -23,6 +23,32 @@ def test_main_enables_unstable_protocol(monkeypatch):
     assert calls["kwargs"]["use_unstable_protocol"] is True
 
 
+def test_main_evidence_no_tools_skips_startup_mcp_discovery(monkeypatch):
+    calls = {}
+
+    async def fake_run_agent(agent, **kwargs):
+        calls["agent"] = agent
+        calls["kwargs"] = kwargs
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            calls["agent_kwargs"] = kwargs
+
+    def fail_discovery():
+        raise AssertionError("MCP discovery must not run in evidence no-tools mode")
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", fail_discovery)
+    monkeypatch.setattr("acp_adapter.server.HermesACPAgent", FakeAgent)
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main(["--evidence-no-tools"])
+
+    assert calls["agent_kwargs"] == {"evidence_no_tools": True}
+    assert calls["kwargs"]["use_unstable_protocol"] is True
+
+
 def test_main_version_prints_without_starting_server(monkeypatch, capsys):
     monkeypatch.setattr(entry, "_setup_logging", lambda: (_ for _ in ()).throw(AssertionError("started server")))
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1481,6 +1481,17 @@ class TestSlashCommands:
         result = agent._handle_slash_command("/model", state)
         assert "test-model" in result
 
+    def test_evidence_no_tools_tools_command_does_not_rebuild_surface(self, mock_manager):
+        state = self._make_state(mock_manager)
+        state.agent.acp_evidence_no_tools = True
+        evidence_agent = HermesACPAgent(session_manager=mock_manager, evidence_no_tools=True)
+
+        with patch("model_tools.get_tool_definitions") as mock_defs:
+            result = evidence_agent._handle_slash_command("/tools", state)
+
+        assert result == "No tools available."
+        mock_defs.assert_not_called()
+
     def test_context_empty(self, agent, mock_manager):
         state = self._make_state(mock_manager)
         state.history = []
@@ -1720,6 +1731,18 @@ class TestRegisterSessionMcpServers:
         # Should not raise
         await agent._register_session_mcp_servers(state, None)
         await agent._register_session_mcp_servers(state, [])
+
+    @pytest.mark.asyncio
+    async def test_evidence_no_tools_rejects_session_mcp_servers(self, mock_manager):
+        """Evidence mode fails closed before registering ACP-provided MCP servers."""
+        from acp.schema import McpServerStdio
+
+        agent = HermesACPAgent(session_manager=mock_manager, evidence_no_tools=True)
+        state = mock_manager.create_session(cwd="/tmp")
+        server = McpServerStdio(name="srv", command="/bin/test", args=[], env=[])
+
+        with pytest.raises(RuntimeError, match="evidence no-tool/no-MCP mode"):
+            await agent._register_session_mcp_servers(state, [server])
 
     @pytest.mark.asyncio
     async def test_registers_stdio_servers(self, agent, mock_manager):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1251,6 +1251,37 @@ class TestPrompt:
         assert os.environ.get("HERMES_SESSION_ID") == "outer-sess"
 
     @pytest.mark.asyncio
+    async def test_prompt_binds_interactive_mode_with_contextvar_not_env(self, agent, monkeypatch):
+        """ACP must use context-local interactive approval state."""
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+        from tools.approval import _is_interactive_cli
+
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        captured: dict[str, object] = {}
+
+        def mock_run(*args, **kwargs):
+            captured["env"] = os.environ.get("HERMES_INTERACTIVE")
+            captured["context_interactive"] = _is_interactive_cli()
+            return {"final_response": "ok", "messages": []}
+
+        state.agent.run_conversation = mock_run
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hi")]
+        await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert captured["env"] is None
+        assert captured["context_interactive"] is True
+        assert os.environ.get("HERMES_INTERACTIVE") is None
+        assert _is_interactive_cli() is False
+
+    @pytest.mark.asyncio
     async def test_prompt_does_not_duplicate_streamed_final_message(self, agent):
         """If ACP already streamed response chunks, final_response should not be sent again."""
         new_resp = await agent.new_session(cwd=".")

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -322,6 +322,71 @@ class TestPersistence:
 
         assert captured["enabled_toolsets"] == ["hermes-acp", "mcp-olympus", "mcp-exa"]
 
+    def test_evidence_no_tools_session_ignores_configured_mcp_toolsets(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            return {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+            }
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.model = kwargs.get("model")
+                self.enabled_toolsets = kwargs.get("enabled_toolsets")
+                self.tools = []
+                self.valid_tool_names = set()
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "mcp_servers": {
+                "olympus": {"command": "python", "enabled": True},
+                "exa": {"url": "https://exa.ai/mcp"},
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", FakeAgent):
+            manager = SessionManager(db=db, evidence_no_tools=True)
+            state = manager.create_session(cwd="/work")
+
+        assert captured["enabled_toolsets"] == []
+        assert state.agent.enabled_toolsets == []
+        assert state.agent.tools == []
+        assert state.agent.valid_tool_names == set()
+        assert state.agent.acp_evidence_no_tools is True
+        assert state.agent._skip_mcp_refresh is True
+
+    def test_evidence_no_tools_clears_agent_factory_tool_surface(self, tmp_path):
+        agent = SimpleNamespace(
+            model="factory-model",
+            enabled_toolsets=["hermes-acp", "mcp-leak"],
+            tools=[{"name": "leaked_tool"}],
+            valid_tool_names={"leaked_tool"},
+        )
+        db = SessionDB(tmp_path / "state.db")
+        manager = SessionManager(agent_factory=lambda: agent, db=db, evidence_no_tools=True)
+
+        state = manager.create_session(cwd="/work")
+
+        assert state.agent is agent
+        assert state.agent.enabled_toolsets == []
+        assert state.agent.tools == []
+        assert state.agent.valid_tool_names == set()
+        assert state.agent.acp_evidence_no_tools is True
+        assert state.agent._skip_mcp_refresh is True
+
     def test_create_session_writes_to_db(self, manager):
         state = manager.create_session(cwd="/project")
         db = manager._get_db()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -47,6 +47,10 @@ _approval_tool_call_id: contextvars.ContextVar[str] = contextvars.ContextVar(
     "approval_tool_call_id",
     default="",
 )
+_hermes_interactive_ctx: contextvars.ContextVar[bool | None] = contextvars.ContextVar(
+    "hermes_interactive_ctx",
+    default=None,
+)
 
 
 def _fire_approval_hook(hook_name: str, **kwargs) -> None:
@@ -106,6 +110,30 @@ def reset_current_observability_context(
     turn_token, tool_token = tokens
     _approval_tool_call_id.reset(tool_token)
     _approval_turn_id.reset(turn_token)
+
+
+def set_hermes_interactive_context(enabled: bool) -> contextvars.Token[bool | None]:
+    """Bind interactive approval mode to the current execution context.
+
+    ACP and gateway worker pools run concurrent turns in shared executor
+    threads. Use a ContextVar for this flag so one session cannot clear another
+    session's interactive approval state through process-global environment
+    mutation.
+    """
+    return _hermes_interactive_ctx.set(bool(enabled))
+
+
+def reset_hermes_interactive_context(token: contextvars.Token[bool | None]) -> None:
+    """Restore the previous context-local interactive approval mode."""
+    _hermes_interactive_ctx.reset(token)
+
+
+def _is_interactive_cli() -> bool:
+    """Return whether approval checks should use interactive CLI callbacks."""
+    interactive = _hermes_interactive_ctx.get()
+    if interactive is not None:
+        return bool(interactive)
+    return env_var_enabled("HERMES_INTERACTIVE")
 
 
 def get_current_session_key(default: str = "default") -> str:
@@ -1344,7 +1372,7 @@ def check_dangerous_command(command: str, env_type: str,
     if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
-    is_cli = env_var_enabled("HERMES_INTERACTIVE")
+    is_cli = _is_interactive_cli()
     is_gateway = _is_gateway_approval_context()
 
     if not is_cli and not is_gateway:
@@ -1604,7 +1632,7 @@ def check_all_command_guards(command: str, env_type: str,
     if _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
-    is_cli = env_var_enabled("HERMES_INTERACTIVE")
+    is_cli = _is_interactive_cli()
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 


### PR DESCRIPTION
Purpose

Add an ACP edge flag for reviewed evidence preflights where Hermes must expose no tools and accept no MCP servers. This is intended as a runtime constraint for future evidence collection, not as a provider/model validation run.

What changed

- Add `--evidence-no-tools` to the ACP entrypoint.
- Skip ACP startup MCP discovery when evidence no-tools mode is enabled.
- Create ACP sessions with an empty tool surface in evidence mode.
- Apply no-tool cleanup to both real `AIAgent` creation and injected `agent_factory` paths.
- Fail closed when ACP session MCP servers are supplied in evidence mode.
- Prevent `/tools` from rebuilding a tool surface in evidence mode.
- Include the design note for the no-tool/no-MCP evidence mode.
- Add focused coverage for startup MCP discovery suppression, configured MCP toolset exclusion, injected-agent cleanup, session MCP rejection, and `/tools` behavior.

Non-scope

- No provider/model run was performed.
- No credential use.
- No core model tool addition.
- No prompt-cache or governance enforcement claim.
- No claim that this mode validates provider behavior by itself.

Local validation

- PASS: `tests/acp/test_session.py tests/agent/test_turn_context.py` -> 58 passed
- PASS: `git diff --check`
- PASS: AST parse changed files
- NOT RUN locally: `tests/acp/test_entry.py tests/acp/test_server.py` because local env lacks `hermes-agent[acp]` / `agent-client-protocol`

Known branch state

The head branch was prepared from the fork main at `8603826e4` and may need to be updated against current upstream `main` if CI or mergeability requires it.

Reviewer entrypoint

Start with `acp_adapter/session.py`, especially `_prepare_agent_for_session()`, then check `acp_adapter/entry.py` and `acp_adapter/server.py` for startup MCP discovery, session MCP rejection, and `/tools` behavior.