### PR TITLE
fix: dedupe GitHub PR review webhooks

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -74,6 +74,20 @@ DEFAULT_PORT = 8644
 _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
 _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
 _RATE_WINDOW_SECONDS = 60.0
+_CODEX_PR_REVIEW_LIFECYCLE_RE = re.compile(
+    r"(?im)^\s*RND-Agent:codex-pr-review\s+lifecycle\b"
+)
+_CODE_REVIEW_SUMMARY_MARKER = "## Code Review Summary"
+_DEFAULT_GITHUB_REVIEW_BOT_LOGINS = frozenset(
+    {"rnd-agent", "rnd-agent[bot]", "hermes-agent", "hermes-agent[bot]"}
+)
+_GITHUB_RETRY_COMMAND_RE = re.compile(
+    r"(?is)(?:^|\s)@RND-Agent\b.*\b(?:retry|rerun|re-run|continue|resume)\b|"
+    r"\b(?:retry|rerun|re-run|continue|resume)\b.*(?:^|\s)@RND-Agent\b"
+)
+_ACTIONABLE_PULL_REQUEST_ACTIONS = frozenset(
+    {"opened", "synchronize", "reopened", "ready_for_review"}
+)
 
 # Hostnames/IP literals that only serve connections originating on the same
 # machine. Anything else is treated as a public bind for safety-rail purposes.
@@ -340,6 +354,195 @@ class WebhookAdapter(BasePlatformAdapter):
             self._prune_seen_deliveries(now)
         return True
 
+    def _github_review_bot_logins(self, route_config: dict) -> set[str]:
+        configured = (
+            route_config.get("github_bot_logins")
+            or route_config.get("bot_logins")
+            or route_config.get("bot_login")
+            or ()
+        )
+        if isinstance(configured, str):
+            configured = [configured]
+        try:
+            extra = {
+                str(login).strip().lower()
+                for login in configured
+                if str(login).strip()
+            }
+        except TypeError:
+            extra = set()
+        return set(_DEFAULT_GITHUB_REVIEW_BOT_LOGINS) | extra
+
+    def _github_pr_review_dedupe_enabled(self, route_config: dict) -> bool:
+        return route_config.get("github_pr_review_dedupe") is True
+
+    def _github_is_review_bot(self, login: Any, route_config: dict) -> bool:
+        if not login:
+            return False
+        return str(login).strip().lower() in self._github_review_bot_logins(
+            route_config
+        )
+
+    def _github_has_human_retry_command(
+        self, payload: dict, route_config: dict
+    ) -> bool:
+        sender_login = ((payload.get("sender") or {}).get("login") or "")
+        if self._github_is_review_bot(sender_login, route_config):
+            return False
+        body = str(((payload.get("comment") or {}).get("body") or ""))
+        return bool(_GITHUB_RETRY_COMMAND_RE.search(body))
+
+    def _is_codex_pr_review_lifecycle_comment(
+        self, payload: dict, route_config: dict
+    ) -> bool:
+        action = str(payload.get("action") or "").lower()
+        if action not in {"created", "edited"}:
+            return False
+
+        comment = payload.get("comment") or {}
+        body = str(comment.get("body") or "")
+        if not _CODEX_PR_REVIEW_LIFECYCLE_RE.search(body):
+            return False
+
+        author_login = ((comment.get("user") or {}).get("login") or "")
+        sender_login = ((payload.get("sender") or {}).get("login") or "")
+        if not (
+            self._github_is_review_bot(author_login, route_config)
+            or self._github_is_review_bot(sender_login, route_config)
+        ):
+            return False
+
+        return not self._github_has_human_retry_command(payload, route_config)
+
+    def _github_pr_context_from_payload(
+        self, payload: dict, event_type: str, route_config: dict
+    ) -> Optional[tuple[str, int, str]]:
+        repo = str(
+            ((payload.get("repository") or {}).get("full_name") or "")
+        ).strip()
+        if not repo:
+            return None
+
+        pr = payload.get("pull_request")
+        pr_number: Any = payload.get("number")
+        head_sha = ""
+        if isinstance(pr, dict):
+            pr_number = pr.get("number") or pr_number
+            head_sha = str(((pr.get("head") or {}).get("sha") or "")).strip()
+        elif event_type == "issue_comment" and isinstance(payload.get("issue"), dict):
+            issue = payload["issue"]
+            if not issue.get("pull_request"):
+                return None
+            pr_number = issue.get("number")
+            if not self._github_has_human_retry_command(payload, route_config):
+                return None
+
+        try:
+            pr_int = int(pr_number)
+        except (TypeError, ValueError):
+            return None
+        if pr_int <= 0:
+            return None
+
+        if not head_sha and event_type == "issue_comment":
+            head_sha = self._github_fetch_pr_head_sha(repo, pr_int)
+        if not head_sha:
+            return None
+        return repo, pr_int, head_sha
+
+    def _github_fetch_pr_head_sha(self, repo: str, pr_number: int) -> str:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo}/pulls/{pr_number}",
+                    "--jq",
+                    ".head.sha",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except Exception as exc:
+            logger.warning("[webhook] GitHub PR head lookup failed: %s", exc)
+            return ""
+        if result.returncode != 0:
+            logger.warning(
+                "[webhook] gh PR head lookup failed for %s#%s", repo, pr_number
+            )
+            return ""
+        return result.stdout.strip()
+
+    def _github_load_pr_reviews(self, repo: str, pr_number: int) -> list[dict]:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo}/pulls/{pr_number}/reviews?per_page=100",
+                    "--paginate",
+                    "--slurp",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except Exception as exc:
+            logger.warning("[webhook] GitHub review dedupe lookup failed: %s", exc)
+            return []
+        if result.returncode != 0:
+            logger.warning(
+                "[webhook] gh review dedupe lookup failed for %s#%s",
+                repo,
+                pr_number,
+            )
+            return []
+        try:
+            data = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError:
+            logger.warning("[webhook] gh review dedupe lookup returned invalid JSON")
+            return []
+        if not isinstance(data, list):
+            return []
+        if data and all(isinstance(page, list) for page in data):
+            flattened: list[dict] = []
+            for page in data:
+                flattened.extend(item for item in page if isinstance(item, dict))
+            return flattened
+        return [item for item in data if isinstance(item, dict)]
+
+    def _github_pr_review_already_done(
+        self, payload: dict, event_type: str, route_config: dict
+    ) -> bool:
+        action = str(payload.get("action") or "").lower()
+        if (
+            event_type == "pull_request"
+            and action not in _ACTIONABLE_PULL_REQUEST_ACTIONS
+        ):
+            return False
+        if event_type == "issue_comment" and not self._github_has_human_retry_command(
+            payload, route_config
+        ):
+            return False
+
+        context = self._github_pr_context_from_payload(
+            payload, event_type, route_config
+        )
+        if not context:
+            return False
+        repo, pr_number, head_sha = context
+        reviews = self._github_load_pr_reviews(repo, pr_number)
+        for review in reviews:
+            if str(review.get("commit_id") or "").strip() != head_sha:
+                continue
+            if _CODE_REVIEW_SUMMARY_MARKER not in str(review.get("body") or ""):
+                continue
+            author_login = ((review.get("user") or {}).get("login") or "")
+            if self._github_is_review_bot(author_login, route_config):
+                return True
+        return False
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
 
