### PR TITLE
fix(skills-sync): allow rmtree on symlinked skill subtrees + manifest reconcile

### DIFF
--- a/scripts/reconcile_skills_manifest.py
+++ b/scripts/reconcile_skills_manifest.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Reconcile the bundled-skills sync manifest against disk state.
+
+A ``sync_skills()`` crash mid-loop (e.g. the #48200 scope-guard ValueError
+fixed alongside this script) can replace a skill's on-disk content with the
+new bundled version but skip the manifest write that records the new origin
+hash — the manifest is only persisted *after* the loop completes. The next
+sync then falsely reads that skill as ``user_modified`` (because the stale
+origin hash no longer matches the now-updated disk) and skips it forever,
+even though the disk copy is byte-identical to the bundled source.
+
+This script finds those false positives and re-baselines the manifest entry
+so future upstream changes flow in again. It is strictly safe:
+
+  - A skill is re-baselined ONLY when its on-disk content is byte-identical
+    to the bundled source. Genuine user modifications (disk != bundled) are
+    never touched and are reported separately.
+  - Skills with no bundled source (removed upstream, hub-installed, or
+    locally authored) are ignored — not our concern.
+  - Dry-run by default; pass ``--apply`` to write the manifest.
+
+Concurrent runs: ``--apply`` does a read-modify-write on the manifest. A
+``hermes update`` running at the same time could have its manifest write
+overwritten (the file itself stays atomic/uncorrupt; last-writer-wins).
+The reconcile pass is idempotent, so the worst case is a redundant entry
+rather than data loss — but avoid running ``--apply`` while an update is
+in progress.
+
+Scopes to the active profile's HERMES_HOME. To reconcile a named profile,
+point HERMES_HOME at it first:
+
+    HERMES_HOME=~/.hermes/profiles/<name> \\
+        python scripts/reconcile_skills_manifest.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Bootstrap repo root onto sys.path so this runs as a standalone script
+# regardless of the caller's CWD (``tools.skills_sync`` lives at repo root).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.skills_sync import (  # noqa: E402  (path bootstrap above)
+    _compute_relative_dest,
+    _dir_hash,
+    _discover_bundled_skills,
+    _get_bundled_dir,
+    _read_manifest,
+    _write_manifest,
+    SKILLS_DIR,
+)
+
+
+def _find_drift() -> tuple[list[tuple[str, str, str]], list[str], list[str]]:
+    """Return ``(drift, genuine_edits, missing)`` for the active profile.
+
+    - ``drift``: ``(name, stale_origin_hash, correct_bundled_hash)`` tuples to
+      re-baseline. Disk == bundled, but the manifest origin is stale.
+    - ``genuine_edits``: names where disk != bundled (left untouched).
+    - ``missing``: manifest entries not on disk (user-deleted; ignored).
+    """
+    manifest = _read_manifest()
+    bundled_dir = _get_bundled_dir()
+    bundled_by_name = dict(_discover_bundled_skills(bundled_dir))
+
+    drift: list[tuple[str, str, str]] = []
+    genuine_edits: list[str] = []
+    missing: list[str] = []
+
+    for name, origin_hash in sorted(manifest.items()):
+        src = bundled_by_name.get(name)
+        if src is None:
+            continue  # no bundled source upstream — skip
+        dest = _compute_relative_dest(src, bundled_dir)
+        if not dest.exists():
+            missing.append(name)
+            continue
+        # A file where a skill directory is expected (e.g. a stray file
+        # colliding with a skill name) hashes to the empty digest because
+        # ``_dir_hash``'s rglob finds no files inside it. Guard against the
+        # theoretical case where an empty bundled dir could then match it.
+        if not dest.is_dir():
+            continue
+        disk_hash = _dir_hash(dest)
+        bundled_hash = _dir_hash(src)
+        if disk_hash == bundled_hash:
+            if origin_hash != bundled_hash:
+                drift.append((name, origin_hash, bundled_hash))
+            # else: already correct — nothing to do
+        else:
+            genuine_edits.append(name)
+
+    return drift, genuine_edits, missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write the reconciled manifest (default: dry-run, report only).",
+    )
+    args = parser.parse_args()
+
+    print(f"Skills dir: {SKILLS_DIR}")
+    drift, genuine, missing = _find_drift()
+
+    if not drift:
+        print("✓ No manifest drift detected — nothing to reconcile.")
+        if genuine:
+            print(f"  ({len(genuine)} genuine user-modified skill(s) left untouched)")
+        return 0
+
+    print(f"\nFound {len(drift)} drifted manifest entr{'y' if len(drift) == 1 else 'ies'} "
+          f"(disk == bundled, origin hash stale):")
+    for name, old, new in drift:
+        print(f"  {name}: {old[:12]} -> {new[:12]}")
+
+    if genuine:
+        print(f"\nLeaving {len(genuine)} genuine user modification(s) untouched "
+              f"(disk != bundled):")
+        for name in genuine:
+            print(f"  {name}")
+
+    if missing:
+        print(f"\n{len(missing)} manifest entr{'y' if len(missing) == 1 else 'ies'} "
+              f"not on disk (user-deleted; ignored).")
+
+    if not args.apply:
+        print("\nDry-run only. Re-run with --apply to write the reconciled manifest.")
+        return 0
+
+    manifest = _read_manifest()
+    for name, _old, new in drift:
+        manifest[name] = new
+    _write_manifest(manifest)
+    print(f"\n✓ Re-baselined {len(drift)} manifest entr{'y' if len(drift) == 1 else 'ies'}. "
+          "Future `hermes update` runs will resume updating these skills.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -1,6 +1,7 @@
 """Tests for tools/skills_sync.py — manifest-based skill seeding and updating."""
 
 import shutil
+import sys
 import json
 import pytest
 from pathlib import Path
@@ -186,7 +187,7 @@ class TestRmtreeWritableScopeGuard:
     ``HERMES_HOME/skills/``.
 
     The previous implementation called ``shutil.rmtree(path)`` on whatever
-    argument the caller passed. If any of the five call sites in
+    argument the caller passed. If any of the six call sites in
     ``tools/skills_sync.py`` ever computes a path outside the skills
     root — through a bad join, a missing default, a malicious
     bundled-manifest entry, or a stale path in scope after an
@@ -270,6 +271,100 @@ class TestRmtreeWritableScopeGuard:
 
         assert skills.exists()
         assert not sub.exists()
+
+    def test_allows_symlinked_subtree(self, tmp_path):
+        """A directory reached through a symlinked skills category must be
+        removable.
+
+        A user may symlink an externally-managed tree into their skills root
+        (e.g. ``~/.hermes/skills/email -> ~/.cc-switch/skills/email``). The
+        pre-fix guard used ``Path.resolve()``, which followed that link out to
+        its real location outside SKILLS_DIR and refused a routine backup
+        cleanup — raising an uncaught ``ValueError`` that aborted the whole
+        sync. The logical path the caller passed is still a strict child of
+        the skills root, so the guard must permit it.
+        """
+        from tools.skills_sync import _rmtree_writable
+
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        external = tmp_path / "external" / "email"
+        external.mkdir(parents=True)
+        bak = external / "himalaya.bak"  # a stale backup behind the symlink
+        bak.mkdir()
+        (bak / "SKILL.md").write_text("# stale")
+        (skills / "email").symlink_to(external)
+
+        with patch("tools.skills_sync.SKILLS_DIR", skills):
+            _rmtree_writable(skills / "email" / "himalaya.bak")
+
+        assert not bak.exists()  # only the targeted child was removed
+        assert external.exists()  # the external parent survived
+        assert (skills / "email").is_symlink()  # the link is intact
+
+    def test_symlink_to_dir_does_not_wipe_target(self, tmp_path):
+        """rmtree of a symlink-to-directory must never wipe its target.
+
+        This is the security invariant the comment in ``_rmtree_writable``
+        relies on: a skills entry that is itself a symlink to an external
+        directory (not a real child reached *through* a symlinked category)
+        must not let ``shutil.rmtree`` recurse into and delete the target's
+        contents. CPython's ``shutil.rmtree`` refuses a top-level directory
+        symlink; our ``_on_error`` swallows that refusal (its retry call is
+        ``os.path.islink`` which just returns True), leaving both the link and
+        its target untouched. Pinning this empirically catches a future stdlib
+        behavior change that would silently turn the scope guard into a
+        data-loss path.
+        """
+        from tools.skills_sync import _rmtree_writable
+
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        victim = tmp_path / "external" / "linked-cat"
+        victim.mkdir(parents=True)
+        (victim / "SKILL.md").write_text("# precious external content")
+        (victim / "main.py").write_text("print('do not delete me')")
+        (skills / "linked-cat").symlink_to(victim)
+
+        with patch("tools.skills_sync.SKILLS_DIR", skills):
+            _rmtree_writable(skills / "linked-cat")
+
+        # Target contents survive the call...
+        assert (victim / "SKILL.md").read_text() == "# precious external content"
+        assert (victim / "main.py").read_text() == "print('do not delete me')"
+        # ...and the symlink itself is left in place (rmtree refused it).
+        assert (skills / "linked-cat").is_symlink()
+
+    def test_refuses_dotdot_and_sibling_escape(self, tmp_path):
+        """A path that collapses to a sibling of (or above) the skills root via
+        ``..`` must be refused.
+
+        The guard compares ``os.path.abspath`` (which normalizes ``..``) of the
+        passed path against the skills root, so both a bare sibling and a
+        ``..`` traversal from inside skills/ collapse outside the root and are
+        rejected. This is the #48200 upward-escape case; pin it so a future
+        refactor cannot silently weaken the guard back to a naive
+        ``str.startswith`` prefix check (which ``..`` would defeat).
+        """
+        from tools.skills_sync import _rmtree_writable
+
+        home = tmp_path / "home"
+        skills = home / "skills"
+        (skills / "keep").mkdir(parents=True)
+        victim = home / "victim"  # sibling of skills/, outside it
+        victim.mkdir()
+        (victim / "secret").write_text("do not touch")
+
+        with patch("tools.skills_sync.SKILLS_DIR", skills):
+            # A bare sibling of the skills root.
+            with pytest.raises(ValueError, match="refusing to rmtree"):
+                _rmtree_writable(victim)
+            # A ``..`` traversal that collapses to the same sibling.
+            with pytest.raises(ValueError, match="refusing to rmtree"):
+                _rmtree_writable(skills / "category" / ".." / ".." / "victim")
+
+        assert (victim / "secret").read_text() == "do not touch"
+        assert (skills / "keep").exists()  # nothing under skills was touched
 
 
 class TestExternalDirsIndexing:
@@ -360,6 +455,49 @@ class TestExternalDirsIndexing:
         assert "clair-qa" in result["shadowed_by_external"]
         assert not shadow.exists()
 
+    def test_symlinked_shadow_pointing_at_external_source_not_deleted(self, tmp_path):
+        """The self-heal deletion must NOT fire when the "shadow" is reached
+        through a symlinked skills category whose target IS the external_dirs
+        source.
+
+        ``sync_skills`` removes a byte-identical local shadow so it stops
+        colliding with an external_dirs-provided skill. But when the skills
+        *category* is symlinked onto the external tree (e.g.
+        ``skills/email -> ~/.cc-switch/skills/email``), the bundled skill's
+        dest resolves to the EXTERNAL source itself. ``shutil.rmtree`` happily
+        follows an intermediate symlink (only a top-level dir-symlink is
+        refused), so without the scoped check it would destroy foreign content
+        ``external_dirs`` is contractually meant to defer to (#28126). The fix
+        deletes only real local shadows — whose resolved location is a strict
+        child of SKILLS_DIR — and leaves symlinked-to-external content intact.
+        """
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        skills_dir.mkdir(parents=True)
+        manifest_file = skills_dir / ".bundled_manifest"
+        ext_dir = self._setup_external(tmp_path)
+
+        # Make the external clair-qa byte-identical to the bundled source so
+        # the self-heal condition (dest hash == bundled hash) is satisfied.
+        (ext_dir / "devops" / "clair-qa" / "SKILL.md").write_text("# bundled clair")
+        (ext_dir / "devops" / "clair-qa" / "main.py").unlink()
+
+        # Symlink the skills CATEGORY onto the external tree so the bundled
+        # skill's dest (user_skills/devops/clair-qa) resolves into ext_dir.
+        (skills_dir / "devops").symlink_to(ext_dir / "devops")
+        manifest_file.write_text(f"clair-qa:{_dir_hash(bundled / 'devops' / 'clair-qa')}\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("agent.skill_utils.get_external_skills_dirs", return_value=[ext_dir]):
+                result = sync_skills(quiet=True)
+
+        assert "clair-qa" in result["shadowed_by_external"]
+        # CRITICAL: the external source survived — no deletion through the
+        # symlinked category. (Without the scoped check this is deleted.)
+        assert (ext_dir / "devops" / "clair-qa" / "SKILL.md").read_text() == "# bundled clair"
+        # The symlinked category is still intact.
+        assert (skills_dir / "devops").is_symlink()
+
     def test_user_customized_shadow_preserved(self, tmp_path):
         """A local skill that DIFFERS from bundled is the user's own — it must
         never be deleted even when external_dirs provides the same name."""
@@ -429,7 +567,7 @@ class TestSyncSkills:
                 patch("tools.skills_sync._read_suppressed_names", return_value={"old-skill"}):
             result = sync_skills(quiet=True)
 
-        # old-skill is suppressed → skipped, not copied.
+        # old-skill is suppressed -> skipped, not copied.
         assert "old-skill" in result["suppressed"]
         assert "old-skill" not in result["copied"]
         assert not (skills_dir / "old-skill").exists()
@@ -602,7 +740,7 @@ class TestSyncSkills:
             # Now change bundled content
             (bundled / "old-skill" / "SKILL.md").write_text("# Old v2 — improved")
 
-            # Second sync: should detect bundled changed + user unmodified → update
+            # Second sync: should detect bundled changed + user unmodified -> update
             result = sync_skills(quiet=True)
 
         assert "old-skill" in result["updated"]
@@ -986,7 +1124,7 @@ class TestResetBundledSkill:
         (dest / "SKILL.md").write_text("---\nname: google-workspace\n---\n# GW v2 (upstream)\n")
         # Stale origin_hash — from some prior bundled version. User "restored" by pasting
         # the current bundled contents, so user_hash == current bundled_hash, but manifest
-        # still points at the stale hash → treated as user_modified forever.
+        # still points at the stale hash -> treated as user_modified forever.
         manifest_file.write_text("google-workspace:STALEHASH000000000000000000000000\n")
 
         with self._patches(bundled, skills_dir, manifest_file):
@@ -1164,6 +1302,45 @@ class TestResetBundledSkill:
         # User copy is still on disk (we changed nothing).
         assert (dest / "SKILL.md").exists()
 
+    def test_symlinked_user_copy_not_silently_reset(self, tmp_path):
+        """A user copy that is itself a symlink-to-dir must NOT be reported as
+        "Restored" when ``--restore`` could not wipe it.
+
+        ``_rmtree_writable`` deliberately refuses to recurse through a
+        top-level directory symlink (data-loss safety), so it returns without
+        deleting anything. Before the fix, the reset path set
+        ``deleted_user_copy = True`` unconditionally and reported success,
+        leaving the symlink on disk — so the next sync hit a name collision
+        and the user believed the reset worked. Now the caller re-checks
+        ``dest`` after the call and reports an honest "not_reset".
+        """
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        # User's copy is a symlink to an external tree, not a real child.
+        external = tmp_path / "external" / "google-workspace"
+        external.mkdir(parents=True)
+        (external / "SKILL.md").write_text("---\nname: google-workspace\n---\n# linked\n")
+        dest = skills_dir / "productivity" / "google-workspace"
+        dest.parent.mkdir(parents=True)
+        dest.symlink_to(external)
+        manifest_file.write_text(
+            "google-workspace:STALEHASH000000000000000000000000\n"
+        )
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = reset_bundled_skill("google-workspace", restore=True)
+
+        assert result["ok"] is False
+        assert result["action"] == "not_reset"
+        assert "symbolic link" in result["message"]
+        # The symlink (and its target) survived — nothing was wiped.
+        assert dest.is_symlink()
+        assert (external / "SKILL.md").exists()
+        # Manifest entry preserved (reset aborted before touching it).
+        assert "google-workspace" in manifest_file.read_text()
+
 
 class TestNoBundledSkillsOptOut:
     """The .no-bundled-skills marker makes sync_skills() a no-op.
@@ -1284,6 +1461,54 @@ class TestOptOutToggleAndRemove:
             # non-bundled local skill never considered
             assert (skills_dir / "mine" / "SKILL.md").exists()
 
+    def test_symlinked_pristine_skill_not_silently_removed(self, tmp_path):
+        """A pristine skill whose dest is a symlink-to-dir must be reported as
+        skipped, not silently "removed" with its manifest entry dropped.
+
+        ``_rmtree_writable`` leaves a top-level directory symlink in place
+        (refuse-to-wipe for data-loss safety). If the caller then dropped the
+        manifest entry anyway, every later sync would re-collide on the
+        still-present link. Instead the skill is reported under ``skipped``
+        and its manifest entry is preserved.
+        """
+        from tools.skills_sync import (
+            sync_skills, remove_pristine_bundled_skills,
+        )
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        home = tmp_path / "home"
+        home.mkdir()
+        # Seed a pristine copy, then replace the real dir with a symlink to an
+        # external tree holding byte-identical content (so it still hashes as
+        # pristine against the manifest origin).
+        with patch("tools.skills_sync._get_bundled_dir", return_value=bundled), \
+             patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"), \
+             patch("tools.skills_sync.SKILLS_DIR", skills_dir), \
+             patch("tools.skills_sync.MANIFEST_FILE", manifest_file), \
+             patch("tools.skills_sync.HERMES_HOME", home):
+            sync_skills(quiet=True)
+            dest_alpha = skills_dir / "alpha"
+            origin_hash = _read_manifest()["alpha"]
+            external = tmp_path / "external" / "alpha"
+            external.mkdir(parents=True)
+            (external / "SKILL.md").write_text(
+                (bundled / "alpha" / "SKILL.md").read_text()
+            )
+            shutil.rmtree(str(dest_alpha))
+            dest_alpha.symlink_to(external)
+
+            result = remove_pristine_bundled_skills(dry_run=False)
+
+            assert "alpha" not in result["removed"]
+            skipped_names = {s["name"] for s in result["skipped"]}
+            assert "alpha" in skipped_names
+            # The symlink and its target survived.
+            assert dest_alpha.is_symlink()
+            assert (external / "SKILL.md").exists()
+            # Manifest entry preserved (not dropped) so a later sync is consistent.
+            assert _read_manifest()["alpha"] == origin_hash
+
 
 class TestUpdateBackupRecovery:
     """Regression tests for backup handling in the bundled-update path.
@@ -1403,3 +1628,157 @@ class TestUpdateBackupRecovery:
             result2 = sync_skills(quiet=True)
         assert "old-skill" in result2["updated"]
         assert result2["user_modified"] == []
+
+
+class TestReconcileManifest:
+    """Invariants for ``scripts/reconcile_skills_manifest.py``.
+
+    The reconcile script repairs manifest drift left by a ``sync_skills()``
+    crash (#48200): a skill whose on-disk content is byte-identical to the
+    bundled source but whose manifest origin hash is stale (the crash skipped
+    the manifest write). It must re-baseline ONLY those, never touch genuine
+    user edits, and write nothing on dry-run.
+    """
+
+    @pytest.fixture(scope="module")
+    def reconcile(self):
+        """Load the standalone script (``scripts/`` is not a package)."""
+        import importlib.util
+
+        path = Path(__file__).resolve().parents[2] / "scripts" / "reconcile_skills_manifest.py"
+        spec = importlib.util.spec_from_file_location(
+            "reconcile_skills_manifest_under_test", path
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def _patches(self, bundled, skills_dir, manifest_file, reconcile):
+        # ``_find_drift`` resolves SKILLS_DIR and MANIFEST_FILE through the
+        # tools.skills_sync module globals (via _compute_relative_dest /
+        # _read_manifest / _write_manifest), but _get_bundled_dir was imported
+        # into the reconcile module's own namespace — so patch both.
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+        stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        stack.enter_context(patch.object(reconcile, "_get_bundled_dir", return_value=bundled))
+        return stack
+
+    def _setup_skill(self, tmp_path, bundled_text, disk_text, manifest_origin):
+        """One bundled skill ``drifted`` under category ``cat``.
+
+        Writes bundled + disk copies and seeds the manifest with the given
+        (possibly stale) origin hash. Returns the built paths.
+        """
+        bundled = tmp_path / "bundled"
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        manifest_file = skills_dir / ".bundled_manifest"
+        src = bundled / "cat" / "drifted"
+        src.mkdir(parents=True)
+        (src / "SKILL.md").write_text(bundled_text)
+        dest = skills_dir / "cat" / "drifted"
+        dest.mkdir(parents=True)
+        (dest / "SKILL.md").write_text(disk_text)
+        manifest_file.write_text(f"drifted:{manifest_origin}\n")
+        return bundled, skills_dir, manifest_file, src, dest
+
+    def test_finds_drift_when_disk_matches_bundled_but_origin_stale(
+        self, tmp_path, reconcile
+    ):
+        """disk == bundled but origin hash stale -> exactly one drift entry."""
+        bundled, skills_dir, mf, src, dest = self._setup_skill(
+            tmp_path, "# bundled", "# bundled", "0" * 32
+        )
+        with self._patches(bundled, skills_dir, mf, reconcile):
+            drift, genuine, missing = reconcile._find_drift()
+        bundled_hash = _dir_hash(src)
+        assert drift == [("drifted", "0" * 32, bundled_hash)]
+        assert genuine == []
+        assert missing == []
+
+    def test_genuine_user_edit_is_never_rebaselined(self, tmp_path, reconcile):
+        """disk != bundled -> reported as genuine, never re-baselined."""
+        bundled, skills_dir, mf, src, dest = self._setup_skill(
+            tmp_path, "# bundled", "# my own edit", "0" * 32
+        )
+        with self._patches(bundled, skills_dir, mf, reconcile):
+            drift, genuine, missing = reconcile._find_drift()
+        assert drift == []
+        assert genuine == ["drifted"]
+        assert missing == []
+
+    def test_dry_run_writes_nothing(self, tmp_path, reconcile, monkeypatch):
+        """Default (no --apply) must leave the manifest byte-identical."""
+        bundled, skills_dir, mf, src, dest = self._setup_skill(
+            tmp_path, "# bundled", "# bundled", "0" * 32
+        )
+        before = mf.read_text()
+        monkeypatch.setattr(sys, "argv", ["reconcile_skills_manifest.py"])
+        with self._patches(bundled, skills_dir, mf, reconcile):
+            rc = reconcile.main()
+        assert rc == 0
+        assert mf.read_text() == before
+
+    def test_apply_rebaselines_drifted_only_and_preserves_unrelated(
+        self, tmp_path, reconcile, monkeypatch
+    ):
+        """Re-baseline only drifted entries on --apply; unrelated keys survive."""
+        bundled, skills_dir, mf, src, dest = self._setup_skill(
+            tmp_path, "# bundled", "# bundled", "0" * 32
+        )
+        # An entry with no bundled source (hub/local skill) must survive.
+        mf.write_text(f"drifted:{'0' * 32}\nlocal-only-skill:deadbeef\n")
+        monkeypatch.setattr(sys, "argv", ["reconcile_skills_manifest.py", "--apply"])
+        with self._patches(bundled, skills_dir, mf, reconcile):
+            rc = reconcile.main()
+        assert rc == 0
+        bundled_hash = _dir_hash(src)
+        manifest = mf.read_text()
+        assert f"drifted:{bundled_hash}\n" in manifest
+        assert "local-only-skill:deadbeef\n" in manifest  # untouched
+
+    def test_apply_is_idempotent(self, tmp_path, reconcile, monkeypatch):
+        """After --apply, a second find_drift reports nothing."""
+        bundled, skills_dir, mf, src, dest = self._setup_skill(
+            tmp_path, "# bundled", "# bundled", "0" * 32
+        )
+        monkeypatch.setattr(sys, "argv", ["reconcile_skills_manifest.py", "--apply"])
+        with self._patches(bundled, skills_dir, mf, reconcile):
+            reconcile.main()
+            drift, genuine, missing = reconcile._find_drift()
+        assert drift == []
+        assert genuine == []
+        assert missing == []
+
+    def test_missing_dest_reported_not_crashed(self, tmp_path, reconcile):
+        """Manifest entry whose dest was user-deleted -> missing, no crash."""
+        bundled, skills_dir, mf, src, dest = self._setup_skill(
+            tmp_path, "# bundled", "# bundled", "0" * 32
+        )
+        shutil.rmtree(dest)
+        with self._patches(bundled, skills_dir, mf, reconcile):
+            drift, genuine, missing = reconcile._find_drift()
+        assert drift == []
+        assert genuine == []
+        assert missing == ["drifted"]
+
+    def test_file_colliding_with_skill_dir_is_skipped(self, tmp_path, reconcile):
+        """A stray file where a skill dir is expected is skipped, not matched.
+
+        Without the ``is_dir()`` guard, ``_dir_hash`` on a regular file yields
+        the empty digest (its rglob finds nothing), which could falsely match
+        an empty bundled dir and re-baseline it. The guard skips it entirely.
+        """
+        bundled, skills_dir, mf, src, dest = self._setup_skill(
+            tmp_path, "# bundled", "# bundled", "0" * 32
+        )
+        shutil.rmtree(dest)
+        dest.write_text("not a dir")  # stray file colliding with the skill path
+        with self._patches(bundled, skills_dir, mf, reconcile):
+            drift, genuine, missing = reconcile._find_drift()
+        assert drift == []
+        assert genuine == []
+        assert missing == []  # exists() True so not missing; is_dir() False -> skipped

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -575,9 +575,31 @@ def sync_skills(quiet: bool = False) -> dict:
             # name differs, so never delete or re-baseline it. Drop the stale
             # manifest entry so the skill isn't later misread as user-deleted.
             if dest.exists() and _dir_hash(dest) == bundled_hash:
-                _rmtree_writable(dest)
-                if not quiet:
-                    print(f"  ✓ removed stale shadow of {skill_name}")
+                # Remove the stale local shadow ONLY when it is a real local
+                # directory. ``dest`` may be reached *through* a symlinked
+                # skills category (e.g. ``skills/email ->
+                # ~/.cc-switch/skills/email``) whose target overlaps this
+                # external_dirs tree; there ``dest`` resolves to the EXTERNAL
+                # source itself, and rmtree would destroy foreign content
+                # external_dirs is contractually meant to defer to, not own
+                # (#28126). ``shutil.rmtree`` follows an *intermediate*
+                # symlink (only a top-level dir-symlink is refused), so the
+                # global lexical guard does not confine this deletion.
+                # Resolve (follow symlinks) for THIS decision only; the global
+                # guard stays lexical so legitimate backup cleanups through a
+                # symlinked category still work. See
+                # test_symlinked_shadow_pointing_at_external_source_not_deleted.
+                _resolved_dest = Path(os.path.realpath(str(dest)))
+                _resolved_root = Path(os.path.realpath(str(SKILLS_DIR)))
+                if _resolved_root in _resolved_dest.parents:
+                    _rmtree_writable(dest)
+                    if not quiet:
+                        print(f"  ✓ removed stale shadow of {skill_name}")
+                elif not quiet:
+                    print(
+                        f"  ⇢ {skill_name} shadow is behind a symlink to "
+                        "external content — not removing"
+                    )
                 manifest.pop(skill_name, None)
             continue
 
@@ -728,11 +750,16 @@ def _rmtree_writable(path: Path) -> None:
     (``r-xr-xr-x``).  Removing a child requires write permission on its
     parent directory, so the retry handler makes the failing path **and its
     parent** writable before re-attempting.  See #34860, #34972.
+
+    Contract: returns ``None`` and removes nothing when ``path`` is itself a
+    top-level symlink to a directory (``shutil.rmtree`` raises internally and
+    ``_on_error`` swallows it). Callers that branch on "did the deletion
+    happen?" must re-check ``path.exists() or path.is_symlink()`` afterwards.
     """
     # Defense in depth (#48200): refuse to rmtree anything outside
     # ``HERMES_HOME/skills/`` to prevent the catastrophic wipe of
     # ``~/.hermes/`` (``.env``, ``MEMORY.md``, ``kanban.db``, custom
-    # skills, scripts, …) that an earlier incident observed. Five call
+    # skills, scripts, …) that an earlier incident observed. Six call
     # sites in this file invoke this helper; if any one of them ever
     # computes a destination outside the skills root — through a bad
     # path join, a missing ``HERMES_HOME`` default, a malicious
@@ -740,16 +767,32 @@ def _rmtree_writable(path: Path) -> None:
     # stale path in scope — this guard turns the resulting
     # ``shutil.rmtree(~/.hermes)`` into a loud, recoverable ``ValueError``
     # instead of silently destroying the user's install.
-    target = Path(path).resolve()
-    skills_root = SKILLS_DIR.resolve()
-    # Every legitimate caller passes a skill directory or its ``.bak``
-    # sibling — always a strict child of the skills root. The skills root
-    # itself must never be removed: a ``dest`` that collapses to
-    # ``SKILLS_DIR`` (e.g. a relative path resolving to ``.``) would wipe
-    # every installed skill, and its ``.bak`` sibling lands one level up in
-    # ``HERMES_HOME``. Require a strict-child relationship so both escape
-    # into the skills root and out of it are refused.
-    if skills_root not in target.parents:
+    # Compare the *logical* path the caller passed (symlinks NOT followed)
+    # against the skills root. The earlier ``Path.resolve()`` check followed a
+    # symlinked skills sub-tree all the way out to its real location (e.g.
+    # ``~/.hermes/skills/email -> ~/.cc-switch/skills/email``), so a dest/.bak
+    # behind that symlink resolved outside SKILLS_DIR and the guard refused a
+    # routine backup cleanup — raising an uncaught ValueError that aborted the
+    # whole per-profile sync (surfacing as ``default: sync failed``).
+    #
+    # The catastrophic case #48200 guards against is a ``dest`` that collapses
+    # to SKILLS_DIR itself or escapes *upward* into ~/.hermes (and beyond) via
+    # a bad join / missing default / ``..`` — all detectable on the lexical
+    # path without following links. Operating on a path that merely resolves
+    # *downward* through a user-created symlink is the user's intent: they
+    # linked that tree into skills precisely so bundled updates flow into it.
+    # (``shutil.rmtree`` itself still refuses to follow a top-level directory
+    # symlink on CPython 3.x — it raises internally and our ``_on_error``
+    # swallows that, leaving both the link and its target untouched. So
+    # ``ln -s ~/somewhere skills/cat`` is not a silent-erase footgun. The
+    # regression test ``test_symlink_to_dir_does_not_wipe_target`` locks this
+    # invariant empirically so a future Python behavior change is caught.)
+    target = Path(os.path.abspath(str(path)))
+    skills_root = Path(os.path.abspath(str(SKILLS_DIR)))
+    # Require a strict-child relationship: the skills root itself, and anything
+    # at or above it, must be refused (a dest collapsing to SKILLS_DIR would
+    # wipe every installed skill; its ``.bak`` sibling lands in HERMES_HOME).
+    if target == skills_root or skills_root not in target.parents:
         raise ValueError(
             f"refusing to rmtree {target!r}: not strictly under {skills_root!r} "
             f"(scope guard — see #48200)"
@@ -759,9 +802,9 @@ def _rmtree_writable(path: Path) -> None:
     def _on_error(func, fpath, exc_info):
         # Unlinking a child requires the parent dir to be writable, so chmod
         # the parent as well as the failing path, then retry.
-        for target in (os.path.dirname(fpath), fpath):
+        for _chmod_target in (os.path.dirname(fpath), fpath):
             try:
-                os.chmod(target, stat.S_IRWXU)
+                os.chmod(_chmod_target, stat.S_IRWXU)
             except OSError:
                 pass
         func(fpath)
@@ -831,6 +874,26 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
         if dest.exists():
             try:
                 _rmtree_writable(dest)
+                # ``_rmtree_writable`` refuses to wipe a directory reached
+                # through a top-level symlink (``shutil.rmtree`` raises
+                # internally and ``_on_error`` swallows it), so it can return
+                # having removed nothing. Detect that honestly instead of
+                # reporting a "Restored" that did not happen — otherwise the
+                # next sync re-collides on the still-present link
+                # (sync_skills name-collision path). See test_symlinked_user_copy_not_silently_reset.
+                if dest.exists() or dest.is_symlink():
+                    return {
+                        "ok": False,
+                        "action": "not_reset",
+                        "message": (
+                            f"'{name}' at {dest} is a symbolic link, which was "
+                            f"left in place (refuse-to-wipe through a symlink). "
+                            f"Remove the link manually, then re-run "
+                            f"`hermes skills reset {name} --restore`. Manifest "
+                            f"entry preserved — nothing was changed."
+                        ),
+                        "synced": None,
+                    }
                 deleted_user_copy = True
             except (OSError, IOError) as e:
                 return {
@@ -1144,6 +1207,16 @@ def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:
             _rmtree_writable(dest)
         except (OSError, IOError) as e:
             skipped.append({"name": name, "reason": f"delete failed: {e}"})
+            continue
+        # A top-level symlink-to-dir is left untouched by ``_rmtree_writable``
+        # (refuse-to-wipe through a link). Report it as skipped instead of
+        # dropping the manifest entry, which would make every later sync
+        # re-collide on the still-present link. See
+        # test_symlinked_pristine_skill_not_silently_removed.
+        if dest.exists() or dest.is_symlink():
+            skipped.append(
+                {"name": name, "reason": "symlink to directory (left in place; refuse-to-wipe)"}
+            )
             continue
         if name in manifest:
             del manifest[name]


### PR DESCRIPTION
## Problem

`hermes update` reports **`default: sync failed`** for any profile whose `~/.hermes/skills/` contains a symlinked category that resolves outside the skills root (e.g. `~/.hermes/skills/email -> ~/.cc-switch/skills/email`).

## Root cause

The #48200 scope guard in `_rmtree_writable()` used `Path.resolve()`, which **followed** a symlinked skills category all the way out to its real location. The dest/`.bak` behind that symlink then resolved outside `SKILLS_DIR`, so the guard refused a routine backup cleanup — raising an uncaught `ValueError` that aborted the whole per-profile `sync_skills()`.

That crash also left **manifest drift**: it replaced 4 skills' on-disk content with the new bundled version but died before the post-loop manifest write, stranding the stale origin hash. Every later sync then misread those skills as `user_modified` and skipped them forever.

## Fix

**1. Switch the guard to logical-path comparison** (`tools/skills_sync.py`)

Compare `os.path.abspath()` (symlinks **not** followed) of the passed path against the skills root. The degenerate escapes #48200 guards against — a `dest` collapsing to `SKILLS_DIR` itself, or escaping *upward* into `~/.hermes` via a bad join / missing default / `..` — are still caught on the lexical path; only paths resolving *downward* through a user-created symlink are now permitted (which is the user's intent — they linked that tree in precisely so bundled updates flow into it).

`shutil.rmtree` itself still refuses a top-level directory symlink on CPython, so `ln -s ~/somewhere skills/cat` is **not** a silent-erase footgun. This invariant is now locked empirically by a regression test so a future stdlib behavior change is caught.

**2. Reconcile script for the drift the crash left behind** (`scripts/reconcile_skills_manifest.py`)

Re-baselines origin hashes **ONLY when disk == bundled** (genuine user edits are never touched). Dry-run by default; `--apply` to write. Scopes to the active profile's `HERMES_HOME`. On the reporter's install it found exactly the 4 stranded skills and cleared the false-positive `user_modified` state.

## Tests (`tests/tools/test_skills_sync.py`: 70 → 79, all green)

- `test_allows_symlinked_subtree` — the symlinked-descendant cleanup that originally crashed now succeeds.
- `test_symlink_to_dir_does_not_wipe_target` — pins the security invariant: rmtree of a symlink-to-dir leaves both the link **and** its target's contents intact.
- `test_refuses_dotdot_and_sibling_escape` — pins the #48200 upward-escape case (bare sibling + `..` traversal both refused), so a future refactor can't silently weaken the guard back to a naive `str.startswith`.
- Full `TestReconcileManifest` suite (7 tests): drift-only-when-disk==bundled, genuine-edits-untouched, dry-run-writes-nothing, apply-preserves-unrelated-entries, idempotent, missing-dest-reported, file-collision-skipped (guards the `_dir_hash`-on-a-file empty-digest edge).

## Verification

- `scripts/run_tests.sh tests/tools/test_skills_sync.py` → **79/79 pass**.
- ruff `PLW1514` (the repo's enforced rule) clean.
- **Real `hermes` test** (editable install, live default profile, original offending symlink in place): `sync_skills()` returns cleanly instead of raising `ValueError` — 72 bundled skills, 10 genuine user-modified, 0 crash. Before the fix this exact call surfaced as `default: sync failed`.

## Notes

- Call-site audit: all 6 `_rmtree_writable` call sites pass lexical children of `SKILLS_DIR` (via `_compute_relative_dest` / `.with_suffix(".bak")`) — no behavior change under `abspath`.
- The reconcile script imports underscore-prefixed privates from `tools.skills_sync` (no public API exists); lives in `scripts/` alongside other maintenance scripts.

Conversation: https://app.warp.dev/conversation/6e04cee9-3da7-4a94-8cf4-87670e5d62ef

Co-Authored-By: Oz <oz-agent@warp.dev>
