### PR TITLE
fix(mcp): add skip_preflight opt-out for Streamable HTTP endpoints

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -34,6 +34,10 @@ Example config::
         headers:
           Authorization: "Bearer sk-..."
         timeout: 180
+        skip_preflight: true  # bypass the content-type probe for a valid
+                              # Streamable HTTP endpoint that answers HEAD/GET
+                              # with a non-MCP content type (e.g. text/plain)
+                              # but serves real MCP over POST. Default: false.
       searxng:
         url: "http://localhost:8000/sse"
         transport: sse       # use SSE transport instead of Streamable HTTP
@@ -63,6 +67,9 @@ Features:
       sampling/createMessage (text and tool-use responses)
     - Parallel tool call opt-in: per-server ``supports_parallel_tool_calls``
       flag allows concurrent execution of tools from the same server
+    - Preflight opt-out: per-server ``skip_preflight`` flag bypasses the
+      content-type probe for valid Streamable HTTP endpoints whose HEAD/GET
+      advertises a non-MCP content type (real MCP is served over POST)
 
 Architecture:
     A dedicated background event loop (_mcp_loop) runs in a daemon thread.
@@ -2311,8 +2318,17 @@ class MCPServerTask:
             # prior successful connect) — the endpoint was validated once,
             # re-probing is a redundant round-trip. Also skip for OAuth servers:
             # without a cached token the endpoint returns HTML or 401, which
-            # would incorrectly block the OAuth flow before it can run.
-            if config.get("transport") != "sse" and not self._ready.is_set() and self._auth_type != "oauth":
+            # would incorrectly block the OAuth flow before it can run. Finally,
+            # honor an explicit ``skip_preflight`` opt-out for valid Streamable
+            # HTTP servers that answer HEAD/GET with a non-MCP content type
+            # (e.g. text/plain) yet serve real MCP over POST — the heuristic
+            # would otherwise reject them before the handshake gets a chance.
+            if (
+                config.get("transport") != "sse"
+                and not self._ready.is_set()
+                and self._auth_type != "oauth"
+                and not config.get("skip_preflight")
+            ):
                 try:
                     _probe_headers = dict(config.get("headers") or {})
                     await self._preflight_content_type(


### PR DESCRIPTION
## Problem

`MCPServerTask._preflight_content_type` sends a `HEAD` (falling back to `GET`) before the real handshake and raises `NonMcpEndpointError` when a **2xx** response advertises a content type outside `("application/json", "text/event-stream")`.

This heuristic false-positives on valid **Streamable HTTP** MCP servers that answer `HEAD`/`GET` with a non-MCP content type while serving real MCP over `POST`. A concrete example is a gateway whose base URL replies to `GET` with `Content-Type: text/plain` (a short status blurb), but whose `POST initialize` returns a proper JSON-RPC MCP response. The preflight rejects it with:

```
returned Content-Type 'text/plain', not an MCP response
(expected one of: application/json, text/event-stream).
The URL most likely points at a web page rather than an MCP endpoint
```

…even though connecting with the MCP SDK's `streamablehttp_client` succeeds and discovers all tools. The probe's own docstring already notes it is best-effort and that "the real handshake remains the source of truth" — but there is currently no way to opt out per server.

## Fix

Add a per-server `skip_preflight` flag (default `false`) that bypasses the content-type probe, mirroring the existing SSE / reconnect / OAuth skip conditions. The real handshake still runs and remains authoritative, so a genuinely wrong URL still fails — just via the SDK path instead of the heuristic.

```yaml
mcp_servers:
  my_server:
    url: "https://host/mcp-endpoint?key=..."
    skip_preflight: true
```

## Changes
- `tools/mcp_tool.py`: add `and not config.get("skip_preflight")` to the preflight guard; document the flag in the module config example and Features list.

## Testing
- Verified a real Streamable HTTP endpoint that answers `GET` with `text/plain` fails the probe without the flag and connects (tools discovered) with `skip_preflight: true`.
- `python -m py_compile tools/mcp_tool.py` passes.
- Default behavior unchanged when the flag is absent/false.