### PR TITLE
perf: cache detect_local_server_type() results per process lifetime

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -552,14 +552,20 @@ def is_local_endpoint(base_url: str) -> bool:
     return False
 
 
+_detect_local_server_type_cache: dict = {}
+
 def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     """Detect which local server is running at base_url by probing known endpoints.
 
     Returns one of: "ollama", "lm-studio", "vllm", "llamacpp", or None.
+    Results are cached per (base_url, api_key) for the lifetime of the process.
     """
     import httpx
 
     normalized = _normalize_base_url(base_url)
+    cache_key = (normalized, api_key)
+    if cache_key in _detect_local_server_type_cache:
+        return _detect_local_server_type_cache[cache_key]
     server_url = normalized
     if server_url.endswith("/v1"):
         server_url = server_url[:-3]
@@ -573,6 +579,7 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
             try:
                 r = client.get(f"{lmstudio_url}/api/v1/models")
                 if r.status_code == 200:
+                    _detect_local_server_type_cache[cache_key] = "lm-studio"
                     return "lm-studio"
             except Exception:
                 pass
@@ -585,6 +592,7 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
                     try:
                         data = r.json()
                         if "models" in data:
+                            _detect_local_server_type_cache[cache_key] = "ollama"
                             return "ollama"
                     except Exception:
                         pass
@@ -596,6 +604,7 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
                 if r.status_code != 200:
                     r = client.get(f"{server_url}/props")  # fallback for older builds
                 if r.status_code == 200 and "default_generation_settings" in r.text:
+                    _detect_local_server_type_cache[cache_key] = "llamacpp"
                     return "llamacpp"
             except Exception:
                 pass
@@ -605,12 +614,14 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
                 if r.status_code == 200:
                     data = r.json()
                     if "version" in data:
+                        _detect_local_server_type_cache[cache_key] = "vllm"
                         return "vllm"
             except Exception:
                 pass
     except Exception:
         pass
 
+    _detect_local_server_type_cache[cache_key] = None
     return None
 
 


### PR DESCRIPTION
## Problem

`detect_local_server_type()` has no cache. Every call fires a full round of HTTP probes:

1. `GET /api/v1/models` (LM Studio)
2. `GET /api/tags` (Ollama)
3. `GET /v1/props` + `GET /props` fallback (llama.cpp)
4. `GET /version` (vLLM)

For endpoints on RFC-1918 private IPs (e.g. `10.x.x.x`, `192.168.x.x`), `is_local_endpoint()` returns `True`, so these probes are triggered on **every context-length resolution** — including once per compression check during long sessions. This causes noticeable latency and unnecessary network noise.

## Fix

Add a module-level dict `_detect_local_server_type_cache` keyed by `(normalized_base_url, api_key)`. All five return paths write to the cache before returning. A failed probe (no endpoint matched) also caches `None` to prevent re-probing a server that does not match any known type.

## Effect

Per process lifetime, each unique endpoint is probed at most once. Subsequent calls return immediately from the cache with zero HTTP requests.

## Testing

- Manually verified with a private-IP Ollama endpoint: second call returns instantly from cache with no outbound HTTP requests.
- No behavioural change for the first call — probe logic is unchanged.