### PR TITLE
fix(skills): publish fetchable metadata for official skills

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1816,6 +1816,26 @@ class TestSkillMetaToDict:
 # ---------------------------------------------------------------------------
 
 
+class TestOptionalSkillSourceMetadata:
+    def test_scan_all_emits_repo_root_relative_metadata(self, tmp_path):
+        optional_root = tmp_path / "optional-skills"
+        skill_dir = optional_root / "finance" / "3-statement-model"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: 3-statement-model\ndescription: test\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+
+        meta = src.inspect("official/finance/3-statement-model")
+
+        assert meta is not None
+        assert meta.repo == "NousResearch/hermes-agent"
+        assert meta.path == "optional-skills/finance/3-statement-model"
+
+
 class TestOptionalSkillSourceBinaryAssets:
     def test_fetch_preserves_binary_assets(self, tmp_path):
         optional_root = tmp_path / "optional-skills"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3052,6 +3052,8 @@ class OptionalSkillSource(SkillSource):
     (search / install / inspect) and labelled "official" with "builtin" trust.
     """
 
+    OFFICIAL_REPO = "NousResearch/hermes-agent"
+
     def __init__(self):
         from hermes_constants import get_optional_skills_dir
 
@@ -3183,7 +3185,7 @@ class OptionalSkillSource(SkillSource):
                 if isinstance(hermes_meta, dict):
                     tags = hermes_meta.get("tags", [])
 
-            rel_path = str(parent.relative_to(self._optional_dir))
+            rel_path = parent.relative_to(self._optional_dir).as_posix()
 
             results.append(SkillMeta(
                 name=name,
@@ -3191,7 +3193,9 @@ class OptionalSkillSource(SkillSource):
                 source="official",
                 identifier=f"official/{rel_path}",
                 trust_level="builtin",
-                path=rel_path,
+                repo=self.OFFICIAL_REPO,
+                # The centralized skills index consumes repo-root-relative paths.
+                path=f"optional-skills/{rel_path}",
                 tags=tags if isinstance(tags, list) else [],
             ))
 


### PR DESCRIPTION
## Summary
Official (`official/*`) skills now publish fetchable index metadata, so index-driven `hermes skills install official/<skill>` works in environments that rely on the hosted `skills-index.json` instead of a local repo checkout.

Salvage of #30512 by @LeonSGP43, cherry-picked onto current `main`. Closes #30482.

## Root cause
`OptionalSkillSource._scan_all()` emitted `repo=""` and a non-repo-root `path=<category>/<skill>` for every official skill. The hosted index consumes `repo` + repo-root-relative `path` to fetch a skill's files from GitHub's Contents API, so all 81 official entries were unfetchable from the index.

## Changes
- `tools/skills_hub.py` — `_scan_all()` now sets `repo="NousResearch/hermes-agent"`, `path="optional-skills/<rel>"`, and `.as_posix()`-normalizes the rel path (Windows backslash → fetchable GitHub path). `identifier` stays `official/<rel>`, so local source-checkout `fetch`/`inspect` are untouched; `inspect()` delegates to `_scan_all()` and inherits the fix.
- `tests/tools/test_skills_hub.py` — asserts the emitted metadata is repo-root-relative and fetchable.

## Validation
| | Before | After |
|---|---|---|
| `repo` for official skill | `""` | `NousResearch/hermes-agent` |
| `path` for official skill | `finance/3-statement-model` | `optional-skills/finance/3-statement-model` |
| Windows path separators | backslash leaks | posix-normalized |
| Local source-checkout install | works | works (unchanged) |

- Targeted tests: `tests/tools/test_skills_hub.py -k OptionalSkillSource` → 3 passed
- E2E with real imports against a temp optional-skills tree: metadata fetchable-shaped, `inspect()` inherits the fix, local `fetch()` still resolves off the identifier.

## Infographic
![PR #30512 infographic](https://v3b.fal.media/files/b/0aa079d6/TPwlBQjVIHSnssRD5WL5S_R9FY4wNU.png)
