### PR TITLE
fix(runtime): ignore stale model.base_url config override for opencode-go/zen

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -38,10 +38,17 @@ class CLIAgentSetupMixin:
         _primary_exc = None
         runtime = None
         try:
+            # Pass the active model so the resolver can derive the correct
+            # api_mode / base_url for it (e.g. opencode-go needs to pick
+            # ``chat_completions`` for non-MiniMax models even when the config
+            # default is a MiniMax model that would imply ``anthropic_messages``
+            # and strip ``/v1`` from the endpoint).
+            _target_model = getattr(self, "model", None) or None
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=_target_model,
             )
         except Exception as exc:
             _primary_exc = exc

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -391,7 +391,26 @@ def _resolve_runtime_from_pool_entry(
         if configured_provider == provider and pool_url_is_default:
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
             if cfg_base_url:
-                base_url = cfg_base_url
+                # For opencode-zen/opencode-go: the gateway /model handler
+                # persists ``model.base_url`` on every switch.  When switching
+                # TO an ``anthropic_messages`` model (e.g. minimax-m3) the
+                # URL is stored WITHOUT ``/v1`` (correct for that mode — the
+                # Anthropic SDK appends ``/v1/messages``).  When the user
+                # then switches to a ``chat_completions`` model (e.g. glm-5.2)
+                # that stale URL would win the config override here and the
+                # OpenAI SDK would hit ``…/chat/completions`` without ``/v1``
+                # → HTTP 404.  Guard by requiring the config URL to still
+                # match the provider's current ``inference_base_url``; if it
+                # does not, silently keep the pool default (which has ``/v1``).
+                # Other providers are unaffected — their config overrides are
+                # legitimate user customizations (proxy URLs, etc.) and pass
+                # through unchanged.
+                if provider in {"opencode-zen", "opencode-go"}:
+                    if cfg_base_url == pconfig.inference_base_url.rstrip("/"):
+                        base_url = cfg_base_url
+                    # Else: keep pool default (with /v1).
+                else:
+                    base_url = cfg_base_url
         configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
         if provider in {"opencode-zen", "opencode-go"}:
             # Re-derive api_mode from the effective model rather than the

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -882,3 +882,57 @@ def test_save_custom_provider_uses_provided_name(monkeypatch, tmp_path):
     entries = saved.get("custom_providers", [])
     assert len(entries) == 1
     assert entries[0]["name"] == "Ollama"
+
+
+def test_ensure_runtime_credentials_passes_target_model_to_resolver(monkeypatch):
+    """Regression: ``_ensure_runtime_credentials`` must pass the active
+    ``self.model`` as ``target_model`` to ``resolve_runtime_provider`` so
+    the api_mode / base_url are derived for the model actually being used,
+    not the config default.
+
+    Before the fix, the resolver used ``model_cfg.default`` (e.g.
+    ``minimax-m3`` → ``anthropic_messages``) and so the resulting
+    ``self.api_mode`` was wrong for any chat invoked with ``-m <other>``.
+    """
+    cli = _import_cli()
+    captured_kwargs = {}
+
+    def _runtime_resolve(**kwargs):
+        captured_kwargs.update(kwargs)
+        return {
+            "provider": "opencode-go",
+            "api_mode": "chat_completions",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "api_key": "test-key",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
+
+    # User runs: hermes chat -m qwen3.7-plus
+    shell = cli.HermesCLI(
+        model="qwen3.7-plus", provider="opencode-go", compact=True, max_turns=1
+    )
+
+    assert shell.model == "qwen3.7-plus"
+    assert shell.requested_provider == "opencode-go"
+
+    assert shell._ensure_runtime_credentials() is True
+
+    # The fix: resolver must receive the active model so it can pick the
+    # right api_mode (chat_completions for qwen3.7-plus, not
+    # anthropic_messages that the minimax-m3 default would imply).
+    assert captured_kwargs.get("target_model") == "qwen3.7-plus", (
+        f"_ensure_runtime_credentials must pass self.model as target_model; "
+        f"got kwargs={captured_kwargs!r}"
+    )
+    # And the resulting CLI state should reflect the chat_completions
+    # resolution, not whatever the config default would have implied.
+    assert shell.api_mode == "chat_completions"
+    assert shell.base_url == "https://opencode.ai/zen/go/v1"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1506,6 +1506,46 @@ def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch
     assert resolved["api_mode"] == "anthropic_messages"
 
 
+def test_opencode_go_stale_config_base_url_ignored_for_chat_completions(monkeypatch):
+    """When the gateway persists a ``model.base_url`` from a previous
+    /model switch (e.g. to MiniMax, which stores the URL without ``/v1``
+    because ``anthropic_messages`` mode strips it), that stale URL must
+    NOT override the provider's ``inference_base_url`` for a subsequent
+    ``chat_completions`` model.  Otherwise the OpenAI SDK constructs
+    ``…/chat/completions`` without ``/v1`` and every non-MiniMax model
+    404s on opencode-go.
+
+    The fix in ``_resolve_runtime_from_pool_entry`` only honours the
+    config ``base_url`` when it still matches the provider's current
+    ``inference_base_url``.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-go",
+            "default": "minimax-m3",
+            # Stale URL persisted by a previous /model minimax-m3 switch —
+            # the /v1 was stripped because anthropic_messages mode did it.
+            "base_url": "https://opencode.ai/zen/go",
+        },
+    )
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    # Resolve for a chat_completions model (GLM) with the stale config.
+    resolved = rp.resolve_runtime_provider(
+        requested="opencode-go", target_model="glm-5.2"
+    )
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "chat_completions"
+    # The stale config URL (without /v1) must NOT win — the pool default
+    # (with /v1) should be used instead.
+    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")


### PR DESCRIPTION
## Summary

The gateway `/model` handler (`gateway/slash_commands.py:1356-1357`) persists `model.base_url` on every model switch. When switching **to** an `anthropic_messages` model (e.g. `minimax-m3` on opencode-go), the URL is stored **without `/v1`** because the Anthropic SDK appends `/v1/messages` itself and the resolver strips the trailing `/v1`.

When the user then switches to a `chat_completions` model (e.g. `glm-5.2`, `qwen3.7-plus`, `kimi-k2.7-code`, `deepseek-v4-pro`), that stale URL (without `/v1`) wins the config override in `_resolve_runtime_from_pool_entry` and the OpenAI SDK hits `https://opencode.ai/zen/go/chat/completions` → **HTTP 404** (HTML "Not Found" page).

This affects all 19 non-MiniMax models on opencode-go when the config default is or was a MiniMax model. The CLI single-query path (`hermes chat -m <model>`) is unaffected because it does not persist `model.base_url` — only the gateway `/model` command does.

## Root cause

`hermes_cli/runtime_provider.py` → `_resolve_runtime_from_pool_entry` (lines 389-394):

```python
pconfig = PROVIDER_REGISTRY.get(provider)
pool_url_is_default = pconfig and base_url.rstrip("/") == pconfig.inference_base_url.rstrip("/")
if configured_provider == provider and pool_url_is_default:
    cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
    if cfg_base_url:
        base_url = cfg_base_url   # ← stale URL from config wins unconditionally
```

The `pool_url_is_default` guard only checks that the **pool's** base_url matches the provider's `inference_base_url` (which it does — the pool uses the plugin default with `/v1`). It does **not** check that the **config's** `base_url` also matches. So a stale config value persisted by a previous `/model` switch to an `anthropic_messages` model (which stripped `/v1`) wins the override.

## Fix

Scope the existing config-override logic to `opencode-zen`/`opencode-go` only: when the config `base_url` does not match the provider's current `inference_base_url`, silently keep the pool default (which includes `/v1`). Other providers are unaffected — their config overrides are legitimate user customizations (proxy URLs, etc.) and pass through unchanged.

```python
if provider in {"opencode-zen", "opencode-go"}:
    if cfg_base_url == pconfig.inference_base_url.rstrip("/"):
        base_url = cfg_base_url
    # Else: keep pool default (with /v1).
else:
    base_url = cfg_base_url
```

## Verification

- New regression test `test_opencode_go_stale_config_base_url_ignored_for_chat_completions`:
  - **RED** without the fix: `assert 'https://opencode.ai/zen/go' == 'https://opencode.ai/zen/go/v1'` → fails
  - **GREEN** with the fix: passes
- 132/133 tests in `test_runtime_provider_resolution.py` pass (1 pre-existing failure: `test_minimax_config_base_url_overrides_hardcoded_default` — MiniMax domain changed from `api.minimaxi.com` to `api.minimax.io`, unrelated to this fix)
- 2 sibling tests confirmed unaffected:
  - `test_config_base_url_honoured_when_provider_matches` (Tencent proxy URL override) → still passes
  - `test_opencode_go_model_derivation_beats_stale_persisted_api_mode` → still passes
- **E2E on live gateway**: `minimax-m3` ↔ `glm-5.2` round-trips work from Telegram after gateway restart; `qwen3.7-plus`, `kimi-k2.7-code`, `deepseek-v4-pro` also confirmed working via CLI

## Related

- #16878 — same bug family, fixed the `/model` switch api_mode derivation but not the stale base_url persistence
- #15319 — same root cause in `delegate_tool.py` (missing `target_model`)
- #53251 — complementary fix for `runtime_override` staleness in `_init_agent`