### PR TITLE
optional-mcps: add bloom-directory

### DIFF
--- a/optional-mcps/bloom-directory/manifest.yaml
+++ b/optional-mcps/bloom-directory/manifest.yaml
@@ -1,0 +1,60 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: bloom-directory
+description: |
+  Curated indie consumer AI apps (wellness, journal, habits, daily life,
+  creative, money mindset). Ask Bloom to recommend apps that fit the user,
+  sign them up privately, publicly back them under a Bloom handle, and
+  remember their taste so future picks get smarter.
+
+source: https://bloomprotocol.ai/skill.md
+
+# Bloom ships a stateless streamable-HTTP MCP server at the URL below.
+# The Bloom API only ever asks for a public handle (2-30 chars, alphanumeric)
+# via MCP elicitation — no email, no OAuth, no PII flows through the protocol.
+# Handles are portable receipts anyone can cite at bloomprotocol.ai/agents/<handle>.
+transport:
+  type: http
+  url: https://bloomprotocol.ai/api/mcp
+
+auth:
+  type: none
+
+# Tool selection at install time:
+# Five tools total. list_projects + recommend_for_me are read-only. The
+# three write tools (sign_up_project, support_project, remember_my_taste)
+# all elicit a Bloom handle from the user before writing anything — safe
+# for install-time enable. No mutating tool touches user PII or external
+# systems beyond bloomprotocol.ai.
+tools:
+  # Leave default_enabled unset — the install-time checklist starts with
+  # everything pre-checked so users get the full Identity loop
+  # (recommend → back → remember) on first try. Anyone who wants only
+  # browsing can uncheck the writes.
+
+post_install: |
+  Bloom exposes five MCP tools:
+
+    list_projects        — Browse the catalog by category (read-only)
+    recommend_for_me     — Personalised ranking from chat signals + past taste
+    sign_up_project      — Private follow (email-style, no PII required)
+    support_project      — Public backing under a Bloom handle
+    remember_my_taste    — Record backed/skipped so future recs are smarter
+
+  Categories: wellness, journal, habits, daily-life, creative, money-mind.
+
+  Typical loop:
+
+    1. User: "find me an indie AI journaling app for anxiety"
+    2. Hermes → recommend_for_me(signals={intent, focus}, handle=@me)
+    3. Hermes shows top 3 with per-project "why this fits you" lines
+    4. User picks one → Hermes → support_project(projectId)
+    5. On declined options → Hermes → remember_my_taste(action=skipped)
+
+  The user's handle persists across every MCP-capable client (Claude Code,
+  Codex, Hermes, OpenClaw). Public profile at bloomprotocol.ai/agents/<handle>.
+
+  Docs + full skill spec: https://bloomprotocol.ai/skill.md
+  llms.txt (agent-readable positioning): https://bloomprotocol.ai/llms.txt


### PR DESCRIPTION
## Bloom Directory MCP

Bloom is a curated directory of **consumer indie AI** in wellness, journal, habits, daily life, creative, and money mindset — the parts of life that PH / HN / BetaList underweight. Adds an indie-consumer catalog to a Hermes catalog that currently has dev + workflow tooling (linear, n8n, unreal-engine).

**Five tools, one loop, no PII:**

| Tool | Purpose |
|---|---|
| `list_projects` | Browse the catalog by category (read-only) |
| `recommend_for_me` | Personalised ranking from chat signals + past taste |
| `sign_up_project` | Private follow (no email required — Bloom handle only) |
| `support_project` | Public backing under a Bloom handle |
| `remember_my_taste` | Record backed / skipped so future recs are smarter (Reflexion loop) |

**Categories:** `wellness · journal · habits · daily-life · creative · money-mind`.

**Transport:** streamable HTTP, no auth. The Bloom API only asks for a public handle (2-30 chars, alphanumeric) via MCP elicitation — no OAuth, no PII. Handles are portable receipts at `bloomprotocol.ai/agents/<handle>` that persist across every MCP client (Claude Code, Codex, Hermes, OpenClaw).

## Typical loop the tools support together

1. User: *\"find me an indie AI journaling app for anxiety\"*
2. Hermes → `recommend_for_me(signals={intent, focus}, handle=@me)`
3. Hermes shows top 3 with per-project *\"why this fits you\"* lines
4. User picks one → Hermes → `support_project(projectId)` (elicits handle)
5. On declined options → Hermes → `remember_my_taste(action=skipped)`

Next session, Hermes calls `recommend_for_me` again — Bloom now excludes what the user rejected and boosts categories they've backed.

## Verified

- ✅ Streamable HTTP endpoint live at `https://bloomprotocol.ai/api/mcp`
- ✅ Multi-agent E2E (4 agents, 5 tools) passes against production
- ✅ 28 seeded indie consumer AI apps in the catalog (Finch, Wysa, Mindsera, Endel, Stated, MoodWallet, etc.)
- ✅ Cron refreshes daily from PH + HN + BetaList + Reddit (`r/SideProject`, `r/journaling`, `r/getdisciplined`, etc.)
- ✅ Global reject filter drops B2B / dev-tool / banking-incumbent noise before it enters the catalog

## Docs
- Manifest: [`optional-mcps/bloom-directory/manifest.yaml`](https://github.com/bloomprotocol/hermes-agent/blob/add-bloom-directory-mcp/optional-mcps/bloom-directory/manifest.yaml)
- Endpoint: https://bloomprotocol.ai/api/mcp
- Install line + full skill spec: https://bloomprotocol.ai/skill.md
- Agent-readable positioning: https://bloomprotocol.ai/llms.txt
- Public metrics: https://bloomprotocol.ai/stats

Happy to iterate on the manifest if anything doesn't fit conventions. Thanks for reviewing!