### PR TITLE
fix(security): close env/config write-deny bypass via trailing arg or comment

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -203,6 +203,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "290862769+friendshipisover@users.noreply.github.com": "friendshipisover",
     "51421+MattKotsenas@users.noreply.github.com": "MattKotsenas",
     "92324143+ypwcharles@users.noreply.github.com": "ypwcharles",
     "mailtowbd@gmail.com": "marco0158",

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -642,6 +642,37 @@ class TestSensitiveRedirectPattern:
         assert key is None
         assert desc is None
 
+    def test_redirect_to_dotenv_with_trailing_arg_requires_approval(self):
+        # The redirection target is still `.env`; the trailing token is just an
+        # extra argument to `echo`, so the file is overwritten. The old
+        # _COMMAND_TAIL anchor required the rest of the line to be empty/a
+        # separator and let this slip past the deny.
+        dangerous, key, desc = detect_dangerous_command("echo secret > .env extra")
+        assert dangerous is True
+        assert key is not None
+        assert "project env/config" in desc.lower()
+
+    def test_redirect_to_dotenv_with_trailing_comment_requires_approval(self):
+        # A trailing `#` comment does not change the redirection target.
+        dangerous, key, desc = detect_dangerous_command("echo secret > .env # note")
+        assert dangerous is True
+        assert key is not None
+        assert "project env/config" in desc.lower()
+
+    def test_append_to_config_yaml_with_trailing_arg_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command("echo mode: prod >> config.yaml foo")
+        assert dangerous is True
+        assert key is not None
+        assert "project env/config" in desc.lower()
+
+    def test_redirect_to_config_yaml_backup_is_safe(self):
+        # `config.yaml.bak` is a different file; the boundary must end the path
+        # token at a word boundary so backup writes stay out of the deny.
+        dangerous, key, desc = detect_dangerous_command("echo x > config.yaml.bak")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
 
 class TestProjectSensitiveCopyPattern:
     def test_cp_to_local_dotenv_requires_approval(self):
@@ -821,6 +852,14 @@ class TestWindowsAbsolutePathFolding:
 class TestProjectSensitiveTeePattern:
     def test_tee_to_local_dotenv_requires_approval(self):
         dangerous, key, desc = detect_dangerous_command("printenv | tee .env.local")
+        assert dangerous is True
+        assert key is not None
+        assert "project env/config" in desc.lower()
+
+    def test_tee_to_dotenv_with_trailing_file_arg_requires_approval(self):
+        # tee writes to every file argument, so `.env` is overwritten even when
+        # another file follows it. The old _COMMAND_TAIL anchor missed this.
+        dangerous, key, desc = detect_dangerous_command("printenv | tee .env backup")
         assert dangerous is True
         assert key is not None
         assert "project env/config" in desc.lower()

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -673,6 +673,28 @@ class TestSensitiveRedirectPattern:
         assert key is None
         assert desc is None
 
+    def test_redirect_to_dotenv_hash_glued_filename_is_safe(self):
+        # A `#` glued to the path is part of the filename, not a comment: the
+        # shell writes to `.env#backup` (a different file), so it must stay out
+        # of the deny — same reasoning as config.yaml.bak. The boundary must
+        # NOT treat `#` as a word boundary (a real comment is whitespace-preceded).
+        dangerous, key, desc = detect_dangerous_command("echo x > .env#backup")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_redirect_to_config_yaml_hash_glued_filename_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("echo x > config.yaml#backup")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_tee_to_dotenv_hash_glued_filename_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("printenv | tee .env#backup")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
 
 class TestProjectSensitiveCopyPattern:
     def test_cp_to_local_dotenv_requires_approval(self):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -258,7 +258,21 @@ _USER_SENSITIVE_WRITE_TARGET = (
     rf'{_CREDENTIAL_FILES})'
 )
 _PROJECT_SENSITIVE_WRITE_TARGET = rf'(?:{_PROJECT_ENV_PATH}|{_PROJECT_CONFIG_PATH})'
+# Anchor for the cp/mv/install rule, where the sensitive path is only a write
+# target when it is the LAST argument (the destination). Requiring end-of-line
+# (or a command separator) keeps `cp config.yaml backup.yaml` — config.yaml as
+# the SOURCE — out of the deny.
 _COMMAND_TAIL = r'(?:\s*(?:&&|\|\||;).*)?$'
+# Boundary for stream-write rules (`>`/`>>` redirection and `tee`), where the
+# sensitive path is ALWAYS a write target no matter what follows it. We only
+# need the path token to END at a shell word boundary — whitespace, a quote, a
+# command separator, a redirection operator, a `#` comment, or end-of-line.
+# Using _COMMAND_TAIL here was too strict: it required the rest of the line to
+# be empty or a command separator, so `echo x > .env extra` (extra arg to echo)
+# and `echo x > .env # note` (trailing comment) slipped past the deny even
+# though the shell still overwrites `.env`. Mirrors the looser system-path
+# redirection rule, which never had this restriction.
+_WRITE_TARGET_BOUNDARY = r'(?=[\s;&|<>#"\']|$)'
 
 # =========================================================================
 # Hardline (unconditional) blocklist
