### PR TITLE
fix(gateway): prevent interim stream from suppressing final reply

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17671,16 +17671,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             """Return True only when the actual final reply reached the user."""
             if consumer is None:
                 return False
-            if getattr(consumer, "final_response_sent", False):
-                return True
-            if previewed:
-                has_delivered_text = getattr(consumer, "has_delivered_text", None)
-                if callable(has_delivered_text):
-                    try:
-                        return bool(has_delivered_text(final_text))
-                    except Exception:
-                        return False
-            return False
+            delivery_flag = (
+                getattr(consumer, "final_response_sent", False)
+                or getattr(consumer, "final_content_delivered", False)
+                or previewed
+            )
+            if not delivery_flag:
+                return False
+            has_delivered_text = getattr(consumer, "has_delivered_text", None)
+            if callable(has_delivered_text):
+                try:
+                    return bool(has_delivered_text(final_text))
+                except Exception:
+                    return False
+            return bool(
+                getattr(consumer, "final_response_sent", False)
+                or getattr(consumer, "final_content_delivered", False)
+            )
 
         try:
             # Run in thread pool to not block.  Use an *inactivity*-based
@@ -18232,9 +18239,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # exact final text was delivered. Unrelated commentary/progress
             # must not be mistaken for the final response (#14238).
             _previewed = bool(response.get("response_previewed"))
-            _content_delivered = bool(
-                _sc and getattr(_sc, "final_content_delivered", False)
-            )
             # Plugin hooks (e.g. transform_llm_output) may have appended content
             # after streaming finished — when the response was transformed, always
             # send the final version so the appended content reaches the client.
@@ -18250,13 +18254,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _final,
                 previewed=_previewed,
             )
-            if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered):
+            if not _is_empty_sentinel and not _transformed and _streamed:
                 logger.info(
                     "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
                     session_key or "?",
                     _streamed,
                     _previewed,
-                    _content_delivered,
+                    bool(_sc and getattr(_sc, "final_content_delivered", False)),
                 )
                 response["already_sent"] = True
             elif not _is_empty_sentinel and _transformed and _sc is not None:

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -679,6 +679,22 @@ class StreamingRefineAgent:
         }
 
 
+class StreamingMismatchAgent:
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.stream_delta_callback:
+            self.stream_delta_callback("intermediate streamed text")
+        return {
+            "final_response": "real final answer",
+            "response_previewed": False,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class QueuedCommentaryAgent:
     calls = 0
 
@@ -1014,6 +1030,29 @@ async def test_run_agent_matrix_streaming_omits_cursor(monkeypatch, tmp_path):
     assert all_text, "expected streamed Matrix content to be sent or edited"
     assert all("▉" not in text for text in all_text)
     assert any("Continuing to refine:" in text for text in all_text)
+
+
+@pytest.mark.asyncio
+async def test_stream_delivery_flag_without_final_text_does_not_suppress_send(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingMismatchAgent,
+        session_id="sess-stream-mismatch",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+    )
+
+    assert result.get("already_sent") is not True
+    assert any(call["content"] == "intermediate streamed text" for call in adapter.sent)
 
 
 class TransformedStreamAgent:


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway final-delivery suppression bug where streamed interim content could be treated as if the final assistant response had already reached the user.

This matters for platforms such as Feishu/Lark because the final send/edit path is where Markdown content can be converted into rich-text post messages.

## Type of Change

- Bug fix
- Tests

## Changes Made

- Tightened final-delivery confirmation in `gateway/run.py`.
- Added a regression test where streamed interim text differs from the final answer.

## How to Test

```bash
uv run --extra dev pytest tests/gateway/test_run_progress_topics.py -q -k "previewed_final or previewed_split or matrix_streaming_omits_cursor or stream_delivery_flag_without_final_text or transformed_response"
uv run --extra dev pytest tests/gateway/test_feishu.py -q -k "build_post_payload or send_uses_post or edit_message"
uv run --extra dev pytest tests/gateway/test_duplicate_reply_suppression.py -q
uv run --extra dev pytest tests/gateway/test_update_streaming.py -q
uv run --extra dev pytest tests/gateway/test_update_command.py -q
uv run --extra dev pytest tests/test_transform_llm_output_hook.py -q