### PR TITLE
fix(agent): strip timestamp field in summary path sanitizer

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1449,7 +1449,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             # bypassing the transport — so mirror that sanitization here:
             # tool_name (SQLite FTS bookkeeping), the codex_* reasoning carriers,
             # and every Hermes-internal underscore-prefixed scaffolding key.
-            for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items"):
+            for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items", "timestamp"):
                 api_msg.pop(schema_foreign, None)
             for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
                 api_msg.pop(internal_key, None)


### PR DESCRIPTION
## Problem

The `timestamp` field is added to messages by `run_agent.py:1594` for SessionDB persistence. The transport layer (`ChatCompletionsTransport.convert_messages()`) strips it at `chat_completions.py:205` before sending to the API.

However, the **summary path** in `handle_max_iterations()` (`chat_completion_helpers.py:1434-1458`) hand-builds API messages and calls `chat.completions.create()` directly, **bypassing the transport**. The summary path sanitizer strips `reasoning`, `finish_reason`, `_thinking_prefill`, `tool_name`, `codex_*` fields, and `_`-prefixed keys — but NOT `timestamp`.

Strict providers (Mistral, Kimi K2.5, Fireworks/OpenCode Go) reject unknown fields with HTTP 400:
```
HTTP 400: 'messages[N].timestamp' is not permitted
```

This is the same class of bug as #55902 (timestamp leaking through the main loop), but in the summary path which was missed by the original fix.

## Fix

Add `"timestamp"` to the `schema_foreign` tuple in the summary path sanitizer, alongside `tool_name`, `codex_reasoning_items`, and `codex_message_items`.

```python
- for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items"):
+ for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items", "timestamp"):
```

## Testing

- `python3 -m py_compile agent/chat_completion_helpers.py` — OK
- Single-line change in the sanitizer tuple

Related: #55902