### PR TITLE
Make Home Assistant aiohttp clients honor proxy environment

### DIFF
--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -115,7 +115,8 @@ class HomeAssistantAdapter(BasePlatformAdapter):
 
             # Dedicated REST session for send() calls
             self._rest_session = aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=30)
+                timeout=aiohttp.ClientTimeout(total=30),
+                trust_env=True,
             )
 
             # Warn if no event filters are configured
@@ -143,7 +144,8 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         ws_url = f"{ws_url}/api/websocket"
 
         self._session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
+            timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=True,
         )
         self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
 
@@ -419,7 +421,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                         body = await resp.text()
                         return SendResult(success=False, error=f"HTTP {resp.status}: {body}")
             else:
-                async with aiohttp.ClientSession() as session:
+                async with aiohttp.ClientSession(trust_env=True) as session:
                     async with session.post(
                         url,
                         headers=headers,
@@ -504,7 +506,8 @@ async def _standalone_send(
 
     try:
         async with aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
+            timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=True,
         ) as session:
             async with session.post(url, headers=headers, json=payload) as resp:
                 if resp.status not in {200, 201}:

--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -141,7 +141,8 @@ class HomeAssistantAdapter(BasePlatformAdapter):
 
             # Dedicated REST session for send() calls
             self._rest_session = aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=30)
+                timeout=aiohttp.ClientTimeout(total=30),
+                trust_env=True,
             )
 
             # Warn if no event filters are configured
@@ -169,7 +170,8 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         ws_url = f"{ws_url}/api/websocket"
 
         self._session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
+            timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=True,
         )
         self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
 
@@ -445,7 +447,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                         body = await resp.text()
                         return SendResult(success=False, error=f"HTTP {resp.status}: {body}")
             else:
