### PR TITLE
fix(gateway): don't persist base_url for non-custom providers on /model switch

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1358,10 +1358,16 @@ class GatewaySlashCommandsMixin:
                                     _persist_cfg["model"] = _persist_model_cfg
                                 _persist_model_cfg["default"] = result.new_model
                                 _persist_model_cfg["provider"] = result.target_provider
-                                if result.base_url:
+                                _is_custom = (
+                                    str(result.target_provider or "")
+                                    .strip().lower() == "custom"
+                                )
+                                if _is_custom and result.base_url:
                                     _persist_model_cfg["base_url"] = result.base_url
-                                if str(result.target_provider or "").strip().lower() != "custom":
-                                    clear_model_endpoint_credentials(_persist_model_cfg, clear_base_url=True)
+                                else:
+                                    clear_model_endpoint_credentials(
+                                        _persist_model_cfg, clear_base_url=True
+                                    )
                                 from hermes_cli.config import save_config
                                 save_config(_persist_cfg)
                             except Exception as e:
@@ -1595,10 +1601,16 @@ class GatewaySlashCommandsMixin:
                         cfg["model"] = model_cfg
                     model_cfg["default"] = result.new_model
                     model_cfg["provider"] = result.target_provider
-                    if result.base_url:
+                    _is_custom = (
+                        str(result.target_provider or "")
+                        .strip().lower() == "custom"
+                    )
+                    if _is_custom and result.base_url:
                         model_cfg["base_url"] = result.base_url
-                    if str(result.target_provider or "").strip().lower() != "custom":
-                        clear_model_endpoint_credentials(model_cfg, clear_base_url=True)
+                    else:
+                        clear_model_endpoint_credentials(
+                            model_cfg, clear_base_url=True
+                        )
                     from hermes_cli.config import save_config
                     save_config(cfg)
                 except Exception as e:

--- a/tests/gateway/test_model_switch_base_url_persist.py
+++ b/tests/gateway/test_model_switch_base_url_persist.py
@@ -1,0 +1,97 @@
+"""Tests for model switch base_url persistence.
+
+Covers:
+- Non-custom providers must NOT persist base_url to config.yaml
+  (the credential pool provides the correct URL; persisting a stripped
+  /v1 for anthropic_messages causes 404 on subsequent chat_completions).
+- Custom providers MUST persist base_url (user-specified endpoint).
+- Regression: #56158 (opencode-go stale base_url → 404).
+
+The fix lives in ``gateway/slash_commands.py`` in both the picker-callback
+and text-command persist paths.  We test the logic indirectly via the
+``clear_model_endpoint_credentials`` contract and a focused stub that
+replicates the persist block.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+from hermes_cli.config import clear_model_endpoint_credentials
+
+
+# ---------------------------------------------------------------------------
+# Unit: clear_model_endpoint_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestClearModelEndpointCredentials:
+    def test_clear_base_url_removes_it(self):
+        cfg = {"default": "m", "provider": "p", "base_url": "https://example.com/v1"}
+        clear_model_endpoint_credentials(cfg, clear_base_url=True)
+        assert "base_url" not in cfg
+
+    def test_clear_base_url_false_keeps_it(self):
+        cfg = {"default": "m", "provider": "p", "base_url": "https://example.com/v1"}
+        clear_model_endpoint_credentials(cfg, clear_base_url=False)
+        assert cfg["base_url"] == "https://example.com/v1"
+
+    def test_clear_api_key_and_mode(self):
+        cfg = {"default": "m", "provider": "p", "api_key": "sk-xxx", "api_mode": "anthropic_messages"}
+        clear_model_endpoint_credentials(cfg, clear_base_url=True)
+        assert "api_key" not in cfg
+        assert "api_mode" not in cfg
+        assert "base_url" not in cfg
+
+
+# ---------------------------------------------------------------------------
+# Integration: replicate the persist block logic
+# ---------------------------------------------------------------------------
+
+
+def _simulate_persist_block(result_target_provider: str, result_base_url: str):
+    """Replicate the /model persist logic and return the final config dict.
+
+    Mirrors the two persist blocks in ``gateway/slash_commands.py``:
+    - Lines 1359-1364 (picker callback)
+    - Lines 1596-1601 (text command)
+    """
+    model_cfg = {"default": "old-model", "provider": "old-provider"}
+    model_cfg["default"] = "new-model"
+    model_cfg["provider"] = result_target_provider
+    # NEW logic: only persist base_url for custom providers
+    if str(result_target_provider or "").strip().lower() == "custom" and result_base_url:
+        model_cfg["base_url"] = result_base_url
+    else:
+        clear_model_endpoint_credentials(model_cfg, clear_base_url=True)
+    return model_cfg
+
+
+class TestPersistBlockBaseUrl:
+    def test_non_custom_provider_does_not_persist_base_url(self):
+        """#56158: opencode-go should not persist stripped /v1 base_url."""
+        cfg = _simulate_persist_block("opencode-go", "https://opencode.ai/zen/go")
+        assert "base_url" not in cfg, (
+            "Non-custom provider must not persist base_url — the pool provides "
+            "the correct URL. Persisting a stripped /v1 causes HTTP 404 when "
+            "switching to a chat_completions model."
+        )
+
+    def test_custom_provider_persists_base_url(self):
+        """Custom endpoints must persist the user-specified base_url."""
+        cfg = _simulate_persist_block("custom", "http://localhost:11434/v1")
+        assert cfg["base_url"] == "http://localhost:11434/v1"
+
+    def test_custom_provider_empty_base_url_not_persisted(self):
+        """Custom provider with no base_url should not set it."""
+        cfg = _simulate_persist_block("custom", "")
+        assert "base_url" not in cfg
+
+    def test_anthropic_provider_does_not_persist_base_url(self):
+        """Built-in anthropic should not persist base_url."""
+        cfg = _simulate_persist_block("anthropic", "https://api.anthropic.com")
+        assert "base_url" not in cfg
+
+    def test_openrouter_provider_does_not_persist_base_url(self):
+        """Built-in openrouter should not persist base_url."""
+        cfg = _simulate_persist_block("openrouter", "https://openrouter.ai/api/v1")
+        assert "base_url" not in cfg


