### PR TITLE
fix(dashboard): skip auto-SSO redirect for password-only providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,13 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+
+    # Password-only providers (e.g. BasicAuthProvider) don't support OAuth
+    # redirect — /auth/login would crash with NotImplementedError.  Let the
+    # /login page render the password form instead.
+    if getattr(provider, "supports_password", False):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -117,6 +117,37 @@ def test_gated_html_redirects_to_login(gated_app):
     assert r.headers["location"].startswith("/auth/login?provider=stub")
 
 
+def test_password_only_provider_skips_auto_sso(gated_app):
+    """A password-only provider (basic) must NOT trigger auto-SSO redirect
+    to /auth/login — it should fall through to /login which renders the
+    password form.  Regression for #56130.
+    """
+    import secrets
+
+    import plugins.dashboard_auth.basic as basic_mod
+
+    clear_providers()
+    register_provider(
+        basic_mod.BasicAuthProvider(
+            username="admin",
+            password_hash=basic_mod.hash_password("pw"),
+            secret=secrets.token_bytes(32),
+        )
+    )
+    try:
+        r = gated_app.get("/", follow_redirects=False)
+        # Should redirect to /login (the password form), not /auth/login
+        assert r.status_code == 302
+        location = r.headers.get("location", "")
+        assert "/auth/login" not in location, (
+            f"password-only provider should not auto-SSO to {location}"
+        )
+        assert "/login" in location
+    finally:
+        clear_providers()
+        register_provider(StubAuthProvider())
+
+
 def test_gated_auth_providers_is_public(gated_app):
     r = gated_app.get("/api/auth/providers")
     assert r.status_code == 200


### PR DESCRIPTION
## What does this PR do?

Fixes an HTTP 500 crash when the dashboard is bound to a non-loopback interface with `basic_auth` configured. The `_auto_sso_response()` middleware unconditionally redirects to `/auth/login` when exactly one session provider is registered, but `BasicAuthProvider` is password-only and crashes with `NotImplementedError` inside `start_login()`.

The fix adds a guard: if the sole provider has `supports_password=True`, skip the auto-SSO redirect and fall through to `/login` which renders the password form.

## Related Issue

Fixes #56130

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/middleware.py` — In `_auto_sso_response()`, skip auto-SSO redirect when the single provider is password-only (`supports_password=True`), letting `/login` render the password form instead.
- `tests/hermes_cli/test_dashboard_auth_middleware.py` — Add `test_password_only_provider_skips_auto_sso` regression test.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_dashboard_auth_middleware.py -q` — all 34 tests should pass (including the new regression test).
2. Run `python -m pytest tests/plugins/dashboard_auth/ -q` — all 181 tests should pass.
3. Manual: configure `basic_auth` in `config.yaml`, start dashboard on non-loopback host, visit `/` — should redirect to `/login` (password form), not crash with 500.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (middleware logic is platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
