### PR TITLE
fix(web): re-check Firecrawl final URLs for SSRF (salvage #35840)

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -51,6 +51,7 @@ import os
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from agent.web_search_provider import WebSearchProvider
+from tools.url_safety import is_safe_url
 from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
@@ -522,6 +523,26 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
 
                 title = metadata.get("title", "")
                 final_url = metadata.get("sourceURL", url)
+
+                # Re-check SSRF safety after any redirect reported by Firecrawl.
+                if not is_safe_url(final_url):
+                    logger.info(
+                        "Blocked redirected web_extract for unsafe final URL: %s",
+                        final_url,
+                    )
+                    results.append(
+                        {
+                            "url": final_url,
+                            "title": title,
+                            "content": "",
+                            "raw_content": "",
+                            "error": (
+                                "Blocked: URL targets a private or internal "
+                                "network address"
+                            ),
+                        }
+                    )
+                    continue
 
                 # Re-check website-access policy after any redirect
                 final_blocked = check_website_access(final_url)

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -413,6 +413,7 @@ class TestWebToolPolicy:
             return True
 
         monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
+        monkeypatch.setattr(firecrawl_provider, "is_safe_url", lambda url: True)
 
         def fake_check(url):
             if url == "https://allowed.test":
@@ -448,6 +449,51 @@ class TestWebToolPolicy:
         assert result["results"][0]["url"] == "https://blocked.test/final"
         assert result["results"][0]["content"] == ""
         assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
+
+    @pytest.mark.asyncio
+    async def test_web_extract_blocks_firecrawl_unsafe_final_url(self, monkeypatch):
+        from tools import web_tools
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        async def _allow_ssrf(_url: str) -> bool:
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
+        monkeypatch.setattr(
+            firecrawl_provider,
+            "is_safe_url",
+            lambda url: url != "http://169.254.169.254/latest/meta-data/",
+        )
+
+        checked_urls = []
+
+        def fake_check(url):
+            checked_urls.append(url)
+            if url == "https://allowed.test":
+                return None
+            pytest.fail(f"unexpected website policy check for unsafe URL: {url}")
+
+        class FakeFirecrawlClient:
+            def scrape(self, url, formats):
+                return {
+                    "markdown": "metadata credentials",
+                    "metadata": {
+                        "title": "Metadata",
+                        "sourceURL": "http://169.254.169.254/latest/meta-data/",
+                    },
+                }
+
+        monkeypatch.setattr(firecrawl_provider, "check_website_access", fake_check)
+        monkeypatch.setattr(firecrawl_provider, "_get_firecrawl_client", lambda: FakeFirecrawlClient())
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fake-key")
+
+        result = json.loads(await web_tools.web_extract_tool(["https://allowed.test"], use_llm_processing=False))
+
+        assert checked_urls == ["https://allowed.test"]
+        assert result["results"][0]["url"] == "http://169.254.169.254/latest/meta-data/"
+        assert result["results"][0]["content"] == ""
+        assert "private or internal network" in result["results"][0]["error"]
 
 
 def test_check_website_access_fails_open_on_malformed_config(tmp_path, monkeypatch):

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -488,7 +488,7 @@ class TestWebToolPolicy:
         monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
         monkeypatch.setenv("FIRECRAWL_API_KEY", "fake-key")
 
-        result = json.loads(await web_tools.web_extract_tool(["https://allowed.test"], use_llm_processing=False))
+        result = json.loads(await web_tools.web_extract_tool(["https://allowed.test"]))
 
         assert checked_urls == ["https://allowed.test"]
         assert result["results"][0]["url"] == "http://169.254.169.254/latest/meta-data/"


### PR DESCRIPTION
## Summary
Firecrawl's reported final URL (`metadata.sourceURL`) is now SSRF-checked with `is_safe_url()` before any scraped content is returned — closing a redirect-based SSRF hole where `web_extract` validated the input URL but not the post-fetch redirect target (e.g. `169.254.169.254` cloud metadata).

Salvage of #35840 by @zapabob — original commit cherry-picked with authorship preserved.

## Changes
- `plugins/web/firecrawl/provider.py`: re-run `is_safe_url(final_url)` right before the existing website-policy re-check; fail-closed, returns an empty blocked result.
- `tests/tools/test_website_policy.py`: regression test for a Firecrawl final URL pointing at the cloud metadata endpoint; adapt to current `web_extract_tool` signature (`async_is_safe_url` input gate, no `use_llm_processing` kwarg).

## Root cause
The input URL is SSRF-gated at the `web_extract_tool` entry (`async_is_safe_url`), but the final-URL path only re-ran `check_website_access` — not the SSRF guard. A redirect to a private/metadata address slipped past.

## Scope
The sibling `plugins/browser/firecrawl` provider has no redirect/final-URL surface, so no matching site there — the bug class is complete with this one change.

## Validation
| | Result |
|---|---|
| `tests/tools/test_website_policy.py` | 21/21 passing |
| New metadata-endpoint final-URL test | blocks, content empty |

## Infographic
![Firecrawl Final-URL SSRF Re-check](https://v3b.fal.media/files/b/0aa079fe/3Sy37z7HcCZvmcu6-a5u2_nVcw8m3n.png)
