### PR TITLE
fix(env): inject MSYS2_ARG_CONV_EXCL=/c on Windows to prevent cmd /c silent failure

### DIFF
--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -196,3 +196,66 @@ class TestExtractCwdFromOutputWindowsMsys:
             env._extract_cwd_from_output(result)
 
         assert env.cwd == str(new_dir)
+
+
+# ---------------------------------------------------------------------------
+# _make_run_env — MSYS2_ARG_CONV_EXCL injection on Windows
+# ---------------------------------------------------------------------------
+
+class TestMsysArgConvExcl:
+    """On Windows, ``_make_run_env`` must inject ``MSYS2_ARG_CONV_EXCL=/c``
+    so Git Bash / MSYS does not rewrite the ``/c`` flag of ``cmd /c`` into a
+    filesystem path before ``cmd.exe`` receives it (issue #56147).
+
+    Without this, ``cmd /c start notepad`` silently fails (the GUI process is
+    never launched) while the bash wrapper still reports ``exit_code: 0``.
+    """
+
+    def test_injects_on_windows(self, monkeypatch):
+        import os
+        from tools.environments import local as local_mod
+        from tools.environments.local import _make_run_env
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        with patch.dict(os.environ, {"PATH": r"C:\Windows\System32"}, clear=True):
+            result = _make_run_env({})
+        assert result.get("MSYS2_ARG_CONV_EXCL") == "/c"
+
+    def test_does_not_inject_on_posix(self, monkeypatch):
+        import os
+        from tools.environments import local as local_mod
+        from tools.environments.local import _make_run_env
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        with patch.dict(os.environ, {}, clear=True):
+            result = _make_run_env({})
+        assert "MSYS2_ARG_CONV_EXCL" not in result
+
+    def test_merges_with_existing_exclusion(self, monkeypatch):
+        import os
+        from tools.environments import local as local_mod
+        from tools.environments.local import _make_run_env
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        with patch.dict(
+            os.environ,
+            {"PATH": r"C:\Windows\System32", "MSYS2_ARG_CONV_EXCL": "/x"},
+            clear=True,
+        ):
+            result = _make_run_env({})
+        assert "/c" in result["MSYS2_ARG_CONV_EXCL"]
+        assert "/x" in result["MSYS2_ARG_CONV_EXCL"]
+
+    def test_does_not_duplicate_when_already_present(self, monkeypatch):
+        import os
+        from tools.environments import local as local_mod
+        from tools.environments.local import _make_run_env
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        with patch.dict(
+            os.environ,
+            {"PATH": r"C:\Windows\System32", "MSYS2_ARG_CONV_EXCL": "/c"},
+            clear=True,
+        ):
+            result = _make_run_env({})
+        assert result["MSYS2_ARG_CONV_EXCL"] == "/c"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -640,6 +640,24 @@ def _make_run_env(env: dict) -> dict:
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         run_env.pop(_marker, None)
 
+    # On Windows, prevent MSYS/Git Bash from rewriting POSIX-style arguments
+    # (e.g. ``/c`` in ``cmd /c start notepad``) into filesystem paths before
+    # the target executable (``cmd.exe``) receives them.  Without this,
+    # ``cmd /c`` silently becomes ``cmd C:/...`` and the GUI launch fails
+    # while the bash wrapper still reports exit_code 0 (issue #56147).
+    # ``MSYS2_ARG_CONV_EXCL`` tells MSYS to skip argument conversion for the
+    # listed patterns.  We only exclude ``/c`` (the ``cmd.exe`` switch) to
+    # keep path translation working for genuine POSIX paths.  If the user
+    # already set this var we merge our exclusion into theirs so we don't
+    # clobber a broader custom exclusion list.
+    if _IS_WINDOWS:
+        _existing = run_env.get("MSYS2_ARG_CONV_EXCL", "")
+        _needed = "/c"
+        if _needed not in _existing.split(";"):
+            run_env["MSYS2_ARG_CONV_EXCL"] = (
+                f"{_existing};{_needed}" if _existing else _needed
+            )
+
     return run_env
 
 


### PR DESCRIPTION
Fixes #56147

## Description

On Windows, Hermes runs commands through `bash -c`. MSYS/Git Bash automatically rewrites POSIX-style arguments like `/c` (the `cmd.exe` switch) into filesystem paths before `cmd.exe` receives them. This causes `cmd /c start notepad` to silently fail — the GUI process is never launched — while the bash wrapper reports `exit_code: 0`, giving false success.

This fix injects `MSYS2_ARG_CONV_EXCL=/c` into the subprocess environment on Windows (in `_make_run_env`). This tells MSYS to skip argument conversion for `/c`, so `cmd.exe` receives the flag intact. The exclusion is narrowly scoped to `/c` only — genuine POSIX path translation still works. If the user already set `MSYS2_ARG_CONV_EXCL`, the fix merges `/c` into their existing exclusion list rather than clobbering it.

## Verification

- Added 4 unit tests in `TestMsysArgConvExcl` covering: injection on Windows, no-op on POSIX, merge with existing exclusions, and no-duplicate when already present.
- All 14 tests in `test_local_env_windows_msys.py` pass.
- All 40 tests in `test_local_env_blocklist.py` pass (no regressions in env building).
- Quality gates: secrets scan clean, personal refs clean, conventional commit format, only 2 files changed (fix + tests).