@@ -549,6 +752,61 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "ignored", "event": event_type}
             )
 
+        # Build a unique delivery ID
+        delivery_id = request.headers.get(
+            "X-GitHub-Delivery",
+            request.headers.get(
+                "svix-id",
+                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+            ),
+        )
+
+        # ── Idempotency ─────────────────────────────────────────
+        # Skip duplicate deliveries (webhook retries).
+        now = time.time()
+        if not self._record_delivery_id(delivery_id, now):
+            logger.info(
+                "[webhook] Skipping duplicate delivery %s", delivery_id
+            )
+            return web.json_response(
+                {"status": "duplicate", "delivery_id": delivery_id},
+                status=200,
+            )
+
+        if self._github_pr_review_dedupe_enabled(route_config):
+            if event_type == "issue_comment" and self._is_codex_pr_review_lifecycle_comment(
+                payload, route_config
+            ):
+                logger.info(
+                    "[webhook] Ignoring Codex PR-review lifecycle comment for route %s",
+                    route_name,
+                )
+                return web.json_response(
+                    {
+                        "status": "ignored",
+                        "event": event_type,
+                        "reason": "codex_pr_review_lifecycle",
+                    }
+                )
+
+            if (
+                event_type in {"pull_request", "issue_comment"}
+                and self._github_pr_review_already_done(
+                    payload, event_type, route_config
+                )
+            ):
+                logger.info(
+                    "[webhook] Skipping PR review for route %s: same-head review already exists",
+                    route_name,
+                )
+                return web.json_response(
+                    {
+                        "status": "duplicate",
+                        "event": event_type,
+                        "reason": "same_head_review_already_done",
+                    }
+                )
+
         # Format prompt from template
         prompt_template = route_config.get("prompt", "")
         prompt = self._render_prompt(
@@ -583,27 +841,6 @@ class WebhookAdapter(BasePlatformAdapter):
                         )
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
-
-        # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
-        )
-
-        # ── Idempotency ─────────────────────────────────────────
-        # Skip duplicate deliveries (webhook retries).
-        now = time.time()
-        if not self._record_delivery_id(delivery_id, now):
-            logger.info(
-                "[webhook] Skipping duplicate delivery %s", delivery_id
-            )
-            return web.json_response(
-                {"status": "duplicate", "delivery_id": delivery_id},
-                status=200,
-            )
 
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -11,6 +11,7 @@ import asyncio
 import hashlib
 import hmac
 import json
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -141,6 +142,394 @@ class TestGitHubPRWebhook:
         assert event.source.platform == Platform.WEBHOOK
         assert "github-pr" in event.source.chat_id
         assert event.message_id == "gh-delivery-001"
