### PR TITLE
fix(matrix): block unsafe image redirects per-hop (salvage #34526)

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -57,7 +57,7 @@ import mimetypes
 import os
 import re
 import time
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urljoin, urlsplit, urlunsplit
 from dataclasses import dataclass, field
 
 from html import escape as _html_escape
@@ -128,6 +128,7 @@ from gateway.platforms.base import (
     SendResult,
     resolve_proxy_url,
     proxy_kwargs_for_aiohttp,
+    _ssrf_redirect_guard,
 )
 from gateway.platforms.helpers import ThreadParticipationTracker
 
@@ -1766,36 +1767,57 @@ class MatrixAdapter(BasePlatformAdapter):
 
         fname = url.rsplit("/", 1)[-1].split("?")[0] or "image.png"
 
+        def _safe_redirect_target(current_url: str, location: str) -> str:
+            """Resolve a redirect Location and re-validate it against SSRF policy.
+
+            A public-looking URL can 302-redirect the gateway toward loopback,
+            private-network, or cloud-metadata endpoints. Validating only the
+            final URL is insufficient because the connection to the unsafe hop
+            has already been made. Re-check every hop before following it.
+            """
+            next_url = urljoin(current_url, location)
+            if not is_safe_url(next_url):
+                raise ValueError("blocked unsafe redirect URL")
+            return next_url
+
         try:
             import aiohttp as _aiohttp
 
             _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(self._proxy_url)
             async with _aiohttp.ClientSession(**_sess_kw) as http:
-                async with http.get(
-                    url,
-                    timeout=_aiohttp.ClientTimeout(total=30),
-                    allow_redirects=True,
-                    **_req_kw,
-                ) as resp:
-                    resp.raise_for_status()
-                    if not is_safe_url(str(resp.url)):
-                        raise ValueError("blocked unsafe redirect URL")
-                    _check_content_length(resp.headers)
-                    parts: list[bytes] = []
-                    total = 0
-                    async for chunk in resp.content.iter_chunked(65536):
-                        total = _append_chunk(parts, total, bytes(chunk))
-                    ct = _check_image_content_type(
-                        getattr(resp, "content_type", None)
-                        or resp.headers.get("content-type", "application/octet-stream")
-                    )
-                    return b"".join(parts), ct, fname
+                fetch_url = url
+                for _ in range(20):
+                    async with http.get(
+                        fetch_url,
+                        timeout=_aiohttp.ClientTimeout(total=30),
+                        allow_redirects=False,
+                        **_req_kw,
+                    ) as resp:
+                        if resp.status in {301, 302, 303, 307, 308}:
+                            location = resp.headers.get("Location")
+                            if not location:
+                                raise ValueError("redirect missing Location")
+                            fetch_url = _safe_redirect_target(fetch_url, location)
+                            continue
+                        resp.raise_for_status()
+                        _check_content_length(resp.headers)
+                        parts: list[bytes] = []
+                        total = 0
+                        async for chunk in resp.content.iter_chunked(65536):
+                            total = _append_chunk(parts, total, bytes(chunk))
+                        ct = _check_image_content_type(
+                            getattr(resp, "content_type", None)
+                            or resp.headers.get("content-type", "application/octet-stream")
+                        )
+                        return b"".join(parts), ct, fname
+                raise ValueError("too many redirects")
         except ImportError:
             import httpx
 
             _httpx_kw: dict = {}
             if self._proxy_url:
                 _httpx_kw["proxy"] = self._proxy_url
+            _httpx_kw["event_hooks"] = {"response": [_ssrf_redirect_guard]}
             async with httpx.AsyncClient(**_httpx_kw) as http:
                 async with http.stream(
                     "GET",
@@ -1804,8 +1826,6 @@ class MatrixAdapter(BasePlatformAdapter):
                     timeout=30,
                 ) as resp:
                     resp.raise_for_status()
-                    if not is_safe_url(str(resp.url)):
-                        raise ValueError("blocked unsafe redirect URL")
                     _check_content_length(resp.headers)
                     parts: list[bytes] = []
                     total = 0

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3385,6 +3385,7 @@ class TestMatrixImageOnlyMediaNormalization:
 
         class _Response:
             url = "https://example.com/image.png"
+            status = 200
             headers = {"Content-Length": "11"}
             content_type = "image/png"
             content = _Content()
@@ -3434,6 +3435,7 @@ class TestMatrixImageOnlyMediaNormalization:
 
         class _Response:
             url = "https://example.com/image.png"
+            status = 200
             headers = {}
             content_type = "image/png"
             content = _Content()
@@ -3472,15 +3474,82 @@ class TestMatrixImageOnlyMediaNormalization:
 
     @pytest.mark.asyncio
     async def test_external_media_download_rejects_unsafe_redirect(self, monkeypatch):
+        """A 302 to a private/loopback target must be blocked per-hop, before
+        the redirect is followed (not only re-checked on the final URL)."""
+        import aiohttp
+        import tools.url_safety as url_safety
+
+        class _RedirectResponse:
+            status = 302
+            headers = {"Location": "http://127.0.0.1/private.png"}
+            content_type = "image/png"
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def raise_for_status(self):
+                return None
+
+        class _Session:
+            def __init__(self):
+                self.requested = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def get(self, url, *_args, **_kwargs):
+                self.requested.append(url)
+                return _RedirectResponse()
+
+        session = _Session()
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda **_kwargs: session)
+        monkeypatch.setattr(
+            url_safety,
+            "is_safe_url",
+            lambda candidate, **_kwargs: str(candidate) == "https://example.com/image.png",
+        )
+
+        with pytest.raises(ValueError, match="unsafe redirect"):
+            await self.adapter._download_external_media_with_cap(
+                "https://example.com/image.png"
+            )
+
+        # Only the initial public URL was fetched — the loopback hop was never
+        # followed because it was rejected before the next GET.
+        assert session.requested == ["https://example.com/image.png"]
+
+    @pytest.mark.asyncio
+    async def test_external_media_download_follows_safe_redirect(self, monkeypatch):
+        """A redirect to another allowed URL is followed and its body returned."""
         import aiohttp
         import tools.url_safety as url_safety
 
         class _Content:
             async def iter_chunked(self, _size):
