### PR TITLE
test(cron): apply run_job patches via ExitStack, not a positional list

### DIFF
--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1,5 +1,6 @@
 """Tests for cron/scheduler.py — origin resolution, delivery routing, and error logging."""
 
+import contextlib
 import json
 import logging
 import os
@@ -1197,10 +1198,24 @@ class TestRunJobSessionPersistence:
         assert success is True
         cleanup_mock.assert_called_once()
 
-    def _make_run_job_patches(self, tmp_path):
-        """Common patches for run_job tests."""
+    @contextlib.contextmanager
+    def _run_job_patches(self, tmp_path, extra=()):
+        """Apply every patch run_job tests need, as one bundle.
+
+        Yields ``(fake_db, mock_agent_cls)``. Using an ExitStack that enters
+        the whole list means a caller can never silently drop a patch by
+        index — the previous positional-list form let a seam split shift
+        ``resolve_runtime_provider`` off the end of the applied slice, so the
+        real resolver ran and (only on a dev machine with ambient creds) hid
+        an auth failure that CI then caught. Every test enters all patches.
+
+        ``extra`` is an iterable of additional context managers (e.g. a
+        per-test ``_get_platform_tools`` patch) entered alongside the base set.
+        """
         fake_db = MagicMock()
-        return fake_db, [
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        base = [
             patch("cron.scheduler._hermes_home", tmp_path),
             patch("cron.scheduler._resolve_origin", return_value=None),
             patch("hermes_cli.env_loader.load_hermes_dotenv"),
@@ -1215,7 +1230,14 @@ class TestRunJobSessionPersistence:
                     "api_mode": "chat_completions",
                 },
             ),
+            patch("run_agent.AIAgent", return_value=mock_agent),
         ]
+        with contextlib.ExitStack() as stack:
+            entered = [stack.enter_context(cm) for cm in base]
+            for cm in extra:
+                stack.enter_context(cm)
+            mock_agent_cls = entered[-1]  # the AIAgent patch
+            yield fake_db, mock_agent_cls
 
     def test_run_job_passes_enabled_toolsets_to_agent(self, tmp_path):
         job = {
@@ -1224,12 +1246,7 @@ class TestRunJobSessionPersistence:
             "prompt": "hello",
             "enabled_toolsets": ["web", "terminal", "file"],
         }
-        fake_db, patches = self._make_run_job_patches(tmp_path)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], \
-             patch("run_agent.AIAgent") as mock_agent_cls:
-            mock_agent = MagicMock()
-            mock_agent.run_conversation.return_value = {"final_response": "ok"}
-            mock_agent_cls.return_value = mock_agent
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
             run_job(job)
 
         kwargs = mock_agent_cls.call_args.kwargs
@@ -1258,12 +1275,7 @@ class TestRunJobSessionPersistence:
             "prompt": "hello",
             "enabled_toolsets": ["web", "terminal", "file"],
         }
-        fake_db, patches = self._make_run_job_patches(tmp_path)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], \
-             patch("run_agent.AIAgent") as mock_agent_cls:
-            mock_agent = MagicMock()
-            mock_agent.run_conversation.return_value = {"final_response": "ok"}
-            mock_agent_cls.return_value = mock_agent
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
             run_job(job)
 
         kwargs = mock_agent_cls.call_args.kwargs
@@ -1285,12 +1297,7 @@ class TestRunJobSessionPersistence:
             "name": "test",
             "prompt": "hello",
         }
-        fake_db, patches = self._make_run_job_patches(tmp_path)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], \
-             patch("run_agent.AIAgent") as mock_agent_cls:
-            mock_agent = MagicMock()
-            mock_agent.run_conversation.return_value = {"final_response": "ok"}
-            mock_agent_cls.return_value = mock_agent
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
             run_job(job)
 
         kwargs = mock_agent_cls.call_args.kwargs
@@ -1311,18 +1318,10 @@ class TestRunJobSessionPersistence:
             "prompt": "hello",
             "enabled_toolsets": ["terminal"],
         }
-        fake_db, patches = self._make_run_job_patches(tmp_path)
         # Even if the user has ``hermes tools`` configured to enable web+file
         # for cron, the per-job override wins.
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], \
-             patch("run_agent.AIAgent") as mock_agent_cls, \
-             patch(
-                 "hermes_cli.tools_config._get_platform_tools",
-                 return_value={"web", "file"},
-             ):
-            mock_agent = MagicMock()
-            mock_agent.run_conversation.return_value = {"final_response": "ok"}
-            mock_agent_cls.return_value = mock_agent
+        extra = [patch("hermes_cli.tools_config._get_platform_tools", return_value={"web", "file"})]
+        with self._run_job_patches(tmp_path, extra=extra) as (_fake_db, mock_agent_cls):
             run_job(job)
 
         kwargs = mock_agent_cls.call_args.kwargs


### PR DESCRIPTION
## Summary

Cron `run_job` tests can no longer silently drop a patch and pass locally while failing on CI. The shared helper now applies its patch bundle via `contextlib.ExitStack` instead of returning a positional list that callers sliced by index.

## Root cause

`TestRunJobSessionPersistence` shared `_make_run_job_patches(tmp_path)` which returned a positional list; each caller applied a fixed slice (`with patches[0], patches[1], … patches[4]:`). When a recent env-loader seam fix split one entry into two, the list grew by one and every caller's slice silently dropped the last entry — `resolve_runtime_provider` — off the end. `run_job` then called the real resolver.

That passed locally because the cron delivery-routing path seeds ambient provider state into a process-global (via plugin discovery) that survives across tests in the same file, so a later test resolved a provider even with blanked creds and an isolated `HERMES_HOME`. On CI's clean runner HOME nothing seeds it, the resolver raised `AuthError`, `AIAgent` was never constructed, and the tests failed with `NoneType … kwargs`.

## Changes

- `tests/cron/test_scheduler.py`: `_make_run_job_patches` → `_run_job_patches`, a `@contextlib.contextmanager` that enters the whole patch bundle via `ExitStack` and yields `(fake_db, mock_agent_cls)`. Callers can no longer drop a patch by index, so a future seam split can't reintroduce the local-green/CI-red split. Behaviour and assertions unchanged.

## Validation

| | Result |
|---|---|
| 4 affected tests, isolated (CI-parity) | pass |
| Full `test_scheduler.py` (192) | pass |
| Full `tests/cron/` (577) | pass |
| ruff | clean |

Verified the failure mode reproduces (drop the provider patch → tests fail on a clean env) and that the ExitStack shape makes it unreachable.

## Infographic

![test hardening infographic](https://v3b.fal.media/files/b/0aa07b57/eW8dGSRe6wW0BUt-o83-D_S19ii3a4.png)