@@ -454,8 +468,8 @@ DANGEROUS_PATTERNS = [
     (r'\b(bash|sh|zsh|ksh)\s+<\s*<?\s*\(\s*(curl|wget)\b', "execute remote script via process substitution"),
     (rf'\btee\b.*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via tee"),
     (rf'>>?\s*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via redirection"),
-    (rf'\btee\b.*["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_COMMAND_TAIL}', "overwrite project env/config via tee"),
-    (rf'>>?\s*["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_COMMAND_TAIL}', "overwrite project env/config via redirection"),
+    (rf'\btee\b.*["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_WRITE_TARGET_BOUNDARY}', "overwrite project env/config via tee"),
+    (rf'>>?\s*["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_WRITE_TARGET_BOUNDARY}', "overwrite project env/config via redirection"),
     (r'\bxargs\s+.*\brm\b', "xargs with rm"),
     # find -exec rm / -execdir rm — the -execdir variant (same semantics,
     # runs in the directory of each match) was previously missed. Claude

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -266,13 +266,19 @@ _COMMAND_TAIL = r'(?:\s*(?:&&|\|\||;).*)?$'
 # Boundary for stream-write rules (`>`/`>>` redirection and `tee`), where the
 # sensitive path is ALWAYS a write target no matter what follows it. We only
 # need the path token to END at a shell word boundary — whitespace, a quote, a
-# command separator, a redirection operator, a `#` comment, or end-of-line.
+# command separator, a redirection operator, or end-of-line.
 # Using _COMMAND_TAIL here was too strict: it required the rest of the line to
 # be empty or a command separator, so `echo x > .env extra` (extra arg to echo)
 # and `echo x > .env # note` (trailing comment) slipped past the deny even
 # though the shell still overwrites `.env`. Mirrors the looser system-path
 # redirection rule, which never had this restriction.
-_WRITE_TARGET_BOUNDARY = r'(?=[\s;&|<>#"\']|$)'
+#
+# `#` is deliberately NOT a boundary char: a real trailing comment always has
+# whitespace before the `#` (already covered by `\s`), whereas a `#` glued to
+# the path is part of the filename. `echo x > .env#backup` writes to the
+# distinct file `.env#backup`, not `.env`, so it must stay OUT of the deny —
+# the same reasoning that keeps `config.yaml.bak` safe.
+_WRITE_TARGET_BOUNDARY = r'(?=[\s;&|<>"\']|$)'
 
 # =========================================================================
 # Hardline (unconditional) blocklist


### PR DESCRIPTION
## Summary

A shell write to a project `.env`/`config.yaml` can no longer skip the approval gate by tacking a trailing argument or `#` comment after the `>`/`>>`/`tee` target — the shell truncates the file either way, so it now correctly requires approval.

Salvage of #40978 by @friendshipisover, rebased onto current `main` with a follow-up fix for a false positive the original patch introduced.

Root cause: the redirection/`tee` deny rules anchored the sensitive path with `_COMMAND_TAIL`, which demanded the rest of the line be empty or a command separator. A trailing token is neither, so `echo secret > .env extra` and `echo secret > .env # note` failed to match and sailed through approval — even though both still overwrite `.env`.

## Changes

- `tools/approval.py`: add `_WRITE_TARGET_BOUNDARY` — a lookahead requiring the path token to END at a shell word boundary (whitespace, quote, separator, redirection op, or EOL) — and apply it to the two stream-write rules. `_COMMAND_TAIL` stays on the `cp`/`mv`/`install` rule, where end-of-line anchoring is correct (sensitive file is only a target as the last arg).
- Follow-up: `#` is deliberately **not** a boundary char. The original patch included it, which made `echo x > .env#backup` flag as dangerous — but that writes to the distinct file `.env#backup`, not `.env` (same class as the `config.yaml.bak` case). A real trailing comment is always whitespace-preceded, already covered by `\s`.
- `tests/tools/test_approval.py`: regression tests for the four attack forms (now blocked) plus the `.bak` / `#backup`-glued false-positive guards (stay safe).

## Validation

| Command | Before | After |
|---|---|---|
| `echo secret > .env extra` | passed | **blocked** |
| `echo secret > .env # note` | passed | **blocked** |
| `echo mode: prod >> config.yaml foo` | passed | **blocked** |
| `printenv \| tee .env backup` | passed | **blocked** |
| `echo x > .env#backup` | safe | safe |
| `echo x > config.yaml#backup` | safe | safe |
| `echo x > config.yaml.bak` | safe | safe |
| `cp config.yaml backup.yaml` | safe | safe |

`scripts/run_tests.sh tests/tools/test_approval.py` → 266 passed. E2E verified via real `detect_dangerous_command` imports and a shell sanity probe confirming which filenames each command actually writes.

Contributor authorship preserved (commit `183033941`).

## Infographic

![Approval gate write-deny bypass closed](https://v3b.fal.media/files/b/0aa07adf/aDOn0YxiSGHPznhiQ-iYz_IHvp6L83.png)
