### PR TITLE
[FOR REVIEW] prompt_caching.enabled toggle for strict Anthropic proxies (re-open of #56105)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -521,9 +521,8 @@ def init_agent(
         from hermes_cli.config import load_config as _load_pc_cfg
 
         _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
-        if isinstance(_pc_cfg, dict) and _pc_cfg.get("enabled") is False:
-            agent._use_prompt_caching = False
-            agent._use_native_cache_layout = False
+        # prompt_caching.enabled=false is honored in _anthropic_prompt_cache_policy
+        # (applied above and on every re-derivation), so no override is needed here.
         _ttl = _pc_cfg.get("cache_ttl", "5m") if isinstance(_pc_cfg, dict) else "5m"
         if _ttl in {"5m", "1h"}:
             agent._cache_ttl = _ttl

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -521,7 +521,10 @@ def init_agent(
         from hermes_cli.config import load_config as _load_pc_cfg
 
         _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
-        _ttl = _pc_cfg.get("cache_ttl", "5m")
+        if isinstance(_pc_cfg, dict) and _pc_cfg.get("enabled") is False:
+            agent._use_prompt_caching = False
+            agent._use_native_cache_layout = False
+        _ttl = _pc_cfg.get("cache_ttl", "5m") if isinstance(_pc_cfg, dict) else "5m"
         if _ttl in {"5m", "1h"}:
             agent._cache_ttl = _ttl
     except Exception:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1508,6 +1508,21 @@ def anthropic_prompt_cache_policy(
     eff_api_mode = api_mode if api_mode is not None else (agent.api_mode or "")
     eff_model = (model if model is not None else agent.model) or ""
 
+    # Global kill switch: prompt_caching.enabled=false disables cache_control
+    # markers on every path (init, /model switch, fallback re-derivation).
+    # Escape hatch for strict Anthropic-compatible proxies that inject their
+    # own markers server-side — stacking ours on top exceeds Anthropic's
+    # 4-breakpoint limit and 400s. Gating here (not just at init) keeps the
+    # switch honored after a model switch or fallback re-evaluates the policy.
+    try:
+        from hermes_cli.config import load_config as _load_pc_cfg
+
+        _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
+        if isinstance(_pc_cfg, dict) and _pc_cfg.get("enabled") is False:
+            return False, False
+    except Exception:
+        pass
+
     # MoA virtual provider: the agent's model/provider are the preset name and
     # "moa" — neither matches any caching branch, so the ACTING AGGREGATOR
     # (often Claude on OpenRouter) silently lost prompt caching entirely

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1410,8 +1410,11 @@ DEFAULT_CONFIG = {
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
-    # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
+    # Set enabled: false as an escape hatch for strict providers that reject
+    # cache_control markers; cache_ttl must be "5m" or "1h" (Anthropic-supported
+    # tiers), other values are ignored.
     "prompt_caching": {
+        "enabled": True,
         "cache_ttl": "5m",
     },
 

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -8,7 +8,7 @@ the native layout on OpenRouter) surfaces loudly.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent
 
@@ -327,6 +327,90 @@ class TestExplicitOverrides:
 
 
 # ─────────────────────────────────────────────────────────────────────
+# prompt_caching.enabled=false global kill switch
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestPromptCachingDisabledKillSwitch:
+    """prompt_caching.enabled=false must disable cache_control markers on
+    every endpoint class and every re-derivation path (init, /model switch,
+    fallback). This is the correct escape hatch for a strict Anthropic-
+    compatible proxy that injects its own markers server-side — a single
+    per-setup toggle, not a blanket strip that would regress the many
+    well-behaved third-party gateways the policy deliberately caches on.
+    """
+
+    def _disabled_cfg(self):
+        return patch(
+            "hermes_cli.config.load_config",
+            return_value={"prompt_caching": {"enabled": False}},
+        )
+
+    def test_disables_native_anthropic(self):
+        agent = _make_agent(
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+            api_mode="anthropic_messages",
+            model="claude-sonnet-4-6",
+        )
+        with self._disabled_cfg():
+            assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_disables_openrouter_claude(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        with self._disabled_cfg():
+            assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_disables_third_party_anthropic_gateway(self):
+        # llm.echo.tech-style LiteLLM proxy — the reported failure case.
+        agent = _make_agent(
+            provider="anthropic",
+            base_url="https://llm.echo.tech",
+            api_mode="anthropic_messages",
+            model="claude-sonnet-4-6",
+        )
+        with self._disabled_cfg():
+            assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_survives_model_switch_re_derivation(self):
+        # Start native Anthropic, /model switch to a proxy — disable must hold.
+        agent = _make_agent(
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+            api_mode="anthropic_messages",
+            model="claude-opus-4.6",
+        )
+        with self._disabled_cfg():
+            assert agent._anthropic_prompt_cache_policy(
+                provider="anthropic",
+                base_url="https://llm.echo.tech",
+                api_mode="anthropic_messages",
+                model="claude-sonnet-4-6",
+            ) == (False, False)
+
+    def test_enabled_true_keeps_third_party_caching_on(self):
+        # The well-behaved third-party gateways a blanket strip would break
+        # must keep caching by default.
+        agent = _make_agent(
+            provider="anthropic",
+            base_url="https://llm.echo.tech",
+            api_mode="anthropic_messages",
+            model="claude-sonnet-4-6",
+        )
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"prompt_caching": {"enabled": True}},
+        ):
+            assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+
+# ─────────────────────────────────────────────────────────────────────
 # Long-lived prefix cache policy (cross-session 1h tier)
 # ─────────────────────────────────────────────────────────────────────
+
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1026,6 +1026,30 @@ class TestInit:
             )
             assert a._cache_ttl == "5m"
 
+    def test_prompt_caching_enabled_false_disables_cache_markers(self):
+        """prompt_caching.enabled=false is an escape hatch for strict providers."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter._anthropic_sdk"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"prompt_caching": {"enabled": False}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                base_url="https://api.anthropic.com/v1/",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a.api_mode == "anthropic_messages"
+            assert a._use_prompt_caching is False
+            assert a._use_native_cache_layout is False
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -380,6 +380,7 @@ Prompt caching is automatically enabled when:
 ```yaml
 # config.yaml — TTL is configurable (must be "5m" or "1h")
 prompt_caching:
+  enabled: true    # set false to stop sending cache_control markers (strict-proxy escape hatch)
   cache_ttl: "5m"
 ```
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -912,16 +912,19 @@ For Claude on **native Anthropic**, **OpenRouter**, and **Nous Portal**, Hermes 
 
 The Qwen Cloud (Alibaba DashScope) upstream caps cache TTL at 5 minutes, so Hermes uses the 5-minute breakpoint TTL there instead. Other Claude-via-third-party paths (AWS Bedrock, Azure Foundry) fall back to the provider's own caching defaults. xAI Grok uses a separate session-pinned conversation-id mechanism — see [xAI prompt caching](/integrations/providers#xai-grok--responses-api--prompt-caching).
 
-No knob exists to disable this — caching is always-on and saves money even on single-turn conversations because the system prompt alone is a meaningful fraction of the input token count.
+Caching is on by default and saves money even on single-turn conversations because the system prompt alone is a meaningful fraction of the input token count. It can be turned off entirely with the `enabled` knob below when a strict provider rejects `cache_control` markers.
 
-The one explicit knob is the cache TTL tier Hermes requests on Anthropic-style breakpoints:
+The explicit knobs are whether caching runs at all and the cache TTL tier Hermes requests on Anthropic-style breakpoints:
 
 ```yaml
 prompt_caching:
+  enabled: true    # set false to stop sending cache_control markers entirely
   cache_ttl: "5m"   # "5m" or "1h" (Anthropic-supported tiers); other values are ignored
 ```
 
 `cache_ttl` selects the breakpoint TTL Hermes attaches for Claude via the native Anthropic API, OpenRouter, and Nous Portal. Only the two Anthropic-supported tiers (`"5m"`, `"1h"`) are honored — any other value is ignored. Providers with their own caps (e.g. Qwen Cloud, which maxes at 5 minutes) still clamp to what the upstream allows.
+
+`enabled` defaults to `true`. Set it to `false` as an escape hatch for strict Anthropic-compatible proxies that inject their own `cache_control` markers server-side — stacking those on top of Hermes' breakpoints can exceed Anthropic's 4-breakpoint limit and return HTTP 400 `"A maximum of 4 blocks with cache_control may be provided"`. Disabling caching on that setup passes requests through without client-side markers so the proxy manages its own.
 
 ## Auxiliary Models
 


### PR DESCRIPTION
## ⚠️ For review — do not merge yet
Re-opens the `prompt_caching.enabled` toggle that was merged as #56105 and then reverted (#56126) so it can be evaluated deliberately. Same code, clean-rebased onto current `main`. Nothing here changes default behavior — this is up for a decision, not a merge.

## Summary
Adds a `prompt_caching.enabled` config toggle (default `true`) so a user on a strict Anthropic-compatible proxy (LiteLLM-style, e.g. `llm.echo.tech`) that injects its own `cache_control` markers can turn off client-side markers entirely — fixing the HTTP 400 `"A maximum of 4 blocks with cache_control may be provided. Found 5"` reported in #13477.

Salvages @janrenz's #35862 (the toggle) + a follow-up that makes the disable survive `/model` switch and fallback re-derivation.

## The concern to evaluate (why it was reverted)
The toggle works by adding a `load_config()`-driven gate at the top of `anthropic_prompt_cache_policy` — the single function that decides whether cache_control markers are emitted. Prompt caching is cost-critical for **every** Claude user (native Anthropic AND OpenRouter Claude), so this touches the highest-blast-radius decision in the caching path. Points to scrutinize before merge:

1. **Default safety.** `enabled` defaults to `true` in `DEFAULT_CONFIG`, and `load_config`'s deep-merge injects it into existing on-disk configs that only had `cache_ttl`. Verified: an existing user's config with just `cache_ttl` loads as `{enabled: True, cache_ttl: "5m"}` → gate does not fire. No one loses caching unless they explicitly set `enabled: false`.
2. **Loader consistency.** The gate always imports `hermes_cli.config.load_config` (the deep-merging loader) regardless of CLI vs gateway, so both surfaces get the same `enabled: True` default. No CLI/gateway loader mismatch.
3. **Hot-path cost.** The policy runs only at init, `/model` switch, and fallback swap — a handful of times per session, NOT per API call. Per-turn marker application reads the cached `agent._use_prompt_caching` bool, never the config. No per-turn disk read.

These were verified after the fact, not before the original merge — which is the process gap this re-open is meant to close.

## Validation (markers stay ON by default)
| path | enabled=true (default) | enabled=false |
|---|---|---|
| OpenRouter Claude | (True, False) — markers ON | (False, False) |
| Native Anthropic | (True, True) — markers ON | (False, False) |
| after `/model` switch | policy-derived | (False, False) |
| after fallback swap | policy-derived | (False, False) |

`test_anthropic_prompt_cache_policy.py` 29/29 green.

## Alternative to weigh
Original #13477 proposed stripping all markers whenever `base_url != anthropic.com`. Rejected because it would kill caching for MiniMax/GLM/Bedrock/Foundry/Kimi/DeepSeek — none of which double-inject. If a per-setup toggle still feels too broad, a narrower option is a capability flag scoped to the specific proxy, or documenting the manual `enabled: false` without wiring the gate into the policy at all.

Closes #13477 *if merged*. Salvages #35862 (@janrenz authorship preserved).

## Infographic
![prompt caching toggle v2](https://v3b.fal.media/files/b/0aa079c2/5eQntoniGNbQBhrsZLGtX_Rw0cSKrf.png)
