### PR TITLE
fix(security): denylist ~/.hermes/mcp-tokens/ for media delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1160,12 +1160,18 @@ def _media_delivery_denied_paths() -> List[Path]:
         # Bitwarden Secrets Manager plaintext disk cache.
         os.path.join("cache", "bws_cache.json"),
     )
-    # Directory trees whose every child is credential material. (MCP OAuth
-    # tokens under mcp-tokens/ are handled by the sibling targeted PR #37222;
-    # session/kanban SQLite stores by #41071 — kept out of this diff to avoid
-    # overlap.)
+    # Directory trees whose every child is credential material.
+    #
+    # mcp-tokens/ holds live MCP OAuth access tokens (<server>.json) and
+    # dynamically-registered client credentials (<server>.client.json); see
+    # tools/mcp_oauth.py. Same credential class as auth.json/credentials/.
+    # The write side already denies it (file_tools _check_sensitive_path);
+    # this pairs the media-delivery (exfil) side so a prompt-injection MEDIA
+    # tag can't deliver a live bearer token as a native attachment.
+    # (session/kanban SQLite stores are handled by #41071 — kept out here.)
     _ROOT_CREDENTIAL_DIRS = (
         "pairing",
+        "mcp-tokens",
     )
     for hermes_root in (_HERMES_HOME, _HERMES_ROOT):
         for rel in _ROOT_CREDENTIAL_FILES:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -991,6 +991,38 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(env_file)) is None
 
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "mcp-tokens/github.json",
+            "mcp-tokens/github.client.json",
+            "mcp-tokens/github.meta.json",
+        ],
+    )
+    def test_denylist_blocks_mcp_oauth_tokens(self, tmp_path, monkeypatch, rel):
+        """Live MCP OAuth tokens/client creds under ~/.hermes/mcp-tokens/ must
+        never deliver as native media — same exfil class as auth.json/.env.
+        Sibling to the pairing/ directory denylist entry.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        (hermes_dir / "mcp-tokens").mkdir(parents=True)
+        secret = hermes_dir / rel
+        secret.write_text('{"access_token": "live-bearer-abc123"}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr(
+            "gateway.platforms.base._HERMES_HOME",
+            hermes_dir,
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._HERMES_ROOT",
+            hermes_dir,
+        )
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
+
     def test_denylist_blocks_hermes_config_in_active_profile(self, tmp_path, monkeypatch):
         """The active profile config stays blocked in default mode."""
         self._patch_roots(monkeypatch)


### PR DESCRIPTION
## Summary
Media delivery can no longer auto-attach a live MCP OAuth bearer token. `mcp-tokens/` is now on the media-delivery denylist, pairing the exfil side with the read/write guard that already blocked it.

Salvage of #37222 by @briandevans, cherry-picked onto current `main` with authorship preserved.

**Root cause:** `_media_delivery_denied_paths()` in `gateway/platforms/base.py` denied `.env`, `auth.json`, `credentials/`, `config.yaml`, and `pairing/` — but not `mcp-tokens/`. The read/write guard (`agent/file_safety.py`) already denied that directory, so the delivery/exfil side trailed the write side. A prompt-injection `MEDIA:~/.hermes/mcp-tokens/github.json` tag would, in default (non-strict) mode, deliver a live bearer token as a native gateway attachment.

## Changes
- `gateway/platforms/base.py`: add `"mcp-tokens"` to `_ROOT_CREDENTIAL_DIRS`. Directory-prefix containment (`_path_is_within`) seals the whole subtree (`<server>.json` / `.client.json` / `.meta.json`), mirroring `pairing/`. Comment updated (the old text pointed at this PR as the pending sibling).
- `tests/gateway/test_platform_base.py`: parametrized test asserting `validate_media_delivery_path` returns `None` for the three token file types.

## Validation
| | Before | After |
|---|---|---|
| `MEDIA:mcp-tokens/github.json` | delivered (leak) | `None` (denied) |
| `pairing/` , `auth.json` | denied | denied (no regression) |
| legit `cache/images/*.png` | delivers | delivers (feature preserved) |

- `scripts/run_tests.sh tests/gateway/test_platform_base.py` → 177/177 pass (3 new cases).
- E2E with real imports against a temp `HERMES_HOME`: all three token files DENIED, control siblings still denied, fresh cache image still delivers.

## Infographic
![PR #37222 infographic](https://v3b.fal.media/files/b/0aa07aa8/znXdZB1967JHKvfIo_U-5_IEZCd7Tj.png)

_Nous Research_
