### PR TITLE
fix(anthropic): tool_use/tool_result adjacency + OAuth claude-code/ UA (salvage #52145 #51948)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2103,57 +2103,81 @@ def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
     """Strip tool_use blocks with no matching tool_result, and vice versa.
 
     Context compression or session truncation can remove either side of a
-    tool-call pair.  Anthropic rejects both orphans with HTTP 400.
-
+    tool-call pair, or insert messages between a tool_use and its result.
+    Anthropic requires each tool_use to have a matching tool_result in the
+    IMMEDIATELY FOLLOWING user message — a global ID match is not enough.
     Mutates ``result`` in place.
     """
-    # Strip orphaned tool_use blocks (no matching tool_result follows)
-    tool_result_ids = set()
-    for m in result:
-        if m["role"] == "user" and isinstance(m["content"], list):
-            for block in m["content"]:
-                if block.get("type") == "tool_result":
-                    tool_result_ids.add(block.get("tool_use_id"))
-    for m in result:
-        if m["role"] == "assistant" and isinstance(m["content"], list):
-            kept = [
-                b
-                for b in m["content"]
-                if b.get("type") != "tool_use" or b.get("id") in tool_result_ids
-            ]
-            # If stripping an orphaned tool_use mutated a turn that also carries a
-            # signed thinking block, that block's Anthropic signature was computed
-            # against the ORIGINAL (un-stripped) turn content and is now invalid.
-            # Anthropic rejects the replayed turn with HTTP 400 "thinking blocks in
-            # the latest assistant message cannot be modified".  Flag the turn so
-            # _manage_thinking_signatures can demote the dead signature instead of
-            # replaying it verbatim.  See hermes-agent: extended-thinking + parallel
-            # tool batch interrupted mid-flight → non-retryable 400 crash-loop.
-            if len(kept) != len(m["content"]) and any(
-                isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"}
-                for b in m["content"]
-            ):
-                m["_thinking_signature_invalidated"] = True
-            m["content"] = kept
-            if not m["content"]:
-                m["content"] = [{"type": "text", "text": "(tool call removed)"}]
+    # Pass 1: For each assistant message with tool_use blocks, check that
+    # EACH tool_use ID has a matching tool_result in the immediately following
+    # user message.  Strip tool_use blocks that lack an adjacent result —
+    # Anthropic rejects non-adjacent pairs with HTTP 400 even when the IDs
+    # match somewhere later in the conversation.
+    for i, m in enumerate(result):
+        if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
+            continue
+        tool_use_ids_in_turn = {
+            b.get("id")
+            for b in m["content"]
+            if isinstance(b, dict) and b.get("type") == "tool_use"
+        }
+        if not tool_use_ids_in_turn:
+            continue
 
-    # Strip orphaned tool_result blocks (no matching tool_use precedes them)
-    tool_use_ids = set()
+        # Collect result IDs from the immediately following user message only.
+        adjacent_result_ids: set = set()
+        if i + 1 < len(result):
+            nxt = result[i + 1]
+            if nxt.get("role") == "user" and isinstance(nxt.get("content"), list):
+                for block in nxt["content"]:
+                    if isinstance(block, dict) and block.get("type") == "tool_result":
+                        adjacent_result_ids.add(block.get("tool_use_id"))
+
+        orphaned = tool_use_ids_in_turn - adjacent_result_ids
+        if not orphaned:
+            continue
+
+        kept = [
+            b
+            for b in m["content"]
+            if not (isinstance(b, dict) and b.get("type") == "tool_use" and b.get("id") in orphaned)
+        ]
+        # If stripping an orphaned tool_use mutated a turn that also carries a
+        # signed thinking block, that block's Anthropic signature was computed
+        # against the ORIGINAL (un-stripped) turn content and is now invalid.
+        # Anthropic rejects the replayed turn with HTTP 400 "thinking blocks in
+        # the latest assistant message cannot be modified".  Flag the turn so
+        # _manage_thinking_signatures can demote the dead signature instead of
+        # replaying it verbatim.  See hermes-agent: extended-thinking + parallel
+        # tool batch interrupted mid-flight → non-retryable 400 crash-loop.
+        if len(kept) != len(m["content"]) and any(
+            isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"}
+            for b in m["content"]
+        ):
+            m["_thinking_signature_invalidated"] = True
+        m["content"] = kept if kept else [{"type": "text", "text": "(tool call removed)"}]
+
+    # Pass 2: Rebuild the set of tool_use IDs that survived pass 1, then
+    # strip tool_result blocks that no longer have any matching tool_use
+    # anywhere in the conversation.
+    surviving_tool_use_ids: set = set()
     for m in result:
-        if m["role"] == "assistant" and isinstance(m["content"], list):
+        if m.get("role") == "assistant" and isinstance(m.get("content"), list):
             for block in m["content"]:
-                if block.get("type") == "tool_use":
-                    tool_use_ids.add(block.get("id"))
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    surviving_tool_use_ids.add(block.get("id"))
+
     for m in result:
-        if m["role"] == "user" and isinstance(m["content"], list):
-            m["content"] = [
-                b
-                for b in m["content"]
-                if b.get("type") != "tool_result" or b.get("tool_use_id") in tool_use_ids
-            ]
-            if not m["content"]:
-                m["content"] = [{"type": "text", "text": "(tool result removed)"}]
+        if m.get("role") != "user" or not isinstance(m.get("content"), list):
+            continue
+        new_content = [
+            b
+            for b in m["content"]
+            if not (isinstance(b, dict) and b.get("type") == "tool_result")
+            or b.get("tool_use_id") in surviving_tool_use_ids
+        ]
+        if len(new_content) != len(m["content"]):
+            m["content"] = new_content if new_content else [{"type": "text", "text": "(tool result removed)"}]
 
 
 def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -817,7 +817,7 @@ def build_anthropic_client(
         kwargs["auth_token"] = api_key
         kwargs["default_headers"] = {
             "anthropic-beta": ",".join(all_betas),
-            "user-agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+            "user-agent": f"claude-code/{_get_claude_code_version()} (external, cli)",
             "x-app": "cli",
         }
     else:
@@ -1045,7 +1045,7 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
             data=data,
             headers={
                 "Content-Type": content_type,
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                "User-Agent": f"claude-code/{_get_claude_code_version()} (external, cli)",
             },
             method="POST",
         )
@@ -1478,6 +1478,8 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
         # Anthropic migrated the OAuth token endpoint to platform.claude.com;
         # console.anthropic.com now 404s. Try the new host first, then fall
         # back to console for older deployments (mirrors the refresh path).
+        # Use the claude-code/ UA prefix: Anthropic blocks claude-cli/ on the
+        # OAuth token endpoint (returns 404 for all versions).
         result = None
         last_error = None
         for endpoint in _OAUTH_TOKEN_URLS:
@@ -1486,7 +1488,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
                 data=exchange_data,
                 headers={
                     "Content-Type": "application/json",
-                    "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                    "User-Agent": f"claude-code/{_get_claude_code_version()} (external, cli)",
                 },
                 method="POST",
             )

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -996,6 +996,57 @@ class TestConvertMessages:
         assert len(tool_results) == 1
         assert tool_results[0]["tool_use_id"] == "tc_valid"
 