-                async with aiohttp.ClientSession() as session:
+                async with aiohttp.ClientSession(trust_env=True) as session:
                     async with session.post(
                         url,
                         headers=headers,
@@ -530,7 +532,8 @@ async def _standalone_send(
 
     try:
         async with aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
+            timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=True,
         ) as session:
             async with session.post(url, headers=headers, json=payload) as resp:
                 if resp.status not in {200, 201}:

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -16,6 +16,7 @@ from gateway.config import (
 )
 from plugins.platforms.homeassistant.adapter import (
     HomeAssistantAdapter,
+    _standalone_send,
     check_ha_requirements,
 )
 
@@ -517,6 +518,8 @@ class TestSendViaRestApi:
         assert call_args[1]["json"]["title"] == "Hermes Agent"
         assert call_args[1]["json"]["message"] == "Test notification"
         assert "Bearer tok" in call_args[1]["headers"]["Authorization"]
+        # Session must be proxy-env-aware so Agent Vault credential injection works
+        assert mock_aiohttp.ClientSession.call_args.kwargs.get("trust_env") is True
 
     @pytest.mark.asyncio
     async def test_send_http_error(self):
@@ -587,3 +590,89 @@ class TestWsUrlConstruction:
         adapter = HomeAssistantAdapter(config)
         ws_url = adapter._hass_url.replace("http://", "ws://").replace("https://", "wss://")
         assert ws_url == "wss://ha.example.com"
+
+
+# ---------------------------------------------------------------------------
+# Proxy environment support (Agent Vault credential injection)
+# ---------------------------------------------------------------------------
+
+
+class TestTrustEnv:
+    """All Home Assistant aiohttp sessions must opt in to proxy env handling.
+
+    Without trust_env=True, aiohttp ignores HTTPS_PROXY/HTTP_PROXY, so
+    traffic bypasses an env-based credential-injection proxy (e.g. Agent
+    Vault) that curl/requests/httpx would honor by default.
+    """
+
+    @staticmethod
+    def _mock_ws_session():
+        """Mock session whose ws_connect() completes the HA auth handshake."""
+        mock_ws = MagicMock()
+        mock_ws.send_json = AsyncMock()
+        mock_ws.receive_json = AsyncMock(side_effect=[
+            {"type": "auth_required"},
+            {"type": "auth_ok"},
+            {"success": True},
+        ])
+
+        mock_session = MagicMock()
+        mock_session.ws_connect = AsyncMock(return_value=mock_ws)
+        return mock_session
+
+    @pytest.mark.asyncio
+    async def test_ws_connect_uses_trust_env(self):
+        adapter = _make_adapter()
+        mock_session = self._mock_ws_session()
+
+        with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+            mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+            mock_aiohttp.ClientTimeout = lambda total: total
+
+            success = await adapter._ws_connect()
+
+        assert success is True
+        assert mock_aiohttp.ClientSession.call_args.kwargs.get("trust_env") is True
+
+    @pytest.mark.asyncio
+    async def test_connect_rest_session_uses_trust_env(self):
+        adapter = _make_adapter()
+        mock_session = self._mock_ws_session()
+
+        with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+            mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+            mock_aiohttp.ClientTimeout = lambda total: total
+
+            success = await adapter.connect()
+
+        assert success is True
+        # Called twice: once for the WS session, once for the dedicated REST session
+        for call in mock_aiohttp.ClientSession.call_args_list:
+            assert call.kwargs.get("trust_env") is True
+
+        adapter._listen_task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_uses_trust_env(self):
+        pconfig = MagicMock()
+        pconfig.token = "tok"
+        pconfig.extra = {"url": "http://ha.local:8123"}
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+            mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+            mock_aiohttp.ClientTimeout = lambda total: total
+
+            result = await _standalone_send(pconfig, "ha_events", "Test notification")
+
+        assert result.get("success") is True
+        assert mock_aiohttp.ClientSession.call_args.kwargs.get("trust_env") is True

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -16,6 +16,7 @@ from gateway.config import (
 )
 from plugins.platforms.homeassistant.adapter import (
     HomeAssistantAdapter,
+    _standalone_send,
     check_ha_requirements,
     validate_ha_config,
 )
@@ -299,6 +300,8 @@ class TestSendViaRestApi:
         assert call_args[1]["json"]["title"] == "Hermes Agent"
         assert call_args[1]["json"]["message"] == "Test notification"
         assert "Bearer tok" in call_args[1]["headers"]["Authorization"]
+        # Session must be proxy-env-aware so Agent Vault credential injection works
+        assert mock_aiohttp.ClientSession.call_args.kwargs.get("trust_env") is True
 
 
 # ---------------------------------------------------------------------------
@@ -318,3 +321,88 @@ class TestWsUrlConstruction:
         ws_url = adapter._hass_url.replace("http://", "ws://").replace("https://", "wss://")
         assert ws_url == "ws://ha:8123"
 
+
+# ---------------------------------------------------------------------------
+# Proxy environment support (Agent Vault credential injection)
+# ---------------------------------------------------------------------------
+
+
+class TestTrustEnv:
+    """All Home Assistant aiohttp sessions must opt in to proxy env handling.
+
+    Without trust_env=True, aiohttp ignores HTTPS_PROXY/HTTP_PROXY, so
+    traffic bypasses an env-based credential-injection proxy (e.g. Agent
+    Vault) that curl/requests/httpx would honor by default.
+    """
+
+    @staticmethod
+    def _mock_ws_session():
+        """Mock session whose ws_connect() completes the HA auth handshake."""
+        mock_ws = MagicMock()
+        mock_ws.send_json = AsyncMock()
+        mock_ws.receive_json = AsyncMock(side_effect=[
+            {"type": "auth_required"},
+            {"type": "auth_ok"},
+            {"success": True},
+        ])
+
+        mock_session = MagicMock()
+        mock_session.ws_connect = AsyncMock(return_value=mock_ws)
+        return mock_session
+
+    @pytest.mark.asyncio
+    async def test_ws_connect_uses_trust_env(self):
+        adapter = _make_adapter()
+        mock_session = self._mock_ws_session()
+
+        with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+            mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+            mock_aiohttp.ClientTimeout = lambda total: total
+
+            success = await adapter._ws_connect()
+
+        assert success is True
+        assert mock_aiohttp.ClientSession.call_args.kwargs.get("trust_env") is True
+
+    @pytest.mark.asyncio
+    async def test_connect_rest_session_uses_trust_env(self):
+        adapter = _make_adapter()
+        mock_session = self._mock_ws_session()
+
+        with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+            mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+            mock_aiohttp.ClientTimeout = lambda total: total
+
+            success = await adapter.connect()
+
+        assert success is True
+        # Called twice: once for the WS session, once for the dedicated REST session
+        for call in mock_aiohttp.ClientSession.call_args_list:
+            assert call.kwargs.get("trust_env") is True
+
+        adapter._listen_task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_uses_trust_env(self):
+        pconfig = MagicMock()
+        pconfig.token = "tok"
+        pconfig.extra = {"url": "http://ha.local:8123"}
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+            mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+            mock_aiohttp.ClientTimeout = lambda total: total
+
+            result = await _standalone_send(pconfig, "ha_events", "Test notification")
+
+        assert result.get("success") is True
+        assert mock_aiohttp.ClientSession.call_args.kwargs.get("trust_env") is True

--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -5,7 +5,7 @@ handler validation, and availability gating.
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -17,6 +17,10 @@ from tools.homeassistant_tool import (
     _get_headers,
     _handle_get_state,
     _handle_call_service,
+    _async_list_entities,
+    _async_get_state,
+    _async_call_service,
+    _async_list_services,
     _BLOCKED_DOMAINS,
     _ENTITY_ID_RE,
     _SERVICE_NAME_RE,
@@ -516,3 +520,85 @@ class TestRegistration:
         invalidate_check_fn_cache()
         defs = registry.get_definitions({"ha_list_entities", "ha_get_state", "ha_call_service"})
         assert len(defs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Proxy environment support (Agent Vault credential injection)
+# ---------------------------------------------------------------------------
+
+
+def _mock_aiohttp_session(json_result=None):
+    """Build a mock aiohttp session + response for ``async with`` patterns.
+
+    Mirrors the helper in tests/gateway/test_homeassistant.py: the session
+    constructor is sync, so it's a MagicMock, while __aenter__/__aexit__ on
+    both the session and the response context managers are AsyncMock.
+    """
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = AsyncMock(return_value=json_result)
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=mock_response)
+    mock_session.post = MagicMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_session
+
+
+class TestTrustEnv:
+    """Home Assistant aiohttp sessions must opt in to proxy env handling.
+
+    Without trust_env=True, aiohttp ignores HTTPS_PROXY/HTTP_PROXY, so
+    traffic bypasses an env-based credential-injection proxy (e.g. Agent
+    Vault) that curl/requests/httpx would honor by default.
+    """
+
+    @pytest.mark.asyncio
+    async def test_list_entities_uses_trust_env(self, monkeypatch):
+        monkeypatch.setenv("HASS_URL", "http://ha.local:8123")
+        monkeypatch.setenv("HASS_TOKEN", "test-token")
+        mock_session = _mock_aiohttp_session(json_result=[])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session) as mock_ctor:
+            await _async_list_entities()
+
+        assert mock_ctor.call_args.kwargs.get("trust_env") is True
+
+    @pytest.mark.asyncio
+    async def test_get_state_uses_trust_env(self, monkeypatch):
+        monkeypatch.setenv("HASS_URL", "http://ha.local:8123")
+        monkeypatch.setenv("HASS_TOKEN", "test-token")
+        mock_session = _mock_aiohttp_session(
+            json_result={"entity_id": "sun.sun", "state": "above_horizon"}
+        )
+
+        with patch("aiohttp.ClientSession", return_value=mock_session) as mock_ctor:
+            await _async_get_state("sun.sun")
+
+        assert mock_ctor.call_args.kwargs.get("trust_env") is True
+
+    @pytest.mark.asyncio
+    async def test_call_service_uses_trust_env(self, monkeypatch):
+        monkeypatch.setenv("HASS_URL", "http://ha.local:8123")
+        monkeypatch.setenv("HASS_TOKEN", "test-token")
+        mock_session = _mock_aiohttp_session(json_result=[])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session) as mock_ctor:
+            await _async_call_service("light", "turn_on", entity_id="light.kitchen")
+
+        assert mock_ctor.call_args.kwargs.get("trust_env") is True
+
+    @pytest.mark.asyncio
+    async def test_list_services_uses_trust_env(self, monkeypatch):
+        monkeypatch.setenv("HASS_URL", "http://ha.local:8123")
+        monkeypatch.setenv("HASS_TOKEN", "test-token")
+        mock_session = _mock_aiohttp_session(json_result=[])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session) as mock_ctor:
+            await _async_list_services()
+
+        assert mock_ctor.call_args.kwargs.get("trust_env") is True

