### PR TITLE
optional-mcps: add bloom — memory-native indie AI companion

### DIFF
--- a/optional-mcps/bloom-directory/manifest.yaml
+++ b/optional-mcps/bloom-directory/manifest.yaml
@@ -1,0 +1,84 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: bloom-directory
+description: |
+  An indie AI catalog that grows with you — curated for being human.
+
+  Bloom pairs with Hermes' persistent memory to build a shared
+  understanding of what actually helps you. Your Hermes agent knows the
+  context of your life; Bloom knows the indie apps that fit.
+
+  Human-centered indie AI: lifestyle, wellness, habits, creativity,
+  money mindset. Every backing you make deepens a portable identity
+  at bloomprotocol.ai/agents/<your-handle> that persists across every
+  MCP-capable client — but only Hermes has the long-term memory to
+  make it compound over time.
+
+source: https://bloomprotocol.ai/skill.md
+
+# Bloom ships a stateless streamable-HTTP MCP server at the URL below.
+# The Bloom API only ever asks for a public handle (2-30 chars,
+# alphanumeric) via MCP elicitation — no email, no OAuth, no PII flows
+# through the protocol. Handles are portable public receipts anyone can
+# cite at bloomprotocol.ai/agents/<handle>.
+transport:
+  type: http
+  url: https://bloomprotocol.ai/api/mcp
+
+auth:
+  type: none
+
+# Tool selection at install time:
+# Five tools total. list_projects + recommend_for_me are read-only. The
+# three write tools (sign_up_project, support_project, remember_my_taste)
+# all elicit a Bloom handle from the user before writing anything — safe
+# for install-time enable. No mutating tool touches user PII or external
+# systems beyond bloomprotocol.ai.
+#
+# The install-time checklist starts with everything pre-checked so users
+# get the full memory-native Identity loop (recommend → back → remember)
+# on first try. Anyone who wants only browsing can uncheck the writes.
+tools: {}
+
+post_install: |
+  Bloom exposes five MCP tools:
+
+    list_projects        — Browse the catalog by category (read-only)
+    recommend_for_me     — Personalised ranking from chat signals +
+                            past taste (READS the context Hermes
+                            accumulates about the user)
+    sign_up_project      — Private follow (email-style, no PII required)
+    support_project      — Public backing under a Bloom handle
+    remember_my_taste    — Record backed/skipped so future recs are
+                            smarter (WRITES to the shared identity)
+
+  Categories: lifestyle · wellness · habits · creativity · money-mind.
+
+  Why Bloom + Hermes uniquely fit:
+
+  Hermes accumulates context across sessions. Bloom curates apps matched
+  to that context. Together they create a discovery loop no other
+  MCP-capable client × directory pairing offers:
+
+    Session 1: User talks to Hermes about anxiety + sleep problems
+                 → Hermes → recommend_for_me(context) → Bloom returns
+                   Wysa + Endel + Mindsera with personalised whyFits
+                 → User backs Mindsera → Hermes calls support_project
+                   and remember_my_taste(backed)
+
+    Session 5 (three weeks later): User mentions money guilt
+                 → Hermes remembers user is journaling-oriented,
+                   skipped Wysa last time
+                 → recommend_for_me returns MoodWallet (reflective
+                   money mindset) — NOT Vera (numbers-heavy, doesn't
+                   fit the user's taste pattern)
+
+  The user's Bloom handle also works in Claude Code, Codex, OpenClaw —
+  same identity everywhere. But only Hermes has the persistent memory
+  to keep the loop compounding.
+
+  Docs + full skill spec: https://bloomprotocol.ai/skill.md
+  Public metrics:         https://bloomprotocol.ai/stats
+  llms.txt positioning:   https://bloomprotocol.ai/llms.txt


### PR DESCRIPTION
## The pitch

**The only indie AI catalog that grows with you — powered by Hermes' memory, curated for being human.**

Bloom pairs with Hermes' persistent memory to build a shared understanding of what actually helps the user. Hermes knows the context of the user's life; Bloom knows the indie apps that fit. Together they close a discovery loop no other MCP-capable client × directory pairing offers.

## What Bloom is

Bloom is a curated place for **human-centered indie AI** — consumer apps in *lifestyle · wellness · habits · creativity · money mindset* built by independent makers. Not another dev-tool / trading / productivity catalog. It's for the parts of life that make you human.

## Five tools, one loop

| Tool | What it does |
|---|---|
| `list_projects` | Browse the catalog by category (read-only) |
| `recommend_for_me` | **Reads Hermes' accumulated context** + returns personalised picks with per-project *\"why this fits you\"* lines |
| `sign_up_project` | Private follow (email-style, no PII) |
| `support_project` | Public backing under a Bloom handle |
| `remember_my_taste` | **Writes the user's backed / skipped decisions** so future recommendations reflect the taste over time |

## The unique Bloom + Hermes fit

Other MCP clients (ChatGPT plugins, Claude.ai chat) don't retain conversation memory the way Hermes does. That memory IS the context `recommend_for_me` reads. So Bloom + Hermes = **the deepest personalisation loop in the MCP ecosystem**.

```
Session 1 (week 1):
  User: \"Find me something that could help my mornings.\"
  Hermes has been listening → knows anxiety + sleep + CBT-curious
  → recommend_for_me(context={anxiety, sleep, cbt-interest})
  → Bloom returns Wysa + Endel + Mindsera with personalised whyFits
  → User backs Mindsera → support_project + remember_my_taste(backed)

Session 5 (three weeks later):
  User: \"I've been thinking about money.\"
  Hermes remembers the journaling pattern + CBT interest
  → recommend_for_me(context={money-guilt, likes-journaling}, handle=@user)
  → Bloom returns MoodWallet + Stated (reflective money mindset)
  → NOT Vera (numbers-heavy — doesn't fit the user's taste)
  → User backs MoodWallet. Loop tightens.
```

## Transport + privacy

- **Streamable HTTP, no auth** — endpoint at `https://bloomprotocol.ai/api/mcp`
- Bloom only asks for a public handle (2-30 chars) via MCP elicitation — **no OAuth, no PII**
- Handles are portable public receipts anyone can cite at `bloomprotocol.ai/agents/<handle>`
- The same handle works in Claude Code, Codex, OpenClaw — same identity everywhere. But only Hermes has the persistent memory to make the loop compound over time.

## Verified

- ✅ Streamable HTTP endpoint live at `https://bloomprotocol.ai/api/mcp`
- ✅ Multi-agent E2E (4 agents including `bloom-identity`) passes against production — `recommend → skip → re-recommend correctly excludes skipped project`
- ✅ Three-protagonist E2E (23 assertions) passes end-to-end
- ✅ 28 seeded human-centered indie AI apps live in the catalog (Finch, Wysa, Mindsera, Endel, Stated, MoodWallet, etc.)
- ✅ Daily cron refreshes supply from Product Hunt + Hacker News + BetaList + Reddit (r/SideProject, r/journaling, r/getdisciplined, r/decidingtobebetter, r/personalfinance)
- ✅ Global reject filter drops B2B / dev-tool / banking-incumbent / crypto-trading noise before it enters the catalog

## Extends the Hermes catalog

Current catalog: linear · n8n · unreal-engine — all workflow / dev tooling. Bloom adds the **consumer indie AI** slot, aligned with Hermes' identity as a local-first, memory-persistent runtime that's willing to be personal.

## Links

- Manifest: [`optional-mcps/bloom-directory/manifest.yaml`](https://github.com/bloomprotocol/hermes-agent/blob/bloom-directory-v2/optional-mcps/bloom-directory/manifest.yaml)
- Endpoint: https://bloomprotocol.ai/api/mcp
- Install line + skill spec: https://bloomprotocol.ai/skill.md
- Agent-readable positioning: https://bloomprotocol.ai/llms.txt
- Public growth metrics: https://bloomprotocol.ai/stats

Happy to iterate on the manifest if anything doesn't fit conventions. Thanks for reviewing!