### PR TITLE
fix(gateway): prevent Discord disconnects from blocking event loop

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2155,6 +2155,35 @@ def get_model_context_length(
     return DEFAULT_FALLBACK_CONTEXT
 
 
+async def get_model_context_length_async(
+    model: str,
+    base_url: str = "",
+    api_key: str = "",
+    config_context_length: int | None = None,
+    provider: str = "",
+    custom_providers: list | None = None,
+) -> int:
+    """Async variant of get_model_context_length.
+
+    Offloads the entire synchronous resolution chain (which contains
+    blocking HTTP calls via ``requests``) to a background thread so it
+    does not freeze the asyncio event loop and cause Discord heartbeat
+    timeouts.
+
+    Shares all logic with the sync version — no code duplication.
+    """
+    import asyncio
+    return await asyncio.to_thread(
+        get_model_context_length,
+        model,
+        base_url=base_url,
+        api_key=api_key,
+        config_context_length=config_context_length,
+        provider=provider,
+        custom_providers=custom_providers,
+    )
+
+
 def estimate_tokens_rough(text: str) -> int:
     """Rough token estimate (~4 chars/token) for pre-flight checks.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9743,7 +9743,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if "@" in message_text:
             try:
                 from agent.context_references import preprocess_context_references_async
-                from agent.model_metadata import get_model_context_length
+                from agent.model_metadata import get_model_context_length_async
 
                 _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
                 _msg_runtime = _resolve_runtime_agent_kwargs()
@@ -9757,7 +9757,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _msg_config_ctx = int(_msg_raw_ctx)
                 except Exception:
                     pass
-                _msg_ctx_len = get_model_context_length(
+                _msg_ctx_len = await get_model_context_length_async(
                     self._model,
                     base_url=self._base_url or _msg_runtime.get("base_url") or "",
                     api_key=_msg_runtime.get("api_key") or "",
@@ -10095,7 +10095,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if history and len(history) >= 4:
             from agent.model_metadata import (
                 estimate_messages_tokens_rough,
-                get_model_context_length,
+                get_model_context_length_async,
             )
 
             # Read model + compression config from config.yaml.
@@ -10196,7 +10196,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
 
             if _hyg_compression_enabled:
-                _hyg_context_length = get_model_context_length(
+                _hyg_context_length = await get_model_context_length_async(
                     _hyg_model,
                     base_url=_hyg_base_url or "",
                     api_key=_hyg_api_key or "",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "5848605+itenev@users.noreply.github.com": "itenev",  # PR #22753 salvage (asyncify model-context resolution in gateway message path so blocking requests.get can't starve Discord heartbeats)
     "290873280+rrevenanttt@users.noreply.github.com": "rrevenanttt",  # PR #40773 salvage (close hardline rm bypass via quoted paths and ${HOME} brace form)
     "290871358+Vesna-9@users.noreply.github.com": "Vesna-9",  # PR #41274 salvage (collapse shell line continuations before dangerous/hardline pattern matching so `rm -rf \<newline>/` can't bypass the yolo-proof hardline floor)
     "214165399+kernel-t1@users.noreply.github.com": "kernel-t1",  # PR #41349 salvage (.env sanitizer: only split when line starts with a known KEY= and preceding values are plain tokens; keep URL/query/whitespace secrets verbatim)


### PR DESCRIPTION
## Summary
The Discord gateway no longer disconnects with `ClientConnectionResetError` when the agent resolves model metadata during message handling.

Root cause: `agent/models_dev.py` fetches the models.dev registry with a synchronous `requests.get(timeout=15)`. Called from the async gateway handlers, that call blocked the single-threaded asyncio event loop for up to 15s — starving Discord heartbeats and triggering "Cannot write to closing transport" disconnects.

## Changes
- `agent/model_metadata.py`: add `get_model_context_length_async()` — offloads the entire existing sync resolution chain to a worker thread via `asyncio.to_thread()`. The sync path stays the single source of truth for the models.dev cache.
- `gateway/run.py`: switch the two async call sites (`_prepare_inbound_message_text`, `_handle_message_with_agent`) to `await get_model_context_length_async(...)`. The third call site (`_format_session_info`) is a plain sync `def` and is correctly left untouched.

## Salvage note
Salvaged from @itenev's PR #22753 with authorship preserved. Dropped the original PR's `fetch_models_dev_async` / `lookup_models_dev_context_async` aiohttp variants (86 LOC): they had **zero callers** (dead code) and had drifted from the sync cache logic (missing the fresh-by-mtime disk-cache short-circuit). The `to_thread` wrapper already runs the sync path off-loop, so the parallel aiohttp implementation was redundant. Net: 119/-4 → 34/-4.

## Validation
E2E: cold-cache resolution (0.49s real network fetch through the sync chain) while a 50ms heartbeat task ran concurrently.

| | Before (on-loop) | After (`to_thread`) |
|---|---|---|
| Max event-loop gap | ~490ms (loop frozen) | 52ms (responsive) |
| Discord heartbeat | starved | steady |
| Context resolved | — | 1,000,000 (int, correct) |

Tests: `tests/agent/test_models_dev.py` + `tests/agent/test_model_metadata.py` — 137 passed.

## Infographic
![PR #22753 infographic](https://v3b.fal.media/files/b/0aa07bf1/m4elNSp2CZD_9hkPXqNsh_uUv5g7Wb.png)
