### PR TITLE
fix(browser): redact CDP URL credentials at every supervisor/log egress (salvage #55883)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -400,6 +400,30 @@ def _redact_url_userinfo(text: str) -> str:
     )
 
 
+def redact_cdp_url(value: object) -> str:
+    """Mask secrets in a CDP/browser endpoint URL before it is logged.
+
+    The global ``redact_sensitive_text`` deliberately passes web-URL query
+    params and ``user:pass@`` userinfo through unmasked (OAuth callbacks,
+    magic-link / pre-signed URLs the agent is meant to follow -- see the
+    web-URL note above). CDP discovery endpoints are NOT such a workflow:
+    their query-string tokens and userinfo passwords are pure credentials
+    that must never reach the logs. So for CDP URLs we opt INTO the two URL
+    redactors that the global pass leaves off.
+
+    This is the single source of truth for CDP-URL log redaction. Every site
+    that emits a resolved CDP URL to a log or exception message -- the browser
+    tool's session/discovery logs and the supervisor's attach-timeout error --
+    routes through here so the policy can never drift between call sites.
+    """
+    text = redact_sensitive_text("" if value is None else str(value))
+    if not text:
+        return text
+    text = _redact_url_query_params(text)
+    text = _redact_url_userinfo(text)
+    return text
+
+
 def _redact_http_request_target_query_params(text: str) -> str:
     """Redact sensitive query params in HTTP access-log request targets."""
     def _sub(m: re.Match) -> str:

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -411,10 +411,11 @@ def redact_cdp_url(value: object) -> str:
     that must never reach the logs. So for CDP URLs we opt INTO the two URL
     redactors that the global pass leaves off.
 
