### PR TITLE
fix(desktop): validate URL protocol before loading in hidden title-extraction window

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3518,6 +3518,18 @@ function runRenderTitleJob(rawUrl) {
   return new Promise(resolve => {
     if (!app.isReady()) return resolve('')
 
+    // Only http(s) URLs can be loaded in a hidden BrowserWindow for title
+    // extraction. Non-http protocols (e.g. bitbrowser://) would otherwise
+    // trigger the OS external protocol handler dialog as a side effect.
+    try {
+      const parsed = new URL(rawUrl)
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return resolve('')
+      }
+    } catch {
+      return resolve('')
+    }
+
     const partitionSession = getLinkTitleSession()
     if (!partitionSession) return resolve('')
 


### PR DESCRIPTION
## What

The `runRenderTitleJob` function loads arbitrary URLs in a hidden BrowserWindow
to extract page titles. When the URL uses a non-http protocol (e.g. `bitbrowser://`),
Electron/Chromium delegates the protocol to the OS, which shows a dialog.

## Root cause

The function lacks protocol validation before calling `loadURL()`. A link
artifact with a `bitbrowser://cc/` URL triggers the OS dialog.

## Fix

Added a protocol check at the top of `runRenderTitleJob`. Only `http:` and
`https:` URLs proceed. All other protocols are silently skipped.

## How to test

1. Open the Artifacts page with a link artifact whose href is `bitbrowser://...`
2. Before: OS shows protocol handler dialog
3. After: no dialog, link silently skipped

## Platforms tested

Windows 10 (Hermes Desktop v0.17.0)