### PR TITLE
fix(security): close shell line-continuation bypass in command detection

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "290873280+rrevenanttt@users.noreply.github.com": "rrevenanttt",  # PR #40773 salvage (close hardline rm bypass via quoted paths and ${HOME} brace form)
+    "290871358+Vesna-9@users.noreply.github.com": "Vesna-9",  # PR #41274 salvage (collapse shell line continuations before dangerous/hardline pattern matching so `rm -rf \<newline>/` can't bypass the yolo-proof hardline floor)
     "jnibarger01@gmail.com": "jnibarger01",  # PR #35130 salvage (ReDoS-bound threat-pattern filler + FTS5 query cap + V4A Move-File approval/traversal targets)
     "290868363+petrichor-op@users.noreply.github.com": "petrichor-op",  # PR #41281 salvage (never persist ephemeral empty-response recovery scaffolding to the SQLite session store / JSON log; filter by flag not position)
     "283494121+redactdeveloper@users.noreply.github.com": "redactdeveloper",  # PR #36897 salvage (route /sessions & /history through prompt_toolkit-safe print; filter doctor missing-key summary to CLI-enabled toolsets)

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -201,6 +201,37 @@ def test_quoted_and_brace_paths_are_hardline_blocked(command):
 
 
 # -------------------------------------------------------------------------
+# Shell line-continuation bypass
+# -------------------------------------------------------------------------
+#
+# A backslash immediately followed by a newline is a POSIX line
+# continuation: the shell removes BOTH characters and joins the tokens, so
+# `rm -rf \<newline>/` executes as `rm -rf /`. The normalizer used to strip
+# only backslash-escapes of NON-newline characters (`\\([^\n])`), leaving the
+# dangling backslash wedged between tokens — which broke the structured
+# rm/dd/mkfs patterns and let a root wipe slip past the hardline floor.
+
+# (command_with_continuation, description_substring) — each is the
+# line-continuation form of a command already in _HARDLINE_BLOCK.
+_HARDLINE_LINE_CONTINUATION = [
+    ("rm -rf \\\n/", "root"),            # split before the path
+    ("rm -r\\\nf /", "root"),            # split inside the flag bundle
+    ("rm -rf \\\n~", "home"),            # home-directory wipe
+    ("rm -rf \\\r\n/", "root"),          # CRLF line ending
+    ("mkfs.ext4 \\\n/dev/sda1", "mkfs"),  # filesystem format
+]
+
+
+@pytest.mark.parametrize("command,desc_substr", _HARDLINE_LINE_CONTINUATION)
+def test_hardline_blocks_line_continuation(command, desc_substr):
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"line-continuation bypassed hardline detection: {command!r}"
+    assert desc and desc_substr in desc.lower(), (
+        f"unexpected description {desc!r} for {command!r}"
+    )
+
+
+# -------------------------------------------------------------------------
 # Integration with the approval flow
 # -------------------------------------------------------------------------
 
@@ -248,6 +279,21 @@ def test_yolo_env_var_cannot_bypass_hardline(clean_session, monkeypatch):
         r2 = check_all_command_guards(cmd, "local")
         assert r2["approved"] is False, f"yolo leaked hardline on {cmd!r} (check_all_command_guards)"
         assert r2.get("hardline") is True
+
+
+def test_line_continuation_root_wipe_cannot_bypass_hardline(clean_session, monkeypatch):
+    """A line-continuation root wipe must stay blocked even under yolo.
+
+    `rm -rf \\<newline>/` runs as `rm -rf /`. Yolo bypasses the regular
+    dangerous-command layer, so the hardline floor is the only thing left to
+    catch it — it must hold.
+    """
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    result = check_all_command_guards("rm -rf \\\n/", "local")
+    assert result["approved"] is False, "yolo leaked a line-continuation root wipe"
+    assert result.get("hardline") is True
+    assert "BLOCKED (hardline)" in result["message"]
 
 
 def test_session_yolo_cannot_bypass_hardline(clean_session):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -661,6 +661,16 @@ def _normalize_command_for_detection(command: str) -> str:
     command = command.replace('\x00', '')
     # Normalize Unicode (fullwidth Latin, halfwidth Katakana, etc.)
     command = unicodedata.normalize('NFKC', command)