-    This is the single source of truth for CDP-URL log redaction. Every site
-    that emits a resolved CDP URL to a log or exception message -- the browser
-    tool's session/discovery logs and the supervisor's attach-timeout error --
-    routes through here so the policy can never drift between call sites.
+    This is the single source of truth for redacting a CDP URL that is passed
+    *directly* to a log or error message. Callers that instead need to redact an
+    exception whose text embeds the URL (e.g. a ``websockets`` connect error)
+    should route that through their own error-text helper, which delegates here
+    -- see ``tools.browser_supervisor._redact_cdp_error_text``.
     """
     text = redact_sensitive_text("" if value is None else str(value))
     if not text:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from agent.redact import redact_sensitive_text, RedactingFormatter
+from agent.redact import redact_cdp_url, redact_sensitive_text, RedactingFormatter
 
 
 @pytest.fixture(autouse=True)
@@ -908,3 +908,45 @@ class TestFireworksToken:
     def test_prefix_visible_in_masked_output(self):
         result = redact_sensitive_text(self.KEY, force=True)
         assert result.startswith("fw_AA")
+
+
+class TestRedactCdpUrl:
+    """redact_cdp_url() is the single chokepoint for CDP endpoint log redaction.
+
+    Unlike the global pass (which deliberately lets web-URL query params and
+    userinfo through for OAuth/magic-link workflows), CDP endpoint credentials
+    are pure secrets and must always be masked. Both the browser tool's
+    session/discovery logs and the supervisor's attach-timeout error route
+    through this helper.
+    """
+
+    def test_masks_query_string_token(self):
+        url = "wss://cdp.example/devtools/browser/abc?token=super-secret-999"
+        out = redact_cdp_url(url)
+        assert "super-secret-999" not in out
+        assert "token=***" in out
+
+    def test_masks_multiple_query_credentials(self):
+        url = "wss://provider.example/session?token=aaa-secret&apikey=bbb-secret"
+        out = redact_cdp_url(url)
+        assert "aaa-secret" not in out
+        assert "bbb-secret" not in out
+
+    def test_masks_userinfo_password(self):
+        url = "wss://user:p4ssw0rd@cdp.example/devtools/browser/x"
+        out = redact_cdp_url(url)
+        assert "p4ssw0rd" not in out
+        assert "user:***@" in out
+
+    def test_plain_url_passes_through(self):
+        url = "ws://localhost:9222/devtools/browser/abc123"
+        assert redact_cdp_url(url) == url
+
+    def test_non_string_input_coerced(self):
+        # Exceptions and other objects are stringified, not crashed on.
+        exc = RuntimeError("connect failed: wss://h/x?token=leak-me")
+        out = redact_cdp_url(exc)
+        assert "leak-me" not in out
+
+    def test_none_returns_empty(self):
+        assert redact_cdp_url(None) == ""

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -256,3 +256,95 @@ class TestCDPSupervisorTimeoutRedaction:
                 assert "127.0.0.1:9222" in str(exc)
             else:
                 raise AssertionError("TimeoutError was not raised")
+
+
+class TestCDPSupervisorStartErrorRedaction:
+    """CDPSupervisor.start() must not leak the CDP URL via the connect-error path.
+
+    The more common failure mode than attach-timeout: the first
+    websockets.connect(self.cdp_url) raises (bad URI, refused, TLS), the raw
+    exception is stashed as self._start_error, and start() re-raises it. Those
+    websockets exceptions embed the full raw cdp_url -- token and userinfo --
+    in their message. start() must re-raise a REDACTED error and must not leak
+    the secret via the exception message or the traceback cause chain.
+    """
+
+    def _run_start_hitting_error(self, cdp_url: str, start_error: BaseException):
+        """Invoke start() so it takes the _start_error re-raise branch.
+
+        start() clears _ready_event / _start_error and launches a thread, so we
+        can't pre-seed them. Instead we stub threading.Thread: the fake thread's
+        start() synchronously populates _start_error and sets the ready event,
+        exactly as the real supervisor loop does on a first-connect failure.
+        """
+        import threading
+        from tools.browser_supervisor import CDPSupervisor
+
+        sup = CDPSupervisor.__new__(CDPSupervisor)
+        sup.task_id = "test-task"
+        sup.cdp_url = cdp_url
+        sup._start_error = None
+        sup._stop_requested = False
+        sup._loop = None
+        sup._thread = None
+        sup._ready_event = threading.Event()
+
+        def _fake_thread(*args, **kwargs):
+            fake = Mock()
+
+            def _start():
+                sup._start_error = start_error
+                sup._ready_event.set()
+
+            fake.start.side_effect = _start
+            fake.is_alive.return_value = False
+            return fake
+
+        with patch("threading.Thread", side_effect=_fake_thread), patch.object(sup, "stop"):
+            sup.start(timeout=5.0)
+
+    def test_start_error_redacts_query_token(self):
+        # A realistic websockets-style error embedding the raw URL + token.
+        raw = "wss://cdp.example/devtools/browser/abc?token=super-secret-999"
+        err = ValueError(f"{raw} isn't a valid URI: hostname isn't provided")
+        try:
+            self._run_start_hitting_error(raw, err)
+        except Exception as exc:  # noqa: BLE001 - asserting on the surface
+            msg = str(exc)
+            assert "super-secret-999" not in msg, (
+                "raw token must not appear in the re-raised error message"
+            )
+            # The raw cause must be suppressed so it can't leak via traceback.
+            assert exc.__cause__ is None
+            assert getattr(exc, "__suppress_context__", False) is True
+        else:
+            raise AssertionError("start() did not re-raise the start error")
+
+    def test_start_error_redacts_userinfo_password(self):
+        raw = "wss://user:p4ssw0rd@cdp.example/devtools/browser/x"
+        err = ValueError(f"{raw} isn't a valid URI: hostname isn't provided")
+        try:
+            self._run_start_hitting_error(raw, err)
+        except Exception as exc:  # noqa: BLE001
+            assert "p4ssw0rd" not in str(exc)
+        else:
+            raise AssertionError("start() did not re-raise the start error")
+
+
+class TestRedactCdpErrorText:
+    """The supervisor's error-text chokepoint masks credentials, keeps context."""
+
+    def test_masks_query_token_in_exception(self):
+        from tools.browser_supervisor import _redact_cdp_error_text
+
+        err = ConnectionError("connect wss://h/x?token=leak-me failed")
+        out = _redact_cdp_error_text(err)
+        assert "leak-me" not in out
+
+    def test_preserves_non_secret_context(self):
+        from tools.browser_supervisor import _redact_cdp_error_text
+
+        err = ConnectionError("connect ws://127.0.0.1:9222/x failed: refused")
+        out = _redact_cdp_error_text(err)
+        assert "127.0.0.1:9222" in out
+        assert "refused" in out

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -162,3 +162,97 @@ class TestGetCdpOverride:
         assert resolved == WS_URL
         mock_get.assert_called_once_with(VERSION_URL, timeout=10)
 