--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -5,7 +5,7 @@ handler validation, and availability gating.
 """
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -17,6 +17,10 @@ from tools.homeassistant_tool import (
     _get_headers,
     _handle_get_state,
     _handle_call_service,
+    _async_list_entities,
+    _async_get_state,
+    _async_call_service,
+    _async_list_services,
     _BLOCKED_DOMAINS,
     _ENTITY_ID_RE,
     _SERVICE_NAME_RE,
@@ -379,3 +383,85 @@ class TestRegistration:
         invalidate_check_fn_cache()
         defs = registry.get_definitions({"ha_list_entities", "ha_get_state", "ha_call_service"})
         assert len(defs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Proxy environment support (Agent Vault credential injection)
+# ---------------------------------------------------------------------------
+
+
+def _mock_aiohttp_session(json_result=None):
+    """Build a mock aiohttp session + response for ``async with`` patterns.
+
+    Mirrors the helper in tests/gateway/test_homeassistant.py: the session
+    constructor is sync, so it's a MagicMock, while __aenter__/__aexit__ on
+    both the session and the response context managers are AsyncMock.
+    """
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = AsyncMock(return_value=json_result)
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=mock_response)
+    mock_session.post = MagicMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_session
+
+
+class TestTrustEnv:
+    """Home Assistant aiohttp sessions must opt in to proxy env handling.
+
+    Without trust_env=True, aiohttp ignores HTTPS_PROXY/HTTP_PROXY, so
+    traffic bypasses an env-based credential-injection proxy (e.g. Agent
+    Vault) that curl/requests/httpx would honor by default.
+    """
+
+    @pytest.mark.asyncio
+    async def test_list_entities_uses_trust_env(self, monkeypatch):
+        monkeypatch.setenv("HASS_URL", "http://ha.local:8123")
+        monkeypatch.setenv("HASS_TOKEN", "test-token")
+        mock_session = _mock_aiohttp_session(json_result=[])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session) as mock_ctor:
+            await _async_list_entities()
+
+        assert mock_ctor.call_args.kwargs.get("trust_env") is True
+
+    @pytest.mark.asyncio
+    async def test_get_state_uses_trust_env(self, monkeypatch):
+        monkeypatch.setenv("HASS_URL", "http://ha.local:8123")
+        monkeypatch.setenv("HASS_TOKEN", "test-token")
+        mock_session = _mock_aiohttp_session(
+            json_result={"entity_id": "sun.sun", "state": "above_horizon"}
+        )
+
+        with patch("aiohttp.ClientSession", return_value=mock_session) as mock_ctor:
+            await _async_get_state("sun.sun")
+
+        assert mock_ctor.call_args.kwargs.get("trust_env") is True
+
+    @pytest.mark.asyncio
+    async def test_call_service_uses_trust_env(self, monkeypatch):
+        monkeypatch.setenv("HASS_URL", "http://ha.local:8123")
+        monkeypatch.setenv("HASS_TOKEN", "test-token")
+        mock_session = _mock_aiohttp_session(json_result=[])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session) as mock_ctor:
+            await _async_call_service("light", "turn_on", entity_id="light.kitchen")
+
+        assert mock_ctor.call_args.kwargs.get("trust_env") is True
+
+    @pytest.mark.asyncio
+    async def test_list_services_uses_trust_env(self, monkeypatch):
+        monkeypatch.setenv("HASS_URL", "http://ha.local:8123")
+        monkeypatch.setenv("HASS_TOKEN", "test-token")
+        mock_session = _mock_aiohttp_session(json_result=[])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session) as mock_ctor:
+            await _async_list_services()
+
+        assert mock_ctor.call_args.kwargs.get("trust_env") is True

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -111,7 +111,7 @@ async def _async_list_entities(
 
     hass_url, hass_token = _get_config()
     url = f"{hass_url}/api/states"
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(url, headers=_get_headers(hass_token), timeout=aiohttp.ClientTimeout(total=15)) as resp:
             resp.raise_for_status()
             states = await resp.json()
@@ -125,7 +125,7 @@ async def _async_get_state(entity_id: str) -> Dict[str, Any]:
 
     hass_url, hass_token = _get_config()
     url = f"{hass_url}/api/states/{entity_id}"
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(url, headers=_get_headers(hass_token), timeout=aiohttp.ClientTimeout(total=10)) as resp:
             resp.raise_for_status()
             data = await resp.json()
@@ -187,7 +187,7 @@ async def _async_call_service(
     url = f"{hass_url}/api/services/{domain}/{service}"
     payload = _build_service_payload(entity_id, data)
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.post(
             url,
             headers=_get_headers(hass_token),
@@ -299,7 +299,7 @@ async def _async_list_services(domain: Optional[str] = None) -> Dict[str, Any]:
     hass_url, hass_token = _get_config()
     url = f"{hass_url}/api/services"
     headers = {"Authorization": f"Bearer {hass_token}", "Content-Type": "application/json"}
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=15)) as resp:
             resp.raise_for_status()
             services = await resp.json()

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -112,7 +112,7 @@ async def _async_list_entities(
 
     hass_url, hass_token = _get_config()
     url = f"{hass_url}/api/states"
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(url, headers=_get_headers(hass_token), timeout=aiohttp.ClientTimeout(total=15)) as resp:
             resp.raise_for_status()
             states = await resp.json()
@@ -126,7 +126,7 @@ async def _async_get_state(entity_id: str) -> Dict[str, Any]:
 
     hass_url, hass_token = _get_config()
     url = f"{hass_url}/api/states/{entity_id}"
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(url, headers=_get_headers(hass_token), timeout=aiohttp.ClientTimeout(total=10)) as resp:
             resp.raise_for_status()
             data = await resp.json()
@@ -188,7 +188,7 @@ async def _async_call_service(
     url = f"{hass_url}/api/services/{domain}/{service}"
     payload = _build_service_payload(entity_id, data)
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.post(
             url,
             headers=_get_headers(hass_token),
@@ -300,7 +300,7 @@ async def _async_list_services(domain: Optional[str] = None) -> Dict[str, Any]:
     hass_url, hass_token = _get_config()
     url = f"{hass_url}/api/services"
     headers = {"Authorization": f"Bearer {hass_token}", "Content-Type": "application/json"}
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=15)) as resp:
             resp.raise_for_status()
             services = await resp.json()


### PR DESCRIPTION
## Summary
- Home Assistant REST tools and platform adapter sessions currently construct `aiohttp.ClientSession` without `trust_env=True`, so they ignore `HTTPS_PROXY`/`HTTP_PROXY`. This breaks environments where outbound credentials or routing are provided by an environment proxy, such as Agent Vault (curl/requests/httpx honor these env vars by default, but bare aiohttp does not).
- Enables `trust_env=True` on all 8 `aiohttp.ClientSession` construction sites across `tools/homeassistant_tool.py` and `plugins/platforms/homeassistant/adapter.py`, matching the existing pattern already used in the LINE and SMS adapters.
- Users with local, non-proxied Home Assistant instances can set `NO_PROXY` (e.g. `NO_PROXY=localhost,127.0.0.1,homeassistant.local,.local`) to bypass unintended proxying.

## Test plan
- [x] Added regression tests in `tests/tools/test_homeassistant_tool.py` asserting `trust_env=True` on each of the 4 tool-level session constructions.
- [x] Added regression tests in `tests/gateway/test_homeassistant.py` asserting `trust_env=True` on the WS session, dedicated REST session, `send()` fallback session, and `_standalone_send` session.
- [x] `pytest tests/tools/test_homeassistant_tool.py tests/gateway/test_homeassistant.py` passes (120 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)