+    # Collapse shell line continuations (backslash-newline). The shell removes
+    # BOTH characters and joins the tokens, so `rm -rf \<newline>/` executes as
+    # `rm -rf /`. This must run BEFORE the generic backslash-escape strip below,
+    # whose [^\n] class deliberately skips newlines and would otherwise leave
+    # the dangling backslash wedged between tokens — defeating the structured
+    # rm/mkfs/dd patterns (notably the HARDLINE root-delete floor, which cannot
+    # be bypassed even with yolo). Handles both \n and \r\n line endings. Line
+    # continuations carry no path separator, so this is a no-op on the Windows
+    # home-prefix folds below (which match C:\Users\alice\... — no newline).
+    command = re.sub(r'\\\r?\n', '', command)
     # Fold absolute home / active-profile-home prefixes into their canonical
     # ~/ and ~/.hermes/ forms so static user-sensitive patterns catch
     # /home/alice/.bashrc and C:\Users\alice\.bashrc the same way they catch


### PR DESCRIPTION
## Summary
Closes a shell line-continuation bypass in the dangerous-command detector: `rm -rf \<newline>/` now blocks on the hardline floor instead of slipping past it under `--yolo`.

**Root cause:** `_normalize_command_for_detection` strips backslash-escapes with `re.sub(r'\\([^\n])', r'\1', ...)`, whose `[^\n]` class deliberately skips newlines. A backslash immediately followed by a newline is a POSIX line continuation — the shell removes both characters and joins the tokens. With the dangling `\` left in place, it sits wedged between the flags and the path, so the structured `rm` root-delete pattern (which anchors the path directly after the flags) no longer matches. The hardline blocklist is the unconditional floor meant to hold even under `--yolo` / `approvals.mode=off`, so `rm -rf \<newline>/`, `rm -r\<newline>f /`, and `rm -rf \<newline>~` all slipped past it — a yolo session could wipe the root filesystem. Gap left by 621bf3a87, which added the escape strip only for non-newline chars.

## Changes
- `tools/approval.py`: collapse line continuations (`\` + `\n` or `\r\n`) to nothing **before** the existing escape strip, mirroring the shell. Placed after NFKC and before the home-prefix folds — continuations carry no path separator, so it's a no-op on the Windows `C:\Users\alice\...` folds.
- `tests/tools/test_hardline_blocklist.py`: parametrized `test_hardline_blocks_line_continuation` (root, in-flag, home, CRLF, mkfs forms) + `test_line_continuation_root_wipe_cannot_bypass_hardline` (asserts the continuation root wipe stays blocked under `HERMES_YOLO_MODE=1`).
- `scripts/release.py`: AUTHOR_MAP entry for @Vesna-9.

## Validation
| Input | Before (main) | After |
|---|---|---|
| `rm -rf \<LF>/` | not flagged — bypass | hardline: recursive delete of root |
| `rm -r\<LF>f /` | not flagged — bypass | hardline: recursive delete of root |
| `rm -rf \<LF>~` | not flagged — bypass | hardline: recursive delete of home |
| `echo \<LF>hi` | — | normalizes to `echo hi`, not blocked |

- Bug confirmed on current `main` via real imports; all continuation forms now block on both the hardline and dangerous layers.
- Windows home-prefix fold verified unaffected.
- 364 tests pass (`test_hardline_blocklist.py` + `test_approval.py`).

Salvaged from #41274 with @Vesna-9's authorship preserved (rebase-merge).

## Infographic
![PR #41274 infographic](https://v3b.fal.media/files/b/0aa07ad4/i36dMuL0Xy4yehSliGC0f_hneJPaYR.png)

---
Nous Research
