### PR TITLE
fix(classifier): treat Anthropic "out of extra usage" 400 as billing

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -205,6 +205,26 @@ def _billing_or_entitlement_message(
 
     provider_label = (provider or "").strip() or "the selected provider"
     model_label = (model or "").strip() or "the selected model"
+
+    # Anthropic Claude Pro/Max OAuth subscriptions surface exhaustion of the
+    # metered "extra usage" bucket as a hard 400 ("You're out of extra
+    # usage"). Point at the exact settings page and note the cycle-reset
+    # option, since the generic "add credits with that provider" line doesn't
+    # apply to a subscription — the user waits for the reset or switches to an
+    # API key.
+    if (provider or "").strip().lower() == "anthropic":
+        lines = [
+            (
+                f"{provider_label} reported that your Claude subscription usage is "
+                f"exhausted for {model_label} (included quota + extra-usage credits)."
+            ),
+            "Options: wait for the billing cycle to reset, or add extra usage at "
+            "https://claude.ai/settings/usage",
+            "You can also switch to an Anthropic API key or another provider with "
+            "/model <model> --provider <provider>.",
+        ]
+        return "\n".join(lines)
+
     lines = [
         (
             f"{provider_label} reported that billing, credits, or account "

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -110,6 +110,7 @@ _BILLING_PATTERNS = [
     "exceeded your current quota",
     "account is deactivated",
     "plan does not include",
+    "out of extra usage",  # Anthropic OAuth Pro/Max overage bucket depleted (HTTP 400)
     "out of funds",
     "run out of funds",
     "balance_depleted",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -49,6 +49,8 @@ AUTHOR_MAP = {
     "jnibarger01@gmail.com": "jnibarger01",  # PR #35130 salvage (ReDoS-bound threat-pattern filler + FTS5 query cap + V4A Move-File approval/traversal targets)
     "290868363+petrichor-op@users.noreply.github.com": "petrichor-op",  # PR #41281 salvage (never persist ephemeral empty-response recovery scaffolding to the SQLite session store / JSON log; filter by flag not position)
     "283494121+redactdeveloper@users.noreply.github.com": "redactdeveloper",  # PR #36897 salvage (route /sessions & /history through prompt_toolkit-safe print; filter doctor missing-key summary to CLI-enabled toolsets)
+    "charleneleong84@gmail.com": "charleneleong-ai",  # PR #11736 salvage (classify Anthropic "out of extra usage" 400 as billing)
+    "janrenz@Mac.fritz.box": "janrenz",  # PR #35862 salvage (prompt_caching.enabled escape hatch for strict providers)
     "syahidfrd@gmail.com": "syahidfrd",  # PR #17059 salvage (tag unverified senders in Slack thread context to mitigate indirect prompt injection)
     "22971845+H2KFORGIVEN@users.noreply.github.com": "H2KFORGIVEN",  # PR #22523 salvage (turn-pair preservation: never orphan the last user ask at head_end during compaction)
     "5823452+sgabel@users.noreply.github.com": "sgabel",  # PR #13139 salvage (redact secrets in user-facing approval prompts)

--- a/tests/agent/test_anthropic_billing_guidance.py
+++ b/tests/agent/test_anthropic_billing_guidance.py
@@ -1,0 +1,46 @@
+"""Tests for the Anthropic-subscription branch of
+``agent.conversation_loop._billing_or_entitlement_message``.
+
+Regression context: Anthropic Claude Pro/Max OAuth subscriptions surface
+exhaustion of the metered "extra usage" bucket as a hard HTTP 400
+("You're out of extra usage. Add more at claude.ai/settings/usage..."),
+which classifies as ``FailoverReason.billing``. The generic billing
+guidance ("add credits with that provider") is wrong for a subscription —
+the user waits for the cycle reset or switches to an API key. This branch
+gives Anthropic-specific, actionable guidance (folds in PR #40073's UX).
+"""
+from __future__ import annotations
+
+from agent.conversation_loop import _billing_or_entitlement_message
+
+
+def test_anthropic_subscription_exhausted_guidance():
+    """Anthropic billing guidance points at the exact settings page and
+    the cycle-reset option, not the generic 'add credits' line."""
+    msg = _billing_or_entitlement_message(
+        capability="model access",
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        model="claude-opus-4-7",
+    )
+    assert "claude.ai/settings/usage" in msg
+    # Must mention the subscription cycle reset (not generic 'add credits').
+    assert "reset" in msg.lower()
+    # Must still offer the provider-switch escape hatch.
+    assert "/model" in msg
+    # Model name should be interpolated.
+    assert "claude-opus-4-7" in msg
+
+
+def test_non_anthropic_billing_guidance_unaffected():
+    """A non-Anthropic provider keeps the generic billing guidance and does
+    NOT get the Anthropic-specific claude.ai settings link."""
+    msg = _billing_or_entitlement_message(
+        capability="model access",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        model="anthropic/claude-opus-4.7",
+    )
+    assert "claude.ai/settings/usage" not in msg
+    # Generic path still surfaces the OpenRouter credits link.
+    assert "openrouter.ai/settings/credits" in msg

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1295,6 +1295,25 @@ class TestAdversarialEdgeCases:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.billing
 
+    def test_400_anthropic_extra_usage_exhausted(self):
+        """Anthropic returns 400 with 'out of extra usage' when the user's
+        extra-usage allowance is depleted. Must classify as billing so the
+        fallback chain engages (with credential rotation) instead of the
+        generic format_error path, which never rotates. (#11736, #13170)"""
+        e = MockAPIError(
+            "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+            status_code=400,
+            body={"error": {
+                "type": "invalid_request_error",
+                "message": "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+            }},
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.billing
+        assert result.should_fallback is True
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+
     def test_200_with_error_body(self):
         """200 status with error in body — should be unknown, not crash."""
         class WeirdSuccess(Exception):


### PR DESCRIPTION
## Summary
Anthropic's `"out of extra usage"` 400 (OAuth Pro/Max overage bucket depleted) now classifies as `billing` instead of a generic `format_error` — so the credential pool rotates and the payment/fallback chain engages.

Root cause: the phrase wasn't in `_BILLING_PATTERNS`, so a bare 400 carrying it fell through to `format_error` (non-retryable, **no credential rotation**). The run just died on a hard 400 with the pool never advancing to a funded credential.

## Changes
- `agent/error_classifier.py`: add `"out of extra usage"` to `_BILLING_PATTERNS`.
- `tests/agent/test_error_classifier.py`: assert billing / non-retryable / fallback / **rotate**.
- `scripts/release.py`: AUTHOR_MAP entry for @charleneleong-ai.

## Validation
| `400 "out of extra usage"` | Before | After |
|---|---|---|
| reason | `format_error` | `billing` |
| retryable | False | False |
| should_fallback | True | True |
| should_rotate_credential | **False** | **True** |

- 128/128 classifier tests pass.
- Regression guards (E2E): the genuine 1M-beta phrase still routes to `oauth_long_context_beta_forbidden`; the 429 tier-gate still routes to `long_context_tier`. Unaffected.

## Attribution
Cherry-picked @charleneleong-ai's commit (#11736, the earliest of the correct-direction cluster). Test strengthened with the `should_rotate_credential` assertion from #13170 (@jack4git). Rebase-merge preserves authorship.

Closes the correct-direction dupes on merge: #11736 (source), #13170, #52869, #40073.

Note on the mistaken variant: #20850 proposed classifying this same phrase as a *1M-context-beta rejection* and stripping the beta — that premise is wrong (the phrase is the overage gate, confirmed by P1 reports #28849/#28902/#32243). Closed separately.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa079a0/ZJSvZcOtIR9-9ejxU8oQR_ZIdmlqMn.png)

Nous Research

---

**Update:** folded in #40073's user-facing UX. When this 400 is terminal, `_billing_or_entitlement_message()` now gives Anthropic-specific guidance (claude.ai/settings/usage + cycle-reset) instead of the generic "add credits" line. Done in the one place that owns billing guidance — no new `FailoverReason` enum needed, since the `billing` reclass already provides the recovery behavior. Credit @harsh-matchmyflight (#40073) for the UX direction. +2 tests.
