### PR TITLE
Add stock-sentiment skill (sentiment + smart-money layer for US equities)

### DIFF
--- a/optional-skills/finance/stock-sentiment/SKILL.md
+++ b/optional-skills/finance/stock-sentiment/SKILL.md
@@ -39,7 +39,7 @@ Do not use it for order entry, portfolio management, or personalized advice. It 
 
 ## Prerequisites
 
-- Python 3.8+ using only the standard library (`urllib`, `json`); no third-party packages required. Any HTTP client or plain `curl` works too.
+- Python 3.8+ using only the standard library (`urllib`, `json`); no third-party packages required. Any HTTP client or plain `curl` works too. On macOS python.org installs the client can raise `CERTIFICATE_VERIFY_FAILED` (missing CA certs): run the bundled `Install Certificates.command`, use the system `/usr/bin/python3`, or use `curl` (which uses the system trust store).
 - A free `SENTISENSE_API_KEY`. Generate one from the Developer Console at https://app.sentisense.ai/settings/developer. The key is required on every call; anonymous requests return `401 api_key_required`.
 - Network access to `https://app.sentisense.ai`.
 - Read-only scope. Every endpoint here is a GET. Nothing this skill does can place a trade, move money, or modify account state.
@@ -141,10 +141,10 @@ SMART MONEY  (wrapped in {isPreview, previewReason, data}; free key returns a pr
   GET /api/v1/politicians/member/{slug}                   Member profile (data.recentTrades[]).
   GET /api/v1/institutional/quarters                      Call FIRST; bare array, [0].reportDate is latest.
   GET /api/v1/institutional/holders/{T}?reportDate={Q}    Top 13F holders (data.holders[], largest first).
-  GET /api/v1/analyst/{T}/consensus                       Price-target band (consensus.consensusLabel).
+  GET /api/v1/analyst/{T}/consensus                       Price-target band; data IS the consensus object (data.consensusLabel).
   GET /api/v1/analyst/{T}/actions?lookbackDays=N          Recent rating changes for one ticker.
-  GET /api/v1/analyst/{T}/estimates                       EPS band (estimateLow/Mean/High,
-                                                          numberOfAnalysts) + surprises[]; no revenue.
+  GET /api/v1/analyst/{T}/estimates                       EPS band at data.estimates[0].{estimateLow/Mean/High,
+                                                          numberOfAnalysts} + data.surprises[]; no revenue.
   GET /api/v1/analyst/activity?lookbackDays=N             Market-wide actions (filter actionType client-side).
 
 AI INSIGHTS  (wrapped; batch, carry generatedAt)
@@ -161,11 +161,11 @@ NEWS & STORIES
   GET /api/v1/documents/search?query=...            Topical document search.
 
 SUPPORTING  (price, prices, chart are real-time; profile, popular, calendar, market-summary are reference or batch)
-  GET /api/v1/stocks/price?ticker={T}                       price.currentPrice, price.changePercent.
+  GET /api/v1/stocks/price?ticker={T}                       Flat (no wrapper): currentPrice, changePercent at root.
   GET /api/v1/stocks/prices?tickers=A,B,C                   Batch quotes.
   GET /api/v1/stocks/{T}/profile                            profile.name, sector, industry.
   GET /api/v1/stocks/chart?ticker={T}&timeframe=1D|5D|1W|1M|3M|6M|1Y|ALL   Bars; read each point's timestamp (Unix ms).
-  GET /api/v1/stocks/popular                                Candidate universe for screens.
+  GET /api/v1/stocks/popular                                Bare array of ~75 ticker strings (screen universe).
   GET /api/v1/calendar/earnings?ticker={T}                  data.earnings[]; next date + consensus EPS + confirmed.
   GET /api/v1/market-summary                                Market-wide narrative headline.
 ```
@@ -193,7 +193,7 @@ Answer "what is the overall market mood today."
 
 1. `GET /api/v2/market-mood`.
 
-The response is flat, but the composite is nested under `market`, not the root: `market.currentScore`, `market.phase` (for example Greed or Fear), `market.weeklyChange`, and `market.signals[]` (each sub-gauge with its value and change). Per-sector readings live at `sectors.{SectorName}.{ currentScore, phase, weeklyChange }`; `sectors` is a string-keyed dict, not an array, and has overlapping GICS labels (`Technology` and `Information Technology`, `Healthcare` and `Health Care`), so dedupe those before ranking top and bottom sectors. Report as context: "Market mood 62 (Greed), +4 over the week. Greed leaders: Technology, Communications. Fear: Energy, Utilities." Optionally pair with `GET /api/v1/market-summary` for the narrative headline and `GET /api/v1/insights/market` for the top market-wide signals.
+The response is flat, but the composite is nested under `market`, not the root: `market.currentScore`, `market.phase` (e.g. Fear, Neutral, Optimism, Greed), `market.weeklyChange`, and `market.signals[]` (each sub-gauge with its value and change). Per-sector readings live at `sectors.{SectorName}.{ currentScore, phase, weeklyChange }`; `sectors` is a string-keyed dict, not an array, and has overlapping GICS labels (`Technology` and `Information Technology`, `Healthcare` and `Health Care`), so dedupe those before ranking top and bottom sectors. Report as context: "Market mood 62 (Greed), +4 over the week. Greed leaders: Technology, Communications. Fear: Energy, Utilities." Optionally pair with `GET /api/v1/market-summary` for the narrative headline and `GET /api/v1/insights/market` for the top market-wide signals.
 
 ### 3. Smart-money convergence screen
 

--- a/optional-skills/finance/stock-sentiment/SKILL.md
+++ b/optional-skills/finance/stock-sentiment/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 required_environment_variables:
   - name: SENTISENSE_API_KEY
     prompt: SentiSense API key
-    help: "Free key from Settings > Developer Console at https://sentisense.ai"
+    help: "Free key from the Developer Console: https://app.sentisense.ai/settings/developer"
     required_for: sentiment, smart-money, and AI-insight data
 ---
 # Stock Sentiment Skill
@@ -40,7 +40,7 @@ Do not use it for order entry, portfolio management, or personalized advice. It 
 ## Prerequisites
 
 - Python 3.8+ using only the standard library (`urllib`, `json`); no third-party packages required. Any HTTP client or plain `curl` works too.
-- A free `SENTISENSE_API_KEY`. Generate one from Settings > Developer Console at https://sentisense.ai. The key is required on every call; anonymous requests return `401 api_key_required`.
+- A free `SENTISENSE_API_KEY`. Generate one from the Developer Console at https://app.sentisense.ai/settings/developer. The key is required on every call; anonymous requests return `401 api_key_required`.
 - Network access to `https://app.sentisense.ai`.
 - Read-only scope. Every endpoint here is a GET. Nothing this skill does can place a trade, move money, or modify account state.
 

--- a/optional-skills/finance/stock-sentiment/SKILL.md
+++ b/optional-skills/finance/stock-sentiment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stock-sentiment
-description: "Sentiment and smart money for US stocks: the SentiSense Score, sentiment polarity, market mood (fear/greed), insider and congressional and 13F flows, analyst actions, AI insights, and sentiment-tagged news. Read-only: no trading, no purchases, no wallet access."
+description: "Sentiment and smart-money positioning for US stocks."
 version: 0.1.0
 author: SentiSense
 license: MIT

--- a/optional-skills/finance/stock-sentiment/SKILL.md
+++ b/optional-skills/finance/stock-sentiment/SKILL.md
@@ -154,7 +154,7 @@ AI INSIGHTS  (wrapped; batch, carry generatedAt)
 
 NEWS & STORIES
   GET /api/v1/documents/ticker/{T}?limit=N          Sentiment-tagged feed ({documents, totalCount}); each doc
-                                                   has url, source, published (epoch seconds), averageSentiment; no title.
+                                                   has url, source, sourceName, published (epoch seconds), averageSentiment; no title.
   GET /api/v1/documents/stories?limit=N             Pre-clustered stories; cluster.title is SentiSense-authored and safe to show.
   GET /api/v1/documents/stories/ticker/{T}?limit=N  Stories for one ticker.
   GET /api/v1/documents/stories/{id}                Story detail (PublicStoryDetailDto; aspectPerspectives[], bullishView/bearishView).
@@ -163,7 +163,7 @@ NEWS & STORIES
 SUPPORTING  (price, prices, chart are real-time; profile, popular, calendar, market-summary are reference or batch)
   GET /api/v1/stocks/price?ticker={T}                       Flat (no wrapper): currentPrice, changePercent at root.
   GET /api/v1/stocks/prices?tickers=A,B,C                   Batch quotes.
-  GET /api/v1/stocks/{T}/profile                            profile.name, sector, industry.
+  GET /api/v1/stocks/{T}/profile                            name, sector, industry (flat at root; no profile key).
   GET /api/v1/stocks/chart?ticker={T}&timeframe=1D|5D|1W|1M|3M|6M|1Y|ALL   Bars; read each point's timestamp (Unix ms).
   GET /api/v1/stocks/popular                                Bare array of ~75 ticker strings (screen universe).
   GET /api/v1/calendar/earnings?ticker={T}                  data.earnings[]; next date + consensus EPS + confirmed.

--- a/optional-skills/finance/stock-sentiment/SKILL.md
+++ b/optional-skills/finance/stock-sentiment/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: stock-sentiment
+description: "Sentiment and smart money for US stocks: the SentiSense Score, sentiment polarity, market mood (fear/greed), insider and congressional and 13F flows, analyst actions, AI insights, and sentiment-tagged news via a read-only API."
+version: 0.1.0
+author: SentiSense
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Sentiment, Stocks, Finance, Market, Investing]
+    category: finance
+    related_skills: [stocks, dcf-model, comps-analysis]
+required_environment_variables:
+  - name: SENTISENSE_API_KEY
+    prompt: SentiSense API key
+    help: "Free key from Settings > Developer Console at https://sentisense.ai"
+    required_for: sentiment, smart-money, and AI-insight data
+---
+# Stock Sentiment Skill
+
+The sentiment and smart-money layer for US equities. A quote skill tells you the price; this skill reads what the market feels about a stock (the SentiSense Score, sentiment polarity, mentions, share of voice), where the smart money is moving (insider, congressional, and institutional flows plus analyst actions), and what the AI read of the tape is (per-stock and market-wide insights, sentiment-tagged news), all through the read-only SentiSense API.
+
+Read-only educational data interface. Output is informational context, never a personalized buy or sell recommendation.
+
+## When to Use
+
+Reach for this skill when the question is about perception, positioning, or signal rather than raw price:
+
+- "What is the sentiment on $NVDA?" or "Is the mood on $TSLA bullish or bearish?"
+- "What is the smart money doing this week?" (insider cluster-buys, congressional trades, 13F flows, and analyst upgrades converging on the same tickers).
+- "What is the overall market mood today, fear or greed?"
+- "Is sentiment diverging from price on $COIN?" (price up while sentiment falls, or the reverse).
+- "What is the pre-earnings sentiment setup on $AAPL?"
+- "What is the AI insight on $MSFT, and what are people saying in the news?"
+
+This skill complements the rest of the finance catalog rather than competing with it. The `stocks` skill covers real-time quote, search, history, and compare; `dcf-model` and `comps-analysis` cover intrinsic and relative valuation. This skill adds the sentiment, smart-money, and AI-insight dimension none of those carry. A useful pairing: value a name with `dcf-model` or `comps-analysis`, pull its quote with `stocks`, then read this skill for the sentiment and positioning context around it.
+
+Do not use it for order entry, portfolio management, or personalized advice. It has no write, trading, or wallet surface; every endpoint is a GET.
+
+## Prerequisites
+
+- Python 3.8+ using only the standard library (`urllib`, `json`); no third-party packages required. Any HTTP client or plain `curl` works too.
+- A free `SENTISENSE_API_KEY`. Generate one from Settings > Developer Console at https://sentisense.ai. The key is required on every call; anonymous requests return `401 api_key_required`.
+- Network access to `https://app.sentisense.ai`.
+- Read-only scope. Every endpoint here is a GET. Nothing this skill does can place a trade, move money, or modify account state.
+
+Tiers:
+
+| Tier | Quota | Rate |
+|------|-------|------|
+| Free | 1,000 requests/month | 30 requests/min |
+| PRO ($15/mo) | Unlimited | 300 requests/min |
+
+The free tier exercises every workflow below. Preview-gated endpoints return a truncated but real slice on a free key (for example the top 3 insights); PRO removes the monthly cap and returns full history and full lists.
+
+## How to Run
+
+This skill is invoked through the agent's terminal or shell tool: issue HTTP GET requests to the SentiSense API and synthesize the JSON into a concise, sourced answer. The base URL is `https://app.sentisense.ai`. Authenticate every request with the `X-SentiSense-API-Key` header; keep the key in the shell environment and never place it in a query string or in user-facing output.
+
+```bash
+curl -s -H "X-SentiSense-API-Key: $SENTISENSE_API_KEY" \
+  "https://app.sentisense.ai/api/v2/metrics/entity/NVDA/metric/sentiment"
+```
+
+An anonymous call returns `401 api_key_required`. A rate-limited call returns `429` with a `Retry-After` header; back off for the indicated seconds rather than retrying immediately or serving a stale value.
+
+On Windows, use the bundled Python client (cross-platform) and reference the key as `%SENTISENSE_API_KEY%` (cmd) or `$env:SENTISENSE_API_KEY` (PowerShell) rather than the POSIX `$SENTISENSE_API_KEY` shown above.
+
+Two response envelopes exist; unwrap correctly before reading fields:
+
+- Read FLAT (top-level, no `.data`): `stocks/price`, `stocks/prices`, `stocks/chart`, `stocks/popular`, `stocks/{T}/profile`, `market-mood`, and the metric series (`sentiment`, `sentisense`, `mentions`, and `social_dominance` are bare arrays). `institutional/quarters` is also a bare array.
+- Read WRAPPED as `{ isPreview, previewReason, data }` (use `.data`): `insider/*`, `politicians/*`, `institutional/holders`, `analyst/*`, `insights/*`, and `calendar/earnings` (here `data` is a dict, so read `data.earnings[]`).
+- `documents/ticker` has its own shape `{ documents, totalCount }`; read `.documents[]`.
+
+When unsure, accept both: `rows = raw if isinstance(raw, list) else raw.get("data", raw)`.
+
+An optional stdlib helper, `scripts/sentiment_client.py`, wraps all of this: it injects the auth header, prepends the base URL, and normalizes both envelopes (including the nested sentiment scalar) so the agent reasons over clean values. Use it or plain `curl`, whichever fits the host. The core of the helper is small enough to inline:
+
+```python
+#!/usr/bin/env python3
+"""Minimal stdlib client for the read-only SentiSense API."""
+import json, os, urllib.parse, urllib.request
+
+BASE = "https://app.sentisense.ai"
+
+def get(path, **params):
+    url = BASE + path
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(
+        url, headers={"X-SentiSense-API-Key": os.environ["SENTISENSE_API_KEY"]})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.load(r)
+
+def rows(raw):
+    """Wrap-vs-flat: some endpoints return a bare array, others {isPreview, data}."""
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict) and "data" in raw:
+        return raw["data"]
+    return raw
+
+def latest_sentiment(ticker):
+    """Latest sentiment polarity in [-1, 1]; the scalar is nested at metricValue.value.value."""
+    series = get(f"/api/v2/metrics/entity/{ticker}/metric/sentiment")
+    if not series:
+        return None
+    return float(series[-1]["metricValue"]["value"]["value"])
+```
+
+```bash
+python scripts/sentiment_client.py sentiment NVDA
+python scripts/sentiment_client.py mood
+```
+
+## Quick Reference
+
+All paths are relative to `https://app.sentisense.ai` and are GET. Every call requires the `X-SentiSense-API-Key` header. `{T}` is an uppercase ticker, `{slug}` a member slug, `{id}` a story id. Full schema: https://sentisense.ai/skill.md.
+
+```
+SENTIMENT & MOOD
+  GET /api/v2/metrics/entity/{T}/metric/sentiment?startTime={epochMs}&endTime={epochMs}
+        Sentiment polarity time series. Omit params for the server default 7-day window.
+        Bare array; latest scalar is series[-1].metricValue.value.value (a float in [-1, 1]).
+  GET /api/v2/metrics/entity/{T}/metric/sentisense
+        The SentiSense Score (unbounded composite; report as-is, never normalize to 0-100).
+  GET /api/v2/metrics/entity/{T}/metric/mentions
+        Mention-volume time series (how much a ticker is being talked about).
+  GET /api/v2/metrics/entity/{T}/metric/social_dominance
+        Share-of-conversation time series (a ticker's dominance of the chatter).
+  GET /api/v2/market-mood
+        Composite fear/greed plus sub-signals and per-sector breakdowns. Flat, but the
+        composite is nested: market.currentScore, market.phase, market.weeklyChange,
+        market.signals[]; sectors.{SectorName}.{currentScore, phase, weeklyChange}.
+
+SMART MONEY  (wrapped in {isPreview, previewReason, data}; free key returns a preview slice)
+  GET /api/v1/insider/cluster-buys?lookbackDays=N         Tickers with multiple insider buys.
+  GET /api/v1/insider/trades/{T}?lookbackDays=N           Form 4 rows; transactionType BUY|SELL.
+  GET /api/v1/politicians/activity?lookbackDays=N         Congressional trades; PURCHASE|SALE.
+  GET /api/v1/politicians/filings/{T}?lookbackDays=N      Per-ticker congressional filings.
+  GET /api/v1/politicians/member/{slug}                   Member profile (data.recentTrades[]).
+  GET /api/v1/institutional/quarters                      Call FIRST; bare array, [0].reportDate is latest.
+  GET /api/v1/institutional/holders/{T}?reportDate={Q}    Top 13F holders (data.holders[], largest first).
+  GET /api/v1/analyst/{T}/consensus                       Price-target band (consensus.consensusLabel).
+  GET /api/v1/analyst/{T}/actions?lookbackDays=N          Recent rating changes for one ticker.
+  GET /api/v1/analyst/{T}/estimates                       EPS band (estimateLow/Mean/High,
+                                                          numberOfAnalysts) + surprises[]; no revenue.
+  GET /api/v1/analyst/activity?lookbackDays=N             Market-wide actions (filter actionType client-side).
+
+AI INSIGHTS  (wrapped; batch, carry generatedAt)
+  GET /api/v1/insights/stock/{T}         Per-stock signals ranked by importance; data[0].insightText is the headline. Free preview top 3.
+  GET /api/v1/insights/stock/{T}/types   Available insight types (no auth, no quota cost).
+  GET /api/v1/insights/market            Top market-wide signals (data[], insightText; ticker embedded in insightText).
+
+NEWS & STORIES
+  GET /api/v1/documents/ticker/{T}?limit=N          Sentiment-tagged feed ({documents, totalCount}); each doc
+                                                   has url, source, published (epoch seconds), averageSentiment; no title.
+  GET /api/v1/documents/stories?limit=N             Pre-clustered stories; cluster.title is SentiSense-authored and safe to show.
+  GET /api/v1/documents/stories/ticker/{T}?limit=N  Stories for one ticker.
+  GET /api/v1/documents/stories/{id}                Story detail (PublicStoryDetailDto; aspectPerspectives[], bullishView/bearishView).
+  GET /api/v1/documents/search?query=...            Topical document search.
+
+SUPPORTING  (price, prices, chart are real-time; profile, popular, calendar, market-summary are reference or batch)
+  GET /api/v1/stocks/price?ticker={T}                       price.currentPrice, price.changePercent.
+  GET /api/v1/stocks/prices?tickers=A,B,C                   Batch quotes.
+  GET /api/v1/stocks/{T}/profile                            profile.name, sector, industry.
+  GET /api/v1/stocks/chart?ticker={T}&timeframe=1D|5D|1W|1M|3M|6M|1Y|ALL   Bars; read each point's timestamp (Unix ms).
+  GET /api/v1/stocks/popular                                Candidate universe for screens.
+  GET /api/v1/calendar/earnings?ticker={T}                  data.earnings[]; next date + consensus EPS + confirmed.
+  GET /api/v1/market-summary                                Market-wide narrative headline.
+```
+
+Sentiment is polarity: a float in [-1, 1] where the sign is the direction (negative is bearish and meaningful, positive is bullish) and the magnitude is conviction. Represent the sign unmistakably; do not map it onto a 0-100 scale. The SentiSense Score is a separate, unbounded composite; report it as-is. Mentions and social dominance are their own metric series on the same `/metric/{metricType}` endpoint (`mentions` for talk volume, `social_dominance` for share of the conversation); all four series (`sentiment`, `sentisense`, `mentions`, `social_dominance`) are Public with no quota cost. A separate `/api/v2/metrics/entity/{T}/distribution/{metricType}` endpoint breaks a metric down by source (share of voice, a "where this signal came from" view, not per-source sentiment values).
+
+## Workflows
+
+Opinionated recipes. Each fans out its independent calls in parallel, then synthesizes; none recommends buying or selling. Frame every result as educational context on positioning and mood.
+
+### 1. Sentiment read on a ticker
+
+Answer "what is the market feeling about $T" in a few dense lines. Fire these in parallel:
+
+1. `GET /api/v2/metrics/entity/{T}/metric/sentiment` for the polarity trend (server default 7-day window; the latest scalar is `series[-1].metricValue.value.value`, a float in [-1, 1]).
+2. `GET /api/v2/metrics/entity/{T}/metric/sentisense` for the composite score.
+3. `GET /api/v1/documents/ticker/{T}?limit=8` for mention volume (`totalCount`) and the sentiment-tagged feed.
+4. `GET /api/v1/insights/stock/{T}` for the top AI insight (`data[0].insightText`, with `generatedAt` for freshness).
+
+Synthesize as educational context, leading with the differentiated sentiment read, not the price: "$NVDA sentiment +0.42 over 7d and rising; SentiSense Score elevated; mention volume heavy; latest AI insight: 'Data-center demand commentary firming' (as of the batch time)." Show the `generatedAt` age so the reader knows these are batch metrics.
+
+### 2. Market mood (fear and greed)
+
+Answer "what is the overall market mood today."
+
+1. `GET /api/v2/market-mood`.
+
+The response is flat, but the composite is nested under `market`, not the root: `market.currentScore`, `market.phase` (for example Greed or Fear), `market.weeklyChange`, and `market.signals[]` (each sub-gauge with its value and change). Per-sector readings live at `sectors.{SectorName}.{ currentScore, phase, weeklyChange }`; `sectors` is a string-keyed dict, not an array, and has overlapping GICS labels (`Technology` and `Information Technology`, `Healthcare` and `Health Care`), so dedupe those before ranking top and bottom sectors. Report as context: "Market mood 62 (Greed), +4 over the week. Greed leaders: Technology, Communications. Fear: Energy, Utilities." Optionally pair with `GET /api/v1/market-summary` for the narrative headline and `GET /api/v1/insights/market` for the top market-wide signals.
+
+### 3. Smart-money convergence screen
+
+Find tickers where insider buying, congressional purchases, and analyst upgrades line up in the same window; convergence is the signal a quote feed cannot produce.
+
+1. `GET /api/v1/insider/cluster-buys?lookbackDays=7`.
+2. `GET /api/v1/politicians/activity?lookbackDays=7`, keeping rows with `transactionType == "PURCHASE"`.
+3. `GET /api/v1/analyst/activity?lookbackDays=7`, filtering client-side to `actionType == "UPGRADE"` (there is no server-side type filter).
+
+All three are wrapped: read `.data`. Intersect the three ticker lists and report names appearing in two or more buckets, ranked by total signal count, with a one-liner each: "$NVDA: 4 insiders bought, 1 congressional purchase, 2 analyst upgrades (7d)." If a 7-day bucket returns an empty array (common on quiet weeks; `isPreview:false`, disclosure lag, not an error), widen that specific call to `lookbackDays=30` and note the wider window rather than showing a blank result. For one ticker's full flow, run `insider/trades/{T}`, `politicians/filings/{T}`, `institutional/quarters` then `institutional/holders/{T}?reportDate={Q}`, and `analyst/{T}/actions`. Present as observed positioning, never as advice.
+
+### 4. Pre-earnings sentiment check
+
+Read the sentiment and positioning into an earnings print.
+
+1. `GET /api/v1/calendar/earnings?ticker={T}` for the next report date and consensus (`data.earnings[0].earningsDate`, `confirmed`); an empty response means the name is outside the forward window, so ask the user for the date instead of guessing.
+2. `GET /api/v2/metrics/entity/{T}/metric/sentiment?startTime={now-30d}&endTime={now}` (epoch milliseconds) for the 30-day sentiment trend.
+3. `GET /api/v1/insider/trades/{T}?lookbackDays=60` for recent insider activity (`transactionType` BUY or SELL).
+4. `GET /api/v1/analyst/{T}/estimates` for the EPS band and `surprises[]` beat/miss history.
+5. `GET /api/v1/analyst/{T}/actions?lookbackDays=30` for recent rating changes.
+6. `GET /api/v1/insights/stock/{T}` for the current AI read.
+
+Synthesize the setup as educational context: "$AAPL earnings in 5d: sentiment +0.22 over 30d and trending up; insiders net sellers (2 sells, 0 buys); EPS consensus $1.52 (range $1.48 to $1.55, 28 analysts), beat in 3 of the last 4 quarters; 3 upgrades in 30d. Setup reads mixed-to-constructive." Do not tell the user how to trade the print.
+
+### 5. Sentiment-versus-price divergence
+
+Surface names where perception and price disagree; a bullish gap (price down, sentiment up) and a bearish gap (price up, sentiment down) are the two shapes of interest.
+
+1. `GET /api/v1/stocks/popular` for the candidate list.
+2. For each candidate, in parallel: `GET /api/v1/stocks/chart?ticker={T}&timeframe=1M` (a bare array of intraday bars; filter to `timestamp >= now-7d` and compare the first versus last bar for the 7-day move) and `GET /api/v2/metrics/entity/{T}/metric/sentiment` (server default 7-day window; measure the trend across the returned series).
+3. Rank by the absolute gap between the price move and the sentiment move; report the top few in each direction.
+
+Frame the result as an observed divergence, not a signal to act: "Bullish divergence: $TSLA price -8% while sentiment +0.11 over 7d. Bearish divergence: $COIN price +14% while sentiment -0.09." Keep the real-time price and the batch sentiment labeled with their own freshness; do not blend them into one implied "now."
+
+## Pitfalls
+
+- **Batch, not real time.** Sentiment, the SentiSense Score, mentions, share of voice, news clustering, and AI insights are batch metrics computed on a schedule; only quote, price, and chart points are real time. State a batch value with its `generatedAt` age and never label it "real time."
+- **Empty smart-money windows are normal.** The 7-day insider and congressional feeds often return empty arrays on quiet weeks (disclosure lag, `isPreview:false`, not an error). Widen that specific call to `lookbackDays=30` and note the wider window rather than showing a blank result.
+- **Preview gating is data, not failure.** On the free tier, preview-gated endpoints return `isPreview:true` with a real truncated slice (for example the top 3 insights, the current earnings week, a sliced holder list). Render the slice as the answer and tag it `(preview)`. Mention PRO only when the truncation is materially limiting the answer.
+- **Wrap versus flat differs by endpoint.** Reading `.data` on a flat endpoint (or the reverse) yields nothing. Flat: `stocks/price`, `stocks/prices`, `stocks/chart`, `stocks/popular`, `stocks/{T}/profile`, `market-mood`, the `sentiment`, `sentisense`, `mentions`, and `social_dominance` series, and `institutional/quarters`. Wrapped under `.data`: `insider/*`, `politicians/*`, `institutional/holders`, `analyst/*`, `insights/*`, and `calendar/earnings`. When unsure, accept both.
+- **The sentiment scalar is nested.** The series is a bare array and the float lives at `series[i].metricValue.value.value`; `series[i].metricValue.value` is itself a dict, so there is no top-level `series[i].value` shortcut.
+- **Congress and insider use different verbs.** Insider rows carry `transactionType` BUY or SELL; congressional rows carry PURCHASE or SALE. Filter each with its own vocabulary.
+- **Always fetch quarters first.** Call `institutional/quarters` and pass `[0].reportDate` to `institutional/holders`; never hardcode a quarter.
+- **Documents carry no article title.** The document feed returns URLs, `source`, `published` (epoch seconds), and `averageSentiment`, not the publisher's headline. Pre-clustered story titles (`cluster.title`) are SentiSense-authored and safe to display verbatim; prefer stories when a readable title is needed.
+- **No invented endpoints.** There is no options flow, no dark pool, and no `/congress` (congressional data lives under `/politicians`). The earnings calendar is `/api/v1/calendar/earnings`.
+- **No advice.** When asked "should I buy," return data-grounded synthesis (sentiment, smart-money flow, analyst consensus, AI insight) framed as educational context, not a personal recommendation.
+
+## Verification
+
+Confirm the skill is wired correctly before trusting a synthesis:
+
+1. **Reachability and auth.** `GET /api/v1/insights/stock/AAPL/types` needs no authentication and costs no quota; a `200` with a JSON list confirms the base URL and network. Then repeat one authenticated call, for example `curl -s -o /dev/null -w "%{http_code}" -H "X-SentiSense-API-Key: $SENTISENSE_API_KEY" "https://app.sentisense.ai/api/v2/market-mood"`; a `200` confirms the header and key. A `401 api_key_required` means the header or `SENTISENSE_API_KEY` is missing or wrong; a `429` means the per-minute rate was exceeded, so honor the `Retry-After` hint.
+2. **Sentiment parses.** Fetch `/api/v2/metrics/entity/AAPL/metric/sentiment`, confirm a non-empty array, and read `series[-1].metricValue.value.value`; it should be a float in [-1, 1]. A value outside that range means the wrong nesting was read.
+3. **Mood nests as expected.** Fetch `/api/v2/market-mood` and confirm `market.currentScore`, `market.phase`, and `market.weeklyChange` are present (not at the root), and that `sectors` is a populated dict.
+4. **Envelope check.** Confirm `institutional/quarters` parses as a bare array and `insider/cluster-buys?lookbackDays=30` parses as `{ isPreview, data }` with `data` an array (an empty array on a quiet window is a valid result, not a failure).
+5. **Freshness is surfaced.** Any batch value presented to the user carries its `generatedAt`; if a synthesis omits the age on a sentiment or insight figure, or describes a batch surface as real time, it is not verified.
+
+A run passes when every quoted number traces to a `200` response read this turn, batch and real-time surfaces are labeled distinctly, and the output reads as educational context rather than a recommendation.

