### PR TITLE
fix(security): close abbreviated-flag bypasses in git/sudo approval patterns

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1394,6 +1394,33 @@ class TestGitDestructiveOps:
         assert dangerous is True
         assert "reset" in desc.lower() or "hard" in desc.lower()
 
+    def test_git_reset_hard_abbreviated_har_detected(self):
+        # git's own option parser resolves unambiguous long-flag prefixes,
+        # so `git reset --har` executes identically to `--hard` (verified
+        # against a live git binary) — confirmed real bypass of the
+        # exact-string `--hard` pattern.
+        cmd = "git reset --har HEAD~3"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "reset" in desc.lower() or "hard" in desc.lower()
+
+    def test_git_reset_hard_abbreviated_single_h_detected(self):
+        cmd = "git reset --h"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_git_reset_soft_not_flagged(self):
+        """--soft doesn't discard uncommitted work; must not be flagged."""
+        cmd = "git reset --soft HEAD~1"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_git_reset_help_not_flagged(self):
+        """--help must not resolve as an abbreviation of --hard."""
+        cmd = "git reset --help"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
     def test_git_push_force_detected(self):
         cmd = "git push --force origin main"
         dangerous, _, desc = detect_dangerous_command(cmd)
@@ -1436,6 +1463,34 @@ class TestGitDestructiveOps:
         cmd = "git branch -d feature-branch"
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is True
+
+    def test_git_branch_long_flag_delete_force_detected(self):
+        # `--delete --force` performs the exact same unmerged-branch force
+        # delete as `-D` (verified live), but is a different token
+        # spelling entirely so the `-D\b` pattern never sees it.
+        cmd = "git branch --delete --force feature-branch"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "force delete" in desc.lower()
+
+    def test_git_branch_short_delete_long_force_detected(self):
+        # `-d --force` is git's own documented equivalent of `-D`.
+        cmd = "git branch -d --force feature-branch"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_git_branch_force_first_delete_detected(self):
+        cmd = "git branch --force --delete feature-branch"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_git_branch_long_delete_without_force_not_flagged(self):
+        """Plain --delete (merged-only, equivalent to -d) has no force
+        token, so the new combined delete+force patterns must not fire —
+        only an actual force flag alongside it should trigger."""
+        cmd = "git branch --delete feature-branch"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
 
 
 class TestChmodExecuteCombo:
@@ -1604,6 +1659,25 @@ class TestDetectSudoStdin:
         is_dangerous, _, _ = detect_dangerous_command("sudo --askpass id")
         assert is_dangerous is True
 
+    def test_stdin_abbreviated_flag_detected(self):
+        # sudo's option parser resolves unambiguous long-flag prefixes
+        # just like git's does — `sudo --stdi` runs identically to
+        # `sudo --stdin` (verified against a live sudo binary: both
+        # produce the same "a password is required" outcome, versus a
+        # genuinely unrecognized option which errors differently).
+        is_dangerous, _, _ = detect_dangerous_command("sudo --stdi id")
+        assert is_dangerous is True
+
+    def test_askpass_abbreviated_flag_detected(self):
+        # `--askpass` is the only sudo long option starting with "a", so
+        # any prefix from `--a` up resolves to it unambiguously.
+        is_dangerous, _, _ = detect_dangerous_command("sudo --ask id")
+        assert is_dangerous is True
+
+    def test_askpass_single_char_abbreviation_detected(self):
+        is_dangerous, _, _ = detect_dangerous_command("sudo --a id")
+        assert is_dangerous is True
+
     def test_two_sudo_invocations_second_caught(self):
         # The first sudo here is benign (no -S); the second has -S.
         # Lazy [^;|&\n]*? does NOT span past `;`, so re.search anchors
@@ -1625,6 +1699,17 @@ class TestDetectSudoStdin:
 
     def test_sudo_with_user_no_stdin_flag_safe(self):
         is_dangerous, _, _ = detect_dangerous_command("sudo -u root -i")
