### PR TITLE
security(agent): redact Slack App-Level (xapp-) tokens

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -76,7 +76,8 @@ _PREFIX_PATTERNS = [
     r"ghu_[A-Za-z0-9]{10,}",            # GitHub user-to-server token
     r"ghs_[A-Za-z0-9]{10,}",            # GitHub server-to-server token
     r"ghr_[A-Za-z0-9]{10,}",            # GitHub refresh token
-    r"xox[baprs]-[A-Za-z0-9-]{10,}",    # Slack tokens
+    r"xapp-\d+-[A-Za-z0-9-]{10,}",      # Slack app-Level token
+    r"xox[baprs]-[A-Za-z0-9-]{10,}",    # Slack bot/app/user tokens
     r"AIza[A-Za-z0-9_-]{30,}",          # Google API keys
     r"pplx-[A-Za-z0-9]{10,}",           # Perplexity
     r"fal_[A-Za-z0-9_-]{10,}",          # Fal.ai

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -147,6 +147,7 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bxapp-\d+-[A-Za-z0-9\-]{20,}\b"),
     re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{20,}\b"),
     re.compile(r"\bhf_[A-Za-z0-9]{20,}\b"),
     re.compile(r"\bglpat-[A-Za-z0-9_\-]{20,}\b"),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "5848605+itenev@users.noreply.github.com": "itenev",  # PR #22753 salvage (asyncify model-context resolution in gateway message path so blocking requests.get can't starve Discord heartbeats)
+    "arthur.zhang@ingenico.com": "arthurzhang",  # PR #34718 salvage (redact Slack App-Level xapp- tokens in agent/redact.py + gateway/run.py)
     "290873280+rrevenanttt@users.noreply.github.com": "rrevenanttt",  # PR #40773 salvage (close hardline rm bypass via quoted paths and ${HOME} brace form)
     "290871358+Vesna-9@users.noreply.github.com": "Vesna-9",  # PR #41274 salvage (collapse shell line continuations before dangerous/hardline pattern matching so `rm -rf \<newline>/` can't bypass the yolo-proof hardline floor)
     "214165399+kernel-t1@users.noreply.github.com": "kernel-t1",  # PR #41349 salvage (.env sanitizer: only split when line starts with a known KEY= and preceding values are plain tokens; keep URL/query/whitespace secrets verbatim)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -41,6 +41,12 @@ class TestKnownPrefixes:
         result = redact_sensitive_text(token)
         assert "a" * 14 not in result
 
+    def test_slack_app_token(self):
+        token = "xapp-1-A1234567890-B1234567890-C1234567890"
+        result = redact_sensitive_text(token)
+        assert "A1234567890-B1234567890-C1234567890" not in result
+        assert "xapp-1" in result
+
     def test_google_api_key(self):
         result = redact_sensitive_text("AIzaSyB-abc123def456ghi789jklmno012345")
         assert "abc123def456" not in result


### PR DESCRIPTION
## Summary
Slack App-Level (Socket Mode) tokens — the `xapp-<num>-<hash>` format — are now redacted on both the agent and gateway secret paths, so `SLACK_APP_TOKEN` values no longer leak through to chat users with `security.redact_secrets` enabled.

Root cause: only `xox[baprs]-` was matched. The `xapp-` prefix was absent from `agent/redact.py` (`_PREFIX_PATTERNS`) and from `gateway/run.py` (`_GATEWAY_SECRET_PATTERNS`).

## Changes
- `agent/redact.py`: add `xapp-\d+-[A-Za-z0-9-]{10,}` to the prefix patterns.
- `gateway/run.py`: add `\bxapp-\d+-[A-Za-z0-9\-]{20,}\b` to the gateway secret patterns.
- `tests/agent/test_redact.py`: cover xapp- token redaction.
- `scripts/release.py`: AUTHOR_MAP entry for arthurzhang.

The `\d+-` anchor on the version segment keeps benign text like `xapp-store` from being over-matched.

## Validation
| Check | Result |
|---|---|
| `tests/agent/test_redact.py` | 133 passed |
| E2E — agent/redact path | `xapp-` token redacted |
| E2E — gateway secret path | `xapp-` token matched |
| E2E — benign `xapp-store` | not over-matched |
| E2E — `xoxb-` regression | still redacted |

## Credits
Salvage of #34718 (@arthurzhang, both-file fix + anchored regex). Test cherry-picked from #5282 (@Ruzzgar). Also fixes the gap identified in #4541 (@maymuneth). All three PRs targeted this same `xapp-` gap; closing #4541 and #5282 as duplicates with credit.

## Infographic
![Redact Slack App-Level Tokens](https://v3b.fal.media/files/b/0aa07c61/NKw1zlR-XULhbiNQgyS1n_aQEQqyzR.png)
