### PR TITLE
fix(tui_gateway): don't show cumulative session total as context_used (#50421)

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -194,12 +194,17 @@ class ContextEngine(ABC):
 
         Default returns the standard fields run_agent.py expects.
         """
+        # Clamp the -1 "compression just ran, awaiting real usage" sentinel
+        # (set by conversation_compression) to 0 so status readers don't see a
+        # raw -1 or a negative usage_percent on the transitional turn. Mirrors
+        # the CLI/gateway status-bar paths (cli.py, tui_gateway/server.py).
+        last_prompt = self.last_prompt_tokens if self.last_prompt_tokens > 0 else 0
         return {
-            "last_prompt_tokens": self.last_prompt_tokens,
+            "last_prompt_tokens": last_prompt,
             "threshold_tokens": self.threshold_tokens,
             "context_length": self.context_length,
             "usage_percent": (
-                min(100, self.last_prompt_tokens / self.context_length * 100)
+                min(100, last_prompt / self.context_length * 100)
                 if self.context_length else 0
             ),
             "compression_count": self.compression_count,

--- a/cli.py
+++ b/cli.py
@@ -9254,7 +9254,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         total = agent.session_total_tokens
 
         compressor = agent.context_compressor
-        last_prompt = compressor.last_prompt_tokens
+        last_prompt = compressor.last_prompt_tokens if compressor.last_prompt_tokens > 0 else 0
         ctx_len = compressor.context_length
         pct = min(100, (last_prompt / ctx_len * 100)) if ctx_len else 0
         compressions = compressor.compression_count

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3589,9 +3589,10 @@ class GatewaySlashCommandsMixin:
 
             # Context window and compressions
             ctx = agent.context_compressor
-            if ctx.last_prompt_tokens:
-                pct = min(100, ctx.last_prompt_tokens / ctx.context_length * 100) if ctx.context_length else 0
-                lines.append(t("gateway.usage.label_context", used=f"{ctx.last_prompt_tokens:,}", total=f"{ctx.context_length:,}", pct=f"{pct:.0f}"))
+            _lpt = ctx.last_prompt_tokens if ctx.last_prompt_tokens > 0 else 0
+            if _lpt:
+                pct = min(100, _lpt / ctx.context_length * 100) if ctx.context_length else 0
+                lines.append(t("gateway.usage.label_context", used=f"{_lpt:,}", total=f"{ctx.context_length:,}", pct=f"{pct:.0f}"))
             if ctx.compression_count:
                 lines.append(t("gateway.usage.label_compressions", count=ctx.compression_count))
 

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -120,6 +120,16 @@ class TestDefaults:
         assert status["threshold_tokens"] == 100000
         assert 0 < status["usage_percent"] <= 100
 
+    def test_default_get_status_clamps_post_compression_sentinel(self):
+        """After a compression, last_prompt_tokens is the -1 sentinel. get_status
+        must clamp it to 0 rather than export a raw -1 or a negative
+        usage_percent on the transitional turn."""
+        engine = StubEngine()
+        engine.last_prompt_tokens = -1
+        status = engine.get_status()
+        assert status["last_prompt_tokens"] == 0
+        assert status["usage_percent"] >= 0
+
     def test_on_session_reset(self):
         engine = StubEngine()
         engine.last_prompt_tokens = 999

--- a/tests/run_agent/test_percentage_clamp.py
+++ b/tests/run_agent/test_percentage_clamp.py
@@ -84,8 +84,10 @@ class TestSourceLinesAreClamped:
         # The /usage stats handler was extracted from gateway/run.py into
         # gateway/slash_commands.py (god-file decomposition Phase 3b).
         src = self._read_file("gateway/slash_commands.py")
-        # Check that the stats handler has min(100, ...)
-        assert "min(100, ctx.last_prompt_tokens" in src, (
+        # Check that the stats handler clamps the context pct with min(100, ...).
+        # Assert the clamp intent, not a specific local name (the occupancy
+        # value is read into a clamped `_lpt` local, #50421).
+        assert "min(100, _lpt / ctx.context_length" in src, (
             "gateway/slash_commands.py stats pct is not clamped with min(100, ...)"
         )
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8513,3 +8513,22 @@ def test_get_usage_reports_real_current_occupancy():
     assert usage["context_used"] == 60_000
     assert usage["context_max"] == 120_000
     assert usage["context_percent"] == 50
+
+
+def test_get_usage_clamps_post_compression_sentinel():
+    """Right after a compression, last_prompt_tokens is the -1 sentinel
+    (conversation_compression sets it until the next real usage report). It is
+    truthy, so `or 0` doesn't neutralize it — the guard must clamp <0 to 0 so
+    the transitional turn emits no gauge instead of leaking context_used=-1."""
+    agent = types.SimpleNamespace(
+        model="test-model",
+        session_total_tokens=4_000_000,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=-1,
+            context_length=1_048_576,
+            compression_count=6,
+        ),
+    )
+    usage = server._get_usage(agent)
+    assert "context_used" not in usage
+    assert "context_percent" not in usage

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8474,3 +8474,42 @@ class TestResolveRuntimeWithFallback:
 
         assert agent.model == "gpt-5.5"
         assert captured["provider"] == "deepseek"
+
+
+def test_get_usage_does_not_substitute_cumulative_total_for_context_used():
+    """An external context engine that does not report last_prompt_tokens must
+    not have the cumulative lifetime session_total_tokens shown as its current
+    context occupancy — that substitution produced impossible 1.9m/120k (100%)
+    status-bar readings (#50421). With no real current occupancy known,
+    context_used/percent stay unset rather than wrong."""
+    agent = types.SimpleNamespace(
+        model="test-model",
+        session_total_tokens=1_900_000,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=0,
+            context_length=120_000,
+            compression_count=0,
+        ),
+    )
+    usage = server._get_usage(agent)
+    assert usage.get("context_used") != 1_900_000
+    assert "context_used" not in usage
+    assert "context_percent" not in usage
+
+
+def test_get_usage_reports_real_current_occupancy():
+    """When the compressor reports a real current prompt size, context_used is
+    that value (not the cumulative total) and the percent is sane."""
+    agent = types.SimpleNamespace(
+        model="test-model",
+        session_total_tokens=1_900_000,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=60_000,
+            context_length=120_000,
+            compression_count=2,
+        ),
+    )
+    usage = server._get_usage(agent)
+    assert usage["context_used"] == 60_000
+    assert usage["context_max"] == 120_000
+    assert usage["context_percent"] == 50

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2964,12 +2964,25 @@ def _get_usage(agent) -> dict:
     }
     comp = getattr(agent, "context_compressor", None)
     if comp:
-        ctx_used = getattr(comp, "last_prompt_tokens", 0) or usage["total"] or 0
+        # context_used is the *current-window* occupancy. Do NOT fall back to
+        # usage["total"] (cumulative lifetime session_total_tokens): for an
+        # external context engine that doesn't report last_prompt_tokens that
+        # substitution showed lifetime totals as the live context fill, yielding
+        # impossible readings such as 1.9m/120k clamped to 100% (#50421).
+        #
+        # Per the issue, populate context_used/percent only from a *real*
+        # current-occupancy value and "leave it unknown otherwise" — so a falsy
+        # last_prompt_tokens (0 or missing, i.e. an engine that doesn't track
+        # per-window occupancy) intentionally emits no gauge rather than a
+        # fabricated 0% or the old cumulative reading. The built-in compressor
+        # always reports a real last_prompt_tokens once a turn runs, so it is
+        # unaffected.
+        last_prompt = getattr(comp, "last_prompt_tokens", 0) or 0
         ctx_max = getattr(comp, "context_length", 0) or 0
-        if ctx_max:
-            usage["context_used"] = ctx_used
+        if ctx_max and last_prompt:
+            usage["context_used"] = last_prompt
             usage["context_max"] = ctx_max
-            usage["context_percent"] = max(0, min(100, round(ctx_used / ctx_max * 100)))
+            usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2977,7 +2977,13 @@ def _get_usage(agent) -> dict:
         # fabricated 0% or the old cumulative reading. The built-in compressor
         # always reports a real last_prompt_tokens once a turn runs, so it is
         # unaffected.
+        # Clamp the -1 "compression just ran, awaiting real usage" sentinel
+        # (conversation_compression.py) to 0 so the transitional turn reads as
+        # unknown (no gauge) instead of leaking context_used=-1. Matches the
+        # CLI status-bar path (cli.py _get_status_bar_snapshot).
         last_prompt = getattr(comp, "last_prompt_tokens", 0) or 0
+        if last_prompt < 0:
+            last_prompt = 0
         ctx_max = getattr(comp, "context_length", 0) or 0
         if ctx_max and last_prompt:
             usage["context_used"] = last_prompt


### PR DESCRIPTION
## Summary
The TUI/dashboard status bar no longer shows impossible context-usage readings like `4m/1m` (100% red) when the real context is well within the window.

`tui_gateway/server.py::_get_usage()` computed `context_used = last_prompt_tokens or usage["total"]` — falling back to **cumulative lifetime** `session_total_tokens` whenever `last_prompt_tokens` was falsy. In a long session (this report: 348 tool-turns → ~4M cumulative tokens) the bar rendered `4m/1m` pegged at 100% red even though each API call only sent ~189k/1M. `context_used` is a *current-window* signal; cumulative lifetime usage is not interchangeable with it.

## Changes
- `tui_gateway/server.py`: drop the `or usage["total"]` cumulative fallback — populate `context_used`/`context_percent` only from a real current-occupancy value; emit no gauge when it's unknown (prefer absent over wrong). Clamp the `-1` post-compression sentinel to 0.
- **Whole-bug-class sweep** — the same `-1` sentinel (parked by `conversation_compression.py` after every compression) leaked into other status readers, producing a raw `-1` or a **negative** `usage_percent` on the transitional turn. Clamped at every sibling site:
  - `agent/context_engine.py::get_status()` — the ABC default every external context engine inherits (highest blast radius)
  - `gateway/slash_commands.py` `/usage` context line
  - `cli.py` session-usage printout
- `tests/`: salvaged tests (no cumulative substitution; real occupancy reported) + regression tests for the `-1` sentinel in both `_get_usage` and the ABC `get_status`.

## Root cause
`context_used = getattr(comp, "last_prompt_tokens", 0) or usage["total"] or 0` where `usage["total"]` is cumulative `session_total_tokens`. When `last_prompt_tokens` is falsy (0, or the `-1` sentinel), the `or` chain substitutes lifetime totals as the live context fill. The built-in compressor reports a real `last_prompt_tokens` once a turn runs, so steady-state is unaffected — the bad value surfaces on transitional/edge turns and for external context engines that don't track per-window occupancy (`context.engine: lcm`).

The `-1` sentinel is truthy, so `last_prompt_tokens or 0` does NOT neutralize it — the fix clamps `<0 → 0` at every status reader, mirroring the CLI status-bar path (`cli.py::_get_status_bar_snapshot`, which already clamped). Only `tui_gateway/server.py` had the *cumulative-total* fallback; the sibling sites had the softer negative-percent variant of the same sentinel class.

## Validation
| last_prompt_tokens | Before | After |
|---|---|---|
| falsy (0) + 4M cumulative | `4m/1m` @ 100% (red) | no gauge (unknown) |
| real 189k / 1M | correct | `189k/1M` = 18% |
| `-1` post-compression sentinel | `-1` / negative % leaked | no gauge / clamped to 0 |

- 328 tests pass across `tests/test_tui_gateway_server.py` + `tests/agent/test_context_engine.py` (1 pre-existing unrelated browser-test failure on `origin/main` deselected). ruff clean.
- E2E-verified with real imports against the reporter's exact scenario (glm-5.2, 1M window, ~4M cumulative).
- All consumers of the now-optional `context_used`/`context_percent`/`context_max` keys verified missing-key-safe across Python, Ink TUI (`ui-tui/`), and Electron desktop (`apps/desktop/`).

Salvaged from #50518 by @r266-tech (cherry-picked to preserve authorship), with follow-up commits fixing the `-1` sentinel edge case and widening the fix to sibling status paths. Duplicate of the same core line fixed independently in #55940 (@HenkDz) — both credited on close.

Closes #50421