+
+    @pytest.mark.asyncio
+    async def test_codex_lifecycle_comment_from_review_bot_is_ignored(self):
+        """Bot-authored lifecycle/status comments must not start a review run."""
+        routes = {
+            "github-pr-review": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issue_comment"],
+                "prompt": "Review command: {comment.body}",
+                "deliver": "log",
+                "github_pr_review_dedupe": True,
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        payload = {
+            "action": "created",
+            "issue": {
+                "number": 16,
+                "pull_request": {
+                    "url": "https://api.github.com/repos/Mesitis/alphapulse/pulls/16"
+                },
+            },
+            "comment": {
+                "body": (
+                    "RND-Agent:codex-pr-review lifecycle running "
+                    "head=975d343cdc0764ba204cf31e0146ca7f1bb558f1"
+                ),
+                "user": {"login": "RND-Agent"},
+            },
+            "repository": {"full_name": "Mesitis/alphapulse"},
+            "sender": {"login": "RND-Agent"},
+        }
+
+        app = _create_app(adapter)
+        with patch("gateway.platforms.webhook.subprocess.run") as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/github-pr-review",
+                    json=payload,
+                    headers={
+                        "X-GitHub-Event": "issue_comment",
+                        "X-GitHub-Delivery": "lifecycle-comment-001",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data == {
+            "status": "ignored",
+            "event": "issue_comment",
+            "reason": "codex_pr_review_lifecycle",
+        }
+        adapter.handle_message.assert_not_awaited()
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_same_head_code_review_summary_dedupes_before_agent(self):
+        """A prior same-head RND-Agent formal review summary is terminal."""
+        routes = {
+            "github-pr-review": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "prompt": "Review PR #{number}",
+                "deliver": "log",
+                "github_pr_review_dedupe": True,
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        head_sha = "975d343cdc0764ba204cf31e0146ca7f1bb558f1"
+        payload = {
+            **GITHUB_PR_PAYLOAD,
+            "action": "synchronize",
+            "pull_request": {
+                **GITHUB_PR_PAYLOAD["pull_request"],
+                "head": {"ref": "feature/webhooks", "sha": head_sha},
+            },
+        }
+        prior_reviews = [[{
+            "state": "CHANGES_REQUESTED",
+            "commit_id": head_sha,
+            "body": "## Code Review Summary\n\nFound a blocking issue.",
+            "user": {"login": "RND-Agent"},
+        }]]
+        mock_result = MagicMock(returncode=0, stdout=json.dumps(prior_reviews), stderr="")
+
+        app = _create_app(adapter)
+        with patch(
+            "gateway.platforms.webhook.subprocess.run",
+            return_value=mock_result,
+        ) as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/github-pr-review",
+                    json=payload,
+                    headers={
+                        "X-GitHub-Event": "pull_request",
+                        "X-GitHub-Delivery": "same-head-review-001",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data == {
+            "status": "duplicate",
+            "event": "pull_request",
+            "reason": "same_head_review_already_done",
+        }
+        adapter.handle_message.assert_not_awaited()
+        mock_run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                "repos/org/repo/pulls/42/reviews?per_page=100",
+                "--paginate",
+                "--slurp",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    @pytest.mark.asyncio
+    async def test_same_head_human_retry_dedupes_prior_changes_requested(self):
+        """A same-head retry must not rerun and downgrade CHANGES_REQUESTED."""
+        routes = {
+            "github-pr-review": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issue_comment"],
+                "prompt": "Review command: {comment.body}",
+                "deliver": "log",
+                "github_pr_review_dedupe": True,
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        head_sha = "975d343cdc0764ba204cf31e0146ca7f1bb558f1"
+        payload = {
+            "action": "created",
+            "issue": {
+                "number": 16,
+                "pull_request": {
+                    "url": "https://api.github.com/repos/Mesitis/alphapulse/pulls/16"
+                },
+            },
+            "comment": {
+                "body": "@RND-Agent continue review",
+                "user": {"login": "maintainer"},
+            },
+            "repository": {"full_name": "Mesitis/alphapulse"},
+            "sender": {"login": "maintainer"},
+        }
+        head_result = MagicMock(returncode=0, stdout=f"{head_sha}\n", stderr="")
+        reviews_result = MagicMock(
+            returncode=0,
+            stdout=json.dumps([[
+                {
+                    "state": "CHANGES_REQUESTED",
+                    "commit_id": head_sha,
+                    "body": "## Code Review Summary\n\nBlocking issue remains.",
+                    "user": {"login": "RND-Agent"},
+                }
+            ]]),
+            stderr="",
+        )
+
+        app = _create_app(adapter)
+        with patch(
+            "gateway.platforms.webhook.subprocess.run",
+            side_effect=[head_result, reviews_result],
+        ) as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/github-pr-review",
+                    json=payload,
+                    headers={
+                        "X-GitHub-Event": "issue_comment",
+                        "X-GitHub-Delivery": "same-head-retry-001",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data == {
+            "status": "duplicate",
+            "event": "issue_comment",
+            "reason": "same_head_review_already_done",
+        }
+        adapter.handle_message.assert_not_awaited()
+        assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_generic_pull_request_route_does_not_run_review_dedupe(self):
+        """Ordinary PR routes must not block on review lookup without opt-in."""
+        routes = {
+            "github-pr": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "prompt": "PR #{number}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        head_sha = "975d343cdc0764ba204cf31e0146ca7f1bb558f1"
+        payload = {
+            **GITHUB_PR_PAYLOAD,
+            "action": "synchronize",
+            "pull_request": {
+                **GITHUB_PR_PAYLOAD["pull_request"],
+                "head": {"ref": "feature/webhooks", "sha": head_sha},
+            },
+        }
+
+        app = _create_app(adapter)
+        with patch("gateway.platforms.webhook.subprocess.run") as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/github-pr",
+                    json=payload,
+                    headers={
+                        "X-GitHub-Event": "pull_request",
+                        "X-GitHub-Delivery": "generic-pr-001",
+                    },
+                )
+                assert resp.status == 202
+                data = await resp.json()
+
+        await asyncio.sleep(0.05)
+
+        assert data["status"] == "accepted"
+        adapter.handle_message.assert_awaited_once()
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generic_issue_comment_route_does_not_suppress_lifecycle_comment(self):
+        """Lifecycle comments are only special on opted-in PR-review routes."""
+        routes = {
+            "github-comments": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issue_comment"],
+                "prompt": "Comment: {comment.body}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        payload = {
+            "action": "created",
+            "issue": {
+                "number": 16,
+                "pull_request": {
+                    "url": "https://api.github.com/repos/Mesitis/alphapulse/pulls/16"
+                },
+            },
+            "comment": {
+                "body": (
+                    "RND-Agent:codex-pr-review lifecycle running "
+                    "head=975d343cdc0764ba204cf31e0146ca7f1bb558f1"
+                ),
+                "user": {"login": "RND-Agent"},
+            },
+            "repository": {"full_name": "Mesitis/alphapulse"},
+            "sender": {"login": "RND-Agent"},
+        }
+
+        app = _create_app(adapter)
+        with patch("gateway.platforms.webhook.subprocess.run") as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/github-comments",
+                    json=payload,
+                    headers={
+                        "X-GitHub-Event": "issue_comment",
+                        "X-GitHub-Delivery": "generic-comment-001",
+                    },
+                )
+                assert resp.status == 202
+                data = await resp.json()
+
+        await asyncio.sleep(0.05)
+
+        assert data["status"] == "accepted"
+        adapter.handle_message.assert_awaited_once()
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deliver_only_pull_request_route_does_not_run_review_dedupe(self):
+        """Direct-delivery routes stay on the existing fast path without opt-in."""
+        routes = {
+            "github-pr-alert": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "prompt": "PR #{number}",
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "12345"},
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter._direct_deliver = AsyncMock(return_value=SendResult(success=True))
+
+        head_sha = "975d343cdc0764ba204cf31e0146ca7f1bb558f1"
+        payload = {
+            **GITHUB_PR_PAYLOAD,
+            "action": "synchronize",
+            "pull_request": {
+                **GITHUB_PR_PAYLOAD["pull_request"],
+                "head": {"ref": "feature/webhooks", "sha": head_sha},
+            },
+        }
+
+        app = _create_app(adapter)
+        with patch("gateway.platforms.webhook.subprocess.run") as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/github-pr-alert",
+                    json=payload,
+                    headers={
+                        "X-GitHub-Event": "pull_request",
+                        "X-GitHub-Delivery": "deliver-only-pr-001",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["status"] == "delivered"
+        adapter._direct_deliver.assert_awaited_once()
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_delivery_id_skips_review_dedupe_head_lookup(self):
+        """GitHub retries must hit idempotency before any synchronous gh lookup."""
+        routes = {
+            "github-pr-review": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issue_comment"],
+                "prompt": "Review command: {comment.body}",
+                "deliver": "log",
+                "github_pr_review_dedupe": True,
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+        adapter._record_delivery_id("duplicate-retry-001", time.time())
+
+        payload = {
+            "action": "created",
+            "issue": {
+                "number": 16,
+                "pull_request": {
+                    "url": "https://api.github.com/repos/Mesitis/alphapulse/pulls/16"
+                },
+            },
+            "comment": {
+                "body": "@RND-Agent continue review",
+                "user": {"login": "maintainer"},
+            },
+            "repository": {"full_name": "Mesitis/alphapulse"},
+            "sender": {"login": "maintainer"},
+        }
+
+        app = _create_app(adapter)
+        with patch("gateway.platforms.webhook.subprocess.run") as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/github-pr-review",
+                    json=payload,
+                    headers={
+                        "X-GitHub-Event": "issue_comment",
+                        "X-GitHub-Delivery": "duplicate-retry-001",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data == {
+            "status": "duplicate",
+            "delivery_id": "duplicate-retry-001",
+        }
+        adapter.handle_message.assert_not_awaited()
+        mock_run.assert_not_called()
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- Gate Codex/RND-Agent PR-review lifecycle suppression behind `github_pr_review_dedupe: true` so generic GitHub webhook routes are unaffected.
- Add same-head review dedupe before launching an agent, using prior RND-Agent `## Code Review Summary` reviews without requiring newer artifact markers.
- Move delivery-id idempotency before review/head lookups so GitHub retries do not repeatedly run synchronous `gh api` checks.
- Cover lifecycle no-op, same-head `CHANGES_REQUESTED` dedupe, generic route pass-through, deliver-only pass-through, and duplicate-delivery fast path.

## Request Source / Audit
- Requested by: Simon Shao via Slack thread.
- Request source: Slack thread discussing duplicate output on `Mesitis/alphapulse` PR #16.
- Original request: "修正" after review concluded duplicate same-head RND-Agent PR reviews were not reasonable.
- Related link: https://github.com/Mesitis/alphapulse/pull/16

## Change Source
- Change type: agent-authored fix with Codex-assisted implementation and review.
- Source branch: `origin/main`
- Source commit: `8d3c45012`
- New commit: `94ea3a7fc66829ef51cd1a51c2f08f3a350469ce`

## Target
- Repo: `NousResearch/hermes-agent`
- Base branch: `main`
- Head branch: `RND-Agent:fix/pr-review-lifecycle-dedupe`
- Environment: Hermes webhook GitHub PR-review automation.

## Changed Files
- `gateway/platforms/webhook.py`: adds opt-in PR-review lifecycle suppression, same-head review dedupe, and earlier delivery-id idempotency.
- `tests/gateway/test_webhook_integration.py`: adds regression coverage for PR-review dedupe and generic route non-regression cases.

## Validation
- `python -m pytest tests/gateway/test_webhook_integration.py tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_signature_rate_limit.py tests/gateway/test_webhook_dynamic_routes.py tests/gateway/test_webhook_deliver_only.py -q` -> 109 passed.
- `git diff --check` -> passed.
- Codex review of first pass found over-broad generic webhook impact and idempotency ordering; follow-up fix addressed those findings.

## Risk / Rollback
- Risk: medium-low; behavior is opt-in through `github_pr_review_dedupe: true`, but the opted-in GitHub PR-review route must have this flag set to activate dedupe.
- Rollback: revert this PR to restore previous webhook dispatch behavior.
