### PR TITLE
fix(cron): isolate per-job TERMINAL_CWD from concurrent cron jobs (salvage #50326)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -305,6 +305,62 @@ _running_lock = threading.Lock()
 _sequential_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 
 
+class _ReadWriteLock:
+    """Writer-preferring readers-writer lock.
+
+    Guards the process-global ``os.environ["TERMINAL_CWD"]`` override that a
+    workdir cron job applies for the whole of its agent run.  Workdir jobs are
+    writers: they mutate the shared env and need exclusive access.  Workdir-less
+    jobs are readers: they only observe ``TERMINAL_CWD`` (indirectly, via the
+    terminal / file / code-exec tools), so any number of them may run
+    concurrently with each other, but none may run alongside a writer — that is
+    exactly what stops a workdir-less job from picking up another job's workdir
+    override and running its commands in the wrong directory.
+
+    Writer preference bounds the wait for a workdir job (dispatched on the
+    single-thread sequential pool) so a stream of workdir-less readers cannot
+    starve it.
+    """
+
+    def __init__(self) -> None:
+        self._cond = threading.Condition(threading.Lock())
+        self._readers = 0
+        self._writer_active = False
+        self._writers_waiting = 0
+
+    def acquire_read(self) -> None:
+        with self._cond:
+            while self._writer_active or self._writers_waiting > 0:
+                self._cond.wait()
+            self._readers += 1
+
+    def release_read(self) -> None:
+        with self._cond:
+            self._readers -= 1
+            if self._readers == 0:
+                self._cond.notify_all()
+
+    def acquire_write(self) -> None:
+        with self._cond:
+            self._writers_waiting += 1
+            try:
+                while self._writer_active or self._readers > 0:
+                    self._cond.wait()
+            finally:
+                self._writers_waiting -= 1
+            self._writer_active = True
+
+    def release_write(self) -> None:
+        with self._cond:
+            self._writer_active = False
+            self._cond.notify_all()
+
+
+# Serializes the per-job TERMINAL_CWD override against every other concurrently
+# running cron job.  See _ReadWriteLock and run_job for the usage contract.
+_terminal_cwd_lock = _ReadWriteLock()
+
+
 def _get_parallel_pool(max_workers: Optional[int]) -> concurrent.futures.ThreadPoolExecutor:
     """Return (or create) the persistent parallel pool."""
     global _parallel_pool, _parallel_pool_max_workers
@@ -2252,9 +2308,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     #     .cursorrules from the job's project dir, AND
     #   - the terminal, file, and code-exec tools run commands from there.
     #
-    # tick() serializes workdir-jobs outside the parallel pool, so mutating
-    # os.environ["TERMINAL_CWD"] here is safe for those jobs.  For workdir-less
-    # jobs we leave TERMINAL_CWD untouched — preserves the original behaviour
+    # os.environ["TERMINAL_CWD"] is process-global, so this override is
+    # serialized by _terminal_cwd_lock (acquired just below): a workdir job
+    # holds it as a writer for its whole run, excluding every other job, while
+    # workdir-less jobs hold it as readers and stay parallel with each other.
+    # The sequential pool only keeps workdir jobs from overlapping EACH OTHER;
+    # the lock is what additionally keeps a concurrently-firing workdir-less
+    # parallel-pool job from observing this override and running its shell /
+    # file / code-exec commands in the wrong directory.  For workdir-less jobs
+    # we leave TERMINAL_CWD untouched — preserves the original behaviour
     # (skip_context_files=True, tools use whatever cwd the scheduler has).
     _job_workdir = (job.get("workdir") or "").strip() or None
     if _job_workdir and not Path(_job_workdir).is_dir():
@@ -2265,6 +2327,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             job_id, _job_workdir,
         )
         _job_workdir = None
+
+    _holds_cwd_write = _job_workdir is not None
+    if _holds_cwd_write:
+        _terminal_cwd_lock.acquire_write()
+    else:
+        _terminal_cwd_lock.acquire_read()
+
     _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
     if _job_workdir:
         os.environ["TERMINAL_CWD"] = _job_workdir
