### PR TITLE
fix(cli): restore Kilo alpha router models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -450,6 +450,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4",
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
+        "openrouter/elephant-alpha",
+        "openrouter/owl-alpha",
     ],
     # Alibaba DashScope Coding platform (coding-intl) — default endpoint.
     # Supports Qwen models + third-party providers (GLM, Kimi, MiniMax).

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -57,6 +57,24 @@ class TestOpenRouterModels:
             assert isinstance(desc, str)
 
 
+class TestKiloCodeModels:
+    def test_kilocode_static_picker_includes_openrouter_alpha_models(self):
+        """Kilo Gateway exposes OpenRouter alpha routers, so keep them in the fallback picker."""
+        openrouter_alpha_models = {
+            mid
+            for mid, desc in _models_mod.OPENROUTER_MODELS
+            if desc == "free" and mid.startswith("openrouter/") and "alpha" in mid
+        }
+
+        with patch("hermes_cli.models.provider_model_ids", return_value=[]):
+            kilo_models = {
+                mid for mid, _ in _models_mod.curated_models_for_provider("kilocode")
+            }
+
+        assert openrouter_alpha_models
+        assert openrouter_alpha_models <= kilo_models
+
+
 class TestFetchOpenRouterModels:
     def test_live_fetch_recomputes_free_tags(self, monkeypatch):
         class _Resp:


### PR DESCRIPTION
## Summary
- add OpenRouter alpha router IDs to the Kilo Code fallback model picker
- cover the Kilo fallback with a regression test tied to the curated OpenRouter alpha entries

Fixes #56145

## Tests
- scripts/run_tests.sh tests/hermes_cli/test_models.py