### PR TITLE
fix(tools): replace assert with proper exceptions in production code

### DIFF
--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1011,7 +1011,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+            raise RuntimeError("Container not started — call start() first")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -928,7 +928,8 @@ def _patch_skill(
         target, err = _resolve_skill_target(skill_dir, file_path)
         if err:
             return {"success": False, "error": err}
-        assert target is not None
+        if target is None:
+            return {"success": False, "error": "Internal error: resolved target is None"}
     else:
         # Patching SKILL.md
         target = skill_dir / "SKILL.md"
@@ -1146,7 +1147,8 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+        return {"success": False, "error": "Internal error: resolved target is None"}
     if target.exists():
         read_guard = _background_review_read_before_write_guard(
             name, target, "write_file", file_path
@@ -1192,7 +1194,8 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(skill_dir, file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+        return {"success": False, "error": "Internal error: resolved target is None"}
     if not target.exists():
         # List what's actually there for the model to see
         available = []


### PR DESCRIPTION
## Problem

`assert` statements are stripped when Python runs with the `-O` (optimize) flag. Critical precondition checks in production code silently disappear, allowing invalid states to propagate and cause harder-to-debug failures downstream.

## Fix

Replace 4 `assert` statements with proper exceptions/error returns:

### 1. `tools/environments/docker.py:1014`

```python
# Before (silent with -O)
assert self._container_id, "Container not started"

# After (always executes)
if not self._container_id:
    raise RuntimeError("Container not started — call start() first")
```

### 2. `tools/skill_manager_tool.py:931,1149,1195` (3 instances)

```python
# Before (silent with -O)
assert target is not None

# After (always executes)
if target is None:
    return {"success": False, "error": "Internal error: resolved target is None"}
```

These 3 instances are all after `_resolve_skill_target()` which returns `(target, err)` — if `err` is None, `target` should be non-None, but the assert was the only guard.

## Testing

- `python3 -m py_compile tools/environments/docker.py` — OK
- `python3 -m py_compile tools/skill_manager_tool.py` — OK