### PR TITLE
feat(desktop): add OpenViking configuration flow

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -18,7 +18,7 @@ import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 import type { ConfigFieldSchema, HermesConfigRecord } from '@/types/hermes'
 
-import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS, SECTIONS } from './constants'
+import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS, FIELD_OPTION_LABELS, SECTIONS } from './constants'
 import { fieldCopyForSchemaKey } from './field-copy'
 import { enumOptionsFor, getNested, prettyName, setNested } from './helpers'
 import { MemoryConnect } from './memory/connect'
@@ -405,7 +405,7 @@ export function ConfigSettings({
                     : enumOptionsFor(key, getNested(config, key), config)
                 }
                 onChange={value => updateConfig(setNested(config, key, value))}
-                optionLabels={key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : undefined}
+                optionLabels={key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : FIELD_OPTION_LABELS[key]}
                 schema={field}
                 schemaKey={key}
                 value={getNested(config, key)}

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -227,7 +227,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'code_execution.mode': ['project', 'strict'],
   'context.engine': ['compressor', 'default', 'custom'],
   'delegation.reasoning_effort': ['', 'minimal', 'low', 'medium', 'high', 'xhigh'],
-  'memory.provider': ['', 'builtin', 'hindsight', 'honcho'],
+  'memory.provider': ['', 'builtin', 'hindsight', 'honcho', 'openviking'],
   // Terminal execution backends — kept in sync with the dispatch ladder in
   // tools/terminal_tool.py::_create_environment (local/docker/singularity/
   // modal/daytona/ssh). Remote backends need extra env (image, tokens, host).
@@ -260,6 +260,12 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   // NeuTTS local inference device.
   'tts.neutts.device': ['cpu', 'cuda', 'mps'],
   'updates.non_interactive_local_changes': ['stash', 'discard']
+}
+
+export const FIELD_OPTION_LABELS: Record<string, Record<string, string>> = {
+  'memory.provider': {
+    openviking: 'OpenViking'
+  }
 }
 
 export const FIELD_LABELS: Record<string, string> = defineFieldCopy({

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, it } from 'vitest'
 
 import type { HermesConfigRecord } from '@/types/hermes'
 
+import { FIELD_OPTION_LABELS } from './constants'
 import { defineFieldCopy, fieldCopyForSchemaKey, schemaKeyToFieldCopyKey } from './field-copy'
 import { enumOptionsFor, getNested, providerGroup, setNested, stripToolsetLabel, toolsetDisplayLabel } from './helpers'
 
 describe('settings helpers', () => {
-  it('lists Hindsight as a built-in desktop memory provider option', () => {
+  it('lists Hindsight and OpenViking as built-in desktop memory provider options', () => {
     const options = enumOptionsFor('memory.provider', '', {})
 
     expect(options).toContain('hindsight')
+    expect(options).toContain('openviking')
+    expect(FIELD_OPTION_LABELS['memory.provider'].openviking).toBe('OpenViking')
   })
 
   describe('defineFieldCopy', () => {

--- a/apps/desktop/src/app/settings/memory/connect.test.tsx
+++ b/apps/desktop/src/app/settings/memory/connect.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const getMemoryProviderOAuthStatus = vi.fn()
+const startMemoryProviderOAuth = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getMemoryProviderOAuthStatus: (provider: string) => getMemoryProviderOAuthStatus(provider),
+  startMemoryProviderOAuth: (provider: string) => startMemoryProviderOAuth(provider)
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notifyError: vi.fn()
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('MemoryConnect', () => {
+  it('does not probe OAuth status for OpenViking', async () => {
+    const { MemoryConnect } = await import('./connect')
+    const { container } = render(<MemoryConnect provider="openviking" />)
+
+    await waitFor(() => expect(getMemoryProviderOAuthStatus).not.toHaveBeenCalled())
+    expect(container.textContent).toBe('')
+  })
+
+  it('probes OAuth status for Honcho', async () => {
+    getMemoryProviderOAuthStatus.mockResolvedValue({
+      auth: 'oauth',
+      connected: true,
+      detail: '',
+      state: 'connected'
+    })
+
+    const { MemoryConnect } = await import('./connect')
+    render(<MemoryConnect provider="honcho" />)
+
+    await waitFor(() => expect(getMemoryProviderOAuthStatus).toHaveBeenCalledWith('honcho'))
+    expect(await screen.findByText('oauth set')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/settings/memory/connect.tsx
+++ b/apps/desktop/src/app/settings/memory/connect.tsx
@@ -8,11 +8,12 @@ import type { MemoryProviderOAuthStatus } from '@/types/hermes'
 
 const POLL_MS = 1500
 const POLL_TIMEOUT_MS = 120_000
+const MEMORY_OAUTH_CONNECT_PROVIDERS = new Set(['honcho'])
 
-// Small connect affordance rendered under the provider dropdown. Capability is
-// backend-driven: the status route 404s for providers without an oauth_flow
-// module, so non-OAuth providers render nothing.
+// Small connect affordance rendered under the provider dropdown for memory
+// providers that implement plugins.memory.<provider>.oauth_flow.
 export function MemoryConnect({ provider }: { provider: string }) {
+  const supportsOAuthConnect = MEMORY_OAUTH_CONNECT_PROVIDERS.has(provider)
   const [capable, setCapable] = useState<'no' | 'unknown' | 'yes'>('unknown')
   const [connected, setConnected] = useState(false)
   const [auth, setAuth] = useState<MemoryProviderOAuthStatus['auth']>(null)
@@ -29,6 +30,12 @@ export function MemoryConnect({ provider }: { provider: string }) {
   }, [])
 
   useEffect(() => {
+    if (!supportsOAuthConnect) {
+      setCapable('no')
+
+      return
+    }
+
     let active = true
     setCapable('unknown')
     getMemoryProviderOAuthStatus(provider)
@@ -51,7 +58,7 @@ export function MemoryConnect({ provider }: { provider: string }) {
       active = false
       stop()
     }
-  }, [provider, stop])
+  }, [provider, stop, supportsOAuthConnect])
 
   // An error message isn't sticky — it clears back to the steady state
   // (Connect link, plus the connected badge if a credential is stored).
@@ -120,7 +127,7 @@ export function MemoryConnect({ provider }: { provider: string }) {
     setPhase('idle')
   }, [stop])
 
-  if (capable !== 'yes') {
+  if (!supportsOAuthConnect || capable !== 'yes') {
     return null
   }
 

--- a/apps/desktop/src/app/settings/openviking-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/openviking-config-panel.test.tsx
@@ -1,0 +1,603 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { OpenVikingSetup } from '@/types/hermes'
+
+const getOpenVikingSetup = vi.fn()
+const saveOpenVikingSetup = vi.fn()
+const validateOpenVikingSetup = vi.fn()
+const startOpenVikingLocal = vi.fn()
+
+const OPENVIKING_SERVICE_API_KEY_URL =
+  'https://console.volcengine.com/vikingdb/openviking/region:openviking+cn-beijing'
+
+vi.mock('@/hermes', () => ({
+  getOpenVikingSetup: () => getOpenVikingSetup(),
+  saveOpenVikingSetup: (body: unknown) => saveOpenVikingSetup(body),
+  startOpenVikingLocal: (url: string) => startOpenVikingLocal(url),
+  validateOpenVikingSetup: (body: unknown) => validateOpenVikingSetup(body)
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+function setupPayload(overrides: Partial<OpenVikingSetup> = {}): OpenVikingSetup {
+  return {
+    active: {
+      account: '',
+      actor_peer_id: 'hermes',
+      api_key: '',
+      api_key_set: false,
+      source: 'hermes',
+      url: 'https://api.vikingdb.cn-beijing.volces.com/openviking',
+      user: ''
+    },
+    defaults: {
+      actor_peer_id: 'hermes',
+      service_url: 'https://api.vikingdb.cn-beijing.volces.com/openviking',
+      url: 'http://127.0.0.1:1933'
+    },
+    health: {
+      label: 'Healthy',
+      message: 'OpenViking is reachable.',
+      status: 'healthy'
+    },
+    legacy_env_present: [],
+    local_server: {
+      openviking_server_path: ''
+    },
+    profiles: [
+      {
+        account: '',
+        actor_peer_id: 'profile-agent',
+        api_key_set: true,
+        description: 'https://vps.example (~/.openviking/ovcli.conf.VPS)',
+        display_name: 'VPS',
+        is_active: false,
+        name: 'VPS',
+        path: '/tmp/ovcli.conf.VPS',
+        source: 'saved',
+        url: 'https://vps.example',
+        user: ''
+      }
+    ],
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  getOpenVikingSetup.mockResolvedValue(setupPayload())
+  saveOpenVikingSetup.mockResolvedValue({ ok: true, mode: 'profile', profile_path: '/tmp/ovcli.conf.VPS' })
+  validateOpenVikingSetup.mockResolvedValue({ ok: true, message: '', role: 'user' })
+  startOpenVikingLocal.mockResolvedValue({ ok: false, message: 'openviking-server was not found on PATH.' })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderPanel() {
+  const { OpenVikingConfigPanel } = await import('./openviking-config-panel')
+
+  return render(<OpenVikingConfigPanel />)
+}
+
+async function openWizard() {
+  fireEvent.click(await screen.findByRole('button', { name: 'Configure' }))
+
+  return screen.findByRole('dialog')
+}
+
+async function chooseCredential(label: string) {
+  fireEvent.click(screen.getByRole('combobox', { name: 'Credential' }))
+  fireEvent.click(await screen.findByRole('option', { name: label }))
+}
+
+async function chooseExistingProfiles() {
+  fireEvent.click(screen.getByRole('button', { name: 'Existing Profiles' }))
+  await waitFor(() =>
+    expect((screen.getByRole('button', { name: 'Next' }) as HTMLButtonElement).disabled).toBe(false)
+  )
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+}
+
+describe('OpenVikingConfigPanel', () => {
+  it('shows the current active OpenViking profile and opens the setup wizard', async () => {
+    getOpenVikingSetup.mockResolvedValue(
+      setupPayload({
+        active: {
+          account: '',
+          actor_peer_id: 'profile-agent',
+          api_key: '',
+          api_key_set: true,
+          ovcli_config_path: '/tmp/ovcli.conf.VPS',
+          source: 'ovcli',
+          url: 'https://vps.example',
+          user: ''
+        },
+        profiles: [
+          {
+            account: '',
+            actor_peer_id: 'profile-agent',
+            api_key_set: true,
+            description: 'https://vps.example (~/.openviking/ovcli.conf.VPS)',
+            display_name: 'VPS',
+            is_active: true,
+            name: 'VPS',
+            path: '/tmp/ovcli.conf.VPS',
+            source: 'saved',
+            url: 'https://vps.example',
+            user: ''
+          }
+        ]
+      })
+    )
+
+    await renderPanel()
+
+    expect(await screen.findByText('Active profile')).toBeTruthy()
+    expect(screen.getByText('VPS (Custom)')).toBeTruthy()
+    expect(screen.getByText('https://vps.example')).toBeTruthy()
+    expect(screen.getByText('Healthy')).toBeTruthy()
+    expect(screen.queryByText('Ready to use')).toBeNull()
+    expect(screen.queryByText(/API key configured/)).toBeNull()
+    expect(screen.queryByText(/Agent ID:/)).toBeNull()
+
+    await openWizard()
+
+    expect(screen.getByText('Choose setup')).toBeTruthy()
+    await chooseExistingProfiles()
+    fireEvent.click(screen.getByRole('combobox', { name: 'OpenViking profile' }))
+    expect(await screen.findByRole('option', { name: 'VPS (Active)' })).toBeTruthy()
+  })
+
+  it('labels service-backed active profiles as OpenViking Service', async () => {
+    getOpenVikingSetup.mockResolvedValue(
+      setupPayload({
+        active: {
+          account: '',
+          actor_peer_id: 'hermes',
+          api_key: '',
+          api_key_set: true,
+          ovcli_config_path: '/tmp/ovcli.conf.openstudio',
+          source: 'ovcli',
+          url: 'https://api.vikingdb.cn-beijing.volces.com/openviking',
+          user: ''
+        },
+        profiles: [
+          {
+            account: '',
+            actor_peer_id: 'hermes',
+            api_key_set: true,
+            description: 'https://api.vikingdb.cn-beijing.volces.com/openviking (~/.openviking/ovcli.conf.openstudio)',
+            display_name: 'openstudio',
+            is_active: true,
+            name: 'openstudio',
+            path: '/tmp/ovcli.conf.openstudio',
+            source: 'saved',
+            url: 'https://api.vikingdb.cn-beijing.volces.com/openviking',
+            user: ''
+          }
+        ]
+      })
+    )
+
+    await renderPanel()
+
+    expect(await screen.findByText('openstudio (OpenViking Service)')).toBeTruthy()
+  })
+
+  it('renders unhealthy and unreachable OpenViking status as the primary summary signal', async () => {
+    const detail = 'OpenViking server responded with AuthenticationError: API key rejected by the server.'
+    getOpenVikingSetup.mockResolvedValue(
+      setupPayload({
+        health: {
+          label: 'Unhealthy',
+          message: detail,
+          status: 'unhealthy'
+        }
+      })
+    )
+
+    await renderPanel()
+
+    expect(await screen.findByText('Unhealthy')).toBeTruthy()
+    expect(screen.getByText('Server reached, review details')).toBeTruthy()
+    expect(screen.queryByText(detail)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'View OpenViking status details' }))
+
+    expect(await screen.findByText('OpenViking status details')).toBeTruthy()
+    expect(screen.getByText(detail)).toBeTruthy()
+  })
+
+  it('refreshes OpenViking profiles when the setup wizard opens', async () => {
+    getOpenVikingSetup
+      .mockResolvedValueOnce(setupPayload())
+      .mockResolvedValueOnce(setupPayload({ profiles: [] }))
+
+    await renderPanel()
+    await openWizard()
+
+    await waitFor(() => expect(getOpenVikingSetup).toHaveBeenCalledTimes(2))
+    expect(screen.getByText('No profiles found')).toBeTruthy()
+  })
+
+  it('can refresh the existing profile list from inside the wizard', async () => {
+    getOpenVikingSetup
+      .mockResolvedValueOnce(setupPayload())
+      .mockResolvedValueOnce(setupPayload())
+      .mockResolvedValueOnce(setupPayload())
+      .mockResolvedValueOnce(
+        setupPayload({
+          profiles: [
+            {
+              account: '',
+              actor_peer_id: 'fresh-agent',
+              api_key_set: true,
+              description: 'https://fresh.example (~/.openviking/ovcli.conf.fresh)',
+              display_name: 'fresh',
+              is_active: false,
+              name: 'fresh',
+              path: '/tmp/ovcli.conf.fresh',
+              source: 'saved',
+              url: 'https://fresh.example',
+              user: ''
+            }
+          ]
+        })
+      )
+
+    await renderPanel()
+    await openWizard()
+
+    await chooseExistingProfiles()
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh profiles' }))
+
+    await waitFor(() => expect(getOpenVikingSetup).toHaveBeenCalledTimes(4))
+    expect(screen.getByText('https://fresh.example (~/.openviking/ovcli.conf.fresh)')).toBeTruthy()
+  })
+
+  it('validates and links an existing profile when saving without sending secrets', async () => {
+    await renderPanel()
+    await openWizard()
+
+    await chooseExistingProfiles()
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(screen.queryByRole('button', { name: 'Validate profile' })).toBeNull()
+    expect(screen.getByText('Profile Path:')).toBeTruthy()
+    expect(screen.getByText('/tmp/ovcli.conf.VPS')).toBeTruthy()
+    expect(screen.queryByText('https://vps.example (~/.openviking/ovcli.conf.VPS)')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }))
+
+    await waitFor(() =>
+      expect(validateOpenVikingSetup).toHaveBeenCalledWith({
+        profile_path: '/tmp/ovcli.conf.VPS',
+        values: {}
+      })
+    )
+
+    await waitFor(() =>
+      expect(saveOpenVikingSetup).toHaveBeenCalledWith({
+        profile_path: '/tmp/ovcli.conf.VPS',
+        save_mode: 'profile',
+        values: {}
+      })
+    )
+  })
+
+  it('explains when the selected existing profile no longer exists', async () => {
+    validateOpenVikingSetup.mockRejectedValue(
+      new Error('400: {"detail":"OpenViking profile file was not found: /tmp/ovcli.conf.VPS"}')
+    )
+
+    await renderPanel()
+    await openWizard()
+
+    await chooseExistingProfiles()
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain(
+      'The selected OpenViking profile no longer exists. Refresh profiles or choose another profile.'
+    )
+    expect(saveOpenVikingSetup).not.toHaveBeenCalled()
+  })
+
+  it('keeps the wizard open when dismissing the existing profile dropdown', async () => {
+    await renderPanel()
+    await openWizard()
+
+    await chooseExistingProfiles()
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'OpenViking profile' }))
+    expect(await screen.findByRole('option', { name: 'VPS' })).toBeTruthy()
+
+    fireEvent.pointerDown(document.body)
+    fireEvent.mouseDown(document.body)
+    fireEvent.click(document.body)
+
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeTruthy()
+  })
+
+  it('refreshes stale profiles before showing Existing Profiles details', async () => {
+    getOpenVikingSetup
+      .mockResolvedValueOnce(setupPayload())
+      .mockResolvedValueOnce(setupPayload())
+      .mockResolvedValueOnce(setupPayload({
+        health: {
+          label: 'Profile missing',
+          message: 'The linked OpenViking profile file no longer exists. Choose another profile or recreate it.',
+          status: 'unreachable'
+        },
+        profiles: []
+      }))
+
+    await renderPanel()
+    await openWizard()
+    await waitFor(() => expect(getOpenVikingSetup).toHaveBeenCalledTimes(2))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Existing Profiles' }))
+    await waitFor(() => expect(getOpenVikingSetup).toHaveBeenCalledTimes(3))
+
+    expect(screen.getByText('No profiles found')).toBeTruthy()
+    expect(screen.queryByRole('combobox', { name: 'OpenViking profile' })).toBeNull()
+    expect((screen.getByRole('button', { name: 'Next' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('creates an OpenViking Service profile after validation', async () => {
+    await renderPanel()
+    await openWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    const apiKeyLink = screen.getByRole('link', { name: 'Get OpenViking API key' })
+    expect(apiKeyLink.getAttribute('href')).toBe(OPENVIKING_SERVICE_API_KEY_URL)
+
+    fireEvent.change(screen.getByLabelText('Agent ID'), { target: { value: 'agent' } })
+    fireEvent.change(screen.getByLabelText('OpenViking API key'), { target: { value: 'service-secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(screen.queryByRole('button', { name: 'Validate connection' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }))
+
+    await waitFor(() =>
+      expect(validateOpenVikingSetup).toHaveBeenCalledWith({
+        require_api_key: true,
+        values: {
+          actor_peer_id: 'agent',
+          api_key: 'service-secret',
+          api_key_type: 'user',
+          url: 'https://api.vikingdb.cn-beijing.volces.com/openviking'
+        }
+      })
+    )
+
+    await waitFor(() =>
+      expect(saveOpenVikingSetup).toHaveBeenCalledWith({
+        profile_name: 'openviking_service',
+        save_mode: 'profile',
+        values: {
+          actor_peer_id: 'agent',
+          api_key: 'service-secret',
+          api_key_type: 'user',
+          url: 'https://api.vikingdb.cn-beijing.volces.com/openviking'
+        }
+      })
+    )
+  })
+
+  it('shows validation failures as a visible alert and does not save', async () => {
+    validateOpenVikingSetup.mockResolvedValueOnce({
+      ok: false,
+      message: 'OpenViking validation failed: [Errno 61] Connection refused',
+      role: null
+    })
+
+    await renderPanel()
+    await openWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom Server' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.change(screen.getByLabelText('OpenViking URL'), { target: { value: 'http://127.0.0.1:1934' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('OpenViking could not be reached. Check that the server URL is correct and the server is running.')
+    expect(saveOpenVikingSetup).not.toHaveBeenCalled()
+  })
+
+  it('uses a neutral default profile name for custom servers', async () => {
+    await renderPanel()
+    await openWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom Server' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.change(screen.getByLabelText('OpenViking URL'), { target: { value: 'https://custom.example' } })
+    await chooseCredential('User API key')
+    fireEvent.change(screen.getByLabelText('OpenViking API key'), { target: { value: 'custom-secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }))
+
+    await waitFor(() =>
+      expect(saveOpenVikingSetup).toHaveBeenCalledWith({
+        profile_name: 'openviking_custom',
+        save_mode: 'profile',
+        values: {
+          actor_peer_id: 'hermes',
+          api_key: 'custom-secret',
+          api_key_type: 'user',
+          url: 'https://custom.example'
+        }
+      })
+    )
+  })
+
+  it('requires account and user before validating a custom root API key', async () => {
+    await renderPanel()
+    await openWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom Server' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await chooseCredential('Root API key')
+    fireEvent.change(screen.getByLabelText('OpenViking API key'), { target: { value: 'root-secret' } })
+
+    expect((screen.getByRole('button', { name: 'Continue' }) as HTMLButtonElement).disabled).toBe(true)
+
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-a' } })
+    expect((screen.getByRole('button', { name: 'Continue' }) as HTMLButtonElement).disabled).toBe(true)
+
+    fireEvent.change(screen.getByLabelText('User'), { target: { value: 'user-a' } })
+    expect((screen.getByRole('button', { name: 'Continue' }) as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('saves custom root API keys with root profile metadata', async () => {
+    validateOpenVikingSetup.mockResolvedValueOnce({ ok: true, message: '', role: 'root' })
+
+    await renderPanel()
+    await openWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom Server' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.change(screen.getByLabelText('Profile name'), { target: { value: 'VPS_ROOT' } })
+    fireEvent.change(screen.getByLabelText('OpenViking URL'), { target: { value: 'https://custom.example' } })
+    await chooseCredential('Root API key')
+    fireEvent.change(screen.getByLabelText('OpenViking API key'), { target: { value: 'root-secret' } })
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-a' } })
+    fireEvent.change(screen.getByLabelText('User'), { target: { value: 'user-a' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }))
+
+    await waitFor(() =>
+      expect(saveOpenVikingSetup).toHaveBeenCalledWith({
+        profile_name: 'VPS_ROOT',
+        save_mode: 'profile',
+        values: {
+          account: 'account-a',
+          actor_peer_id: 'hermes',
+          api_key: 'root-secret',
+          api_key_type: 'root',
+          root_api_key: 'root-secret',
+          url: 'https://custom.example',
+          user: 'user-a'
+        }
+      })
+    )
+  })
+
+  it('prompts when a custom user API key validates as a root key', async () => {
+    validateOpenVikingSetup.mockResolvedValueOnce({ ok: true, message: '', role: 'root' })
+
+    await renderPanel()
+    await openWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom Server' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await chooseCredential('User API key')
+    fireEvent.change(screen.getByLabelText('OpenViking URL'), { target: { value: 'https://custom.example' } })
+    fireEvent.change(screen.getByLabelText('OpenViking API key'), { target: { value: 'root-secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }))
+
+    expect(await screen.findByText('This key has root access.')).toBeTruthy()
+    expect(screen.getByText(/Switch to Root API key/)).toBeTruthy()
+    expect(saveOpenVikingSetup).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use as Root API key' }))
+
+    expect(await screen.findByLabelText('Account')).toBeTruthy()
+    expect(screen.getByLabelText('User')).toBeTruthy()
+  })
+
+  it('prompts when a custom root API key validates as a user key', async () => {
+    validateOpenVikingSetup.mockResolvedValueOnce({ ok: true, message: '', role: 'user' })
+
+    await renderPanel()
+    await openWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom Server' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await chooseCredential('Root API key')
+    fireEvent.change(screen.getByLabelText('OpenViking URL'), { target: { value: 'https://custom.example' } })
+    fireEvent.change(screen.getByLabelText('OpenViking API key'), { target: { value: 'user-secret' } })
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-a' } })
+    fireEvent.change(screen.getByLabelText('User'), { target: { value: 'user-a' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }))
+
+    expect(await screen.findByText('This key is a user API key.')).toBeTruthy()
+    expect(screen.getByText(/Switch to User API key/)).toBeTruthy()
+    expect(saveOpenVikingSetup).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use as User API key' }))
+
+    expect(await screen.findByRole('button', { name: 'Continue' })).toBeTruthy()
+    expect(screen.queryByLabelText('Account')).toBeNull()
+    expect(screen.queryByLabelText('User')).toBeNull()
+  })
+
+  it('only shows local server startup for local custom server URLs', async () => {
+    await renderPanel()
+    await openWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom Server' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(screen.getByRole('button', { name: 'Start local server' })).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText('OpenViking URL'), { target: { value: 'https://custom.example' } })
+
+    expect(screen.queryByRole('button', { name: 'Start local server' })).toBeNull()
+  })
+
+  it('shows local start guidance when openviking-server is missing', async () => {
+    getOpenVikingSetup.mockResolvedValue(
+      setupPayload({
+        active: {
+          account: '',
+          actor_peer_id: 'hermes',
+          api_key: '',
+          api_key_set: false,
+          source: 'hermes',
+          url: 'http://127.0.0.1:1933',
+          user: ''
+        }
+      })
+    )
+
+    await renderPanel()
+    await openWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom Server' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Start local server' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('openviking-server was not found on PATH.')
+  })
+
+  it('explains ignored legacy OpenViking environment variables', async () => {
+    getOpenVikingSetup.mockResolvedValue(
+      setupPayload({
+        legacy_env_present: ['OPENVIKING_ENDPOINT', 'OPENVIKING_AGENT']
+      })
+    )
+
+    await renderPanel()
+
+    expect(await screen.findByText('Legacy OpenViking env vars ignored')).toBeTruthy()
+    expect(screen.getByText('Save this setup to clear old variable names.')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/settings/openviking-config-panel.tsx
+++ b/apps/desktop/src/app/settings/openviking-config-panel.tsx
@@ -1,0 +1,1091 @@
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { getOpenVikingSetup, saveOpenVikingSetup, startOpenVikingLocal, validateOpenVikingSetup } from '@/hermes'
+import { ExternalLink } from '@/lib/external-link'
+import { AlertCircle, CheckCircle2, Loader2, Play, RefreshCw, Save, Settings2 } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { notify, notifyError } from '@/store/notifications'
+import type { OpenVikingConnectionValues, OpenVikingHealth, OpenVikingProfile, OpenVikingSetup } from '@/types/hermes'
+
+import { CONTROL_TEXT } from './constants'
+import { LoadingState, Pill } from './primitives'
+
+type SourceMode = 'custom' | 'profile' | 'service'
+type WizardStep = 'details' | 'source' | 'validate'
+type ValidationState = { message: string; tone: 'error' | 'success' }
+type RoleMismatch = 'root-key-selected-as-user' | 'user-key-selected-as-root'
+
+interface FormValues {
+  account: string
+  actor_peer_id: string
+  api_key: string
+  api_key_type: 'none' | 'root' | 'user'
+  url: string
+  user: string
+}
+
+const WIZARD_STEPS: Array<{ id: WizardStep; label: string }> = [
+  { id: 'source', label: 'Source' },
+  { id: 'details', label: 'Details' },
+  { id: 'validate', label: 'Review' }
+]
+
+const OPENVIKING_SERVICE_API_KEY_URL =
+  'https://console.volcengine.com/vikingdb/openviking/region:openviking+cn-beijing'
+
+const CREDENTIAL_OPTIONS: Array<{ label: string; value: FormValues['api_key_type'] }> = [
+  { label: 'No API key', value: 'none' },
+  { label: 'User API key', value: 'user' },
+  { label: 'Root API key', value: 'root' }
+]
+
+function normalizeComparableUrl(url: string) {
+  return url.trim().replace(/\/+$/, '')
+}
+
+function connectionKindForUrl(url: string, serviceUrl: string) {
+  return normalizeComparableUrl(url) === normalizeComparableUrl(serviceUrl) ? 'OpenViking Service' : 'Custom'
+}
+
+function modeFromSetup(setup: OpenVikingSetup): SourceMode {
+  if (setup.active.source === 'ovcli') {
+    return 'profile'
+  }
+
+  return connectionKindForUrl(setup.active.url, setup.defaults.service_url) === 'OpenViking Service' ? 'service' : 'custom'
+}
+
+function apiKeyTypeFromConnection(
+  values: Pick<OpenVikingConnectionValues, 'account' | 'api_key_set' | 'api_key_type' | 'user'>
+): FormValues['api_key_type'] {
+  if (values.api_key_type) {
+    return values.api_key_type
+  }
+
+  if (!values.api_key_set) {
+    return 'none'
+  }
+
+  return values.account || values.user ? 'root' : 'user'
+}
+
+function seedValues(setup: OpenVikingSetup, mode: SourceMode): FormValues {
+  const active = setup.active
+  const customUrl = active.url && active.url !== setup.defaults.service_url ? active.url : setup.defaults.url
+
+  return {
+    account: active.account ?? '',
+    actor_peer_id: active.actor_peer_id || setup.defaults.actor_peer_id,
+    api_key: '',
+    api_key_type: mode === 'service' ? 'user' : apiKeyTypeFromConnection(active),
+    url: mode === 'service' ? setup.defaults.service_url : customUrl,
+    user: active.user ?? ''
+  }
+}
+
+function profileValues(profile: OpenVikingProfile, fallbackAgentId: string): FormValues {
+  return {
+    account: profile.account,
+    actor_peer_id: profile.actor_peer_id || fallbackAgentId,
+    api_key: '',
+    api_key_type: apiKeyTypeFromConnection(profile),
+    url: profile.url,
+    user: profile.user
+  }
+}
+
+function isLocalUrl(url: string): boolean {
+  return /^http:\/\/(127\.0\.0\.1|localhost|\[::1\])(?::\d+)?(?:\/|$)/i.test(url.trim())
+}
+
+function defaultProfileName(mode: SourceMode): string {
+  return mode === 'service' ? 'openviking_service' : 'openviking_custom'
+}
+
+function sourceTitle(mode: SourceMode): string {
+  if (mode === 'profile') {
+    return 'Existing Profiles'
+  }
+
+  return mode === 'service' ? 'OpenViking Service' : 'Custom Server'
+}
+
+function buildConnectionValues(values: FormValues, mode: SourceMode, setup: OpenVikingSetup): OpenVikingConnectionValues {
+  const apiKeyType = mode === 'service' ? 'user' : values.api_key_type
+
+  const payload: OpenVikingConnectionValues = {
+    actor_peer_id: values.actor_peer_id.trim() || setup.defaults.actor_peer_id,
+    api_key_type: apiKeyType,
+    url: mode === 'service' ? setup.defaults.service_url : values.url.trim()
+  }
+
+  if (apiKeyType === 'none') {
+    payload.api_key = ''
+  } else if (values.api_key.trim()) {
+    payload.api_key = values.api_key.trim()
+
+    if (apiKeyType === 'root') {
+      payload.root_api_key = values.api_key.trim()
+    }
+  }
+
+  if (apiKeyType === 'root') {
+    payload.account = values.account.trim()
+    payload.user = values.user.trim()
+  }
+
+  return payload
+}
+
+function requiresRootIdentity(values: FormValues | null, mode: SourceMode): boolean {
+  return mode === 'custom' && values?.api_key_type === 'root'
+}
+
+function messageFromError(err: unknown): string {
+  if (err instanceof Error) {
+    const jsonMatch = err.message.match(/\{.*\}$/)
+
+    if (jsonMatch) {
+      try {
+        const parsed = JSON.parse(jsonMatch[0]) as { detail?: unknown }
+
+        if (typeof parsed.detail === 'string') {
+          return parsed.detail
+        }
+      } catch {
+        return err.message
+      }
+    }
+
+    return err.message
+  }
+
+  return typeof err === 'string' ? err : ''
+}
+
+function validationFailureMessage(message: string): string {
+  const raw = message.trim()
+  const lower = raw.toLowerCase()
+
+  if (!raw) {
+    return 'OpenViking could not be validated. Check the URL and credentials, then try again.'
+  }
+
+  if (
+    lower.includes('profile file was not found') ||
+    lower.includes('profile no longer exists') ||
+    lower.includes('profile could not be loaded')
+  ) {
+    return 'The selected OpenViking profile no longer exists. Refresh profiles or choose another profile.'
+  }
+
+  if (
+    lower.includes('connection refused') ||
+    lower.includes('connection reset') ||
+    lower.includes('timed out') ||
+    lower.includes('timeout') ||
+    lower.includes('not reachable')
+  ) {
+    return 'OpenViking could not be reached. Check that the server URL is correct and the server is running.'
+  }
+
+  if (lower.includes('require') && lower.includes('api key')) {
+    return 'An API key is required for this OpenViking server. Enter an API key and try again.'
+  }
+
+  if (
+    lower.includes('authentication') ||
+    lower.includes('unauthorized') ||
+    lower.includes('forbidden') ||
+    lower.includes('401') ||
+    lower.includes('403')
+  ) {
+    return 'OpenViking rejected the credentials. Check the API key and account/user details, then try again.'
+  }
+
+  if (lower.includes('reported unhealthy')) {
+    return 'OpenViking is reachable but reports an unhealthy status. Check the server health and try again.'
+  }
+
+  return raw
+    .replace(/^OpenViking validation failed:\s*/i, '')
+    .replace(/^OpenViking authentication validation failed:\s*/i, 'Authentication failed: ')
+    .replace(/^OpenViking root API key validation failed:\s*/i, 'Root API key validation failed: ')
+}
+
+function Field({
+  children,
+  hint,
+  id,
+  label
+}: {
+  children: ReactNode
+  hint?: string
+  id: string
+  label: string
+}) {
+  return (
+    <div className="grid gap-1.5">
+      <label className="text-xs font-medium text-muted-foreground" htmlFor={id}>
+        {label}
+      </label>
+      {children}
+      {hint ? <div className="text-xs text-muted-foreground">{hint}</div> : null}
+    </div>
+  )
+}
+
+function SetupChoice({
+  active,
+  children,
+  description,
+  onClick,
+  title
+}: {
+  active: boolean
+  children: ReactNode
+  description: string
+  onClick: () => void
+  title: string
+}) {
+  return (
+    <button
+      aria-label={title}
+      aria-pressed={active}
+      className={cn(
+        'grid min-h-20 gap-1 rounded-md border border-border bg-background px-3 py-2 text-left outline-none transition-colors hover:bg-(--chrome-action-hover) focus-visible:ring-[0.1875rem] focus-visible:ring-ring/50',
+        active && 'border-primary/70 bg-primary/8'
+      )}
+      onClick={onClick}
+      type="button"
+    >
+      <span className="flex items-center justify-between gap-3 text-xs font-semibold text-foreground">
+        {title}
+        {active ? <CheckCircle2 className="size-4 shrink-0 text-primary" /> : null}
+      </span>
+      <span className="text-xs leading-5 text-muted-foreground">{description}</span>
+      {children}
+    </button>
+  )
+}
+
+function Notice({ state }: { state: ValidationState }) {
+  const Icon = state.tone === 'success' ? CheckCircle2 : AlertCircle
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-2 rounded-md border px-3 py-2 text-xs leading-5',
+        state.tone === 'success'
+          ? 'border-primary/30 bg-primary/8 text-foreground'
+          : 'border-destructive/40 bg-destructive/10 text-destructive'
+      )}
+      role={state.tone === 'error' ? 'alert' : 'status'}
+    >
+      <Icon className="mt-0.5 size-3.5 shrink-0" />
+      <span>{state.message}</span>
+    </div>
+  )
+}
+
+function RoleMismatchPrompt({
+  mismatch,
+  onReenterRootKey,
+  onReenterUserKey,
+  onUseAsRootKey,
+  onUseAsUserKey
+}: {
+  mismatch: RoleMismatch
+  onReenterRootKey: () => void
+  onReenterUserKey: () => void
+  onUseAsRootKey: () => void
+  onUseAsUserKey: () => void
+}) {
+  const rootSelectedAsUser = mismatch === 'root-key-selected-as-user'
+  const title = rootSelectedAsUser ? 'This key has root access.' : 'This key is a user API key.'
+
+  const message = rootSelectedAsUser
+    ? 'Switch to Root API key and provide account/user, or enter a user API key.'
+    : 'Switch to User API key, or enter a root API key.'
+
+  return (
+    <div
+      className="grid gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-xs leading-5 text-foreground"
+      role="alert"
+    >
+      <div className="flex items-start gap-2">
+        <AlertCircle className="mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-300" />
+        <div className="grid gap-1">
+          <div className="font-medium">{title}</div>
+          <div className="text-muted-foreground">{message}</div>
+        </div>
+      </div>
+      <div className="flex flex-wrap justify-end gap-2">
+        {rootSelectedAsUser ? (
+          <>
+            <Button onClick={onReenterUserKey} size="sm" type="button" variant="ghost">
+              Enter User API key
+            </Button>
+            <Button onClick={onUseAsRootKey} size="sm" type="button" variant="secondary">
+              Use as Root API key
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button onClick={onReenterRootKey} size="sm" type="button" variant="ghost">
+              Enter Root API key
+            </Button>
+            <Button onClick={onUseAsUserKey} size="sm" type="button" variant="secondary">
+              Use as User API key
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function healthTone(status: OpenVikingHealth['status']) {
+  if (status === 'healthy') {
+    return {
+      dot: 'bg-emerald-500',
+      shell: 'text-emerald-700 dark:text-emerald-300'
+    }
+  }
+
+  if (status === 'unhealthy') {
+    return {
+      dot: 'bg-amber-500 shadow-[0_0_0_3px_rgba(245,158,11,0.18)]',
+      shell: 'border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+    }
+  }
+
+  return {
+    dot: 'bg-rose-500 shadow-[0_0_0_3px_rgba(244,63,94,0.16)]',
+    shell: 'border-rose-500/25 bg-rose-500/10 text-rose-700 dark:text-rose-300'
+  }
+}
+
+function healthSummary(status: OpenVikingHealth['status']) {
+  if (status === 'healthy') {
+    return 'Ready to use'
+  }
+
+  if (status === 'unhealthy') {
+    return 'Server reached, review details'
+  }
+
+  return 'Cannot reach server'
+}
+
+function HealthStatus({ health }: { health: OpenVikingHealth }) {
+  const [detailsOpen, setDetailsOpen] = useState(false)
+  const tone = healthTone(health.status)
+  const summary = healthSummary(health.status)
+  const canShowDetails = health.status !== 'healthy' && Boolean(health.message)
+  const DetailIcon = health.status === 'healthy' ? CheckCircle2 : AlertCircle
+  const showSummary = health.status !== 'healthy'
+
+  return (
+    <div className="min-w-0 sm:text-right">
+      <div className="text-[0.6875rem] font-medium uppercase text-muted-foreground">Status</div>
+      <div className="mt-1 flex min-w-0 flex-col gap-1 sm:items-end">
+        {canShowDetails ? (
+          <button
+            aria-label="View OpenViking status details"
+            className={cn(
+              'inline-flex w-fit items-center gap-2 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-(--chrome-action-hover) focus-visible:ring-[0.1875rem] focus-visible:ring-ring/50',
+              tone.shell
+            )}
+            onClick={() => setDetailsOpen(true)}
+            title={health.message}
+            type="button"
+          >
+            <span className={cn('size-2 rounded-full', tone.dot)} />
+            {health.label}
+          </button>
+        ) : (
+          <div
+            className={cn(
+              'inline-flex w-fit items-center gap-1.5 text-xs font-medium',
+              tone.shell
+            )}
+            role="status"
+            title={health.message}
+          >
+            <span className={cn('size-1.5 rounded-full', tone.dot)} />
+            {health.label}
+          </div>
+        )}
+        {showSummary ? <div className="text-xs text-muted-foreground">{summary}</div> : null}
+      </div>
+      <Dialog onOpenChange={setDetailsOpen} open={detailsOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader className="pr-28 sm:pr-40">
+            <DialogTitle icon={DetailIcon}>OpenViking status details</DialogTitle>
+            <DialogDescription>{summary}</DialogDescription>
+          </DialogHeader>
+          <div className="rounded-md border border-border bg-background px-3 py-2 font-mono text-xs leading-5 break-words text-foreground">
+            {health.message}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+export function OpenVikingConfigPanel() {
+  const [setup, setSetup] = useState<OpenVikingSetup | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [mode, setMode] = useState<SourceMode>('service')
+  const [step, setStep] = useState<WizardStep>('source')
+  const [values, setValues] = useState<FormValues | null>(null)
+  const [profilePath, setProfilePath] = useState('')
+  const [profileName, setProfileName] = useState(defaultProfileName('service'))
+  const [saving, setSaving] = useState(false)
+  const [validating, setValidating] = useState(false)
+  const [starting, setStarting] = useState(false)
+  const [refreshingProfiles, setRefreshingProfiles] = useState(false)
+  const [validation, setValidation] = useState<ValidationState | null>(null)
+  const [roleMismatch, setRoleMismatch] = useState<RoleMismatch | null>(null)
+
+  const applySetupSnapshot = useCallback(
+    (next: OpenVikingSetup, preferred?: { mode?: SourceMode; profilePath?: string }) => {
+      const nextMode = preferred?.mode ?? modeFromSetup(next)
+      const activeProfile = next.profiles.find(profile => profile.is_active) ?? next.profiles[0]
+
+      const preferredProfile = preferred?.profilePath
+        ? next.profiles.find(profile => profile.path === preferred.profilePath)
+        : null
+
+      const profile = preferredProfile ?? activeProfile
+
+      setSetup(next)
+      setMode(nextMode)
+      setProfilePath(profile?.path ?? '')
+      setProfileName(defaultProfileName(nextMode))
+      setValues(nextMode === 'profile' && profile ? profileValues(profile, next.defaults.actor_peer_id) : seedValues(next, nextMode))
+      setValidation(null)
+      setRoleMismatch(null)
+    },
+    []
+  )
+
+  const refresh = useCallback(async (preferred?: { mode?: SourceMode; profilePath?: string }) => {
+    try {
+      const next = await getOpenVikingSetup()
+      applySetupSnapshot(next, preferred)
+    } catch (err) {
+      notifyError(err, 'OpenViking settings failed to load')
+      setSetup(null)
+      setValues(null)
+    }
+  }, [applySetupSnapshot])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const activeProfile = useMemo(
+    () => setup?.profiles.find(profile => profile.is_active) ?? null,
+    [setup?.profiles]
+  )
+
+  const selectedProfile = useMemo(
+    () => setup?.profiles.find(profile => profile.path === profilePath) ?? null,
+    [profilePath, setup?.profiles]
+  )
+
+  const currentStepIndex = WIZARD_STEPS.findIndex(item => item.id === step)
+  const currentStepNumber = currentStepIndex >= 0 ? currentStepIndex + 1 : 1
+  const currentStepLabel = WIZARD_STEPS[currentStepNumber - 1]?.label ?? WIZARD_STEPS[0].label
+  const canStartLocal = mode === 'custom' && values ? isLocalUrl(values.url) : false
+  const rootIdentityRequired = requiresRootIdentity(values, mode)
+  const hasRootIdentity = Boolean(values?.account.trim()) && Boolean(values?.user.trim())
+
+  const canContinueDetails =
+    mode === 'profile'
+      ? Boolean(profilePath)
+      : Boolean(profileName.trim()) &&
+        Boolean(values?.url.trim()) &&
+        Boolean(values?.actor_peer_id.trim()) &&
+        (!rootIdentityRequired || hasRootIdentity)
+
+  const resetValidation = useCallback(() => {
+    setValidation(null)
+    setRoleMismatch(null)
+  }, [])
+
+  const openWizard = useCallback(() => {
+    setStep('source')
+    setValidation(null)
+    setRoleMismatch(null)
+    setDialogOpen(true)
+    void refresh()
+  }, [refresh])
+
+  const refreshProfiles = useCallback(async () => {
+    setRefreshingProfiles(true)
+
+    try {
+      await refresh({ mode: 'profile', profilePath })
+    } finally {
+      setRefreshingProfiles(false)
+    }
+  }, [profilePath, refresh])
+
+  const chooseMode = useCallback(
+    async (nextMode: SourceMode) => {
+      if (!setup) {
+        return
+      }
+
+      setMode(nextMode)
+      setProfileName(defaultProfileName(nextMode))
+      resetValidation()
+
+      if (nextMode === 'profile') {
+        setRefreshingProfiles(true)
+
+        try {
+          await refresh({ mode: 'profile', profilePath })
+        } finally {
+          setRefreshingProfiles(false)
+        }
+
+        return
+      }
+
+      setValues(seedValues(setup, nextMode))
+    },
+    [profilePath, refresh, resetValidation, setup]
+  )
+
+  const updateValue = useCallback(
+    <K extends keyof FormValues>(key: K, value: FormValues[K]) => {
+      resetValidation()
+      setValues(current => (current ? { ...current, [key]: value } : current))
+    },
+    [resetValidation]
+  )
+
+  const chooseProfile = useCallback(
+    (path: string) => {
+      if (!setup) {
+        return
+      }
+
+      const profile = setup.profiles.find(item => item.path === path)
+      setProfilePath(path)
+      resetValidation()
+
+      if (profile) {
+        setValues(profileValues(profile, setup.defaults.actor_peer_id))
+      }
+    },
+    [resetValidation, setup]
+  )
+
+  const validateCurrentSetup = useCallback(async () => {
+    if (!setup || !values) {
+      return false
+    }
+
+    setValidating(true)
+    setValidation(null)
+    setRoleMismatch(null)
+
+    try {
+      const result =
+        mode === 'profile'
+          ? await validateOpenVikingSetup({ profile_path: profilePath, values: {} })
+          : await validateOpenVikingSetup({
+              require_api_key: mode === 'service' || !isLocalUrl(values.url),
+              values: buildConnectionValues(values, mode, setup)
+            })
+
+      if (!result.ok) {
+        setValidation({ message: validationFailureMessage(result.message), tone: 'error' })
+
+        return false
+      }
+
+      if (mode === 'custom' && result.ok) {
+        if (values.api_key_type === 'user' && result.role === 'root') {
+          setRoleMismatch('root-key-selected-as-user')
+
+          return false
+        }
+
+        if (values.api_key_type === 'root' && result.role === 'user') {
+          setRoleMismatch('user-key-selected-as-root')
+
+          return false
+        }
+      }
+
+      setValidation(null)
+
+      return true
+    } catch (err) {
+      setValidation({ message: validationFailureMessage(messageFromError(err)), tone: 'error' })
+
+      return false
+    } finally {
+      setValidating(false)
+    }
+  }, [mode, profilePath, setup, values])
+
+  const useAsRootKey = useCallback(() => {
+    setValues(current => (current ? { ...current, api_key_type: 'root', account: '', user: '' } : current))
+    setValidation(null)
+    setRoleMismatch(null)
+    setStep('details')
+  }, [])
+
+  const useAsUserKey = useCallback(() => {
+    setValues(current => (current ? { ...current, api_key_type: 'user', account: '', user: '' } : current))
+    setValidation(null)
+    setRoleMismatch(null)
+    setStep('details')
+  }, [])
+
+  const reenterRootKey = useCallback(() => {
+    setValues(current => (current ? { ...current, api_key: '', api_key_type: 'root' } : current))
+    setValidation(null)
+    setRoleMismatch(null)
+    setStep('details')
+  }, [])
+
+  const reenterUserKey = useCallback(() => {
+    setValues(current => (current ? { ...current, api_key: '', api_key_type: 'user', account: '', user: '' } : current))
+    setValidation(null)
+    setRoleMismatch(null)
+    setStep('details')
+  }, [])
+
+  const save = useCallback(async () => {
+    if (!setup || !values) {
+      return
+    }
+
+    const validated = await validateCurrentSetup()
+
+    if (!validated) {
+      return
+    }
+
+    setSaving(true)
+
+    try {
+      if (mode === 'profile') {
+        await saveOpenVikingSetup({ profile_path: profilePath, save_mode: 'profile', values: {} })
+      } else {
+        await saveOpenVikingSetup({
+          profile_name: profileName.trim(),
+          save_mode: 'profile',
+          values: buildConnectionValues(values, mode, setup)
+        })
+      }
+
+      notify({ kind: 'success', title: 'OpenViking saved', message: 'Memory provider configuration updated.' })
+      setDialogOpen(false)
+      await refresh()
+    } catch (err) {
+      notifyError(err, 'Failed to save OpenViking settings')
+    } finally {
+      setSaving(false)
+    }
+  }, [mode, profileName, profilePath, refresh, setup, validateCurrentSetup, values])
+
+  const startLocal = useCallback(async () => {
+    if (!values) {
+      return
+    }
+
+    setStarting(true)
+    setValidation(null)
+    setRoleMismatch(null)
+
+    try {
+      const result = await startOpenVikingLocal(values.url)
+      setValidation({ message: result.message, tone: result.ok ? 'success' : 'error' })
+    } catch (err) {
+      notifyError(err, 'Could not start local OpenViking')
+    } finally {
+      setStarting(false)
+    }
+  }, [values])
+
+  if (!setup || !values) {
+    return <LoadingState label="Loading OpenViking settings..." />
+  }
+
+  const activeConnectionKind = connectionKindForUrl(setup.active.url, setup.defaults.service_url)
+
+  const activeTitle = activeProfile
+    ? `${activeProfile.display_name} (${activeConnectionKind})`
+    : sourceTitle(modeFromSetup(setup))
+
+  const activeLabel = activeProfile ? 'Active profile' : setup.active.source === 'ovcli' ? 'Linked profile' : 'Active setup'
+
+  return (
+    <section className="py-3">
+      <div className="grid gap-4 rounded-xl bg-background/60 p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-[length:var(--conversation-text-font-size)] font-medium text-foreground">
+              OpenViking settings
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              Configure Hermes memory with OpenViking profiles, service, or a self-hosted server.
+            </div>
+          </div>
+          <Button onClick={openWizard} size="sm" type="button" variant="secondary">
+            <Settings2 className="size-3.5" />
+            Configure
+          </Button>
+        </div>
+
+        <div className="grid gap-3 rounded-md border border-border bg-background px-3 py-2.5 sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1.5fr)_minmax(12rem,auto)] sm:items-center">
+          <div className="min-w-0">
+            <div className="text-[0.6875rem] font-medium uppercase text-muted-foreground">{activeLabel}</div>
+            <div className="mt-0.5 truncate text-xs font-medium text-foreground">{activeTitle}</div>
+          </div>
+          <div className="min-w-0">
+            <div className="text-[0.6875rem] font-medium uppercase text-muted-foreground">OpenViking URL</div>
+            <div className="mt-0.5 truncate font-mono text-xs text-foreground">{setup.active.url}</div>
+          </div>
+          <HealthStatus health={setup.health} />
+        </div>
+        {setup.legacy_env_present.length > 0 ? (
+          <div
+            className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100"
+            title={setup.legacy_env_present.join(', ')}
+          >
+            <div className="font-medium">Legacy OpenViking env vars ignored</div>
+            <div className="mt-0.5 text-amber-800/80 dark:text-amber-100/80">
+              Save this setup to clear old variable names.
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <Dialog onOpenChange={setDialogOpen} open={dialogOpen}>
+        <DialogContent className="max-w-2xl" onInteractOutside={event => event.preventDefault()}>
+          <div className="absolute right-5 top-11 text-xs font-medium text-muted-foreground">
+            Step {currentStepNumber} of {WIZARD_STEPS.length}: {currentStepLabel}
+          </div>
+          <DialogHeader>
+            <DialogTitle icon={Settings2}>Configure OpenViking</DialogTitle>
+            <DialogDescription>Use a profile, the OpenViking service, or a custom server.</DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4">
+            {step === 'source' ? (
+              <div className="grid gap-3">
+                <div className="text-sm font-medium text-foreground">Choose setup</div>
+                <div className="grid gap-2 sm:grid-cols-3">
+                  <SetupChoice
+                    active={mode === 'service'}
+                    description="Managed endpoint"
+                    onClick={() => void chooseMode('service')}
+                    title="OpenViking Service"
+                  >
+                    <span className="truncate font-mono text-[0.6875rem] text-muted-foreground">
+                      {setup.defaults.service_url}
+                    </span>
+                  </SetupChoice>
+                  <SetupChoice
+                    active={mode === 'profile'}
+                    description={
+                      refreshingProfiles
+                        ? 'Refreshing profiles'
+                        : setup.profiles.length
+                          ? 'Use an ovcli profile'
+                          : 'No profiles found'
+                    }
+                    onClick={() => void chooseMode('profile')}
+                    title="Existing Profiles"
+                  >
+                    <span className="truncate text-[0.6875rem] text-muted-foreground">
+                      {selectedProfile?.display_name ?? setup.profiles[0]?.display_name ?? 'Create one first'}
+                    </span>
+                  </SetupChoice>
+                  <SetupChoice
+                    active={mode === 'custom'}
+                    description="Local, VPS, or self-hosted"
+                    onClick={() => void chooseMode('custom')}
+                    title="Custom Server"
+                  >
+                    <span className="truncate font-mono text-[0.6875rem] text-muted-foreground">
+                      {mode === 'custom' ? values.url : setup.defaults.url}
+                    </span>
+                  </SetupChoice>
+                </div>
+              </div>
+            ) : null}
+
+            {step === 'details' ? (
+              <div className="grid gap-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="text-sm font-medium text-foreground">{sourceTitle(mode)}</div>
+                  {mode === 'service' ? (
+                    <ExternalLink
+                      className="text-xs font-medium text-primary decoration-primary/30 hover:decoration-primary/70"
+                      href={OPENVIKING_SERVICE_API_KEY_URL}
+                      showExternalIcon={false}
+                    >
+                      Get OpenViking API key
+                    </ExternalLink>
+                  ) : null}
+                  {mode === 'profile' ? (
+                    <Button
+                      disabled={refreshingProfiles}
+                      onClick={() => void refreshProfiles()}
+                      size="sm"
+                      type="button"
+                      variant="secondary"
+                    >
+                      {refreshingProfiles ? (
+                        <Loader2 className="size-3.5 animate-spin" />
+                      ) : (
+                        <RefreshCw className="size-3.5" />
+                      )}
+                      Refresh profiles
+                    </Button>
+                  ) : null}
+                </div>
+                {mode === 'profile' ? (
+                  setup.profiles.length > 0 ? (
+                    <Field
+                      hint={selectedProfile?.description}
+                      id="openviking-profile"
+                      label="OpenViking profile"
+                    >
+                      <Select onValueChange={chooseProfile} value={profilePath}>
+                        <SelectTrigger className={CONTROL_TEXT} id="openviking-profile">
+                          <SelectValue placeholder="Choose profile" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {setup.profiles.map(profile => (
+                            <SelectItem key={profile.path} value={profile.path}>
+                              {profile.display_name}
+                              {profile.is_active ? ' (Active)' : ''}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                  ) : (
+                    <div className="rounded-md border border-border bg-background px-3 py-2 text-xs text-muted-foreground">
+                      No OpenViking profiles were found.
+                    </div>
+                  )
+                ) : (
+                  <div className="grid gap-4">
+                    <Field id="openviking-profile-name" label="Profile name">
+                      <Input
+                        className="font-mono"
+                        id="openviking-profile-name"
+                        onChange={event => {
+                          resetValidation()
+                          setProfileName(event.target.value)
+                        }}
+                        value={profileName}
+                      />
+                    </Field>
+
+                    <Field id="openviking-url" label="OpenViking URL">
+                      <Input
+                        className="font-mono"
+                        id="openviking-url"
+                        onChange={event => updateValue('url', event.target.value)}
+                        readOnly={mode === 'service'}
+                        value={mode === 'service' ? setup.defaults.service_url : values.url}
+                      />
+                    </Field>
+
+                    {mode === 'custom' ? (
+                      <Field id="openviking-credential" label="Credential">
+                        <Select
+                          onValueChange={value => updateValue('api_key_type', value as FormValues['api_key_type'])}
+                          value={values.api_key_type}
+                        >
+                          <SelectTrigger className={CONTROL_TEXT} id="openviking-credential">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {CREDENTIAL_OPTIONS.map(option => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </Field>
+                    ) : null}
+
+                    {(mode === 'service' || values.api_key_type !== 'none') && (
+                      <Field id="openviking-api-key" label="OpenViking API key">
+                        <Input
+                          className="font-mono"
+                          id="openviking-api-key"
+                          onChange={event => updateValue('api_key', event.target.value)}
+                          type="password"
+                          value={values.api_key}
+                        />
+                      </Field>
+                    )}
+
+                    {values.api_key_type === 'root' ? (
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <Field id="openviking-account" label="Account">
+                          <Input
+                            className="font-mono"
+                            id="openviking-account"
+                            onChange={event => updateValue('account', event.target.value)}
+                            value={values.account}
+                          />
+                        </Field>
+                        <Field id="openviking-user" label="User">
+                          <Input
+                            className="font-mono"
+                            id="openviking-user"
+                            onChange={event => updateValue('user', event.target.value)}
+                            value={values.user}
+                          />
+                        </Field>
+                      </div>
+                    ) : null}
+
+                    <Field
+                      hint="Identifies this Hermes agent inside OpenViking."
+                      id="openviking-agent-id"
+                      label="Agent ID"
+                    >
+                      <Input
+                        className="font-mono"
+                        id="openviking-agent-id"
+                        onChange={event => updateValue('actor_peer_id', event.target.value)}
+                        value={values.actor_peer_id}
+                      />
+                    </Field>
+
+                    {canStartLocal ? (
+                      <div className="flex justify-start">
+                        <Button disabled={starting} onClick={() => void startLocal()} size="sm" type="button" variant="secondary">
+                          {starting ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+                          Start local server
+                        </Button>
+                      </div>
+                    ) : null}
+                    {validation ? <Notice state={validation} /> : null}
+                  </div>
+                )}
+              </div>
+            ) : null}
+
+            {step === 'validate' ? (
+              <div className="grid gap-4">
+                <div className="grid gap-3 rounded-md border border-border bg-background px-3 py-2.5">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="text-sm font-medium text-foreground">{sourceTitle(mode)}</div>
+                    {mode !== 'profile' ? <Pill>{profileName.trim()}</Pill> : null}
+                  </div>
+                  <div className="grid gap-2 text-xs sm:grid-cols-2">
+                    <div className="min-w-0">
+                      <div className="text-muted-foreground">OpenViking URL</div>
+                      <div className="truncate font-mono text-foreground">{values.url}</div>
+                    </div>
+                    <div className="min-w-0">
+                      <div className="text-muted-foreground">Agent ID</div>
+                      <div className="truncate font-mono text-foreground">{values.actor_peer_id}</div>
+                    </div>
+                  </div>
+                  {mode === 'profile' && selectedProfile ? (
+                    <div className="flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                      <span className="shrink-0">Profile Path:</span>
+                      <span className="truncate font-mono">{selectedProfile.path}</span>
+                    </div>
+                  ) : null}
+                </div>
+
+                {validation ? <Notice state={validation} /> : null}
+                {roleMismatch ? (
+                  <RoleMismatchPrompt
+                    mismatch={roleMismatch}
+                    onReenterRootKey={reenterRootKey}
+                    onReenterUserKey={reenterUserKey}
+                    onUseAsRootKey={useAsRootKey}
+                    onUseAsUserKey={useAsUserKey}
+                  />
+                ) : null}
+
+                {canStartLocal ? (
+                  <div className="flex justify-start">
+                    <Button disabled={starting} onClick={() => void startLocal()} size="sm" type="button" variant="secondary">
+                      {starting ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+                      Start local server
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+
+          <DialogFooter>
+            {step !== 'source' ? (
+              <Button
+                disabled={saving || validating || starting}
+                onClick={() => setStep(step === 'validate' ? 'details' : 'source')}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                Back
+              </Button>
+            ) : null}
+            {step === 'source' ? (
+              <Button
+                disabled={mode === 'profile' && (refreshingProfiles || setup.profiles.length === 0)}
+                onClick={() => setStep('details')}
+                size="sm"
+                type="button"
+              >
+                Next
+              </Button>
+            ) : null}
+            {step === 'details' ? (
+              <Button disabled={!canContinueDetails} onClick={() => setStep('validate')} size="sm" type="button">
+                Continue
+              </Button>
+            ) : null}
+            {step === 'validate' ? (
+              <Button
+                disabled={saving || validating || (mode === 'profile' && !profilePath)}
+                onClick={() => void save()}
+                size="sm"
+                type="button"
+              >
+                {saving || validating ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
+                {validating ? 'Checking...' : saving ? 'Saving...' : 'Save profile'}
+              </Button>
+            ) : null}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  )
+}

--- a/apps/desktop/src/app/settings/provider-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/provider-config-panel.test.tsx
@@ -8,7 +8,11 @@ const saveMemoryProviderConfig = vi.fn()
 
 vi.mock('@/hermes', () => ({
   getMemoryProviderConfig: (provider: string) => getMemoryProviderConfig(provider),
-  saveMemoryProviderConfig: (provider: string, values: unknown) => saveMemoryProviderConfig(provider, values)
+  getOpenVikingSetup: vi.fn(),
+  saveMemoryProviderConfig: (provider: string, values: unknown) => saveMemoryProviderConfig(provider, values),
+  saveOpenVikingSetup: vi.fn(),
+  startOpenVikingLocal: vi.fn(),
+  validateOpenVikingSetup: vi.fn()
 }))
 
 vi.mock('@/store/notifications', () => ({

--- a/apps/desktop/src/app/settings/provider-config-panel.tsx
+++ b/apps/desktop/src/app/settings/provider-config-panel.tsx
@@ -10,6 +10,7 @@ import { notify, notifyError } from '@/store/notifications'
 import type { MemoryProviderConfig, MemoryProviderField } from '@/types/hermes'
 
 import { CONTROL_TEXT } from './constants'
+import { OpenVikingConfigPanel } from './openviking-config-panel'
 import { LoadingState, Pill } from './primitives'
 
 /** Seed editable values from the schema: non-secret fields keep their current
@@ -82,6 +83,14 @@ function FieldControl({
 }
 
 export function ProviderConfigPanel({ provider }: { provider: string }) {
+  if (provider === 'openviking') {
+    return <OpenVikingConfigPanel />
+  }
+
+  return <GenericProviderConfigPanel provider={provider} />
+}
+
+function GenericProviderConfigPanel({ provider }: { provider: string }) {
   const [config, setConfig] = useState<MemoryProviderConfig | null>(null)
   const [values, setValues] = useState<Record<string, string>>({})
   const [expanded, setExpanded] = useState(true)

--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -3,10 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   checkHermesUpdate,
   getActionStatus,
+  getMemoryProviderConfig,
+  getOpenVikingSetup,
   getStatus,
   restartGateway,
+  saveMemoryProviderConfig,
+  saveOpenVikingSetup,
   setApiRequestProfile,
-  updateHermes
+  startOpenVikingLocal,
+  updateHermes,
+  validateOpenVikingSetup
 } from './hermes'
 
 // Contract: every backend-targeted action helper must carry the active gateway
@@ -41,6 +47,21 @@ describe('backend action helpers are profile-scoped', () => {
     void updateHermes()
     void checkHermesUpdate()
     void getActionStatus('gateway-restart')
+
+    for (const call of api.mock.calls) {
+      expect(call[0].profile).toBe('coder')
+    }
+  })
+
+  it('forwards the active profile to memory provider setup calls', () => {
+    setApiRequestProfile('coder')
+
+    void getMemoryProviderConfig('hindsight')
+    void saveMemoryProviderConfig('hindsight', { token: 'secret' })
+    void getOpenVikingSetup()
+    void saveOpenVikingSetup({ save_mode: 'profile', values: { actor_peer_id: 'hermes', url: 'http://127.0.0.1:1933' } })
+    void validateOpenVikingSetup({ values: { actor_peer_id: 'hermes', url: 'http://127.0.0.1:1933' } })
+    void startOpenVikingLocal('http://127.0.0.1:1933')
 
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBe('coder')

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -32,6 +32,11 @@ import type {
   OAuthProvidersResponse,
   OAuthStartResponse,
   OAuthSubmitResponse,
+  OpenVikingSetup,
+  OpenVikingSetupSaveRequest,
+  OpenVikingSetupSaveResponse,
+  OpenVikingSetupValidationRequest,
+  OpenVikingSetupValidationResponse,
   PaginatedSessions,
   ProfileCreatePayload,
   ProfileSetupCommand,
@@ -93,6 +98,13 @@ export type {
   ModelInfoResponse,
   ModelOptionProvider,
   ModelOptionsResponse,
+  OpenVikingConnectionValues,
+  OpenVikingProfile,
+  OpenVikingSetup,
+  OpenVikingSetupSaveRequest,
+  OpenVikingSetupSaveResponse,
+  OpenVikingSetupValidationRequest,
+  OpenVikingSetupValidationResponse,
   PaginatedSessions,
   ProfileCreatePayload,
   ProfileInfo,
@@ -358,15 +370,53 @@ export function saveHermesConfig(config: HermesConfigRecord): Promise<{ ok: bool
 
 export function getMemoryProviderConfig(provider: string): Promise<MemoryProviderConfig> {
   return window.hermesDesktop.api<MemoryProviderConfig>({
+    ...profileScoped(),
     path: `/api/memory/providers/${encodeURIComponent(provider)}/config`
   })
 }
 
 export function saveMemoryProviderConfig(provider: string, values: Record<string, string>): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
+    ...profileScoped(),
     path: `/api/memory/providers/${encodeURIComponent(provider)}/config`,
     method: 'PUT',
     body: { values }
+  })
+}
+
+export function getOpenVikingSetup(): Promise<OpenVikingSetup> {
+  return window.hermesDesktop.api<OpenVikingSetup>({
+    ...profileScoped(),
+    path: '/api/memory/providers/openviking/setup'
+  })
+}
+
+export function saveOpenVikingSetup(body: OpenVikingSetupSaveRequest): Promise<OpenVikingSetupSaveResponse> {
+  return window.hermesDesktop.api<OpenVikingSetupSaveResponse>({
+    ...profileScoped(),
+    path: '/api/memory/providers/openviking/setup',
+    method: 'PUT',
+    body
+  })
+}
+
+export function validateOpenVikingSetup(
+  body: OpenVikingSetupValidationRequest
+): Promise<OpenVikingSetupValidationResponse> {
+  return window.hermesDesktop.api<OpenVikingSetupValidationResponse>({
+    ...profileScoped(),
+    path: '/api/memory/providers/openviking/validate',
+    method: 'POST',
+    body
+  })
+}
+
+export function startOpenVikingLocal(url: string): Promise<{ message: string; ok: boolean }> {
+  return window.hermesDesktop.api<{ message: string; ok: boolean }>({
+    ...profileScoped(),
+    path: '/api/memory/providers/openviking/start-local',
+    method: 'POST',
+    body: { url }
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -151,6 +151,80 @@ export interface MemoryProviderConfig {
   name: string
 }
 
+export interface OpenVikingConnectionValues {
+  account?: string
+  actor_peer_id: string
+  api_key?: string
+  api_key_set?: boolean
+  api_key_type?: 'none' | 'root' | 'user'
+  ovcli_config_path?: string
+  root_api_key?: string
+  source?: 'hermes' | 'ovcli'
+  url: string
+  user?: string
+}
+
+export interface OpenVikingProfile {
+  account: string
+  actor_peer_id: string
+  api_key_set: boolean
+  api_key_type?: 'none' | 'root' | 'user'
+  description: string
+  display_name: string
+  is_active: boolean
+  name: string
+  path: string
+  source: 'active' | 'env' | 'saved'
+  url: string
+  user: string
+}
+
+export interface OpenVikingHealth {
+  label: string
+  message: string
+  status: 'healthy' | 'unhealthy' | 'unreachable'
+}
+
+export interface OpenVikingSetup {
+  active: OpenVikingConnectionValues
+  defaults: {
+    actor_peer_id: string
+    service_url: string
+    url: string
+  }
+  health: OpenVikingHealth
+  legacy_env_present: string[]
+  local_server?: {
+    openviking_server_path?: string
+  }
+  profiles: OpenVikingProfile[]
+}
+
+export interface OpenVikingSetupSaveRequest {
+  profile_name?: string
+  profile_path?: string
+  save_mode: 'profile'
+  values: Partial<OpenVikingConnectionValues>
+}
+
+export interface OpenVikingSetupSaveResponse {
+  mode?: 'profile'
+  ok: boolean
+  profile_path?: string
+}
+
+export interface OpenVikingSetupValidationRequest {
+  profile_path?: string
+  require_api_key?: boolean
+  values: Partial<OpenVikingConnectionValues>
+}
+
+export interface OpenVikingSetupValidationResponse {
+  message: string
+  ok: boolean
+  role: 'root' | 'user' | null
+}
+
 export interface MessagingEnvVarInfo {
   advanced: boolean
   description: string

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3734,9 +3734,15 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
-    "OPENVIKING_ENDPOINT": {
+    "OPENVIKING_URL": {
         "description": "OpenViking server URL (default: http://127.0.0.1:1933)",
-        "prompt": "OpenViking endpoint",
+        "prompt": "OpenViking URL",
+        "category": "tool",
+        "advanced": True,
+    },
+    "OPENVIKING_ACTOR_PEER_ID": {
+        "description": "OpenViking Agent ID for peer-scoped memories (default: hermes)",
+        "prompt": "OpenViking Agent ID",
         "category": "tool",
         "advanced": True,
     },

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -776,6 +776,26 @@ class MemoryProviderConfigUpdate(BaseModel):
     values: Dict[str, str] = {}
 
 
+class OpenVikingSetupUpdate(BaseModel):
+    values: Dict[str, str] = {}
+    save_mode: str = "profile"
+    profile_name: str = ""
+    profile_path: str = ""
+    profile: Optional[str] = None
+
+
+class OpenVikingValidateRequest(BaseModel):
+    values: Dict[str, str] = {}
+    require_api_key: Optional[bool] = None
+    profile_path: str = ""
+    profile: Optional[str] = None
+
+
+class OpenVikingStartLocalRequest(BaseModel):
+    url: str
+    profile: Optional[str] = None
+
+
 class MessagingPlatformUpdate(BaseModel):
     enabled: Optional[bool] = None
     env: Dict[str, str] = {}
@@ -3894,6 +3914,92 @@ async def update_memory_provider_config(name: str, body: MemoryProviderConfigUpd
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception:
         _log.exception("PUT /api/memory/providers/%s/config failed", name)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@app.get("/api/memory/providers/openviking/setup")
+async def get_openviking_setup(profile: Optional[str] = None):
+    try:
+        import plugins.memory.openviking as openviking
+
+        with _config_profile_scope(profile):
+            config = load_config()
+            memory_config = config.get("memory") if isinstance(config, dict) else {}
+            provider_config = (
+                memory_config.get("openviking", {})
+                if isinstance(memory_config, dict)
+                else {}
+            )
+            return openviking.get_desktop_openviking_setup(provider_config)
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("GET /api/memory/providers/openviking/setup failed")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@app.post("/api/memory/providers/openviking/validate")
+async def validate_openviking_setup(body: OpenVikingValidateRequest, profile: Optional[str] = None):
+    try:
+        import plugins.memory.openviking as openviking
+
+        with _config_profile_scope(body.profile or profile):
+            return openviking.validate_desktop_openviking_setup(
+                body.values,
+                require_api_key=body.require_api_key,
+                profile_path=body.profile_path,
+            )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception:
+        _log.exception("POST /api/memory/providers/openviking/validate failed")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@app.put("/api/memory/providers/openviking/setup")
+async def update_openviking_setup(body: OpenVikingSetupUpdate, profile: Optional[str] = None):
+    try:
+        import plugins.memory.openviking as openviking
+
+        with _config_profile_scope(body.profile or profile):
+            config = load_config()
+            result = openviking.save_desktop_openviking_setup(
+                config=config,
+                hermes_home=get_hermes_home(),
+                values=body.values,
+                save_mode=body.save_mode,
+                profile_name=body.profile_name,
+                profile_path=body.profile_path,
+            )
+            save_config(config)
+            from hermes_cli.config import reload_env
+
+            reload_env()
+            return result
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception:
+        _log.exception("PUT /api/memory/providers/openviking/setup failed")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@app.post("/api/memory/providers/openviking/start-local")
+async def start_openviking_local(body: OpenVikingStartLocalRequest, profile: Optional[str] = None):
+    try:
+        import plugins.memory.openviking as openviking
+
+        with _config_profile_scope(body.profile or profile):
+            return openviking.start_desktop_openviking_local(body.url)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception:
+        _log.exception("POST /api/memory/providers/openviking/start-local failed")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -14,27 +14,28 @@ Context database by Volcengine (ByteDance) with filesystem-style knowledge hiera
 hermes memory setup    # select "openviking"
 ```
 
-The setup can link to an existing `~/.openviking/ovcli.conf`, copy its current
-connection values into Hermes, or create a minimal `ovcli.conf` when one does
-not exist.
+The setup links Hermes to an existing OpenViking CLI profile or creates a new
+`~/.openviking/ovcli.conf.<name>` profile and links Hermes to it.
 
-Or manually:
+Manual env overrides are still supported for advanced/runtime use:
 ```bash
 hermes config set memory.provider openviking
-echo "OPENVIKING_ENDPOINT=http://localhost:1933" >> ~/.hermes/.env
+echo "OPENVIKING_URL=http://localhost:1933" >> ~/.hermes/.env
 ```
 
 ## Config
 
-All config via environment variables in `.env`:
+Normal setup stores connection values in an OpenViking CLI profile and stores
+only the profile link in Hermes. These environment variables can override the
+linked profile at runtime:
 
 | Env Var | Default | Description |
 |---------|---------|-------------|
-| `OPENVIKING_ENDPOINT` | `http://127.0.0.1:1933` | Server URL |
+| `OPENVIKING_URL` | `http://127.0.0.1:1933` | Server URL |
 | `OPENVIKING_API_KEY` | (none) | User/admin API key for authenticated servers |
 | `OPENVIKING_ACCOUNT` | `default` | Tenant account for local/trusted mode |
 | `OPENVIKING_USER` | `default` | Tenant user for local/trusted mode |
-| `OPENVIKING_AGENT` | `hermes` | Hermes peer ID in OpenViking, used for peer-scoped memories |
+| `OPENVIKING_ACTOR_PEER_ID` | `hermes` | Hermes Agent ID in OpenViking, used for peer-scoped memories |
 
 When `OPENVIKING_API_KEY` is set, Hermes lets OpenViking derive account/user
 identity from the key. In local or trusted deployments without an API key,
@@ -55,9 +56,10 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 
 `viking_remember` writes directly to OpenViking with `POST /api/v1/content/write`
 and `mode=create`. It creates peer-scoped memory files under
-`viking://user/peers/${OPENVIKING_AGENT}/memories/...`; OpenViking may return a
-canonical user-scoped form such as
-`viking://user/default/peers/${OPENVIKING_AGENT}/memories/...` in API-key mode.
+`viking://user/peers/${OPENVIKING_ACTOR_PEER_ID}/memories/...`; OpenViking may
+return a canonical user-scoped form such as
+`viking://user/default/peers/${OPENVIKING_ACTOR_PEER_ID}/memories/...` in
+API-key mode.
 Explicit remembers do not depend on session commit extraction.
 
 Hermes built-in `memory` tool additions are mirrored to OpenViking after the

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -7,13 +7,13 @@ automatic memory extraction, and session management.
 Original PR #3369 by Mibayy, rewritten to use the full OpenViking session
 lifecycle instead of read-only search endpoints.
 
-Config via environment variables (profile-scoped via each profile's .env)
-or a linked OpenViking CLI config:
-  OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
-  OPENVIKING_API_KEY   — API key (required for authenticated servers)
-  OPENVIKING_ACCOUNT   — Tenant account for local/trusted mode (default: default)
-  OPENVIKING_USER      — Tenant user for local/trusted mode (default: default)
-  OPENVIKING_AGENT     — Hermes peer ID in OpenViking (default: hermes)
+Config normally uses a linked OpenViking CLI profile. Environment variables can
+still override individual runtime values:
+  OPENVIKING_URL            — Server URL (default: http://127.0.0.1:1933)
+  OPENVIKING_API_KEY        — API key (required for authenticated servers)
+  OPENVIKING_ACCOUNT        — Tenant account for local/trusted mode (default: default)
+  OPENVIKING_USER           — Tenant user for local/trusted mode (default: default)
+  OPENVIKING_ACTOR_PEER_ID  — Agent ID in OpenViking (default: hermes)
 
 Capabilities:
   - Automatic memory extraction on session commit (6 categories)
@@ -53,20 +53,22 @@ from utils import atomic_json_write, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
+_DEFAULT_URL = "http://127.0.0.1:1933"
 _OPENVIKING_SERVICE_ENDPOINT = "https://api.vikingdb.cn-beijing.volces.com/openviking"
-_DEFAULT_AGENT = "hermes"
-_AGENT_PROMPT_LABEL = "Hermes peer ID in OpenViking"
+_DEFAULT_ACTOR_PEER_ID = "hermes"
+_AGENT_ID_PROMPT_LABEL = "Agent ID"
 _OVCLI_CONFIG_ENV = "OPENVIKING_CLI_CONFIG_FILE"
 _OVCLI_DEFAULT_RELATIVE_PATH = ".openviking/ovcli.conf"
 _OVCLI_SAVED_PREFIX = "ovcli.conf."
 _OPENVIKING_ENV_KEYS = (
-    "OPENVIKING_ENDPOINT",
+    "OPENVIKING_URL",
     "OPENVIKING_API_KEY",
     "OPENVIKING_ACCOUNT",
     "OPENVIKING_USER",
-    "OPENVIKING_AGENT",
+    "OPENVIKING_ACTOR_PEER_ID",
 )
+_OPENVIKING_LEGACY_ENV_KEYS = ("OPENVIKING_ENDPOINT", "OPENVIKING_AGENT")
+_OPENVIKING_ENV_KEYS_TO_REMOVE = _OPENVIKING_ENV_KEYS + _OPENVIKING_LEGACY_ENV_KEYS
 _TIMEOUT = 30.0
 _SESSION_DRAIN_TIMEOUT = 10.0
 _DEFERRED_COMMIT_TIMEOUT = (_TIMEOUT * 2) + 5.0
@@ -128,6 +130,15 @@ class _OpenVikingHTTPError(RuntimeError):
     def __init__(self, message: str, status_code: Optional[int] = None):
         super().__init__(message)
         self.status_code = status_code
+
+
+class _OpenVikingProfileNotFoundError(ValueError):
+    """Hermes is linked to an OpenViking profile file that no longer exists."""
+
+
+_MISSING_LINKED_PROFILE_MESSAGE = (
+    "The linked OpenViking profile file no longer exists. Choose another profile or recreate it."
+)
 
 
 def _sanitize_openviking_error_message(message: str, status_code: Optional[int] = None) -> str:
@@ -228,7 +239,7 @@ class _VikingClient:
 
     def __init__(self, endpoint: str, api_key: str = "",
                  account: Optional[str] = None, user: Optional[str] = None,
-                 agent: Optional[str] = None):
+                 actor_peer_id: Optional[str] = None):
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
         # Account/user are local/trusted-mode tenant identity. API-key requests
@@ -236,7 +247,11 @@ class _VikingClient:
         # after OpenViking explicitly asks for asserted tenant identity.
         self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
         self._user = user or os.environ.get("OPENVIKING_USER", "default")
-        self._agent = agent if agent is not None else os.environ.get("OPENVIKING_AGENT", _DEFAULT_AGENT)
+        self._actor_peer_id = (
+            actor_peer_id
+            if actor_peer_id is not None
+            else os.environ.get("OPENVIKING_ACTOR_PEER_ID", _DEFAULT_ACTOR_PEER_ID)
+        )
         self._httpx = _get_httpx()
         if self._httpx is None:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
@@ -246,8 +261,8 @@ class _VikingClient:
             include_tenant = not bool(self._api_key)
 
         h = {"Content-Type": "application/json"}
-        if self._agent:
-            h["X-OpenViking-Actor-Peer"] = self._agent
+        if self._actor_peer_id:
+            h["X-OpenViking-Actor-Peer"] = self._actor_peer_id
         if include_tenant:
             if self._account:
                 h["X-OpenViking-Account"] = self._account
@@ -698,19 +713,32 @@ def _load_ovcli_config(path: Optional[Path] = None) -> dict:
     return data
 
 
+def _load_required_ovcli_config(path: Path) -> dict:
+    if not path.exists() or not path.is_file():
+        raise _OpenVikingProfileNotFoundError(f"OpenViking profile file was not found: {path}")
+    return _load_ovcli_config(path)
+
+
 def _connection_values_from_ovcli(data: dict) -> dict:
     api_key = _clean_config_value(data.get("api_key")) or _clean_config_value(data.get("root_api_key"))
     root_api_key = _clean_config_value(data.get("root_api_key"))
     send_identity = not api_key or api_key == root_api_key
     account = _clean_config_value(data.get("account") or data.get("account_id"))
     user = _clean_config_value(data.get("user") or data.get("user_id"))
+    if root_api_key and api_key == root_api_key:
+        api_key_type = "root"
+    elif api_key:
+        api_key_type = "user"
+    else:
+        api_key_type = "none"
     return {
-        "endpoint": _normalize_openviking_url(data.get("url")),
+        "url": _normalize_openviking_url(data.get("url")),
         "api_key": api_key,
         "root_api_key": root_api_key,
+        "api_key_type": api_key_type,
         "account": account if send_identity else "",
         "user": user if send_identity else "",
-        "agent": _clean_config_value(data.get("actor_peer_id") or data.get("agent_id")),
+        "actor_peer_id": _clean_config_value(data.get("actor_peer_id") or data.get("agent_id")),
     }
 
 
@@ -742,7 +770,7 @@ def _validate_openviking_identity_value(value: str, *, field: str) -> tuple[bool
 def _normalize_openviking_url(url: str) -> str:
     trimmed = _clean_config_value(url).rstrip("/")
     if not trimmed:
-        return _DEFAULT_ENDPOINT
+        return _DEFAULT_URL
     lower = trimmed.lower()
     if lower in {"::1", "[::1]"}:
         return "http://[::1]:1933"
@@ -759,6 +787,8 @@ def _normalize_openviking_url(url: str) -> str:
 
 
 def _load_profile(path: Path, *, source: str, name: str) -> Optional[_OvcliProfile]:
+    if not path.exists() or not path.is_file():
+        return None
     try:
         data = _load_ovcli_config(path)
     except Exception as e:
@@ -784,9 +814,13 @@ def _profiles_equivalent(left: _OvcliProfile, right: _OvcliProfile) -> bool:
     return left.values == right.values
 
 
-def _discover_ovcli_profiles() -> list[_OvcliProfile]:
+def _discover_ovcli_profiles(*, active_path: Optional[Path] = None) -> list[_OvcliProfile]:
     profiles: list[_OvcliProfile] = []
     seen_paths: set[str] = set()
+    explicit_active_path = active_path.expanduser() if active_path is not None else None
+    explicit_active_identity = (
+        _profile_identity(explicit_active_path) if explicit_active_path is not None else ""
+    )
 
     def add(path: Path, *, source: str, name: str) -> None:
         if not path.exists() or not path.is_file():
@@ -797,6 +831,8 @@ def _discover_ovcli_profiles() -> list[_OvcliProfile]:
         profile = _load_profile(path, source=source, name=name)
         if profile is None:
             return
+        if explicit_active_identity and identity == explicit_active_identity:
+            profile = replace(profile, is_active=True)
         seen_paths.add(identity)
         profiles.append(profile)
 
@@ -804,8 +840,12 @@ def _discover_ovcli_profiles() -> list[_OvcliProfile]:
     if env_path:
         add(Path(env_path).expanduser(), source="env", name=_OVCLI_CONFIG_ENV)
 
-    active_path = _default_ovcli_config_path()
-    active_profile = _load_profile(active_path, source="active", name="active") if active_path.exists() else None
+    default_active_path = _default_ovcli_config_path()
+    default_active_profile = (
+        _load_profile(default_active_path, source="active", name="active")
+        if default_active_path.exists()
+        else None
+    )
 
     config_dir = _ovcli_config_dir()
     saved_start = len(profiles)
@@ -818,18 +858,27 @@ def _discover_ovcli_profiles() -> list[_OvcliProfile]:
                 continue
             add(path, source="saved", name=name)
 
-    if active_profile is not None:
+    if explicit_active_path is not None:
+        if explicit_active_identity not in seen_paths:
+            active_profile = _load_profile(explicit_active_path, source="active", name="active")
+            if active_profile is not None:
+                profiles.append(replace(active_profile, is_active=True))
+            elif default_active_profile is not None:
+                default_active_identity = _profile_identity(default_active_profile.path)
+                if default_active_identity not in seen_paths:
+                    profiles.append(default_active_profile)
+    elif default_active_profile is not None:
         marked_active = False
         for idx in range(saved_start, len(profiles)):
-            if profiles[idx].source == "saved" and _profiles_equivalent(profiles[idx], active_profile):
+            if profiles[idx].source == "saved" and _profiles_equivalent(profiles[idx], default_active_profile):
                 profiles[idx] = replace(profiles[idx], is_active=True)
                 marked_active = True
                 break
         has_env_profile = any(profile.source == "env" for profile in profiles)
         has_saved_profile = any(profile.source == "saved" for profile in profiles)
-        active_identity = _profile_identity(active_profile.path)
+        active_identity = _profile_identity(default_active_profile.path)
         if not marked_active and not has_env_profile and not has_saved_profile and active_identity not in seen_paths:
-            profiles.append(active_profile)
+            profiles.append(default_active_profile)
 
     return profiles
 
@@ -873,37 +922,26 @@ def _resolve_connection_settings(provider_config: Optional[dict] = None) -> dict
     ovcli_values: dict = {}
     if provider_config.get("use_ovcli_config"):
         ovcli_path = _resolve_ovcli_config_path(str(provider_config.get("ovcli_config_path") or ""))
-        ovcli_values = _connection_values_from_ovcli(_load_ovcli_config(ovcli_path))
+        ovcli_values = _connection_values_from_ovcli(_load_required_ovcli_config(ovcli_path))
 
-    endpoint_env = _env_value("OPENVIKING_ENDPOINT")
+    url_env = _env_value("OPENVIKING_URL")
     api_key_env = _env_value("OPENVIKING_API_KEY")
     account_env = _env_value("OPENVIKING_ACCOUNT")
     user_env = _env_value("OPENVIKING_USER")
-    agent_env = _env_value("OPENVIKING_AGENT")
+    actor_peer_env = _env_value("OPENVIKING_ACTOR_PEER_ID")
 
     return {
-        "endpoint": _first_nonempty(endpoint_env, ovcli_values.get("endpoint"), default=_DEFAULT_ENDPOINT),
+        "url": _first_nonempty(url_env, ovcli_values.get("url"), default=_DEFAULT_URL),
         "api_key": api_key_env if api_key_env is not None else ovcli_values.get("api_key", ""),
+        "api_key_type": "" if api_key_env is not None else ovcli_values.get("api_key_type", ""),
         "account": account_env if account_env is not None else ovcli_values.get("account", ""),
         "user": user_env if user_env is not None else ovcli_values.get("user", ""),
-        "agent": _first_nonempty(agent_env, ovcli_values.get("agent"), default=_DEFAULT_AGENT),
+        "actor_peer_id": _first_nonempty(
+            actor_peer_env,
+            ovcli_values.get("actor_peer_id"),
+            default=_DEFAULT_ACTOR_PEER_ID,
+        ),
     }
-
-
-def _env_writes_from_connection_values(values: dict) -> dict:
-    writes = {}
-    mapping = {
-        "OPENVIKING_ENDPOINT": "endpoint",
-        "OPENVIKING_API_KEY": "api_key",
-        "OPENVIKING_ACCOUNT": "account",
-        "OPENVIKING_USER": "user",
-        "OPENVIKING_AGENT": "agent",
-    }
-    for env_key, value_key in mapping.items():
-        value = _clean_config_value(values.get(value_key))
-        if value:
-            writes[env_key] = value
-    return writes
 
 
 def _restrict_secret_file_permissions(path: Path) -> None:
@@ -962,12 +1000,14 @@ def _remember_ovcli_path(provider_config: dict, ovcli_path: Path) -> None:
 
 
 def _ovcli_data_from_connection_values(values: dict) -> dict:
-    data = {"url": _normalize_openviking_url(_clean_config_value(values.get("endpoint")) or _DEFAULT_ENDPOINT)}
+    data = {"url": _normalize_openviking_url(_clean_config_value(values.get("url")) or _DEFAULT_URL)}
     api_key = _clean_config_value(values.get("api_key"))
     root_api_key = _clean_config_value(values.get("root_api_key"))
+    if not root_api_key and _clean_config_value(values.get("api_key_type")) == "root":
+        root_api_key = api_key
     account = _clean_config_value(values.get("account"))
     user = _clean_config_value(values.get("user"))
-    agent = _clean_config_value(values.get("agent")) or _DEFAULT_AGENT
+    actor_peer_id = _clean_config_value(values.get("actor_peer_id")) or _DEFAULT_ACTOR_PEER_ID
     if api_key:
         data["api_key"] = api_key
     if root_api_key:
@@ -976,8 +1016,8 @@ def _ovcli_data_from_connection_values(values: dict) -> dict:
         data["account"] = account
     if user:
         data["user"] = user
-    if agent:
-        data["actor_peer_id"] = agent
+    if actor_peer_id:
+        data["actor_peer_id"] = actor_peer_id
     return data
 
 
@@ -1009,14 +1049,14 @@ def _validate_openviking_reachability(endpoint: str) -> tuple[bool, str]:
 
 
 def _validate_openviking_auth(values: dict) -> tuple[bool, str]:
-    endpoint = _normalize_openviking_url(values.get("endpoint"))
+    endpoint = _normalize_openviking_url(values.get("url"))
     try:
         client = _VikingClient(
             endpoint,
             _clean_config_value(values.get("api_key")),
             account=_clean_config_value(values.get("account")),
             user=_clean_config_value(values.get("user")),
-            agent=_clean_config_value(values.get("agent")) or _DEFAULT_AGENT,
+            actor_peer_id=_clean_config_value(values.get("actor_peer_id")) or _DEFAULT_ACTOR_PEER_ID,
         )
         client.validate_auth()
     except Exception as e:
@@ -1025,12 +1065,12 @@ def _validate_openviking_auth(values: dict) -> tuple[bool, str]:
 
 
 def _validate_openviking_root_access(values: dict) -> tuple[bool, str]:
-    endpoint = _normalize_openviking_url(values.get("endpoint"))
+    endpoint = _normalize_openviking_url(values.get("url"))
     try:
         client = _VikingClient(
             endpoint,
             _clean_config_value(values.get("api_key")),
-            agent=_clean_config_value(values.get("agent")) or _DEFAULT_AGENT,
+            actor_peer_id=_clean_config_value(values.get("actor_peer_id")) or _DEFAULT_ACTOR_PEER_ID,
         )
         client.validate_root_access()
     except Exception as e:
@@ -1076,7 +1116,7 @@ def _validate_openviking_setup_values(
     *,
     require_api_key: bool = False,
 ) -> tuple[bool, str, Optional[str]]:
-    endpoint = _normalize_openviking_url(values.get("endpoint"))
+    endpoint = _normalize_openviking_url(values.get("url"))
     api_key = _clean_config_value(values.get("api_key"))
     if require_api_key and not api_key:
         return False, "Remote OpenViking configs require an API key.", None
@@ -1087,7 +1127,7 @@ def _validate_openviking_setup_values(
             api_key,
             account=_clean_config_value(values.get("account")),
             user=_clean_config_value(values.get("user")),
-            agent=_clean_config_value(values.get("agent")) or _DEFAULT_AGENT,
+            actor_peer_id=_clean_config_value(values.get("actor_peer_id")) or _DEFAULT_ACTOR_PEER_ID,
         )
         health = client.health_payload()
         if health.get("healthy") is False:
@@ -1329,7 +1369,7 @@ def _prompt_manual_connection_values(prompt, select, cancelled, *, service: bool
         print(f"  OpenViking Service endpoint: {endpoint}")
     else:
         while True:
-            endpoint = _normalize_openviking_url(prompt("OpenViking server URL", default=_DEFAULT_ENDPOINT))
+            endpoint = _normalize_openviking_url(prompt("OpenViking server URL", default=_DEFAULT_URL))
             _print_validation_progress("Checking OpenViking server...")
             reachable, message = _validate_openviking_reachability(endpoint)
             if reachable:
@@ -1353,12 +1393,12 @@ def _prompt_manual_connection_values(prompt, select, cancelled, *, service: bool
     prefilled_agent = ""
     while True:
         values = {
-            "endpoint": endpoint,
+            "url": endpoint,
             "api_key": "",
             "root_api_key": "",
             "account": "",
             "user": "",
-            "agent": "",
+            "actor_peer_id": "",
         }
         if not api_key_type and is_local:
             credential_choice = select(
@@ -1374,9 +1414,9 @@ def _prompt_manual_connection_values(prompt, select, cancelled, *, service: bool
             if credential_choice == cancelled:
                 return _SETUP_CANCELLED
             if credential_choice == 0:
-                values["agent"] = _clean_config_value(
-                    prompt(_AGENT_PROMPT_LABEL, default=_DEFAULT_AGENT)
-                ) or _DEFAULT_AGENT
+                values["actor_peer_id"] = _clean_config_value(
+                    prompt(_AGENT_ID_PROMPT_LABEL, default=_DEFAULT_ACTOR_PEER_ID)
+                ) or _DEFAULT_ACTOR_PEER_ID
                 _print_validation_progress("Validating OpenViking local dev access...")
                 valid, message, _role = _validate_openviking_setup_values(values)
                 if valid:
@@ -1491,12 +1531,12 @@ def _prompt_manual_connection_values(prompt, select, cancelled, *, service: bool
                 continue
 
         if prefilled_agent:
-            values["agent"] = prefilled_agent
+            values["actor_peer_id"] = prefilled_agent
             prefilled_agent = ""
         else:
-            values["agent"] = _clean_config_value(
-                prompt(_AGENT_PROMPT_LABEL, default=_DEFAULT_AGENT)
-            ) or _DEFAULT_AGENT
+            values["actor_peer_id"] = _clean_config_value(
+                prompt(_AGENT_ID_PROMPT_LABEL, default=_DEFAULT_ACTOR_PEER_ID)
+            ) or _DEFAULT_ACTOR_PEER_ID
         _print_validation_progress("Validating OpenViking API access...")
         valid, message, role = _validate_openviking_setup_values(
             values,
@@ -1518,7 +1558,7 @@ def _prompt_manual_connection_values(prompt, select, cancelled, *, service: bool
                     )
                     if route_choice == 0:
                         prefilled_api_key = values["api_key"]
-                        prefilled_agent = values["agent"]
+                        prefilled_agent = values["actor_peer_id"]
                         api_key_type = "root"
                         continue
                     if route_choice == 1:
@@ -1559,48 +1599,41 @@ def _link_ovcli_profile(
     env_path: Path,
     ovcli_path: Path,
 ) -> None:
-    for key in ("endpoint", "api_key", "root_api_key", "account", "user", "agent", "api_key_type"):
+    for key in (
+        "url",
+        "api_key",
+        "root_api_key",
+        "account",
+        "user",
+        "actor_peer_id",
+        "api_key_type",
+        "endpoint",
+        "agent",
+    ):
         provider_config.pop(key, None)
     provider_config["use_ovcli_config"] = True
     _remember_ovcli_path(provider_config, ovcli_path)
     _set_openviking_provider(config, provider_config)
-    _write_env_vars(env_path, {}, remove_keys=_OPENVIKING_ENV_KEYS)
-    for key in _OPENVIKING_ENV_KEYS:
+    _write_env_vars(env_path, {}, remove_keys=_OPENVIKING_ENV_KEYS_TO_REMOVE)
+    for key in _OPENVIKING_ENV_KEYS_TO_REMOVE:
         os.environ.pop(key, None)
-
-
-def _save_hermes_only_config(
-    *,
-    config: dict,
-    provider_config: dict,
-    env_path: Path,
-    values: dict,
-) -> None:
-    provider_config["use_ovcli_config"] = False
-    provider_config.pop("ovcli_config_path", None)
-    _set_openviking_provider(config, provider_config)
-    _write_env_vars(
-        env_path,
-        _env_writes_from_connection_values(values),
-        remove_keys=_OPENVIKING_ENV_KEYS,
-    )
 
 
 def _profile_display_name(profile: _OvcliProfile) -> str:
     if profile.source == "env":
         return _OVCLI_CONFIG_ENV
     if profile.source == "active":
-        return "ovcli.conf"
+        return "Current OpenViking config"
     return profile.name
 
 
 def _profile_description(profile: _OvcliProfile) -> str:
-    endpoint = _clean_config_value(profile.values.get("endpoint")) or _DEFAULT_ENDPOINT
+    endpoint = _clean_config_value(profile.values.get("url")) or _DEFAULT_URL
     return f"{endpoint} ({profile.path})"
 
 
 def _validate_profile_for_setup(profile: _OvcliProfile) -> tuple[bool, str, Optional[str]]:
-    require_api_key = not _is_local_openviking_url(profile.values.get("endpoint", ""))
+    require_api_key = not _is_local_openviking_url(profile.values.get("url", ""))
     return _validate_openviking_setup_values(profile.values, require_api_key=require_api_key)
 
 
@@ -1676,7 +1709,7 @@ def _run_existing_profile_setup(
         return _SETUP_CANCELLED
 
 
-def _mirror_manual_config_to_openviking_store(
+def _save_manual_config_to_openviking_profile(
     *,
     prompt,
     select,
@@ -1724,44 +1757,222 @@ def _run_create_profile_setup(
     if values is None:
         return False
 
-    save_choice = select(
-        "  Save OpenViking config",
-        [
-            ("Keep in Hermes only", "write values only to Hermes .env"),
-            ("Mirror to OpenViking store", "write ~/.openviking/ovcli.conf.<name> and link it"),
-        ],
-        default=1,
-        cancel_returns=cancelled,
+    ovcli_path = _save_manual_config_to_openviking_profile(
+        prompt=prompt,
+        select=select,
+        cancelled=cancelled,
+        values=values,
     )
-    if save_choice == cancelled:
+    if ovcli_path is _SETUP_CANCELLED:
         return _SETUP_CANCELLED
 
-    if save_choice == 1:
-        ovcli_path = _mirror_manual_config_to_openviking_store(
-            prompt=prompt,
-            select=select,
-            cancelled=cancelled,
-            values=values,
-        )
-        if ovcli_path is _SETUP_CANCELLED:
-            return _SETUP_CANCELLED
-        _link_ovcli_profile(
-            config=config,
-            provider_config=provider_config,
-            env_path=env_path,
-            ovcli_path=ovcli_path,
-        )
-        _print_openviking_ready("Created and linked OpenViking profile.", ovcli_path)
-        return True
-
-    _save_hermes_only_config(
+    _link_ovcli_profile(
         config=config,
         provider_config=provider_config,
         env_path=env_path,
-        values=values,
+        ovcli_path=ovcli_path,
     )
-    _print_openviking_ready("Connection saved to Hermes .env.")
+    _print_openviking_ready("Created and linked OpenViking profile.", ovcli_path)
     return True
+
+
+def _redact_connection_values(values: dict) -> dict:
+    api_key_type = _clean_config_value(values.get("api_key_type"))
+    if api_key_type not in {"none", "root", "user"}:
+        if _clean_config_value(values.get("root_api_key")):
+            api_key_type = "root"
+        elif _clean_config_value(values.get("api_key")) and (
+            _clean_config_value(values.get("account")) or _clean_config_value(values.get("user"))
+        ):
+            api_key_type = "root"
+        elif _clean_config_value(values.get("api_key")):
+            api_key_type = "user"
+        else:
+            api_key_type = "none"
+
+    return {
+        "url": _normalize_openviking_url(values.get("url")),
+        "api_key": "",
+        "api_key_set": bool(_clean_config_value(values.get("api_key"))),
+        "api_key_type": api_key_type,
+        "account": _clean_config_value(values.get("account")),
+        "user": _clean_config_value(values.get("user")),
+        "actor_peer_id": _clean_config_value(values.get("actor_peer_id")) or _DEFAULT_ACTOR_PEER_ID,
+    }
+
+
+def _desktop_profile_payload(profile: _OvcliProfile) -> dict:
+    values = _redact_connection_values(profile.values)
+    values.pop("api_key", None)
+    values.update({
+        "source": profile.source,
+        "name": profile.name,
+        "display_name": _profile_display_name(profile),
+        "description": _profile_description(profile),
+        "path": str(profile.path),
+        "is_active": profile.is_active,
+    })
+    return values
+
+
+def _desktop_health_payload(values: dict) -> dict:
+    endpoint = _normalize_openviking_url(values.get("url"))
+    ok, message, _role = _validate_openviking_setup_values(
+        values,
+        require_api_key=not _is_local_openviking_url(endpoint),
+    )
+    if ok:
+        return {
+            "status": "healthy",
+            "label": "Healthy",
+            "message": "OpenViking connection is healthy.",
+        }
+
+    reachable, reachability_message = _validate_openviking_reachability(endpoint)
+    if (
+        reachable
+        or reachability_message.startswith(_OPENVIKING_RESPONDED_FAILURE_PREFIX)
+        or "reported unhealthy" in reachability_message
+    ):
+        return {
+            "status": "unhealthy",
+            "label": "Unhealthy",
+            "message": message,
+        }
+
+    return {
+        "status": "unreachable",
+        "label": "Unreachable",
+        "message": reachability_message or message,
+    }
+
+
+def _desktop_missing_profile_health_payload() -> dict:
+    return {
+        "status": "unreachable",
+        "label": "Profile missing",
+        "message": _MISSING_LINKED_PROFILE_MESSAGE,
+    }
+
+
+def _default_connection_values() -> dict:
+    return {
+        "url": _DEFAULT_URL,
+        "api_key": "",
+        "api_key_type": "none",
+        "account": "",
+        "user": "",
+        "actor_peer_id": _DEFAULT_ACTOR_PEER_ID,
+    }
+
+
+def get_desktop_openviking_setup(provider_config: Optional[dict] = None) -> dict:
+    """Return a redacted, non-interactive OpenViking setup snapshot for Desktop."""
+    provider_config = dict(provider_config or {})
+    missing_linked_profile = False
+    active_ovcli_path: Optional[Path] = None
+    if provider_config.get("use_ovcli_config"):
+        active_ovcli_path = _resolve_ovcli_config_path(str(provider_config.get("ovcli_config_path") or ""))
+        missing_linked_profile = not active_ovcli_path.exists() or not active_ovcli_path.is_file()
+    settings = _default_connection_values() if missing_linked_profile else _resolve_connection_settings(provider_config)
+    active = _redact_connection_values(settings)
+    active["source"] = "ovcli" if provider_config.get("use_ovcli_config") else "hermes"
+    if provider_config.get("use_ovcli_config"):
+        active["ovcli_config_path"] = str(active_ovcli_path)
+
+    return {
+        "defaults": {
+            "url": _DEFAULT_URL,
+            "service_url": _OPENVIKING_SERVICE_ENDPOINT,
+            "actor_peer_id": _DEFAULT_ACTOR_PEER_ID,
+        },
+        "active": active,
+        "health": (
+            _desktop_missing_profile_health_payload()
+            if missing_linked_profile
+            else _desktop_health_payload(settings)
+        ),
+        "profiles": [
+            _desktop_profile_payload(profile)
+            for profile in _discover_ovcli_profiles(active_path=active_ovcli_path)
+        ],
+        "legacy_env_present": [
+            key for key in _OPENVIKING_LEGACY_ENV_KEYS if _env_value(key) is not None
+        ],
+        "local_server": {
+            "openviking_server_path": shutil.which("openviking-server") or "",
+        },
+    }
+
+
+def validate_desktop_openviking_setup(
+    values: dict,
+    *,
+    require_api_key: Optional[bool] = None,
+    profile_path: str = "",
+) -> dict:
+    if profile_path:
+        path = Path(profile_path).expanduser()
+        profile = _load_profile(path, source="saved", name=path.name)
+        if profile is None:
+            if not path.exists() or not path.is_file():
+                raise _OpenVikingProfileNotFoundError(f"OpenViking profile file was not found: {path}")
+            raise ValueError("OpenViking profile could not be loaded. Refresh profiles or choose another profile.")
+        values = dict(profile.values)
+    else:
+        values = dict(values or {})
+    if require_api_key is None:
+        require_api_key = not _is_local_openviking_url(values.get("url", ""))
+    ok, message, role = _validate_openviking_setup_values(
+        values,
+        require_api_key=bool(require_api_key),
+    )
+    return {"ok": ok, "message": message, "role": role}
+
+
+def save_desktop_openviking_setup(
+    *,
+    config: dict,
+    hermes_home: str | Path,
+    values: Optional[dict] = None,
+    save_mode: str = "profile",
+    profile_name: str = "",
+    profile_path: str = "",
+) -> dict:
+    """Persist OpenViking setup from Desktop using the same helpers as CLI setup."""
+    values = dict(values or {})
+    provider_config = dict(
+        ((config.get("memory") or {}).get("openviking") or {})
+        if isinstance(config.get("memory"), dict)
+        else {}
+    )
+    env_path = Path(hermes_home).expanduser() / ".env"
+
+    if save_mode != "profile":
+        raise ValueError("save_mode must be 'profile'.")
+
+    if profile_path:
+        path = Path(profile_path).expanduser()
+    else:
+        if not _is_valid_ovcli_profile_name(profile_name):
+            raise ValueError("OpenViking profile name can only contain letters, numbers, '-' and '_'.")
+        path = _ovcli_config_dir() / f"{_OVCLI_SAVED_PREFIX}{profile_name}"
+        _write_ovcli_config(path, values)
+    _link_ovcli_profile(
+        config=config,
+        provider_config=provider_config,
+        env_path=env_path,
+        ovcli_path=path,
+    )
+    return {"ok": True, "mode": "profile", "profile_path": str(path)}
+
+
+def start_desktop_openviking_local(url: str) -> dict:
+    normalized = _normalize_openviking_url(url)
+    if not _is_local_openviking_url(normalized):
+        return {"ok": False, "message": "Only local OpenViking URLs can be started from Desktop."}
+    started, message = _start_local_openviking_server(normalized)
+    return {"ok": started, "message": message}
 
 
 # ---------------------------------------------------------------------------
@@ -1772,15 +1983,31 @@ class OpenVikingMemoryProvider(MemoryProvider):
     """Full bidirectional memory via OpenViking context database."""
 
     def backup_paths(self) -> List[str]:
-        """OpenViking's ovcli config lives at ~/.openviking/ovcli.conf by
-        default (or OPENVIKING_CLI_CONFIG_FILE). Capture the resolved file so
-        endpoint/api-key survive a backup/import cycle."""
+        """Capture OpenViking CLI config files so profile links survive backup."""
         try:
-            cfg = _resolve_ovcli_config_path()
             # The home-scoped guard in the backup walk drops anything outside
             # the user's home; an env override pointing elsewhere is skipped
             # there rather than here.
-            return [str(cfg)]
+            paths: List[Path] = []
+            resolved = _resolve_ovcli_config_path()
+            if resolved.exists():
+                paths.append(resolved)
+
+            config_dir = _ovcli_config_dir()
+            if config_dir.exists():
+                paths.extend(
+                    path
+                    for path in sorted(
+                        (
+                            path
+                            for path in config_dir.iterdir()
+                            if path.is_file() and path.name.startswith("ovcli.conf")
+                        ),
+                        key=lambda path: path.name.lower(),
+                    )
+                    if path not in paths
+                )
+            return [str(path) for path in paths]
         except Exception:
             return []
 
@@ -1823,26 +2050,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return "openviking"
 
     def is_available(self) -> bool:
-        """Check if OpenViking endpoint is configured. No network calls."""
-        if os.environ.get("OPENVIKING_ENDPOINT"):
+        """Check if OpenViking URL is configured. No network calls."""
+        if os.environ.get("OPENVIKING_URL"):
             return True
         provider_config = _load_hermes_openviking_config()
         if not provider_config.get("use_ovcli_config"):
             return False
         try:
             ovcli_path = _resolve_ovcli_config_path(str(provider_config.get("ovcli_config_path") or ""))
-            return bool(_connection_values_from_ovcli(_load_ovcli_config(ovcli_path)).get("endpoint"))
+            return bool(_connection_values_from_ovcli(_load_ovcli_config(ovcli_path)).get("url"))
         except Exception:
             return False
 
     def get_config_schema(self):
         return [
             {
-                "key": "endpoint",
+                "key": "url",
                 "description": "OpenViking server URL",
                 "required": True,
-                "default": _DEFAULT_ENDPOINT,
-                "env_var": "OPENVIKING_ENDPOINT",
+                "default": _DEFAULT_URL,
+                "env_var": "OPENVIKING_URL",
             },
             {
                 "key": "api_key",
@@ -1861,13 +2088,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 "env_var": "OPENVIKING_USER",
             },
             {
-                "key": "agent",
-                "description": (
-                    "Hermes peer ID in OpenViking, sent as the actor peer and "
-                    "used for peer-scoped memories"
-                ),
+                "key": "actor_peer_id",
+                "description": "Agent ID in OpenViking, used for peer-scoped memories",
                 "default": "hermes",
-                "env_var": "OPENVIKING_AGENT",
+                "env_var": "OPENVIKING_ACTOR_PEER_ID",
             },
             {
                 "key": "recall_limit",
@@ -1935,8 +2159,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
             display = {
                 "use_ovcli_config": True,
                 "ovcli_config_path": str(ovcli_path),
-                "endpoint": settings.get("endpoint") or _DEFAULT_ENDPOINT,
-                "agent": settings.get("agent") or _DEFAULT_AGENT,
+                "url": settings.get("url") or _DEFAULT_URL,
+                "actor_peer_id": settings.get("actor_peer_id") or _DEFAULT_ACTOR_PEER_ID,
             }
             if settings.get("account"):
                 display["account"] = settings["account"]
@@ -2060,7 +2284,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 self._api_key,
                 account=self._account,
                 user=self._user,
-                agent=self._agent,
+                actor_peer_id=self._agent,
             )
             if not client.health():
                 _emit_runtime_warning(
@@ -2124,12 +2348,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
         )
 
     def initialize(self, session_id: str, **kwargs) -> None:
-        settings = _resolve_connection_settings(_load_hermes_openviking_config())
-        self._endpoint = settings["endpoint"]
-        self._api_key = settings["api_key"]
-        self._account = settings["account"]
-        self._user = settings["user"]
-        self._agent = settings["agent"]
+        global _last_active_provider
+
         self._session_id = session_id
         self._turn_count = 0
         warning_callback = (
@@ -2142,11 +2362,27 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if kwargs.get("platform") == "cli"
             else None
         )
+        try:
+            settings = _resolve_connection_settings(_load_hermes_openviking_config())
+        except Exception as e:
+            _emit_runtime_warning(
+                f"{_format_openviking_exception(e)} OpenViking memory disabled for this Hermes run.",
+                warning_callback,
+            )
+            self._client = None
+            _last_active_provider = self
+            return
+
+        self._endpoint = settings["url"]
+        self._api_key = settings["api_key"]
+        self._account = settings["account"]
+        self._user = settings["user"]
+        self._agent = settings["actor_peer_id"]
 
         try:
             self._client = _VikingClient(
                 self._endpoint, self._api_key,
-                account=self._account, user=self._user, agent=self._agent,
+                account=self._account, user=self._user, actor_peer_id=self._agent,
             )
             health_state, health_message = _classify_runtime_openviking_health(self._client, self._endpoint)
             if health_state == "unreachable":
@@ -2165,7 +2401,6 @@ class OpenVikingMemoryProvider(MemoryProvider):
             self._client = None
 
         # Register as the last active provider for atexit safety net
-        global _last_active_provider
         _last_active_provider = self
 
     def system_prompt_block(self) -> str:
@@ -2362,7 +2597,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             self._api_key,
             account=self._account,
             user=self._user,
-            agent=self._agent,
+            actor_peer_id=self._agent,
         )
 
     @staticmethod
@@ -2505,7 +2740,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 self._api_key,
                 account=self._account,
                 user=self._user,
-                agent=self._agent,
+                actor_peer_id=self._agent,
             )
             cfg = self._recall_config()
             candidate_limit = max(cfg["limit"] * 4, 20)
@@ -3067,7 +3302,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
                     break
         batch_messages = self._messages_to_openviking_batch(
             turn_messages,
-            assistant_peer_id=getattr(self, "_agent", _DEFAULT_AGENT),
+            assistant_peer_id=getattr(self, "_agent", _DEFAULT_ACTOR_PEER_ID),
         )
 
         if _sync_trace_enabled():
@@ -3255,7 +3490,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             try:
                 client = _VikingClient(
                     self._endpoint, self._api_key,
-                    account=self._account, user=self._user, agent=self._agent,
+                    account=self._account, user=self._user, actor_peer_id=self._agent,
                 )
                 client.post("/api/v1/content/write", {
                     "uri": uri,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -462,6 +462,254 @@ class TestWebServerEndpoints:
         assert fields["api_key"]["value"] == ""
         assert "secret-value" not in json.dumps(data)
 
+    def test_get_openviking_setup_returns_plugin_payload(self, monkeypatch):
+        from hermes_cli.config import load_config, save_config
+        import plugins.memory.openviking as openviking_module
+
+        config = load_config()
+        config.setdefault("memory", {})["openviking"] = {
+            "use_ovcli_config": True,
+            "ovcli_config_path": "/tmp/ovcli.conf",
+        }
+        save_config(config)
+        seen = {}
+
+        def fake_setup(provider_config):
+            seen["provider_config"] = provider_config
+            return {
+                "defaults": {
+                    "url": "http://127.0.0.1:1933",
+                    "service_url": "https://service.example",
+                    "actor_peer_id": "hermes",
+                },
+                "active": {"source": "ovcli", "url": "https://vps.example"},
+                "profiles": [],
+                "legacy_env_present": [],
+            }
+
+        monkeypatch.setattr(openviking_module, "get_desktop_openviking_setup", fake_setup)
+
+        resp = self.client.get("/api/memory/providers/openviking/setup")
+
+        assert resp.status_code == 200
+        assert seen["provider_config"] == {
+            "use_ovcli_config": True,
+            "ovcli_config_path": "/tmp/ovcli.conf",
+        }
+        assert resp.json()["active"] == {"source": "ovcli", "url": "https://vps.example"}
+
+    def test_get_openviking_setup_reads_requested_profile_config(self, monkeypatch):
+        from hermes_constants import get_hermes_home
+        from hermes_cli import profiles
+        import plugins.memory.openviking as openviking_module
+
+        default_home = get_hermes_home()
+        profiles_root = default_home / "profiles"
+        worker_home = profiles_root / "worker_alpha"
+        worker_home.mkdir(parents=True, exist_ok=True)
+        (worker_home / "config.yaml").write_text(
+            yaml.safe_dump({
+                "memory": {
+                    "provider": "openviking",
+                    "openviking": {
+                        "use_ovcli_config": True,
+                        "ovcli_config_path": "/tmp/worker-ovcli.conf",
+                    },
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+        monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+        seen = {}
+
+        def fake_setup(provider_config):
+            seen["provider_config"] = provider_config
+            return {
+                "defaults": {
+                    "url": "http://127.0.0.1:1933",
+                    "service_url": "https://service.example",
+                    "actor_peer_id": "hermes",
+                },
+                "active": {"source": "ovcli", "url": "https://worker.example"},
+                "profiles": [],
+                "legacy_env_present": [],
+            }
+
+        monkeypatch.setattr(openviking_module, "get_desktop_openviking_setup", fake_setup)
+
+        resp = self.client.get(
+            "/api/memory/providers/openviking/setup",
+            params={"profile": "worker_alpha"},
+        )
+
+        assert resp.status_code == 200
+        assert seen["provider_config"] == {
+            "use_ovcli_config": True,
+            "ovcli_config_path": "/tmp/worker-ovcli.conf",
+        }
+        assert resp.json()["active"] == {"source": "ovcli", "url": "https://worker.example"}
+
+    def test_put_openviking_setup_rejects_hermes_only_save_mode(self):
+        resp = self.client.put(
+            "/api/memory/providers/openviking/setup",
+            json={
+                "save_mode": "hermes",
+                "values": {
+                    "url": "https://openviking.example",
+                    "api_key": "ov-secret",
+                    "actor_peer_id": "agent",
+                },
+            },
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "save_mode must be 'profile'."
+
+    def test_put_openviking_setup_writes_openviking_profile_and_selects_provider(self, monkeypatch, tmp_path):
+        from hermes_cli.config import load_config, load_env
+        import plugins.memory.openviking as openviking_module
+
+        monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+
+        resp = self.client.put(
+            "/api/memory/providers/openviking/setup",
+            json={
+                "save_mode": "profile",
+                "profile_name": "VPS",
+                "values": {
+                    "url": "https://openviking.example",
+                    "api_key": "ov-secret",
+                    "actor_peer_id": "agent",
+                },
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        profile_path = tmp_path / ".openviking" / "ovcli.conf.VPS"
+        assert resp.json()["profile_path"] == str(profile_path)
+        assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+            "url": "https://openviking.example",
+            "api_key": "ov-secret",
+            "actor_peer_id": "agent",
+        }
+        config = load_config()
+        assert config["memory"]["provider"] == "openviking"
+        assert config["memory"]["openviking"] == {
+            "use_ovcli_config": True,
+            "ovcli_config_path": str(profile_path),
+        }
+        env = load_env()
+        assert "OPENVIKING_URL" not in env
+        assert "OPENVIKING_API_KEY" not in env
+        assert "OPENVIKING_ACTOR_PEER_ID" not in env
+        assert "OPENVIKING_ENDPOINT" not in env
+        assert "OPENVIKING_AGENT" not in env
+
+    def test_put_openviking_setup_writes_requested_profile_config(self, monkeypatch, tmp_path):
+        from hermes_constants import get_hermes_home
+        from hermes_cli import profiles
+        import plugins.memory.openviking as openviking_module
+
+        default_home = get_hermes_home()
+        profiles_root = default_home / "profiles"
+        worker_home = profiles_root / "worker_alpha"
+        worker_home.mkdir(parents=True, exist_ok=True)
+        (default_home / "config.yaml").write_text(
+            yaml.safe_dump({"memory": {"provider": "builtin"}}),
+            encoding="utf-8",
+        )
+        (worker_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+        (worker_home / ".env").write_text(
+            "OPENVIKING_ENDPOINT=http://legacy.local\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+        monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+        monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+
+        resp = self.client.put(
+            "/api/memory/providers/openviking/setup",
+            params={"profile": "worker_alpha"},
+            json={
+                "save_mode": "profile",
+                "profile_name": "VPS",
+                "values": {
+                    "url": "https://openviking.example",
+                    "api_key": "ov-secret",
+                    "actor_peer_id": "agent",
+                },
+            },
+        )
+
+        assert resp.status_code == 200
+        profile_path = tmp_path / ".openviking" / "ovcli.conf.VPS"
+        worker_config = yaml.safe_load((worker_home / "config.yaml").read_text(encoding="utf-8"))
+        assert worker_config["memory"]["provider"] == "openviking"
+        assert worker_config["memory"]["openviking"] == {
+            "use_ovcli_config": True,
+            "ovcli_config_path": str(profile_path),
+        }
+        root_config = yaml.safe_load((default_home / "config.yaml").read_text(encoding="utf-8"))
+        assert root_config == {"memory": {"provider": "builtin"}}
+        assert "OPENVIKING_ENDPOINT" not in (worker_home / ".env").read_text(encoding="utf-8")
+
+    def test_post_openviking_validate_delegates_to_plugin(self, monkeypatch):
+        import plugins.memory.openviking as openviking_module
+
+        seen = {}
+
+        def fake_validate(values, *, require_api_key=None, profile_path=""):
+            seen["values"] = values
+            seen["require_api_key"] = require_api_key
+            seen["profile_path"] = profile_path
+            return {"ok": True, "message": "", "role": "user"}
+
+        monkeypatch.setattr(openviking_module, "validate_desktop_openviking_setup", fake_validate)
+
+        resp = self.client.post(
+            "/api/memory/providers/openviking/validate",
+            json={
+                "values": {
+                    "url": "https://openviking.example",
+                    "actor_peer_id": "agent",
+                },
+                "require_api_key": True,
+                "profile_path": "/tmp/ovcli.conf.VPS",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "message": "", "role": "user"}
+        assert seen == {
+            "values": {"url": "https://openviking.example", "actor_peer_id": "agent"},
+            "require_api_key": True,
+            "profile_path": "/tmp/ovcli.conf.VPS",
+        }
+
+    def test_post_openviking_start_local_delegates_to_plugin(self, monkeypatch):
+        import plugins.memory.openviking as openviking_module
+
+        monkeypatch.setattr(
+            openviking_module,
+            "start_desktop_openviking_local",
+            lambda url: {"ok": False, "message": f"missing server for {url}"},
+        )
+
+        resp = self.client.post(
+            "/api/memory/providers/openviking/start-local",
+            json={"url": "http://localhost:1933"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ok": False,
+            "message": "missing server for http://localhost:1933",
+        }
+
     def test_get_moa_models_returns_provider_model_slots(self):
         resp = self.client.get("/api/model/moa")
         assert resp.status_code == 200

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -1032,10 +1032,10 @@ class TestOpenVikingAutoRecallPrefetch:
             "OPENVIKING_API_KEY",
         ):
             monkeypatch.delenv(key, raising=False)
-        monkeypatch.setenv("OPENVIKING_ENDPOINT", endpoint)
+        monkeypatch.setenv("OPENVIKING_URL", endpoint)
         monkeypatch.setenv("OPENVIKING_ACCOUNT", "acct")
         monkeypatch.setenv("OPENVIKING_USER", "user")
-        monkeypatch.setenv("OPENVIKING_AGENT", "hermes")
+        monkeypatch.setenv("OPENVIKING_ACTOR_PEER_ID", "hermes")
 
         provider = OpenVikingMemoryProvider()
         try:

--- a/tests/plugins/memory/test_openviking_backup_paths.py
+++ b/tests/plugins/memory/test_openviking_backup_paths.py
@@ -1,0 +1,20 @@
+def test_openviking_backup_paths_include_named_ovcli_profiles(tmp_path, monkeypatch):
+    import plugins.memory.openviking as openviking_module
+    from plugins.memory.openviking import OpenVikingMemoryProvider
+
+    openviking_home = tmp_path / ".openviking"
+    openviking_home.mkdir()
+    active_path = openviking_home / "ovcli.conf"
+    backup_path = openviking_home / "ovcli.conf.bak"
+    saved_path = openviking_home / "ovcli.conf.VPS"
+    active_path.write_text("{}", encoding="utf-8")
+    backup_path.write_text("{}", encoding="utf-8")
+    saved_path.write_text("{}", encoding="utf-8")
+    (openviking_home / "other.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+
+    paths = OpenVikingMemoryProvider().backup_paths()
+
+    assert paths == [str(active_path), str(backup_path), str(saved_path)]
+

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -17,7 +17,7 @@ from plugins.memory.openviking import (
 
 
 def _clear_openviking_tenant_env(monkeypatch):
-    for name in ("OPENVIKING_ACCOUNT", "OPENVIKING_USER", "OPENVIKING_AGENT"):
+    for name in ("OPENVIKING_ACCOUNT", "OPENVIKING_USER", "OPENVIKING_ACTOR_PEER_ID"):
         monkeypatch.delenv(name, raising=False)
 
 
@@ -30,10 +30,12 @@ def _isolate_openviking_home(tmp_path, monkeypatch):
 def _clear_openviking_env(monkeypatch):
     for key in (
         "OPENVIKING_ENDPOINT",
+        "OPENVIKING_URL",
         "OPENVIKING_API_KEY",
         "OPENVIKING_ACCOUNT",
         "OPENVIKING_USER",
         "OPENVIKING_AGENT",
+        "OPENVIKING_ACTOR_PEER_ID",
         "OPENVIKING_CLI_CONFIG_FILE",
     ):
         monkeypatch.delenv(key, raising=False)
@@ -96,10 +98,485 @@ def test_ovcli_config_writer_restricts_file_permissions(tmp_path):
 
     openviking_module._write_ovcli_config(
         config_path,
-        {"endpoint": "http://remote.example", "api_key": "secret"},
+        {"url": "http://remote.example", "api_key": "secret"},
     )
 
     assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+
+
+def test_openviking_config_uses_canonical_url_and_actor_peer_env(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    ovcli_path = tmp_path / "ovcli.conf"
+    ovcli_path.write_text(
+        json.dumps({
+            "url": "http://profile.local",
+            "api_key": "profile-key",
+            "actor_peer_id": "profile-agent",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENVIKING_URL", "http://env.local")
+    monkeypatch.setenv("OPENVIKING_ACTOR_PEER_ID", "env-agent")
+
+    settings = openviking_module._resolve_connection_settings({
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(ovcli_path),
+    })
+
+    assert settings["url"] == "http://env.local"
+    assert settings["actor_peer_id"] == "env-agent"
+    assert "endpoint" not in settings
+    assert "agent" not in settings
+
+
+def test_openviking_legacy_env_names_are_not_runtime_aliases(monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://legacy.local")
+    monkeypatch.setenv("OPENVIKING_AGENT", "legacy-agent")
+
+    settings = openviking_module._resolve_connection_settings({})
+
+    assert settings["url"] == openviking_module._DEFAULT_URL
+    assert settings["actor_peer_id"] == openviking_module._DEFAULT_ACTOR_PEER_ID
+
+
+def test_openviking_desktop_setup_redacts_secrets_and_reports_profiles(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_setup_values",
+        lambda values, *, require_api_key=False: (True, "", "user"),
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_reachability",
+        lambda endpoint: (True, ""),
+    )
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text(
+        "OPENVIKING_URL=http://hermes.local\n"
+        "OPENVIKING_API_KEY=hermes-secret\n"
+        "OPENVIKING_ACTOR_PEER_ID=hermes-agent\n"
+        "OPENVIKING_ENDPOINT=http://legacy.local\n",
+        encoding="utf-8",
+    )
+    openviking_home = tmp_path / ".openviking"
+    openviking_home.mkdir()
+    saved_path = openviking_home / "ovcli.conf.VPS"
+    saved_path.write_text(
+        json.dumps({
+            "url": "https://vps.example",
+            "api_key": "profile-secret",
+            "actor_peer_id": "profile-agent",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OPENVIKING_URL", "http://hermes.local")
+    monkeypatch.setenv("OPENVIKING_API_KEY", "hermes-secret")
+    monkeypatch.setenv("OPENVIKING_ACTOR_PEER_ID", "hermes-agent")
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://legacy.local")
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+
+    payload = openviking_module.get_desktop_openviking_setup({"use_ovcli_config": False})
+
+    assert payload["defaults"] == {
+        "url": openviking_module._DEFAULT_URL,
+        "service_url": openviking_module._OPENVIKING_SERVICE_ENDPOINT,
+        "actor_peer_id": openviking_module._DEFAULT_ACTOR_PEER_ID,
+    }
+    assert payload["active"]["source"] == "hermes"
+    assert payload["active"]["url"] == "http://hermes.local"
+    assert payload["active"]["api_key_set"] is True
+    assert payload["active"]["api_key"] == ""
+    assert payload["active"]["actor_peer_id"] == "hermes-agent"
+    assert payload["health"] == {
+        "status": "healthy",
+        "label": "Healthy",
+        "message": "OpenViking connection is healthy.",
+    }
+    assert payload["legacy_env_present"] == ["OPENVIKING_ENDPOINT"]
+    assert payload["profiles"] == [{
+        "source": "saved",
+        "name": "VPS",
+        "display_name": "VPS",
+        "description": f"https://vps.example ({saved_path})",
+        "path": str(saved_path),
+        "url": "https://vps.example",
+        "api_key_set": True,
+        "api_key_type": "user",
+        "account": "",
+        "user": "",
+        "actor_peer_id": "profile-agent",
+        "is_active": False,
+    }]
+
+
+def test_openviking_desktop_setup_marks_hermes_linked_profile_active_by_path(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_setup_values",
+        lambda values, *, require_api_key=False: (
+            False,
+            "OpenViking validation failed: AuthenticationError: invalid key",
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_reachability",
+        lambda endpoint: (False, "OpenViking server responded but reported unhealthy status."),
+    )
+    openviking_home = tmp_path / ".openviking"
+    openviking_home.mkdir()
+    linked_path = openviking_home / "ovcli.conf.serverless"
+    default_path = openviking_home / "ovcli.conf"
+    volcano_path = openviking_home / "ovcli.conf.volcano_studio"
+
+    linked_path.write_text(
+        json.dumps({
+            "url": "https://serverless.example/openviking",
+            "api_key": "serverless-secret",
+            "actor_peer_id": "hermes",
+        }),
+        encoding="utf-8",
+    )
+    default_profile = {
+        "url": "https://volcano.example/openviking",
+        "api_key": "volcano-secret",
+        "actor_peer_id": "hermes",
+    }
+    default_path.write_text(json.dumps(default_profile), encoding="utf-8")
+    volcano_path.write_text(json.dumps(default_profile), encoding="utf-8")
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+
+    payload = openviking_module.get_desktop_openviking_setup({
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(linked_path),
+    })
+
+    assert payload["active"]["source"] == "ovcli"
+    assert payload["active"]["ovcli_config_path"] == str(linked_path)
+    assert payload["health"] == {
+        "status": "unhealthy",
+        "label": "Unhealthy",
+        "message": "OpenViking validation failed: AuthenticationError: invalid key",
+    }
+    profile_states = {profile["name"]: profile["is_active"] for profile in payload["profiles"]}
+    assert profile_states == {
+        "serverless": True,
+        "volcano_studio": False,
+    }
+
+
+def test_openviking_desktop_setup_labels_default_active_config_without_filename(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_setup_values",
+        lambda values, *, require_api_key=False: (True, "", "user"),
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_reachability",
+        lambda endpoint: (True, ""),
+    )
+    openviking_home = tmp_path / ".openviking"
+    openviking_home.mkdir()
+    active_path = openviking_home / "ovcli.conf"
+    saved_path = openviking_home / "ovcli.conf.VPS"
+    active_path.write_text(
+        json.dumps({
+            "url": "https://active.example/openviking",
+            "api_key": "active-secret",
+            "actor_peer_id": "hermes",
+        }),
+        encoding="utf-8",
+    )
+    saved_path.write_text(
+        json.dumps({
+            "url": "https://vps.example/openviking",
+            "api_key": "vps-secret",
+            "actor_peer_id": "hermes",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+
+    payload = openviking_module.get_desktop_openviking_setup({
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(active_path),
+    })
+
+    active_profile = next(profile for profile in payload["profiles"] if profile["is_active"])
+    assert active_profile["source"] == "active"
+    assert active_profile["display_name"] == "Current OpenViking config"
+    assert "ovcli.conf" not in active_profile["display_name"]
+
+
+def test_openviking_desktop_setup_uses_authenticated_profile_health(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_setup_values",
+        lambda values, *, require_api_key=False: (True, "", "user"),
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_reachability",
+        lambda endpoint: (False, "OpenViking server responded with AuthenticationError: missing key."),
+    )
+    openviking_home = tmp_path / ".openviking"
+    openviking_home.mkdir()
+    linked_path = openviking_home / "ovcli.conf.openstudio"
+    linked_path.write_text(
+        json.dumps({
+            "url": "https://api.vikingdb.cn-beijing.volces.com/openviking",
+            "api_key": "service-secret",
+            "actor_peer_id": "hermes",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+
+    payload = openviking_module.get_desktop_openviking_setup({
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(linked_path),
+    })
+
+    assert payload["active"]["source"] == "ovcli"
+    assert payload["active"]["api_key_set"] is True
+    assert payload["health"] == {
+        "status": "healthy",
+        "label": "Healthy",
+        "message": "OpenViking connection is healthy.",
+    }
+
+
+def test_openviking_desktop_setup_reports_missing_linked_profile(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    openviking_home = tmp_path / ".openviking"
+    openviking_home.mkdir()
+    active_path = openviking_home / "ovcli.conf"
+    active_path.write_text(
+        json.dumps({
+            "url": "https://active.example/openviking",
+            "api_key": "active-secret",
+            "actor_peer_id": "hermes",
+        }),
+        encoding="utf-8",
+    )
+    missing_path = openviking_home / "ovcli.conf.openstudio"
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_setup_values",
+        lambda values, *, require_api_key=False: pytest.fail("missing profile should not be probed"),
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_reachability",
+        lambda endpoint: pytest.fail("missing profile should not be probed"),
+    )
+
+    payload = openviking_module.get_desktop_openviking_setup({
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(missing_path),
+    })
+
+    assert payload["active"]["source"] == "ovcli"
+    assert payload["active"]["ovcli_config_path"] == str(missing_path)
+    assert payload["health"] == {
+        "status": "unreachable",
+        "label": "Profile missing",
+        "message": "The linked OpenViking profile file no longer exists. Choose another profile or recreate it.",
+    }
+    assert [(profile["source"], profile["path"], profile["is_active"]) for profile in payload["profiles"]] == [
+        ("active", str(active_path), False),
+    ]
+
+
+def test_openviking_desktop_setup_reports_unreachable_health(monkeypatch):
+    _clear_openviking_env(monkeypatch)
+
+    def unreachable(endpoint):
+        return False, f"OpenViking server is not reachable at {endpoint}: [Errno 61] Connection refused"
+
+    monkeypatch.setattr(openviking_module, "_validate_openviking_reachability", unreachable)
+    monkeypatch.setenv("OPENVIKING_URL", "http://127.0.0.1:1934")
+
+    payload = openviking_module.get_desktop_openviking_setup({"use_ovcli_config": False})
+
+    assert payload["health"] == {
+        "status": "unreachable",
+        "label": "Unreachable",
+        "message": "OpenViking server is not reachable at http://127.0.0.1:1934: [Errno 61] Connection refused",
+    }
+
+
+def test_openviking_desktop_validate_profile_path_uses_profile_secret(tmp_path, monkeypatch):
+    profile_path = tmp_path / "ovcli.conf.VPS"
+    profile_path.write_text(
+        json.dumps({
+            "url": "https://vps.example/openviking",
+            "api_key": "profile-secret",
+            "actor_peer_id": "profile-agent",
+        }),
+        encoding="utf-8",
+    )
+    captured: dict[str, object] = {}
+
+    def validate_values(values, *, require_api_key):
+        captured["values"] = values
+        captured["require_api_key"] = require_api_key
+        return True, "ok", "user"
+
+    monkeypatch.setattr(openviking_module, "_validate_openviking_setup_values", validate_values)
+
+    result = openviking_module.validate_desktop_openviking_setup({}, profile_path=str(profile_path))
+
+    assert result == {"ok": True, "message": "ok", "role": "user"}
+    assert captured["require_api_key"] is True
+    assert captured["values"]["url"] == "https://vps.example/openviking"
+    assert captured["values"]["api_key"] == "profile-secret"
+    assert captured["values"]["account"] == ""
+    assert captured["values"]["user"] == ""
+    assert captured["values"]["actor_peer_id"] == "profile-agent"
+
+
+def test_openviking_desktop_validate_missing_profile_path_reports_missing_file(tmp_path, monkeypatch):
+    missing_path = tmp_path / "ovcli.conf.missing"
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_setup_values",
+        lambda values, *, require_api_key=False: pytest.fail("missing profile should not be probed"),
+    )
+
+    with pytest.raises(ValueError, match="OpenViking profile file was not found"):
+        openviking_module.validate_desktop_openviking_setup({}, profile_path=str(missing_path))
+
+
+def test_openviking_desktop_save_rejects_hermes_only_mode(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    env_path = hermes_home / ".env"
+    env_path.write_text(
+        "OPENVIKING_URL=http://old.local\n"
+        "OPENVIKING_API_KEY=existing-secret\n"
+        "OPENVIKING_ACTOR_PEER_ID=old-agent\n",
+        encoding="utf-8",
+    )
+
+    config = {"memory": {"openviking": {}}}
+
+    with pytest.raises(ValueError, match="save_mode must be 'profile'"):
+        openviking_module.save_desktop_openviking_setup(
+            config=config,
+            hermes_home=hermes_home,
+            values={
+                "url": "https://api.vikingdb.cn-beijing.volces.com/openviking",
+                "actor_peer_id": "agent",
+            },
+            save_mode="hermes",
+        )
+
+    env = env_path.read_text(encoding="utf-8")
+    assert "OPENVIKING_URL=http://old.local" in env
+    assert "OPENVIKING_API_KEY=existing-secret" in env
+    assert "OPENVIKING_ACTOR_PEER_ID=old-agent" in env
+
+
+def test_openviking_desktop_save_profile_clears_stale_env_values(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+    env_path = hermes_home / ".env"
+    env_path.write_text(
+        "OPENVIKING_URL=http://old.local\n"
+        "OPENVIKING_API_KEY=existing-secret\n"
+        "OPENVIKING_ACTOR_PEER_ID=old-agent\n",
+        encoding="utf-8",
+    )
+
+    config = {"memory": {"openviking": {}}}
+
+    result = openviking_module.save_desktop_openviking_setup(
+        config=config,
+        hermes_home=hermes_home,
+        values={
+            "url": "http://127.0.0.1:1933",
+            "api_key": "",
+            "actor_peer_id": "agent",
+        },
+        save_mode="profile",
+        profile_name="local",
+    )
+
+    profile_path = tmp_path / ".openviking" / "ovcli.conf.local"
+    assert result == {"ok": True, "mode": "profile", "profile_path": str(profile_path)}
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "http://127.0.0.1:1933",
+        "actor_peer_id": "agent",
+    }
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
+    env = env_path.read_text(encoding="utf-8")
+    assert "OPENVIKING_" not in env
+
+
+def test_openviking_desktop_save_profile_persists_root_api_key_metadata(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_setup_values",
+        lambda values, *, require_api_key=False: (True, "", "root"),
+    )
+
+    config = {"memory": {"openviking": {}}}
+
+    result = openviking_module.save_desktop_openviking_setup(
+        config=config,
+        hermes_home=hermes_home,
+        values={
+            "url": "https://vps.example",
+            "api_key": "root-secret",
+            "api_key_type": "root",
+            "account": "acct",
+            "user": "alice",
+            "actor_peer_id": "agent",
+        },
+        save_mode="profile",
+        profile_name="VPS_ROOT",
+    )
+
+    profile_path = tmp_path / ".openviking" / "ovcli.conf.VPS_ROOT"
+    assert result == {"ok": True, "mode": "profile", "profile_path": str(profile_path)}
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "https://vps.example",
+        "api_key": "root-secret",
+        "root_api_key": "root-secret",
+        "account": "acct",
+        "user": "alice",
+        "actor_peer_id": "agent",
+    }
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
+
+    payload = openviking_module.get_desktop_openviking_setup(config["memory"]["openviking"])
+    assert payload["active"]["api_key_type"] == "root"
+    assert payload["active"]["account"] == "acct"
+    assert payload["active"]["user"] == "alice"
 
 
 def test_secret_permission_restriction_logs_chmod_failure(tmp_path, monkeypatch, caplog):
@@ -136,11 +613,12 @@ def test_linked_ovcli_config_is_read_at_runtime(tmp_path, monkeypatch):
     settings = openviking_module._resolve_connection_settings(provider_config)
 
     assert settings == {
-        "endpoint": "http://openviking-one.local",
+        "url": "http://openviking-one.local",
         "api_key": "key-one",
+        "api_key_type": "user",
         "account": "",
         "user": "",
-        "agent": "agent-one",
+        "actor_peer_id": "agent-one",
     }
 
     ovcli_path.write_text(
@@ -155,11 +633,12 @@ def test_linked_ovcli_config_is_read_at_runtime(tmp_path, monkeypatch):
     settings = openviking_module._resolve_connection_settings(provider_config)
 
     assert settings == {
-        "endpoint": "http://openviking-two.local",
+        "url": "http://openviking-two.local",
         "api_key": "key-two",
+        "api_key_type": "user",
         "account": "",
         "user": "",
-        "agent": "agent-two",
+        "actor_peer_id": "agent-two",
     }
 
 
@@ -176,11 +655,11 @@ def test_openviking_env_overrides_linked_ovcli_config(tmp_path, monkeypatch):
         }),
         encoding="utf-8",
     )
-    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://env.local")
+    monkeypatch.setenv("OPENVIKING_URL", "http://env.local")
     monkeypatch.setenv("OPENVIKING_API_KEY", "env-key")
     monkeypatch.setenv("OPENVIKING_ACCOUNT", "env-account")
     monkeypatch.setenv("OPENVIKING_USER", "env-user")
-    monkeypatch.setenv("OPENVIKING_AGENT", "env-agent")
+    monkeypatch.setenv("OPENVIKING_ACTOR_PEER_ID", "env-agent")
 
     settings = openviking_module._resolve_connection_settings({
         "use_ovcli_config": True,
@@ -188,11 +667,12 @@ def test_openviking_env_overrides_linked_ovcli_config(tmp_path, monkeypatch):
     })
 
     assert settings == {
-        "endpoint": "http://env.local",
+        "url": "http://env.local",
         "api_key": "env-key",
+        "api_key_type": "",
         "account": "env-account",
         "user": "env-user",
-        "agent": "env-agent",
+        "actor_peer_id": "env-agent",
     }
 
 
@@ -215,7 +695,7 @@ def test_openviking_cli_config_env_overrides_saved_profile_path(tmp_path, monkey
         "ovcli_config_path": str(saved_path),
     })
 
-    assert settings["endpoint"] == "http://env-profile.local"
+    assert settings["url"] == "http://env-profile.local"
     assert settings["api_key"] == "env-profile-key"
 
 
@@ -272,11 +752,11 @@ def test_link_ovcli_profile_removes_stale_inline_config(tmp_path):
     config = {"memory": {}}
     provider_config = {
         "use_ovcli_config": False,
-        "endpoint": "http://stale.local",
+        "url": "http://stale.local",
         "api_key": "stale-key",
         "account": "default",
         "user": "default",
-        "agent": "stale-agent",
+        "actor_peer_id": "stale-agent",
         "api_key_type": "root",
     }
     ovcli_path = tmp_path / "ovcli.conf.VPS_ROOT"
@@ -335,12 +815,13 @@ def test_post_setup_existing_profile_picker_validates_and_links_saved_profile(tm
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
     assert validate_calls == [{
-        "endpoint": "https://vps.example",
+        "url": "https://vps.example",
         "api_key": "user-key",
         "root_api_key": "",
+        "api_key_type": "user",
         "account": "",
         "user": "",
-        "agent": "",
+        "actor_peer_id": "",
     }]
     assert config["memory"]["provider"] == "openviking"
     assert config["memory"]["openviking"] == {
@@ -352,7 +833,7 @@ def test_post_setup_existing_profile_picker_validates_and_links_saved_profile(tm
     assert "OTHER_KEY=keep" in env_text
 
 
-def test_post_setup_create_remote_user_profile_can_mirror_to_openviking_store(tmp_path, monkeypatch):
+def test_post_setup_create_remote_user_profile_creates_openviking_profile(tmp_path, monkeypatch):
     _clear_openviking_env(monkeypatch)
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
@@ -362,15 +843,21 @@ def test_post_setup_create_remote_user_profile_can_mirror_to_openviking_store(tm
 
     from hermes_cli import memory_setup
 
-    choices = iter([1, 0, 1])
-    monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
+    select_titles = []
+
+    def select(title, *args, **kwargs):
+        select_titles.append(title)
+        return next(choices)
+
+    choices = iter([1, 0])
+    monkeypatch.setattr(memory_setup, "_curses_select", select)
     monkeypatch.setattr(
         memory_setup,
         "_prompt",
         _prompt_from_values({
             "OpenViking server URL": "https://openviking.example",
             "OpenViking user API key": "user-secret",
-            "Hermes peer ID in OpenViking": "hermes",
+            "Agent ID": "hermes",
             "OpenViking profile name": "VPS",
         }),
     )
@@ -378,9 +865,9 @@ def test_post_setup_create_remote_user_profile_can_mirror_to_openviking_store(tm
 
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
-    mirrored_path = tmp_path / ".openviking" / "ovcli.conf.VPS"
-    assert mirrored_path.exists()
-    assert json.loads(mirrored_path.read_text(encoding="utf-8")) == {
+    profile_path = tmp_path / ".openviking" / "ovcli.conf.VPS"
+    assert profile_path.exists()
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
         "url": "https://openviking.example",
         "api_key": "user-secret",
         "actor_peer_id": "hermes",
@@ -388,44 +875,61 @@ def test_post_setup_create_remote_user_profile_can_mirror_to_openviking_store(tm
     assert config["memory"]["provider"] == "openviking"
     assert config["memory"]["openviking"] == {
         "use_ovcli_config": True,
-        "ovcli_config_path": str(mirrored_path),
+        "ovcli_config_path": str(profile_path),
     }
     env_path = hermes_home / ".env"
     if env_path.exists():
         assert "OPENVIKING_" not in env_path.read_text(encoding="utf-8")
+    assert "  Save OpenViking config" not in select_titles
 
 
-def test_post_setup_create_remote_user_can_keep_hermes_only(tmp_path, monkeypatch):
+def test_post_setup_create_remote_user_always_links_openviking_profile(tmp_path, monkeypatch):
     _clear_openviking_env(monkeypatch)
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
     _allow_setup_validation(monkeypatch)
 
     from hermes_cli import memory_setup
 
-    choices = iter([1, 0, 0])
-    monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
+    select_titles = []
+
+    def select(title, *args, **kwargs):
+        select_titles.append(title)
+        return next(choices)
+
+    choices = iter([1, 0])
+    monkeypatch.setattr(memory_setup, "_curses_select", select)
     monkeypatch.setattr(
         memory_setup,
         "_prompt",
         _prompt_from_values({
             "OpenViking server URL": "https://openviking.example",
             "OpenViking user API key": "user-secret",
-            "Hermes peer ID in OpenViking": "agent",
+            "Agent ID": "agent",
+            "OpenViking profile name": "VPS",
         }),
     )
     config = {"memory": {}}
 
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
+    profile_path = tmp_path / ".openviking" / "ovcli.conf.VPS"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "https://openviking.example",
+        "api_key": "user-secret",
+        "actor_peer_id": "agent",
+    }
     assert config["memory"]["provider"] == "openviking"
-    assert config["memory"]["openviking"] == {"use_ovcli_config": False}
-    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
-    assert "OPENVIKING_ENDPOINT=https://openviking.example" in env_text
-    assert "OPENVIKING_API_KEY=user-secret" in env_text
-    assert "OPENVIKING_AGENT=agent" in env_text
-    assert not (tmp_path / "home" / ".openviking").exists()
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
+    assert "  Save OpenViking config" not in select_titles
+    env_path = hermes_home / ".env"
+    if env_path.exists():
+        assert "OPENVIKING_" not in env_path.read_text(encoding="utf-8")
 
 
 def test_post_setup_create_openviking_service_validates_after_api_key(tmp_path, monkeypatch):
@@ -448,16 +952,18 @@ def test_post_setup_create_openviking_service_validates_after_api_key(tmp_path, 
         MagicMock(side_effect=AssertionError("service setup validates only after API key entry")),
     )
     monkeypatch.setattr(openviking_module, "_validate_openviking_setup_values", validate_values)
-    choices = iter([0, 0])
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
+    choices = iter([0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     monkeypatch.setattr(
         memory_setup,
         "_prompt",
         _prompt_from_values(
-            {
-                "OpenViking API key": "service-secret",
-                "Hermes peer ID in OpenViking": "agent",
-            },
+                {
+                    "OpenViking API key": "service-secret",
+                    "Agent ID": "agent",
+                    "OpenViking profile name": "service",
+                },
             forbidden={"OpenViking server URL", "OpenViking user API key", "OpenViking root API key"},
         ),
     )
@@ -466,21 +972,27 @@ def test_post_setup_create_openviking_service_validates_after_api_key(tmp_path, 
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
     assert validation_calls == [(
-        {
-            "endpoint": "https://api.vikingdb.cn-beijing.volces.com/openviking",
-            "api_key": "service-secret",
-            "root_api_key": "",
-            "account": "",
-            "user": "",
-            "agent": "agent",
-            "api_key_type": "user",
-        },
+            {
+                "url": "https://api.vikingdb.cn-beijing.volces.com/openviking",
+                "api_key": "service-secret",
+                "root_api_key": "",
+                "account": "",
+                "user": "",
+                "actor_peer_id": "agent",
+                "api_key_type": "user",
+            },
         True,
     )]
-    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
-    assert "OPENVIKING_ENDPOINT=https://api.vikingdb.cn-beijing.volces.com/openviking" in env_text
-    assert "OPENVIKING_API_KEY=service-secret" in env_text
-    assert "OPENVIKING_AGENT=agent" in env_text
+    profile_path = tmp_path / ".openviking" / "ovcli.conf.service"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "https://api.vikingdb.cn-beijing.volces.com/openviking",
+        "api_key": "service-secret",
+        "actor_peer_id": "agent",
+    }
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
 
 
 def test_post_setup_remote_blank_api_key_cancels_without_saving(tmp_path, monkeypatch):
@@ -519,6 +1031,7 @@ def test_post_setup_user_key_path_can_route_detected_root_key_to_root_setup(tmp_
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
 
     from hermes_cli import memory_setup
 
@@ -528,7 +1041,7 @@ def test_post_setup_user_key_path_can_route_detected_root_key_to_root_setup(tmp_
 
     monkeypatch.setattr(openviking_module, "_validate_openviking_reachability", lambda endpoint: (True, ""))
     monkeypatch.setattr(openviking_module, "_validate_openviking_setup_values", validate_values)
-    choices = iter([1, 0, 0, 0])
+    choices = iter([1, 0, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     prompt_events = []
 
@@ -541,7 +1054,8 @@ def test_post_setup_user_key_path_can_route_detected_root_key_to_root_setup(tmp_
             "OpenViking user API key": "root-secret",
             "OpenViking account": "acct",
             "OpenViking user": "alice",
-            "Hermes peer ID in OpenViking": "agent",
+            "Agent ID": "agent",
+            "OpenViking profile name": "VPS_ROOT",
         }
         return values.get(label, default or "")
 
@@ -550,12 +1064,20 @@ def test_post_setup_user_key_path_can_route_detected_root_key_to_root_setup(tmp_
 
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
-    assert prompt_events.count("Hermes peer ID in OpenViking") == 1
-    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
-    assert "OPENVIKING_API_KEY=root-secret" in env_text
-    assert "OPENVIKING_ACCOUNT=acct" in env_text
-    assert "OPENVIKING_USER=alice" in env_text
-    assert "OPENVIKING_AGENT=agent" in env_text
+    assert prompt_events.count("Agent ID") == 1
+    profile_path = tmp_path / ".openviking" / "ovcli.conf.VPS_ROOT"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "https://openviking.example",
+        "api_key": "root-secret",
+        "root_api_key": "root-secret",
+        "account": "acct",
+        "user": "alice",
+        "actor_peer_id": "agent",
+    }
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
 
 
 def test_post_setup_root_key_path_can_route_detected_user_key_to_user_setup(tmp_path, monkeypatch):
@@ -563,6 +1085,7 @@ def test_post_setup_root_key_path_can_route_detected_user_key_to_user_setup(tmp_
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
 
     from hermes_cli import memory_setup
 
@@ -572,7 +1095,7 @@ def test_post_setup_root_key_path_can_route_detected_user_key_to_user_setup(tmp_
 
     monkeypatch.setattr(openviking_module, "_validate_openviking_reachability", lambda endpoint: (True, ""))
     monkeypatch.setattr(openviking_module, "_validate_openviking_setup_values", validate_values)
-    choices = iter([1, 1, 0, 0])
+    choices = iter([1, 1, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     monkeypatch.setattr(
         memory_setup,
@@ -581,7 +1104,8 @@ def test_post_setup_root_key_path_can_route_detected_user_key_to_user_setup(tmp_
             {
                 "OpenViking server URL": "https://openviking.example",
                 "OpenViking root API key": "user-secret",
-                "Hermes peer ID in OpenViking": "agent",
+                "Agent ID": "agent",
+                "OpenViking profile name": "VPS_USER",
             },
             forbidden={"OpenViking user API key", "OpenViking account", "OpenViking user"},
         ),
@@ -590,11 +1114,16 @@ def test_post_setup_root_key_path_can_route_detected_user_key_to_user_setup(tmp_
 
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
-    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
-    assert "OPENVIKING_API_KEY=user-secret" in env_text
-    assert "OPENVIKING_AGENT=agent" in env_text
-    assert "OPENVIKING_ACCOUNT" not in env_text
-    assert "OPENVIKING_USER" not in env_text
+    profile_path = tmp_path / ".openviking" / "ovcli.conf.VPS_USER"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "https://openviking.example",
+        "api_key": "user-secret",
+        "actor_peer_id": "agent",
+    }
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
 
 
 def test_manual_root_key_flow_prints_validation_progress(monkeypatch, capsys):
@@ -617,7 +1146,7 @@ def test_manual_root_key_flow_prints_validation_progress(monkeypatch, capsys):
             "OpenViking root API key": "root-secret",
             "OpenViking account": "acct",
             "OpenViking user": "alice",
-            "Hermes peer ID in OpenViking": "agent",
+            "Agent ID": "agent",
         }),
         lambda *args, **kwargs: next(choices),
         -1,
@@ -677,10 +1206,10 @@ def test_start_local_openviking_server_writes_output_to_log(tmp_path, monkeypatc
 
 def test_https_local_endpoint_is_not_runtime_autostart_eligible(monkeypatch):
     _clear_openviking_env(monkeypatch)
-    monkeypatch.setenv("OPENVIKING_ENDPOINT", "https://localhost:1934")
+    monkeypatch.setenv("OPENVIKING_URL", "https://localhost:1934")
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "https://localhost:1934"
 
         def health(self):
@@ -707,10 +1236,10 @@ def test_https_local_endpoint_is_not_runtime_autostart_eligible(monkeypatch):
 
 def test_runtime_does_not_autostart_when_local_server_reports_unhealthy(monkeypatch):
     _clear_openviking_env(monkeypatch)
-    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1934")
+    monkeypatch.setenv("OPENVIKING_URL", "http://localhost:1934")
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "http://localhost:1934"
 
         def health(self):
@@ -793,7 +1322,7 @@ def test_manual_setup_does_not_offer_autostart_when_local_server_is_unhealthy(mo
     _clear_openviking_env(monkeypatch)
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "http://localhost:1933"
 
         def health_payload(self):
@@ -831,13 +1360,13 @@ def test_manual_setup_does_not_offer_autostart_when_local_server_is_unhealthy(mo
 
 def test_initialize_autostarts_local_openviking_in_background_when_runtime_health_fails(monkeypatch):
     _clear_openviking_env(monkeypatch)
-    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://127.0.0.1:1934")
+    monkeypatch.setenv("OPENVIKING_URL", "http://127.0.0.1:1934")
     health_calls = []
     start_calls = []
     waiter_calls = []
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "http://127.0.0.1:1934"
 
         def health(self):
@@ -879,12 +1408,12 @@ def test_runtime_openviking_waiter_attaches_client_after_health_recovers(monkeyp
     wait_calls = []
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             self.endpoint = endpoint
             self.api_key = api_key
             self.account = account
             self.user = user
-            self.agent = agent
+            self.actor_peer_id = actor_peer_id
 
         def health(self):
             return True
@@ -951,10 +1480,10 @@ def test_runtime_openviking_waiter_warns_when_background_start_times_out(monkeyp
 
 def test_initialize_does_not_autostart_remote_openviking(monkeypatch, caplog):
     _clear_openviking_env(monkeypatch)
-    monkeypatch.setenv("OPENVIKING_ENDPOINT", "https://openviking.example")
+    monkeypatch.setenv("OPENVIKING_URL", "https://openviking.example")
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "https://openviking.example"
 
         def health(self):
@@ -982,10 +1511,10 @@ def test_initialize_does_not_autostart_remote_openviking(monkeypatch, caplog):
 
 def test_initialize_warns_clearly_when_local_runtime_autostart_fails(monkeypatch, caplog):
     _clear_openviking_env(monkeypatch)
-    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1934")
+    monkeypatch.setenv("OPENVIKING_URL", "http://localhost:1934")
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "http://localhost:1934"
 
         def health(self):
@@ -1014,10 +1543,10 @@ def test_initialize_warns_clearly_when_local_runtime_autostart_fails(monkeypatch
 
 def test_initialize_emits_cli_warning_when_local_runtime_autostart_fails(monkeypatch):
     _clear_openviking_env(monkeypatch)
-    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1934")
+    monkeypatch.setenv("OPENVIKING_URL", "http://localhost:1934")
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "http://localhost:1934"
 
         def health(self):
@@ -1044,10 +1573,10 @@ def test_initialize_emits_cli_warning_when_local_runtime_autostart_fails(monkeyp
 
 def test_initialize_does_not_emit_cli_warning_when_callback_absent(monkeypatch):
     _clear_openviking_env(monkeypatch)
-    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1934")
+    monkeypatch.setenv("OPENVIKING_URL", "http://localhost:1934")
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "http://localhost:1934"
 
         def health(self):
@@ -1071,6 +1600,7 @@ def test_post_setup_local_server_down_can_offer_autostart(tmp_path, monkeypatch)
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
     monkeypatch.setattr(openviking_module, "_validate_openviking_setup_values", lambda values, *, require_api_key=False: (True, "", None))
 
     from hermes_cli import memory_setup
@@ -1085,14 +1615,15 @@ def test_post_setup_local_server_down_can_offer_autostart(tmp_path, monkeypatch)
     monkeypatch.setattr(openviking_module, "_validate_openviking_reachability", validate_reachability)
     monkeypatch.setattr(openviking_module, "_start_local_openviking_server", lambda endpoint: (started.append(endpoint) or True, "started"))
     monkeypatch.setattr(openviking_module, "_wait_for_openviking_health", lambda endpoint, **kwargs: True)
-    choices = iter([1, 0, 0, 0])
+    choices = iter([1, 0, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     monkeypatch.setattr(
         memory_setup,
         "_prompt",
         _prompt_from_values({
             "OpenViking server URL": "localhost",
-            "Hermes peer ID in OpenViking": "agent",
+            "Agent ID": "agent",
+            "OpenViking profile name": "local",
         }),
     )
     config = {"memory": {}}
@@ -1101,9 +1632,15 @@ def test_post_setup_local_server_down_can_offer_autostart(tmp_path, monkeypatch)
 
     assert started == ["http://localhost:1933"]
     assert reachability_calls == ["http://localhost:1933"]
-    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
-    assert "OPENVIKING_ENDPOINT=http://localhost:1933" in env_text
-    assert "OPENVIKING_API_KEY" not in env_text
+    profile_path = tmp_path / ".openviking" / "ovcli.conf.local"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "http://localhost:1933",
+        "actor_peer_id": "agent",
+    }
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
 
 
 def test_post_setup_invalid_env_profile_can_create_new_config(tmp_path, monkeypatch):
@@ -1115,11 +1652,12 @@ def test_post_setup_invalid_env_profile_can_create_new_config(tmp_path, monkeypa
     ovcli_path.write_text("{", encoding="utf-8")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(ovcli_path))
+    monkeypatch.setattr(openviking_module.Path, "home", staticmethod(lambda: tmp_path))
     _allow_setup_validation(monkeypatch)
 
     from hermes_cli import memory_setup
 
-    choices = iter([1, 0, 0])
+    choices = iter([1, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     monkeypatch.setattr(
         memory_setup,
@@ -1127,7 +1665,8 @@ def test_post_setup_invalid_env_profile_can_create_new_config(tmp_path, monkeypa
         _prompt_from_values({
             "OpenViking server URL": "https://openviking.example",
             "OpenViking user API key": "user-secret",
-            "Hermes peer ID in OpenViking": "agent",
+            "Agent ID": "agent",
+            "OpenViking profile name": "VPS",
         }),
     )
     config = {"memory": {}}
@@ -1135,7 +1674,16 @@ def test_post_setup_invalid_env_profile_can_create_new_config(tmp_path, monkeypa
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
     assert ovcli_path.read_text(encoding="utf-8") == "{"
-    assert config["memory"]["openviking"] == {"use_ovcli_config": False}
+    profile_path = tmp_path / ".openviking" / "ovcli.conf.VPS"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "https://openviking.example",
+        "api_key": "user-secret",
+        "actor_peer_id": "agent",
+    }
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
 
 
 def test_tool_search_sorts_by_raw_score_across_buckets():
@@ -1568,7 +2116,7 @@ def test_viking_client_delete_uses_identity_headers(monkeypatch):
         api_key="test-key",
         account="acct",
         user="alice",
-        agent="hermes",
+        actor_peer_id="hermes",
     )
     captured = {}
 
@@ -1600,7 +2148,7 @@ def test_viking_client_post_allows_per_request_timeout(monkeypatch):
         api_key="test-key",
         account="acct",
         user="alice",
-        agent="hermes",
+        actor_peer_id="hermes",
     )
     captured = {}
 
@@ -1632,7 +2180,7 @@ def test_viking_client_upload_temp_file_uses_multipart_identity_headers(tmp_path
         api_key="test-key",
         account="test-account",
         user="test-user",
-        agent="test-agent",
+        actor_peer_id="test-agent",
     )
     captured_kwargs = {}
 
@@ -1707,7 +2255,7 @@ def test_viking_client_headers_include_bearer_when_api_key_set():
         api_key="test-key",
         account="acct",
         user="usr",
-        agent="hermes",
+        actor_peer_id="hermes",
     )
     headers = client._headers()
     assert headers["X-API-Key"] == "test-key"
@@ -1725,7 +2273,7 @@ def test_viking_client_headers_send_tenant_in_local_mode():
         api_key="",
         account="default",
         user="default",
-        agent="hermes",
+        actor_peer_id="hermes",
     )
     headers = client._headers()
     assert headers["X-OpenViking-Account"] == "default"
@@ -1743,7 +2291,7 @@ def test_viking_client_headers_send_tenant_when_empty_falls_back_to_default(monk
         api_key="",
         account="",
         user="",
-        agent="hermes",
+        actor_peer_id="hermes",
     )
     headers = client._headers()
     assert headers["X-OpenViking-Account"] == "default"
@@ -1760,7 +2308,7 @@ def test_viking_client_headers_can_include_tenant_for_trusted_retry():
         api_key="test-key",
         account="real-account",
         user="real-user",
-        agent="hermes",
+        actor_peer_id="hermes",
     )
     headers = client._headers(include_tenant=True)
     assert headers["X-OpenViking-Account"] == "real-account"
@@ -1774,7 +2322,7 @@ def test_viking_client_retries_with_tenant_headers_for_trusted_mode(monkeypatch)
         api_key="test-key",
         account="acct",
         user="usr",
-        agent="hermes",
+        actor_peer_id="hermes",
     )
     captured_headers = []
 
@@ -1819,7 +2367,7 @@ def test_viking_client_health_sends_auth_headers(monkeypatch):
         api_key="test-key",
         account="",
         user="",
-        agent="hermes",
+        actor_peer_id="hermes",
     )
     captured = {}
 
@@ -1844,7 +2392,7 @@ def test_viking_client_validate_auth_uses_authenticated_system_status(monkeypatc
         api_key="test-key",
         account="acct",
         user="alice",
-        agent="hermes",
+        actor_peer_id="hermes",
     )
     captured = {}
 
@@ -1878,7 +2426,7 @@ def test_viking_client_validate_root_access_uses_admin_accounts(monkeypatch):
         api_key="root-key",
         account="",
         user="",
-        agent="hermes",
+        actor_peer_id="hermes",
     )
     captured = {}
 
@@ -1906,7 +2454,7 @@ def test_validate_openviking_reachability_uses_health_only(monkeypatch):
     events = []
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "https://openviking.example"
             assert api_key == ""
 
@@ -1929,12 +2477,12 @@ def test_validate_openviking_auth_uses_status_without_health(monkeypatch):
     events = []
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "https://openviking.example"
             assert api_key == "test-key"
             assert account == "acct"
             assert user == "alice"
-            assert agent == "hermes"
+            assert actor_peer_id == "hermes"
 
         def validate_auth(self):
             events.append("status")
@@ -1943,11 +2491,11 @@ def test_validate_openviking_auth_uses_status_without_health(monkeypatch):
     monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
 
     ok, message = openviking_module._validate_openviking_auth({
-        "endpoint": "https://openviking.example",
+        "url": "https://openviking.example",
         "api_key": "test-key",
         "account": "acct",
         "user": "alice",
-        "agent": "hermes",
+        "actor_peer_id": "hermes",
     })
 
     assert ok is True
@@ -1959,12 +2507,12 @@ def test_validate_openviking_root_access_uses_admin_endpoint(monkeypatch):
     events = []
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "https://openviking.example"
             assert api_key == "root-key"
             assert account == ""
             assert user == ""
-            assert agent == "hermes"
+            assert actor_peer_id == "hermes"
 
         def validate_root_access(self):
             events.append("admin")
@@ -1973,7 +2521,7 @@ def test_validate_openviking_root_access_uses_admin_endpoint(monkeypatch):
     monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
 
     ok, message = openviking_module._validate_openviking_root_access({
-        "endpoint": "https://openviking.example",
+        "url": "https://openviking.example",
         "api_key": "root-key",
     })
 
@@ -1990,7 +2538,7 @@ def test_validate_openviking_setup_values_blocks_remote_without_api_key(monkeypa
     monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
 
     ok, message, role = openviking_module._validate_openviking_setup_values(
-        {"endpoint": "https://openviking.example"},
+        {"url": "https://openviking.example"},
         require_api_key=True,
     )
 
@@ -2003,7 +2551,7 @@ def test_validate_openviking_setup_values_local_dev_no_key_uses_health_only(monk
     events = []
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "http://localhost:1933"
             assert api_key == ""
 
@@ -2020,7 +2568,7 @@ def test_validate_openviking_setup_values_local_dev_no_key_uses_health_only(monk
     monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
 
     ok, message, role = openviking_module._validate_openviking_setup_values(
-        {"endpoint": "localhost", "agent": "hermes"}
+        {"url": "localhost", "actor_peer_id": "hermes"}
     )
 
     assert ok is True
@@ -2033,7 +2581,7 @@ def test_validate_openviking_setup_values_user_key_runs_status_and_classifies_ro
     events = []
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "https://openviking.example"
             assert api_key == "user-key"
             assert account == ""
@@ -2054,7 +2602,7 @@ def test_validate_openviking_setup_values_user_key_runs_status_and_classifies_ro
     monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
 
     ok, message, role = openviking_module._validate_openviking_setup_values(
-        {"endpoint": "https://openviking.example", "api_key": "user-key"},
+        {"url": "https://openviking.example", "api_key": "user-key"},
         require_api_key=True,
     )
 
@@ -2068,7 +2616,7 @@ def test_validate_openviking_setup_values_root_key_runs_admin_probe(monkeypatch)
     events = []
 
     class FakeVikingClient:
-        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+        def __init__(self, endpoint, api_key="", account="", user="", actor_peer_id=""):
             assert endpoint == "https://openviking.example"
             assert api_key == "root-key"
             assert account == "acct"
@@ -2089,11 +2637,11 @@ def test_validate_openviking_setup_values_root_key_runs_admin_probe(monkeypatch)
     monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
 
     ok, message, role = openviking_module._validate_openviking_setup_values(
-        {
-            "endpoint": "https://openviking.example",
-            "api_key": "root-key",
-            "account": "acct",
-            "user": "alice",
+            {
+                "url": "https://openviking.example",
+                "api_key": "root-key",
+                "account": "acct",
+                "user": "alice",
         },
         require_api_key=True,
     )

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -298,12 +298,12 @@ openviking-server
 
 # Then configure Hermes
 hermes memory setup    # select "openviking"
-# Or manually:
-hermes config set memory.provider openviking
-echo "OPENVIKING_ENDPOINT=http://localhost:1933" >> ~/.hermes/.env
-# Authenticated servers should use a user/admin API key:
-echo "OPENVIKING_API_KEY=..." >> ~/.hermes/.env
 ```
+
+OpenViking setup links Hermes to an existing OpenViking CLI profile or creates a
+new `~/.openviking/ovcli.conf.<name>` profile. Environment variables such as
+`OPENVIKING_URL`, `OPENVIKING_API_KEY`, and `OPENVIKING_ACTOR_PEER_ID` are still
+supported as advanced runtime overrides.
 
 **Key features:**
 - Tiered context loading: L0 (~100 tokens) → L1 (~2k) → L2 (full)
@@ -311,7 +311,7 @@ echo "OPENVIKING_API_KEY=..." >> ~/.hermes/.env
 - `viking://` URI scheme for hierarchical knowledge browsing
 
 `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` are used for local/trusted mode.
-`OPENVIKING_AGENT` is Hermes' peer ID in OpenViking for peer-scoped memories.
+`OPENVIKING_ACTOR_PEER_ID` is Hermes' Agent ID in OpenViking for peer-scoped memories.
 
 ---
 
@@ -608,9 +608,9 @@ hermes memory setup
 Each provider's data is isolated per [profile](/user-guide/profiles):
 
 - **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
-- **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
+- **Config file providers** (Honcho, Mem0, Hindsight, OpenViking, Supermemory) store or link config files so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
-- **Env var providers** (OpenViking) are configured via each profile's `.env` file
+- **Env var providers** use each profile's `.env` file for runtime overrides
 
 ## Building a Memory Provider
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -281,15 +281,19 @@ openviking-server
 
 # 然后配置 Hermes
 hermes memory setup    # 选择 "openviking"
-# 或手动配置：
-hermes config set memory.provider openviking
-echo "OPENVIKING_ENDPOINT=http://localhost:1933" >> ~/.hermes/.env
 ```
+
+OpenViking 设置会将 Hermes 链接到已有的 OpenViking CLI profile，或创建新的
+`~/.openviking/ovcli.conf.<name>` profile 并链接到 Hermes。`OPENVIKING_URL`、
+`OPENVIKING_API_KEY`、`OPENVIKING_ACTOR_PEER_ID` 等环境变量仍可作为高级运行时覆盖项使用。
 
 **主要特性：**
 - 分层上下文加载：L0（约 100 tokens）→ L1（约 2k）→ L2（完整）
 - 会话提交时自动提取记忆（profile、偏好、实体、事件、案例、模式）
 - `viking://` URI 方案用于层级知识浏览
+
+`OPENVIKING_ACCOUNT` 和 `OPENVIKING_USER` 用于本地/可信模式。
+`OPENVIKING_ACTOR_PEER_ID` 是 Hermes 在 OpenViking 中用于 peer-scoped memories 的 Agent ID。
 
 ---
 
@@ -540,9 +544,9 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 每个提供者的数据按 [profile](/user-guide/profiles) 隔离：
 
 - **本地存储提供者**（Holographic、ByteRover）使用 `$HERMES_HOME/` 路径，各 profile 路径不同
-- **配置文件提供者**（Honcho、Mem0、Hindsight、Supermemory）将配置存储在 `$HERMES_HOME/` 中，每个 profile 拥有独立凭证
+- **配置文件提供者**（Honcho、Mem0、Hindsight、OpenViking、Supermemory）存储或链接配置文件，每个 profile 拥有独立凭证
 - **云端提供者**（RetainDB）自动派生 profile 范围的项目名称
-- **环境变量提供者**（OpenViking）通过每个 profile 的 `.env` 文件配置
+- **环境变量提供者**通过每个 profile 的 `.env` 文件提供运行时覆盖项
 
 ## 构建记忆提供者
 


### PR DESCRIPTION
## Summary

- Add a Desktop OpenViking configuration panel and wizard for OpenViking Service, Existing Profiles, and Custom Server setup.
- Persist Desktop and CLI setup through named OpenViking CLI profile files, then link Hermes to the selected profile path without duplicating secrets into Hermes env.
- Add profile-scoped OpenViking Desktop API endpoints, missing-profile handling, health/status UX, backup coverage for ovcli profiles, and updated docs/tests.

## Why

OpenViking could already be configured manually, but Hermes Desktop did not expose a first-class setup path. This makes OpenViking usable from Desktop while keeping ovcli profiles as the shared source of truth and avoiding unexpected writes to the default ovcli.conf.

## Validation

- `npm run test:ui -- src/app/settings/openviking-config-panel.test.tsx src/hermes-profile-scope.test.ts`
- `npx eslint src/app/settings/openviking-config-panel.tsx src/app/settings/openviking-config-panel.test.tsx`
- `npm run typecheck`
- `uv run pytest tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_openviking_backup_paths.py -q`
- `uv run pytest tests/hermes_cli/test_web_server.py -q`
- `uv run ruff check plugins/memory/openviking/__init__.py tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_openviking_backup_paths.py hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`
