### PR TITLE
fix(browser): block private-page interactions after eval navigation (salvage #55949)

### DIFF
--- a/tests/tools/test_browser_private_page_action_guard.py
+++ b/tests/tools/test_browser_private_page_action_guard.py
@@ -57,3 +57,50 @@ def test_click_still_runs_when_current_page_is_public(monkeypatch):
 
     assert out == {"success": True, "clicked": "@e1"}
     assert calls == [("task-1", "click", ["@e1"])]
+
+
+def test_guard_inactive_does_not_block_or_probe(monkeypatch):
+    """When the SSRF guard is inactive (local backend / allow_private_urls),
+    the action must proceed WITHOUT even probing the page URL — a private-looking
+    current URL is irrelevant. This is the branch most likely to silently regress
+    if the guard condition is ever inverted, so it is exercised explicitly."""
+    calls = []
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: False)
+
+    def fail_probe(task_id):
+        raise AssertionError("_current_page_private_url must not be probed when guard inactive")
+
+    monkeypatch.setattr(browser_tool, "_current_page_private_url", fail_probe)
+
+    def fake_run(task_id, command, args):
+        calls.append((task_id, command, args))
+        return {"success": True}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
+
+    out = json.loads(browser_tool.browser_click("@e1", task_id="task-1"))
+
+    assert out == {"success": True, "clicked": "@e1"}
+    assert calls == [("task-1", "click", ["@e1"])]
+
+
+def test_camofox_short_circuits_before_guard(monkeypatch):
+    """Camofox mode returns from the dedicated camofox_* path BEFORE reaching the
+    private-page guard, so the guard's helpers must never be consulted. Guards the
+    ordering invariant (camofox early-return precedes _last_session_key + guard)."""
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: True)
+
+    def fail_guard(task_id):
+        raise AssertionError("guard must not run in camofox mode")
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", fail_guard)
+    monkeypatch.setattr(browser_tool, "_current_page_private_url", fail_guard)
+
+    import tools.browser_camofox as camofox
+
+    monkeypatch.setattr(camofox, "camofox_click", lambda ref, task_id: '{"success": true, "camofox": true}')
+
+    out = json.loads(browser_tool.browser_click("@e1", task_id="task-1"))
+
+    assert out == {"success": True, "camofox": True}

