### PR TITLE
fix(anthropic): preserve tool_use cache_control markers (salvage #52534)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1891,6 +1891,18 @@ def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _apply_assistant_cache_control_to_last_cacheable_block(
+    blocks: List[Dict[str, Any]],
+    cache_control: Any,
+) -> None:
+    if not isinstance(cache_control, dict):
+        return
+    for block in reversed(blocks):
+        if isinstance(block, dict) and block.get("type") in {"text", "tool_use"}:
+            block.setdefault("cache_control", dict(cache_control))
+            break
+
+
 def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     """Convert an assistant message to Anthropic content blocks.
 
@@ -1945,6 +1957,9 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
                     clean["input"] = redacted
             replayed.append(clean)
         if replayed:
+            _apply_assistant_cache_control_to_last_cacheable_block(
+                replayed, m.get("cache_control")
+            )
             return {"role": "assistant", "content": replayed}
 
     blocks = _extract_preserved_thinking_blocks(m)
@@ -1970,11 +1985,9 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
             "name": fn.get("name", ""),
             "input": parsed_args,
         })
-    if isinstance(m.get("cache_control"), dict):
-        for block in reversed(blocks):
-            if isinstance(block, dict) and block.get("type") in {"text", "tool_use"}:
-                block.setdefault("cache_control", dict(m["cache_control"]))
-                break
+    _apply_assistant_cache_control_to_last_cacheable_block(
+        blocks, m.get("cache_control")
+    )
     # Kimi's /coding endpoint (Anthropic protocol) requires assistant
     # tool-call messages to carry reasoning_content when thinking is
     # enabled server-side.  Preserve it as a thinking block so Kimi

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1970,6 +1970,11 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
             "name": fn.get("name", ""),
             "input": parsed_args,
         })
+    if isinstance(m.get("cache_control"), dict):
+        for block in reversed(blocks):
+            if isinstance(block, dict) and block.get("type") in {"text", "tool_use"}:
+                block.setdefault("cache_control", dict(m["cache_control"]))
+                break
     # Kimi's /coding endpoint (Anthropic protocol) requires assistant
     # tool-call messages to carry reasoning_content when thinking is
     # enabled server-side.  Preserve it as a thinking block so Kimi

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -109,6 +109,7 @@ AUTHOR_MAP = {
     "yashiel@skyner.co.za": "yashiels",  # PR #53284 salvage (discord markdown table-to-bullet conversion; #21168)
     "46495124+yungchentang@users.noreply.github.com": "yungchentang",  # PR #53622 salvage (drain Telegram general send pool on pool timeout before retry; #53524)
     "15205536+595650661@users.noreply.github.com": "595650661",  # PR #37851 salvage (classify MiniMax new_sensitive content filter → content_policy_blocked; #32421)
+    "qWaitCrypto@users.noreply.github.com": "qWaitCrypto",  # PR #52534 salvage (preserve assistant tool_use cache_control marker in Anthropic conversion so cache breakpoints aren't dropped from the wire)
     "benbenwyb@gmail.com": "benbenlijie",  # PR #47205 salvage (named custom-provider extra_body + Z.AI Coding overload adaptive backoff; #50663)
     "dana@added-value.co.il": "Danamove",  # PR #46726 salvage (kill venv-resident pythonw gateway before recreating venv on Windows; #47036/#47557/#47910)
     "rcint@klaith.com": "rc-int",  # PR #9126 salvage / co-author (cap subagent summary size vs parent context overflow)

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1024,6 +1024,28 @@ class TestConvertMessages:
         assert assistant_blocks[0]["text"] == "Hello from assistant"
         assert assistant_blocks[0]["cache_control"] == {"type": "ephemeral"}
 
+    def test_assistant_tool_use_cache_control_is_preserved(self):
+        messages = apply_anthropic_cache_control([
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Run the tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_1", "function": {"name": "test_tool", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+        ], native_anthropic=True)
+
+        _, result = convert_messages_to_anthropic(messages)
+        assistant_msg = [m for m in result if m["role"] == "assistant"][0]
+        tool_use = assistant_msg["content"][-1]
+
+        assert tool_use["type"] == "tool_use"
+        assert tool_use["id"] == "tc_1"
+        assert tool_use["cache_control"] == {"type": "ephemeral"}
+
     def test_tool_cache_control_is_preserved_on_tool_result_block(self):
         messages = apply_anthropic_cache_control([
             {"role": "system", "content": "System prompt"},

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1046,6 +1046,50 @@ class TestConvertMessages:
         assert tool_use["id"] == "tc_1"
         assert tool_use["cache_control"] == {"type": "ephemeral"}
 
+    def test_ordered_replay_tool_use_cache_control_is_preserved(self):
+        messages = apply_anthropic_cache_control([
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Run the tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "anthropic_content_blocks": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Need a tool.",
+                        "signature": "sig_1",
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "tc_1",
+                        "name": "test_tool",
+                        "input": {"query": "raw"},
+                    },
+                ],
+                "tool_calls": [
+                    {
+                        "id": "tc_1",
+                        "function": {
+                            "name": "test_tool",
+                            "arguments": '{"query":"redacted"}',
+                        },
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+        ], native_anthropic=True)
+
+        _, result = convert_messages_to_anthropic(messages)
+        assistant_msg = [m for m in result if m["role"] == "assistant"][0]
+        thinking, tool_use = assistant_msg["content"]
+
+        assert thinking["type"] == "thinking"
+        assert "cache_control" not in thinking
+        assert tool_use["type"] == "tool_use"
+        assert tool_use["id"] == "tc_1"
+        assert tool_use["input"] == {"query": "redacted"}
+        assert tool_use["cache_control"] == {"type": "ephemeral"}
+
     def test_tool_cache_control_is_preserved_on_tool_result_block(self):
         messages = apply_anthropic_cache_control([
             {"role": "system", "content": "System prompt"},


### PR DESCRIPTION
## Summary
Assistant tool-call turns selected as Anthropic cache breakpoints now keep their `cache_control` marker on the wire — previously it was silently dropped, discarding a paid-for prompt-cache breakpoint on native Anthropic tool loops.

**Root cause:** an assistant tool-call message is `{"role":"assistant","content":"","tool_calls":[...]}`. Because `content == ""`, `_apply_cache_marker` sets a *top-level* `msg["cache_control"]`. `_convert_assistant_message()` then rebuilds Anthropic `tool_use` blocks from `tool_calls` but never copied that marker onto a block — and Anthropic only honors `cache_control` on content blocks. Sibling paths already preserved it (assistant text blocks inline the marker; `tool_result` copies it) — `tool_use` was the one gap.

## Changes
- `agent/anthropic_adapter.py`: new `_apply_assistant_cache_control_to_last_cacheable_block()` helper copies the top-level assistant `cache_control` onto the last converted `text`/`tool_use` block, wired into both the normal and ordered-replay conversion paths. Uses `setdefault` on the last cacheable block, so it never lands on a thinking block (which would break signature validation).
- `tests/agent/test_anthropic_adapter.py`: two regression tests — plain tool-call turn, and the interleaved-thinking ordered-replay path (asserts marker lands on `tool_use`, not the preceding `thinking`).
- `scripts/release.py`: AUTHOR_MAP entry for the contributor's noreply email.

## Validation
| | Before fix (main) | After fix |
|---|---|---|
| New regression tests | 2 FAIL — `KeyError: 'cache_control'` | pass |
| Full adapter suite | — | 171/171 pass |

Salvage of #52534 by @qWaitCrypto, cherry-picked onto current `main` with authorship preserved.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa07b87/7Texx8T0JYrJS86g9SNIH_4YKzk93m.png)
