### PR TITLE
docs: unify /new and /reset rows in gateway slash-commands table

### DIFF
--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -205,8 +205,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | Command | Description |
 |---------|-------------|
 | `/start` | Platform-protocol command. Many chat platforms (Telegram, Discord, …) send `/start` automatically the first time a user opens a bot conversation. Hermes acknowledges the ping silently — no agent reply, no session burn — so first-contact handshakes don't waste a turn. You can also send it explicitly to confirm the gateway is reachable. |
-| `/new` | Start a new conversation. |
-| `/reset` | Reset conversation history. |
+| `/new [name]` (alias: `/reset`) | Start a new session (fresh session ID + history). Optional `[name]` sets the initial session title. Append `now`, `--yes`, or `-y` to skip the confirmation modal — e.g. `/reset now`, `/new --yes my-experiment`. |
 | `/status` | Show session info, followed by a local **Session recap** block (recent turn counts, top tools used, files touched, latest prompt + reply). |
 | `/stop` | Kill all running background processes and interrupt the running agent. |
 | `/model [provider:model]` | Show or change the model. Supports provider switches (`/model zai:glm-5`), custom endpoints (`/model custom:model`), named custom providers (`/model custom:local:qwen`), auto-detect (`/model custom`), and user-defined aliases (`/model fav`, `/model grok` — see [Custom model aliases](#custom-model-aliases)). Use `--global` to persist the change to config.yaml. **Note:** `/model` can only switch between already-configured providers. To add a new provider or set up API keys, use `hermes model` from your terminal (outside the chat session). |


### PR DESCRIPTION
## Summary

The messaging gateway slash-commands table now shows `/new` and `/reset` as one command instead of two with divergent descriptions.

`/reset` is an alias of `/new` (`COMMAND_REGISTRY` in `hermes_cli/commands.py:68` — same handler, fresh session ID + history), but the gateway table in `slash-commands.md` still listed them separately as "Start a new conversation" and "Reset conversation history", implying different behavior.

## Changes

- `website/docs/reference/slash-commands.md`: collapse the gateway table's `/new` and `/reset` rows into a single `/new [name]` (alias: `/reset`) row, matching the registry wording and the CLI table already on line 39.

## Validation

| | Before | After |
|---|---|---|
| Gateway table | `/new` = "Start a new conversation"; `/reset` = "Reset conversation history" (2 rows, implies different behavior) | one row: `/new [name]` (alias: `/reset`) — "Start a new session (fresh session ID + history)" |

Docs-only, +1/−2, one file. Closes #42829.

Supersedes #42886 — that PR bundled an already-on-main Matrix HTML sanitizer against a moved file path and shipped the docs table with malformed `||` row prefixes. Credit to @EdderTalmor and reporter @TheDenStudios.

## Infographic

![PR #42886 gateway docs fix](https://v3b.fal.media/files/b/0aa07c96/2aPaW3SuekTulFqzSiK8V_DbupWD7c.png)
