### PR TITLE
[codex] Enforce AGENTS.md context budget

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -60,6 +60,16 @@ Fixes #
 - [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
 - [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
 
+### AGENTS.md Impact
+
+<!-- Complete this section if your PR edits AGENTS.md. Otherwise check N/A. AGENTS.md is injected into coding-agent context, so changes affect latency, cost, and instruction salience. -->
+
+- [ ] N/A — this PR does not edit `AGENTS.md`
+- [ ] I treated `AGENTS.md` as runtime prompt surface, not ordinary documentation
+- [ ] I classified each `AGENTS.md` change as invariant vs reference; invariants remain inline
+- [ ] I considered moving long rationale/examples to developer docs or references and leaving only a short summary/link in `AGENTS.md`
+- [ ] Net `AGENTS.md` size change: <!-- e.g. +420 chars / -3,200 chars -->
+
 ## For New Skills
 
 <!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -137,6 +137,40 @@ jobs:
         run: |
           ruff check .
 
+  context-budget:
+    # AGENTS.md is runtime prompt surface. Keep it below the context-file
+    # budget so critical instructions are never silently truncated.
+    name: AGENTS.md context budget (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Check AGENTS.md context budget
+        run: |
+          set +e
+          python scripts/check_context_file_budget.py \
+            AGENTS.md \
+            --warn-chars 30000 \
+            --max-chars 38000 \
+            > context-budget.txt 2>&1
+          status=$?
+          cat context-budget.txt
+          {
+            echo "### AGENTS.md context budget"
+            echo
+            echo '```'
+            cat context-budget.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
   windows-footguns:
     # Static guardrails on Windows-unsafe Python primitives — os.kill(pid, 0),
     # os.killpg, os.setsid, signal.SIGKILL without getattr fallback,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,20 @@ Instructions for AI coding assistants and developers working on the hermes-agent
 
 **Never give up on the right solution.**
 
+## AGENTS.md is Runtime Prompt Surface
+
+This file is loaded into coding-agent context, so edits affect latency, cost,
+and instruction salience for every session in this repo. Keep it as the compact
+runtime contract: invariants, high-blast-radius pitfalls, core file map, and
+verification rules. Move long rationale, history, exhaustive subsystem docs, and
+rarely-needed examples to developer docs or references, leaving short summaries
+and links here. Treat changes to this file as context-impacting, not ordinary
+documentation cleanup.
+
+Detailed rationale and long subsystem notes live in
+`website/docs/developer-guide/agents-md-reference.md`; load that file only when
+the current task needs the extra detail.
+
 ## What Hermes Is
 
 Hermes is a personal AI agent that runs the same agent core across a CLI, a
@@ -26,1106 +40,16 @@ reviewing any change:
   high. Most new capability should arrive as a CLI command + skill, a
   service-gated tool, or a plugin — not as core surface.
 
-## Contribution Rubric — What We Want / What We Don't
-
-This is the project's intent layer. Use it two ways:
-
-1. **For humans and for your own work** — what gets merged and what gets
-   rejected, so a contribution aims at the target.
-2. **For automated review (the triage sweeper)** — guidance on when a PR is
-   safe to close on the three allowed reasons (`implemented_on_main`,
-   `cannot_reproduce`, `incoherent`) and, just as important, **when NOT to
-   close** one. Taste-based "we don't want this / out of scope" closes are NOT
-   an automated decision — those stay with a human maintainer. The sweeper's
-   job here is to recognize design intent and *avoid wrongly closing a
-   legitimate contribution*, not to make the won't-implement call itself.
-
-Read the balance right: Hermes ships a **lot** — most merges are bug fixes to
-real reported behavior, and the product surface (platforms, channels,
-providers, models, desktop/TUI features) expands aggressively and on purpose.
-The restraint below is aimed squarely at the **core agent + the model tool
-schema**, the one place where every addition is paid for on every API call.
-"Smallest footprint" governs *how a capability is wired into the core*, NOT
-whether the product is allowed to grow. We are expansive at the edges and
-conservative at the waist.
-
-### What we want
-
-- **Fix real bugs, well.** The bulk of what lands is `fix(...)` against an
-  actual reported symptom. A good fix reproduces the symptom on current
-  `main`, points to the exact line where it manifests, and fixes the whole bug
-  class — sibling call paths included — not just the one site the reporter hit.
-- **Expand reach at the edges.** New platform adapters, channels, providers,
-  models, and desktop/TUI/dashboard features are welcome and land routinely,
-  including large ones (a new messaging channel, a session-cap feature, a
-  Windows PTY bridge). Breadth in the product is a goal, not a footprint
-  concern — as long as it integrates with the existing setup/config UX
-  (`hermes tools`, `hermes setup`, auto-install) rather than bolting on a raw
-  env var.
-- **Refactor god-files into clean modules.** Extracting a multi-thousand-line
-  cluster out of `cli.py` / `run_agent.py` / `gateway/run.py` into a focused
-  mixin or module is wanted work, even when the diff is huge and mechanical
-  (large `+N/-N` refactors merge regularly). The "every line traces to the
-  request" test applies to *feature* PRs; a declared refactor's request IS the
-  extraction.
-- **Keep the core narrow.** New *model tools* are the expensive exception —
-  every tool ships on every API call. Prefer, in order: extend existing code →
-  CLI command + skill → service-gated tool (`check_fn`) → plugin → MCP server
-  in the catalog → new core tool (last resort). See "The Footprint Ladder."
-- **Extend, don't duplicate.** Before adding a module/manager/hook, check
-  whether existing infrastructure already covers the use case. When several PRs
-  integrate the same *category*, design one shared interface instead of merging
-  them one at a time (see the ABC + orchestrator note under the Footprint
-  Ladder).
-- **Behavior contracts over snapshots.** Tests should assert how two pieces of
-  data must relate (invariants), not freeze a current value (model lists,
-  config version literals, enumeration counts). See "Don't write
-  change-detector tests."
-- **E2E validation, not just green unit mocks.** For anything touching
-  resolution chains, config propagation, security boundaries, remote
-  backends, or file/network I/O, exercise the real path with real imports
-  against a temp `HERMES_HOME`. Mocks hide integration bugs.
-- **Cache-, alternation-, and invariant-safe.** Preserve prompt caching, strict
-  message role alternation (never two same-role messages in a row; never a
-  synthetic user message injected mid-loop), and a system prompt that is
-  byte-stable for the life of a conversation.
-- **Contributor credit preserved.** Salvage external work by cherry-picking
-  (rebase-merge) so authorship survives in git history; don't reimplement from
-  scratch when you can build on top.
-
-### What we don't want (rejected even when well-built)
-
-- **Speculative infrastructure.** Hooks, callbacks, or extension points with no
-  concrete consumer. Adding a hook is easy; removing one after plugins depend
-  on it is hard. A hook is NOT speculative if a contributor has a real, stated
-  use case — even if the consumer ships separately.
-- **New `HERMES_*` env vars for non-secret config.** `.env` is for secrets
-  only (API keys, tokens, passwords). All behavioral settings — timeouts,
-  thresholds, feature flags, display prefs — go in `config.yaml`. Bridge to an
-  internal env var if the mechanism needs one, but user-facing docs point to
-  `config.yaml`. Reject PRs that tell users to "set X in your .env" unless X
-  is a credential.
-- **A new core tool when terminal + file already do the job, or when a skill
-  would.** If the only barrier is file visibility on a remote backend, fix the
-  mount, not the toolset.
-- **Lazy-reading escape hatches on instructional tools.** No `offset`/`limit`
-  pagination on tools that load content the agent must read fully (skills,
-  prompts, playbooks). Models will read page 1 and skip the rest.
-- **"Fixes" that destroy the feature they secure.** A mitigation that kills the
-  feature's purpose is the wrong mitigation. Read the original commit's intent
-  (`git log -p -S`) before restricting behavior; find a fix that preserves the
-  feature.
-- **Outbound telemetry / usage attribution without opt-in gating.** No new
-  analytics, third-party identifier tagging, or attribution tags until a
-  generic user-facing opt-in (config gate + setup prompt + `hermes tools`
-  toggle) exists. Park behind a label, do not merge.
-- **Change-detector tests, cache-breaking mid-conversation, dead code wired in
-  without E2E proof, and plugins that touch core files.** Plugins live in their
-  own directory and work within the ABCs/hooks we provide; if a plugin needs
-  more, widen the generic plugin surface, don't special-case it in core.
-- **Third-party products / other people's projects integrated into the core
-  tree.** Observability backends, vendor SaaS integrations, analytics dashboards,
-  and similar "someone else's product" plugins do NOT land under `plugins/` in
-  this repo. They place an ongoing maintenance burden on us to keep them working
-  against a fast-moving core, for a backend we don't own. Ship them as a
-  **standalone plugin repo** users install into `~/.hermes/plugins/` (or via a
-  pip entry point), and promote them in the Nous Research Discord
-  (`#plugins-skills-and-skins`). This is a coupling-and-maintenance decision, not
-  a quality bar — the plugin can be excellent and still be a close. PRs that add
-  such a directory to the tree are closed with a pointer to publish it as its own
-  repo.
-
-### Before you call it a bug — verify the premise (and when NOT to close)
-
-The most common reason a well-written PR gets closed is not code quality — it
-is that the change is built on a **wrong premise**, or it treats an
-**intentional design as a gap**. These patterns cut both ways: they tell a
-human reviewer what to scrutinize, and they tell the automated sweeper when a
-PR is NOT safe to close as `implemented_on_main` / `cannot_reproduce` (when in
-doubt, leave it open for a human). They are distilled from real closes.
-
-- **"Intentional design, not a gap."** A limitation that looks like an
-  oversight is often deliberate. Before "fixing" a missing link or a
-  restriction, ask whether the isolation IS the design. Example: profiles are
-  independent islands on purpose — a PR adding live config inheritance from the
-  default profile was closed because coupling profiles together is exactly what
-  the design prevents (the copy-at-creation `--clone` path already covers the
-  legitimate "start from my default" case). Read the original commit's intent
-  (`git log -p -S "<symbol>"`) before assuming something is unfinished.
-- **"The premise doesn't hold against how X actually works."** A PR's
-  justification frequently rests on a wrong mental model of an existing
-  mechanism. Trace the real code/runtime before accepting the rationale. Two
-  real closes: a rate-limit "re-probe during cooldown" PR (the breaker only
-  trips on a *confirmed-empty* account bucket, so re-probing just hammers a
-  bucket we've already proven empty); a usage-accumulation fix whose new branch
-  **never executes at runtime** because an earlier guard already popped the
-  state it depended on. If you can't point to the exact line where the bug
-  manifests AND show the fix changes that line's behavior, you haven't verified
-  the premise.
-- **"This fix was wrong — the absence/omission was deliberate."** Adding the
-  obvious-looking missing piece can break things the omission was protecting.
-  Example: restoring "missing" `__init__.py` files made a test tree importable
-  as a dotted package that shadowed the real plugin, deleting its `register()`
-  at import time. The absence was load-bearing.
-- **"Overreached / resurrected an approach we'd moved past."** Scope creep that
-  supersedes an agreed-on base, or revives a direction the maintainers
-  deliberately closed, gets rejected even when the code works. Keep the change
-  to the narrow piece that was actually agreed; offer the rest as a focused
-  follow-up.
-
-The throughline: **verify the claim AND the intent against the codebase before
-writing or merging a fix.** A confirmed reproduction on current `main` plus a
-line-level account of where the fix acts beats a plausible-sounding rationale
-every time. When in doubt about intent, it is cheaper to ask than to ship a
-fix that fights the design.
-
-### The Footprint Ladder (new capability decision)
-
-Each rung adds more permanent surface than the one above. Choose the highest
-(least-footprint) rung that correctly solves the problem:
-
-1. **Extend existing code** — the capability is a variation of something that
-   already exists. Zero new surface.
-2. **CLI command + skill** — manages config/state/infra expressible as shell
-   commands. The agent runs `hermes <subcommand>` guided by a skill. Zero
-   model-tool footprint. Default choice for subscriptions, scheduled tasks,
-   service setup. Examples: `hermes webhook`, `hermes cron`, `hermes tools`.
-3. **Service-gated tool (`check_fn`)** — needs structured params/returns AND
-   only appears when a prerequisite is configured. Zero footprint otherwise.
-   Examples: Home Assistant tools (gated on token), memory-provider tools.
-4. **Plugin** — third-party/niche/user-specific capability that doesn't ship in
-   core. Lives in `~/.hermes/plugins/` or a pip package, discovered at runtime.
-5. **MCP server (in the catalog)** — if the capability genuinely needs to be a
-   tool (structured I/O the agent invokes) but isn't core-fundamental, prefer
-   building it as an MCP server and adding it to the MCP catalog over growing
-   the core toolset. The agent connects to it through the built-in MCP client;
-   zero permanent core-schema footprint, and it's reusable by any MCP host.
-6. **New core tool** — only when the capability is fundamental, broadly useful
-   to nearly every user, and unreachable via terminal + file (or an MCP server).
-   Examples of correct core tools: terminal, read_file, web_search,
-   browser_navigate.
-
-When 3+ open PRs try to integrate the same *category* of thing (memory
-backends, providers, notifiers), don't merge them one at a time — design an
-ABC + orchestrator, wrap the existing built-in as the first provider, and turn
-the competing PRs into plugins against that interface.
-
-## Development Environment
-
-```bash
-# Prefer .venv; fall back to venv if that's what your checkout has.
-source .venv/bin/activate   # or: source venv/bin/activate
-```
-
-`scripts/run_tests.sh` probes `.venv` first, then `venv`, then
-`$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
-main checkout).
-
-## Project Structure
-
-File counts shift constantly — don't treat the tree below as exhaustive.
-The canonical source is the filesystem. The notes call out the load-bearing
-entry points you'll actually edit.
-
-```
-hermes-agent/
-├── run_agent.py          # AIAgent class — core conversation loop (~12k LOC)
-├── model_tools.py        # Tool orchestration, discover_builtin_tools(), handle_function_call()
-├── toolsets.py           # Toolset definitions, _HERMES_CORE_TOOLS list
-├── cli.py                # HermesCLI class — interactive CLI orchestrator (~11k LOC)
-├── hermes_state.py       # SessionDB — SQLite session store (FTS5 search)
-├── hermes_constants.py   # get_hermes_home(), display_hermes_home() — profile-aware paths
-├── hermes_logging.py     # setup_logging() — agent.log / errors.log / gateway.log (profile-aware)
-├── batch_runner.py       # Parallel batch processing
-├── agent/                # Agent internals (provider adapters, memory, caching, compression, etc.)
-├── hermes_cli/           # CLI subcommands, setup wizard, plugins loader, skin engine
-├── tools/                # Tool implementations — auto-discovered via tools/registry.py
-│   └── environments/     # Terminal backends (local, docker, ssh, modal, daytona, singularity)
-├── gateway/              # Messaging gateway — run.py + session.py + platforms/
-│   ├── platforms/        # Adapter per platform (telegram, discord, slack, whatsapp,
-│   │                     #   homeassistant, signal, matrix, mattermost, email, sms,
-│   │                     #   dingtalk, wecom, weixin, feishu, qqbot, bluebubbles,
-│   │                     #   yuanbao, webhook, api_server, ...). See ADDING_A_PLATFORM.md.
-│   └── builtin_hooks/    # Extension point for always-registered gateway hooks (none shipped)
-├── plugins/              # Plugin system (see "Plugins" section below)
-│   ├── memory/           # Memory-provider plugins (honcho, mem0, supermemory, ...)
-│   ├── context_engine/   # Context-engine plugins
-│   ├── model-providers/  # Inference backend plugins (openrouter, anthropic, gmi, ...)
-│   ├── kanban/           # Multi-agent board dispatcher + worker plugin
-│   ├── hermes-achievements/  # Gamified achievement tracking
-│   ├── observability/    # Metrics / traces / logs plugin
-│   ├── image_gen/        # Image-generation providers
-│   └── <others>/         # disk-cleanup, google_meet, platforms, spotify,
-│                         #   strike-freedom-cockpit, ...
-├── optional-skills/      # Heavier/niche skills shipped but NOT active by default
-├── skills/               # Built-in skills bundled with the repo
-├── ui-tui/               # Ink (React) terminal UI — `hermes --tui`
-│   └── src/              # entry.tsx, app.tsx, gatewayClient.ts + app/components/hooks/lib
-├── tui_gateway/          # Python JSON-RPC backend for the TUI
-├── acp_adapter/          # ACP server (VS Code / Zed / JetBrains integration)
-├── cron/                 # Scheduler — jobs.py, scheduler.py
-├── scripts/              # run_tests.sh, release.py, auxiliary scripts
-├── website/              # Docusaurus docs site
-└── tests/                # Pytest suite (~17k tests across ~900 files as of May 2026)
-```
-
-**User config:** `~/.hermes/config.yaml` (settings), `~/.hermes/.env` (API keys only).
-**Logs:** `~/.hermes/logs/` — `agent.log` (INFO+), `errors.log` (WARNING+),
-`gateway.log` when running the gateway. Profile-aware via `get_hermes_home()`.
-Browse with `hermes logs [--follow] [--level ...] [--session ...]`.
-
-## TypeScript Style
-
-Applies to TypeScript across Hermes: desktop, TUI, website, and future TS packages.
-
-- Prefer small nanostores over component state when state is shared, reused, or read by distant UI.
-- Let each feature own its atoms. Chat state belongs near chat, shell state near shell, shared state in `src/store`.
-- Components that render from an atom should use `useStore`. Non-rendering actions should read with `$atom.get()`.
-- Do not pass state through three components when the leaf can subscribe to the atom.
-- Keep persistence beside the atom that owns it.
-- Keep route roots thin. They compose routes and shell; they should not become controllers.
-- No monolithic hooks. A hook should own one narrow job.
-- Prefer colocated action modules over hidden god hooks.
-- If a callback is pure side effect, use the terse void form:
-  `onState={st => void setGatewayState(st)}`.
-- Async UI handlers should make intent explicit:
-  `onClick={() => void save()}`.
-- Prefer interfaces for public props and shared object shapes. Avoid `type X = { ... }` for object props.
-- Extend React primitives for props: `React.ComponentProps<'button'>`, `React.ComponentProps<typeof Dialog>`, `Omit<...>`, `Pick<...>`.
-- Table-driven beats condition ladders when mapping ids, routes, or views.
-- `src/app` owns routes, pages, and page-specific components.
-- `src/store` owns shared atoms.
-- `src/lib` owns shared pure helpers.
-
-## File Dependency Chain
-
-```
-tools/registry.py  (no deps — imported by all tool files)
-       ↑
-tools/*.py  (each calls registry.register() at import time)
-       ↑
-model_tools.py  (imports tools/registry + triggers tool discovery)
-       ↑
-run_agent.py, cli.py, batch_runner.py, environments/
-```
-
----
-
-## AIAgent Class (run_agent.py)
-
-The real `AIAgent.__init__` takes ~60 parameters (credentials, routing, callbacks,
-session context, budget, credential pool, etc.). The signature below is the
-minimum subset you'll usually touch — read `run_agent.py` for the full list.
-
-```python
-class AIAgent:
-    def __init__(self,
-        base_url: str = None,
-        api_key: str = None,
-        provider: str = None,
-        api_mode: str = None,              # "chat_completions" | "codex_responses" | ...
-        model: str = "",                   # empty → resolved from config/provider later
-        max_iterations: int = 90,          # tool-calling iterations (shared with subagents)
-        enabled_toolsets: list = None,
-        disabled_toolsets: list = None,
-        quiet_mode: bool = False,
-        save_trajectories: bool = False,
-        platform: str = None,              # "cli", "telegram", etc.
-        session_id: str = None,
-        skip_context_files: bool = False,
-        skip_memory: bool = False,
-        credential_pool=None,
-        # ... plus callbacks, thread/user/chat IDs, iteration_budget, fallback_model,
-        # checkpoints config, prefill_messages, service_tier, reasoning_config, etc.
-    ): ...
-
-    def chat(self, message: str) -> str:
-        """Simple interface — returns final response string."""
-
-    def run_conversation(self, user_message: str, system_message: str = None,
-                         conversation_history: list = None, task_id: str = None) -> dict:
-        """Full interface — returns dict with final_response + messages."""
-```
-
-### Agent Loop
-
-The core loop is inside `run_conversation()` — entirely synchronous, with
-interrupt checks, budget tracking, and a one-turn grace call:
-
-```python
-while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) \
-        or self._budget_grace_call:
-    if self._interrupt_requested: break
-    response = client.chat.completions.create(model=model, messages=messages, tools=tool_schemas)
-    if response.tool_calls:
-        for tool_call in response.tool_calls:
-            result = handle_function_call(tool_call.name, tool_call.args, task_id)
-            messages.append(tool_result_message(result))
-        api_call_count += 1
-    else:
-        return response.content
-```
-
-Messages follow OpenAI format: `{"role": "system/user/assistant/tool", ...}`.
-Reasoning content is stored in `assistant_msg["reasoning"]`.
-
----
-
-## CLI Architecture (cli.py)
-
-- **Rich** for banner/panels, **prompt_toolkit** for input with autocomplete
-- **KawaiiSpinner** (`agent/display.py`) — animated faces during API calls, `┊` activity feed for tool results
-- `load_cli_config()` in cli.py merges hardcoded defaults + user config YAML
-- **Skin engine** (`hermes_cli/skin_engine.py`) — data-driven CLI theming; initialized from `display.skin` config key at startup; skins customize banner colors, spinner faces/verbs/wings, tool prefix, response box, branding text
-- `process_command()` is a method on `HermesCLI` — dispatches on canonical command name resolved via `resolve_command()` from the central registry
-- Skill slash commands: `agent/skill_commands.py` scans `~/.hermes/skills/`, injects as **user message** (not system prompt) to preserve prompt caching
-
-### Slash Command Registry (`hermes_cli/commands.py`)
-
-All slash commands are defined in a central `COMMAND_REGISTRY` list of `CommandDef` objects. Every downstream consumer derives from this registry automatically:
-
-- **CLI** — `process_command()` resolves aliases via `resolve_command()`, dispatches on canonical name
-- **Gateway** — `GATEWAY_KNOWN_COMMANDS` frozenset for hook emission, `resolve_command()` for dispatch
-- **Gateway help** — `gateway_help_lines()` generates `/help` output
-- **Telegram** — `telegram_bot_commands()` generates the BotCommand menu
-- **Slack** — `slack_subcommand_map()` generates `/hermes` subcommand routing
-- **Autocomplete** — `COMMANDS` flat dict feeds `SlashCommandCompleter`
-- **CLI help** — `COMMANDS_BY_CATEGORY` dict feeds `show_help()`
-
-### Adding a Slash Command
-
-1. Add a `CommandDef` entry to `COMMAND_REGISTRY` in `hermes_cli/commands.py`:
-```python
-CommandDef("mycommand", "Description of what it does", "Session",
-           aliases=("mc",), args_hint="[arg]"),
-```
-2. Add handler in `HermesCLI.process_command()` in `cli.py`:
-```python
-elif canonical == "mycommand":
-    self._handle_mycommand(cmd_original)
-```
-3. If the command is available in the gateway, add a handler in `gateway/run.py`:
-```python
-if canonical == "mycommand":
-    return await self._handle_mycommand(event)
-```
-4. For persistent settings, use `save_config_value()` in `cli.py`
-
-**CommandDef fields:**
-- `name` — canonical name without slash (e.g. `"background"`)
-- `description` — human-readable description
-- `category` — one of `"Session"`, `"Configuration"`, `"Tools & Skills"`, `"Info"`, `"Exit"`
-- `aliases` — tuple of alternative names (e.g. `("bg",)`)
-- `args_hint` — argument placeholder shown in help (e.g. `"<prompt>"`, `"[name]"`)
-- `cli_only` — only available in the interactive CLI
-- `gateway_only` — only available in messaging platforms
-- `gateway_config_gate` — config dotpath (e.g. `"display.tool_progress_command"`); when set on a `cli_only` command, the command becomes available in the gateway if the config value is truthy. `GATEWAY_KNOWN_COMMANDS` always includes config-gated commands so the gateway can dispatch them; help/menus only show them when the gate is open.
-
-**Adding an alias** requires only adding it to the `aliases` tuple on the existing `CommandDef`. No other file changes needed — dispatch, help text, Telegram menu, Slack mapping, and autocomplete all update automatically.
-
----
-
-## TUI Architecture (ui-tui + tui_gateway)
-
-The TUI is a full replacement for the classic (prompt_toolkit) CLI, activated via `hermes --tui` or `HERMES_TUI=1`.
-
-### Process Model
-
-```
-hermes --tui
-  └─ Node (Ink)  ──stdio JSON-RPC──  Python (tui_gateway)
-       │                                  └─ AIAgent + tools + sessions
-       └─ renders transcript, composer, prompts, activity
-```
-
-TypeScript owns the screen. Python owns sessions, tools, model calls, and slash command logic.
-
-### Transport
-
-Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. See `tui_gateway/server.py` for the full method/event catalog.
-
-### Key Surfaces
-
-| Surface | Ink component | Gateway method |
-|---------|---------------|----------------|
-| Chat streaming | `app.tsx` + `messageLine.tsx` | `prompt.submit` → `message.delta/complete` |
-| Tool activity | `thinking.tsx` | `tool.start/progress/complete` |
-| Approvals | `prompts.tsx` | `approval.respond` ← `approval.request` |
-| Clarify/sudo/secret | `prompts.tsx`, `maskedPrompt.tsx` | `clarify/sudo/secret.respond` |
-| Session picker | `sessionPicker.tsx` | `session.list/resume` |
-| Slash commands | Local handler + fallthrough | `slash.exec` → `_SlashWorker`, `command.dispatch` |
-| Completions | `useCompletion` hook | `complete.slash`, `complete.path` |
-| Theming | `theme.ts` + `branding.tsx` | `gateway.ready` with skin data |
-
-### Slash Command Flow
-
-1. Built-in client commands (`/help`, `/quit`, `/clear`, `/resume`, `/copy`, `/paste`, etc.) handled locally in `app.tsx`
-2. Everything else → `slash.exec` (runs in persistent `_SlashWorker` subprocess) → `command.dispatch` fallback
-
-### Dev Commands
-
-```bash
-cd ui-tui
-npm install       # first time
-npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm start         # production
-npm run build     # full build (hermes-ink + tsc)
-npm run typecheck # typecheck only (tsc --noEmit)
-npm run lint      # eslint
-npm run fmt       # prettier
-npm test          # vitest
-```
-
-### TUI in the Dashboard (`hermes dashboard` → `/chat`)
-
-The dashboard embeds the real `hermes --tui` — **not** a rewrite.  See `hermes_cli/pty_bridge.py` + the `@app.websocket("/api/pty")` endpoint in `hermes_cli/web_server.py`.
-
-- Browser loads `web/src/pages/ChatPage.tsx`, which mounts xterm.js's `Terminal` with the WebGL renderer, `@xterm/addon-fit` for container-driven resize, and `@xterm/addon-unicode11` for modern wide-character widths.
-- `/api/pty?token=…` upgrades to a WebSocket; auth uses the same ephemeral `_SESSION_TOKEN` as REST, via query param (browsers can't set `Authorization` on WS upgrade).
-- The server spawns whatever `hermes --tui` would spawn, through `ptyprocess` (POSIX PTY — WSL works, native Windows does not).
-- Frames: raw PTY bytes each direction; resize via `\x1b[RESIZE:<cols>;<rows>]` intercepted on the server and applied with `TIOCSWINSZ`.
-
-**Do not re-implement the primary chat experience in React.** The main transcript, composer/input flow (including slash-command behavior), and PTY-backed terminal belong to the embedded `hermes --tui` — anything new you add to Ink shows up in the dashboard automatically. If you find yourself rebuilding the transcript or composer for the dashboard, stop and extend Ink instead.
-
-**Structured React UI around the TUI is allowed when it is not a second chat surface.** Sidebar widgets, inspectors, summaries, status panels, and similar supporting views (e.g. `ChatSidebar`, `ModelPickerDialog`, `ToolCall`) are fine when they complement the embedded TUI rather than replacing the transcript / composer / terminal. Keep their state independent of the PTY child's session and surface their failures non-destructively so the terminal pane keeps working unimpaired.
-
-### Electron Desktop Chat App (`apps/desktop/`)
-
-A **separate** chat surface from both the classic CLI and the dashboard's embedded TUI. It is an Electron + React + nanostore renderer (`@assistant-ui/react`) that talks to a `tui_gateway` backend over JSON-RPC (`requestGateway(method, params)`). The WebSocket/JSON-RPC transport lives in the framework-agnostic `apps/shared` package (`@hermes/shared` — `JsonRpcGatewayClient` + WS URL helpers), which the web dashboard (`web/`) also consumes; **desktop has no build/runtime dependency on the dashboard frontend** — it spawns a headless `hermes serve` backend server (the same gateway `dashboard` serves, minus the browser UI). `dashboard` and `serve` share `cmd_dashboard`/`start_server` but are independent surfaces — neither launches the other. The one exception is a backward-compat *fallback*: `serve` is newer, so the desktop spawn (`electron/backend-command.cjs` + `backendSupportsServe()` in `main.cjs`) detects whether the resolved runtime registers `serve` and, only when it does not (an older managed install / PATH `hermes` the app hasn't updated yet), rewrites the argv to the legacy `dashboard --no-open`. Without that, a new app against an un-upgraded runtime would crash on an unknown subcommand and brick every mid-upgrade user. It does NOT embed `hermes --tui` — it has its own composer, transcript, and slash-command pipeline. Route desktop bugs to the `hermes-desktop-app-work` skill, not `hermes-dashboard-work`.
-
-**Slash commands in the desktop app are curated client-side, then dispatched to the backend.** The pipeline:
-
-- **Backend already provides everything.** `tui_gateway/server.py` `commands.catalog` (empty-query list) and `complete.slash` (typed-query completions) both include built-in commands, user `quick_commands`, AND skill-derived commands (`scan_skill_commands()` / `get_skill_commands()`). The desktop app does not need a new RPC to see skills.
-- **The renderer curates via `apps/desktop/src/lib/desktop-slash-commands.ts`.** This is the load-bearing file. It holds `DESKTOP_COMMANDS` (the ~19 built-ins shown in the palette) plus block-lists for terminal-only / messaging-only / picker-owned / settings-owned / advanced commands that should NOT clutter the desktop popover.
-  - `isDesktopSlashCommand(name)` — gates **execution**. Returns true for built-ins AND for any non-built-in (skill / quick command), so typed extension commands run.
-  - `isDesktopSlashSuggestion(name)` — gates **discovery/completion**. Used by BOTH completion paths in `app/chat/composer/hooks/use-slash-completions.ts` (empty-query catalog filter + typed-query `complete.slash` filter) and by `filterDesktopCommandsCatalog`.
-  - `isDesktopSlashExtensionCommand(name)` — true when the command is NOT a known Hermes built-in (i.e. a skill or user quick command). Both suggestion and catalog-filter paths allow extensions through so skill commands surface in the palette. (Added when fixing "skill commands missing from the desktop slash palette" — the curated allow-list was silently dropping every skill/quick command from completions even though they executed fine when typed.)
-- **Dispatch** lives in `app/session/hooks/use-prompt-actions.ts` (`runSlash`): built-ins that the desktop owns (`/skin`, `/help`, `/new`, …) are handled locally or via `commands.catalog`; everything else goes to `slash.exec`, falling back to `command.dispatch` (which the gateway resolves into skill / alias / exec directives). A skill command resolves to `{type: "skill", message}` and is submitted as a normal prompt.
-
-**Rule:** the desktop slash palette's curation is about hiding noise (terminal-only / messaging-only built-ins), NOT about hiding user-activated extensions. Skill commands and `quick_commands` are extensions the backend surfaces — they belong in completions. If you tighten `desktop-slash-commands.ts`, keep `isDesktopSlashExtensionCommand` flowing into both the suggestion and catalog-filter paths. Tests: `apps/desktop/src/lib/desktop-slash-commands.test.ts` (run via the repo-root `vitest`, since `apps/desktop` resolves deps from the root workspace install).
-
----
-
-## Adding New Tools
-
-Before adding any tool, settle the footprint question first (see "The
-Footprint Ladder" in the Contribution Rubric): most capabilities should NOT
-be core tools. For custom or local-only tools, do **not** edit Hermes core.
-Use the plugin route instead: create `~/.hermes/plugins/<name>/plugin.yaml`
-and `~/.hermes/plugins/<name>/__init__.py`, then register tools with
-`ctx.register_tool(...)`. Plugin toolsets are discovered automatically and can be
-enabled or disabled without touching `tools/` or `toolsets.py`.
-
-Use the built-in route below only when the user is explicitly contributing a new
-core Hermes tool that should ship in the base system.
-
-Built-in/core tools require changes in **2 files**:
-
-**1. Create `tools/your_tool.py`:**
-```python
-import json, os
-from tools.registry import registry
-
-def check_requirements() -> bool:
-    return bool(os.getenv("EXAMPLE_API_KEY"))
-
-def example_tool(param: str, task_id: str = None) -> str:
-    return json.dumps({"success": True, "data": "..."})
-
-registry.register(
-    name="example_tool",
-    toolset="example",
-    schema={"name": "example_tool", "description": "...", "parameters": {...}},
-    handler=lambda args, **kw: example_tool(param=args.get("param", ""), task_id=kw.get("task_id")),
-    check_fn=check_requirements,
-    requires_env=["EXAMPLE_API_KEY"],
-)
-```
-
-**2. Add to `toolsets.py`** — either `_HERMES_CORE_TOOLS` (all platforms) or a new toolset. **This step is required:** auto-discovery imports the tool and registers its schema, but the tool is only *exposed to an agent* if its name appears in a toolset. `_HERMES_CORE_TOOLS` is not dead code — it's the default bundle every platform's base toolset inherits from.
-
-Auto-discovery: any `tools/*.py` file with a top-level `registry.register()` call is imported automatically — no manual import list to maintain. Wiring into a toolset is still a deliberate, manual step.
-
-The registry handles schema collection, dispatch, availability checking, and error wrapping. All handlers MUST return a JSON string.
-
-**Path references in tool schemas**: If the schema description mentions file paths (e.g. default output directories), use `display_hermes_home()` to make them profile-aware. The schema is generated at import time, which is after `_apply_profile_override()` sets `HERMES_HOME`.
-
-**State files**: If a tool stores persistent state (caches, logs, checkpoints), use `get_hermes_home()` for the base directory — never `Path.home() / ".hermes"`. This ensures each profile gets its own state.
-
-**Agent-level tools** (todo, memory): intercepted by `run_agent.py` before `handle_function_call()`. See `tools/todo_tool.py` for the pattern.
-
----
-
-## Dependency Pinning Policy
-
-All dependencies must have upper bounds to limit supply-chain attack surface.
-This policy was established after the litellm compromise (PR #2796, #2810) and
-reinforced after the Mini Shai-Hulud worm campaign (May 2026).
-
-| Source type | Treatment | Example |
-|---|---|---|
-| PyPI package | `>=floor,<next_major` | `"httpx>=0.28.1,<1"` |
-| Git URL | Commit SHA | `git+https://...@<40-char-sha>` |
-| GitHub Actions | Commit SHA + comment | `uses: actions/checkout@<sha>  # v4` |
-| CI-only pip | `==exact` | `pyyaml==6.0.2` |
-
-**When adding a new dependency to `pyproject.toml`:**
-1. Pin to `>=current_version,<next_major` for post-1.0 (e.g. `>=1.5.0,<2`).
-2. For pre-1.0 packages, use `<0.(current_minor + 2)` (e.g. `>=0.29,<0.32`).
-3. Never commit a bare `>=X.Y.Z` without a ceiling — CI and reviewers will reject it.
-4. Run `uv lock` to regenerate `uv.lock` with hashes.
-
-Reference: #2810 (bounds pass), #9801 (SHA pinning + audit CI).
-
----
-
-## Adding Configuration
-
-### config.yaml options:
-1. Add to `DEFAULT_CONFIG` in `hermes_cli/config.py`
-2. Bump `_config_version` (check the current value at the top of `DEFAULT_CONFIG`)
-   ONLY if you need to actively migrate/transform existing user config
-   (renaming keys, changing structure). Adding a new key to an existing
-   section is handled automatically by the deep-merge and does NOT require
-   a version bump.
-
-### Top-level `config.yaml` sections (non-exhaustive):
-
-`model`, `agent`, `terminal`, `compression`, `display`, `stt`, `tts`,
-`memory`, `security`, `delegation`, `smart_model_routing`, `checkpoints`,
-`auxiliary`, `curator`, `skills`, `gateway`, `logging`, `cron`, `profiles`,
-`plugins`, `honcho`.
-
-`auxiliary` holds per-task overrides for side-LLM work (curator, vision,
-embedding, title generation, session_search, etc.) — each task can pin
-its own provider/model/base_url/max_tokens/reasoning_effort. See
-`agent/auxiliary_client.py::_resolve_auto` for resolution order.
-
-`curator` holds the background skill-maintenance config —
-`enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
-`archive_after_days`, `backup` (nested).
-
-### .env variables (SECRETS ONLY — API keys, tokens, passwords):
-1. Add to `OPTIONAL_ENV_VARS` in `hermes_cli/config.py` with metadata:
-```python
-"NEW_API_KEY": {
-    "description": "What it's for",
-    "prompt": "Display name",
-    "url": "https://...",
-    "password": True,
-    "category": "tool",  # provider, tool, messaging, setting
-},
-```
-
-Non-secret settings (timeouts, thresholds, feature flags, paths, display
-preferences) belong in `config.yaml`, not `.env`. If internal code needs an
-env var mirror for backward compatibility, bridge it from `config.yaml` to
-the env var in code (see `gateway_timeout`, `terminal.cwd` → `TERMINAL_CWD`).
-
-### Config loaders (three paths — know which one you're in):
-
-| Loader | Used by | Location |
-|--------|---------|----------|
-| `load_cli_config()` | CLI mode | `cli.py` — merges CLI-specific defaults + user YAML |
-| `load_config()` | `hermes tools`, `hermes setup`, most CLI subcommands | `hermes_cli/config.py` — merges `DEFAULT_CONFIG` + user YAML |
-| Direct YAML load | Gateway runtime | `gateway/run.py` + `gateway/config.py` — reads user YAML raw |
-
-If you add a new key and the CLI sees it but the gateway doesn't (or vice
-versa), you're on the wrong loader. Check `DEFAULT_CONFIG` coverage.
-
-### Working directory:
-- **CLI** — uses the process's current directory (`os.getcwd()`).
-- **Messaging** — uses `terminal.cwd` from `config.yaml`. The gateway bridges this
-  to the `TERMINAL_CWD` env var for child tools. **`MESSAGING_CWD` has been
-  removed** — the config loader prints a deprecation warning if it's set in
-  `.env`. Same for `TERMINAL_CWD` in `.env`; the canonical setting is
-  `terminal.cwd` in `config.yaml`.
-
----
-
-## Skin/Theme System
-
-The skin engine (`hermes_cli/skin_engine.py`) provides data-driven CLI visual customization. Skins are **pure data** — no code changes needed to add a new skin.
-
-### Architecture
-
-```
-hermes_cli/skin_engine.py    # SkinConfig dataclass, built-in skins, YAML loader
-~/.hermes/skins/*.yaml       # User-installed custom skins (drop-in)
-```
-
-- `init_skin_from_config()` — called at CLI startup, reads `display.skin` from config
-- `get_active_skin()` — returns cached `SkinConfig` for the current skin
-- `set_active_skin(name)` — switches skin at runtime (used by `/skin` command)
-- `load_skin(name)` — loads from user skins first, then built-ins, then falls back to default
-- Missing skin values inherit from the `default` skin automatically
-
-### What skins customize
-
-| Element | Skin Key | Used By |
-|---------|----------|---------|
-| Banner panel border | `colors.banner_border` | `banner.py` |
-| Banner panel title | `colors.banner_title` | `banner.py` |
-| Banner section headers | `colors.banner_accent` | `banner.py` |
-| Banner dim text | `colors.banner_dim` | `banner.py` |
-| Banner body text | `colors.banner_text` | `banner.py` |
-| Response box border | `colors.response_border` | `cli.py` |
-| Spinner faces (waiting) | `spinner.waiting_faces` | `display.py` |
-| Spinner faces (thinking) | `spinner.thinking_faces` | `display.py` |
-| Spinner verbs | `spinner.thinking_verbs` | `display.py` |
-| Spinner wings (optional) | `spinner.wings` | `display.py` |
-| Tool output prefix | `tool_prefix` | `display.py` |
-| Per-tool emojis | `tool_emojis` | `display.py` → `get_tool_emoji()` |
-| Agent name | `branding.agent_name` | `banner.py`, `cli.py` |
-| Welcome message | `branding.welcome` | `cli.py` |
-| Response box label | `branding.response_label` | `cli.py` |
-| Prompt symbol | `branding.prompt_symbol` | `cli.py` |
-
-### Built-in skins
-
-- `default` — Classic Hermes gold/kawaii (the current look)
-- `ares` — Crimson/bronze war-god theme with custom spinner wings
-- `mono` — Clean grayscale monochrome
-- `slate` — Cool blue developer-focused theme
-
-### Adding a built-in skin
-
-Add to `_BUILTIN_SKINS` dict in `hermes_cli/skin_engine.py`:
-
-```python
-"mytheme": {
-    "name": "mytheme",
-    "description": "Short description",
-    "colors": { ... },
-    "spinner": { ... },
-    "branding": { ... },
-    "tool_prefix": "┊",
-},
-```
-
-### User skins (YAML)
-
-Users create `~/.hermes/skins/<name>.yaml`:
-
-```yaml
-name: cyberpunk
-description: Neon-soaked terminal theme
-
-colors:
-  banner_border: "#FF00FF"
-  banner_title: "#00FFFF"
-  banner_accent: "#FF1493"
-
-spinner:
-  thinking_verbs: ["jacking in", "decrypting", "uploading"]
-  wings:
-    - ["⟨⚡", "⚡⟩"]
-
-branding:
-  agent_name: "Cyber Agent"
-  response_label: " ⚡ Cyber "
-
-tool_prefix: "▏"
-```
-
-Activate with `/skin cyberpunk` or `display.skin: cyberpunk` in config.yaml.
-
----
-
-## Plugins
-
-Hermes has two plugin surfaces. Both live under `plugins/` in the repo so
-repo-shipped plugins can be discovered alongside user-installed ones in
-`~/.hermes/plugins/` and pip-installed entry points.
-
-### General plugins (`hermes_cli/plugins.py` + `plugins/<name>/`)
-
-`PluginManager` discovers plugins from `~/.hermes/plugins/`, `./.hermes/plugins/`,
-and pip entry points. Each plugin exposes a `register(ctx)` function that
-can:
-
-- Register Python-callback lifecycle hooks:
-  `pre_tool_call`, `post_tool_call`, `pre_llm_call`, `post_llm_call`,
-  `on_session_start`, `on_session_end`
-- Register new tools via `ctx.register_tool(...)`
-- Register CLI subcommands via `ctx.register_cli_command(...)` — the
-  plugin's argparse tree is wired into `hermes` at startup so
-  `hermes <pluginname> <subcmd>` works with no change to `main.py`
-
-Hooks are invoked from `model_tools.py` (pre/post tool) and `run_agent.py`
-(lifecycle). **Discovery timing pitfall:** `discover_plugins()` only runs
-as a side effect of importing `model_tools.py`. Code paths that read plugin
-state without importing `model_tools.py` first must call `discover_plugins()`
-explicitly (it's idempotent).
-
-### Memory-provider plugins (`plugins/memory/<name>/`)
-
-Separate discovery system for pluggable memory backends. Current built-in
-providers include **honcho, mem0, supermemory, byterover, hindsight,
-holographic, openviking, retaindb**.
-
-Each provider implements the `MemoryProvider` ABC (see `agent/memory_provider.py`)
-and is orchestrated by `agent/memory_manager.py`. Lifecycle hooks include
-`sync_turn(turn_messages)`, `prefetch(query)`, `shutdown()`, and optional
-`post_setup(hermes_home, config)` for setup-wizard integration.
-
-**CLI commands via `plugins/memory/<name>/cli.py`:** if a memory plugin
-defines `register_cli(subparser)`, `discover_plugin_cli_commands()` finds
-it at argparse setup time and wires it into `hermes <plugin>`. The
-framework only exposes CLI commands for the **currently active** memory
-provider (read from `memory.provider` in config.yaml), so disabled
-providers don't clutter `hermes --help`.
-
-**Rule (Teknium, May 2026):** plugins MUST NOT modify core files
-(`run_agent.py`, `cli.py`, `gateway/run.py`, `hermes_cli/main.py`, etc.).
-If a plugin needs a capability the framework doesn't expose, expand the
-generic plugin surface (new hook, new ctx method) — never hardcode
-plugin-specific logic into core. PR #5295 removed 95 lines of hardcoded
-honcho argparse from `main.py` for exactly this reason.
-
-**No new in-tree memory providers (policy, May 2026):** the set of
-built-in memory providers under `plugins/memory/` is closed. New memory
-backends must ship as **standalone plugin repos** that users install
-into `~/.hermes/plugins/` (or via pip entry points) — they implement
-the same `MemoryProvider` ABC, register through the same discovery
-path, and integrate via `hermes memory setup` / `post_setup()` without
-landing in this tree. PRs that add a new directory under
-`plugins/memory/` will be closed with a pointer to publish the
-provider as its own repo. Existing in-tree providers stay; bug fixes
-to them are welcome.
-
-**No new third-party-product plugins in-tree (policy, June 2026):** the
-same rule applies beyond memory providers. Plugins that integrate
-someone else's product or project — observability/metrics backends,
-vendor SaaS connectors, analytics dashboards, paid-service tie-ins —
-must ship as **standalone plugin repos** that users install into
-`~/.hermes/plugins/` (or via pip entry points). They register through
-the existing plugin discovery path and use the ABCs/hooks/ctx surface
-we expose; nothing special is needed in core. The reason is
-maintenance load: every product we absorb into the tree becomes our
-burden to keep working against a fast-moving core, for a backend we
-don't own. Promote standalone plugins in the Nous Research Discord
-(`#plugins-skills-and-skins`). PRs that add such a directory under
-`plugins/` are closed with a pointer to publish it as its own repo —
-this is a coupling decision, not a quality judgment. (The
-`observability/`, `kanban/`, `disk-cleanup/`, etc. directories already
-in the tree are existing precedent, not an invitation to add more
-third-party-product plugins alongside them.)
-
-### Model-provider plugins (`plugins/model-providers/<name>/`)
-
-Every inference backend (openrouter, anthropic, gmi, deepseek, nvidia, …)
-ships as a plugin here. Each plugin's `__init__.py` calls
-`providers.register_provider(ProviderProfile(...))` at module load.
-`providers/__init__.py._discover_providers()` is a **lazy, separate
-discovery system** — scanned on first `get_provider_profile()` or
-`list_providers()` call, NOT by the general PluginManager.
-
-Scan order:
-1. Bundled: `<repo>/plugins/model-providers/<name>/`
-2. User: `$HERMES_HOME/plugins/model-providers/<name>/`
-3. Legacy: `<repo>/providers/<name>.py` (back-compat)
-
-User plugins of the same name override bundled ones — `register_provider()`
-is last-writer-wins. This lets third parties swap out any built-in
-profile without a repo patch.
-
-The general PluginManager records `kind: model-provider` manifests but does
-NOT import them (would double-instantiate `ProviderProfile`). Plugins
-without an explicit `kind:` get auto-coerced via a source-text heuristic
-(`register_provider` + `ProviderProfile` in `__init__.py`).
-
-Full authoring guide: `website/docs/developer-guide/model-provider-plugin.md`.
-
-### Dashboard / context-engine / image-gen plugin directories
-
-`plugins/context_engine/`, `plugins/image_gen/`, etc. follow the same
-pattern (ABC + orchestrator + per-plugin directory). Context engines
-plug into `agent/context_engine.py`; image-gen providers into
-`agent/image_gen_provider.py`. Reference / docs-companion plugins
-(`example-dashboard`, `strike-freedom-cockpit`, `plugin-llm-example`,
-`plugin-llm-async-example`) live in the
-[`hermes-example-plugins`](https://github.com/NousResearch/hermes-example-plugins)
-companion repo, not in this tree.
-
----
-
-## Skills
-
-Two parallel surfaces:
-
-- **`skills/`** — built-in skills shipped and loadable by default.
-  Organized by category directories (e.g. `skills/github/`, `skills/mlops/`).
-- **`optional-skills/`** — heavier or niche skills shipped with the repo but
-  NOT active by default. Installed explicitly via
-  `hermes skills install official/<category>/<skill>`. Adapter lives in
-  `tools/skills_hub.py` (`OptionalSkillSource`). Categories include
-  `autonomous-ai-agents`, `blockchain`, `communication`, `creative`,
-  `devops`, `email`, `health`, `mcp`, `migration`, `mlops`, `productivity`,
-  `research`, `security`, `web-development`.
-
-When reviewing skill PRs, check which directory they target — heavy-dep or
-niche skills belong in `optional-skills/`.
-
-### SKILL.md frontmatter
-
-Standard fields: `name`, `description`, `version`, `author`, `license`,
-`platforms` (OS-gating list: `[macos]`, `[linux, macos]`, ...),
-`metadata.hermes.tags`, `metadata.hermes.category`,
-`metadata.hermes.related_skills`, `metadata.hermes.config` (config.yaml
-settings the skill needs — stored under `skills.config.<key>`, prompted
-during setup, injected at load time).
-
-Top-level `tags:` and `category:` are also accepted and mirrored from
-`metadata.hermes.*` by the loader.
-
-### Skill authoring standards (HARDLINE)
-
-Every new or modernized skill — bundled, optional, or contributed —
-must meet these standards before merge. Reviewers reject PRs that
-violate them.
-
-1. **`description` ≤ 60 characters, one sentence, ends with a period.**
-   Long descriptions bloat skill listings and dilute the model's
-   attention when many skills are loaded. State the capability, not
-   the implementation. No marketing words ("powerful",
-   "comprehensive", "seamless", "advanced"). Don't repeat the skill
-   name. Verify with:
-   ```python
-   import re, pathlib
-   m = re.search(r'^description: (.*)$',
-                 pathlib.Path('skills/<cat>/<name>/SKILL.md').read_text(),
-                 re.MULTILINE)
-   assert len(m.group(1)) <= 60, len(m.group(1))
-   ```
-
-2. **Tools referenced in SKILL.md prose must be native Hermes tools or
-   MCP servers the skill explicitly expects.** When the skill needs a
-   capability, point at the proper tool by name in backticks
-   (`` `terminal` ``, `` `web_extract` ``, `` `read_file` ``,
-   `` `patch` ``, `` `search_files` ``, `` `vision_analyze` ``,
-   `` `browser_navigate` ``, `` `delegate_task` ``, etc.). Do NOT
-   name shell utilities the agent already has wrapped — `grep` →
-   `search_files`, `cat`/`head`/`tail` → `read_file`, `sed`/`awk` →
-   `patch`, `find`/`ls` → `search_files target='files'`. If the skill
-   depends on an MCP server, name the MCP server and document the
-   expected setup in `## Prerequisites`. Anything else (third-party
-   CLIs, shell pipelines, etc.) is fair game inside script files but
-   should not be the headline interaction surface in the prose.
-
-3. **`platforms:` gating audited against actual script imports.**
-   Skills that use POSIX-only primitives (`fcntl`, `termios`,
-   `os.setsid`, `os.kill(pid, 0)` for liveness, `/proc`, `/tmp`
-   hardcoded, `signal.SIGKILL`, bash heredocs, `osascript`, `apt`,
-   `systemctl`) must declare their supported platforms. Default
-   posture: try to fix it cross-platform first — `tempfile.gettempdir`,
-   `pathlib.Path`, `psutil.pid_exists`, Python-level filtering instead
-   of `grep`. Gate to a narrower set only when the dependency is
-   genuinely platform-bound.
-
-4. **`author` credits the human contributor first.** For external
-   contributions, the contributor's real name + GitHub handle goes
-   first; "Hermes Agent" is the secondary collaborator. If the
-   contributor's commit shows "Hermes Agent" as author (because they
-   used Hermes to draft the skill), replace it with their actual name
-   — credit the human, not the tool.
-
-5. **SKILL.md body uses the modern section order.** `# <Skill> Skill`
-   title, 2-3 sentence intro stating what it does and doesn't do,
-   `## When to Use`, `## Prerequisites`, `## How to Run`,
-   `## Quick Reference`, `## Procedure`, `## Pitfalls`,
-   `## Verification`. Target ~200 lines for a complex skill,
-   ~100 lines for a simple one. Cut redundant intro fluff, marketing
-   prose, and re-explanations of env vars already in
-   `## Prerequisites`.
-
-6. **Scripts go in `scripts/`, references in `references/`,
-   templates in `templates/`.** Don't expect the model to inline-write
-   parsers, XML walkers, or non-trivial logic every call — ship a
-   helper script. Reference it from SKILL.md by path relative to the
-   skill directory.
-
-7. **Tests live at `tests/skills/test_<skill>_skill.py`** and use only
-   stdlib + pytest + `unittest.mock`. No live network calls. Run via
-   `scripts/run_tests.sh tests/skills/test_<skill>_skill.py -q`.
-
-8. **`.env.example` additions are isolated to a clearly delimited
-   block.** Don't touch the surrounding file — contributor-supplied
-   `.env.example` versions are usually stale and edits outside the
-   skill's own block must be dropped during salvage.
-
-The full salvage / modernization checklist for external skill PRs
-lives in the `hermes-agent-dev` skill at
-`references/new-skill-pr-salvage.md` — load it before polishing
-contributor skill PRs.
-
----
-
-## Toolsets
-
-All toolsets are defined in `toolsets.py` as a single `TOOLSETS` dict.
-Each platform's adapter picks a base toolset (e.g. Telegram uses
-`"messaging"`); `_HERMES_CORE_TOOLS` is the default bundle most
-platforms inherit from.
-
-Current toolset keys: `browser`, `clarify`, `code_execution`, `cronjob`,
-`debugging`, `delegation`, `discord`, `discord_admin`, `feishu_doc`,
-`feishu_drive`, `file`, `homeassistant`, `image_gen`, `kanban`, `memory`,
-`messaging`, `moa`, `rl`, `safe`, `search`, `session_search`, `skills`,
-`spotify`, `terminal`, `todo`, `tts`, `video`, `vision`, `web`, `yuanbao`.
-
-Enable/disable per platform via `hermes tools` (the curses UI) or the
-`tools.<platform>.enabled` / `tools.<platform>.disabled` lists in
-`config.yaml`.
-
----
-
-## Delegation (`delegate_task`)
-
-`tools/delegate_tool.py` spawns a subagent with an isolated
-context + terminal session. By default the parent waits for the
-child's summary before continuing its own loop. With `background=true`,
-Hermes returns a delegation id immediately and the result re-enters the
-conversation later through the async-delegation completion queue.
-
-Two shapes:
-
-- **Single:** pass `goal` (+ optional `context`, `toolsets`).
-- **Batch (parallel):** pass `tasks: [...]` — each gets its own subagent
-  running concurrently. Concurrency is capped by
-  `delegation.max_concurrent_children` (default 3).
-
-Roles:
-
-- `role="leaf"` (default) — focused worker. Cannot call `delegate_task`,
-  `clarify`, `memory`, `send_message`, `execute_code`.
-- `role="orchestrator"` — retains `delegate_task` so it can spawn its
-  own workers. Gated by `delegation.orchestrator_enabled` (default true)
-  and bounded by `delegation.max_spawn_depth` (default 2).
-
-Key config knobs (under `delegation:` in `config.yaml`):
-`max_concurrent_children`, `max_spawn_depth`, `child_timeout_seconds`,
-`orchestrator_enabled`, `subagent_auto_approve`, `inherit_mcp_toolsets`,
-`max_iterations`.
-
-Durability rule: background `delegate_task` is detached from the current
-turn but still process-local. For work that must survive process restart, use
-`cronjob` or `terminal(background=True, notify_on_complete=True)` instead.
-
----
-
-## Curator (skill lifecycle)
-
-Background skill-maintenance system that tracks usage on agent-created
-skills and auto-archives stale ones. Users never lose skills; archives
-go to `~/.hermes/skills/.archive/` and are restorable.
-
-- **Core:** `agent/curator.py` (review loop, auto-transitions, LLM review
-  prompt) + `agent/curator_backup.py` (pre-run tar.gz snapshots).
-- **CLI:** `hermes_cli/curator.py` wires `hermes curator <verb>` where
-  verbs are: `status`, `run`, `pause`, `resume`, `pin`, `unpin`,
-  `archive`, `restore`, `prune`, `backup`, `rollback`.
-- **Telemetry:** `tools/skill_usage.py` owns the sidecar
-  `~/.hermes/skills/.usage.json` — per-skill `use_count`, `view_count`,
-  `patch_count`, `last_activity_at`, `state` (active / stale /
-  archived), `pinned`.
-
-Invariants:
-- Curator only touches skills with `created_by: "agent"` provenance —
-  bundled + hub-installed skills are off-limits.
-- Never deletes; max destructive action is archive.
-- Pinned skills are exempt from every auto-transition and from the
-  LLM review pass.
-- `skill_manage(action="delete")` refuses pinned skills; patch/edit/
-  write_file/remove_file go through so the agent can keep improving
-  pinned skills.
-
-Config section (`curator:` in `config.yaml`):
-`enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
-`archive_after_days`, `backup.*`.
-
-Full user-facing docs: `website/docs/user-guide/features/curator.md`.
-
----
-
-## Cron (scheduled jobs)
-
-`cron/jobs.py` (job store) + `cron/scheduler.py` (tick loop). Agents
-schedule jobs via the `cronjob` tool; users via `hermes cron <verb>`
-(`list`, `add`, `edit`, `pause`, `resume`, `run`, `remove`) or the
-`/cron` slash command.
-
-Supported schedule formats:
-- Duration: `"30m"`, `"2h"`, `"1d"`
-- "every" phrase: `"every 2h"`, `"every monday 9am"`
-- 5-field cron expression: `"0 9 * * *"`
-- ISO timestamp (one-shot): `"2026-06-01T09:00:00Z"`
-
-Per-job fields include `skills` (load specific skills), `model` /
-`provider` overrides, `script` (pre-run data-collection script whose
-stdout is injected into the prompt; `no_agent=True` turns the script
-into the entire job), `context_from` (chain job A's last output into
-job B's prompt), `workdir` (run in a specific directory with its
-`AGENTS.md`/`CLAUDE.md` loaded), and multi-platform delivery.
-
-Hardening invariants:
-- **3-minute hard interrupt** on cron sessions — runaway agent loops
-  cannot monopolize the scheduler.
-- Catchup window: half the job's period, clamped to 120s–2h.
-- Grace window: 120s for one-shot jobs whose fire time was missed.
-- File lock at `~/.hermes/cron/.tick.lock` prevents duplicate ticks
-  across processes.
-- Cron sessions pass `skip_memory=True` by default; memory providers
-  intentionally do not run during cron.
-
-Cron deliveries are **not** mirrored into the target gateway session —
-they land in their own cron session with a header/footer frame so the
-main conversation's message-role alternation stays intact.
-
----
-
-## Kanban (multi-agent work queue)
-
-Durable SQLite-backed board that lets multiple profiles / workers
-collaborate on shared tasks. Users drive it via `hermes kanban <verb>`;
-workers spawned by the dispatcher drive it via a dedicated `kanban_*`
-toolset so their schema footprint is zero when they're not inside a
-kanban task.
-
-- **CLI:** `hermes_cli/kanban.py` wires `hermes kanban` with verbs
-  `init`, `create`, `list` (alias `ls`), `show`, `assign`, `link`,
-  `unlink`, `comment`, `complete`, `block`, `unblock`, `archive`,
-  `tail`, plus less-commonly-used `watch`, `stats`, `runs`, `log`,
-  `assignees`, `heartbeat`, `notify-*`, `dispatch`, `daemon`, `gc`.
-- **Worker/orchestrator toolset:** `tools/kanban_tools.py` exposes
-  `kanban_show`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`,
-  `kanban_comment`, `kanban_create`, `kanban_link`; profiles that
-  explicitly enable the `kanban` toolset outside a dispatcher-spawned
-  task also get `kanban_list` and `kanban_unblock` for board routing.
-- **Dispatcher:** long-lived loop that (default every 60s) reclaims
-  stale claims, promotes ready tasks, atomically claims, and spawns
-  assigned profiles. Runs **inside the gateway** by default via
-  `kanban.dispatch_in_gateway: true`.
-- **Plugin assets:** `plugins/kanban/dashboard/` (web UI) +
-  `plugins/kanban/systemd/` (`hermes-kanban-dispatcher.service` for
-  standalone dispatcher deployment).
-
-Isolation model:
-- **Board** is the hard boundary — workers are spawned with
-  `HERMES_KANBAN_BOARD` pinned in their env so they can't see other
-  boards.
-- **Tenant** is a soft namespace *within* a board — one specialist
-  fleet can serve multiple businesses with workspace-path + memory-key
-  isolation.
-- After `kanban.failure_limit` consecutive non-success attempts on the
-  same task (default: 2), the dispatcher auto-blocks it to prevent spin
-  loops.
-
-Full user-facing docs: `website/docs/user-guide/features/kanban.md`.
-
----
-
 ## Important Policies
+
+### Dependency Pinning Is Supply-Chain Control
+
+When adding or changing dependencies, keep the supply-chain invariant inline:
+PyPI ranges need `>=floor,<next_major`, Git URL dependencies pin a full commit
+SHA, GitHub Actions pin a full SHA plus a version comment, and CI-only pip
+installs may use `==exact`. Do not add unbounded `>=X.Y.Z` specs. See
+[Dependency pinning policy](CONTRIBUTING.md#dependency-pinning-policy-supply-chain-hardening)
+and [AGENTS.md Reference](website/docs/developer-guide/agents-md-reference.md#dependency-pinning-policy).
 
 ### Prompt Caching Must Not Break
 
@@ -1152,64 +76,6 @@ in config.yaml (or `HERMES_BACKGROUND_NOTIFICATIONS` env var):
 - `result` — only the final completion message
 - `error` — only the final message when exit code != 0
 - `off` — no watcher messages at all
-
----
-
-## Profiles: Multi-Instance Support
-
-Hermes supports **profiles** — multiple fully isolated instances, each with its own
-`HERMES_HOME` directory (config, API keys, memory, sessions, skills, gateway, etc.).
-
-The core mechanism: `_apply_profile_override()` in `hermes_cli/main.py` sets
-`HERMES_HOME` before any module imports. All `get_hermes_home()` references
-automatically scope to the active profile.
-
-### Rules for profile-safe code
-
-1. **Use `get_hermes_home()` for all HERMES_HOME paths.** Import from `hermes_constants`.
-   NEVER hardcode `~/.hermes` or `Path.home() / ".hermes"` in code that reads/writes state.
-   ```python
-   # GOOD
-   from hermes_constants import get_hermes_home
-   config_path = get_hermes_home() / "config.yaml"
-
-   # BAD — breaks profiles
-   config_path = Path.home() / ".hermes" / "config.yaml"
-   ```
-
-2. **Use `display_hermes_home()` for user-facing messages.** Import from `hermes_constants`.
-   This returns `~/.hermes` for default or `~/.hermes/profiles/<name>` for profiles.
-   ```python
-   # GOOD
-   from hermes_constants import display_hermes_home
-   print(f"Config saved to {display_hermes_home()}/config.yaml")
-
-   # BAD — shows wrong path for profiles
-   print("Config saved to ~/.hermes/config.yaml")
-   ```
-
-3. **Module-level constants are fine** — they cache `get_hermes_home()` at import time,
-   which is AFTER `_apply_profile_override()` sets the env var. Just use `get_hermes_home()`,
-   not `Path.home() / ".hermes"`.
-
-4. **Tests that mock `Path.home()` must also set `HERMES_HOME`** — since code now uses
-   `get_hermes_home()` (reads env var), not `Path.home() / ".hermes"`:
-   ```python
-   with patch.object(Path, "home", return_value=tmp_path), \
-        patch.dict(os.environ, {"HERMES_HOME": str(tmp_path / ".hermes")}):
-       ...
-   ```
-
-5. **Gateway platform adapters should use token locks** — if the adapter connects with
-   a unique credential (bot token, API key), call `acquire_scoped_lock()` from
-   `gateway.status` in the `connect()`/`start()` method and `release_scoped_lock()` in
-   `disconnect()`/`stop()`. This prevents two profiles from using the same credential.
-   See `plugins/platforms/irc/adapter.py` for the canonical pattern.
-
-6. **Profile operations are HOME-anchored, not HERMES_HOME-anchored** — `_get_profiles_root()`
-   returns `Path.home() / ".hermes" / "profiles"`, NOT `get_hermes_home() / "profiles"`.
-   This is intentional — it lets `hermes -p coder profile list` see all profiles regardless
-   of which one is active.
 
 ## Known Pitfalls
 
@@ -1274,83 +140,173 @@ def profile_env(tmp_path, monkeypatch):
     return home
 ```
 
----
-
 ## Testing
 
-**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces
-hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8,
-`-n auto` xdist workers, in-tree subprocess-isolation plugin). Direct `pytest`
-on a 16+ core developer machine with API keys set diverges from CI in ways
-that have caused multiple "works locally, fails in CI" incidents (and the reverse).
+**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly for
+normal verification. The wrapper enforces CI-parity: credential env vars unset,
+`HOME` / `HERMES_HOME` isolated, TZ=UTC, LANG=C.UTF-8, xdist, and the in-tree
+subprocess-per-test isolation plugin.
 
 ```bash
 scripts/run_tests.sh                                  # full suite, CI-parity
 scripts/run_tests.sh tests/gateway/                   # one directory
 scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
 scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
+scripts/run_tests.sh --no-isolate tests/foo/          # disable isolation only for debugging
 ```
 
-### Subprocess-per-test-file isolation
+If you must bypass the wrapper (e.g. IDE), activate `.venv` / `venv` and run
+`python -m pytest ...`; the isolation plugin still loads unless `--no-isolate`
+is passed.
 
-Every test file runs in a freshly-spawned Python subprocess via `run_tests_parallel.py`. This means module-level dicts/sets and
-ContextVars from one test file cannot leak into the next.
+Don't write change-detector tests for expected-to-change data (model catalogs,
+config version literals, provider enumeration counts). Assert behavior and
+relationships instead: catalog plumbing works, migrations bump to current,
+plan-only models don't leak, and every catalog model has required metadata.
+See `website/docs/developer-guide/agents-md-reference.md#testing` for examples.
 
-### Why the wrapper
+## Contribution Rubric — Runtime Summary
 
-|                     | Without wrapper                             | With wrapper                              |
-| ------------------- | ------------------------------------------- | ----------------------------------------- |
-| Provider API keys   | Whatever is in your env (auto-detects pool) | All env vars except a specific few unset. |
-| HOME / `~/.hermes/` | Your real config+auth.json                  | Temp dir per test                         |
-| Timezone            | Local TZ (PDT etc.)                         | UTC                                       |
-| Locale              | Whatever is set                             | C.UTF-8                                   |
+Hermes ships a lot at the edges and stays conservative at the core waist.
+Use this rubric to avoid wrong-premise fixes and permanent core footprint.
+Full rationale and examples are in
+`website/docs/developer-guide/agents-md-reference.md#contribution-rubric`.
 
+What we want:
+- Fix real, reproduced bugs on current `main`; point to the line where the bug
+  manifests and fix the class, not just one call site.
+- Expand product reach at the edges: platform adapters, providers, desktop/TUI,
+  dashboard features, plugins, skills, and setup/config UX.
+- Refactor god-files into focused modules when the request is explicitly a
+  refactor and behavior is preserved.
+- Keep the core narrow: new model tools are expensive because every tool ships
+  on every API call.
+- Extend existing infrastructure instead of duplicating managers/hooks.
+- Preserve cache stability, strict message role alternation, and byte-stable
+  system prompts for the life of a conversation.
 
-### Don't write change-detector tests
+What we don't want:
+- Speculative hooks with no concrete consumer.
+- New user-facing `HERMES_*` env vars for non-secret config; use config.yaml.
+- New core tools when terminal/file/CLI+skill/plugin/MCP can solve it.
+- Lazy-reading pagination on instructional tools the agent must read fully.
+- Security "fixes" that destroy the protected feature's purpose.
+- Outbound telemetry/attribution without explicit opt-in gating.
+- Change-detector tests or cache-breaking mid-conversation changes.
 
-A test is a **change-detector** if it fails whenever data that is **expected
-to change** gets updated — model catalogs, config version numbers,
-enumeration counts, hardcoded lists of provider models. These tests add no
-behavioral coverage; they just guarantee that routine source updates break
-CI and cost engineering time to "fix."
+Before calling something a bug, verify both the premise and the original intent
+against the codebase (`git log -p -S` is often useful). If unsure, ask rather
+than shipping a fix that fights the design.
 
-**Do not write:**
+Footprint ladder for new capability, least footprint first:
+1. Extend existing code.
+2. CLI command + skill.
+3. Service-gated tool (`check_fn`) that appears only when configured.
+4. Plugin.
+5. MCP server in the catalog.
+6. New core tool only as a last resort for broadly useful fundamentals.
 
-```python
-# catalog snapshot — breaks every model release
-assert "gemini-2.5-pro" in _PROVIDER_MODELS["gemini"]
-assert "MiniMax-M2.7" in models
+Plugins MUST NOT modify core files; expose capability through generic plugin
+surfaces instead.
 
-# config version literal — breaks every schema bump
-assert DEFAULT_CONFIG["_config_version"] == 21
+## Development Environment
 
-# enumeration count — breaks every time a skill/provider is added
-assert len(_PROVIDER_MODELS["huggingface"]) == 8
+```bash
+# Prefer .venv; fall back to venv if that's what your checkout has.
+source .venv/bin/activate   # or: source venv/bin/activate
 ```
 
-**Do write:**
+`scripts/run_tests.sh` probes `.venv` first, then `venv`, then
+`$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
+main checkout).
 
-```python
-# behavior: does the catalog plumbing work at all?
-assert "gemini" in _PROVIDER_MODELS
-assert len(_PROVIDER_MODELS["gemini"]) >= 1
+## Project Structure
 
-# behavior: does migration bump the user's version to current latest?
-assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+File counts shift constantly — the filesystem is canonical. Load detailed
+subsystem reference from `website/docs/developer-guide/agents-md-reference.md`
+when needed. Load-bearing entry points:
 
-# invariant: no plan-only model leaks into the legacy list
-assert not (set(moonshot_models) & coding_plan_only_models)
+- `run_agent.py` — `AIAgent` core conversation loop.
+- `agent/prompt_builder.py` / `agent/system_prompt.py` — prompt assembly,
+  context files, truncation, skills prompt cache.
+- `model_tools.py`, `toolsets.py`, `tools/registry.py` — tool discovery,
+  schema shaping, execution, and toolset membership.
+- `cli.py`, `hermes_cli/` — CLI, setup, config, subcommands, curses UI.
+- `gateway/` — messaging gateway runner, sessions, adapters, platform guards.
+- `plugins/` — plugin system; third-party/niche capability belongs here when
+  possible instead of core.
+- `skills/`, `optional-skills/` — bundled and optional procedural memory.
+- `cron/`, `tools/cronjob_tools.py` — scheduled jobs.
+- `tests/` — pytest suite; use `scripts/run_tests.sh`.
 
-# invariant: every model in the catalog has a context-length entry
-for m in _PROVIDER_MODELS["huggingface"]:
-    assert m.lower() in DEFAULT_CONTEXT_LENGTHS_LOWER
-```
+User config is under `get_hermes_home()` (`config.yaml`, `.env` for secrets
+only). Logs are under `get_hermes_home() / "logs"`; browse with
+`hermes logs [--follow] [--level ...] [--session ...]`.
 
-The rule: if the test reads like a snapshot of current data, delete it. If
-it reads like a contract about how two pieces of data must relate, keep it.
-When a PR adds a new provider/model and you want a test, make the test
-assert the relationship (e.g. "catalog entries all have context lengths"),
-not the specific names.
+## TypeScript Style
 
-Reviewers should reject new change-detector tests; authors should convert
-them into invariants before re-requesting review.
+Applies to TypeScript across Hermes: desktop, TUI, website, and future TS packages.
+
+- Prefer small nanostores over component state when state is shared, reused, or read by distant UI.
+- Let each feature own its atoms. Chat state belongs near chat, shell state near shell, shared state in `src/store`.
+- Components that render from an atom should use `useStore`. Non-rendering actions should read with `$atom.get()`.
+- Do not pass state through three components when the leaf can subscribe to the atom.
+- Keep persistence beside the atom that owns it.
+- Keep route roots thin. They compose routes and shell; they should not become controllers.
+- No monolithic hooks. A hook should own one narrow job.
+- Prefer colocated action modules over hidden god hooks.
+- If a callback is pure side effect, use the terse void form:
+  `onState={st => void setGatewayState(st)}`.
+- Async UI handlers should make intent explicit:
+  `onClick={() => void save()}`.
+- Prefer interfaces for public props and shared object shapes. Avoid `type X = { ... }` for object props.
+- Extend React primitives for props: `React.ComponentProps<'button'>`, `React.ComponentProps<typeof Dialog>`, `Omit<...>`, `Pick<...>`.
+- Table-driven beats condition ladders when mapping ids, routes, or views.
+- `src/app` owns routes, pages, and page-specific components.
+- `src/store` owns shared atoms.
+- `src/lib` owns shared pure helpers.
+
+## Architecture Reference Index
+
+Keep runtime rules inline; open
+`website/docs/developer-guide/agents-md-reference.md` for long subsystem detail.
+
+- File dependency chain: CLI/gateway/TUI/API construct an `AIAgent`, which uses
+  prompt builders, provider adapters, model tools, terminal/browser/file tools,
+  memory, skills, and session storage. Trace definitions/usages before editing.
+- AIAgent / CLI / TUI architecture: avoid god-file growth unless doing an
+  explicit extraction; preserve prompt caching and role alternation.
+- Adding tools: prefer existing tools, CLI+skill, service-gated tools, plugins,
+  or MCP before core tools. New core schemas must avoid cross-tool references
+  unless added dynamically in `get_tool_definitions()`.
+- Configuration: user-facing non-secret behavior belongs in config.yaml, not
+  `.env`; use profile-aware paths (`get_hermes_home()`, `display_hermes_home()`).
+- Plugins/skills/toolsets/delegation/cron/kanban/curator: keep capability at the
+  edges and load detailed references only for tasks touching that subsystem.
+
+## Profiles: Multi-Instance Support
+
+Hermes supports **profiles** — multiple fully isolated instances, each with its own
+`HERMES_HOME` directory (config, API keys, memory, sessions, skills, gateway, etc.).
+
+The core mechanism: `_apply_profile_override()` in `hermes_cli/main.py` sets
+`HERMES_HOME` before any module imports. All `get_hermes_home()` references
+automatically scope to the active profile.
+
+### Rules for profile-safe code
+
+1. **Use `get_hermes_home()` for all HERMES_HOME paths.** Import from `hermes_constants`.
+   NEVER hardcode `~/.hermes` or `Path.home() / ".hermes"` in code that reads/writes state.
+2. **Use `display_hermes_home()` for user-facing messages.** Import from `hermes_constants`.
+   This returns `~/.hermes` for default or `~/.hermes/profiles/<name>` for profiles.
+3. **Module-level constants are fine** — they cache `get_hermes_home()` at import time,
+   which is AFTER `_apply_profile_override()` sets the env var. Just use `get_hermes_home()`,
+   not `Path.home() / ".hermes"`.
+4. **Tests that mock `Path.home()` must also set `HERMES_HOME`** since code now uses
+   `get_hermes_home()`.
+5. **Gateway platform adapters should use token locks** — if the adapter connects with
+   a unique credential (bot token, API key), call `acquire_scoped_lock()` from
+   `gateway.status` in `connect()`/`start()` and release it in `disconnect()`/`stop()`.
+6. **Profile operations are HOME-anchored, not HERMES_HOME-anchored** — `_get_profiles_root()`
+   returns `Path.home() / ".hermes" / "profiles"`, NOT `get_hermes_home() / "profiles"`.
+   This is intentional so any active profile can list all profiles.

--- a/docs/plans/2026-07-01-agents-md-context-budget.md
+++ b/docs/plans/2026-07-01-agents-md-context-budget.md
@@ -1,0 +1,296 @@
+# AGENTS.md Context Budget Management Plan
+
+> **For Hermes:** Hermes owns this workstream. Use this document as the source of truth when coordinating with Claude/Codex. Claude/Codex may review, implement scoped tasks, or verify, but Hermes keeps final policy/scope/merge judgment.
+
+**Goal:** Treat `AGENTS.md` as a runtime prompt surface, not ordinary documentation, and keep it under a managed context budget through policy, CI guardrails, and a Phase 3 slimming pass.
+
+**Architecture:** `AGENTS.md` remains the short runtime contract injected into coding-agent sessions. Long explanatory material moves to stable docs/reference files with short summaries and links left in `AGENTS.md`. CI enforces the budget so future upstream updates cannot silently degrade latency, cost, or instruction quality.
+
+**Tech Stack:** Python stdlib scripts, GitHub Actions, existing Markdown docs, existing `scripts/run_tests.sh` verification.
+
+---
+
+## 0. Current State Snapshot
+
+- Repo: `NousResearch/hermes-agent` checkout at `/Users/presencemanager/.hermes/hermes-agent`.
+- Runtime config: `context_file_max_chars: 40000` in `~/.hermes/config.yaml`.
+- Current `AGENTS.md`: about 69k chars / 1,370 lines, so Hermes truncates it when building project context.
+- Current warning observed on model switch:
+  - `Context file AGENTS.md TRUNCATED: 69213 chars exceeds limit of 40000`
+- Primary recent growth source:
+  - `6b330522e docs(agents): add Design Philosophy + Contribution Rubric to AGENTS.md (#42641)` grew `AGENTS.md` from about 57k chars to about 69k chars.
+- Existing PR template: `.github/PULL_REQUEST_TEMPLATE.md` has a generic docs/AGENTS checkbox, but no context-impact checklist.
+- Existing CI: `.github/workflows/lint.yml` has blocking static checks; no context-file budget check yet.
+
+## 1. Ownership and Coordination Protocol
+
+### Hermes owns
+
+- Budget values and enforcement policy.
+- What belongs inline in `AGENTS.md` vs moved to docs/reference.
+- Final semantic review and integration.
+- Deciding when Phase 1/2/3 are complete.
+
+### Claude role: design-risk and semantic-regression reviewer
+
+Claude should not start by editing. Ask Claude to review:
+
+- Whether the policy is too strict or too loose.
+- Which instructions must remain inline.
+- Which sections are likely to suffer semantic regression during slimming.
+- Whether contributors will understand the CI failure and how to fix it.
+
+### Codex role: implementation lane
+
+Codex may implement scoped tasks only:
+
+- Budget checker script + tests.
+- GitHub Actions wiring.
+- PR checklist/doc updates.
+- Section classification table for Phase 3.
+- Slimming patch after Hermes approves classification.
+
+### Shared rule
+
+`AGENTS.md` is a context-impacting runtime file. Changes to it are not ordinary docs cleanup.
+
+## 2. Policy
+
+### Budget
+
+Initial policy:
+
+- Warning budget: 30,000 chars.
+- Hard max: 40,000 chars.
+- Phase 3 target: under 40,000 chars; preferably 30,000-35,000 chars.
+
+Rationale:
+
+- `AGENTS.md` is injected into every coding-agent session for this repo.
+- Larger project context increases first-turn and model-switch latency and cost.
+- Long instruction files lower salience of critical instructions.
+- The configured runtime cap is currently 40,000 chars; exceeding it causes truncation and unpredictable loss of later sections.
+
+### Inline vs reference criteria
+
+Keep inline in `AGENTS.md` only if it is needed in most coding-agent sessions:
+
+- Safety/correctness invariants.
+- Prompt caching and role-alternation constraints.
+- Repo-specific test commands and verification norms.
+- Core file map and ownership boundaries.
+- Common footguns with high blast radius.
+- Rules that prevent irreversible or expensive mistakes.
+
+Move out of `AGENTS.md` when material is:
+
+- Long rationale or history.
+- Detailed subsystem reference used only occasionally.
+- Human contribution philosophy.
+- Exhaustive feature descriptions.
+- Duplicated by website docs or developer guide pages.
+- Examples that can be retrieved on demand with `read_file`.
+
+## 3. Phase Plan
+
+### Phase 1 — Policy and checklist
+
+Objective: Make `AGENTS.md` budget management an explicit repo policy.
+
+Tasks:
+
+1. Add a short `AGENTS.md` policy block near the top:
+   - `AGENTS.md` is runtime prompt surface.
+   - Keep it under budget.
+   - Move long explanations to docs/reference.
+2. Add an `AGENTS.md impact checklist` to `.github/PULL_REQUEST_TEMPLATE.md`.
+3. Add developer docs explaining context-file budget policy, likely under `website/docs/developer-guide/prompt-assembly.md` or a small new developer-guide page.
+
+Definition of Done:
+
+- PR authors touching `AGENTS.md` are told to report net char impact.
+- The docs explain why `AGENTS.md` is treated differently from normal documentation.
+- No large content movement required yet.
+
+### Phase 2 — CI guard tooling
+
+Objective: Add the guard tooling and tests before turning it into a blocking gate.
+
+Important sequencing constraint: current `AGENTS.md` is already over the proposed
+40,000 char max. A hard-fail CI job cannot be enabled until Phase 3 brings the
+file under budget. Phase 2 may add the script, tests, and either no CI wiring yet
+or advisory-only CI (`continue-on-error: true` / summary-only). Phase 3 flips the
+guard to blocking after the slimming patch passes locally.
+
+Tasks:
+
+1. Add `scripts/check_context_file_budget.py` using Python stdlib only.
+2. Support args:
+   - file path, e.g. `AGENTS.md`
+   - `--warn-chars 30000`
+   - `--max-chars 40000`
+   - optional `--encoding utf-8`
+3. Behavior:
+   - Print current char and byte count.
+   - Exit 0 under warning budget.
+   - Print warning between warning and max, still exit 0 unless an optional strict flag is introduced.
+   - Exit nonzero above max.
+   - Error text must mention: `AGENTS.md is injected into every coding-agent session`.
+   - Error text must tell contributors to move explanatory content to docs/reference and keep short summaries inline.
+4. Add tests for pass/warn/fail and actionable error output.
+5. Add CI wiring only in advisory mode, or leave CI wiring for Phase 3.
+
+Definition of Done:
+
+- A local command can fail when `AGENTS.md` exceeds 40k chars.
+- Tests cover checker behavior.
+- The script and tests are ready for CI.
+- If wired during Phase 2, CI is advisory-only while `AGENTS.md` remains over budget.
+
+### Phase 3 — Slim AGENTS.md
+
+Objective: Reduce `AGENTS.md` below budget without losing runtime-critical instructions.
+
+Safe workflow:
+
+1. Classification only; no edits yet.
+   - For each `AGENTS.md` section, classify as:
+     - `keep-inline`
+     - `summarize-inline`
+     - `move-to-docs`
+     - `remove-duplicate`
+2. Hermes reviews and approves classification.
+3. Move long explanatory sections to docs/reference.
+4. Leave short summaries and links in `AGENTS.md`.
+5. Flip context budget CI to blocking once the local budget checker passes.
+6. Claude performs semantic-regression review:
+   - Did any must-preserve instruction disappear?
+   - Are links discoverable?
+   - Does the slim file still guide a coding agent with no extra context?
+6. Run relevant tests and the context budget checker.
+
+Likely high-yield candidates for extraction:
+
+- Long Contribution Rubric details: keep short policy bullets inline, move rationale and examples to developer docs.
+- Detailed subsystem descriptions: keep file map and critical boundaries inline, move long reference sections to existing developer-guide pages.
+- Long testing rationale: keep `scripts/run_tests.sh` rule and key caveats inline, move detailed history to docs.
+- Long plugin/skill descriptions: keep extension decision ladder inline, move deep reference to existing plugin/skill docs.
+
+Definition of Done:
+
+- `AGENTS.md` < 40,000 chars, preferably < 35,000 chars.
+- Moved content has stable docs/reference locations.
+- `AGENTS.md` links to moved content.
+- Budget checker passes.
+- Context budget CI is blocking after the slimming patch.
+- Claude semantic review finds no must-preserve instruction loss or the issues are addressed.
+
+## 4. Communication Templates
+
+### Claude request
+
+Use this prompt for Claude:
+
+```text
+この案件は Hermes 主導です。Claude は design-risk reviewer として参加してください。
+実装はまだしないでください。
+
+Source of truth:
+- docs/plans/2026-07-01-agents-md-context-budget.md
+
+背景:
+Hermes repo の AGENTS.md は coding agent の system/project context に毎回注入されます。
+現在 AGENTS.md が約69k chars まで増え、context_file_max_chars=40000 を超えて truncation warning が出ています。
+これは latency / cost / instruction quality に影響します。
+
+Hermes の方針:
+- AGENTS.md を runtime prompt surface として正式管理する
+- Phase 1: policy / PR checklist を追加
+- Phase 2: CI guard で size budget を enforce
+- Phase 3: AGENTS.md をスリム化し、長文は docs/reference に移動
+- AGENTS.md は runtime-critical contract に限定する
+- 詳細説明は docs/agent-guides/ や website/docs/developer-guide/ に逃がす
+
+お願いしたいこと:
+1. この方針のリスクを指摘してください。
+2. AGENTS.md から落としてはいけない instruction のカテゴリを挙げてください。
+3. CI budget を hard fail にする場合の contributor friction を評価してください。
+4. Phase 3 のスリム化で semantic regression が起きやすい箇所を指摘してください。
+5. 実装はせず、レビュー結果だけを返してください。
+
+出力形式:
+- Major concerns
+- Minor concerns
+- Must-preserve instructions
+- Suggested budget policy
+- Phase 3 review checklist
+```
+
+### Codex request for Phase 2
+
+Use this prompt for Codex:
+
+```text
+この案件は Hermes 主導です。Codex は implementation lane として参加してください。
+まず Phase 2 の CI guard だけを担当してください。AGENTS.md の大規模リライトはまだしないでください。
+
+Source of truth:
+- docs/plans/2026-07-01-agents-md-context-budget.md
+
+Task:
+1. `scripts/check_context_file_budget.py` を追加してください。
+2. 対象ファイル、warning budget、max budget を引数で指定できるようにしてください。
+3. AGENTS.md が max を超えた場合、なぜ問題か分かる actionable error を出してください。
+4. tests を追加してください。
+5. CI workflow に追加する最小差分を提案してください。実装する場合は Phase 2 では advisory-only にしてください。現在の `AGENTS.md` は既に max 超過なので、blocking 化は Phase 3 後に行います。
+6. `scripts/run_tests.sh` で関連テストを実行してください。
+
+Constraints:
+- 新しい runtime dependency は増やさない
+- AGENTS.md 本文はこの task では編集しない
+- budget 値は当面:
+  - warn: 30000 chars
+  - max: 40000 chars
+- エラー文には “AGENTS.md is injected into every coding-agent session” を含める
+- Hermes repo の既存 style に合わせる
+
+Completion report:
+- 変更ファイル
+- 実装内容
+- 実行したテストと結果
+- 未確認事項
+- Phase 3 に渡すべき注意点
+```
+
+## 5. Operator / Atsushi involvement required
+
+Hermes can proceed autonomously through local planning, bridge requests, small code patches, and local tests.
+
+Atsushi is needed for:
+
+- Starting or instructing a live Claude Code session if no watcher/session is currently active.
+- Starting or instructing a live Codex session if no watcher/session is currently active.
+- Approving any push/PR creation/merge to upstream.
+- Deciding whether CI should initially warn-only or hard-fail if maintainers push back.
+- Final approval before large Phase 3 content deletion/movement if the semantic review has unresolved concerns.
+
+## 6. Verification Commands
+
+Local checks to run during implementation:
+
+```bash
+python scripts/check_context_file_budget.py AGENTS.md --warn-chars 30000 --max-chars 40000
+scripts/run_tests.sh tests/scripts/test_check_context_file_budget.py
+```
+
+For docs/checklist-only changes, also inspect the rendered Markdown in the changed files.
+
+## 7. Stop Conditions
+
+Pause and ask Atsushi if:
+
+- The slimming patch removes or rewrites high-priority operational rules rather than moving/summarizing them.
+- CI guard causes broad unrelated failures.
+- Claude and Codex disagree on must-preserve instructions.
+- The implementation requires upstream push/PR/merge.
+- The repo is stale enough that local files no longer match current upstream around AGENTS.md/CI paths.

--- a/scripts/check_context_file_budget.py
+++ b/scripts/check_context_file_budget.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Check that runtime context files stay within a managed character budget."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+RUNTIME_CONTEXT_EXPLANATION = (
+    "AGENTS.md is injected into every coding-agent session"
+)
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{value!r} is not an integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("budget values must be non-negative")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check a context file's character count against warn and max budgets."
+        )
+    )
+    parser.add_argument("file", type=Path, help="context file to check, e.g. AGENTS.md")
+    parser.add_argument(
+        "--warn-chars",
+        type=_positive_int,
+        default=30_000,
+        help="warning budget in decoded characters (default: 30000)",
+    )
+    parser.add_argument(
+        "--max-chars",
+        type=_positive_int,
+        default=38_000,
+        help="maximum budget in decoded characters (default: 38000)",
+    )
+    parser.add_argument(
+        "--encoding",
+        default="utf-8",
+        help="text encoding used to decode the file (default: utf-8)",
+    )
+    parser.add_argument(
+        "--strict-warning",
+        action="store_true",
+        help="exit nonzero when the file exceeds --warn-chars",
+    )
+    return parser
+
+
+def _read_context_file(path: Path, encoding: str) -> tuple[str, int]:
+    raw = path.read_bytes()
+    return raw.decode(encoding), len(raw)
+
+
+def check_file(
+    path: Path,
+    *,
+    warn_chars: int,
+    max_chars: int,
+    encoding: str,
+    strict_warning: bool = False,
+) -> int:
+    if warn_chars > max_chars:
+        print(
+            f"error: --warn-chars ({warn_chars}) must be <= --max-chars ({max_chars})",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not path.exists():
+        print(f"error: context file not found: {path}", file=sys.stderr)
+        return 2
+    if not path.is_file():
+        print(f"error: context path is not a file: {path}", file=sys.stderr)
+        return 2
+
+    try:
+        text, byte_count = _read_context_file(path, encoding)
+    except UnicodeDecodeError as exc:
+        print(
+            f"error: could not decode {path} with encoding {encoding!r}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    char_count = len(text)
+    label = str(path)
+    print(
+        f"{label}: chars={char_count} bytes={byte_count} "
+        f"warn_chars={warn_chars} max_chars={max_chars}"
+    )
+
+    if char_count > max_chars:
+        print(
+            (
+                f"error: {label} exceeds the context-file max budget "
+                f"({char_count} > {max_chars} chars). "
+                f"{RUNTIME_CONTEXT_EXPLANATION}; oversized runtime context "
+                "increases latency/cost and can be truncated, hiding critical "
+                "instructions. Keep invariants inline; move explanatory "
+                "reference material to docs/reference and keep only short "
+                "runtime-critical summaries plus links inline."
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    if char_count > warn_chars:
+        print(
+            (
+                f"warning: {label} exceeds the warning budget "
+                f"({char_count} > {warn_chars} chars). "
+                "Consider moving long rationale, examples, and subsystem "
+                "reference material to docs/reference before it reaches the "
+                "hard max."
+            ),
+            file=sys.stderr,
+        )
+        return 1 if strict_warning else 0
+
+    print(f"ok: {label} is within the context-file warning budget.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return check_file(
+        args.file,
+        warn_chars=args.warn_chars,
+        max_chars=args.max_chars,
+        encoding=args.encoding,
+        strict_warning=args.strict_warning,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_context_file_budget.py
+++ b/tests/scripts/test_check_context_file_budget.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_budget_module():
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "check_context_file_budget.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_check_context_file_budget_under_test",
+        module_path,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_passes_under_warning_budget(tmp_path, capsys):
+    budget = _load_budget_module()
+    context_file = tmp_path / "AGENTS.md"
+    context_file.write_text("short runtime contract\n", encoding="utf-8")
+
+    status = budget.main([
+        str(context_file),
+        "--warn-chars",
+        "30",
+        "--max-chars",
+        "40",
+    ])
+
+    assert status == 0
+    captured = capsys.readouterr()
+    assert "chars=23" in captured.out
+    assert "ok:" in captured.out
+    assert captured.err == ""
+
+
+def test_warns_between_warning_and_max_without_failing(tmp_path, capsys):
+    budget = _load_budget_module()
+    context_file = tmp_path / "AGENTS.md"
+    context_file.write_text("x" * 35, encoding="utf-8")
+
+    status = budget.main([
+        str(context_file),
+        "--warn-chars",
+        "30",
+        "--max-chars",
+        "40",
+    ])
+
+    assert status == 0
+    captured = capsys.readouterr()
+    assert "chars=35" in captured.out
+    assert "warning:" in captured.err
+    assert "docs/reference" in captured.err
+
+
+def test_strict_warning_can_fail_before_max(tmp_path, capsys):
+    budget = _load_budget_module()
+    context_file = tmp_path / "AGENTS.md"
+    context_file.write_text("x" * 35, encoding="utf-8")
+
+    status = budget.main([
+        str(context_file),
+        "--warn-chars",
+        "30",
+        "--max-chars",
+        "40",
+        "--strict-warning",
+    ])
+
+    assert status == 1
+    captured = capsys.readouterr()
+    assert "warning:" in captured.err
+
+
+def test_fails_above_max_with_actionable_agents_md_error(tmp_path, capsys):
+    budget = _load_budget_module()
+    context_file = tmp_path / "AGENTS.md"
+    context_file.write_text("x" * 41, encoding="utf-8")
+
+    status = budget.main([
+        str(context_file),
+        "--warn-chars",
+        "30",
+        "--max-chars",
+        "40",
+    ])
+
+    assert status == 1
+    captured = capsys.readouterr()
+    assert "chars=41" in captured.out
+    assert "AGENTS.md is injected into every coding-agent session" in captured.err
+    assert "Keep invariants inline" in captured.err
+    assert "move explanatory reference material to docs/reference" in captured.err
+    assert "short runtime-critical summaries plus links inline" in captured.err
+
+
+def test_rejects_warning_budget_above_max(tmp_path, capsys):
+    budget = _load_budget_module()
+    context_file = tmp_path / "AGENTS.md"
+    context_file.write_text("short\n", encoding="utf-8")
+
+    status = budget.main([
+        str(context_file),
+        "--warn-chars",
+        "50",
+        "--max-chars",
+        "40",
+    ])
+
+    assert status == 2
+    captured = capsys.readouterr()
+    assert "--warn-chars" in captured.err

--- a/website/docs/developer-guide/agents-md-reference.md
+++ b/website/docs/developer-guide/agents-md-reference.md
@@ -1,0 +1,182 @@
+---
+sidebar_position: 6
+title: "AGENTS.md Reference"
+description: "Detailed reference material moved out of AGENTS.md to keep the runtime prompt compact"
+---
+
+# AGENTS.md Reference
+
+`AGENTS.md` is runtime prompt surface. It should stay compact and contain only
+rules a coding agent needs in most sessions. This page holds longer rationale,
+subsystem reference pointers, and examples that agents can load on demand.
+
+## Context budget policy
+
+Hermes loads project context files such as `AGENTS.md` into the coding-agent
+system prompt. Oversized context increases first-turn/model-switch latency and
+cost, and the runtime truncates files beyond `context_file_max_chars`. If an
+invariant sits past the cut line, the agent may silently miss it.
+
+Budget discipline:
+
+- Keep runtime-critical invariants inline in `AGENTS.md`.
+- Move rationale, history, detailed subsystem docs, and rarely-used examples
+  here or to other developer docs.
+- Leave a short summary plus link in `AGENTS.md`.
+- Keep hard CI budget below the runtime truncation limit to preserve margin.
+- Review each `AGENTS.md` change as either invariant or reference; invariants
+  must stay inline.
+
+## Dependency pinning policy
+
+Dependency pinning is a supply-chain invariant, not ordinary docs guidance. The
+short rule stays inline in `AGENTS.md`; this reference records the treatment by
+source type. See also
+[`CONTRIBUTING.md`](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#dependency-pinning-policy-supply-chain-hardening).
+
+| Source type | Required treatment | Rationale |
+|---|---|---|
+| PyPI package | `>=floor,<next_major` | PyPI versions are immutable once published, but new versions can be pushed into your range. A `<next_major` ceiling prevents silent major-version jumps. |
+| Git URL | Full commit SHA | Branches and tags are mutable refs; SHAs are content-addressed. |
+| GitHub Actions | Full commit SHA plus version comment | Action tags are mutable refs, so pin `uses:` to a SHA and keep the human-readable version as a comment. |
+| CI-only pip installs | `==exact` | Hermetic CI builds can be exact because churn is acceptable there. |
+
+Every new PyPI dependency in a PR must have a `<next_major` upper bound.
+Unbounded `>=X.Y.Z` specs are rejected by review and flagged by supply-chain CI.
+For pre-1.0 packages, keep a narrow minor-version window rather than allowing
+all `<1` releases.
+
+## Contribution rubric
+
+Hermes is expansive at the product edges and conservative at the core waist.
+New platforms, providers, desktop/TUI/dashboard features, plugins, skills, and
+setup/config UX are welcome when they fit existing extension surfaces. New core
+model tools are expensive because their schemas are sent on every API call, so
+they are a last resort.
+
+### What we want
+
+- Real bug fixes with reproduction on current `main`, a line-level account of
+  where the symptom manifests, and a fix for the whole bug class.
+- Edge expansion through adapters, providers, plugins, skills, CLI commands,
+  and setup/config UX.
+- Declared refactors that extract god-files into focused modules while
+  preserving behavior.
+- Behavior-contract tests that assert relationships and invariants, not
+  snapshots of model catalogs, config versions, or enumeration counts.
+- E2E validation for resolution chains, config propagation, security
+  boundaries, remote backends, and file/network I/O.
+- Cache-safe, role-alternation-safe changes that keep the system prompt stable
+  for the life of a conversation.
+  Strict role alternation means never writing two same-role messages in a row.
+
+### What we don't want
+
+- Speculative hooks or callbacks with no concrete consumer.
+- User-facing `HERMES_*` env vars for non-secret behavior; put behavior in
+  `config.yaml` and reserve `.env` for credentials.
+- Core tools when terminal/file, CLI+skill, plugin, or MCP can solve it.
+- Pagination/offset escape hatches on instructional tools the agent must read
+  fully.
+- Security mitigations that destroy the feature they secure.
+- Outbound telemetry or attribution without opt-in gating.
+- Plugins that modify core files instead of using generic plugin surfaces.
+
+### Verify premise and intent
+
+Before accepting or writing a fix, verify the claimed bug against the actual
+code and runtime. Some limitations are intentional design (for example,
+profile isolation). Some apparently missing pieces are load-bearing omissions.
+Use `git log -p -S "<symbol>"` to understand original intent before changing a
+restriction. If you cannot point to the exact line where the bug manifests and
+show how the fix changes that behavior, the premise is not yet verified.
+
+### Footprint ladder
+
+Choose the least permanent surface that solves the problem:
+
+1. Extend existing code.
+2. CLI command + skill.
+3. Service-gated tool with `check_fn` so the schema appears only when configured.
+4. Plugin.
+5. MCP server in the catalog.
+6. New core tool only when fundamental, broadly useful, and unreachable through
+   the surfaces above.
+
+## Testing
+
+Use `scripts/run_tests.sh` for normal verification because it mirrors CI:
+credential variables are unset, `HOME` / `HERMES_HOME` are isolated, timezone is
+UTC, locale is C.UTF-8, xdist is enabled, and the in-tree subprocess isolation
+plugin prevents per-test state leakage.
+
+Useful commands:
+
+```bash
+scripts/run_tests.sh
+scripts/run_tests.sh tests/gateway/
+scripts/run_tests.sh tests/agent/test_foo.py::test_x
+scripts/run_tests.sh -v --tb=long
+scripts/run_tests.sh --no-isolate tests/foo/
+```
+
+Avoid change-detector tests:
+
+```python
+# Bad: freezes a changing catalog snapshot
+assert "gemini-2.5-pro" in _PROVIDER_MODELS["gemini"]
+assert DEFAULT_CONFIG["_config_version"] == 21
+
+# Good: asserts relationships or behavior
+assert "gemini" in _PROVIDER_MODELS
+assert len(_PROVIDER_MODELS["gemini"]) >= 1
+assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+for model in _PROVIDER_MODELS["huggingface"]:
+    assert model.lower() in DEFAULT_CONTEXT_LENGTHS_LOWER
+```
+
+## Subsystem reference index
+
+Load code directly for exact definitions; this index points to entry points.
+
+- `run_agent.py` — `AIAgent`, conversation loop, provider dispatch,
+  streaming/non-streaming, compression, turn lifecycle.
+- `agent/system_prompt.py` and `agent/prompt_builder.py` — stable/context/
+  volatile prompt tiers, context file loading, truncation, skills prompt cache.
+- `model_tools.py`, `toolsets.py`, `tools/registry.py` — tool discovery,
+  schema post-processing, toolset membership, and tool execution.
+- `tools/` — built-in tool implementations; auto-discovered through the
+  registry. Prefer service-gated tools for optional integrations.
+- `cli.py`, `hermes_cli/` — CLI orchestration, setup, config commands,
+  curses UI, subcommands.
+- `gateway/run.py`, `gateway/session.py`, `gateway/platforms/` — gateway
+  runner, sessions, adapters, approval/control message bypass paths.
+- `ui-tui/`, `tui_gateway/` — Ink TUI frontend and Python JSON-RPC backend.
+- `plugins/` — plugin system; memory providers, model providers, platforms,
+  context engines, observability, image generation, kanban, and other edge
+  capabilities.
+- `skills/`, `optional-skills/` — bundled skills and heavier/niche skills.
+- `cron/` and `tools/cronjob_tools.py` — scheduled jobs.
+- `agent/subdirectory_hints.py` — progressive discovery of subdirectory
+  `AGENTS.md` / `CLAUDE.md` hints as files are read.
+- `hermes_constants.py` — profile-aware `get_hermes_home()` and
+  `display_hermes_home()`.
+- `hermes_state.py` — session SQLite store and FTS search.
+
+## Configuration notes
+
+- Non-secret behavior belongs in `config.yaml`.
+- `.env` is for credentials only.
+- Use `get_hermes_home()` for code paths and `display_hermes_home()` for
+  user-facing paths.
+- Module-level constants may call `get_hermes_home()` after profile override has
+  run; do not use `Path.home() / ".hermes"` for active-profile state.
+- Gateway adapters with unique credentials should use scoped locks in
+  `gateway.status` to prevent two profiles from using the same token.
+
+## TypeScript notes
+
+The short TypeScript runtime style stays in `AGENTS.md`; deeper details should
+live near the owning frontend package. Keep route roots thin, prefer nanostores
+for shared state, colocate action modules, and use table-driven mappings for
+ids/routes/views.

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -235,6 +235,20 @@ All context files are:
 - **Truncated** — capped at `context_file_max_chars` characters (default 20,000) using 70/20 head/tail ratio with a truncation marker
 - **YAML frontmatter stripped** — `.hermes.md` frontmatter is removed (reserved for future config overrides)
 
+### Context-file budget discipline
+
+Project instruction files such as `AGENTS.md` are runtime prompt surface, not
+ordinary documentation. They are loaded into coding-agent context, so unbounded
+growth directly affects first-turn/model-switch latency, token cost, and the
+salience of critical instructions. Keep these files focused on rules and
+high-blast-radius pitfalls the agent needs in most sessions. Move long
+rationale, history, exhaustive subsystem references, and rarely-needed examples
+to developer docs or reference files, then leave short summaries and links in
+the context file.
+
+For Hermes' own repo, changes to `AGENTS.md` should be treated as
+context-impacting changes and reviewed for size impact as well as correctness.
+
 ## API-call-time-only layers
 
 These are intentionally *not* persisted as part of the cached system prompt:


### PR DESCRIPTION
## Summary

This PR treats `AGENTS.md` as runtime prompt surface and puts it under an explicit context budget.

- Slims `AGENTS.md` from roughly 70k chars to 16,444 chars / 16,496 bytes.
- Moves long rationale/reference material to `website/docs/developer-guide/agents-md-reference.md`.
- Keeps runtime-critical invariants inline, including dependency pinning, prompt caching, known pitfalls, testing, and the plugin/core-file boundary.
- Adds `scripts/check_context_file_budget.py` with configurable warn/max budgets.
- Adds tests for pass/warn/fail/actionable error behavior.
- Adds a blocking context-budget CI job now that `AGENTS.md` is below budget.
- Adds an `AGENTS.md Impact` checklist to the PR template and docs notes in prompt assembly.

## Why

`AGENTS.md` is injected into every coding-agent session. Letting it grow without a budget increases latency/cost, reduces instruction salience, and risks truncating later runtime-critical instructions.

This keeps the short runtime contract inline and moves long explanatory material to reference docs.

## Validation

Run on the prepared branch/worktree:

```bash
python3 scripts/check_context_file_budget.py AGENTS.md --warn-chars 30000 --max-chars 40000
python3 scripts/check_context_file_budget.py AGENTS.md --warn-chars 30000 --max-chars 38000
git diff --check HEAD~1..HEAD
uv tool run ruff check scripts/check_context_file_budget.py tests/scripts/test_check_context_file_budget.py
scripts/run_tests.sh tests/scripts/test_check_context_file_budget.py tests/agent/test_prompt_builder.py tests/agent/test_coding_context.py tests/hermes_cli/test_prompt_size.py
```

Result: all pass; targeted test run reports 227 passed.

## Review Notes

Hermes owner review found that the dependency-pinning policy was moved out of runtime context. That is fixed: a short supply-chain rule is back inline in `AGENTS.md`, with detailed treatment in `website/docs/developer-guide/agents-md-reference.md`.

Claude semantic-regression review approved with one P2 before merge: restore the hard rule that plugins must not modify core files. That is fixed inline in `AGENTS.md`; the reference doc also now uses the hard `modify core files` phrasing. Claude also noted a P3 role-alternation definition gap; the reference doc now states the concrete definition.

This remains a draft PR until Atsushi/Hermes decide to mark it ready after reviewing the final diff and any GitHub checks.