### PR TITLE
fix(platforms): strip secrets from bridge subprocess env

### DIFF
--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -47,6 +47,7 @@ from gateway.platforms.base import (
     merge_pending_message_event,
 )
 from gateway.session import build_session_key
+from tools.environments.local import hermes_subprocess_env
 
 logger = logging.getLogger(__name__)
 
@@ -539,7 +540,9 @@ class RaftAdapter(BasePlatformAdapter):
             "--wake-adapter", "wake-channel",
             "--wake-channel-endpoint", endpoint,
         ]
-        env = {**os.environ, "RAFT_CHANNEL_TOKEN": self._bridge_token}
+        env = hermes_subprocess_env(inherit_credentials=False)
+        env["RAFT_PROFILE"] = profile
+        env["RAFT_CHANNEL_TOKEN"] = self._bridge_token
         try:
             self._bridge_process = subprocess.Popen(
                 cmd, env=env, stdin=subprocess.DEVNULL

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -32,6 +32,7 @@ from hermes_constants import (
     get_hermes_dir,
     with_hermes_node_path,
 )
+from tools.environments.local import hermes_subprocess_env
 
 logger = logging.getLogger(__name__)
 
@@ -621,8 +622,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Build bridge subprocess environment.
             # Pass WHATSAPP_REPLY_PREFIX from config.yaml so the Node bridge
             # can use it without the user needing to set a separate env var.
-            # with_hermes_node_path() copies os.environ when called with no arg.
-            bridge_env = with_hermes_node_path()
+            bridge_env = with_hermes_node_path(hermes_subprocess_env(inherit_credentials=False))
+            bridge_env["WHATSAPP_MODE"] = whatsapp_mode
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             # Pass the profile-aware cache directories so the bridge writes

--- a/tests/gateway/test_raft_adapter.py
+++ b/tests/gateway/test_raft_adapter.py
@@ -425,6 +425,36 @@ class TestRaftConfig:
         assert _is_connected(PlatformConfig(enabled=True, extra={"enabled": True})) is True
         assert _is_connected(PlatformConfig(enabled=True, extra={})) is False
 
+    def test_spawn_bridge_strips_unneeded_hermes_secrets(self, monkeypatch):
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setenv("RAFT_PROFILE", "my-agent")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-secret")
+        monkeypatch.setenv("AUXILIARY_VISION_API_KEY", "sk-aux-secret")
+        monkeypatch.setenv("GATEWAY_RELAY_SECRET", "relay-secret")
+
+        captured = {}
+
+        class DummyProc:
+            pid = 1234
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs["env"]
+            return DummyProc()
+
+        adapter = _make_adapter(bridge_token="bridge-token")
+
+        with patch("plugins.platforms.raft.adapter.shutil.which", return_value="/usr/bin/raft"), \
+             patch("plugins.platforms.raft.adapter.subprocess.Popen", side_effect=fake_popen):
+            adapter._spawn_bridge(4321)
+
+        env = captured["env"]
+        assert env["RAFT_PROFILE"] == "my-agent"
+        assert env["RAFT_CHANNEL_TOKEN"] == "bridge-token"
+        assert "OPENAI_API_KEY" not in env
+        assert "AUXILIARY_VISION_API_KEY" not in env
+        assert "GATEWAY_RELAY_SECRET" not in env
+
     def test_register_calls_register_platform(self):
         registered = {}
         hooks = {}

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -310,7 +310,11 @@ class TestDepRefreshStamp:
 
 class TestCacheDirEnvPassthrough:
     @pytest.mark.asyncio
-    async def test_bridge_spawn_env_has_cache_dirs(self, tmp_path):
+    async def test_bridge_spawn_env_has_cache_dirs(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_MODE", "bot")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-secret")
+        monkeypatch.setenv("AUXILIARY_VISION_API_KEY", "sk-aux-secret")
+        monkeypatch.setenv("GATEWAY_RELAY_SECRET", "relay-secret")
         bridge_dir = _setup_bridge_dir(tmp_path)
         _fresh_node_modules(bridge_dir)
         adapter = _make_adapter(
@@ -339,3 +343,7 @@ class TestCacheDirEnvPassthrough:
         assert env["HERMES_IMAGE_CACHE_DIR"] == str(get_image_cache_dir())
         assert env["HERMES_AUDIO_CACHE_DIR"] == str(get_audio_cache_dir())
         assert env["HERMES_DOCUMENT_CACHE_DIR"] == str(get_document_cache_dir())
+        assert env["WHATSAPP_MODE"] == "bot"
+        assert "OPENAI_API_KEY" not in env
+        assert "AUXILIARY_VISION_API_KEY" not in env
+        assert "GATEWAY_RELAY_SECRET" not in env


### PR DESCRIPTION
## Summary

Strip Hermes secrets from platform bridge subprocess environments.

Raft and WhatsApp both spawn local bridge subprocesses from the gateway process. Those subprocesses previously inherited the full gateway `os.environ`:

- `plugins/platforms/raft/adapter.py` used `{**os.environ, "RAFT_CHANNEL_TOKEN": ...}`.
- `plugins/platforms/whatsapp/adapter.py` called `with_hermes_node_path()` with no base env, which copies `os.environ`.

That leaks unrelated Hermes credentials and gateway-internal secrets into platform bridge child processes, including provider API keys, `AUXILIARY_*` side-LLM credentials, and `GATEWAY_RELAY_*` material.

## Changes

- Build the Raft bridge env from `hermes_subprocess_env(inherit_credentials=False)`.
- Re-add only the Raft bridge values the child actually needs: `RAFT_PROFILE` and `RAFT_CHANNEL_TOKEN`.
- Build the WhatsApp bridge env from the same sanitized helper before adding Hermes-managed Node paths.
- Re-add the WhatsApp bridge values the child actually needs: `WHATSAPP_MODE`, cache directory paths, and optional reply prefix.
- Add regression coverage proving provider/internal secrets are not passed to either bridge subprocess.

## Why

Platform bridges do not need LLM provider credentials or gateway relay credentials. They only need their own narrow bridge configuration. This mirrors the subprocess secret-stripping policy now used by the terminal/codex/docker child-process paths.

## Tests

```text
python -m pytest tests/gateway/test_raft_adapter.py -q --timeout-method=thread
17 passed

python -m pytest tests/gateway/test_whatsapp_stale_bridge.py tests/gateway/test_whatsapp_reply_prefix.py -q --timeout-method=thread
19 passed