### PR TITLE
fix(bluebubbles): drop participant-address fallback in _resolve_chat_guid

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -433,8 +433,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         If *target* already contains a semicolon (raw GUID format like
         ``iMessage;-;user@example.com``), it is returned as-is.  Otherwise
-        the adapter queries the BlueBubbles chat list and matches on
-        ``chatIdentifier`` or participant address.
+        the adapter queries the BlueBubbles chat list and matches strictly
+        on ``chatIdentifier`` / ``identifier``.
+
+        Participant membership is intentionally NOT used as a fallback:
+        the same contact can appear in a 1:1 DM and in any number of group
+        chats, so a participant match would let an outbound DM reply leak
+        into a group thread (see #24157). When no exact chat identity
+        matches, return ``None`` and let the caller create a fresh DM
+        explicitly via ``_create_chat_for_handle``.
         """
         target = (target or "").strip()
         if not target:
@@ -459,12 +466,6 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                         while len(self._guid_cache) > _GUID_CACHE_SIZE:
                             self._guid_cache.popitem(last=False)
                     return guid
-                for part in chat.get("participants", []) or []:
-                    if (part.get("address") or "").strip() == target and guid:
-                        self._guid_cache[target] = guid
-                        while len(self._guid_cache) > _GUID_CACHE_SIZE:
-                            self._guid_cache.popitem(last=False)
-                        return guid
         except Exception:
             pass
         return None

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -455,7 +455,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         try:
             payload = await self._api_post(
                 "/api/v1/chat/query",
-                {"limit": 100, "offset": 0, "with": ["participants"]},
+                {"limit": 100, "offset": 0},
             )
             for chat in payload.get("data", []) or []:
                 guid = chat.get("guid") or chat.get("chatGuid")

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -426,6 +426,110 @@ class TestBlueBubblesGuidResolution:
         )
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_exact_chat_identifier_match_returns_dm_guid(self, monkeypatch):
+        """A 1:1 DM whose chatIdentifier equals the target resolves to its guid."""
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(path, payload):
+            return {
+                "data": [
+                    {
+                        "guid": "iMessage;-;user@example.com",
+                        "chatIdentifier": "user@example.com",
+                        "participants": [{"address": "user@example.com"}],
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        result = await adapter._resolve_chat_guid("user@example.com")
+        assert result == "iMessage;-;user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_participant_only_match_does_not_resolve_to_group(self, monkeypatch):
+        """Regression for #24157: contact appearing as a participant in a group
+        chat must NOT be selected when no DM with that exact chatIdentifier exists.
+
+        Otherwise an outbound DM reply leaks into the group thread.
+        """
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(path, payload):
+            return {
+                "data": [
+                    {
+                        "guid": "iMessage;+;chat0000000000-family-group",
+                        "chatIdentifier": "chat0000000000",
+                        "participants": [
+                            {"address": "user@example.com"},
+                            {"address": "+15555550100"},
+                        ],
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        result = await adapter._resolve_chat_guid("user@example.com")
+        assert result is None, (
+            "participant-only match must not resolve to a group GUID — DM "
+            "replies would leak into the group thread"
+        )
+
+    @pytest.mark.asyncio
+    async def test_dm_chosen_over_group_when_both_contain_contact(self, monkeypatch):
+        """Even when a group chat is returned BEFORE a DM in the query result,
+        the resolver must lock onto the DM by chatIdentifier and not the
+        group via participant fallback.
+        """
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(path, payload):
+            return {
+                "data": [
+                    {
+                        "guid": "iMessage;+;chat0000000000-family-group",
+                        "chatIdentifier": "chat0000000000",
+                        "participants": [{"address": "user@example.com"}],
+                    },
+                    {
+                        "guid": "iMessage;-;user@example.com",
+                        "chatIdentifier": "user@example.com",
+                        "participants": [{"address": "user@example.com"}],
+                    },
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        result = await adapter._resolve_chat_guid("user@example.com")
+        assert result == "iMessage;-;user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_unresolved_target_is_not_cached(self, monkeypatch):
+        """When no exact match is found, the resolver must NOT cache anything.
+
+        Otherwise a later attempt — after the DM has been created — would
+        keep returning the stale ``None`` from cache. Also guards against a
+        latent variant of #24157 where a group GUID could be cached under a
+        bare address key and persist across calls.
+        """
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(path, payload):
+            return {
+                "data": [
+                    {
+                        "guid": "iMessage;+;chat0000000000-family-group",
+                        "chatIdentifier": "chat0000000000",
+                        "participants": [{"address": "user@example.com"}],
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        await adapter._resolve_chat_guid("user@example.com")
+        assert "user@example.com" not in adapter._guid_cache
+
 
 class TestBlueBubblesAttachmentDownload:
     """Verify _download_attachment routes to the correct cache helper."""


### PR DESCRIPTION
## Summary
BlueBubbles outbound 1:1 replies can no longer leak into a group thread. `_resolve_chat_guid` now resolves only by raw GUID passthrough or exact `chatIdentifier`/`identifier` match — the participant-address fallback that caused the misroute is gone. Fixes #24157.

## Root cause
`_resolve_chat_guid` scanned each chat's `participants[].address`. When the same contact (`user@example.com`) sits in both a DM and a group, and the group was returned first by `POST /api/v1/chat/query`, the participant fallback fired on the group's iteration, returned the group GUID, and cached it under the bare address — so every subsequent DM reply landed in the group.

## Changes
- `gateway/platforms/bluebubbles.py`: remove the participant-scan fallback in `_resolve_chat_guid`; drop the now-unused `with:[participants]` from the chat query. Unmatched target returns `None`.
- `tests/gateway/test_bluebubbles.py`: 4 regression tests (DM-first-wins, group-only→None, exact-match, no cache poisoning).

## Caller safety (all 6 `_resolve_chat_guid` sites audited)
`None` is handled everywhere: `send()` creates a fresh DM for address-shaped targets, `_send_attachment()` returns a clean failure, and typing/read/`get_chat_info` are `if guid:`-guarded (skip silently rather than act on a wrong group GUID). No behavioral regression.

## Validation
| | Before | After |
|---|---|---|
| Contact in DM + group, group returned first | resolves to **group GUID** (leak) | resolves to **DM GUID** |
| Contact only in a group | resolves to group GUID | `None`, not cached |
| Targeted suite | — | 60/60 pass |
| Live E2E (real imports) | — | DM-first-wins, group-only→None uncached, passthrough OK |

Salvage of #24229 by @briandevans, cherry-picked onto current main with authorship preserved.

## Infographic
![BlueBubbles DM leak fix](https://v3b.fal.media/files/b/0aa079a9/16vN1HEbU7xwoaPUyIIq2_oavVLfN0.png)