-                yield b"ok"
+                yield b"imgbytes"
 
-        class _Response:
-            url = "http://127.0.0.1/private.png"
+        class _RedirectResponse:
+            status = 302
+            headers = {"Location": "https://cdn.example.com/final.png"}
+            content_type = "image/png"
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def raise_for_status(self):
+                return None
+
+        class _OkResponse:
+            status = 200
             headers = {}
             content_type = "image/png"
             content = _Content()
@@ -3495,26 +3564,85 @@ class TestMatrixImageOnlyMediaNormalization:
                 return None
 
         class _Session:
+            def __init__(self):
+                self.requested = []
+
             async def __aenter__(self):
                 return self
 
             async def __aexit__(self, *_args):
                 return None
 
-            def get(self, *_args, **_kwargs):
-                return _Response()
+            def get(self, url, *_args, **_kwargs):
+                self.requested.append(url)
+                return _RedirectResponse() if len(self.requested) == 1 else _OkResponse()
 
-        monkeypatch.setattr(aiohttp, "ClientSession", lambda **_kwargs: _Session())
-        monkeypatch.setattr(
-            url_safety,
-            "is_safe_url",
-            lambda candidate, **_kwargs: str(candidate) == "https://example.com/image.png",
+        session = _Session()
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda **_kwargs: session)
+        monkeypatch.setattr(url_safety, "is_safe_url", lambda *_args, **_kwargs: True)
+
+        data, ct, _fname = await self.adapter._download_external_media_with_cap(
+            "https://example.com/image.png"
         )
 
-        with pytest.raises(ValueError, match="unsafe redirect"):
-            await self.adapter._download_external_media_with_cap(
-                "https://example.com/image.png"
-            )
+        assert data == b"imgbytes"
+        assert ct == "image/png"
+        assert session.requested == [
+            "https://example.com/image.png",
+            "https://cdn.example.com/final.png",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_external_media_download_httpx_installs_redirect_guard(self, monkeypatch):
+        """The httpx fallback re-checks redirect targets via the shared guard."""
+        import tools.url_safety as url_safety
+        from gateway.platforms.base import _ssrf_redirect_guard
+
+        clients = []
+
+        class _Content:
+            async def iter_chunked(self, _size):
+                yield b"ok"
+
+        class _Response:
+            headers = {"content-type": "image/png"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self):
+                yield b"ok"
+
+        class _Client:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                clients.append(self)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def stream(self, *_args, **_kwargs):
+                return _Response()
+
+        monkeypatch.setattr(url_safety, "is_safe_url", lambda *_args, **_kwargs: True)
+        with patch.dict(sys.modules, {"aiohttp": None}):
+            with patch("httpx.AsyncClient", _Client):
+                data, ct, _fname = await self.adapter._download_external_media_with_cap(
+                    "https://example.com/image.png"
+                )
+
+        assert data == b"ok"
+        assert ct == "image/png"
+        assert clients[0].kwargs["event_hooks"]["response"] == [_ssrf_redirect_guard]
 
     @pytest.mark.asyncio
     async def test_external_media_download_rejects_unsafe_initial_url(self):
@@ -3534,6 +3662,7 @@ class TestMatrixImageOnlyMediaNormalization:
 
         class _Response:
             url = "https://example.com/image.png"
+            status = 200
             headers = {}
             content_type = "text/html"
             content = _Content()


### PR DESCRIPTION
## Summary
Matrix outbound image downloads now re-validate every redirect hop, closing an SSRF hole where a public URL could 302-redirect the gateway into loopback / private-network / cloud-metadata endpoints.

Root cause: `_download_external_media_with_cap()` followed redirects (`allow_redirects=True` / `follow_redirects=True`) and only checked `is_safe_url()` on the **final** URL — by then the connection to the unsafe intermediate hop had already been made. The codebase's own `_ssrf_redirect_guard` docstring describes exactly this bypass, and the two `base.py` download sites already guard per-hop; Matrix was the one path that didn't.

Salvage of #34526 by @heathley — the original diff targeted `gateway/platforms/matrix.py`, which has since migrated to the bundled plugin `plugins/platforms/matrix/adapter.py` and had its download logic refactored into `_download_external_media_with_cap()`. The fix is re-expressed against the current helper, authorship preserved.

## Changes
- `plugins/platforms/matrix/adapter.py`: aiohttp path resolves redirects manually with `allow_redirects=False`, validating each `Location` via `is_safe_url` before following (aiohttp can't use the httpx response event hook); httpx fallback installs the shared `_ssrf_redirect_guard` event hook. Size-cap / content-type checks preserved.
- `tests/gateway/test_matrix.py`: rewrote the redirect test to a real 302→loopback flow (asserts the unsafe hop is never fetched), added a safe-redirect-chain-followed test and an httpx-guard-wiring test; updated sibling download mocks for the new redirect loop.

## Validation
| | Result |
|---|---|
| `tests/gateway/test_matrix.py` | 235 passed |
| E2E: live 302 → `127.0.0.1/latest/meta-data/` | blocked before connect |
| E2E: direct safe image fetch | 200, bytes returned |

## Infographic
![PR #34526 infographic](https://v3b.fal.media/files/b/0aa07c72/adP4Vuxus-yHLLeEiG9eH_frj0Elz9.png)
