### PR TITLE
fix(disk-cleanup): protect cron output root from cleanup (salvage #49271)

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -166,11 +166,13 @@ def _is_protected_cron_path(p: Path) -> bool:
     """Return True if *p* is a cron control-plane file/directory that must
     never be deleted.
 
-    This only matches the directory itself, known control-plane files
-    (``jobs.json``, ``.tick.lock``), and the ``output/`` root directory.
-    It does NOT blanket-protect files under ``cron/output/`` because those
-    run artifacts are disposable, but deleting the output root itself is too
-    broad and can erase every job's retained run history at once.
+    This matches, by EXACT path only, the ``cron/`` directory itself, known
+    control-plane files (``jobs.json``, ``.tick.lock``), and the ``output/``
+    root directory. It does NOT (and must not be "simplified" to) blanket-match
+    everything under ``cron/output/`` — those run artifacts are disposable and
+    are cleaned by retention policy; only the ``output/`` root itself is
+    protected, because deleting it wholesale erases every job's retained run
+    history at once.
     """
     # Lazily build the set once per process so HERMES_HOME is resolved
     # exactly once.

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -166,9 +166,11 @@ def _is_protected_cron_path(p: Path) -> bool:
     """Return True if *p* is a cron control-plane file/directory that must
     never be deleted.
 
-    This only matches the directory itself and known control-plane files
-    (``jobs.json``, ``.tick.lock``) — it does NOT blanket-protect
-    everything under ``cron/`` because ``cron/output/`` is disposable.
+    This only matches the directory itself, known control-plane files
+    (``jobs.json``, ``.tick.lock``), and the ``output/`` root directory.
+    It does NOT blanket-protect files under ``cron/output/`` because those
+    run artifacts are disposable, but deleting the output root itself is too
+    broad and can erase every job's retained run history at once.
     """
     # Lazily build the set once per process so HERMES_HOME is resolved
     # exactly once.
@@ -177,6 +179,7 @@ def _is_protected_cron_path(p: Path) -> bool:
         for parent in ("cron", "cronjobs"):
             base = hermes_home / parent
             _PROTECTED_CRON_PATHS.add(str(base))
+            _PROTECTED_CRON_PATHS.add(str(base / "output"))
             _PROTECTED_CRON_PATHS.add(str(base / "jobs.json"))
             _PROTECTED_CRON_PATHS.add(str(base / ".tick.lock"))
     resolved = str(p.resolve())
@@ -566,7 +569,7 @@ def guess_category(path: Path) -> Optional[str]:
             # (e.g. ``jobs.json``, ``.tick.lock``) must never be
             # auto-tracked — deleting it wipes the live scheduler
             # registry. See issue #32164.
-            if len(rel.parts) >= 2 and rel.parts[1] == "output":
+            if len(rel.parts) >= 3 and rel.parts[1] == "output":
                 return "cron-output"
             return None
         if top == "cache":

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -136,6 +136,13 @@ class TestGuessCategory:
         p.write_text("x")
         assert dg.guess_category(p) == "cron-output"
 
+    def test_cron_output_root_not_tracked(self, _isolate_env):
+        """The cron/output root is durable container state, not an artifact."""
+        dg = _load_lib()
+        output_root = _isolate_env / "cron" / "output"
+        output_root.mkdir(parents=True)
+        assert dg.guess_category(output_root) is None
+
     def test_cron_jobs_json_not_tracked(self, _isolate_env):
         """Regression for #32164: the cron registry must never be tracked."""
         dg = _load_lib()
@@ -227,6 +234,29 @@ class TestStaleCronEntryMigration:
         summary = dg.quick()
         assert summary["deleted"] == 0, "cron/ dir must not be deleted"
         assert cron_dir.exists()
+
+    def test_quick_skips_stale_cron_output_for_output_root(self, _isolate_env):
+        """Stale entry for cron/output itself must not delete all job output."""
+        dg = _load_lib()
+        output_root = _isolate_env / "cron" / "output"
+        job_dir = output_root / "job_1"
+        job_dir.mkdir(parents=True)
+        run_md = job_dir / "run.md"
+        run_md.write_text("x")
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(output_root),
+            "category": "cron-output",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": 0,
+        }]))
+
+        summary = dg.quick()
+        assert summary["deleted"] == 0, "cron/output root must not be deleted"
+        assert output_root.exists()
+        assert run_md.exists()
 
     def test_quick_skips_protected_cron_paths_defense_in_depth(self, _isolate_env):
         """Defense-in-depth: even if guess_category returned cron-output


### PR DESCRIPTION
## Summary

Salvage of #49271 by @martinramos002-bot (rebased onto current `main`). Stops the disk-cleanup plugin from deleting the cron **output root** (`~/.hermes/cron/output`) while still letting individual run artifacts below it be cleaned by retention policy.

## The bug

The disk-cleanup plugin classifies anything under `cron/output/` as disposable `cron-output`. That includes the `cron/output` **root directory itself** — deleting it wholesale erases *every* job's retained run history at once, far broader than expiring one run artifact.

## The fix

- Add `str(base / "output")` to `_PROTECTED_CRON_PATHS` in `_is_protected_cron_path` (for both `cron` and `cronjobs` parents) — a hard block on deleting the output root.
- In `guess_category`, tighten the gate from `len(rel.parts) >= 2` to `>= 3`: `rel` is relative to `hermes_home`, so `cron/output` is `('cron','output')` (len 2) → no longer categorized deletable, while a real artifact at `cron/output/<file>` (len 3) or deeper stays `cron-output` and is still cleaned.

Two independent defenses for the same invariant (root not deletable): the category gate, and the protected-paths hard block as defense-in-depth.

## Verification

Verified against current `main` (applied + behaviorally probed): `cron/output` root → protected; `cron/output/run.md` (len 3 file), `cron/output/job_1/run.md` (len 4), `cron/output/job_1` (len 3 dir) all still deleted; a stale `tracked.json` entry pointing at the root is dropped by `quick()`'s re-validation and hard-blocked by `_is_protected_cron_path` (both canonicalize via `.resolve()`). No off-by-one, no over-broad protection, no residual deletion path.

Ran hermes-agent-dev + hermes-pr-review Phase 2c (4-part structured) on the final salvage.

## Tests

`tests/plugins/test_disk_cleanup_plugin.py` — output-root-not-tracked, stale-entry-for-output-root-not-deleted, plus existing artifact-still-cleaned coverage. (CI runs the full suite.)

Supersedes #49271. Full credit to @martinramos002-bot.
