### PR TITLE
fix(gateway): bind Telegram handoffs to DM topics

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1245,13 +1245,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 DeliveryRouter,
                 DeliveryTarget,
                 _looks_like_int,
-                _looks_like_telegram_private_chat_id,
+                looks_like_telegram_private_chat_id,
             )
 
             is_private_dm_topic = (
                 platform == Platform.TELEGRAM
                 and thread_id is not None
-                and _looks_like_telegram_private_chat_id(str(chat_id))
+                and looks_like_telegram_private_chat_id(str(chat_id))
                 and _looks_like_int(str(thread_id))
             )
             if is_private_dm_topic:

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -59,7 +59,14 @@ from .session import SessionSource
 from .dead_targets import DeadTargetRegistry
 
 
-def _looks_like_telegram_private_chat_id(chat_id: Optional[str]) -> bool:
+def looks_like_telegram_private_chat_id(chat_id: Optional[str]) -> bool:
+    """True when ``chat_id`` is a positive int — Telegram's private-chat shape.
+
+    Telegram private chats use positive chat IDs; groups/channels/supergroups
+    use negative IDs. This is the single source of truth for that heuristic,
+    reused by the handoff seed path in ``gateway/run.py`` so handoff-created
+    DM topics key the same way as inbound DM-topic messages.
+    """
     if chat_id is None:
         return False
     try:
@@ -467,7 +474,7 @@ class DeliveryRouter:
             target_thread_id = target.thread_id
             is_named_telegram_private_topic = (
                 target.platform == Platform.TELEGRAM
-                and _looks_like_telegram_private_chat_id(target.chat_id)
+                and looks_like_telegram_private_chat_id(target.chat_id)
                 and not _looks_like_int(target_thread_id)
                 and "thread_id" not in send_metadata
                 and "message_thread_id" not in send_metadata
@@ -490,7 +497,7 @@ class DeliveryRouter:
                 send_metadata["telegram_dm_topic_created_for_send"] = True
             elif (
                 target.platform == Platform.TELEGRAM
-                and _looks_like_telegram_private_chat_id(target.chat_id)
+                and looks_like_telegram_private_chat_id(target.chat_id)
                 and "thread_id" not in send_metadata
                 and "message_thread_id" not in send_metadata
                 and not has_explicit_direct_topic

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1676,7 +1676,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
-from gateway.delivery import DeliveryRouter
+from gateway.delivery import DeliveryRouter, looks_like_telegram_private_chat_id
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
@@ -6823,12 +6823,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # handoff turn binds a generic `thread` session key while real replies
         # arrive on a `dm` session key.
         home_chat_id = str(home.chat_id)
-        is_telegram_private_chat = False
-        if platform == Platform.TELEGRAM:
-            try:
-                is_telegram_private_chat = int(home_chat_id) > 0
-            except (TypeError, ValueError):
-                is_telegram_private_chat = False
+        is_telegram_private_chat = (
+            platform == Platform.TELEGRAM
+            and looks_like_telegram_private_chat_id(home_chat_id)
+        )
 
         if new_thread_id and not is_telegram_private_chat:
             dest_chat_type = "thread"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6814,26 +6814,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             str(home.thread_id) if home.thread_id else None
         )
 
-        # Determine chat_type for the destination source. If we created a
-        # thread, key the session_key as a thread (build_session_key sets
-        # thread sessions to user-shared by default, which is what we
-        # want — the synthetic turn and any later real-user message both
-        # land on the same key without needing a user_id).
-        if new_thread_id:
+        # Determine chat_type/user_id for the destination source.
+        #
+        # Telegram private-chat DM topics are represented differently from
+        # group/forum threads by the inbound adapter. A handoff-created topic
+        # in a positive Telegram chat_id must therefore use the same DM-topic
+        # source shape as the user's next real message; otherwise the synthetic
+        # handoff turn binds a generic `thread` session key while real replies
+        # arrive on a `dm` session key.
+        home_chat_id = str(home.chat_id)
+        is_telegram_private_chat = False
+        if platform == Platform.TELEGRAM:
+            try:
+                is_telegram_private_chat = int(home_chat_id) > 0
+            except (TypeError, ValueError):
+                is_telegram_private_chat = False
+
+        if new_thread_id and not is_telegram_private_chat:
             dest_chat_type = "thread"
+            dest_user_id = "system:handoff"
         else:
-            # No thread — assume DM-style for the home channel. For
-            # group/channel home channels without thread support
-            # (Matrix/WhatsApp/Signal), the platform's own keying makes
-            # the synthetic turn shared anyway (single-DM platforms).
+            # No thread — assume DM-style for the home channel. For Telegram
+            # private-chat topics, use the real user id (same as chat_id) so
+            # topic-mode checks and binding persistence see the same identity as
+            # subsequent inbound user messages.
             dest_chat_type = "dm"
+            dest_user_id = home_chat_id if is_telegram_private_chat else "system:handoff"
 
         dest_source = SessionSource(
             platform=platform,
-            chat_id=str(home.chat_id),
+            chat_id=home_chat_id,
             chat_name=home.name,
             chat_type=dest_chat_type,
-            user_id="system:handoff",
+            user_id=dest_user_id,
             user_name="Handoff",
             thread_id=effective_thread_id,
         )

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from hermes_state import SessionDB
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
@@ -798,6 +798,49 @@ async def test_first_message_inside_topic_records_topic_binding(tmp_path, monkey
     assert binding["session_key"] == build_session_key(_make_source(thread_id="17585"))
 
 
+
+
+@pytest.mark.asyncio
+async def test_handoff_to_telegram_dm_topic_uses_dm_lane_not_generic_thread(tmp_path):
+    """Handoff-created Telegram DM topics must use the real DM-topic lane.
+
+    A positive Telegram chat_id is a private chat. If handoff treats the new
+    topic as generic chat_type="thread" with user_id="system:handoff", the
+    synthetic turn lands under agent:...:thread:chat:topic while real user
+    replies arrive as chat_type="dm" with user_id=chat_id. Recovery then sees
+    the topic as unbound and can rewrite it to another recent topic.
+    """
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    runner = _make_runner(session_db=session_db)
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="208214988",
+        name="Tester DM",
+    )
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.create_handoff_thread = AsyncMock(return_value="17585")
+    adapter.send.return_value = SimpleNamespace(success=True)
+    captured = {}
+
+    async def fake_handle_message(event):
+        captured["source"] = event.source
+        return "handoff ok"
+
+    runner._handle_message = AsyncMock(side_effect=fake_handle_message)
+
+    await runner._process_handoff({
+        "id": "cli-session",
+        "title": "CLI work",
+        "handoff_platform": "telegram",
+    })
+
+    expected_source = _make_source(thread_id="17585")
+    expected_key = build_session_key(expected_source)
+    runner.session_store.switch_session.assert_called_once_with(expected_key, "cli-session")
+    assert captured["source"].chat_type == "dm"
+    assert captured["source"].user_id == "208214988"
+    assert captured["source"].thread_id == "17585"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Handoffs into a Telegram private-chat topic now land on the same DM-topic session lane the user's next real message uses — no more orphaned handoff context or cross-topic recovery bleed.

Root cause: `/handoff telegram` seeded the synthetic turn as a generic `chat_type="thread"` source with `user_id="system:handoff"`, producing key `agent:main:telegram:thread:<chat>:<topic>`. Real inbound DM-topic messages arrive as `chat_type="dm"`, `user_id=<chat_id>` → key `agent:main:telegram:dm:<chat>:<topic>`. The two keys never matched, so the handoff turn was orphaned, no `telegram_dm_topic_bindings` row was written, and topic-recovery could misroute the first real reply into a different recent topic.

## Changes

- `gateway/run.py::_process_handoff`: for positive (private) Telegram chat IDs, seed the destination source as `chat_type="dm"`, `user_id=str(chat_id)`, keeping `thread_id`. Group/forum threads keep the existing `thread` behavior.
- `gateway/delivery.py`: promote the existing `_looks_like_telegram_private_chat_id` heuristic to a public `looks_like_telegram_private_chat_id` and reuse it from the handoff path instead of duplicating the `int(chat_id) > 0` check.

## Validation

| | OLD handoff key | NEW handoff key | inbound reply key |
|---|---|---|---|
| private DM | `...:telegram:thread:208214988:17585` ✗ | `...:telegram:dm:208214988:17585` ✓ | `...:telegram:dm:208214988:17585` |
| group | `...:telegram:thread:-100123:17585` (unchanged) | | |

- `scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_thread_fallback.py` → 92 passed
- `scripts/run_tests.sh tests/gateway/test_delivery.py` → 28 passed (helper rename)
- E2E: verified handoff and inbound-reply keys converge for private chats and stay `thread` for groups.

Salvages #29794 by @hehehe0803 (authorship preserved via cherry-pick).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa079d5/xQ8q9BTQfZ67dGS6cer1D_LF15SazS.png)