+
+class TestCreateCdpSession:
+    """_create_cdp_session() must sanitize the CDP URL before logging.
+
+    PR #54851 added _sanitize_url_for_logs() and wired it into the three log
+    sites inside _resolve_cdp_override(). This test guards the fourth site
+    that was missed: the logger.info call inside _create_cdp_session(), which
+    receives the already-resolved CDP URL and could contain a query-string
+    token (e.g. wss://provider.example/session?token=secret).
+    """
+
+    def test_redacts_token_in_session_creation_log(self):
+        from tools.browser_tool import _create_cdp_session
+
+        cdp_url_with_token = "wss://cdp.example/devtools/browser/abc?token=super-secret-token-999"
+
+        with patch("tools.browser_tool.logger.info") as mock_info:
+            result = _create_cdp_session("task-1", cdp_url_with_token)
+
+        assert result["cdp_url"] == cdp_url_with_token, "raw URL must be stored unmodified"
+
+        mock_info.assert_called_once()
+        logged_args = " ".join(str(a) for a in mock_info.call_args.args)
+        assert "super-secret-token-999" not in logged_args
+        assert "token=***" in logged_args
+
+    def test_plain_url_without_secrets_passes_through(self):
+        from tools.browser_tool import _create_cdp_session
+
+        plain_url = "ws://localhost:9222/devtools/browser/abc123"
+
+        with patch("tools.browser_tool.logger.info") as mock_info:
+            _create_cdp_session("task-2", plain_url)
+
+        logged_args = " ".join(str(a) for a in mock_info.call_args.args)
+        assert "localhost:9222" in logged_args
+
+
+class TestCDPSupervisorTimeoutRedaction:
+    """CDPSupervisor.start() TimeoutError must not expose raw CDP credentials.
+
+    The supervisor raises TimeoutError(f"... (cdp_url={self.cdp_url[:80]}...)")
+    when attach times out.  A URL with a query-string token (e.g.
+    wss://provider.example/session?token=secret) would embed the raw secret
+    in the exception message, which propagates to caller logs and tracebacks.
+    """
+
+    def _make_timed_out_supervisor(self, cdp_url: str):
+        """Return a CDPSupervisor whose start() will time out immediately."""
+        import threading
+        from tools.browser_supervisor import CDPSupervisor
+
+        sup = CDPSupervisor.__new__(CDPSupervisor)
+        sup.task_id = "test-task"
+        sup.cdp_url = cdp_url
+        sup._start_error = None
+        sup._stop_requested = False
+        sup._loop = None
+        # _thread = None so the is_alive() early-return guard is skipped.
+        sup._thread = None
+        # _ready_event that never fires so wait() always returns False.
+        never_ready = threading.Event()
+        sup._ready_event = never_ready
+        return sup
+
+    def test_timeout_error_redacts_query_token(self):
+        cdp_url = "wss://cdp.example/devtools/browser/abc?token=super-secret-999"
+        sup = self._make_timed_out_supervisor(cdp_url)
+
+        with patch("threading.Thread") as mock_thread_cls, patch.object(sup, "stop"):
+            mock_thread_cls.return_value = Mock()
+            try:
+                sup.start(timeout=0.001)
+            except TimeoutError as exc:
+                msg = str(exc)
+                assert "super-secret-999" not in msg, (
+                    "raw token must not appear in TimeoutError message"
+                )
+                assert "cdp_url=" in msg
+            else:
+                raise AssertionError("TimeoutError was not raised")
+
+    def test_timeout_error_preserves_plain_url(self):
+        plain_url = "ws://127.0.0.1:9222/devtools/browser/abc"
+        sup = self._make_timed_out_supervisor(plain_url)
+
+        with patch("threading.Thread") as mock_thread_cls, patch.object(sup, "stop"):
+            mock_thread_cls.return_value = Mock()
+            try:
+                sup.start(timeout=0.001)
+            except TimeoutError as exc:
+                assert "127.0.0.1:9222" in str(exc)
+            else:
+                raise AssertionError("TimeoutError was not raised")

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -341,9 +341,18 @@ class CDPSupervisor:
         self._thread.start()
         if not self._ready_event.wait(timeout=timeout):
             self.stop()
+            try:
+                from agent.redact import (
+                    _redact_url_query_params,
+                    _redact_url_userinfo,
+                    redact_sensitive_text,
+                )
+                _safe_url = _redact_url_userinfo(_redact_url_query_params(redact_sensitive_text(self.cdp_url)))
+            except Exception:
+                _safe_url = "<cdp_url redacted>"
             raise TimeoutError(
                 f"CDP supervisor did not attach within {timeout}s "
-                f"(cdp_url={self.cdp_url[:80]}...)"
+                f"(cdp_url={_safe_url[:80]}...)"
             )
         if self._start_error is not None:
             err = self._start_error

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -342,12 +342,8 @@ class CDPSupervisor:
         if not self._ready_event.wait(timeout=timeout):
             self.stop()
             try:
