### PR TITLE
fix(cli,tui-gateway): sanitize env and redact output in exec quick commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8600,12 +8600,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         try:
                             # shell=True is intentional: quick_commands are user-defined
                             # shell snippets from config.yaml — not agent/LLM controlled.
+                            # Sanitize env to prevent credential leakage —
+                            # quick commands run in the CLI process which
+                            # has all API keys in os.environ.
+                            from tools.environments.local import _sanitize_subprocess_env
+                            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
                             result = subprocess.run(
                                 exec_cmd, shell=True, capture_output=True,
-                                text=True, timeout=30
+                                text=True, timeout=30, env=sanitized_env
                             )
                             output = result.stdout.strip() or result.stderr.strip()
                             if output:
+                                from agent.redact import redact_sensitive_text
+                                output = redact_sensitive_text(output)
                                 self._console_print(_rich_text_from_ansi(output))
                             else:
                                 self._console_print("[dim]Command returned no output[/]")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11310,6 +11310,11 @@ def _(rid, params: dict) -> dict:
     if name in qcmds:
         qc = qcmds[name]
         if qc.get("type") == "exec":
+            # Sanitize env to prevent credential leakage —
+            # quick commands run in the TUI server process which
+            # has all API keys in os.environ.
+            from tools.environments.local import _sanitize_subprocess_env
+            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
             r = subprocess.run(
                 qc.get("command", ""),
                 shell=True,
@@ -11317,12 +11322,16 @@ def _(rid, params: dict) -> dict:
                 text=True,
                 timeout=30,
                 stdin=subprocess.DEVNULL,
+                env=sanitized_env,
             )
             output = (
                 (r.stdout or "")
                 + ("\n" if r.stdout and r.stderr else "")
                 + (r.stderr or "")
             ).strip()[:4000]
+            if output:
+                from agent.redact import redact_sensitive_text
+                output = redact_sensitive_text(output)
             if r.returncode != 0:
                 return _err(
                     rid,


### PR DESCRIPTION
## Summary

Closes the last two paths where `type: exec` quick commands could leak provider credentials — the CLI and TUI-gateway. This completes the parity #23584 started when it fixed only `gateway/run.py`.

**Root cause:** `HermesCLI.process_command()` and `tui_gateway/server.py`'s `command.dispatch` both ran `exec` quick commands via `subprocess.run(shell=True)` with no `env=`, so the child process inherited every API key and bot token in `os.environ`. Output was returned raw to the terminal / web-UI client with no redaction.

## Changes

- `cli.py`: `_sanitize_subprocess_env(os.environ.copy())` → `env=sanitized_env`, plus `redact_sensitive_text(output)` before display.
- `tui_gateway/server.py`: same fix in `command.dispatch` (kept the existing `stdin=subprocess.DEVNULL`).

Both mirror the merged #23584 approach exactly.

## Validation

| | Before | After |
|---|---|---|
| Provider keys in child env | inherited (leak) | stripped |
| `env` output secrets | present | none |
| Residual secret pattern in output | shown raw | `redact_sensitive_text` masks |

E2E-verified with real imports: `_sanitize_subprocess_env` strips `ANTHROPIC_API_KEY`/`OPENROUTER_API_KEY` from the child env, an `env` subprocess run under it emits no secret-bearing lines, and `redact_sensitive_text` masks any remaining `sk-ant-…` pattern.

Salvage of #23690 by @AhmetArif0 — cherry-picked onto current `main` with authorship preserved.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa07991/cQB2DHmnZZ6DZ5j0syzTS_dCgI90ft.png)