@@ -2773,6 +2842,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 os.environ.pop("TERMINAL_CWD", None)
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
+        # Release the cwd lock now that the env is restored, so a waiting
+        # workdir job (or queued reader) can proceed without seeing the override.
+        if _holds_cwd_write:
+            _terminal_cwd_lock.release_write()
+        else:
+            _terminal_cwd_lock.release_read()
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
@@ -2999,9 +3074,11 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
             return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
 
         # Partition due jobs: those with a per-job workdir mutate
-        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global —
-        # so they MUST run sequentially to avoid corrupting each other.  Jobs
-        # without a workdir leave env untouched and stay parallel-safe.
+        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so
+        # they queue on the single-thread sequential pool to run one at a time.
+        # That alone only keeps workdir jobs from overlapping EACH OTHER;
+        # run_job's _terminal_cwd_lock is what additionally stops a concurrently
+        # firing workdir-less parallel-pool job from observing the override.
         sequential_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
         parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2328,18 +2328,28 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         )
         _job_workdir = None
 
+    # Snapshot the current env value BEFORE acquiring the lock so the finally
+    # below can always restore it, even if an exception fires before we set the
+    # override inside the try.  This read can't leak the lock (it precedes the
+    # acquire) and is a no-op for workdir-less jobs (they never mutate the env).
+    _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
+
     _holds_cwd_write = _job_workdir is not None
     if _holds_cwd_write:
         _terminal_cwd_lock.acquire_write()
     else:
         _terminal_cwd_lock.acquire_read()
 
-    _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
-    if _job_workdir:
-        os.environ["TERMINAL_CWD"] = _job_workdir
-        logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
-
+    # Everything after the acquire MUST live inside this try, so the finally
+    # below always releases the lock even if the env override or any later
+    # statement raises.  A leaked writer would deadlock the whole scheduler
+    # (every future job blocks on acquire_*); a leaked reader blocks all
+    # future writers.  Acquire itself can't leak (it either blocks or returns).
     try:
+        if _job_workdir:
+            os.environ["TERMINAL_CWD"] = _job_workdir
+            logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
+
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart. Route through
         # load_hermes_dotenv (not a bare load_dotenv) and reset the secret-

--- a/tests/cron/test_terminal_cwd_lock.py
+++ b/tests/cron/test_terminal_cwd_lock.py
@@ -132,3 +132,60 @@ def test_reader_never_observes_writer_override():
     assert not wt.is_alive() and not rt.is_alive()
     # The reader saw the restored value, never the writer's /project/A override.
     assert observations == ["<scheduler>"]
+
+
+def test_run_job_releases_cwd_lock_when_body_raises(tmp_path):
+    """A workdir job whose run_job body raises must still RELEASE the writer lock.
+
+    Regression for the leak that made the fix "still broken": the acquire was
+    placed before the try whose finally releases, so an exception in the
+    unprotected window (or anywhere in the body) leaked the writer lock and
+    deadlocked the whole scheduler. This asserts the lock is free again after a
+    raising run — acquire_write() must not block.
+    """
+    from unittest.mock import MagicMock, patch
+    import cron.scheduler as sched
+
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    job = {"id": "boom-job", "name": "boom", "prompt": "hi", "workdir": str(workdir)}
+
+    # Force a raise in the WINDOW BETWEEN acquire and the try body — the exact
+    # spot the buggy placement left unprotected. With the fix these statements
+    # are inside the try (finally releases); with the bug the lock leaks.
+    # logger.info(...) fires right after os.environ["TERMINAL_CWD"] is set for a
+    # workdir job, in that window, so making it raise exercises the leak path.
+    real_info = sched.logger.info
+
+    def _raise_on_workdir_log(msg, *args, **kwargs):
+        if isinstance(msg, str) and "using workdir" in msg:
+            raise RuntimeError("boom")
+        return real_info(msg, *args, **kwargs)
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch.object(sched.logger, "info", side_effect=_raise_on_workdir_log), \
+         patch("hermes_state.SessionDB", return_value=MagicMock()):
+        # run_job catches its own body exceptions and returns (False, ...);
+        # it must not propagate, and it must release the lock either way.
+        success, _out, _final, _err = sched.run_job(job)
+
+    assert success is False
+
+    # If the writer lock leaked, this acquire would block forever. Prove it's
+    # free by acquiring as a writer from another thread under a short timeout.
+    acquired = threading.Event()
+
+    def try_acquire():
+        sched._terminal_cwd_lock.acquire_write()
+        try:
+            acquired.set()
+        finally:
+            sched._terminal_cwd_lock.release_write()
+
+    t = threading.Thread(target=try_acquire, daemon=True)
+    t.start()
+    assert acquired.wait(timeout=5), "writer lock was leaked by run_job on exception"
+    t.join(timeout=5)

