### PR TITLE
fix: keep empty required array instead of stripping it

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -120,14 +120,14 @@ def test_required_pruned_to_existing_properties():
     assert out[0]["function"]["parameters"]["required"] == ["name"]
 
 
-def test_required_all_missing_is_dropped():
+def test_required_all_missing_becomes_empty_list():
     tools = [_tool("t", {
         "type": "object",
         "properties": {},
         "required": ["x", "y"],
     })]
     out = sanitize_tool_schemas(tools)
-    assert "required" not in out[0]["function"]["parameters"]
+    assert out[0]["function"]["parameters"]["required"] == []
 
 
 def test_well_formed_schema_unchanged():

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -329,7 +329,7 @@ def _sanitize_node(node: Any, path: str) -> Any:
         props = out.get("properties") or {}
         valid = [r for r in out["required"] if isinstance(r, str) and r in props]
         if not valid:
-            out.pop("required", None)
+            out["required"] = []
         elif len(valid) != len(out["required"]):
             out["required"] = valid
 


### PR DESCRIPTION
Closes #ISSUE_NUM_PLACEHOLDER

## Problem

`schema_sanitizer.py`'s `_sanitize_node` pops the `required` key entirely when all entries reference non-existent properties:

```python
out.pop("required", None)
```

This turns valid schemas like `{"type": "object", "properties": {}, "required": []}` into `{"type": "object", "properties": {}}`. Strict OpenAI-compatible backends (Azure, custom proxies) reject this with HTTP 400.

## Fix

```python
out["required"] = []
```

## Verification

43/43 tests pass in `tests/tools/test_schema_sanitizer.py`.

## Changes

- `tools/schema_sanitizer.py`: keep empty `required: []` instead of popping
- `tests/tools/test_schema_sanitizer.py`: update test to assert new behavior