### PR TITLE
fix(cli): stop .env sanitizer from splitting secrets that embed a known KEY=

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6700,6 +6700,23 @@ def invalidate_env_cache() -> None:
     _env_cache = None
 
 
+_STRUCTURED_VALUE_MARKERS = ("://", "?", "&")
+
+
+def _looks_like_structured_value(value: str) -> bool:
+    """True when ``value`` looks like a URL/query string or holds whitespace.
+
+    Such a value is treated as one opaque secret. An embedded
+    ``KNOWN_KEY=`` substring inside it (e.g. a webhook URL carrying a query
+    parameter, or a proxy base URL with an embedded key) is part of the value,
+    not the start of a second .env entry, so the concatenation splitter must
+    not break on it. Plain token secrets (API keys) never contain these.
+    """
+    if any(marker in value for marker in _STRUCTURED_VALUE_MARKERS):
+        return True
+    return any(ch.isspace() for ch in value)
+
+
 def _sanitize_env_lines(lines: list) -> list:
     """Fix corrupted .env lines before reading or writing.
 
@@ -6748,10 +6765,32 @@ def _sanitize_env_lines(lines: list) -> list:
             )
         })
 
-        if len(split_positions) > 1:
-            for i, pos in enumerate(split_positions):
-                end = split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
-                part = stripped[pos:end].strip()
+        # Only treat the line as a concatenation when it actually begins with a
+        # known KEY= (split_positions[0] == 0). A first match at a non-zero
+        # offset means the matches sit inside a value, so splitting there would
+        # silently drop the leading text — keep the line intact instead.
+        split_into_entries = False
+        segments: list[str] = []
+        if len(split_positions) > 1 and split_positions[0] == 0:
+            segments = [
+                stripped[pos:(
+                    split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
+                )]
+                for i, pos in enumerate(split_positions)
+            ]
+            # A genuine concatenation has a simple token value in every segment
+            # that precedes a boundary. If a preceding value looks structured
+            # (a URL/query string or whitespace), the embedded KNOWN_KEY= is
+            # part of that value rather than a new entry, so we must not split —
+            # otherwise we truncate the real secret and fabricate a bogus one.
+            split_into_entries = all(
+                not _looks_like_structured_value(seg.split("=", 1)[1])
+                for seg in segments[:-1]
+            )
+
+        if split_into_entries:
+            for seg in segments:
+                part = seg.strip()
                 if part:
                     sanitized.append(part + "\n")
         else:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "290873280+rrevenanttt@users.noreply.github.com": "rrevenanttt",  # PR #40773 salvage (close hardline rm bypass via quoted paths and ${HOME} brace form)
     "290871358+Vesna-9@users.noreply.github.com": "Vesna-9",  # PR #41274 salvage (collapse shell line continuations before dangerous/hardline pattern matching so `rm -rf \<newline>/` can't bypass the yolo-proof hardline floor)
+    "214165399+kernel-t1@users.noreply.github.com": "kernel-t1",  # PR #41349 salvage (.env sanitizer: only split when line starts with a known KEY= and preceding values are plain tokens; keep URL/query/whitespace secrets verbatim)
     "jnibarger01@gmail.com": "jnibarger01",  # PR #35130 salvage (ReDoS-bound threat-pattern filler + FTS5 query cap + V4A Move-File approval/traversal targets)
     "290868363+petrichor-op@users.noreply.github.com": "petrichor-op",  # PR #41281 salvage (never persist ephemeral empty-response recovery scaffolding to the SQLite session store / JSON log; filter by flag not position)
     "283494121+redactdeveloper@users.noreply.github.com": "redactdeveloper",  # PR #36897 salvage (route /sessions & /history through prompt_toolkit-safe print; filter doctor missing-key summary to CLI-enabled toolsets)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -613,6 +613,23 @@ class TestSanitizeEnvLines:
         assert result[0].startswith("GLM_API_KEY=")
         assert result[1].startswith("LM_API_KEY=")
 
+    def test_value_embedding_known_key_not_split(self):
+        """A single valid line whose value embeds a known KEY= (e.g. a URL with
+        a query parameter) must be preserved verbatim — not truncated into a
+        bogus pair."""
+        lines = [
+            "OPENAI_BASE_URL=https://proxy.example.com/v1?TAVILY_API_KEY=sk-embedded\n",
+        ]
+        result = _sanitize_env_lines(lines)
+        assert result == lines, f"embedded key in value corrupted the secret: {result}"
+
+    def test_leading_text_before_first_key_not_dropped(self):
+        """When the first known KEY= is not at the line start, the leading text
+        must not be silently dropped."""
+        lines = ["export OPENAI_API_KEY=sk1ANTHROPIC_API_KEY=sk2\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == lines, f"leading text was dropped: {result}"
+
     def test_save_env_value_fixes_corruption_on_write(self, tmp_path):
         """save_env_value sanitizes corrupted lines when writing a new key."""
         env_file = tmp_path / ".env"


### PR DESCRIPTION
## Summary
The `.env` sanitizer no longer corrupts a valid secret whose value embeds a known Hermes `KEY=` substring (e.g. a proxy base URL carrying a query parameter). Because the sanitizer runs on every `load_env()`/`save_env_value()`/`remove_env_value()`/`sanitize_env_file()`, the corruption was written back to `~/.hermes/.env` and re-applied on every read — persistent loss of the canonical secrets store.

Root cause: `_sanitize_env_lines()` split on *any* embedded known-`KEY=` match at *any* offset. A value like `OPENAI_BASE_URL=https://proxy/v1?TAVILY_API_KEY=sk-...` was truncated at the inner `TAVILY_API_KEY=` and a bogus second entry fabricated; a first match at a non-zero offset also silently dropped everything before it.

## Changes
- `hermes_cli/config.py`: split only when the line **starts** with a known `KEY=` and **every** value preceding a boundary is a plain token. New `_looks_like_structured_value()` treats URL/query (`://`, `?`, `&`) or whitespace-bearing values as opaque secrets, so an embedded `KEY=` inside them stays part of the value. Genuine plain-token concatenations still split.
- `tests/hermes_cli/test_config.py`: +2 regression tests (embedded key preserved verbatim; leading text not dropped).
- `scripts/release.py`: AUTHOR_MAP entry for the contributor.

## Validation
| Case | Before | After |
|---|---|---|
| `OPENAI_BASE_URL=https://proxy/v1?TAVILY_API_KEY=sk-...` | truncated + bogus 2nd entry | preserved verbatim |
| `export OPENAI_API_KEY=sk1ANTHROPIC_API_KEY=sk2` | leading text dropped | preserved verbatim |
| genuine plain-token concat | split into 2 | split into 2 (no regression) |

`tests/hermes_cli/test_config.py`: 132/132 pass. Verified live against current `main` via the real `_sanitize_env_lines()` code path.

## Infographic
![.env sanitizer fix](https://v3b.fal.media/files/b/0aa07ae0/GGgxCE5kfkZJ77DHPdrWn_YYwcWM8x.png)

---
Salvaged from #41349 by @kernel-t1 — authorship preserved via cherry-pick + rebase-merge.

Nous Research