--- a/tests/cron/test_terminal_cwd_lock.py
+++ b/tests/cron/test_terminal_cwd_lock.py
@@ -1,0 +1,134 @@
+"""Tests for the TERMINAL_CWD readers-writer lock in cron/scheduler.py.
+
+Workdir cron jobs override the process-global ``os.environ["TERMINAL_CWD"]``
+for their whole agent run.  Workdir-less jobs run concurrently on a separate
+pool and read that same global (via the terminal / file / code-exec tools), so
+without serialization they execute commands in another job's workdir.
+
+``_ReadWriteLock`` models workdir jobs as writers (exclusive) and workdir-less
+jobs as readers (concurrent with each other, excluded from a writer's run).
+These tests assert that contract.
+"""
+
+import threading
+
+
+def _lock():
+    import cron.scheduler as sched
+
+    return sched._ReadWriteLock()
+
+
+def test_multiple_readers_run_concurrently():
+    """Workdir-less jobs (readers) hold the lock simultaneously."""
+    lock = _lock()
+    # Barrier of 3 only releases if both reader threads hold the read lock at
+    # the same time as the main thread waits — proving readers are concurrent.
+    barrier = threading.Barrier(3, timeout=5)
+
+    def reader():
+        lock.acquire_read()
+        try:
+            barrier.wait()
+        finally:
+            lock.release_read()
+
+    threads = [threading.Thread(target=reader) for _ in range(2)]
+    for t in threads:
+        t.start()
+
+    # Does not raise BrokenBarrierError -> both readers were holding at once.
+    barrier.wait(timeout=5)
+    for t in threads:
+        t.join(timeout=5)
+        assert not t.is_alive()
+
+
+def test_writer_waits_for_active_reader():
+    """A workdir job (writer) cannot acquire while a reader holds the lock."""
+    lock = _lock()
+    order = []
+    reader_holding = threading.Event()
+    let_reader_go = threading.Event()
+
+    def reader():
+        lock.acquire_read()
+        try:
+            reader_holding.set()
+            let_reader_go.wait(timeout=5)
+            order.append("reader-release")
+        finally:
+            lock.release_read()
+
+    def writer():
+        reader_holding.wait(timeout=5)
+        lock.acquire_write()
+        try:
+            order.append("writer-acquire")
+        finally:
+            lock.release_write()
+
+    rt = threading.Thread(target=reader)
+    wt = threading.Thread(target=writer)
+    rt.start()
+    wt.start()
+
+    # Give the writer time to try (and block) while the reader still holds.
+    reader_holding.wait(timeout=5)
+    let_reader_go.set()
+
+    rt.join(timeout=5)
+    wt.join(timeout=5)
+    assert not rt.is_alive() and not wt.is_alive()
+    # The writer only ran after the reader released — never alongside it.
+    assert order == ["reader-release", "writer-acquire"]
+
+
+def test_reader_never_observes_writer_override():
+    """Regression: the cross-pool TERMINAL_CWD corruption.
+
+    A workdir job (writer) overriding the shared cwd must never be observed by
+    a concurrent workdir-less job (reader).  ``shared["cwd"]`` stands in for
+    ``os.environ["TERMINAL_CWD"]``: the reader, even though it starts while the
+    writer holds the override, must block until the writer restores the value.
+    """
+    lock = _lock()
+    shared = {"cwd": "<scheduler>"}
+    observations = []
+    writer_holding = threading.Event()
+    release_writer = threading.Event()
+
+    def writer():
+        lock.acquire_write()
+        try:
+            shared["cwd"] = "/project/A"
+            writer_holding.set()
+            release_writer.wait(timeout=5)
+        finally:
+            shared["cwd"] = "<scheduler>"
+            lock.release_write()
+
+    def reader():
+        # Start only once the writer holds the lock and has applied the
+        # override — the exact window the old code corrupted.
+        writer_holding.wait(timeout=5)
+        lock.acquire_read()
+        try:
+            observations.append(shared["cwd"])
+        finally:
+            lock.release_read()
+
+    wt = threading.Thread(target=writer)
+    rt = threading.Thread(target=reader)
+    wt.start()
+    rt.start()
+
+    # The reader is now blocked on the writer; let the writer finish.
+    writer_holding.wait(timeout=5)
+    release_writer.set()
+
+    wt.join(timeout=5)
+    rt.join(timeout=5)
+    assert not wt.is_alive() and not rt.is_alive()
+    # The reader saw the restored value, never the writer's /project/A override.
+    assert observations == ["<scheduler>"]


