### PR TITLE
fix(agent,tools): add "from e" to re-raised exceptions (6 instances)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -999,7 +999,7 @@ def init_agent(
                 else:
                     print("⚠️  Warning: API key appears invalid or missing")
         except Exception as e:
-            raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
+            raise RuntimeError(f"Failed to initialize OpenAI client: {e}") from e
     
     # Provider fallback chain — ordered list of backup providers tried
     # when the primary is exhausted (rate-limit, overload, connection

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -57,7 +57,7 @@ class DaytonaEnvironment(BaseEnvironment):
         except ImportError:
             pass
         except Exception as e:
-            raise ImportError(str(e))
+            raise ImportError(str(e)) from e
         from daytona import (
             Daytona,
             CreateSandboxFromImageParams,

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -88,7 +88,7 @@ def _ensure_modal_sdk() -> None:
     except ImportError:
         pass
     except Exception as e:
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
 
 
 def _resolve_modal_image(image_spec: Any) -> Any:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -91,7 +91,7 @@ def _import_edge_tts():
     except ImportError:
         pass
     except Exception as e:
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
     import edge_tts
     return edge_tts
 
@@ -112,7 +112,7 @@ def _import_elevenlabs():
         # so older code paths still get a clean ImportError.
         pass
     except Exception as e:  # FeatureUnavailable or any unexpected error
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
     from elevenlabs.client import ElevenLabs
     return ElevenLabs
 
@@ -135,7 +135,7 @@ def _import_mistral_client():
     except ImportError:
         pass
     except Exception as e:  # FeatureUnavailable or any unexpected error
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
     from mistralai.client import Mistral
     return Mistral
 


### PR DESCRIPTION
## Problem

Re-raising exceptions with `str(e)` in the message but without `from e` discards the original traceback chain. When the re-raised exception is caught by a higher handler, the root cause is lost — only the string representation survives.

## Fix

Add `from e` to 6 re-raised exceptions across 4 files:

1. **agent/agent_init.py:1001** — `raise RuntimeError(f"Failed to initialize OpenAI client: {e}")`
2. **tools/tts_tool.py:93,114,137** — `raise ImportError(str(e))` (3 instances, TTS dependency checks)
3. **tools/environments/daytona.py:59** — `raise ImportError(str(e))` (Daytona SDK import)
4. **tools/environments/modal.py:90** — `raise ImportError(str(e))` (Modal SDK import)

## Testing

- `python3 -m py_compile` on all 4 files — OK
- Mechanical change: add `from e` to existing raise statements