-                from agent.redact import (
-                    _redact_url_query_params,
-                    _redact_url_userinfo,
-                    redact_sensitive_text,
-                )
-                _safe_url = _redact_url_userinfo(_redact_url_query_params(redact_sensitive_text(self.cdp_url)))
+                from agent.redact import redact_cdp_url
+                _safe_url = redact_cdp_url(self.cdp_url)
             except Exception:
                 _safe_url = "<cdp_url redacted>"
             raise TimeoutError(

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -34,6 +34,25 @@ from websockets.asyncio.client import ClientConnection
 logger = logging.getLogger(__name__)
 
 
+def _redact_cdp_error_text(exc: object) -> str:
+    """Redact any CDP endpoint credentials from an error's string form.
+
+    ``websockets`` bakes the raw target URL into its exception messages
+    (``InvalidURI``, connection errors, TLS failures all embed the full
+    ``self.cdp_url`` — including a ``?token=`` query credential or
+    ``user:pass@`` userinfo). Every supervisor egress point that turns such an
+    exception into log text or a re-raised message MUST route through here so
+    those credentials never reach Hermes logs or tracebacks. Falls back to a
+    fixed sentinel if redaction itself raises, erring toward masking.
+    """
+    try:
+        from agent.redact import redact_cdp_url
+
+        return redact_cdp_url(str(exc))
+    except Exception:
+        return "<error redacted>"
+
+
 # ── Config defaults ───────────────────────────────────────────────────────────
 
 DIALOG_POLICY_MUST_RESPOND = "must_respond"
@@ -353,7 +372,14 @@ class CDPSupervisor:
         if self._start_error is not None:
             err = self._start_error
             self.stop()
-            raise err
+            # ``err`` is a raw ``websockets`` exception whose message embeds the
+            # full cdp_url (token / userinfo). Re-raise a redacted RuntimeError
+            # and suppress the raw cause (``from None``) so no credential leaks
+            # via the message OR the traceback chain. Type is not load-bearing:
+            # the sole caller (_ensure_cdp_supervisor) only logs it.
+            raise RuntimeError(
+                f"CDP supervisor failed to start: {_redact_cdp_error_text(err)}"
+            ) from None
 
     def stop(self, timeout: float = 5.0) -> None:
         """Cancel the supervisor task and join the thread."""
@@ -631,7 +657,7 @@ class CDPSupervisor:
                     return
                 logger.warning(
                     "CDP supervisor %s: connect failed (attempt %s): %s",
-                    self.task_id, attempt, e,
+                    self.task_id, attempt, _redact_cdp_error_text(e),
                 )
                 await asyncio.sleep(min(backoff, 10.0))
                 backoff = min(backoff * 2, 10.0)
@@ -668,7 +694,7 @@ class CDPSupervisor:
                     "CDP supervisor %s: session dropped after %.1fs: %s",
                     self.task_id,
                     time.time() - last_success_at,
-                    e,
+                    _redact_cdp_error_text(e),
                 )
             finally:
                 with self._state_lock:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -65,11 +65,7 @@ import requests
 from typing import Dict, Any, Optional, List, Tuple, Union
 from pathlib import Path
 from agent.auxiliary_client import call_llm
-from agent.redact import (
-    redact_sensitive_text,
-    _redact_url_query_params,
-    _redact_url_userinfo,
-)
+from agent.redact import redact_cdp_url
 from hermes_constants import agent_browser_runnable, get_hermes_home
 from utils import env_int, is_truthy_value
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
@@ -244,21 +240,13 @@ _command_timeout_resolved = False
 def _sanitize_url_for_logs(value: object) -> str:
     """Mask secrets in logged browser endpoint URLs and URL-like errors.
 
-    The global ``redact_sensitive_text`` deliberately passes web-URL query
-    params and ``user:pass@`` userinfo through unmasked (OAuth callbacks,
-    magic-link / pre-signed URLs the agent is meant to follow — see the
-    web-URL note in ``agent/redact.py``). CDP discovery endpoints are NOT
-    such a workflow: their query-string tokens and userinfo passwords are
-    pure credentials that must never reach the logs. So at these log sites
-    we opt INTO the URL redactors that the global pass leaves off, reusing
-    the shared ``redact.py`` helpers rather than a second regex.
+    Thin wrapper over :func:`agent.redact.redact_cdp_url`, which is the single
+    source of truth for CDP-URL log redaction. Kept as a local name because
+    several browser-tool log sites reference it; the redaction policy itself
+    lives once in ``redact.py`` so the browser tool and the CDP supervisor
+    cannot drift apart.
     """
