### PR TITLE
fix: honor explicitly configured api_mode for custom OpenAI-compatible providers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3605,7 +3605,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         )
         self._provider_source: Optional[str] = None
         self.provider = self.requested_provider
-        self.api_mode = "chat_completions"
+        self.api_mode = CLI_CONFIG["model"].get("api_mode") or "chat_completions"
         self.acp_command: Optional[str] = None
         self.acp_args: list[str] = []
         self.base_url = (

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -127,13 +127,9 @@ def _resolve_plain_custom_api_mode(model_cfg: Dict[str, Any], base_url: str) -> 
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     detected_mode = _detect_api_mode_for_url(base_url)
 
-    if configured_mode == "codex_responses" and detected_mode != "codex_responses":
-        logger.info(
-            "Ignoring persisted custom api_mode=codex_responses for non-OpenAI endpoint %s",
-            base_url or "(unknown)",
-        )
-        configured_mode = None
-
+    # Honor explicitly configured api_mode for custom providers that declare
+    # their own api_mode (e.g. providers: section with api_mode: codex_responses).
+    # Only fall back to detection/default when no explicit mode is set.
     return configured_mode or detected_mode or "chat_completions"
 
 


### PR DESCRIPTION
## Problem

Users configuring third-party OpenAI-compatible relay endpoints (e.g. `ssnaiyun.com`, `shitrouter.com`) that support the **Responses API** (`codex_responses`) cannot use it — Hermes silently forces `chat_completions` regardless of the `model.api_mode` setting in `config.yaml`.

This affects users in regions where direct OpenAI/API access requires a relay, many of which now support the newer Responses API format.

## Root Cause

**1. `cli.py` ignores `model.api_mode` from config**

```python
# Before (line 3608)
self.api_mode = "chat_completions"  # hardcoded, never reads config
```

The CLI never reads `model.api_mode` from `config.yaml`, always defaulting to `chat_completions`.

**2. `runtime_provider.py` silently discards `codex_responses` for non-OpenAI domains**

```python
# Before (_resolve_plain_custom_api_mode)
if configured_mode == "codex_responses" and detected_mode != "codex_responses":
    logger.info("Ignoring persisted custom api_mode=codex_responses for non-OpenAI endpoint %s", base_url)
    configured_mode = None
```

This guard was intended to prevent stale persisted config from forcing generic relays onto the Responses path, but it also blocks **explicitly configured** `api_mode: codex_responses` for relays that genuinely support it.

## Fix

**1. `cli.py`**: Read `model.api_mode` from config with fallback to `chat_completions`:

```python
self.api_mode = CLI_CONFIG["model"].get("api_mode") or "chat_completions"
```

**2. `runtime_provider.py`**: Remove the override guard — honor explicitly configured `api_mode`, fall back to URL-based detection only when no mode is set:

```python
return configured_mode or detected_mode or "chat_completions"
```

## Configuration Example

```yaml
model:
  default: glm-5.2
  provider: openai-api
  base_url: ''
  api_mode: codex_responses   # now respected for relay endpoints

custom_providers:
  - name: openai-responses
    base_url: 'https://relay.example.com/v1'
    key_env: OPENAI_API_KEY
    api_mode: codex_responses
    model: glm-5.2
```

## Testing

- Verified with `ssnaiyun.com/v1` (GLM-5.2) and `api.shitrouter.com/v1` (GPT-5.5) — both relays support Responses API
- Agent log confirms `codex_stream_request` instead of `chat_completion_stream_request` after the fix
- No regressions for `chat_completions` (default fallback unchanged)

## Changes

- `cli.py`: 1 line changed
- `hermes_cli/runtime_provider.py`: 5 lines removed, 2 lines added