--- a/optional-skills/finance/stock-sentiment/SKILL.md
+++ b/optional-skills/finance/stock-sentiment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stock-sentiment
-description: "Sentiment and smart money for US stocks: the SentiSense Score, sentiment polarity, market mood (fear/greed), insider and congressional and 13F flows, analyst actions, AI insights, and sentiment-tagged news via a read-only API."
+description: "Sentiment and smart money for US stocks: the SentiSense Score, sentiment polarity, market mood (fear/greed), insider and congressional and 13F flows, analyst actions, AI insights, and sentiment-tagged news. Read-only: no trading, no purchases, no wallet access."
 version: 0.1.0
 author: SentiSense
 license: MIT

--- a/optional-skills/finance/stock-sentiment/SKILL.md
+++ b/optional-skills/finance/stock-sentiment/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 required_environment_variables:
   - name: SENTISENSE_API_KEY
     prompt: SentiSense API key
-    help: "Free key from the Developer Console: https://app.sentisense.ai/settings/developer"
+    help: "Free key at https://app.sentisense.ai/get-api-key"
     required_for: sentiment, smart-money, and AI-insight data
 ---
 # Stock Sentiment Skill
@@ -40,7 +40,7 @@ Do not use it for order entry, portfolio management, or personalized advice. It 
 ## Prerequisites
 
 - Python 3.8+ using only the standard library (`urllib`, `json`); no third-party packages required. Any HTTP client or plain `curl` works too. On macOS python.org installs the client can raise `CERTIFICATE_VERIFY_FAILED` (missing CA certs): run the bundled `Install Certificates.command`, use the system `/usr/bin/python3`, or use `curl` (which uses the system trust store).
