### PR TITLE
fix(security): extend /proc read block to maps siblings + auxv + pagemap

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -93,7 +93,7 @@ class TestDevicePathBlocking(unittest.TestCase):
         self.assertFalse(_is_blocked_device_path("/proc/self/fd/3"))
 
     def test_proc_sensitive_pseudo_files_blocked(self):
-        """environ/cmdline/maps under /proc/<pid> must be blocked (issue #4427)."""
+        """environ/cmdline/maps (and maps variants) under /proc/<pid> must be blocked (issue #4427)."""
         for path in (
             "/proc/self/environ",
             "/proc/12345/environ",
@@ -101,6 +101,14 @@ class TestDevicePathBlocking(unittest.TestCase):
             "/proc/99/cmdline",
             "/proc/self/maps",
             "/proc/1/maps",
+            "/proc/self/smaps",
+            "/proc/12345/smaps",
+            "/proc/self/smaps_rollup",
+            "/proc/99/smaps_rollup",
+            "/proc/self/numa_maps",
+            "/proc/1/numa_maps",
+            "/proc/self/mem",
+            "/proc/12345/mem",
         ):
             self.assertTrue(_is_blocked_device(path), f"{path} should be blocked")
 

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -109,6 +109,21 @@ class TestDevicePathBlocking(unittest.TestCase):
             "/proc/1/numa_maps",
             "/proc/self/mem",
             "/proc/12345/mem",
+            "/proc/self/auxv",
+            "/proc/1/auxv",
+            "/proc/self/pagemap",
+            "/proc/99/pagemap",
+        ):
+            self.assertTrue(_is_blocked_device(path), f"{path} should be blocked")
+
+    def test_proc_task_thread_sensitive_files_blocked(self):
+        """Per-thread /proc/<pid>/task/<tid>/<file> aliases leak the same data."""
+        for path in (
+            "/proc/self/task/1234/maps",
+            "/proc/self/task/1234/smaps",
+            "/proc/self/task/1234/auxv",
+            "/proc/self/task/1234/pagemap",
+            "/proc/self/task/1234/environ",
         ):
             self.assertTrue(_is_blocked_device(path), f"{path} should be blocked")
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -367,8 +367,22 @@ def _is_blocked_device_path(path: str) -> bool:
     # memory layout (ASLR bypass) from the host process (issue #4427).
     # /proc/*/mem exposes raw process memory; block it as defense-in-depth even
     # though it requires address knowledge to exploit usefully.
+    # /proc/*/auxv leaks AT_RANDOM (stack canary seed) plus AT_BASE/AT_PHDR
+    # load addresses — an ASLR oracle on par with maps. /proc/*/pagemap exposes
+    # virtual->physical translation. Both are blocked alongside the maps family.
+    # endswith matches both /proc/<pid>/X and /proc/<pid>/task/<tid>/X.
     if normalized.startswith("/proc/") and normalized.endswith(
-        ("/environ", "/cmdline", "/maps", "/smaps", "/smaps_rollup", "/numa_maps", "/mem")
+        (
+            "/environ",
+            "/cmdline",
+            "/maps",
+            "/smaps",
+            "/smaps_rollup",
+            "/numa_maps",
+            "/mem",
+            "/auxv",
+            "/pagemap",
+        )
     ):
         return True
     return False

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -362,10 +362,13 @@ def _is_blocked_device_path(path: str) -> bool:
         ("/fd/0", "/fd/1", "/fd/2")
     ):
         return True
-    # /proc/*/environ, /proc/*/cmdline, /proc/*/maps can leak secrets,
-    # command-line args, and memory layout from the host process (issue #4427)
+    # /proc/*/environ, /proc/*/cmdline, /proc/*/maps (and the maps variants
+    # smaps, smaps_rollup, numa_maps) can leak secrets, command-line args, and
+    # memory layout (ASLR bypass) from the host process (issue #4427).
+    # /proc/*/mem exposes raw process memory; block it as defense-in-depth even
+    # though it requires address knowledge to exploit usefully.
     if normalized.startswith("/proc/") and normalized.endswith(
-        ("/environ", "/cmdline", "/maps")
+        ("/environ", "/cmdline", "/maps", "/smaps", "/smaps_rollup", "/numa_maps", "/mem")
     ):
         return True
     return False


### PR DESCRIPTION
## Summary
`read_file` now blocks six more `/proc/*` pseudo-files that leaked the same ASLR layout `/proc/*/maps` was hidden to protect (PR #4609). Previously `_is_blocked_device_path()` only matched `endswith(("/environ", "/cmdline", "/maps"))`, so every sibling below slipped through.

| Path | Leak | Was blocked? |
|------|------|--------------|
| `/proc/*/smaps` | Superset of maps: full VMA list + addresses | ❌ |
| `/proc/*/smaps_rollup` | Aggregated VMA addresses | ❌ |
| `/proc/*/numa_maps` | VMA dump + NUMA annotations | ❌ |
| `/proc/*/mem` | Raw RW process memory | ❌ |
| `/proc/*/auxv` | AT_RANDOM canary seed + AT_BASE/AT_PHDR load addrs | ❌ |
| `/proc/*/pagemap` | Virtual→physical translation | ❌ |

`read_file("/proc/self/smaps")` or `/proc/self/auxv` recovered the exact address layout #4609 set out to hide.

## Changes
- `tools/file_tools.py`: extend the `endswith` tuple in `_is_blocked_device_path()` to cover smaps / smaps_rollup / numa_maps / mem (@AhmetArif0's commit) plus auxv / pagemap. `endswith` matches both `/proc/<pid>/X` and the per-thread `/proc/<pid>/task/<tid>/X` alias.
- `tests/tools/test_file_read_guards.py`: regression assertions for all six new paths + a new test for the `/proc/<pid>/task/<tid>/*` thread-alias form.

Same suffix-tuple pattern as #4609. A regex/set refactor across the full `/proc` leak surface (stack, syscall, wchan, kallsyms, …) is a worthwhile follow-up but out of scope for closing this immediate gap.

## Validation
| | Before | After |
|---|---|---|
| `/proc/self/{smaps,smaps_rollup,numa_maps,mem,auxv,pagemap}` | readable | blocked |
| `/proc/self/task/<tid>/{maps,auxv,pagemap,…}` | readable | blocked |
| `/proc/{cpuinfo,meminfo,version,uptime,status}` | readable | readable (no false positive) |

- `tests/tools/test_file_read_guards.py`: 43/43 pass.
- E2E with real imports against a temp `HERMES_HOME`: all 10 sensitive paths refused at both the `_is_blocked_device` guard and the `read_file` surface; all 5 legit `/proc` paths still readable.

Salvage of #32238 (@AhmetArif0, commit cherry-picked with authorship preserved). Closes #34430, closes #32238.

## Infographic

![proc-read-guard-hardened](https://v3b.fal.media/files/b/0aa07c44/lsDiZ3T1woEnbVlfLQyn3_1GHRnV85.png)
