### PR TITLE
feat(raft): add gateway setup wizard (salvage #51786)

### DIFF
--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -754,6 +754,48 @@ def _env_enablement() -> Optional[dict]:
     return {"enabled": True}
 
 
+def interactive_setup() -> None:
+    """Interactive ``hermes gateway setup`` flow for the Raft platform.
+
+    Lazy-imports CLI helpers so the plugin stays importable in gateway runtime
+    and test contexts. The flow persists ``RAFT_PROFILE`` to the Hermes env
+    file so the Raft adapter auto-enables after a gateway restart.
+    """
+    from hermes_cli.cli_output import (
+        print_header,
+        print_info,
+        print_success,
+        print_warning,
+        prompt,
+        prompt_yes_no,
+    )
+    from hermes_cli.config import get_env_value, save_env_value
+
+    print_header("Raft")
+    existing_profile = get_env_value("RAFT_PROFILE")
+    if existing_profile:
+        print_info(f"Raft: already configured (profile: {existing_profile})")
+        if not prompt_yes_no("Reconfigure Raft?", False):
+            print_info(f"Keeping RAFT_PROFILE={existing_profile}.")
+            return
+
+    print_info("Connect Hermes to Raft as an external agent.")
+    print_info("Create the External Agent in Raft first, then run:")
+    print_info("  raft agent login --server <server-url> --agent <agent-id> --profile-slug <slug>")
+    print()
+
+    profile = prompt("Raft profile slug", default=existing_profile or "")
+    if not profile:
+        print_warning("Raft profile slug is required; skipping Raft setup")
+        return
+
+    save_env_value("RAFT_PROFILE", profile.strip())
+
+    print()
+    print_success("Raft configuration saved")
+    print_info("Restart the gateway for changes to take effect: hermes gateway restart")
+
+
 def register(ctx) -> None:
     """Plugin entry point — called by the Hermes plugin system."""
     ctx.register_platform(
@@ -764,6 +806,7 @@ def register(ctx) -> None:
         is_connected=_is_connected,
         required_env=["RAFT_PROFILE"],
         install_hint="Install the Raft CLI from https://raft.build",
+        setup_fn=interactive_setup,
         env_enablement_fn=_env_enablement,
         emoji="🔔",
         platform_hint=(

--- a/tests/gateway/test_raft_adapter.py
+++ b/tests/gateway/test_raft_adapter.py
@@ -32,6 +32,7 @@ from plugins.platforms.raft.adapter import (
     _on_session_end,
     _on_session_finalize,
     check_raft_requirements,
+    interactive_setup,
     register,
 )
 from gateway.session import build_session_key
@@ -425,6 +426,34 @@ class TestRaftConfig:
         assert _is_connected(PlatformConfig(enabled=True, extra={"enabled": True})) is True
         assert _is_connected(PlatformConfig(enabled=True, extra={})) is False
 
+    def test_interactive_setup_saves_raft_profile(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("RAFT_PROFILE", raising=False)
+        monkeypatch.setattr("builtins.input", lambda _prompt: "dev-profile")
+
+        interactive_setup()
+
+        assert (tmp_path / ".env").read_text(encoding="utf-8") == "RAFT_PROFILE=dev-profile\n"
+        assert os.environ["RAFT_PROFILE"] == "dev-profile"
+        out = capsys.readouterr().out
+        assert "Raft configuration saved" in out
+        assert "hermes gateway restart" in out
+
+    def test_interactive_setup_keeps_existing_profile_when_not_reconfigured(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        env_path = tmp_path / ".env"
+        env_path.write_text("RAFT_PROFILE=existing\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("RAFT_PROFILE", "existing")
+        monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+        interactive_setup()
+
+        assert env_path.read_text(encoding="utf-8") == "RAFT_PROFILE=existing\n"
+        assert os.environ["RAFT_PROFILE"] == "existing"
+        assert "Keeping RAFT_PROFILE=existing" in capsys.readouterr().out
+
     def test_register_calls_register_platform(self):
         registered = {}
         hooks = {}
@@ -441,6 +470,7 @@ class TestRaftConfig:
         assert registered["name"] == "raft"
         assert registered["label"] == "Raft"
         assert registered["emoji"] == "🔔"
+        assert registered["setup_fn"] is interactive_setup
         assert "profile show" in registered["platform_hint"]
         assert "manual get" in registered["platform_hint"]
         assert "--profile" in registered["platform_hint"]


### PR DESCRIPTION
## Summary
`hermes gateway setup` now runs a real interactive wizard for Raft instead of falling through to a generic env-var hint.

Raft was the only bundled platform plugin without a `setup_fn` — every sibling (IRC, Matrix, Feishu, DingTalk, Line, Photon, SimpleX…) already registers one. This closes that gap.

## Changes
- `plugins/platforms/raft/adapter.py`: add `interactive_setup()` — lazy-imports `cli_output` helpers, detects an existing `RAFT_PROFILE`, offers a reconfigure prompt, and persists via `save_env_value()`. Register `setup_fn=interactive_setup` (a documented forwarded `PlatformEntry` kwarg).
- `tests/gateway/test_raft_adapter.py`: cover save, keep-existing-when-not-reconfigured, and `setup_fn` registration.

## Validation
| | Result |
|---|---|
| `tests/gateway/test_raft_adapter.py` | 18/18 pass |
| Base vs current main | 0 commits behind |
| Diff | exactly the 2 claimed files (+73/-0) |
| Core changes | none |

Salvage of #51786 by @xxchan — cherry-picked onto current main with authorship preserved.

## Infographic

![Raft Gateway Setup Wizard](https://v3b.fal.media/files/b/0aa07c74/LbYeIqQIx6CWkciHUnBxA_NdnKpInK.png)
