### PR TITLE
fix(compressor): skip context-summary markers as last-user tail anchor

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2224,9 +2224,21 @@ This compaction should PRIORITISE preserving all information related to the focu
     def _find_last_user_message_idx(
         self, messages: List[Dict[str, Any]], head_end: int
     ) -> int:
-        """Return the index of the last user-role message at or after *head_end*, or -1."""
+        """Return the index of the last user-role message at or after *head_end*, or -1.
+
+        A context-compaction handoff banner can be inserted as a ``role="user"``
+        message (see the summary-role selection in ``compress``). It is internal
+        continuity state, not a real user turn, so it must not be picked as the
+        tail anchor — otherwise ``_ensure_last_user_message_in_tail`` protects
+        the summary and rolls the genuine last user message into the next
+        compaction, re-triggering the active-task loss the anchor exists to
+        prevent.
+        """
         for i in range(len(messages) - 1, head_end - 1, -1):
-            if messages[i].get("role") == "user":
+            msg = messages[i]
+            if msg.get("role") == "user" and not self._is_context_summary_content(
+                msg.get("content")
+            ):
                 return i
         return -1
 

--- a/tests/agent/test_compressor_assistant_tail_anchor.py
+++ b/tests/agent/test_compressor_assistant_tail_anchor.py
@@ -477,6 +477,51 @@ class TestCompactionRollupReproduction:
 # ---------------------------------------------------------------------------
 
 
+class TestFindLastUserMessageIdxSkipsSummaryMarker:
+    """A context-compaction handoff banner is inserted with ``role="user"``
+    when the head ends in an assistant/tool message (see the summary-role
+    selection in ``compress``). ``_find_last_user_message_idx`` must NOT treat
+    that banner as the latest user turn — otherwise, on a resumed or
+    multi-compaction session, ``_ensure_last_user_message_in_tail`` anchors the
+    tail to the summary and rolls the genuine last user message into the next
+    compaction, re-triggering the active-task loss the anchor exists to prevent.
+    (Salvaged from #36626 / issue #36624.)
+    """
+
+    def test_skips_user_role_context_summary_marker(self, compressor):
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "REAL current task"},
+            {"role": "assistant", "content": "working on it"},
+            # A handoff summary re-inserted as a user-role message after resume.
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\n## Active Task\nold"},
+            {"role": "assistant", "content": "continuing from the real task"},
+        ]
+        # Latest *real* user message is index 1, not the summary at index 3.
+        assert compressor._find_last_user_message_idx(messages, head_end=1) == 1
+
+    def test_returns_real_user_when_no_summary_present(self, compressor):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "second"},
+        ]
+        assert compressor._find_last_user_message_idx(messages, head_end=1) == 3
+
+    def test_all_user_messages_are_summaries_returns_minus_one(self, compressor):
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\nhandoff"},
+        ]
+        assert compressor._find_last_user_message_idx(messages, head_end=1) == -1
+
+
 class TestSourceGuardrail:
     @pytest.fixture
     def source(self) -> str:


### PR DESCRIPTION
## Summary

Context compaction no longer mistakes its own handoff banner for the latest user turn. A `[CONTEXT COMPACTION — REFERENCE ONLY]` summary is inserted with `role="user"` when the protected head ends in an assistant/tool message; on a resumed or multi-compaction session, `_find_last_user_message_idx` returned that banner as the "latest user message", so `_ensure_last_user_message_in_tail` anchored the tail to the summary and rolled the genuine last user turn into the next compaction — the exact active-task loss the anchor exists to prevent (#10896 / #22523).

Root cause: `_find_last_user_message_idx` returned *any* `role="user"` message. The fix reuses the existing `_is_context_summary_content` helper (already used by `_find_latest_context_summary` and the summarizer serialization) to skip summary banners.

## Changes

- `agent/context_compressor.py`: `_find_last_user_message_idx` skips context-summary markers when locating the last real user turn.
- `tests/agent/test_compressor_assistant_tail_anchor.py`: adds `TestFindLastUserMessageIdxSkipsSummaryMarker` (skips user-role summary; returns real user when no summary; -1 when all user messages are summaries).

## Validation

| | Before | After |
|---|---|---|
| last-user anchor with a user-role summary banner present | anchors to the summary → real user rolled into compaction (task loss) | anchors to the real user turn → protected in tail |
| targeted tests | — | 24/24 `test_compressor_assistant_tail_anchor.py` green |
| compression suites | — | 139/139 (`test_context_compressor.py` + `test_compression_boundary.py`) green |
| E2E | — | fixed path anchors real user (idx 2); simulated old path anchors summary (idx 4) |

## Salvage note

Salvaged from #36626 by Frank Song (issue #36624), authorship preserved. The PR's other two proposed changes are superseded on current `main` and were intentionally dropped:

- Demoting completed tool results *inside* the protected tail → covered by the min_tail floor `_MAX_TAIL_MESSAGE_FLOOR=8` (#39170) and no-op compression counting at `compress_start >= compress_end` (#40803); demoting the tail the model is about to read is unnecessary and risky.
- Preflight `compression_exhausted` terminal result → main already returns `compression_exhausted` on the 413 path and an explicit "auto-compaction disabled" terminal error.

## Infographic

![Context compaction tail-anchor fix](https://v3b.fal.media/files/b/0aa07aab/pklpe8Ehx0DyXoS8aeQET_VOgHZhUh.png)

— Nous Research