### PR DESCRIPTION
fix(gateway): don't persist base_url for non-custom providers on /model switch

## What does this PR do?

When switching models via `/model` (both the picker callback and text
command paths), the gateway persists `result.base_url` to `config.yaml`
for all providers. For multi-mode providers like `opencode-go` that serve
both `anthropic_messages` and `chat_completions` models, the base URL
differs by api_mode:

- `anthropic_messages`: `https://opencode.ai/zen/go` (no `/v1` — the SDK
  appends `/v1/messages`)
- `chat_completions`: `https://opencode.ai/zen/go/v1`

Persisting the stripped `/v1` URL from an `anthropic_messages` model
causes all subsequent `chat_completions` models on the same provider to
receive HTTP 404, because the stale config `base_url` overrides the
pool's correct `/v1` URL.

The fix: only persist `base_url` for `custom` providers (where the user
explicitly specifies an endpoint). Built-in providers resolve their
base URL from the credential pool, which always has the canonical value.

## Related Issue

Fixes #56158

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py`: In both the picker-callback persist block
  (line ~1361) and text-command persist block (line ~1598), only set
  `model.base_url` in config when `target_provider == "custom"`. For all
  other providers, call `clear_model_endpoint_credentials()` to remove
  stale endpoint fields.
- `tests/gateway/test_model_switch_base_url_persist.py`: 8 regression
  tests covering the persist-block logic and the
  `clear_model_endpoint_credentials` contract.

## How to Test

1. Set `model.provider: opencode-go` and `model.default: minimax-m3` in
   config.yaml
2. From Telegram/gateway, send `/model minimax-m3` — should work
   (anthropic_messages)
3. Send `/model glm-5.2` — before this fix, returns HTTP 404 because
   `model.base_url` is `https://opencode.ai/zen/go` (no `/v1`). After
   this fix, the pool provides the correct `/v1` URL and the model works.
4. Verify `config.yaml` does NOT contain `model.base_url` after switching
   to a non-custom provider.
5. Run `pytest tests/gateway/test_model_switch_base_url_persist.py -v` —
   all 8 tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
