### PR TITLE
fix(memory): handle replace and remove in holographic on_memory_write

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
@@ -241,14 +241,37 @@ class HolographicMemoryProvider(MemoryProvider):
             return
         self._auto_extract_facts(messages)
 
-    def on_memory_write(self, action: str, target: str, content: str) -> None:
+    def on_memory_write(self, action: str, target: str, content: str, *, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Mirror built-in memory writes as facts."""
-        if action == "add" and self._store and content:
-            try:
-                category = "user_pref" if target == "user" else "general"
+        if not self._store:
+            return
+        try:
+            category = "user_pref" if target == "user" else "general"
+            if action == "add" and content:
                 self._store.add_fact(content, category=category)
-            except Exception as e:
-                logger.debug("Holographic memory_write mirror failed: %s", e)
+            elif action == "replace" and content:
+                old_text = (metadata or {}).get("old_text")
+                fact_id = self._find_fact_id_by_content(old_text) if old_text else None
+                if fact_id is not None:
+                    self._store.update_fact(fact_id, content=content)
+                else:
+                    self._store.add_fact(content, category=category)
+            elif action == "remove":
+                old_text = (metadata or {}).get("old_text")
+                if old_text:
+                    fact_id = self._find_fact_id_by_content(old_text)
+                    if fact_id is not None:
+                        self._store.remove_fact(fact_id)
+        except Exception as e:
+            logger.warning("Holographic memory_write mirror failed: %s", e)
+
+    def _find_fact_id_by_content(self, text: str) -> Optional[int]:
+        """Find a fact ID by exact content match."""
+        with self._store._lock:
+            row = self._store._conn.execute(
+                "SELECT fact_id FROM facts WHERE content = ?", (text.strip(),)
+            ).fetchone()
+        return int(row["fact_id"]) if row else None
 
     def shutdown(self) -> None:
         # Close the SQLite connection deterministically instead of leaking it

--- a/tests/plugins/memory/test_holographic_memory_write.py
+++ b/tests/plugins/memory/test_holographic_memory_write.py
@@ -1,0 +1,196 @@
+"""Tests for HolographicMemoryProvider.on_memory_write — #55095.
+
+Covers add, replace, and remove actions including metadata handling and
+graceful fallback behavior.
+"""
+
+import pytest
+
+from plugins.memory.holographic import HolographicMemoryProvider
+
+
+def _make_provider(tmp_path):
+    db_path = str(tmp_path / "memory_store.db")
+    provider = HolographicMemoryProvider(config={"db_path": db_path, "hrr_dim": 64})
+    provider.initialize(session_id="test-session")
+    return provider
+
+
+class TestOnMemoryWriteAdd:
+    def test_add_action_creates_fact(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider.on_memory_write("add", "user", "User prefers dark mode")
+
+        row = provider._store._conn.execute(
+            "SELECT content, category FROM facts WHERE content = ?",
+            ("User prefers dark mode",),
+        ).fetchone()
+        assert row is not None
+        assert row["content"] == "User prefers dark mode"
+        assert row["category"] == "user_pref"
+
+    def test_add_action_general_target(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider.on_memory_write("add", "project", "Uses Python 3.12")
+
+        row = provider._store._conn.execute(
+            "SELECT category FROM facts WHERE content = ?",
+            ("Uses Python 3.12",),
+        ).fetchone()
+        assert row is not None
+        assert row["category"] == "general"
+
+
+class TestOnMemoryWriteReplace:
+    def test_replace_finds_and_updates_existing_fact(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        # Seed the original fact
+        provider._store.add_fact("User prefers vim", category="user_pref")
+
+        provider.on_memory_write(
+            "replace", "user", "User prefers neovim",
+            metadata={"old_text": "User prefers vim"},
+        )
+
+        # Old content should be gone
+        old = provider._store._conn.execute(
+            "SELECT fact_id FROM facts WHERE content = ?",
+            ("User prefers vim",),
+        ).fetchone()
+        assert old is None
+
+        # New content should exist
+        new = provider._store._conn.execute(
+            "SELECT content, category FROM facts WHERE content = ?",
+            ("User prefers neovim",),
+        ).fetchone()
+        assert new is not None
+        assert new["content"] == "User prefers neovim"
+
+    def test_replace_falls_back_to_add_when_old_fact_not_found(self, tmp_path):
+        provider = _make_provider(tmp_path)
+
+        provider.on_memory_write(
+            "replace", "user", "User prefers emacs",
+            metadata={"old_text": "nonexistent old content"},
+        )
+
+        row = provider._store._conn.execute(
+            "SELECT content, category FROM facts WHERE content = ?",
+            ("User prefers emacs",),
+        ).fetchone()
+        assert row is not None
+        assert row["category"] == "user_pref"
+
+    def test_replace_falls_back_to_add_when_no_metadata(self, tmp_path):
+        provider = _make_provider(tmp_path)
+
+        provider.on_memory_write("replace", "user", "User prefers emacs")
+
+        row = provider._store._conn.execute(
+            "SELECT content FROM facts WHERE content = ?",
+            ("User prefers emacs",),
+        ).fetchone()
+        assert row is not None
+
+    def test_replace_falls_back_to_add_when_metadata_missing_old_text(self, tmp_path):
+        provider = _make_provider(tmp_path)
+
+        provider.on_memory_write(
+            "replace", "user", "User prefers emacs",
+            metadata={"other_key": "value"},
+        )
+
+        row = provider._store._conn.execute(
+            "SELECT content FROM facts WHERE content = ?",
+            ("User prefers emacs",),
+        ).fetchone()
+        assert row is not None
+
+
+class TestOnMemoryWriteRemove:
+    def test_remove_finds_and_removes_existing_fact(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider._store.add_fact("Outdated preference", category="user_pref")
+
+        provider.on_memory_write(
+            "remove", "user", "",
+            metadata={"old_text": "Outdated preference"},
+        )
+
+        row = provider._store._conn.execute(
+            "SELECT fact_id FROM facts WHERE content = ?",
+            ("Outdated preference",),
+        ).fetchone()
+        assert row is None
+
+    def test_remove_is_idempotent_when_fact_not_found(self, tmp_path):
+        provider = _make_provider(tmp_path)
+
+        # Should not raise
+        provider.on_memory_write(
+            "remove", "user", "",
+            metadata={"old_text": "never existed"},
+        )
+
+    def test_remove_no_op_when_no_metadata(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider._store.add_fact("Should remain", category="general")
+
+        # No metadata means no old_text, so nothing to look up
+        provider.on_memory_write("remove", "user", "")
+
+        row = provider._store._conn.execute(
+            "SELECT fact_id FROM facts WHERE content = ?",
+            ("Should remain",),
+        ).fetchone()
+        assert row is not None
+
+    def test_remove_no_op_when_metadata_missing_old_text(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider._store.add_fact("Should remain", category="general")
+
+        provider.on_memory_write("remove", "user", "", metadata={})
+
+        row = provider._store._conn.execute(
+            "SELECT fact_id FROM facts WHERE content = ?",
+            ("Should remain",),
+        ).fetchone()
+        assert row is not None
+
+
+class TestMetadataHandling:
+    def test_metadata_old_text_is_used_for_replace(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider._store.add_fact("Original fact", category="general")
+
+        provider.on_memory_write(
+            "replace", "project", "Updated fact",
+            metadata={"old_text": "Original fact"},
+        )
+
+        assert provider._find_fact_id_by_content("Original fact") is None
+        assert provider._find_fact_id_by_content("Updated fact") is not None
+
+    def test_metadata_old_text_is_used_for_remove(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider._store.add_fact("Fact to remove", category="general")
+
+        provider.on_memory_write(
+            "remove", "project", "",
+            metadata={"old_text": "Fact to remove"},
+        )
+
+        assert provider._find_fact_id_by_content("Fact to remove") is None
+
+    def test_none_metadata_handled_gracefully_for_replace(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        # Should not raise, falls back to add
+        provider.on_memory_write("replace", "user", "New content", metadata=None)
+
+        assert provider._find_fact_id_by_content("New content") is not None
+
+    def test_none_metadata_handled_gracefully_for_remove(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        # Should not raise, no-op
+        provider.on_memory_write("remove", "user", "", metadata=None)


### PR DESCRIPTION
## Summary

Fixes #55095 — The holographic memory plugin's `on_memory_write` hook only processed the `add` action. When the built-in memory tool performed `replace` or `remove` operations, the holographic fact store silently drifted out of sync: replaced entries remained stale, and removed entries persisted as ghosts.

## Changes

**`plugins/memory/holographic/__init__.py`:**

1. Accept `metadata` keyword parameter to receive `old_text` from the memory manager bridge
2. Handle `replace` action: find existing fact by `old_text` via exact content match, update via `update_fact()`; fall back to `add_fact()` if the old fact isn't found
3. Handle `remove` action: find existing fact by `old_text`, remove via `remove_fact()`; idempotent no-op if not found
4. Add `_find_fact_id_by_content()` private helper for exact-match lookup on the facts table
5. Bump failure log level from `debug` → `warning` for better observability

**`tests/plugins/memory/test_holographic_memory_write.py`** (new):

14 regression tests covering:
- `add` action (existing behavior preserved)
- `replace` with existing fact (updates correctly)
- `replace` fallback to `add` when old fact not found
- `replace` with missing/None metadata (graceful fallback)
- `remove` with existing fact (deletes correctly)
- `remove` idempotent when fact not found
- `remove` no-op with missing metadata
- Metadata `old_text` propagation for both actions

## Design Decisions

- **Exact content match over FTS5**: The helper uses `WHERE content = ?` (leveraging the UNIQUE constraint) rather than FTS5 search. This is precise and avoids false-positive matches on partial content overlap.
- **Fall-back to add on replace miss**: If `old_text` doesn't match any existing fact (e.g. the fact was already manually removed), we still store the new content. This matches the built-in memory's behavior.
- **Thread safety**: `_find_fact_id_by_content` uses the store's existing `_lock` for safe concurrent access.
- **Backward compatible**: The `metadata` parameter is keyword-only with a default of `None`, matching the bridge's introspection-based dispatch (`_provider_memory_write_metadata_mode` detects `keyword` mode).

## Testing

```
$ pytest tests/plugins/memory/test_holographic_memory_write.py tests/plugins/memory/test_holographic_shutdown_closes_db.py tests/plugins/memory/test_holographic_retrieval.py -v
26 passed in 1.00s
```

All existing holographic tests continue to pass.