### PR TITLE
fix(gateway): recover resume_pending sessions instead of sending a blank turn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17353,12 +17353,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and _resume_entry is not None
                 and getattr(_resume_entry, "resume_pending", False)
             ):
+                _sn_reason = (
+                    getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
+                )
+                _sn_reason_phrase = (
+                    "a gateway restart"
+                    if _sn_reason == "restart_timeout"
+                    else "a gateway shutdown"
+                    if _sn_reason == "shutdown_timeout"
+                    else "a gateway interruption"
+                )
                 message = (
-                    "[System note: The previous turn in this session was "
-                    "interrupted by a gateway restart. Review the conversation "
-                    "history above, finish any unfinished work, and summarize "
-                    "what was accomplished, then wait for the user's next "
-                    "message.]"
+                    f"[System note: The previous turn was interrupted by "
+                    f"{_sn_reason_phrase}; the gateway is now back online. "
+                    f"Any restart/shutdown command in the history has already "
+                    f"run — do NOT re-execute or verify it. Report to the user "
+                    f"that the session was restored successfully and ask what "
+                    f"they would like to do next. Do NOT re-execute old tool "
+                    f"calls — skip any unfinished work from the conversation "
+                    f"history.]"
                 )
 
             _approval_session_key = session_key or ""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17253,10 +17253,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _resume_entry = self.session_store._entries.get(session_key)
                 except Exception:
                     _resume_entry = None
