### PR TITLE
fix(config): honor codex app server api_mode alias

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -368,8 +368,10 @@ def _maybe_apply_codex_app_server_runtime(
     """Optional opt-in: rewrite api_mode → "codex_app_server" for OpenAI/Codex
     providers when the user has explicitly enabled that runtime via
     `model.openai_runtime: codex_app_server` in config.yaml.
+    `model.api_mode: codex_app_server` is accepted as a compatibility alias so
+    users are not silently left on the default Codex Responses transport.
 
-    Default behavior is preserved: when the key is unset, "auto", or empty,
+    Default behavior is preserved: when neither key selects the app server,
     this function is a no-op. Only providers in {"openai", "openai-codex"}
     are eligible — other providers (anthropic, openrouter, etc.) cannot be
     rerouted through codex.
@@ -380,7 +382,8 @@ def _maybe_apply_codex_app_server_runtime(
     if provider not in {"openai", "openai-codex"}:
         return api_mode
     runtime = str(model_cfg.get("openai_runtime") or "").strip().lower()
-    if runtime == "codex_app_server":
+    configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+    if runtime == "codex_app_server" or configured_mode == "codex_app_server":
         return "codex_app_server"
     return api_mode
 
@@ -1373,7 +1376,11 @@ def _resolve_explicit_runtime(
                 base_url = creds.get("base_url", "").rstrip("/") or base_url
         return {
             "provider": "openai-codex",
-            "api_mode": "codex_responses",
+            "api_mode": _maybe_apply_codex_app_server_runtime(
+                provider="openai-codex",
+                api_mode="codex_responses",
+                model_cfg=model_cfg,
+            ),
             "base_url": base_url,
             "api_key": api_key,
             "source": "explicit",
@@ -1705,7 +1712,11 @@ def resolve_runtime_provider(
             creds = resolve_codex_runtime_credentials()
             return {
                 "provider": "openai-codex",
-                "api_mode": "codex_responses",
+                "api_mode": _maybe_apply_codex_app_server_runtime(
+                    provider="openai-codex",
+                    api_mode="codex_responses",
+                    model_cfg=model_cfg,
+                ),
                 "base_url": creds.get("base_url", "").rstrip("/"),
                 "api_key": creds.get("api_key", ""),
                 "source": creds.get("source", "hermes-auth-store"),

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -260,6 +260,38 @@ def test_resolve_runtime_provider_codex(monkeypatch):
     assert resolved["requested_provider"] == "openai-codex"
 
 
+def test_resolve_runtime_provider_codex_app_server_accepts_api_mode_alias(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-codex",
+            "default": "gpt-5.5",
+            "api_mode": "codex_app_server",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_codex_runtime_credentials",
+        lambda: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "codex-token",
+            "source": "codex-auth-json",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+    assert resolved["api_mode"] == "codex_app_server"
+
+
 def test_resolve_runtime_provider_qwen_oauth(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
     monkeypatch.setattr(


### PR DESCRIPTION
Fixes #56182.\n\nAccepts model.api_mode: codex_app_server as a compatibility alias for model.openai_runtime: codex_app_server when resolving OpenAI Codex runtimes, including explicit and auth-store resolution paths. Adds targeted runtime-provider coverage.