### PR TITLE
fix(auxiliary): treat aux <task>.model: auto as sentinel, not a literal model id

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5257,6 +5257,16 @@ def _resolve_task_provider_model(
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
+    # 'auto' is a sentinel meaning "inherit from main runtime / auto-detect", not
+    # a literal model id. Without this, a config of `auxiliary.<task>.model: auto`
+    # propagates the literal string "auto" to the wire, where the provider returns
+    # a 200 OK with an error-text body (e.g. "the model 'auto' does not exist"),
+    # which downstream consumers like ContextCompressor accept as the task output.
+    # The provider-side 'auto' is handled in _resolve_auto() via main_runtime
+    # fallback, so dropping cfg_model to None here lets that path do its job.
+    if cfg_model and cfg_model.lower() == "auto":
+        cfg_model = None
+
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -818,6 +818,7 @@ AUTHOR_MAP = {
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
     "123342691+banditburai@users.noreply.github.com": "banditburai",
     "9063726+Kyzcreig@users.noreply.github.com": "Kyzcreig",
+    "kyzcreig@gmail.com": "Kyzcreig",
     "270082434+crayfish-ai@users.noreply.github.com": "crayfish-ai",
     "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     "268667990+Roy-oss1@users.noreply.github.com": "Roy-oss1",


### PR DESCRIPTION
## Summary
`auxiliary.<task>.model: auto` now behaves like `model: ""` — it inherits the user's main model — instead of shipping the literal string `"auto"` to the provider as a model id.

Root cause: `provider: auto` has always been a documented sentinel (checked `!= "auto"` throughout the resolver), but the *model* field was never taught the same convention. Only `model: ""` resolved to `None`. A user who wrote `model: auto` (mirroring the `provider: auto` they see documented) got the string `"auto"` sent to the wire, where the provider replies 200 OK with an error-text body (`"the model 'auto' does not exist"`). `ContextCompressor` then accepts that error text as the compressed summary — silent context corruption, no exception raised.

## Changes
- `agent/auxiliary_client.py`: in `_resolve_task_provider_model()`, normalize `cfg_model.lower() == "auto"` to `None` before `resolved_model = model or cfg_model`, so the existing `_resolve_auto()` main-model fallback fills it in. (contributor commit)
- `scripts/release.py`: add `kyzcreig@gmail.com` to AUTHOR_MAP (the cherry-picked commit is authored under the plain email).

## Validation
| config | before | after |
|---|---|---|
| `model: auto` | `("auto", "auto", …)` → wire rejects | `("auto", None, …)` → main model |
| `model: AUTO` | `("…", "AUTO", …)` | `("…", None, …)` |
| `model: ""` | `("auto", None, …)` | `("auto", None, …)` (unchanged) |
| `model: google/gemini-2.5-flash` | preserved | preserved |

- E2E with real imports against an isolated `HERMES_HOME`: `auto` / `AUTO` / `""` all resolve to `None`; a real model id survives untouched; `model: auto` now returns the exact same tuple as `model: ""`.
- `293/293` aux resolver tests pass (`test_auxiliary_client.py` + `test_auxiliary_main_first.py`), 0 failures.

Salvaged from #24361 by @Kyzcreig with authorship preserved. Supersedes the identical resubmission #34296.

## Infographic
![PR #24361 infographic](https://v3b.fal.media/files/b/0aa07b28/3okCGHxTarZZ0nS8wJGFR_BQk8FUDM.png)
