### PR TITLE
feat(web): allow plugin-registered backends through the availability gate

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -147,6 +147,15 @@ def _get_backend() -> str:
     if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
         return configured
 
+    # Plugin-registered backends — accept if a provider exists
+    try:
+        from agent.web_search_registry import get_provider  # type: ignore[import-untyped]
+
+        if get_provider(configured) is not None:
+            return configured
+    except Exception:
+        pass
+
     # Fallback for manual / legacy config — pick the highest-priority
     # available backend. Explicit user credentials (TAVILY_API_KEY etc.)
     # beat the managed-tool-gateway probe so a deliberate setup is not
@@ -235,6 +244,16 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+
+    # Plugin-registered backends — consult the provider itself
+    try:
+        from agent.web_search_registry import get_provider  # type: ignore[import-untyped]
+
+        provider = get_provider(backend)
+        if provider is not None:
+            return provider.is_available()
+    except Exception:
+        pass
     return False
 
 
@@ -854,6 +873,16 @@ def check_web_api_key() -> bool:
     configured = _load_web_config().get("backend", "").lower().strip()
     if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
         return _is_backend_available(configured)
+
+    # Plugin-registered backends
+    try:
+        from agent.web_search_registry import get_provider  # type: ignore[import-untyped]
+
+        if get_provider(configured) is not None:
+            return _is_backend_available(configured)
+    except Exception:
+        pass
+
     return any(
         _is_backend_available(backend)
         for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")


### PR DESCRIPTION
## Summary

_is_backend_available() and _get_backend() use hardcoded backend-name whitelists that reject any backend registered by a plugin (community or user-installed). A plugin can call ctx.register_web_search_provider(), the provider appears in the registry, but web_extract and web_search silently fall back to a different backend because the availability gate never consults the registry.

This makes the plugin system's own register_web_search_provider() API — the recommended way to add backends — non-functional for its intended purpose.

## Problem

Three places in tools/web_tools.py maintain hardcoded lists of known backend names:

| Location | What it does | Effect on plugin backends |
|---|---|---|
| _is_backend_available() (L214-241) | Returns True only for known names | Unknown name -> None (falsy) -> gate fails |
| _get_backend() (L147) | if configured in {known set} | Unknown name -> skipped -> falls through to env-var auto-detect |
| check_web_api_key() (L861) | Same whitelist pattern | Same rejection |

A user who follows the standard plugin workflow — `hermes plugins install <plugin> --enable` then `hermes config set web.extract_backend <name>` — will see web_extract silently fall back to ddgs with no indication that the plugin backend was the intended target.

## Solution

After the existing hardcoded checks, fall back to the web search registry. If a provider with the requested name is registered, delegate the availability decision to provider.is_available().

Three locations updated (~29 lines added):
- _is_backend_available() — after all hardcoded checks, before return False
- _get_backend() — after the whitelist check, before the env-var fallback
- check_web_api_key() — after the whitelist check

### Why this is safe

- Short-circuit preserved — the hardcoded checks run first, so every existing backend's behaviour is identical. No regression.
- Exception-guarded — the registry lookup is wrapped in try/except so a broken plugin import can't break the agent loop.
- Already the contract — PluginContext.register_web_search_provider() exists. The registry already stores providers. get_provider() works. This change connects the last missing link.

## Related

- Community plugin alexandrustefan/hermes-smart-fetch — works around this gap today by registering standalone tools but cannot function as a drop-in web_extract backend.
- Issue #21508 (Ollama backend) — required modifying the same source files; this generic solution would have made it a plugin-only install.