### PR TITLE
fix(file): block credential paths from search results

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -293,7 +293,7 @@ def get_read_block_error(path: str) -> Optional[str]:
     # .env contents — .env.example is the documented-shape substitute. The
     # terminal tool can still ``cat .env``; this is defense-in-depth, not a
     # boundary (see module docstring).
-    if resolved.name in _BLOCKED_PROJECT_ENV_BASENAMES:
+    if resolved.name.lower() in _BLOCKED_PROJECT_ENV_BASENAMES:
         return (
             f"Access denied: {path} is a secret-bearing environment file "
             "and cannot be read to prevent credential leakage. "

--- a/tests/agent/test_file_safety.py
+++ b/tests/agent/test_file_safety.py
@@ -44,6 +44,19 @@ class TestEnvFileReadBlocking:
         error = get_read_block_error("/home/user/app/services/api/.env.production")
         assert error is not None
 
+    @pytest.mark.parametrize("basename", [
+        ".ENV",
+        ".Env.Local",
+        ".ENV.PRODUCTION",
+        ".ENVRC",
+    ])
+    def test_blocked_env_basenames_case_insensitive(self, basename):
+        """Secret-bearing .env basenames are blocked regardless of case."""
+        error = get_read_block_error(f"/tmp/project/{basename}")
+        assert error is not None, f"{basename} should be blocked"
+        assert "Access denied" in error
+        assert "environment file" in error.lower()
+
     def test_blocked_env_absolute_path(self):
         """Absolute paths to .env files are blocked."""
         error = get_read_block_error("/opt/myapp/.env")

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -190,6 +190,98 @@ def test_read_file_tool_blocks_nested_google_oauth_path(
     assert "ACCESS_TOKEN_MARKER" not in json.dumps(out)
 
 
+def test_search_tool_blocks_direct_auth_json_path(fake_home, monkeypatch):
+    """Searching a credential file directly must not invoke the search backend."""
+    import json
+
+    import tools.file_tools as ft
+
+    auth = _create(fake_home, "auth.json")
+    auth.write_text("SEARCH_DIRECT_AUTH_SECRET", encoding="utf-8")
+
+    def fail_if_called(task_id="default"):
+        raise AssertionError("search backend should not run for blocked path")
+
+    monkeypatch.setattr(ft, "_get_file_ops", fail_if_called)
+
+    out = json.loads(
+        ft.search_tool(
+            pattern="SEARCH_DIRECT_AUTH_SECRET",
+            path=str(auth),
+            task_id="search-direct-auth-json",
+        )
+    )
+    raw = json.dumps(out)
+    assert "error" in out
+    assert "credential store" in out["error"]
+    assert "SEARCH_DIRECT_AUTH_SECRET" not in raw
+
+
+def test_search_tool_filters_credential_results(fake_home, tmp_path, monkeypatch):
+    """Directory searches omit credential and MCP-token result entries."""
+    import json
+
+    from tools.file_operations import SearchMatch, SearchResult
+    import tools.file_tools as ft
+
+    auth = _create(fake_home, "auth.json")
+    token = _create(fake_home, Path("mcp-tokens") / "provider.json")
+    safe = _create(fake_home, "notes.txt")
+
+    class FakeFileOps:
+        def search(self, **kwargs):
+            return SearchResult(
+                matches=[
+                    SearchMatch(
+                        path=str(auth),
+                        line_number=1,
+                        content="SEARCH_AUTH_SECRET",
+                    ),
+                    SearchMatch(
+                        path=str(token),
+                        line_number=1,
+                        content="SEARCH_MCP_SECRET",
+                    ),
+                    SearchMatch(
+                        path=str(safe),
+                        line_number=1,
+                        content="public note",
+                    ),
+                ],
+                files=[str(auth), str(token), str(safe)],
+                total_count=5,
+                truncated=True,
+            )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": FakeFileOps())
+    monkeypatch.setattr(
+        ft, "_get_live_tracking_cwd", lambda task_id="default": None
+    )
+
+    search_response = ft.search_tool(
+        pattern="SEARCH",
+        path=str(fake_home),
+        task_id="search-filter-credentials",
+    )
+    out = json.loads(search_response.split("\n\n[Hint:", 1)[0])
+    raw = json.dumps(out)
+    returned_paths = {
+        match["path"] for match in out.get("matches", [])
+    } | set(out.get("files", []))
+
+    assert "SEARCH_AUTH_SECRET" not in raw
+    assert "SEARCH_MCP_SECRET" not in raw
+    assert str(auth) not in returned_paths
+    assert str(token) not in returned_paths
+    assert "public note" in raw
+    assert str(safe) in returned_paths
+    assert out["_omitted"].startswith("4 result(s) omitted")
+    assert out["total_count"] == 5
+    assert out["truncated"] is True
+    assert "[Hint: Results truncated." in search_response
+
+
 # ---------------------------------------------------------------------------
 # Widening: .env, webhook_subscriptions.json, mcp-tokens/
 # ---------------------------------------------------------------------------

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -411,6 +411,55 @@ def _is_blocked_device(filepath: str, base_dir: str | Path | None = None) -> boo
     return False
 
 
+def _search_result_read_block_error(path: str, task_id: str = "default") -> str | None:
+    """Return the read-safety error for a search result path.
+
+    Search backends may return paths relative to the task cwd, while
+    ``get_read_block_error`` expects an already-resolved path when the task cwd
+    can differ from the Python process cwd. Mirror ``read_file_tool``'s path
+    resolution before applying the shared read guard.
+    """
+    try:
+        resolved = _resolve_path_for_task(path, task_id)
+    except (OSError, ValueError, RuntimeError):
+        return get_read_block_error(path)
+    return get_read_block_error(str(resolved))
+
+
+def _filter_read_blocked_search_results(result, task_id: str = "default") -> int:
+    """Remove credential/cache/env paths from a SearchResult in-place."""
+    omitted = 0
+
+    if hasattr(result, "matches") and result.matches:
+        allowed_matches = []
+        for match in result.matches:
+            if _search_result_read_block_error(match.path, task_id):
+                omitted += 1
+                continue
+            allowed_matches.append(match)
+        result.matches = allowed_matches
+
+    if hasattr(result, "files") and result.files:
+        allowed_files = []
+        for file_path in result.files:
+            if _search_result_read_block_error(file_path, task_id):
+                omitted += 1
+                continue
+            allowed_files.append(file_path)
+        result.files = allowed_files
+
+    if hasattr(result, "counts") and result.counts:
+        allowed_counts = {}
+        for file_path, count in result.counts.items():
+            if _search_result_read_block_error(file_path, task_id):
+                omitted += 1
+                continue
+            allowed_counts[file_path] = count
+        result.counts = allowed_counts
+
+    return omitted
+
+
 # Paths that file tools should refuse to write to without going through the
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
 _SENSITIVE_PATH_PREFIXES = (
@@ -1732,16 +1781,31 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 "already_searched": count,
             }, ensure_ascii=False)
 
+        try:
+            resolved_path = _resolve_path_for_task(path, task_id)
+        except (OSError, ValueError, RuntimeError):
+            resolved_path = None
+        block_error = get_read_block_error(str(resolved_path) if resolved_path else path)
+        if block_error:
+            return json.dumps({"error": block_error}, ensure_ascii=False)
+
         file_ops = _get_file_ops(task_id)
         result = file_ops.search(
             pattern=pattern, path=path, target=target, file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
+        omitted = _filter_read_blocked_search_results(result, task_id)
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
                     m.content = redact_sensitive_text(m.content, file_read=True)
         result_dict = result.to_dict(densify=True)
+
+        if omitted:
+            result_dict["_omitted"] = (
+                f"{omitted} result(s) omitted because they target credential, "
+                "token, cache, or secret-bearing environment files."
+            )
 
         if count >= 3:
             result_dict["_warning"] = (


### PR DESCRIPTION
## Summary
`search_tool` now honours the same read-safety guard that `read_file_tool` already enforces — credential stores, MCP token files, and secret-bearing `.env` files no longer leak through file-search output. Salvage of #35841 by @zapabob, rebased onto current `main`.

Confirmed on `main` before the fix: searching `~/.hermes` for a token returned `auth.json`'s raw contents, and `.ENV` / `.Env.Local` bypassed the read guard entirely (case-sensitive basename check).

## Changes
- `tools/file_tools.py`: `search_tool` returns the read-block error for a directly-searched credential path, and filters blocked paths out of `matches` / `files` / `counts` before returning. `total_count` / `truncated` pagination metadata is preserved so safe later results stay reachable. An `_omitted` note reports how many entries were withheld.
- `agent/file_safety.py`: `.env`-family basename blocking is now case-insensitive (`.ENV`, `.Env.Local`, …).
- Tests: search-path guard coverage + case-insensitive basename cases.

Framed (and implemented) as defense-in-depth, consistent with the module's own docstring — the terminal tool remains the explicit escape hatch. This closes a confusion/leak surface for models that respect tool denials, not a security boundary.

## Validation
| Path | Before | After |
|---|---|---|
| Direct search of `auth.json` | returns raw secret | access denied, backend never runs |
| Directory search surfacing a credential file | secret in `matches` | omitted, `_omitted` note, `total_count` preserved |
| `files`-mode listing `auth.json` | returned | filtered |
| Safe file in same search | returned | still returned |
| `.ENV` / `.Env.Local` read | not blocked | blocked |

- Targeted suite: `tests/agent/test_file_safety.py` + `tests/agent/test_file_safety_credentials.py` → 44 passed.
- Live E2E against the real search backend (isolated `HERMES_HOME`): direct-auth blocked, directory leak gone, files-mode filtered, safe files kept, case-insensitive `.env` blocking confirmed.

## Infographic
![PR #35841 infographic](https://v3b.fal.media/files/b/0aa07a1a/ZJDAxnpj0g1-szlKniksI_lF0vgU6p.png)

Nous Research
