### PR TITLE
fix(context): parse vLLM's token-based output-cap error format (#43553)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1145,6 +1145,23 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         if _available >= 1:
             return _available
 
+    # vLLM style: both the window and the prompt are reported in TOKENS, e.g.
+    #   "This model's maximum context length is 131072 tokens. However, you
+    #    requested 65536 output tokens and your prompt contains at least 65537
+    #    input tokens, for a total of at least 131073 tokens. Please reduce
+    #    the length of the input prompt or the number of requested output
+    #    tokens."
+    # Available output = window - input. When the input alone is at or over
+    # the window this stays None, so the caller correctly falls through to
+    # compression instead of futilely shrinking the output cap.
+    _m_vllm_input = re.search(
+        r'prompt contains (?:at least )?(\d+)\s*input tokens', error_lower
+    )
+    if _m_ctx_tok and _m_vllm_input:
+        _available = int(_m_ctx_tok.group(1)) - int(_m_vllm_input.group(1))
+        if _available >= 1:
+            return _available
+
     return None
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -218,6 +218,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "tgmerritt@gmail.com": "tgmerritt",  # PR #43553 salvage (parse vLLM's token-based output-cap error format so over-cap max_tokens 400s reduce the output cap instead of death-looping into compression)
     "13277570+justin-cyhuang@users.noreply.github.com": "justin-cyhuang",
     "agent@tranquil-flow.dev": "Tranquil-Flow",
     "jason@hermes-jc": "jcjc81",

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -120,3 +120,49 @@ class TestIsOutputCapError:
 
     def test_unrelated_error_is_not_output_cap(self):
         assert is_output_cap_error("some unrelated 400 error") is False
+
+
+class TestParseVllmTokenBasedOutputCap:
+    """vLLM reports both the window and the prompt in TOKENS.
+
+    Until this format was parsed, the recovery path misclassified it as
+    prompt-too-long and looped through compression (which frees little) while
+    retrying with the same oversized max_tokens — terminating in "cannot
+    compress further" even though simply lowering the output cap would have
+    succeeded.
+    """
+
+    # Verbatim vLLM 0.22 / OpenAI-compatible server response (max_tokens set).
+    _VLLM_MSG = (
+        "This model's maximum context length is 131072 tokens. However, you "
+        "requested 65536 output tokens and your prompt contains at least "
+        "65537 input tokens, for a total of at least 131073 tokens. Please "
+        "reduce the length of the input prompt or the number of requested "
+        "output tokens."
+    )
+
+    def test_vllm_token_based_format(self):
+        # available output = 131072 - 65537 = 65535
+        assert parse_available_output_tokens_from_error(self._VLLM_MSG) == 65535
+
+    def test_vllm_without_at_least_qualifier(self):
+        # Some versions omit the "at least" hedge.
+        msg = ("This model's maximum context length is 131072 tokens. However, "
+               "you requested 4096 output tokens and your prompt contains "
+               "100000 input tokens, for a total of 104096 tokens.")
+        assert parse_available_output_tokens_from_error(msg) == 31072
+
+    def test_vllm_retry_fits_inside_window(self):
+        # The retried cap plus the reported input must fit in the window.
+        available = parse_available_output_tokens_from_error(self._VLLM_MSG)
+        assert available is not None
+        assert available + 65537 <= 131072
+
+    def test_vllm_input_alone_exceeds_window_returns_none(self):
+        # Input >= window -> lowering the output cap cannot help; the caller
+        # must fall through to the compression path.
+        msg = ("This model's maximum context length is 131072 tokens. However, "
+               "you requested 1024 output tokens and your prompt contains at "
+               "least 140000 input tokens, for a total of at least 141024 "
+               "tokens.")
+        assert parse_available_output_tokens_from_error(msg) is None


### PR DESCRIPTION
## Summary

Over-cap `max_tokens` 400s that report the prompt size in **tokens** now drive the output-cap repair path instead of death-looping into compression.

Root cause: `parse_available_output_tokens_from_error()` already gated this error in as an output-cap failure, but every extraction pattern (Anthropic `available_tokens:`, OpenRouter `(A of text input, …)`, the character-based llama.cpp/LM Studio variant, DashScope `Range of max_tokens should be [1, N]`) missed the token-based phrasing `"prompt contains N input tokens"`. It returned `None`, so recovery misclassified the failure as prompt-too-long and compressed — which frees little — while each retry re-sent the same oversized `max_tokens`, terminating in *"cannot compress further"* on a small session.

## Changes
- `agent/model_metadata.py`: new extraction branch for `"prompt contains [at least] N input tokens"`; `available output = window − input`, reusing the already-parsed window figure (`_m_ctx_tok`). When input alone ≥ window it stays `None`, so the caller correctly falls through to compression.
- `tests/test_output_cap_parsing.py`: `TestParseVllmTokenBasedOutputCap` (4 cases): verbatim message, no-`at least` variant, retry-fits-inside-window invariant, and input-exceeds-window → `None`.

## Validation

| Case | Before | After |
|---|---|---|
| token-based over-cap 400 | `None` → compression loop → "cannot compress further" | available output extracted → one retry fits |
| input alone ≥ window | `None` | `None` (compression path preserved) |
| char-based / DashScope / Anthropic / OpenRouter | parsed | parsed (no regression) |
| real prompt overflow | `None` | `None` |

- `scripts/run_tests.sh tests/test_output_cap_parsing.py` — 20 passed.
- E2E with real imports: all extraction cases correct, all sibling branches regression-free.

Salvage of #43553 by @tgmerritt — cherry-picked onto current `main` with authorship preserved.

## Infographic

![PR #43553 infographic](https://v3b.fal.media/files/b/0aa07d14/6yuscFn_pmLDx49KJbtWV_51DaYl6G.png)