+        assert is_dangerous is False
+
+    def test_sudo_set_home_not_confused_with_stdin_abbreviation(self):
+        # `--set-home` shares no prefix with `--stdin` beyond "--s", so
+        # the broadened `--st[a-z]*` pattern must not catch it.
+        is_dangerous, _, _ = detect_dangerous_command("sudo --set-home id")
+        assert is_dangerous is False
+
+    def test_sudo_shell_flag_not_confused_with_stdin_abbreviation(self):
+        # `--shell` shares "--s" but not "--st" with `--stdin`.
+        is_dangerous, _, _ = detect_dangerous_command("sudo --shell id")
         assert is_dangerous is False
 
     def test_man_sudo_safe(self):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -643,11 +643,27 @@ DANGEROUS_PATTERNS = [
     (r'\b(bash|sh|zsh|ksh)\s+<<', "shell execution via heredoc"),
     # Git destructive operations that can lose uncommitted work or rewrite
     # shared history. Not captured by rm/chmod/etc patterns.
-    (r'\bgit\s+reset\s+--hard\b', "git reset --hard (destroys uncommitted changes)"),
+    # `git reset --hard` accepts any unambiguous long-flag prefix (--h,
+    # --ha, --har, --hard) because git's own option parser resolves
+    # abbreviated long flags -- `--hard` is the only `git reset` mode
+    # starting with "h" (siblings are --soft/--mixed/--merge/--keep), so
+    # this cannot collide with another reset mode. It also does not match
+    # `--help`, which git special-cases before mode resolution.
+    (r'\bgit\s+reset\s+--h(?:a(?:r(?:d)?)?)?\b', "git reset --hard (destroys uncommitted changes)"),
     (r'\bgit\s+push\b.*--forc[a-z]*\b', "git force push (rewrites remote history)"),
     (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
     (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
     (r'\bgit\s+branch\s+-D\b', "git branch force delete"),
+    # `-D` is shorthand for `-d --force`; the long-flag spellings
+    # (`--delete`, `--force`) are different tokens entirely, so they slip
+    # past the `-D\b` pattern above even though `git branch -d --force`
+    # and `git branch --delete --force` delete an unmerged branch exactly
+    # like `-D` does. Match delete+force in either order, bounded to the
+    # same command segment (not spanning `;`/`|`/`&`/newline) the same
+    # way the sudo patterns below do, to avoid contaminating an unrelated
+    # later command in the same script.
+    (r'\bgit\s+branch\b[^;|&\n]*?(?:-d\b|--delete\b)[^;|&\n]*?(?:-f\b|--force\b)', "git branch force delete (long flags)"),
+    (r'\bgit\s+branch\b[^;|&\n]*?(?:-f\b|--force\b)[^;|&\n]*?(?:-d\b|--delete\b)', "git branch force delete (long flags, force-first)"),
     # Script execution after chmod +x — catches the two-step pattern where
     # a script is first made executable then immediately run. The script
     # content may contain dangerous commands that individual patterns miss.
@@ -665,7 +681,14 @@ DANGEROUS_PATTERNS = [
     # are gated below. Lazy `[^;|&\n]*?` allows flag arguments (e.g.
     # `sudo -u root -S whoami`) without spanning command separators. See
     # #17873 category 4.
-    (r'\bsudo\b[^;|&\n]*?\s+(?:-s\b|--stdin\b|-a\b|--askpass\b)',
+    # sudo's own option parser (like git's) resolves unambiguous
+    # long-flag prefixes, so `sudo --stdi` runs identically to
+    # `sudo --stdin` and `sudo --ask` to `sudo --askpass` -- confirmed
+    # against a live sudo binary. `--st[a-z]*` and `--a[a-z]*` are safe
+    # to match broadly: per `man sudo`, `--stdin` is the only long option
+    # starting with "st" (siblings are --shell/--set-home) and
+    # `--askpass` is the only one starting with "a" at all.
+    (r'\bsudo\b[^;|&\n]*?\s+(?:-s\b|--st[a-z]*\b|-a\b|--a[a-z]*\b)',
      "sudo with privilege flag (stdin/askpass/shell/list)"),
     # Combined short-flag form: -nS, -ns, -sa, -las — sudo flags packed
     # into a single -X token. Catches the same threat class.


### PR DESCRIPTION
## Summary

`git`'s and `sudo`'s own option parsers resolve unambiguous long-flag prefixes, so an agent-issued command using an abbreviated flag executes identically to the full-flag form while evading the exact-string `DANGEROUS_PATTERNS` regexes in `tools/approval.py` that are supposed to gate it. Confirmed live against real `git`/`sudo` binaries (not just static analysis):

- `git reset --har` (or `--ha`, `--h`) discards all uncommitted changes exactly like `git reset --hard`, but only the literal `--hard\b` was matched.
- `git branch --delete --force` (and `-d --force`, `--force --delete`) force-deletes an unmerged branch exactly like `-D`, but only the `-D\b` token was matched — `--delete`/`--force` are different token spellings entirely.
- `sudo --stdi` / `sudo --ask` behave identically to `sudo --stdin` / `sudo --askpass` (confirmed: both produce the same "a password is required" outcome, versus a genuinely unrecognized option which errors differently), evading the brute-force-password-guessing guard.

## Changes

- `tools/approval.py`:
  - `git reset` pattern now accepts any unambiguous prefix of `--hard` (`--h`, `--ha`, `--har`, `--hard`). Scoped so it cannot collide with sibling reset modes (`--soft`/`--mixed`/`--merge`/`--keep`, none of which start with "h") or with `--help` (git special-cases `--help` before mode resolution, confirmed live).
  - Added two new `git branch` patterns catching `-d`/`--delete` combined with `-f`/`--force` in either order, scoped to the same command segment (bounded by `;`/`|`/`&`/newline, matching the existing lazy-match convention already used by the sudo patterns) so it can't bleed into an unrelated later command.
  - Broadened the sudo privilege-flag pattern's long-flag alternatives from exact `--stdin`/`--askpass` to `--st[a-z]*`/`--a[a-z]*`. Per `man sudo`, `--stdin` is the only long option starting with "st" (siblings `--shell`/`--set-home` diverge at the 3rd character) and `--askpass` is the only one starting with "a" at all, so this can't misfire on an unrelated sudo flag.
- `tests/tools/test_approval.py`: added positive cases for each abbreviated form (`--har`, `--h`, long-flag branch delete+force in both orders, `--stdi`, `--ask`, `--a`) and negative cases guarding against false positives (`--soft`, `--help`, plain `--delete` without force, `--set-home`, `--shell`).

## Test plan

- [x] `pytest tests/tools/test_approval.py -q` — 288 passed
- [x] `pytest tests/tools/test_hardline_blocklist.py -q` — 181 passed (unaffected, sanity check)
- [x] `pytest tests/tools/test_yolo_mode.py -q` — 19 passed (uses full-flag `git reset --hard` example, unaffected)
- [x] `ruff check tools/approval.py tests/tools/test_approval.py` — clean
- [x] Live-verified all three bypasses against real `git`/`sudo` binaries before writing the fix