### PR TITLE
fix(cron): decode job script stdout as UTF-8 to prevent silent empty capture on non-UTF-8 Windows locales

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1635,6 +1635,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=script_timeout,
             cwd=str(path.parent),
             env=_sanitize_subprocess_env(os.environ.copy()),


### PR DESCRIPTION
## Problem

On Windows with a non-UTF-8 system locale (e.g. Korean cp949), scheduled cron jobs whose data-collection script prints UTF-8 output (emoji / CJK) are captured as **empty**, even though the child script exits 0 and prints correctly. The job's `last_status` shows `ok` and `last_delivery_error` is `None`, but nothing is delivered — the scheduler logs:

```
cron.scheduler: Job 'NAME': script produced no output, skipping AI call.
cron.scheduler: Job 'ID': agent returned [SILENT] - skipping delivery
```

and the saved output file (`~/.hermes/cron/output/<job_id>/<ts>.md`) is 0 bytes.

## Root cause

`cron/scheduler.py::_run_job_script` runs the script with `subprocess.run(..., text=True)` but **without `encoding=`**. In text mode without an explicit encoding, Python decodes the child's stdout using `locale.getpreferredencoding()`, which on a non-UTF-8 system locale is cp949 (Korean), cp1252, etc. A script that writes UTF-8 bytes is then decoded with the wrong codec, so the capture comes back empty/garbled while the child itself printed fine. That asymmetry (child prints OK, parent captures nothing) is the tell-tale sign.

## Fix

Pass `encoding="utf-8", errors="replace"` to that `subprocess.run`, so job-script stdout is always decoded as UTF-8 regardless of host locale. `errors="replace"` keeps a stray non-UTF-8 byte from raising instead of silently emptying the capture.

## Verification

Reproduced on Korean Windows (ANSI code page 949): a cron job whose script prints Korean/emoji JSON captured 0 bytes and delivered nothing (`[SILENT]`); the identical script run directly (its own stdout UTF-8) printed ~7 KB fine. With this 2-line change the parent captures the full output and delivery resumes. A pure-ASCII script was unaffected either way, isolating the bug to the parent-side decode.
