### PR TITLE
fix(tools): preserve empty required array instead of dropping key

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -120,14 +120,14 @@ def test_required_pruned_to_existing_properties():
     assert out[0]["function"]["parameters"]["required"] == ["name"]
 
 
-def test_required_all_missing_is_dropped():
+def test_required_all_missing_becomes_empty_list():
     tools = [_tool("t", {
         "type": "object",
         "properties": {},
         "required": ["x", "y"],
     })]
     out = sanitize_tool_schemas(tools)
-    assert "required" not in out[0]["function"]["parameters"]
+    assert out[0]["function"]["parameters"]["required"] == []
 
 
 def test_well_formed_schema_unchanged():

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -329,7 +329,7 @@ def _sanitize_node(node: Any, path: str) -> Any:
         props = out.get("properties") or {}
         valid = [r for r in out["required"] if isinstance(r, str) and r in props]
         if not valid:
-            out.pop("required", None)
+            out["required"] = []
         elif len(valid) != len(out["required"]):
             out["required"] = valid
 


### PR DESCRIPTION
## What does this PR do?

Fixes `schema_sanitizer._sanitize_node()` dropping the `required` key entirely when all entries reference non-existent properties. Strict OpenAI-compatible backends (Azure OpenAI, custom proxies) reject the missing `required` field as `null` with HTTP 400. The fix replaces `out.pop("required", None)` with `out["required"] = []`, which is valid JSON Schema and universally accepted.

## Related Issue

Fixes #56123

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/schema_sanitizer.py:332` — Replace `out.pop("required", None)` with `out["required"] = []` so that schemas with all-missing required entries still carry an empty array instead of omitting the key entirely.
- `tests/tools/test_schema_sanitizer.py` — Rename `test_required_all_missing_is_dropped` to `test_required_all_missing_becomes_empty_list` and assert `required == []` instead of asserting the key is absent.

## How to Test

1. Run `python -m pytest tests/tools/test_schema_sanitizer.py -xvs` — all 43 tests should pass.
2. Verify the behavior: `sanitize_tool_schemas([{"type": "function", "function": {"name": "t", "parameters": {"type": "object", "properties": {}, "required": ["x"]}}}])` should produce `required: []` (not absent).
3. On a strict OpenAI-compatible backend (e.g. Azure OpenAI), a tool with empty `properties` and `required` entries referencing non-existent fields should no longer trigger HTTP 400.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```python
# Before fix: required key is dropped
>>> out = {"type": "object", "properties": {}, "required": ["x", "y"]}
>>> # After _sanitize_node: {"type": "object", "properties": {}}  # required missing!

# After fix: required key is preserved as empty array
>>> # After _sanitize_node: {"type": "object", "properties": {}, "required": []}  # valid JSON Schema
```