### PR DESCRIPTION
## Summary

Salvage of #50326 by @entropy-0x (rebased onto current `main` + a rework commit fixing a lock-leak). Isolates a per-job `TERMINAL_CWD` from concurrently-running cron jobs.

## The bug

A cron job with a per-job `workdir` overrides the process-global `os.environ["TERMINAL_CWD"]` for its whole agent run. The scheduler runs workdir jobs on a single-thread sequential pool and workdir-less jobs on a separate parallel pool — but **both pools run in the same process and share `os.environ`**. While a workdir job holds the override, any workdir-less job firing in the same window reads that global (via the terminal / file / code-exec tools) and runs its commands in the **wrong directory** — a file write or delete can land in another job's tree. Confirmed still present on current `main`.

## The fix

@entropy-0x's fix: a writer-preferring readers-writer lock (`_ReadWriteLock`). Workdir jobs acquire it as **writers** (exclusive for their run); workdir-less jobs acquire it as **readers** (parallel with each other, never alongside a writer's override). Guarantee is based on run overlap, so it holds across ticks.

## Rework in this salvage (why the original was still broken)

The original acquired the lock **before** the `try:` whose `finally:` is the only release site, with the env-override statements (`os.environ[...] = workdir`; `logger.info`) in the unprotected window between acquire and try. An exception there (a raising log handler, an `os.environ` error, a thread interrupt) propagated out of `run_job` **without running the finally**, leaking the lock — a leaked **writer permanently deadlocks the whole scheduler** (every future job blocks on `acquire_*`). Fix:

- Snapshot `_prior_terminal_cwd` **before** the acquire (so the finally can always restore env).
- Open the `try:` immediately after acquire and move the env-override lines inside it, so the existing finally always releases.
- Add a **mutation-verified** regression test: a workdir job whose in-window `logger.info` raises must still release the writer lock (verified: reverting the placement makes the test fail).

The `_ReadWriteLock` class itself, reader/writer partitioning, and re-entrancy were all correct — the only defect was lock placement relative to the try/finally.

## Review

Ran hermes-agent-dev + hermes-pr-review Phase 2c (4-part structured) on the final salvage.

## Tests

`tests/cron/test_terminal_cwd_lock.py` — concurrent readers, writer-excludes-reader, the cross-pool regression, and the new leak-on-exception guard. (CI runs the full suite.)

Supersedes #50326. Full credit to @entropy-0x.
