### PR TITLE
feat(moa): aggregator fallback chain + multi-aggregator config

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -372,6 +372,7 @@ def aggregate_moa_context(
     api_messages: list[dict[str, Any]],
     reference_models: list[dict[str, str]],
     aggregator: dict[str, str],
+    fallback_aggregators: list[dict[str, str]] | None = None,
     temperature: float = 0.6,
     aggregator_temperature: float = 0.4,
     max_tokens: int | None = None,
@@ -410,19 +411,25 @@ def aggregate_moa_context(
         f"Reference responses:\n{joined}"
     )
 
-    agg_label = _slot_label(aggregator)
-    try:
-        response = call_llm(
-            task="moa_aggregator",
-            messages=[{"role": "user", "content": synth_prompt}],
-            temperature=aggregator_temperature,
-            max_tokens=max_tokens,
-            **_slot_runtime(aggregator),
-        )
-        synthesis = _extract_text(response)
-    except Exception as exc:
-        logger.warning("MoA aggregator model %s failed: %s", agg_label, exc)
-        synthesis = ""
+    aggregator_candidates = [aggregator] + list(fallback_aggregators or [])
+    synthesis = ""
+    used_label = ""
+    for candidate in aggregator_candidates:
+        used_label = _slot_label(candidate)
+        try:
+            response = call_llm(
+                task="moa_aggregator",
+                messages=[{"role": "user", "content": synth_prompt}],
+                temperature=aggregator_temperature,
+                max_tokens=max_tokens,
+                **_slot_runtime(candidate),
+            )
+            synthesis = _extract_text(response)
+            if synthesis:
+                break
+        except Exception as exc:
+            logger.warning("MoA aggregator model %s failed: %s", used_label, exc)
+            continue
 
     if not synthesis:
         synthesis = joined
@@ -431,9 +438,9 @@ def aggregate_moa_context(
         "[Mixture of Agents context — use this as private guidance for the "
         "normal Hermes agent loop. You may call tools, continue reasoning, or "
         "finish normally.]\n"
-        f"Aggregator: {agg_label}\n"
+        f"Aggregator: {used_label or _slot_label(aggregator)}\n"
         f"References: {', '.join(_slot_label(slot) for slot in reference_models)}\n\n"
-        f"{synthesis.strip()}"
+        f"{synthesis.strip() if synthesis else joined.strip()}"
     )
 
 
@@ -481,6 +488,7 @@ class MoAChatCompletions:
         messages = list(api_kwargs.get("messages") or [])
         reference_models = preset.get("reference_models") or []
         aggregator = preset.get("aggregator") or {}
+        fallback_aggregators = preset.get("fallback_aggregators") or []
         # MoA does not cap reference or aggregator output: each model uses its
         # own maximum. Passing max_tokens=None makes call_llm omit the parameter
         # (it never caps by default), so a long aggregator synthesis is never
@@ -569,23 +577,29 @@ class MoAChatCompletions:
             raise RuntimeError("MoA aggregator cannot be another MoA preset")
         agg_kwargs = dict(api_kwargs)
         agg_kwargs["messages"] = agg_messages
-        # The aggregator is the acting model. Resolve its slot to the provider's
-        # real runtime (base_url/api_key/api_mode) and call it through the same
-        # request-building path any model uses — so per-model wire-format
-        # handling (anthropic_messages, max_completion_tokens, fixed/forbidden
-        # temperature) applies identically to it. MoA imposes no output cap:
-        # max_tokens is passed through from the caller (normally None → omitted
-        # → the model's real maximum). The preset's old hardcoded 4096 default
-        # is gone — it truncated long syntheses.
-        return call_llm(
-            task="moa_aggregator",
-            messages=agg_messages,
-            temperature=aggregator_temperature,
-            max_tokens=agg_kwargs.get("max_tokens"),
-            tools=agg_kwargs.get("tools"),
-            extra_body=agg_kwargs.get("extra_body"),
-            **_slot_runtime(aggregator),
-        )
+
+        last_exc: Exception | None = None
+        for candidate in [aggregator] + list(fallback_aggregators):
+            # call_llm omits None-typed kwargs per its contract; build a
+            # concrete kwargs dict to satisfy Pyright strict mode.
+            max_tok = agg_kwargs.get("max_tokens")
+            call_kwargs: dict[str, Any] = {
+                "task": "moa_aggregator",
+                "messages": agg_messages,
+                "temperature": aggregator_temperature,
+                "tools": agg_kwargs.get("tools") or [],
+                "extra_body": agg_kwargs.get("extra_body") or {},
+            }
+            if isinstance(max_tok, (int, float)) and not isinstance(max_tok, bool):
+                call_kwargs["max_tokens"] = int(max_tok)
+            call_kwargs.update(_slot_runtime(candidate))
+            try:
+                return call_llm(**call_kwargs)
+            except Exception as exc:
+                last_exc = exc
+                logger.warning("MoA aggregator %s failed, trying next: %s", _slot_label(candidate), exc)
+                continue
+        raise RuntimeError(f"All MoA aggregators failed: {last_exc}") from last_exc
 
 
 class MoAClient:

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -21,6 +21,25 @@ DEFAULT_MOA_AGGREGATOR: dict[str, str] = {
 }
 
 
+def _coerce_slot_list(raw: Any) -> list[dict[str, str]]:
+    """Coerce a raw value into a list of clean model slots.
+
+    Accepts a single slot dict, a list of slot dicts, or None/other (→ []).
+    Slots missing provider or model are dropped. A slot whose provider is
+    ``"moa"`` is dropped (would recurse).
+    """
+    if isinstance(raw, dict):
+        raw = [raw]
+    elif not isinstance(raw, list):
+        return []
+    out: list[dict[str, str]] = []
+    for item in raw:
+        slot = _clean_slot(item)
+        if slot is not None:
+            out.append(slot)
+    return out
+
+
 def _coerce_float(value: Any, default: float) -> float:
     if value is None or value == "":
         return default
@@ -85,12 +104,15 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
     if not refs:
         refs = deepcopy(DEFAULT_MOA_REFERENCE_MODELS)
 
-    aggregator = _clean_slot(raw.get("aggregator")) or deepcopy(DEFAULT_MOA_AGGREGATOR)
+    aggregator_list = _coerce_slot_list(raw.get("aggregator"))
+    if not aggregator_list:
+        aggregator_list = [deepcopy(DEFAULT_MOA_AGGREGATOR)]
 
     return {
         "enabled": bool(raw.get("enabled", True)),
         "reference_models": refs,
-        "aggregator": aggregator,
+        "aggregator": aggregator_list[0],
+        "fallback_aggregators": aggregator_list[1:],
         "reference_temperature": _coerce_float(raw.get("reference_temperature"), 0.6),
         "aggregator_temperature": _coerce_float(raw.get("aggregator_temperature"), 0.4),
         "max_tokens": _coerce_int(raw.get("max_tokens"), 4096),


### PR DESCRIPTION
## Summary

`reference_models` already has built-in fallback — if one reference fails, the rest continue. But `aggregator` was a single hardcoded slot with no fallback path. A single aggregator failure turns the whole MoA conversation into a hard error inside the acting loop.

This PR allows aggregator to be specified as either a single dict (backward compatible) or a list. All entries are tried in order until one succeeds.

## Changes

- `hermes_cli/moa_config.py`: new `_coerce_slot_list()` — accepts single dict / list, normalizes to `aggregator` + `fallback_aggregators`
- `agent/moa_loop.py::aggregate_moa_context()`: tries `[aggregator] + fallback_aggregators` before degrading to raw reference output
- `agent/moa_loop.py::MoAChatCompletions.create()`: retries the next candidate on failure instead of raising

## Config examples

List form (new, with fallback):

```yaml
moa:
  aggregator:
    - provider: openai-codex
      model: gpt-5.5
    - provider: openrouter
      model: anthropic/claude-opus-4.8
```

Single dict form (backward compatible, unchanged behavior):

```yaml
moa:
  aggregator:
    provider: openai-codex
    model: gpt-5.5
```

## Motivation

Eliminates the SPOF in the aggregator that was inconsistent with the existing fallback design in reference_models.