-    text = redact_sensitive_text(value)
-    if not text:
-        return text
-    text = _redact_url_query_params(text)
-    text = _redact_url_userinfo(text)
-    return text
+    return redact_cdp_url(value)
 
 
 def _get_command_timeout() -> int:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1945,7 +1945,7 @@ def _create_cdp_session(task_id: str, cdp_url: str) -> Dict[str, str]:
     import uuid
     session_name = f"cdp_{uuid.uuid4().hex[:10]}"
     logger.info("Created CDP browser session %s → %s for task %s",
-                session_name, cdp_url, task_id)
+                session_name, _sanitize_url_for_logs(cdp_url), task_id)
     return {
         "session_name": session_name,
         "bb_session_id": None,


### PR DESCRIPTION
## Summary

Salvage of #55883 (by @srojk34), rebased onto current `main` with the residual leak paths closed and the redaction policy consolidated into single chokepoints.

CDP endpoint URLs from hosted providers (Browserbase, Anchor, any CDP-over-HTTP provider) carry credentials in the query string (`?token=…`) or userinfo (`user:pass@`). #54851 added `_sanitize_url_for_logs()` for three log sites in `_resolve_cdp_override()` but missed every other place a resolved `cdp_url` reaches a log or exception. This PR closes the whole class.

## Leak sites closed

1. **`_create_cdp_session()` `logger.info`** — logged the raw resolved URL on every new CDP session (@srojk34's original fix).
2. **`CDPSupervisor.start()` attach-timeout `TimeoutError`** — interpolated raw `cdp_url[:80]` into the error, which `_ensure_cdp_supervisor()` logs (@srojk34's follow-up, in response to review on the original PR).
3. **`CDPSupervisor.start()` first-connect `raise err`** — the more common failure mode: when `websockets.connect(cdp_url)` fails (bad URI / refused / TLS), the raw `websockets` exception embeds the full URL (`InvalidURI: "wss://…?token=… isn't a valid URI…"`) and was re-raised verbatim. Now re-raised as a redacted `RuntimeError` with `from None` so the secret leaks via neither the message nor the traceback cause chain.
4. **Two reconnect `logger.warning` sites** (`connect failed`, `session dropped`) — logged the same raw connect exception.

## Architecture

Two enforced chokepoints instead of duplicated inline compositions:

- `agent.redact.redact_cdp_url()` — the single policy for redacting a CDP URL passed *directly* to a log/error (opts into the query-param + userinfo redactors that the global pass deliberately leaves off for OAuth/magic-link URLs). Both `browser_tool._sanitize_url_for_logs` (now a thin wrapper) and the supervisor route through it.
- `tools.browser_supervisor._redact_cdp_error_text()` — redacts an *exception's* text (where `websockets` bakes the URL in) before it is logged or re-raised; delegates to `redact_cdp_url`. All four supervisor egress points go through it.

The raw URL is preserved unmodified for the real connection and in the returned session dict — only the logged/raised representation is redacted.

## Tests

- `TestCreateCdpSession` — session-creation log redacts token, raw URL preserved in return value, plain URLs pass through.
- `TestCDPSupervisorTimeoutRedaction` — timeout error redacts token, preserves plain host.
- `TestCDPSupervisorStartErrorRedaction` — re-raised connect error redacts token + userinfo; raw cause suppressed (`__cause__ is None`, `__suppress_context__`). Verified with a mutation check (reverting to raw `raise err` fails these).
- `TestRedactCdpErrorText` — the supervisor helper masks credentials while preserving non-secret context (host, reason).
- `TestRedactCdpUrl` (in `tests/agent/test_redact.py`) — direct seam tests: query token, multiple credentials, userinfo, plain-URL passthrough, exception coercion, `None`.

`pytest tests/tools/test_browser_cdp_override.py tests/agent/test_redact.py tests/tools/test_browser_secret_exfil.py` → **161 passed**. `tests/tools/test_browser_supervisor.py` → 22 skipped (no Chrome CDP fixture), imports clean.

Closes #55883.

Co-authored-by: srojk34 <286497132+srojk34@users.noreply.github.com>