+    def test_strips_tool_use_when_result_not_immediately_adjacent(self):
+        """A tool_use whose result appears LATER but not in the immediately
+        following user message must be stripped (adjacency, #52145).
+
+        The old logic matched tool_result ids globally across the whole
+        transcript, so it would wrongly KEEP such a tool_use; Anthropic then
+        400s because the result does not follow the tool_use turn. The adjacency
+        rewrite only honors a result in the next user message.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_late", "function": {"name": "search", "arguments": "{}"}},
+                ],
+            },
+            {"role": "user", "content": "actually, something else"},
+            {"role": "assistant", "content": "sure"},
+            {"role": "tool", "tool_call_id": "tc_late", "content": "late result"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        for m in result:
+            if m["role"] == "assistant" and isinstance(m["content"], list):
+                assert all(b.get("type") != "tool_use" for b in m["content"]), (
+                    "non-adjacent tool_use should have been stripped"
+                )
+        for m in result:
+            if m["role"] == "user" and isinstance(m["content"], list):
+                assert all(b.get("type") != "tool_result" for b in m["content"]), (
+                    "orphaned late tool_result should have been stripped"
+                )
+
+    def test_keeps_tool_use_when_result_immediately_adjacent(self):
+        """Control: an adjacent tool_use/result pair is preserved (no false strip)."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_ok", "function": {"name": "search", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_ok", "content": "good"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        asst = [m for m in result if m["role"] == "assistant"][0]
+        assert any(b.get("type") == "tool_use" for b in asst["content"])
+        user = [m for m in result if m["role"] == "user"][0]
+        assert any(b.get("type") == "tool_result" for b in user["content"])
+
     def test_system_with_cache_control(self):
         messages = [
             {

--- a/tests/agent/test_anthropic_oauth_ua_prefix.py
+++ b/tests/agent/test_anthropic_oauth_ua_prefix.py
@@ -58,9 +58,16 @@ class TestOAuthUserAgentPrefix:
         except AttributeError:
             pytest.skip("run_hermes_oauth_login_pure not found")
 
-        assert "claude-cli/" not in source, (
-            "run_hermes_oauth_login_pure still uses claude-cli/ UA"
-        )
+        # Only fail on claude-cli/ in an actual User-Agent header line — a
+        # comment that references the old behavior (e.g. "Anthropic blocks
+        # claude-cli/ on the OAuth endpoint") is allowed. Mirrors the
+        # header-scoped check in test_no_claude_cli_in_source.
+        for i, line in enumerate(source.split("\n"), 1):
+            stripped = line.strip()
+            if "claude-cli/" in stripped and ("User-Agent" in stripped or "user-agent" in stripped):
+                pytest.fail(
+                    f"Line {i}: run_hermes_oauth_login_pure still uses claude-cli/ UA header: {stripped}"
+                )
         assert "claude-code/" in source, (
             "run_hermes_oauth_login_pure should use claude-code/ UA"
         )

--- a/tests/agent/test_anthropic_oauth_ua_prefix.py
+++ b/tests/agent/test_anthropic_oauth_ua_prefix.py
@@ -73,17 +73,22 @@ class TestOAuthUserAgentPrefix:
         )
 
     def test_token_refresh_ua_prefix(self):
-        """_refresh_oauth_token_raw must not send claude-cli/ UA."""
+        """refresh_anthropic_oauth_pure must not send claude-cli/ UA."""
         import inspect
         import agent.anthropic_adapter as mod
 
-        # Find the function that does the actual refresh HTTP call
-        for name in ("_refresh_oauth_token_raw", "_do_token_refresh", "_refresh_oauth_token"):
-            func = getattr(mod, name, None)
-            if func and callable(func):
-                source = inspect.getsource(func)
-                if "urllib.request.Request" in source:
-                    assert "claude-cli/" not in source, (
-                        f"{name} still uses claude-cli/ UA"
-                    )
-                    break
+        func = getattr(mod, "refresh_anthropic_oauth_pure", None)
+        if func is None or not callable(func):
+            pytest.skip("refresh_anthropic_oauth_pure not found")
+        source = inspect.getsource(func)
+
+        # Header-scoped check (comments referencing claude-cli/ are allowed).
+        for i, line in enumerate(source.split("\n"), 1):
+            stripped = line.strip()
+            if "claude-cli/" in stripped and ("User-Agent" in stripped or "user-agent" in stripped):
+                pytest.fail(
+                    f"Line {i}: refresh_anthropic_oauth_pure still uses claude-cli/ UA header: {stripped}"
+                )
+        assert "claude-code/" in source, (
+            "refresh_anthropic_oauth_pure should use claude-code/ UA"
+        )

--- a/tests/agent/test_anthropic_oauth_ua_prefix.py
+++ b/tests/agent/test_anthropic_oauth_ua_prefix.py
@@ -1,0 +1,82 @@
+"""Regression tests for the OAuth User-Agent header in anthropic_adapter.py.
+
+Anthropic now 404s the OAuth token endpoint for any ``claude-cli/`` UA prefix
+(issue #48534). The adapter must use ``claude-code/`` instead.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestOAuthUserAgentPrefix:
+    """All OAuth-related HTTP requests must use ``claude-code/`` UA, not ``claude-cli/``."""
+
+    def test_build_anthropic_client_oauth_ua(self):
+        """build_anthropic_client with OAuth token must use claude-code UA."""
+        from agent.anthropic_adapter import build_anthropic_client
+
+        mock_sdk = MagicMock()
+        with patch("agent.anthropic_adapter._get_anthropic_sdk", return_value=mock_sdk):
+            build_anthropic_client("sk-ant-oauth-abc123", "https://api.anthropic.com")
+
+        # Inspect the kwargs passed to Anthropic()
+        call_kwargs = mock_sdk.Anthropic.call_args[1]
+        headers = call_kwargs.get("default_headers", {})
+        ua = headers.get("user-agent", "") or headers.get("User-Agent", "")
+
+        assert "claude-code/" in ua, f"Expected claude-code/ in UA, got: {ua}"
+        assert "claude-cli/" not in ua, f"Must not use claude-cli/ prefix: {ua}"
+
+    def test_no_claude_cli_in_source(self):
+        """Source file must not contain claude-cli/ UA pattern (blocks OAuth)."""
+        import inspect
+        import agent.anthropic_adapter as mod
+
+        source = inspect.getsource(mod)
+        # Allow claude-cli in comments/strings that reference the old behavior
+        # but not in actual header assignments
+        lines = source.split("\n")
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            if "claude-cli/" in stripped and ("User-Agent" in stripped or "user-agent" in stripped):
+                pytest.fail(
+                    f"Line {i}: claude-cli/ still used in User-Agent header: {stripped}"
+                )
+
+    def test_token_exchange_ua_prefix(self):
+        """run_hermes_oauth_login_pure must not send claude-cli/ UA."""
+        import inspect
+        import agent.anthropic_adapter as mod
+
+        # Get the source of the exchange function
+        try:
+            source = inspect.getsource(mod.run_hermes_oauth_login_pure)
+        except AttributeError:
+            pytest.skip("run_hermes_oauth_login_pure not found")
+
+        assert "claude-cli/" not in source, (
+            "run_hermes_oauth_login_pure still uses claude-cli/ UA"
+        )
+        assert "claude-code/" in source, (
+            "run_hermes_oauth_login_pure should use claude-code/ UA"
+        )
+
+    def test_token_refresh_ua_prefix(self):
+        """_refresh_oauth_token_raw must not send claude-cli/ UA."""
+        import inspect
+        import agent.anthropic_adapter as mod
+
+        # Find the function that does the actual refresh HTTP call
+        for name in ("_refresh_oauth_token_raw", "_do_token_refresh", "_refresh_oauth_token"):
+            func = getattr(mod, name, None)
+            if func and callable(func):
+                source = inspect.getsource(func)
+                if "urllib.request.Request" in source:
+                    assert "claude-cli/" not in source, (
+                        f"{name} still uses claude-cli/ UA"
+                    )
+                    break


### PR DESCRIPTION
## Summary

Batch salvage of two complementary `agent/anthropic_adapter.py` fixes, rebased onto current `main`. Both bugs confirmed still-present; disjoint regions, no conflict.

## Fixes

**#52145 (@fsaad1984) — enforce tool_use/tool_result adjacency in `_strip_orphaned_tool_blocks`**
The old logic collected tool_result ids across *all* user messages and kept any assistant `tool_use` whose id appeared *anywhere*. Anthropic requires each `tool_use` to have its `tool_result` in the *immediately following* user message — a stale match elsewhere in the transcript would keep a genuinely-orphaned `tool_use` and 400 the request. Rewritten to adjacency-checked two-pass logic: pass 1 strips a `tool_use` whose result isn't in the next user message; pass 2 removes results orphaned by pass 1.

**#51948 (@DhivinX) — OAuth UA `claude-cli/` → `claude-code/`**
Anthropic 404s the OAuth token endpoint for the `claude-cli/` UA prefix (#48534). Switched all three OAuth UA sites — `build_anthropic_client` (:820), `refresh_anthropic_oauth_pure` (:1048), `run_hermes_oauth_login_pure` (:1491) — to `claude-code/`.

## Review follow-ups (mine)

A structured review of the salvage surfaced three test-quality issues, all fixed:
- **#52145 shipped no behavior test.** Added `test_strips_tool_use_when_result_not_immediately_adjacent` (the exact non-adjacent case the old global match got wrong) + an adjacent-pair control. Mutation-checked: reverting to a global match fails the non-adjacent test.
- **`test_token_exchange_ua_prefix` false-failed on a comment** (naive whole-function substring). Scoped it to actual `User-Agent` header lines, matching its sibling.
- **`test_token_refresh_ua_prefix` was vacuous** — it bound to a wrapper (`_refresh_oauth_token`) with no HTTP call, so its assert never ran. Retargeted at the real refresh site `refresh_anthropic_oauth_pure`. Mutation-checked: reverting :1048 now fails it.

## Verification

- All UA + adjacency + existing-orphan tests pass (10/10 for the touched surface).
- Note: `test_anthropic_adapter.py` has ~15 **pre-existing** failures on current `main` in unrelated OAuth-token-*resolution* classes (`TestResolveAnthropicToken` / `TestRefreshOauthToken` / `TestRunOauthSetupToken`) — verified identical on clean `origin/main` with none of these changes applied. Not introduced by this PR.

Closes #52145. Closes #51948.

Co-authored-by: fsaad1984 <38867992+fsaad1984@users.noreply.github.com>
Co-authored-by: DhivinX <20087092+DhivinX@users.noreply.github.com>
