### PR TITLE
fix(caching): prompt_caching.enabled toggle for strict Anthropic proxies (salvage #35862, closes #13477)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -521,9 +521,8 @@ def init_agent(
         from hermes_cli.config import load_config as _load_pc_cfg
 
         _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
-        if isinstance(_pc_cfg, dict) and _pc_cfg.get("enabled") is False:
-            agent._use_prompt_caching = False
-            agent._use_native_cache_layout = False
+        # prompt_caching.enabled=false is honored in _anthropic_prompt_cache_policy
+        # (applied above and on every re-derivation), so no override is needed here.
         _ttl = _pc_cfg.get("cache_ttl", "5m") if isinstance(_pc_cfg, dict) else "5m"
         if _ttl in {"5m", "1h"}:
             agent._cache_ttl = _ttl

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -521,7 +521,10 @@ def init_agent(
         from hermes_cli.config import load_config as _load_pc_cfg
 
         _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
-        _ttl = _pc_cfg.get("cache_ttl", "5m")
+        if isinstance(_pc_cfg, dict) and _pc_cfg.get("enabled") is False:
+            agent._use_prompt_caching = False
+            agent._use_native_cache_layout = False
+        _ttl = _pc_cfg.get("cache_ttl", "5m") if isinstance(_pc_cfg, dict) else "5m"
         if _ttl in {"5m", "1h"}:
             agent._cache_ttl = _ttl
     except Exception:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1443,6 +1443,21 @@ def anthropic_prompt_cache_policy(
     eff_api_mode = api_mode if api_mode is not None else (agent.api_mode or "")
     eff_model = (model if model is not None else agent.model) or ""
 
+    # Global kill switch: prompt_caching.enabled=false disables cache_control
+    # markers on every path (init, /model switch, fallback re-derivation).
+    # Escape hatch for strict Anthropic-compatible proxies that inject their
+    # own markers server-side — stacking ours on top exceeds Anthropic's
+    # 4-breakpoint limit and 400s. Gating here (not just at init) keeps the
+    # switch honored after a model switch or fallback re-evaluates the policy.
+    try:
+        from hermes_cli.config import load_config as _load_pc_cfg
+
+        _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
+        if isinstance(_pc_cfg, dict) and _pc_cfg.get("enabled") is False:
+            return False, False
+    except Exception:
+        pass
+
     model_lower = eff_model.lower()
     provider_lower = eff_provider.lower()
     is_claude = "claude" in model_lower

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1391,8 +1391,11 @@ DEFAULT_CONFIG = {
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
-    # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
+    # Set enabled: false as an escape hatch for strict providers that reject
+    # cache_control markers; cache_ttl must be "5m" or "1h" (Anthropic-supported
+    # tiers), other values are ignored.
     "prompt_caching": {
+        "enabled": True,
         "cache_ttl": "5m",
     },
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "janrenz@Mac.fritz.box": "janrenz",  # PR #35862 salvage (prompt_caching.enabled escape hatch for strict providers)
     "syahidfrd@gmail.com": "syahidfrd",  # PR #17059 salvage (tag unverified senders in Slack thread context to mitigate indirect prompt injection)
     "5823452+sgabel@users.noreply.github.com": "sgabel",  # PR #13139 salvage (redact secrets in user-facing approval prompts)
     "130270192+CRWuTJ@users.noreply.github.com": "CRWuTJ",  # PR #17082 salvage (cancel delayed Telegram deliveries on disconnect so buffered flushes don't dispatch into a torn-down session)

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -8,7 +8,7 @@ the native layout on OpenRouter) surfaces loudly.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent
 
@@ -327,6 +327,90 @@ class TestExplicitOverrides:
 
 
 # ─────────────────────────────────────────────────────────────────────
+# prompt_caching.enabled=false global kill switch
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestPromptCachingDisabledKillSwitch:
+    """prompt_caching.enabled=false must disable cache_control markers on
+    every endpoint class and every re-derivation path (init, /model switch,
+    fallback). This is the correct escape hatch for a strict Anthropic-
+    compatible proxy that injects its own markers server-side — a single
+    per-setup toggle, not a blanket strip that would regress the many
+    well-behaved third-party gateways the policy deliberately caches on.
+    """
+
+    def _disabled_cfg(self):
+        return patch(
+            "hermes_cli.config.load_config",
+            return_value={"prompt_caching": {"enabled": False}},
+        )
+
+    def test_disables_native_anthropic(self):
+        agent = _make_agent(
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+            api_mode="anthropic_messages",
+            model="claude-sonnet-4-6",
+        )
+        with self._disabled_cfg():
+            assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_disables_openrouter_claude(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        with self._disabled_cfg():
+            assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_disables_third_party_anthropic_gateway(self):
+        # llm.echo.tech-style LiteLLM proxy — the reported failure case.
+        agent = _make_agent(
+            provider="anthropic",
+            base_url="https://llm.echo.tech",
+            api_mode="anthropic_messages",
+            model="claude-sonnet-4-6",
+        )
+        with self._disabled_cfg():
+            assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_survives_model_switch_re_derivation(self):
+        # Start native Anthropic, /model switch to a proxy — disable must hold.
+        agent = _make_agent(
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+            api_mode="anthropic_messages",
+            model="claude-opus-4.6",
+        )
+        with self._disabled_cfg():
+            assert agent._anthropic_prompt_cache_policy(
+                provider="anthropic",
+                base_url="https://llm.echo.tech",
+                api_mode="anthropic_messages",
+                model="claude-sonnet-4-6",
+            ) == (False, False)
+
+    def test_enabled_true_keeps_third_party_caching_on(self):
+        # The well-behaved third-party gateways a blanket strip would break
+        # must keep caching by default.
+        agent = _make_agent(
+            provider="anthropic",
+            base_url="https://llm.echo.tech",
+            api_mode="anthropic_messages",
+            model="claude-sonnet-4-6",
+        )
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"prompt_caching": {"enabled": True}},
+        ):
+            assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+
+# ─────────────────────────────────────────────────────────────────────
 # Long-lived prefix cache policy (cross-session 1h tier)
 # ─────────────────────────────────────────────────────────────────────
+
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -986,6 +986,30 @@ class TestInit:
             )
             assert a._cache_ttl == "5m"
 
+    def test_prompt_caching_enabled_false_disables_cache_markers(self):
+        """prompt_caching.enabled=false is an escape hatch for strict providers."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter._anthropic_sdk"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"prompt_caching": {"enabled": False}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                base_url="https://api.anthropic.com/v1/",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a.api_mode == "anthropic_messages"
+            assert a._use_prompt_caching is False
+            assert a._use_native_cache_layout is False
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -362,6 +362,7 @@ Prompt caching is automatically enabled when:
 ```yaml
 # config.yaml — TTL is configurable (must be "5m" or "1h")
 prompt_caching:
+  enabled: true    # set false to stop sending cache_control markers (strict-proxy escape hatch)
   cache_ttl: "5m"
 ```
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -915,16 +915,19 @@ For Claude on **native Anthropic**, **OpenRouter**, and **Nous Portal**, Hermes 
 
 The Qwen Cloud (Alibaba DashScope) upstream caps cache TTL at 5 minutes, so Hermes uses the 5-minute breakpoint TTL there instead. Other Claude-via-third-party paths (AWS Bedrock, Azure Foundry) fall back to the provider's own caching defaults. xAI Grok uses a separate session-pinned conversation-id mechanism — see [xAI prompt caching](/integrations/providers#xai-grok--responses-api--prompt-caching).
 
-No knob exists to disable this — caching is always-on and saves money even on single-turn conversations because the system prompt alone is a meaningful fraction of the input token count.
+Caching is on by default and saves money even on single-turn conversations because the system prompt alone is a meaningful fraction of the input token count. It can be turned off entirely with the `enabled` knob below when a strict provider rejects `cache_control` markers.
 
-The one explicit knob is the cache TTL tier Hermes requests on Anthropic-style breakpoints:
+The explicit knobs are whether caching runs at all and the cache TTL tier Hermes requests on Anthropic-style breakpoints:
 
 ```yaml
 prompt_caching:
+  enabled: true    # set false to stop sending cache_control markers entirely
   cache_ttl: "5m"   # "5m" or "1h" (Anthropic-supported tiers); other values are ignored
 ```
 
 `cache_ttl` selects the breakpoint TTL Hermes attaches for Claude via the native Anthropic API, OpenRouter, and Nous Portal. Only the two Anthropic-supported tiers (`"5m"`, `"1h"`) are honored — any other value is ignored. Providers with their own caps (e.g. Qwen Cloud, which maxes at 5 minutes) still clamp to what the upstream allows.
+
+`enabled` defaults to `true`. Set it to `false` as an escape hatch for strict Anthropic-compatible proxies that inject their own `cache_control` markers server-side — stacking those on top of Hermes' breakpoints can exceed Anthropic's 4-breakpoint limit and return HTTP 400 `"A maximum of 4 blocks with cache_control may be provided"`. Disabling caching on that setup passes requests through without client-side markers so the proxy manages its own.
 
 ## Auxiliary Models
 


### PR DESCRIPTION
## Summary
Adds a `prompt_caching.enabled` config toggle so a user on a strict Anthropic-compatible proxy (LiteLLM-style, e.g. `llm.echo.tech`) that injects its own `cache_control` markers can turn off client-side markers entirely — fixing the HTTP 400 `"A maximum of 4 blocks with cache_control may be provided. Found 5"` reported in #13477 without regressing caching for every well-behaved third-party gateway.

Salvages @janrenz's PR #35862 (the config toggle), then closes the gap it left: the disable must survive `/model` switches and fallback re-derivation.

## Why the toggle, not a third-party strip
The original report (#13477) proposed stripping ALL markers whenever `base_url` isn't `anthropic.com`. That matches *every* non-Anthropic endpoint, so it would kill caching for MiniMax, Zhipu GLM, Bedrock, Foundry, Kimi, DeepSeek — all of which `anthropic_prompt_cache_policy` deliberately caches on and none of which double-inject. Wrong lever. The real problem is one misbehaving proxy adding a 5th marker on top of our 4; the correct fix is a per-setup opt-out.

## Changes
- `hermes_cli/config.py`: add `prompt_caching.enabled: true` default + escape-hatch comment.
- `agent/agent_runtime_helpers.py`: gate `anthropic_prompt_cache_policy` on `enabled=false` → returns `(False, False)` before any branch, so init, `/model` switch, and fallback all honor it.
- `agent/agent_init.py`: keep @janrenz's `isinstance` hardening on the `cache_ttl` read; drop the now-redundant init-only override (the policy gate covers it).
- `tests/`: policy-level kill-switch tests (native / OpenRouter / third-party / model-switch survival / enabled-true-keeps-caching) + @janrenz's init test.
- `website/docs/`: document the `enabled` toggle.
- `scripts/release.py`: AUTHOR_MAP entry for @janrenz.

## Root cause
Client never exceeds 4 markers on native Anthropic (traced E2E: `apply_anthropic_cache_control` marks system + last-3, tool-merge collapses them 1:1). The proxy adds a 5th server-side. The only client-side lever that helps is not sending markers to that proxy — a config toggle.

## Validation
| path | enabled=false | enabled=true (default) |
|---|---|---|
| native Anthropic | (False, False) | (True, True) |
| OpenRouter Claude | (False, False) | (True, False) |
| third-party proxy | (False, False) | (True, True) |
| after `/model` switch | (False, False) | policy-derived |
| after fallback swap | (False, False) | policy-derived |

E2E confirmed the disable survives all three re-derivation paths and re-enabling restores caching. `test_anthropic_prompt_cache_policy.py` 29/29 green; `test_run_agent.py` caching subset 9/9 green.

Closes #13477 (via the toggle, not the proposed strip). Salvages #35862 with authorship preserved.

## Infographic
![prompt caching kill switch](https://v3b.fal.media/files/b/0aa0787e/FP2tXI3_3WsNYpXtCn3-0_acrwmN8l.png)
