### PR TITLE
fix(tests): Wrong project root resolution

### DIFF
--- a/tests/gateway/test_plugin_platform_interface.py
+++ b/tests/gateway/test_plugin_platform_interface.py
@@ -7,14 +7,16 @@ enumeration — and verifies each one implements the required contract.
 
 import importlib
 import sys
-from pathlib import Path
 from types import ModuleType
 from typing import Any
 from unittest.mock import MagicMock
+from collections.abc import Callable
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+from hermes_cli.config import get_project_root
+
+PROJECT_ROOT = get_project_root()
 PLATFORMS_DIR = PROJECT_ROOT / "plugins" / "platforms"
 
 
@@ -75,6 +77,25 @@ class _MockPluginContext:
         )
         platform_registry.register(entry)
         self.registered_names.append(name)
+
+    def register_cli_command(
+        self,
+        name: str,
+        help: str,
+        setup_fn: Callable,
+        handler_fn: Callable | None = None,
+        description: str = "",
+    ) -> None:
+        """Stub method for some plugin platforms to register a cli command
+
+        Tests do not verify cli comand registration. This method does nothing.
+        """
+
+    def register_hook(self, hook_name: str, callback: Callable) -> None:
+        """Stub method for some plugin platforms to register a hook
+
+        Tests do not verify hook registration. This method does nothing.
+        """
 
 
 def _import_platform_module(name: str) -> ModuleType:
@@ -139,8 +160,13 @@ def test_platform_entry_has_required_fields(platform_name: str, clean_registry):
 
 
 @pytest.mark.parametrize("platform_name", _PLATFORM_NAMES)
-def test_adapter_factory_produces_valid_adapter(platform_name: str, clean_registry):
+def test_adapter_factory_produces_valid_adapter(platform_name: str, clean_registry, monkeypatch):
     """The adapter factory must return an object with the base interface."""
+
+    # Make SmsAdapter.__init__ run
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "auth_token")
+
     module = _import_platform_module(platform_name)
     ctx = _MockPluginContext()
     module.register(ctx)


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Test gateway/test_plugin_platform_interface.py has a few issues:

* Project root is not resolved correctly. Missing one Path.parent call. It causes no platform plugin is discovered, then _PLATFORM_NAMES references an empty list, then no test run.
* Register method register_cli_command and register_hook are missing in class _MockPluginContext. Some platform plugins need them.
* Missing environment variables TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN for SmsAdapter.__init__.

This commit fixes them by:

* Calling method get_project_root instead of calling Path.parent manually.
* Adding stub methods register_cli_command and register_hook to class _MockPluginContext. They do nothing as tests do not verify registered cli commands and hooks.
* Patching os.environ to add TWILIO_* environment variables.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Update `test_plugin_platform_interface.py` to make tests run.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `python3 -m pytest -v tests/gateway/test_plugin_platform_interface.py`
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

