### PR TITLE
fix(approval): detect Windows destructive shell commands

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -82,6 +82,56 @@ class TestDetectDangerousRm:
         assert "delete" in desc.lower()
 
 
+class TestWindowsShellDestructiveCommands:
+    def test_cmd_del_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"cmd /c del /f /q C:\tmp\hermes-victim\file.txt"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows cmd destructive delete"
+
+    def test_cmd_rmdir_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"cmd.exe /k rmdir /s /q C:\tmp\hermes-victim"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows cmd destructive delete"
+
+    def test_powershell_remove_item_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"powershell -NoProfile -Command Remove-Item -Recurse -Force C:\tmp\hermes-victim"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows PowerShell destructive delete"
+
+    def test_pwsh_rm_alias_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"pwsh -c rm -Recurse -Force C:\tmp\hermes-victim"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_powershell_encoded_command_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "powershell -EncodedCommand SQBFAFgA"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "PowerShell encoded command execution"
+
+    def test_plain_text_does_not_trigger_windows_delete(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "echo remember to del old notes"
+        )
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+
 class TestDetectDangerousSudo:
     def test_shell_via_c_flag(self):
         is_dangerous, key, desc = detect_dangerous_command("bash -c 'echo pwned'")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -488,6 +488,12 @@ DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
+    # Windows shell front-ends have destructive built-ins that do not look like
+    # Unix `rm`. Gate only when they are executed through cmd/powershell so
+    # ordinary prose or filenames containing "del"/"rd" do not trip the guard.
+    (r'\bcmd(?:\.exe)?\s+/(?:c|k)\s+.*\b(?:del|erase|rd|rmdir)\b', "Windows cmd destructive delete"),
+    (r'\b(?:powershell|pwsh)(?:\.exe)?\b.*\s-(?:command|c)\b.*\b(?:remove-item|del|erase|rd|rmdir|rm)\b', "Windows PowerShell destructive delete"),
+    (r'\b(?:powershell|pwsh)(?:\.exe)?\b.*\s-(?:encodedcommand|enc|e)\b', "PowerShell encoded command execution"),
     (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),
     (r'\bchmod\s+--recursive\b.*(777|666|o\+[rwx]*w|a\+[rwx]*w)', "recursive world/other-writable (long flag)"),
     (r'\bchown\s+(-[^\s]*)?R\s+root', "recursive chown to root"),


### PR DESCRIPTION
## Summary

Detect destructive Windows shell built-ins in the dangerous-command approval gate.

The approval classifier already catches Unix deletion paths (`rm -rf`), interpreter execution (`python -c`, `node -e`, etc.), and recent encoded/decode-to-shell bypasses. However, Windows shell front-ends could execute equivalent destructive file deletion without matching any approval pattern:

- `cmd /c del /f /q C:\...`
- `cmd /c rmdir /s /q C:\...`
- `powershell -Command Remove-Item -Recurse -Force C:\...`
- `pwsh -c rm -Recurse -Force C:\...`
- `powershell -EncodedCommand ...`

These returned safe from `detect_dangerous_command()` and could proceed without an approval prompt.

## Changes

- Add detection for destructive `cmd.exe /c|/k` built-ins: `del`, `erase`, `rd`, `rmdir`.
- Add detection for destructive PowerShell/Pwsh commands and aliases: `Remove-Item`, `del`, `erase`, `rd`, `rmdir`, `rm`.
- Gate PowerShell encoded-command execution because it hides the actual command text from the classifier.
- Add regression tests for Windows cmd, PowerShell, pwsh alias, encoded command, and a plain-text non-trigger case.

## Tests

```text
python -m pytest tests/tools/test_approval.py -k "WindowsShellDestructiveCommands or WindowsAbsolutePathFolding" -q --timeout-method=thread
11 passed, 261 deselected