-- A free `SENTISENSE_API_KEY`. Generate one from the Developer Console at https://app.sentisense.ai/settings/developer. The key is required on every call; anonymous requests return `401 api_key_required`.
+- A free `SENTISENSE_API_KEY`. Get one at https://app.sentisense.ai/get-api-key. The key is required on every call; anonymous requests return `401 api_key_required`.
 - Network access to `https://app.sentisense.ai`.
 - Read-only scope. Every endpoint here is a GET. Nothing this skill does can place a trade, move money, or modify account state.
 
@@ -139,7 +139,7 @@ SMART MONEY  (wrapped in {isPreview, previewReason, data}; free key returns a pr
   GET /api/v1/politicians/activity?lookbackDays=N         Congressional trades; PURCHASE|SALE.
   GET /api/v1/politicians/filings/{T}?lookbackDays=N      Per-ticker congressional filings.
   GET /api/v1/politicians/member/{slug}                   Member profile (data.recentTrades[]).
-  GET /api/v1/institutional/quarters                      Call FIRST; bare array, [0].reportDate is latest.
+  GET /api/v1/institutional/quarters                      Call FIRST; bare array. Use reportDate of first entry whose pending is not true; skip pending:true (fall back to [0] only if all pending).
   GET /api/v1/institutional/holders/{T}?reportDate={Q}    Top 13F holders (data.holders[], largest first).
   GET /api/v1/analyst/{T}/consensus                       Price-target band; data IS the consensus object (data.consensusLabel).
   GET /api/v1/analyst/{T}/actions?lookbackDays=N          Recent rating changes for one ticker.
@@ -236,7 +236,7 @@ Frame the result as an observed divergence, not a signal to act: "Bullish diverg
 - **Wrap versus flat differs by endpoint.** Reading `.data` on a flat endpoint (or the reverse) yields nothing. Flat: `stocks/price`, `stocks/prices`, `stocks/chart`, `stocks/popular`, `stocks/{T}/profile`, `market-mood`, the `sentiment`, `sentisense`, `mentions`, and `social_dominance` series, and `institutional/quarters`. Wrapped under `.data`: `insider/*`, `politicians/*`, `institutional/holders`, `analyst/*`, `insights/*`, and `calendar/earnings`. When unsure, accept both.
 - **The sentiment scalar is nested.** The series is a bare array and the float lives at `series[i].metricValue.value.value`; `series[i].metricValue.value` is itself a dict, so there is no top-level `series[i].value` shortcut.
 - **Congress and insider use different verbs.** Insider rows carry `transactionType` BUY or SELL; congressional rows carry PURCHASE or SALE. Filter each with its own vocabulary.
-- **Always fetch quarters first.** Call `institutional/quarters` and pass `[0].reportDate` to `institutional/holders`; never hardcode a quarter.
+- **Always fetch quarters first.** Call `institutional/quarters` and pass the `reportDate` of the first quarter whose `pending` is not true to `institutional/holders`; skip any `pending:true` entry (within ~45 days of a quarter close the most-recent quarter is still filing and holds almost no holders), and fall back to `[0]` only if every entry is `pending:true`. Never hardcode a quarter.
 - **Documents carry no article title.** The document feed returns URLs, `source`, `published` (epoch seconds), and `averageSentiment`, not the publisher's headline. Pre-clustered story titles (`cluster.title`) are SentiSense-authored and safe to display verbatim; prefer stories when a readable title is needed.
 - **No invented endpoints.** There is no options flow, no dark pool, and no `/congress` (congressional data lives under `/politicians`). The earnings calendar is `/api/v1/calendar/earnings`.
 - **No advice.** When asked "should I buy," return data-grounded synthesis (sentiment, smart-money flow, analyst consensus, AI insight) framed as educational context, not a personal recommendation.

--- a/optional-skills/finance/stock-sentiment/SKILL.md
+++ b/optional-skills/finance/stock-sentiment/SKILL.md
@@ -2,7 +2,7 @@
 name: stock-sentiment
 description: "Sentiment and smart-money positioning for US stocks."
 version: 0.1.0
-author: SentiSense
+author: TheSentiTrader (TheSentiTrader), SentiSense
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -51,7 +51,7 @@ Tiers:
 | Free | 1,000 requests/month | 30 requests/min |
 | PRO ($15/mo) | Unlimited | 300 requests/min |
 
-The free tier exercises every workflow below. Preview-gated endpoints return a truncated but real slice on a free key (for example the top 3 insights); PRO removes the monthly cap and returns full history and full lists.
+The free tier exercises every recipe below. Preview-gated endpoints return a truncated but real slice on a free key (for example the top 3 insights); PRO removes the monthly cap and returns full history and full lists.
 
 ## How to Run
 
@@ -172,7 +172,7 @@ SUPPORTING  (price, prices, chart are real-time; profile, popular, calendar, mar
 
 Sentiment is polarity: a float in [-1, 1] where the sign is the direction (negative is bearish and meaningful, positive is bullish) and the magnitude is conviction. Represent the sign unmistakably; do not map it onto a 0-100 scale. The SentiSense Score is a separate, unbounded composite; report it as-is. Mentions and social dominance are their own metric series on the same `/metric/{metricType}` endpoint (`mentions` for talk volume, `social_dominance` for share of the conversation); all four series (`sentiment`, `sentisense`, `mentions`, `social_dominance`) are Public with no quota cost. A separate `/api/v2/metrics/entity/{T}/distribution/{metricType}` endpoint breaks a metric down by source (share of voice, a "where this signal came from" view, not per-source sentiment values).
 
-## Workflows
+## Procedure
 
 Opinionated recipes. Each fans out its independent calls in parallel, then synthesizes; none recommends buying or selling. Frame every result as educational context on positioning and mood.
 

--- a/optional-skills/finance/stock-sentiment/scripts/sentiment_client.py
+++ b/optional-skills/finance/stock-sentiment/scripts/sentiment_client.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Minimal, read-only stdlib client for the SentiSense API.
+
+No third-party packages. Reads SENTISENSE_API_KEY from the environment, injects
+the X-SentiSense-API-Key header, prepends the base URL, and normalizes the two
+response envelopes so callers reason over clean values. Every endpoint is a GET;
+nothing here can trade, move money, or modify account state.
+
+Usage:
+  python sentiment_client.py sentiment NVDA
+  python sentiment_client.py mood
+  python sentiment_client.py cluster-buys --days 7
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+BASE = "https://app.sentisense.ai"
+
+
+def get(path, **params):
+    """GET {BASE}{path} with the auth header; returns parsed JSON or exits non-zero."""
+    params = {k: v for k, v in params.items() if v is not None}
+    url = BASE + path + ("?" + urllib.parse.urlencode(params) if params else "")
+    key = os.environ.get("SENTISENSE_API_KEY")
+    if not key:
+        sys.exit("SENTISENSE_API_KEY is not set "
+                 "(free key: Settings > Developer Console at https://sentisense.ai)")
+    req = urllib.request.Request(url, headers={"X-SentiSense-API-Key": key})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as e:
+        retry = e.headers.get("Retry-After")
+        hint = f" (Retry-After: {retry}s)" if retry else ""
+        sys.exit(f"HTTP {e.code} on {path}{hint}")
+    except urllib.error.URLError as e:
+        sys.exit(f"network error on {path}: {e.reason}")
+
+
+def rows(raw):
+    """Wrap-vs-flat: bare arrays and flat dicts pass through; {..., data} unwraps."""
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict) and "data" in raw:
+        return raw["data"]
+    return raw
+
+
+def sentiment_scalar(series):
+    """Latest polarity in [-1, 1]; the float is nested at metricValue.value.value."""
+    if not series:
+        return None
+    return float(series[-1]["metricValue"]["value"]["value"])
+
+
+def out(obj):
+    print(json.dumps(obj, indent=2, default=str))
+
+
+def metric(ticker, slug, start=None, end=None):
+    return get(f"/api/v2/metrics/entity/{ticker.upper()}/metric/{slug}",
+               startTime=start, endTime=end)
+
+
+def cmd_series(a, slug):
+    series = metric(a.ticker, slug, getattr(a, "start", None), getattr(a, "end", None))
+    out({"metric": slug, "ticker": a.ticker.upper(),
+         "points": len(series) if isinstance(series, list) else None,
+         "latest": sentiment_scalar(series) if slug in ("sentiment", "sentisense") else
+                   (series[-1] if isinstance(series, list) and series else None)})
+
+
+def cmd_mood(_a):
+    m = get("/api/v2/market-mood")
+    market = m.get("market", {})
+    sectors = m.get("sectors", {})
+    # sectors is a dict with overlapping GICS labels; keep the first of each score.
+    ranked = sorted(sectors.items(), key=lambda kv: kv[1].get("currentScore", 0), reverse=True)
+    out({"score": market.get("currentScore"), "phase": market.get("phase"),
+         "weeklyChange": market.get("weeklyChange"),
+         "signals": market.get("signals", []),
+         "topSectors": [k for k, _ in ranked[:3]],
+         "bottomSectors": [k for k, _ in ranked[-3:]]})
+
+
+def cmd_holders(a):
+    quarters = get("/api/v1/institutional/quarters")  # bare array, [0] is latest
+    if not quarters:
+        sys.exit("no institutional quarters available")
+    q = quarters[0].get("reportDate")
+    out(rows(get(f"/api/v1/institutional/holders/{a.ticker.upper()}", reportDate=q)))
+
+
+def main():
+    p = argparse.ArgumentParser(description="Read-only SentiSense API client.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def simple(name):
+        return sub.add_parser(name)
+
+    def ticker_cmd(name, *opts):
+        sp = sub.add_parser(name)
+        sp.add_argument("ticker")
+        for o, d in opts:
+            sp.add_argument(o, default=d)
+        return sp
+
+    # sentiment / score / mentions / social dominance time series
+    s = ticker_cmd("sentiment"); s.add_argument("--start"); s.add_argument("--end")
+    ticker_cmd("score"); ticker_cmd("mentions"); ticker_cmd("dominance")
+    simple("mood")
+    # AI insights
+    ticker_cmd("insights"); simple("market-insights"); ticker_cmd("insight-types")
+    # smart money
+    cb = simple("cluster-buys"); cb.add_argument("--days", default="7")
+    ticker_cmd("insider", ("--days", "90"))
+    cg = simple("congress"); cg.add_argument("--days", default="7")
+    ticker_cmd("filings", ("--days", "90"))
+    ticker_cmd("holders"); ticker_cmd("consensus")
+    ticker_cmd("actions", ("--days", "90")); ticker_cmd("estimates")
+    aa = simple("analyst-activity"); aa.add_argument("--days", default="7")
+    # calendar / news / stories / quotes
+    ticker_cmd("earnings")
+    ticker_cmd("news", ("--limit", "8"))
+    st = simple("stories"); st.add_argument("--ticker"); st.add_argument("--limit", default="10")
+    ticker_cmd("price")
+    ch = ticker_cmd("chart"); ch.add_argument("--timeframe", default="1M")
+    simple("popular")
+
+    a = p.parse_args()
+    t = getattr(a, "ticker", None)
+    T = t.upper() if t else None
+    days = getattr(a, "days", None)
+
+    if a.cmd == "sentiment":
+        cmd_series(a, "sentiment")
+    elif a.cmd == "score":
+        cmd_series(a, "sentisense")
+    elif a.cmd == "mentions":
+        cmd_series(a, "mentions")
+    elif a.cmd == "dominance":
+        cmd_series(a, "social_dominance")
+    elif a.cmd == "mood":
+        cmd_mood(a)
+    elif a.cmd == "insights":
+        out(rows(get(f"/api/v1/insights/stock/{T}")))
+    elif a.cmd == "market-insights":
+        out(rows(get("/api/v1/insights/market")))
+    elif a.cmd == "insight-types":
+        out(get(f"/api/v1/insights/stock/{T}/types"))
+    elif a.cmd == "cluster-buys":
+        out(rows(get("/api/v1/insider/cluster-buys", lookbackDays=days)))
+    elif a.cmd == "insider":
+        out(rows(get(f"/api/v1/insider/trades/{T}", lookbackDays=days)))
+    elif a.cmd == "congress":
+        out(rows(get("/api/v1/politicians/activity", lookbackDays=days)))
+    elif a.cmd == "filings":
+        out(rows(get(f"/api/v1/politicians/filings/{T}", lookbackDays=days)))
+    elif a.cmd == "holders":
+        cmd_holders(a)
+    elif a.cmd == "consensus":
+        out(rows(get(f"/api/v1/analyst/{T}/consensus")))
+    elif a.cmd == "actions":
+        out(rows(get(f"/api/v1/analyst/{T}/actions", lookbackDays=days)))
+    elif a.cmd == "estimates":
+        out(rows(get(f"/api/v1/analyst/{T}/estimates")))
+    elif a.cmd == "analyst-activity":
+        out(rows(get("/api/v1/analyst/activity", lookbackDays=days)))
+    elif a.cmd == "earnings":
+        out(rows(get("/api/v1/calendar/earnings", ticker=T)))
+    elif a.cmd == "news":
+        raw = get(f"/api/v1/documents/ticker/{T}", limit=a.limit)
+        out({"totalCount": raw.get("totalCount"), "documents": raw.get("documents", [])})
+    elif a.cmd == "stories":
+        path = (f"/api/v1/documents/stories/ticker/{a.ticker.upper()}"
+                if a.ticker else "/api/v1/documents/stories")
+        out(rows(get(path, limit=a.limit)))
+    elif a.cmd == "price":
+        out(get("/api/v1/stocks/price", ticker=T))
+    elif a.cmd == "chart":
+        out(get("/api/v1/stocks/chart", ticker=T, timeframe=a.timeframe))
+    elif a.cmd == "popular":
+        out(get("/api/v1/stocks/popular"))
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/finance/stock-sentiment/scripts/sentiment_client.py
+++ b/optional-skills/finance/stock-sentiment/scripts/sentiment_client.py
@@ -43,6 +43,9 @@ def get(path, **params):
                 "'Install Certificates.command', or use the system python3, or plain curl.)"
                 if "CERTIFICATE_VERIFY_FAILED" in str(e.reason) else "")
         sys.exit(f"network error on {path}: {e.reason}{hint}")
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        # A 200 with a non-JSON body (maintenance page, WAF/captcha, truncation).
+        sys.exit(f"non-JSON response from {path}: {e}")
 
 
 def rows(raw):
@@ -52,6 +55,15 @@ def rows(raw):
     if isinstance(raw, dict) and "data" in raw:
         return raw["data"]
     return raw
+
+
+def shaped(raw):
+    """Like rows(), but preserve free-tier preview flags so callers can tag truncated
+    data. When the envelope is a preview, keep isPreview/previewReason alongside data;
+    otherwise return the bare rows unchanged."""
+    if isinstance(raw, dict) and raw.get("isPreview") and "data" in raw:
+        return {"isPreview": True, "previewReason": raw.get("previewReason"), "data": raw["data"]}
+    return rows(raw)
 
 
 def sentiment_scalar(series):
@@ -66,7 +78,7 @@ def out(obj):
 
 
 def metric(ticker, slug, start=None, end=None):
-    return get(f"/api/v2/metrics/entity/{ticker.upper()}/metric/{slug}",
+    return get(f"/api/v2/metrics/entity/{urllib.parse.quote(ticker.upper(), safe='')}/metric/{slug}",
                startTime=start, endTime=end)
 
 
@@ -105,7 +117,7 @@ def cmd_holders(a):
     if not quarters:
         sys.exit("no institutional quarters available")
     q = quarters[0].get("reportDate")
-    out(rows(get(f"/api/v1/institutional/holders/{a.ticker.upper()}", reportDate=q)))
+    out(shaped(get(f"/api/v1/institutional/holders/{urllib.parse.quote(a.ticker.upper(), safe='')}", reportDate=q)))
 
 
 def main():
@@ -147,6 +159,7 @@ def main():
     a = p.parse_args()
     t = getattr(a, "ticker", None)
     T = t.upper() if t else None
+    TE = urllib.parse.quote(T, safe="") if T else None  # percent-encoded for URL path segments
     days = getattr(a, "days", None)
 
     if a.cmd == "sentiment":
@@ -160,38 +173,38 @@ def main():
     elif a.cmd == "mood":
         cmd_mood(a)
     elif a.cmd == "insights":
-        out(rows(get(f"/api/v1/insights/stock/{T}")))
+        out(shaped(get(f"/api/v1/insights/stock/{TE}")))
     elif a.cmd == "market-insights":
-        out(rows(get("/api/v1/insights/market")))
+        out(shaped(get("/api/v1/insights/market")))
     elif a.cmd == "insight-types":
-        out(get(f"/api/v1/insights/stock/{T}/types"))
+        out(get(f"/api/v1/insights/stock/{TE}/types"))
     elif a.cmd == "cluster-buys":
-        out(rows(get("/api/v1/insider/cluster-buys", lookbackDays=days)))
+        out(shaped(get("/api/v1/insider/cluster-buys", lookbackDays=days)))
     elif a.cmd == "insider":
-        out(rows(get(f"/api/v1/insider/trades/{T}", lookbackDays=days)))
+        out(shaped(get(f"/api/v1/insider/trades/{TE}", lookbackDays=days)))
     elif a.cmd == "congress":
-        out(rows(get("/api/v1/politicians/activity", lookbackDays=days)))
+        out(shaped(get("/api/v1/politicians/activity", lookbackDays=days)))
     elif a.cmd == "filings":
-        out(rows(get(f"/api/v1/politicians/filings/{T}", lookbackDays=days)))
+        out(shaped(get(f"/api/v1/politicians/filings/{TE}", lookbackDays=days)))
     elif a.cmd == "holders":
         cmd_holders(a)
     elif a.cmd == "consensus":
-        out(rows(get(f"/api/v1/analyst/{T}/consensus")))
+        out(shaped(get(f"/api/v1/analyst/{TE}/consensus")))
     elif a.cmd == "actions":
-        out(rows(get(f"/api/v1/analyst/{T}/actions", lookbackDays=days)))
+        out(shaped(get(f"/api/v1/analyst/{TE}/actions", lookbackDays=days)))
     elif a.cmd == "estimates":
-        out(rows(get(f"/api/v1/analyst/{T}/estimates")))
+        out(shaped(get(f"/api/v1/analyst/{TE}/estimates")))
     elif a.cmd == "analyst-activity":
-        out(rows(get("/api/v1/analyst/activity", lookbackDays=days)))
+        out(shaped(get("/api/v1/analyst/activity", lookbackDays=days)))
     elif a.cmd == "earnings":
-        out(rows(get("/api/v1/calendar/earnings", ticker=T)))
+        out(shaped(get("/api/v1/calendar/earnings", ticker=T)))
     elif a.cmd == "news":
-        raw = get(f"/api/v1/documents/ticker/{T}", limit=a.limit)
+        raw = get(f"/api/v1/documents/ticker/{TE}", limit=a.limit)
         out({"totalCount": raw.get("totalCount"), "documents": raw.get("documents", [])})
     elif a.cmd == "stories":
-        path = (f"/api/v1/documents/stories/ticker/{a.ticker.upper()}"
+        path = (f"/api/v1/documents/stories/ticker/{urllib.parse.quote(a.ticker.upper(), safe='')}"
                 if a.ticker else "/api/v1/documents/stories")
-        out(rows(get(path, limit=a.limit)))
+        out(shaped(get(path, limit=a.limit)))
     elif a.cmd == "price":
         out(get("/api/v1/stocks/price", ticker=T))
     elif a.cmd == "chart":

--- a/optional-skills/finance/stock-sentiment/scripts/sentiment_client.py
+++ b/optional-skills/finance/stock-sentiment/scripts/sentiment_client.py
@@ -39,7 +39,10 @@ def get(path, **params):
         hint = f" (Retry-After: {retry}s)" if retry else ""
         sys.exit(f"HTTP {e.code} on {path}{hint}")
     except urllib.error.URLError as e:
-        sys.exit(f"network error on {path}: {e.reason}")
+        hint = ("  (CA certs missing: common on macOS python.org installs. Run the bundled "
+                "'Install Certificates.command', or use the system python3, or plain curl.)"
+                if "CERTIFICATE_VERIFY_FAILED" in str(e.reason) else "")
+        sys.exit(f"network error on {path}: {e.reason}{hint}")
 
 
 def rows(raw):
@@ -79,8 +82,17 @@ def cmd_mood(_a):
     m = get("/api/v2/market-mood")
     market = m.get("market", {})
     sectors = m.get("sectors", {})
-    # sectors is a dict with overlapping GICS labels; keep the first of each score.
-    ranked = sorted(sectors.items(), key=lambda kv: kv[1].get("currentScore", 0), reverse=True)
+    # Dedupe overlapping GICS labels (e.g. "Health Care" vs "Healthcare",
+    # "Information Technology" vs "Technology"), keeping the highest-scoring
+    # variant, before ranking top/bottom.
+    alias = {"information technology": "technology", "health care": "healthcare"}
+    canon = lambda s: alias.get(s.strip().lower(), s.strip().lower())
+    best = {}
+    for label, v in sectors.items():
+        k = canon(label)
+        if k not in best or v.get("currentScore", 0) > best[k][1].get("currentScore", 0):
+            best[k] = (label, v)
+    ranked = sorted(best.values(), key=lambda kv: kv[1].get("currentScore", 0), reverse=True)
     out({"score": market.get("currentScore"), "phase": market.get("phase"),
          "weeklyChange": market.get("weeklyChange"),
          "signals": market.get("signals", []),

--- a/optional-skills/finance/stock-sentiment/scripts/sentiment_client.py
+++ b/optional-skills/finance/stock-sentiment/scripts/sentiment_client.py
@@ -29,7 +29,7 @@ def get(path, **params):
     key = os.environ.get("SENTISENSE_API_KEY")
     if not key:
         sys.exit("SENTISENSE_API_KEY is not set "
-                 "(free key: Settings > Developer Console at https://sentisense.ai)")
+                 "(free key: https://app.sentisense.ai/settings/developer)")
     req = urllib.request.Request(url, headers={"X-SentiSense-API-Key": key})
     try:
         with urllib.request.urlopen(req, timeout=20) as r:

--- a/optional-skills/finance/stock-sentiment/scripts/sentiment_client.py
+++ b/optional-skills/finance/stock-sentiment/scripts/sentiment_client.py
@@ -29,7 +29,7 @@ def get(path, **params):
     key = os.environ.get("SENTISENSE_API_KEY")
     if not key:
         sys.exit("SENTISENSE_API_KEY is not set "
-                 "(free key: https://app.sentisense.ai/settings/developer)")
+                 "(free key: https://app.sentisense.ai/get-api-key)")
     req = urllib.request.Request(url, headers={"X-SentiSense-API-Key": key})
     try:
         with urllib.request.urlopen(req, timeout=20) as r:
@@ -116,7 +116,11 @@ def cmd_holders(a):
     quarters = get("/api/v1/institutional/quarters")  # bare array, [0] is latest
     if not quarters:
         sys.exit("no institutional quarters available")
-    q = quarters[0].get("reportDate")
+    # The most-recent quarter is often still filing (pending:true) and holds
+    # almost no holders; use the newest settled quarter, falling back to the
+    # latest only if every quarter is still pending.
+    latest = next((x for x in quarters if not x.get("pending")), quarters[0])
+    q = latest.get("reportDate")
     out(shaped(get(f"/api/v1/institutional/holders/{urllib.parse.quote(a.ticker.upper(), safe='')}", reportDate=q)))
 
 

--- a/tests/skills/test_stock_sentiment_skill.py
+++ b/tests/skills/test_stock_sentiment_skill.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "finance"
+    / "stock-sentiment"
+)
+SCRIPT_PATH = SKILL_DIR / "scripts" / "sentiment_client.py"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("stock_sentiment_skill", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- Pending-quarter selection (cmd_holders) --------------------------------
+
+def _run_holders(mod, quarters):
+    """Invoke cmd_holders with a mocked network; return the params passed to the
+    holders GET (so we can assert which reportDate was chosen)."""
+    calls = []
+
+    def fake_get(path, **params):
+        calls.append((path, params))
+        if path == "/api/v1/institutional/quarters":
+            return quarters
+        return {"data": {"holders": []}}
+
+    with patch.object(mod, "get", side_effect=fake_get):
+        mod.cmd_holders(types.SimpleNamespace(ticker="nvda"))
+
+    holders_calls = [c for c in calls if "holders" in c[0]]
+    assert holders_calls, "cmd_holders never queried the holders endpoint"
+    return holders_calls[0]
+
+
+def test_cmd_holders_skips_pending_quarter():
+    mod = load_module()
+    quarters = [
+        {"reportDate": "2026-06-30", "pending": True},   # still filing
+        {"reportDate": "2026-03-31", "pending": False},  # newest settled
+    ]
+    path, params = _run_holders(mod, quarters)
+    assert "NVDA" in path
+    assert params["reportDate"] == "2026-03-31"
+
+
+def test_cmd_holders_uses_latest_when_not_pending():
+    mod = load_module()
+    quarters = [
+        {"reportDate": "2026-03-31", "pending": False},
+        {"reportDate": "2025-12-31", "pending": False},
+    ]
+    _, params = _run_holders(mod, quarters)
+    assert params["reportDate"] == "2026-03-31"
+
+
+def test_cmd_holders_falls_back_when_all_pending():
+    mod = load_module()
+    quarters = [
+        {"reportDate": "2026-06-30", "pending": True},
+        {"reportDate": "2026-03-31", "pending": True},
+    ]
+    _, params = _run_holders(mod, quarters)
+    assert params["reportDate"] == "2026-06-30"  # falls back to [0]
+
+
+def test_cmd_holders_treats_missing_pending_as_settled():
+    mod = load_module()
+    quarters = [{"reportDate": "2026-03-31"}]  # no pending key => settled
+    _, params = _run_holders(mod, quarters)
+    assert params["reportDate"] == "2026-03-31"
+
+
+# --- Envelope handling (rows / shaped) --------------------------------------
+
+def test_rows_unwraps_data_and_passes_flat_through():
+    mod = load_module()
+    assert mod.rows([1, 2, 3]) == [1, 2, 3]
+    assert mod.rows({"data": [1, 2]}) == [1, 2]
+    assert mod.rows({"score": 5}) == {"score": 5}
+
+
+def test_shaped_preserves_preview_flags():
+    mod = load_module()
+    envelope = {"isPreview": True, "previewReason": "PRO_REQUIRED", "data": [{"a": 1}]}
+    shaped = mod.shaped(envelope)
+    assert shaped["isPreview"] is True
+    assert shaped["previewReason"] == "PRO_REQUIRED"
+    assert shaped["data"] == [{"a": 1}]
+    # Non-preview wrapped payloads collapse to their rows.
+    assert mod.shaped({"data": [{"a": 1}]}) == [{"a": 1}]
+
+
+def test_sentiment_scalar_reads_nested_value():
+    mod = load_module()
+    series = [{"metricValue": {"value": {"value": -0.42}}}]
+    assert mod.sentiment_scalar(series) == -0.42
+    assert mod.sentiment_scalar([]) is None
+
+
+# --- Frontmatter / script contracts -----------------------------------------
+
+def test_script_key_url_matches_skill_md():
+    """The script's onboarding URL must match SKILL.md's, not the stale one."""
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert "/get-api-key" in source
+    assert "/settings/developer" not in source
+
+
+def test_script_sends_api_key_header():
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert "X-SentiSense-API-Key" in source
+
+
+def test_client_is_read_only():
+    """No mutating verbs: every request is a GET."""
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert "method=" not in source  # urllib defaults to GET; no POST/PUT/DELETE
+
+
+def test_skill_frontmatter_names_human_contributor_first():
+    lines = SKILL_MD.read_text(encoding="utf-8").splitlines()
+    author = next((ln for ln in lines if ln.startswith("author:")), "")
+    assert author, "SKILL.md is missing an author line"
+    # A human contributor handle must lead the org attribution.
+    assert author.index("TheSentiTrader") < author.index("SentiSense")


### PR DESCRIPTION
## Summary

Adds `optional-skills/finance/stock-sentiment/`: a read-only skill that provides the sentiment, smart-money, and AI-insight layer for US equities, complementing the existing finance skills.

Where `stocks` covers quotes, search, history, and compare, this covers what the other finance skills do not: per-stock sentiment (the SentiSense Score, sentiment polarity, mentions, social dominance), market mood (fear/greed), smart-money convergence (insider, congressional, and 13F flows plus analyst actions), AI insights, and sentiment-tagged news. It pairs naturally with `stocks`, `dcf-model`, and `comps-analysis` (declared in `related_skills`).

## What it adds

- Six opinionated workflows: sentiment read, market mood, smart-money convergence, per-ticker flow, pre-earnings sentiment, and sentiment-vs-price divergence. Each is framed as educational context, never a buy or sell recommendation.
- Read-only: every endpoint is a GET; no write, trading, or wallet surface.
- Python 3.8+ standard library only. Works with plain `curl` or the bundled `scripts/sentiment_client.py` (no third-party packages, no pip install).
- Requires a free `SENTISENSE_API_KEY` (declared in `required_environment_variables`); the skill returns a real preview slice on the free tier.
- Follows the optional-skill format: `metadata.hermes.tags` + `category: finance` + `related_skills`, with the standard When to Use / Prerequisites / How to Run / Quick Reference / Workflows / Pitfalls / Verification sections.

## Testing

- Every endpoint in the Quick Reference was verified live against the API (all return 200).
- `scripts/sentiment_client.py` compiles under Python 3.8+ (`python3 -m py_compile`).

Data is provided by the SentiSense API under its own terms; the skill is an educational data interface.