--- a/tests/tools/test_browser_private_page_action_guard.py
+++ b/tests/tools/test_browser_private_page_action_guard.py
@@ -1,0 +1,59 @@
+"""Regression tests for private-page browser interaction guards."""
+
+import json
+
+import pytest
+
+from tools import browser_tool
+
+
+PRIVATE_URL = "http://169.254.169.254/latest/meta-data/"
+
+
+@pytest.fixture(autouse=True)
+def _browser_mode(monkeypatch):
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_last_session_key", lambda task_id: task_id)
+
+
+@pytest.mark.parametrize(
+    ("tool_call", "args"),
+    [
+        (browser_tool.browser_click, ("@e1",)),
+        (browser_tool.browser_type, ("@e1", "do-not-send-this")),
+        (browser_tool.browser_press, ("Enter",)),
+    ],
+)
+def test_private_page_blocks_state_changing_actions(monkeypatch, tool_call, args):
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(browser_tool, "_current_page_private_url", lambda task_id: PRIVATE_URL)
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("browser command should not run on a private page")
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fail_run)
+
+    out = json.loads(tool_call(*args, task_id="task-1"))
+
+    assert out["success"] is False
+    assert PRIVATE_URL in out["error"]
+    assert "private or internal address" in out["error"]
+    assert "do-not-send-this" not in json.dumps(out)
+
+
+def test_click_still_runs_when_current_page_is_public(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(browser_tool, "_current_page_private_url", lambda task_id: None)
+
+    def fake_run(task_id, command, args):
+        calls.append((task_id, command, args))
+        return {"success": True}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
+
+    out = json.loads(browser_tool.browser_click("e1", task_id="task-1"))
+
+    assert out == {"success": True, "clicked": "@e1"}
+    assert calls == [("task-1", "click", ["@e1"])]

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2953,6 +2953,9 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
         return camofox_click(ref, task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
+    blocked = _blocked_private_page_action(effective_task_id, "click")
+    if blocked is not None:
+        return blocked
 
     # Ensure ref starts with @
     if not ref.startswith("@"):
@@ -2991,6 +2994,9 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         return camofox_type(ref, text, task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
+    blocked = _blocked_private_page_action(effective_task_id, "type")
+    if blocked is not None:
+        return blocked
 
     # Ensure ref starts with @
     if not ref.startswith("@"):
@@ -3126,6 +3132,9 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
         return camofox_press(key, task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
+    blocked = _blocked_private_page_action(effective_task_id, "press")
+    if blocked is not None:
+        return blocked
     result = _run_browser_command(effective_task_id, "press", [key])
 
     if result.get("success"):
@@ -3143,6 +3152,23 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
 
 
 
+
+
+def _blocked_private_page_action(effective_task_id: str, action: str) -> Optional[str]:
+    """Return a blocked payload when an unsafe cloud page would receive input."""
+    if not _eval_ssrf_guard_active(effective_task_id):
+        return None
+    blocked_url = _current_page_private_url(effective_task_id)
+    if not blocked_url:
+        return None
+    return json.dumps({
+        "success": False,
+        "error": (
+            "Blocked: page URL targets a private or internal address "
+            f"({blocked_url}). Refusing to {action} on this page in this "
+            "browser mode."
+        ),
+    }, ensure_ascii=False)
 
 
 def browser_console(clear: bool = False, expression: Optional[str] = None, task_id: Optional[str] = None) -> str:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3151,9 +3151,6 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-
-
-
 def _blocked_private_page_action(effective_task_id: str, action: str) -> Optional[str]:
     """Return a blocked payload when an unsafe cloud page would receive input."""
     if not _eval_ssrf_guard_active(effective_task_id):


### PR DESCRIPTION
## Summary

Salvage of #55949 (rebased onto current `main` + review follow-up). Blocks state-changing browser interactions (`browser_click`, `browser_type`, `browser_press`) when a cloud-browser page has landed on a private/internal URL after JavaScript-driven navigation.

Original PR #55949 by @necoweb3 was 67 commits behind `main`. Its commit is cherry-picked here verbatim (authorship preserved) and rebased onto current `main`, plus one review follow-up commit under my identity.

## Why

Recent browser SSRF hardening (#54132, #54435, #54477) covers content-returning paths — `browser_snapshot`, `browser_vision`, `browser_console`, `browser_get_images` — which re-check the current page URL after eval-driven navigation and refuse to return private-network content.

The **state-changing interaction** sinks had no sibling guard. If a page was navigated to a private/internal URL through an eval-driven path (e.g. `location.href = 'http://169.254.169.254/...'` via `browser_console`), `browser_click`, `browser_type`, and `browser_press` would still send input to that page. In cloud-browser mode that crosses the same private-network boundary — as a side-effect primitive rather than a read primitive. Reproduced on current `main`: click/type/press all reach `_run_browser_command` on a synthetic private page, and `browser_type` echoes the typed sentinel back.

## Changes

- Add a shared private-page action guard `_blocked_private_page_action` in `tools/browser_tool.py`.
- Refuse `browser_click`, `browser_type`, and `browser_press` when the current cloud-browser page is private/internal.
- Reuse the existing `_eval_ssrf_guard_active()` and `_current_page_private_url()` checks (identical fail-open-on-probe-error semantics as the snapshot/vision/eval guards).
- Leave local/Camofox behavior unchanged (camofox early-return precedes the guard).
- Leave non-state-changing navigation helpers (`back`, `scroll`) unchanged — they send no attacker-controlled input to the page.

## Review follow-up (this salvage)

- **Add `test_guard_inactive_does_not_block_or_probe`** — the guard-inactive branch (local backend / `allow_private_urls`) must proceed WITHOUT probing the page URL. This was the untested branch most likely to silently regress if the condition is inverted; a mutation check (flipping `if not ...` → `if ...`) confirms the new test fails as designed.
- **Add `test_camofox_short_circuits_before_guard`** — asserts the camofox early-return precedes the guard so its helpers are never consulted in local/Camofox mode.
- Fix PEP8: 3 → 2 blank lines before the helper.

## Tests

```text
python -m pytest tests/tools/test_browser_private_page_action_guard.py -q --timeout-method=thread
6 passed

python -m pytest tests/tools/test_browser_private_page_action_guard.py \
  tests/tools/test_browser_eval_ssrf.py tests/tools/test_browser_get_images_ssrf.py \
  tests/tools/test_browser_snapshot_ssrf.py -q --timeout-method=thread
40 passed
```

Full browser suite: 458 passed, 3 failed (pre-existing `test_browser_secret_exfil.py::TestWebExtractSecretExfil`, unrelated — verified identical on `HEAD~1`), 30 skipped. This change introduces zero new failures.

Supersedes #55949. Credit to @necoweb3 for the original fix.