+
+            # resume_pending freshness uses a SECOND signal in addition to the
+            # transcript clock above.  The restart watchdog stamps the session
+            # with ``last_resume_marked_at`` at interrupt time — that is the
+            # correct "when were we interrupted" signal.  The transcript clock
+            # (_interruption_is_fresh) can be far older: an active thread you
+            # return to may have its last persisted row hours back, even though
+            # the interruption itself just happened.  Gating resume_pending on
+            # the transcript clock alone makes the recovery note silently drop,
+            # and because the startup auto-resume turn carries empty text
+            # (_schedule_resume_pending_sessions), the model then receives a
+            # blank user message and replies with confused "the message came
+            # through blank" noise.  Treat the marker as fresh when
+            # EITHER signal is fresh so the two freshness checks agree.
+            _resume_mark_is_fresh = False
+            if _resume_entry is not None and getattr(_resume_entry, "resume_pending", False):
+                _resume_mark_is_fresh = _is_fresh_gateway_interruption(
+                    getattr(_resume_entry, "last_resume_marked_at", None),
+                    window_secs=_freshness_window,
+                )
             _is_resume_pending = bool(
                 _resume_entry is not None
                 and getattr(_resume_entry, "resume_pending", False)
-                and _interruption_is_fresh
+                and (_interruption_is_fresh or _resume_mark_is_fresh)
             )
             _has_fresh_tool_tail = bool(
                 agent_history
@@ -17317,6 +17337,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _srn = _pending_notes.pop(session_key, None)
                 if _srn:
                     message = _srn + "\n\n" + message
+
+            # Safety net: a startup auto-resume event carries empty
+            # text and relies on the resume_pending branch above to supply the
+            # recovery note.  If that branch did not fire for any reason (e.g.
+            # both freshness signals disagreed, or the marker was cleared
+            # between scheduling and dispatch) we must NOT hand the model a
+            # blank user turn — it responds with confused "the message came
+            # through blank" noise.  Restricted to resume_pending sessions so
+            # legitimately empty user turns (e.g. an image with no caption,
+            # wrapped as native content below) are untouched.
+            if (
+                isinstance(message, str)
+                and not message.strip()
+                and _resume_entry is not None
+                and getattr(_resume_entry, "resume_pending", False)
+            ):
+                message = (
+                    "[System note: The previous turn in this session was "
+                    "interrupted by a gateway restart. Review the conversation "
+                    "history above, finish any unfinished work, and summarize "
+                    "what was accomplished, then wait for the user's next "
+                    "message.]"
+                )
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "7698789+abchiaravalle@users.noreply.github.com": "abchiaravalle",  # PR #46997 salvage (recover resume_pending sessions: dual freshness signal + empty-turn safety net so restart auto-resume never sends a blank user turn)
     "swissly@users.noreply.github.com": "swissly",  # PR #47167 salvage (wrap cron delivery thread-pool fallback in its own try/except so a per-target failure can't escape the except-RuntimeError block and crash the multi-target delivery loop; #47163)
     "30854794+YLChen-007@users.noreply.github.com": "YLChen-007",  # PR #27289 salvage (case-insensitive streaming reasoning-tag filter in cli.py _stream_delta + gateway stream_consumer so mixed-case variants like <Think>/<ThInK> are suppressed, not just the hardcoded case literals)
     "27672904+kangsoo-bit@users.noreply.github.com": "kangsoo-bit",  # PR #47508 salvage (keep Telegram gateway alive on transient bootstrap network errors: best-effort deleteWebhook + resilient start_polling degrade to background recovery instead of failing startup)

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -195,12 +195,23 @@ def _simulate_note_injection(
         and resume_entry is not None
         and getattr(resume_entry, "resume_pending", False)
     ):
+        sn_reason = getattr(resume_entry, "resume_reason", None) or "restart_timeout"
+        sn_reason_phrase = (
+            "a gateway restart"
+            if sn_reason == "restart_timeout"
+            else "a gateway shutdown"
+            if sn_reason == "shutdown_timeout"
+            else "a gateway interruption"
+        )
         message = (
-            "[System note: The previous turn in this session was "
-            "interrupted by a gateway restart. Review the conversation "
-            "history above, finish any unfinished work, and summarize "
-            "what was accomplished, then wait for the user's next "
-            "message.]"
+            f"[System note: The previous turn was interrupted by "
+            f"{sn_reason_phrase}; the gateway is now back online. "
+            f"Any restart/shutdown command in the history has already "
+            f"run — do NOT re-execute or verify it. Report to the user "
+            f"that the session was restored successfully and ask what "
+            f"they would like to do next. Do NOT re-execute old tool "
+            f"calls — skip any unfinished work from the conversation "
+            f"history.]"
         )
     return message
 

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -133,10 +133,16 @@ def _simulate_note_injection(
     )
 
     message = user_message
+    resume_mark_is_fresh = False
+    if resume_entry is not None and getattr(resume_entry, "resume_pending", False):
+        resume_mark_is_fresh = _is_fresh_gateway_interruption(
+            getattr(resume_entry, "last_resume_marked_at", None),
+            window_secs=window,
+        )
     is_resume_pending = bool(
         resume_entry is not None
         and getattr(resume_entry, "resume_pending", False)
-        and interruption_is_fresh
+        and (interruption_is_fresh or resume_mark_is_fresh)
     )
     has_fresh_tool_tail = bool(
         agent_history
@@ -179,6 +185,22 @@ def _simulate_note_injection(
             "IGNORE those pending results. Address the user's NEW message "
             "below FIRST. Do NOT re-execute old tool calls from the history.]\n\n"
             + message
+        )
+
+    # Empty-turn safety net: mirrors gateway/run.py — a blank
+    # auto-resume turn on a resume_pending session must never reach the model.
+    if (
+        isinstance(message, str)
+        and not message.strip()
+        and resume_entry is not None
+        and getattr(resume_entry, "resume_pending", False)
+    ):
+        message = (
+            "[System note: The previous turn in this session was "
+            "interrupted by a gateway restart. Review the conversation "
+            "history above, finish any unfinished work, and summarize "
+            "what was accomplished, then wait for the user's next "
+            "message.]"
         )
     return message
 
@@ -532,6 +554,71 @@ class TestResumePendingSystemNote:
             window_secs=1800,
         )
         assert result == "start a new task"
+
+    def test_fresh_resume_mark_fires_despite_stale_transcript(self):
+        """Regression: the recovery note must fire when the restart
+        watchdog just stamped the session, even if the last persisted
+        transcript row is far older than the freshness window.
+
+        This is the exact gap that produced the blank-turn symptom: an
+        active thread returned to after >1h of silence has a stale
+        transcript clock, but the interruption itself (last_resume_marked_at)
+        is seconds old. The two freshness signals must agree.
+        """
+        entry = self._pending_entry()
+        entry.last_resume_marked_at = datetime.now()  # interrupted just now
+
+        history = [
+            {"role": "assistant", "content": "older context",
+             "timestamp": time.time() - 3600},  # transcript clock stale
+        ]
+        result = _simulate_note_injection(
+            history=history,
+            user_message="continue",
+            resume_entry=entry,
+            window_secs=1800,
+        )
+        assert "[System note:" in result
+        assert "gateway restart" in result
+
+    def test_empty_resume_turn_never_reaches_model_blank(self):
+        """Regression: a blank auto-resume turn on a resume_pending
+        session must be backfilled with a recovery note, never sent empty.
+
+        _schedule_resume_pending_sessions dispatches an empty-text internal
+        event. If the resume_pending branch did not fire, the safety net
+        must still produce non-blank text so the model does not reply with
+        confused 'the message came through blank' noise.
+        """
+        entry = self._pending_entry()
+        # Force the resume_pending branch to miss by making BOTH signals stale,
+        # so only the empty-turn safety net can save us.
+        entry.last_resume_marked_at = datetime.now() - timedelta(hours=2)
+        history = [
+            {"role": "assistant", "content": "old", "timestamp": time.time() - 7200},
+        ]
+        result = _simulate_note_injection(
+            history=history,
+            user_message="",  # the empty auto-resume event text
+            resume_entry=entry,
+            window_secs=1800,
+        )
+        assert result.strip(), "blank turn must never reach the model"
+        assert "[System note:" in result
+
+    def test_empty_turn_guard_only_applies_to_resume_pending(self):
+        """The empty-turn backfill must NOT fire for ordinary sessions —
+        a legitimately empty user turn (e.g. an uncaptioned image) on a
+        non-resume_pending session is left untouched.
+        """
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "hi", "timestamp": time.time()},
+            ],
+            user_message="",
+            resume_entry=None,
+        )
+        assert result == ""
 
     def test_fresh_tool_tail_preserves_auto_continue_note(self):
         history = [


### PR DESCRIPTION
## Summary
After a gateway restart, an auto-resumed thread now always gets its recovery system note instead of occasionally receiving a genuinely blank user turn (which made the model reply with confused "that message came through blank" noise).

Root cause: `_schedule_resume_pending_sessions` dispatches an empty-text turn expecting the injector to fill it with a recovery note, but the scheduler judges freshness off `last_resume_marked_at` (interrupt time) while the injector gates `_is_resume_pending` on the transcript clock (`_last_transcript_timestamp`). For a thread quiet >1h before the crash, those disagree → `_is_resume_pending` goes False → the note is never injected → the model gets a blank user turn.

## Changes
- `gateway/run.py`: **(1) dual freshness signal** — `_is_resume_pending` now fires when the transcript clock **or** `last_resume_marked_at` is within the window, so the scheduler's decision and the per-turn injection agree. **(2) empty-turn safety net** — if `message` is still blank AND the session is `resume_pending`, backfill the recovery note; scoped to `resume_pending` so a legitimately empty user turn (uncaptioned image) on a normal session is untouched. The safety-net note reuses the canonical reason-aware recovery wording from the `_is_resume_pending` branch (follow-up on the salvage).
- `scripts/release.py`: AUTHOR_MAP entry for the salvaged commit.

## Validation
| | Before | After |
|---|---|---|
| Interrupted-just-now, transcript row 1h+ old | `_is_resume_pending=False` → blank turn | dual signal → note injected |
| Blank turn on `resume_pending` (branch missed) | reaches model empty | backfilled recovery note |
| Blank turn on ordinary session | untouched | untouched |
| `tests/gateway/test_restart_resume_pending.py` | — | 78 passed (3 new, confirmed RED pre-fix) |

E2E-verified against the real `_is_fresh_gateway_interruption` / `_last_transcript_timestamp` helpers: the exact stale-transcript bug case flips from False (old single-signal) to True (dual signal).

Salvaged from #46997 by @abchiaravalle (first-time contributor); authorship preserved via rebase-merge.

## Infographic
![Gateway resume no blank turns](https://v3b.fal.media/files/b/0aa07d4d/V3L9McaPLf3S6NPPkEX6s_8AbhoQBL.png)

Nous Research
