### PR TITLE
fix(auxiliary_client): demote resolve_provider_client fall-throughs to logger.debug with dedup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,45 @@ hermes-agent/
 `gateway.log` when running the gateway. Profile-aware via `get_hermes_home()`.
 Browse with `hermes logs [--follow] [--level ...] [--session ...]`.
 
+### Log rotation
+
+All three files use Python `RotatingFileHandler` (see `hermes_logging.py`),
+governed by `logging.max_size_mb` (default 5 MiB) and `logging.backup_count`
+(default 3) in `config.yaml`. Per-file:
+
+| File         | Rotation policy                                            |
+| ------------ | ---------------------------------------------------------- |
+| `agent.log`  | 5 MiB × 3 plain-text backups (`agent.log.1` … `.3`)        |
+| `errors.log` | 5 MiB × 3 gzip-compressed backups (`errors.log.1.gz` … `.3.gz`) |
+| `gateway.log`| 5 MiB × 3 plain-text backups                               |
+
+`errors.log` is the only one with gzip compression — the WARNING/ERROR volume
+tends to be lower but spikier, so compressing gives a much better disk-usage
+profile without losing triage value. The compression happens inside
+`_ManagedRotatingFileHandler._doRolloverCompressed()` which does its OWN
+rename chain over the `.gz` suffix (stdlib's `doRollover` walks `.N` plain-text
+and would strand `.2`/`.3` as plain text while `.1.gz` was freshly written).
+Read backups with `zcat ~/.hermes/logs/errors.log.1.gz`.
+
+**To force a rotation manually** (e.g. before sending logs to support, or to
+free disk without waiting for the threshold):
+
+```bash
+# Truncate the active log in place; the next emit will reopen it and
+# the existing contents remain readable from .1 (or .1.gz).
+: > ~/.hermes/logs/errors.log
+
+# To force an immediate rollover of the current contents into .1.gz,
+# pre-fill past max_size_mb and emit one warning:
+truncate -s 6M ~/.hermes/logs/errors.log
+python3 -c "import logging; logging.getLogger('manual').warning('rotate-now')"
+```
+
+To **disable compression**, pass `compress_rotated=False` to `_add_rotating_handler`
+in `hermes_logging.py:setup_logging()`. To **change thresholds at runtime**, set
+`logging.max_size_mb` / `logging.backup_count` under `config.yaml`; the next
+gateway restart (or `setup_logging(force=True)` call) picks them up.
+
 ## TypeScript Style
 
 Applies to TypeScript across Hermes: desktop, TUI, website, and future TS packages.

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -109,6 +109,21 @@ from utils import base_url_host_matches, base_url_hostname, env_float, model_for
 logger = logging.getLogger(__name__)
 
 
+# ── resolve_provider_client dedup (silent-fix option d) ──────────────────
+# Both warning sites in resolve_provider_client (the "unknown provider" and
+# "unhandled auth_type" fall-throughs) were demoted to logger.debug so they
+# don't spam logs on every retry loop. We still want the first occurrence to
+# surface — that one carrys real diagnostic value (typo in a provider name,
+# PROVIDER_REGISTRY/auth_type drift bug). Subsequent identical messages are
+# suppressed for the lifetime of the process.
+#
+# Two independent sets keep the per-call branch linear (no tuple packing at
+# warning #1 where auth_type is unknown) and let each set be cleared
+# independently by tests if needed.
+_LOGGED_UNKNOWN_PROVIDER_KEYS: set = set()
+_LOGGED_UNHANDLED_AUTHTYPE_KEYS: set = set()
+
+
 # ── Interrupt protection for atomic auxiliary tasks ──────────────────────
 # Some auxiliary tasks must NOT be aborted mid-flight by a gateway interrupt
 # (e.g. an incoming user message while the agent is busy). Context
@@ -4272,7 +4287,11 @@ def resolve_provider_client(
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig is None:
-        logger.warning("resolve_provider_client: unknown provider %r", provider)
+        # Demoted from logger.warning to debug; dedup keyed by provider name
+        # so the first occurrence surfaces but repeated retries stay silent.
+        if provider not in _LOGGED_UNKNOWN_PROVIDER_KEYS:
+            _LOGGED_UNKNOWN_PROVIDER_KEYS.add(provider)
+            logger.debug("resolve_provider_client: unknown provider %r", provider)
         return None, None
 
     if pconfig.auth_type == "api_key":
@@ -4464,8 +4483,14 @@ def resolve_provider_client(
                        "directly supported, try 'auto'", provider)
         return None, None
 
-    logger.warning("resolve_provider_client: unhandled auth_type %s for %s",
-                   pconfig.auth_type, provider)
+    # Demoted from logger.warning to debug; dedup keyed on (auth_type,
+    # provider) so the first occurrence surfaces (real schema-drift bug)
+    # but per-call retries stay silent.
+    _auth_dedup_key = (pconfig.auth_type, provider)
+    if _auth_dedup_key not in _LOGGED_UNHANDLED_AUTHTYPE_KEYS:
+        _LOGGED_UNHANDLED_AUTHTYPE_KEYS.add(_auth_dedup_key)
+        logger.debug("resolve_provider_client: unhandled auth_type %s for %s",
+                     pconfig.auth_type, provider)
     return None, None
 
 

--- a/gateway/memory_monitor.py
+++ b/gateway/memory_monitor.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import gc
 import glob
+import itertools
 import logging
 import os
 import pickle
@@ -80,6 +81,13 @@ _heap_dump_top_n: int = 50
 _heap_dump_max_files: int = 5
 _heap_dump_in_flight: bool = False  # guard against re-entrance if dump is slow
 _peak_rss_mb: int = 0  # running peak across the lifetime of this process
+
+# Monotonic counter for sub-second uniqueness in dump filenames.  Two dumps
+# in the same wall-clock second get distinct filenames so rotation can see
+# each one.  itertools.count is process-local and never reused — combined
+# with the timestamp, two dumps will never collide on name within a
+# process's lifetime.
+_dump_seq = itertools.count(1)
 
 
 # ---------------------------------------------------------------------------
@@ -302,7 +310,8 @@ def _take_heap_dump(top_n: int) -> Optional[Path]:
             ],
         }
         ts_label = time.strftime("%Y%m%d-%H%M%S")
-        out_path = _heap_dump_dir / f"heap-{ts_label}-{os.getpid()}.pkl"
+        seq = next(_dump_seq)
+        out_path = _heap_dump_dir / f"heap-{ts_label}-{os.getpid()}-{seq}.pkl"
         with open(out_path, "wb") as f:
             pickle.dump(payload, f, protocol=pickle.HIGHEST_PROTOCOL)
         return out_path

--- a/gateway/memory_monitor.py
+++ b/gateway/memory_monitor.py
@@ -1,4 +1,4 @@
-"""Periodic process memory usage logging for the gateway.
+"""Periodic process memory sampling + heap-dump-on-threshold for the gateway.
 
 Ported from cline/cline#10343 (src/standalone/memory-monitor.ts).
 
@@ -7,58 +7,151 @@ agent instances, session transcripts, tool schemas, memory providers, MCP
 connections, etc.  A slow leak in any of those subsystems is invisible
 in a single log line — you only see it by watching RSS climb over hours.
 
-This module emits a single structured ``[MEMORY] ...`` line every N
-minutes (default 5) so maintainers investigating a suspected leak can
-grep ``agent.log`` / ``gateway.log`` for a time series of RSS + Python
-GC stats.  The timer runs in a background thread and shuts down cleanly
-with the gateway.
+This module does two things:
 
-Design notes (parity with the Cline port):
+1. **Periodic RSS sampling** — every N seconds (default 60) log a structured
+   ``[MEMORY] rss=...MB peak=...MB ...`` line with PID, current RSS,
+   peak RSS, GC counts, and thread count.  Baseline snapshot on start,
+   final snapshot on shutdown.
+
+2. **Heap dump on threshold** — when current RSS crosses a configurable
+   threshold (default 4 GiB, well below the observed 25.5 GB peak),
+   a heap snapshot is captured via ``tracemalloc`` and pickled into
+   ``~/.hermes/logs/heap-dumps/`` with rotation (oldest evicted).
+
+Design notes:
   * Grep-friendly single-line format beginning ``[MEMORY]``.
-  * Final snapshot logged on shutdown so "last RSS before exit" is
-    always in the log.
-  * Baseline snapshot logged immediately on start.
+  * ``[MEMORY] HEAP_DUMP`` line on every dump with path + size.
   * Daemon thread — never blocks process exit.
-  * Uses ``resource`` (stdlib, Linux/macOS) first and falls back to
-    ``psutil`` when ``resource`` isn't available (Windows).  Both are
-    optional; when neither works we emit a single WARNING and disable
-    the monitor rather than crashing the gateway.
+  * Linux: reads ``/proc/self/statm`` for current RSS (reliable,
+    always-current) and ``resource.getrusage().ru_maxrss`` for peak.
+  * Windows / macOS / BSD: uses ``psutil`` (already an optional dep
+    for memory introspection on those platforms).
+  * Heap dumps use ``tracemalloc`` (stdlib) — captures Python object
+    allocations, not native/C memory.  Enough to find a Python-level
+    leak; if the leak is in a C extension, the dump still shows
+    Python-side attribution that points to the offender.
+  * Threshold=0 disables the trigger entirely (use during benchmark
+    runs where you only want sampling, not dumps).
 
-Config: ``logging.memory_monitor`` in ``config.yaml`` — see
-``hermes_cli/config.py`` for the defaults block.
+Config: ``logging.memory_monitor`` block in ``config.yaml`` — see
+``hermes_cli/config.py`` for the defaults.  Tunable knobs:
+
+    logging:
+      memory_monitor:
+        enabled: true           # master switch (default: true)
+        interval_seconds: 60    # how often to sample RSS
+        heap_dump_threshold_mb: 4096   # 4 GiB; 0 disables
+        heap_dump_dir: null     # defaults to ~/.hermes/logs/heap-dumps
+        heap_dump_top_n: 50     # top allocation sites captured per dump
+        heap_dump_max_files: 5  # rotation count
 """
 
 from __future__ import annotations
 
 import gc
+import glob
 import logging
 import os
+import pickle
 import sys
 import threading
 import time
-from typing import Optional
+import tracemalloc
+from pathlib import Path
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
 _BYTES_TO_MB = 1024 * 1024
+_KB_TO_MB = 1024 * 1024
 
 _monitor_thread: Optional[threading.Thread] = None
 _stop_event: Optional[threading.Event] = None
 _start_time: Optional[float] = None
-_interval_seconds: float = 300.0  # 5 minutes
+_interval_seconds: float = 60.0
 _lock = threading.Lock()
+
+# Heap-dump trigger state — module-level so the periodic loop can read/write
+# without holding the long-lived lock for the (slow) dump itself.
+_heap_dump_threshold_mb: int = 0  # 0 = disabled
+_heap_dump_dir: Optional[Path] = None
+_heap_dump_top_n: int = 50
+_heap_dump_max_files: int = 5
+_heap_dump_in_flight: bool = False  # guard against re-entrance if dump is slow
+_peak_rss_mb: int = 0  # running peak across the lifetime of this process
+
+
+# ---------------------------------------------------------------------------
+# RSS source — Linux /proc/self/statm + resource.getrusage, psutil fallback
+# ---------------------------------------------------------------------------
+
+
+def _read_proc_self_rss_kb() -> Optional[int]:
+    """Read current RSS (in KiB) from /proc/self/statm.  Linux-only.
+
+    /proc/self/statm fields are: size resident shared text lib data dt
+    All values are in pages (multiply by page size for bytes).  Field 1
+    (resident) is the current RSS — what we want, not ru_maxrss which
+    is a high-water mark that only ever climbs.
+    """
+    try:
+        with open("/proc/self/statm", "r", encoding="ascii") as f:
+            line = f.readline()
+        # Field 1 is RSS in pages.  Avoid a getconf syscall by reading
+        # /proc/self/smaps_rollup is overkill; just trust the standard
+        # 4 KiB page size — wrong on PowerPC / aarch64 with 64K pages,
+        # but Linux x86_64 + arm64 server kernels all use 4K.
+        rss_pages = int(line.split()[1])
+        return rss_pages * 4  # 4 KiB → KiB
+    except Exception:
+        return None
 
 
 def _get_rss_mb() -> Optional[int]:
-    """Return current process resident set size in MB, or None if unavailable.
+    """Return current process RSS in MB, or None if unavailable.
 
-    Tries ``resource.getrusage`` first (Linux/macOS, no extra deps), then
-    falls back to ``psutil`` which is an optional hermes-agent dep.
+    Linux:   /proc/self/statm (current, reliable).
+    macOS:   resource.getrusage().ru_maxrss is in BYTES on macOS — gives
+             peak, not current, but it's the only stdlib option.  Acceptable
+             for trend monitoring.
+    Windows: psutil fallback.
     """
-    # Linux / macOS — resource is stdlib.  On Linux ru_maxrss is in KB,
-    # on macOS it is in bytes (yes, really).  We use it as a cheap
-    # "current" RSS — ru_maxrss reports the high-water mark for the
-    # process, which is what you actually want for leak detection.
+    if sys.platform.startswith("linux"):
+        kb = _read_proc_self_rss_kb()
+        if kb is not None:
+            return int(kb / 1024)
+
+    # Fallback for macOS / non-Linux: resource gives peak RSS only.
+    # Good enough for trend detection — we expose peak alongside current
+    # so the operator can tell which signal they're seeing.
+    try:
+        import resource
+
+        maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if sys.platform == "darwin":
+            return int(maxrss / _BYTES_TO_MB)
+        # Other unices (BSD): bytes
+        return int(maxrss / _BYTES_TO_MB) if maxrss > 10 * 1024 * 1024 else int(maxrss / 1024)
+    except Exception:
+        pass
+
+    try:
+        import psutil  # type: ignore
+
+        rss = psutil.Process(os.getpid()).memory_info().rss
+        return int(rss / _BYTES_TO_MB)
+    except Exception:
+        return None
+
+
+def _get_peak_rss_mb() -> Optional[int]:
+    """Return process peak RSS in MB, or None if unavailable.
+
+    Uses ``resource.getrusage().ru_maxrss`` which is the OS-reported
+    high-water mark for the lifetime of the process.  Unit is
+    KB on Linux, bytes on macOS, bytes on Windows.
+    """
     try:
         import resource
 
@@ -68,16 +161,206 @@ def _get_rss_mb() -> Optional[int]:
         # Linux / other unices: KB
         return int(maxrss / 1024)
     except Exception:
-        pass
-
-    # Fallback: psutil (Windows, or unusual unix without resource).
-    try:
-        import psutil  # type: ignore
-
-        rss = psutil.Process(os.getpid()).memory_info().rss
-        return int(rss / _BYTES_TO_MB)
-    except Exception:
         return None
+
+
+# ---------------------------------------------------------------------------
+# Configuration helper — reads logging.memory_monitor from config.yaml
+# ---------------------------------------------------------------------------
+
+
+def _resolve_hermes_home() -> Optional[Path]:
+    """Best-effort resolve of ~/.hermes for log directory fallback.
+
+    Imports lazily so this module can be unit-tested without the full
+    Hermes config stack present.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        return Path(get_hermes_home())
+    except Exception:
+        pass
+    env = os.environ.get("HERMES_HOME")
+    if env:
+        return Path(env)
+    return Path.home() / ".hermes"
+
+
+def _resolve_memory_monitor_config() -> dict[str, Any]:
+    """Read the ``logging.memory_monitor`` block from config.yaml.
+
+    Returns a dict with all expected keys; missing keys get sensible
+    defaults so callers don't have to defensively ``.get()`` everywhere.
+
+    We never raise — the monitor is best-effort observability, and a
+    malformed config must not prevent the gateway from starting.
+    """
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "interval_seconds": 60,
+        "heap_dump_threshold_mb": 4096,
+        "heap_dump_dir": None,
+        "heap_dump_top_n": 50,
+        "heap_dump_max_files": 5,
+    }
+    try:
+        from hermes_cli.config import read_raw_config  # type: ignore
+
+        raw = read_raw_config() or {}
+        logging_block = raw.get("logging") or {}
+        if not isinstance(logging_block, dict):
+            return defaults
+        mm = logging_block.get("memory_monitor")
+        if not isinstance(mm, dict):
+            return defaults
+        for key in defaults:
+            if key in mm:
+                defaults[key] = mm[key]
+    except Exception as e:
+        logger.debug("[MEMORY] Could not read logging.memory_monitor config: %s", e)
+    return defaults
+
+
+# ---------------------------------------------------------------------------
+# Heap dump machinery
+# ---------------------------------------------------------------------------
+
+
+def _rotate_heap_dumps(directory: Path, max_files: int) -> None:
+    """Keep only the ``max_files`` most recent ``.pkl`` dumps in ``directory``.
+
+    Eviction is purely age-based — assumes dump filenames encode timestamp
+    prefix (which they do — ``heap-YYYYMMDD-HHMMSS.pkl``), so ``glob``
+    sorted by name gives chronological order.
+    """
+    try:
+        files = sorted(directory.glob("heap-*.pkl"))
+    except Exception:
+        return
+    excess = len(files) - max_files
+    if excess <= 0:
+        return
+    for old in files[:excess]:
+        try:
+            old.unlink()
+        except Exception:
+            pass
+
+
+def _take_heap_dump(top_n: int) -> Optional[Path]:
+    """Capture a tracemalloc snapshot and persist it to disk.
+
+    Returns the path written, or None on failure.  Always tries to
+    stop any prior tracemalloc session before starting — leaks tend to
+    be diagnosed in production where the cost of leaving tracemalloc
+    running is acceptable during the dump window itself.
+    """
+    global _heap_dump_dir
+
+    if _heap_dump_dir is None:
+        hermes_home = _resolve_hermes_home()
+        if hermes_home is None:
+            logger.warning("[MEMORY] HEAP_DUMP skipped — no HERMES_HOME to write to")
+            return None
+        _heap_dump_dir = hermes_home / "logs" / "heap-dumps"
+    try:
+        _heap_dump_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        logger.warning("[MEMORY] HEAP_DUMP skipped — cannot create %s: %s", _heap_dump_dir, e)
+        return None
+
+    was_tracing = tracemalloc.is_tracing()
+    if not was_tracing:
+        tracemalloc.start()
+
+    try:
+        snap = tracemalloc.take_snapshot()
+        try:
+            stats = snap.statistics("traceback")
+        except Exception:
+            # tracemalloc requires tracebacks to be captured at allocation
+            # time — start(25) caps the frame depth.  If we started above
+            # with default depth=1, statistics() will raise.  Fall back to
+            # filename grouping.
+            stats = snap.statistics("filename")
+        top = stats[:top_n]
+        payload = {
+            "ts": time.time(),
+            "pid": os.getpid(),
+            "rss_mb_at_dump": _get_rss_mb(),
+            "peak_rss_mb_at_dump": _get_peak_rss_mb(),
+            "top_allocations": [
+                {
+                    # traceback.statistic objects aren't trivially pickleable;
+                    # serialize the fields we actually want to read offline.
+                    "size_bytes": getattr(s, "size", 0),
+                    "count": getattr(s, "count", 0),
+                    "traceback": str(getattr(s, "traceback", "")),
+                }
+                for s in top
+            ],
+        }
+        ts_label = time.strftime("%Y%m%d-%H%M%S")
+        out_path = _heap_dump_dir / f"heap-{ts_label}-{os.getpid()}.pkl"
+        with open(out_path, "wb") as f:
+            pickle.dump(payload, f, protocol=pickle.HIGHEST_PROTOCOL)
+        return out_path
+    except Exception as e:
+        logger.warning("[MEMORY] HEAP_DUMP failed: %s", e)
+        return None
+    finally:
+        if not was_tracing:
+            try:
+                tracemalloc.stop()
+            except Exception:
+                pass
+
+
+def _maybe_trigger_heap_dump(current_rss_mb: int) -> None:
+    """If RSS crosses threshold and trigger hasn't fired recently, dump.
+
+    ``_heap_dump_in_flight`` guards against re-entrance: tracemalloc
+    snapshots can take seconds on a process with GB of live allocations,
+    and we don't want the next sample tick to start a second dump.
+    Re-arming happens automatically once the dump completes and the
+    RSS comes back down below threshold (next crossing fires again).
+    """
+    global _heap_dump_in_flight
+    if _heap_dump_threshold_mb <= 0:
+        return
+    if _heap_dump_in_flight:
+        return
+    if current_rss_mb < _heap_dump_threshold_mb:
+        return
+    _heap_dump_in_flight = True
+    try:
+        logger.warning(
+            "[MEMORY] HEAP_DUMP_TRIGGERED rss=%dMB threshold=%dMB",
+            current_rss_mb,
+            _heap_dump_threshold_mb,
+        )
+        out_path = _take_heap_dump(_heap_dump_top_n)
+        if out_path is not None:
+            try:
+                size_bytes = out_path.stat().st_size
+            except Exception:
+                size_bytes = -1
+            logger.warning(
+                "[MEMORY] HEAP_DUMP path=%s size=%d top_n=%d",
+                out_path,
+                size_bytes,
+                _heap_dump_top_n,
+            )
+            if _heap_dump_dir is not None and _heap_dump_max_files > 0:
+                _rotate_heap_dumps(_heap_dump_dir, _heap_dump_max_files)
+    finally:
+        _heap_dump_in_flight = False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 def log_memory_usage(prefix: str = "") -> None:
@@ -92,7 +375,14 @@ def log_memory_usage(prefix: str = "") -> None:
         Optional extra tag inserted after ``[MEMORY]`` — e.g.
         ``"baseline"``, ``"shutdown"``.
     """
+    global _peak_rss_mb
     rss = _get_rss_mb()
+    peak = _get_peak_rss_mb()
+    if rss is not None and rss > _peak_rss_mb:
+        _peak_rss_mb = rss
+    # If /proc gave us current but resource failed for peak, still report
+    # the in-process running peak so the operator sees trend.
+    effective_peak = peak if peak is not None else _peak_rss_mb
     uptime = int(time.monotonic() - _start_time) if _start_time else 0
     # gc.get_stats() returns per-generation collection counts; the sum
     # is a cheap proxy for "how much garbage have we created".
@@ -109,21 +399,30 @@ def log_memory_usage(prefix: str = "") -> None:
     tag = f"{prefix} " if prefix else ""
     if rss is None:
         logger.info(
-            "[MEMORY] %srss=unavailable gc=%s threads=%d uptime=%ds",
+            "[MEMORY] %srss=unavailable peak=%dMB gc=%s threads=%d uptime=%ds pid=%d",
             tag,
+            effective_peak,
             gc_counts,
             thread_count,
             uptime,
+            os.getpid(),
         )
     else:
         logger.info(
-            "[MEMORY] %srss=%dMB gc=%s threads=%d uptime=%ds",
+            "[MEMORY] %srss=%dMB peak=%dMB gc=%s threads=%d uptime=%ds pid=%d",
             tag,
             rss,
+            effective_peak,
             gc_counts,
             thread_count,
             uptime,
+            os.getpid(),
         )
+
+    # Heap-dump trigger fires AFTER the log line so the operator sees the
+    # triggering RSS sample in the same second as the dump notice.
+    if rss is not None:
+        _maybe_trigger_heap_dump(rss)
 
 
 def _monitor_loop(stop_event: threading.Event, interval: float) -> None:
@@ -136,18 +435,49 @@ def _monitor_loop(stop_event: threading.Event, interval: float) -> None:
             logger.debug("Memory monitor iteration failed: %s", e)
 
 
-def start_memory_monitoring(interval_seconds: float = 300.0) -> bool:
+def _apply_config(cfg: dict[str, Any]) -> None:
+    """Apply resolved config block to module state.  Called under ``_lock``."""
+    global _interval_seconds, _heap_dump_threshold_mb
+    global _heap_dump_dir, _heap_dump_top_n, _heap_dump_max_files
+    try:
+        _interval_seconds = max(1.0, float(cfg.get("interval_seconds", 60)))
+    except (TypeError, ValueError):
+        _interval_seconds = 60.0
+    try:
+        _heap_dump_threshold_mb = int(cfg.get("heap_dump_threshold_mb", 4096))
+    except (TypeError, ValueError):
+        _heap_dump_threshold_mb = 4096
+    raw_dir = cfg.get("heap_dump_dir")
+    if raw_dir:
+        try:
+            _heap_dump_dir = Path(raw_dir).expanduser()
+        except Exception:
+            _heap_dump_dir = None
+    else:
+        _heap_dump_dir = None
+    try:
+        _heap_dump_top_n = max(1, int(cfg.get("heap_dump_top_n", 50)))
+    except (TypeError, ValueError):
+        _heap_dump_top_n = 50
+    try:
+        _heap_dump_max_files = max(0, int(cfg.get("heap_dump_max_files", 5)))
+    except (TypeError, ValueError):
+        _heap_dump_max_files = 5
+
+
+def start_memory_monitoring(interval_seconds: float | None = None) -> bool:
     """Start periodic memory usage logging in a daemon thread.
 
-    Logs immediately to capture a baseline, then every ``interval_seconds``.
-    Safe to call multiple times — subsequent calls are no-ops while the
-    first monitor is still running.
+    Reads ``logging.memory_monitor`` from config.yaml unless ``interval_seconds``
+    is passed explicitly (useful for tests).  Logs immediately to capture
+    a baseline, then every ``interval_seconds``.  Safe to call multiple
+    times — subsequent calls are no-ops while the first monitor is still
+    running.
 
     Parameters
     ----------
     interval_seconds
-        How often to log.  Default 300s (5 minutes), matching the
-        upstream cline/cline implementation.
+        Override the configured interval.  ``None`` = use config value.
 
     Returns
     -------
@@ -166,13 +496,27 @@ def start_memory_monitoring(interval_seconds: float = 300.0) -> bool:
         # "rss=unavailable" forever — warn once and bail.
         if _get_rss_mb() is None:
             logger.warning(
-                "[MEMORY] Memory monitoring unavailable: neither resource.getrusage "
-                "nor psutil could read process RSS — skipping periodic logging.",
+                "[MEMORY] Memory monitoring unavailable: neither /proc/self/statm "
+                "nor resource.getrusage nor psutil could read process RSS — "
+                "skipping periodic logging."
             )
             return False
 
+        cfg = _resolve_memory_monitor_config()
+        if not cfg.get("enabled", True):
+            logger.info("[MEMORY] Memory monitoring disabled via logging.memory_monitor.enabled")
+            return False
+
+        _apply_config(cfg)
+        if interval_seconds is not None:
+            try:
+                # Floor at 0.01s — fast enough for tests, slow enough that a
+                # misconfigured prod won't melt the CPU logging 1000×/s.
+                _interval_seconds = max(0.01, float(interval_seconds))
+            except (TypeError, ValueError):
+                pass
+
         _start_time = time.monotonic()
-        _interval_seconds = float(interval_seconds)
         _stop_event = threading.Event()
 
         # Baseline snapshot before the loop starts.
@@ -187,8 +531,11 @@ def start_memory_monitoring(interval_seconds: float = 300.0) -> bool:
         _monitor_thread.start()
 
         logger.info(
-            "[MEMORY] Periodic memory monitoring started (interval: %ds)",
+            "[MEMORY] Periodic memory monitoring started (interval: %ds, "
+            "heap_dump_threshold: %dMB, heap_dump_dir: %s)",
             int(_interval_seconds),
+            _heap_dump_threshold_mb,
+            _heap_dump_dir or "<default ~/.hermes/logs/heap-dumps>",
         )
         return True
 
@@ -228,3 +575,27 @@ def is_running() -> bool:
     """True if the background monitor thread is alive."""
     with _lock:
         return _monitor_thread is not None and _monitor_thread.is_alive()
+
+
+def configure_for_test(
+    *,
+    threshold_mb: int = 0,
+    dump_dir: Optional[Path] = None,
+    top_n: int = 50,
+    max_files: int = 5,
+    interval_seconds: float = 60.0,
+) -> None:
+    """Test-only: set module-level heap-dump config without touching the thread.
+
+    Lets tests exercise the threshold trigger and rotation logic without
+    having to write a full config.yaml or start the background thread.
+    Safe to call repeatedly; resets to defaults on every call.
+    """
+    global _heap_dump_threshold_mb, _heap_dump_dir
+    global _heap_dump_top_n, _heap_dump_max_files, _interval_seconds, _heap_dump_in_flight
+    _heap_dump_threshold_mb = int(threshold_mb)
+    _heap_dump_dir = Path(dump_dir).expanduser() if dump_dir is not None else None
+    _heap_dump_top_n = int(top_n)
+    _heap_dump_max_files = int(max_files)
+    _interval_seconds = float(interval_seconds)
+    _heap_dump_in_flight = False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -63,10 +63,110 @@ from hermes_cli.fallback_config import get_fallback_chain
 # long-lived gateways (each AIAgent holds LLM clients, tool schemas,
 # memory providers, etc.).  LRU order + idle TTL eviction are enforced
 # from _enforce_agent_cache_cap() and _session_expiry_watcher() below.
-_AGENT_CACHE_MAX_SIZE = 128
+#
+# Defaults are the floor; operators can override per-deployment via
+# ``gateway.agent_cache`` in config.yaml (see _resolve_agent_cache_config).
+# The previous hardcoded MAX_SIZE=128 was suspected as the RSS-bloat root
+# cause when many sessions were simultaneously mid-turn (cap eviction
+# intentionally skips active agents — see _enforce_agent_cache_cap).
+_AGENT_CACHE_MAX_SIZE = 96
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
+_AGENT_CACHE_SWEEP_INTERVAL_SECS = 60.0  # idle-TTL sweep cadence (was 300s)
+# Memory-based soft cap: when the gateway RSS exceeds this many MiB the
+# cache cap is tightened (proportionally) and an extra sweep is fired.
+# 0 disables the memory guardrail — the count cap is the only bound.
+# Default 2 GiB; targets the 25.5 GB peak observed on long-lived gateways
+# by clamping growth before it escapes to swap.
+_AGENT_CACHE_MAX_RSS_MIB = 2048
+_AGENT_CACHE_RSS_OVERRIDE_RATIO = 0.5  # halve the cap when over the RSS floor
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+
+
+def _resolve_agent_cache_config() -> dict:
+    """Read ``gateway.agent_cache`` overrides from config.yaml.
+
+    Returns a dict with keys ``max_size`` (int), ``idle_ttl_secs`` (float),
+    ``sweep_interval_secs`` (float), ``max_rss_mib`` (int), and
+    ``rss_override_ratio`` (float).  Missing keys fall back to the
+    module-level defaults above so behaviour never regresses when the
+    block is absent.  Invalid values (non-numeric, negative) are
+    discarded and the default is used.
+    """
+    result: dict = {
+        "max_size": _AGENT_CACHE_MAX_SIZE,
+        "idle_ttl_secs": _AGENT_CACHE_IDLE_TTL_SECS,
+        "sweep_interval_secs": _AGENT_CACHE_SWEEP_INTERVAL_SECS,
+        "max_rss_mib": _AGENT_CACHE_MAX_RSS_MIB,
+        "rss_override_ratio": _AGENT_CACHE_RSS_OVERRIDE_RATIO,
+    }
+    try:
+        from hermes_cli.config import cfg_get, load_config as _load_cfg
+        cfg = _load_cfg()
+        block = cfg_get(cfg, "gateway", "agent_cache")
+    except Exception:
+        block = None
+    if not isinstance(block, dict):
+        return result
+
+    raw_max = block.get("max_size")
+    if isinstance(raw_max, int) and not isinstance(raw_max, bool) and 1 <= raw_max <= 100_000:
+        result["max_size"] = raw_max
+
+    raw_idle = block.get("idle_ttl_secs")
+    if isinstance(raw_idle, (int, float)) and not isinstance(raw_idle, bool) and 0 < raw_idle <= 86_400:
+        result["idle_ttl_secs"] = float(raw_idle)
+
+    raw_sweep = block.get("sweep_interval_secs")
+    if isinstance(raw_sweep, (int, float)) and not isinstance(raw_sweep, bool) and 0 < raw_sweep <= 3_600:
+        result["sweep_interval_secs"] = float(raw_sweep)
+
+    raw_rss = block.get("max_rss_mib")
+    if isinstance(raw_rss, int) and not isinstance(raw_rss, bool) and 0 <= raw_rss <= 1_048_576:
+        result["max_rss_mib"] = raw_rss
+
+    raw_ratio = block.get("rss_override_ratio")
+    if isinstance(raw_ratio, (int, float)) and not isinstance(raw_ratio, bool) and 0 < raw_ratio <= 1:
+        result["rss_override_ratio"] = float(raw_ratio)
+    return result
+
+
+def _read_rss_mib() -> int | None:
+    """Return the gateway's RSS in MiB, or ``None`` if unavailable.
+
+    Reads /proc/self/statm so it works on Linux without psutil.  Used
+    by the memory-guardrail path; intentionally best-effort — a failure
+    here must NEVER take down the gateway.
+    """
+    try:
+        with open("/proc/self/statm", "r") as f:
+            parts = f.read().split()
+        # statm: size resident shared text lib data dt
+        pages = int(parts[1])
+        # Linux page size is 4 KiB on every supported arch for hermes-agent
+        return (pages * 4096) // (1024 * 1024)
+    except Exception:
+        return None
+
+
+def _effective_agent_cache_cap() -> int:
+    """Return the cap to use RIGHT NOW, honouring the RSS guardrail.
+
+    When RSS exceeds ``max_rss_mib`` the cap is shrunk to
+    ``max(1, int(max_size * rss_override_ratio))`` so the next sweep is
+    more aggressive.  Drops back to ``max_size`` once RSS is back under
+    the floor.
+    """
+    cfg = _resolve_agent_cache_config()
+    cap = cfg["max_size"]
+    rss_floor = cfg["max_rss_mib"]
+    if rss_floor <= 0:
+        return cap
+    rss = _read_rss_mib()
+    if rss is None or rss <= rss_floor:
+        return cap
+    shrunk = max(1, int(cap * cfg["rss_override_ratio"]))
+    return shrunk
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
@@ -6609,15 +6709,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             err = getattr(result, "error", "send returned success=False")
             raise RuntimeError(f"adapter.send failed: {err}")
 
-    async def _session_expiry_watcher(self, interval: int = 300):
-        """Background task that finalizes expired sessions.
+    async def _session_expiry_watcher(self, interval: float | None = None):
+        """Background task that finalizes expired sessions and sweeps idle cache.
 
-        Runs every ``interval`` seconds (default 5 min).  For each session
-        whose reset policy has expired, invokes ``on_session_finalize``
-        hooks, cleans up the cached AIAgent's tool resources, evicts the
-        cache entry so it can be garbage-collected, and marks the session
-        so it won't be finalized again.
+        Runs every ``interval`` seconds (default from
+        ``gateway.agent_cache.sweep_interval_secs`` in config.yaml,
+        falling back to ``_AGENT_CACHE_SWEEP_INTERVAL_SECS`` = 60s, was
+        hardcoded 300s).  For each session whose reset policy has expired,
+        invokes ``on_session_finalize`` hooks, cleans up the cached
+        AIAgent's tool resources, evicts the cache entry so it can be
+        garbage-collected, and marks the session so it won't be finalized
+        again.
+
+        The faster sweep cadence (60s vs the old 5 min) closes the
+        eviction gap that let idle cached agents accumulate past the LRU
+        cap when many sessions were simultaneously mid-turn.
         """
+        if interval is None:
+            interval = _resolve_agent_cache_config()["sweep_interval_secs"]
         await asyncio.sleep(60)  # initial delay — let the gateway fully start
         _finalize_failures: dict[str, int] = {}  # session_id -> consecutive failure count
         _MAX_FINALIZE_RETRIES = 3
@@ -6781,11 +6890,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._last_session_store_prune_ts = time.time()
             except Exception as e:
                 logger.debug("Session expiry watcher error: %s", e)
-            # Sleep in small increments so we can stop quickly
-            for _ in range(interval):
+            # Sleep in small increments so we can stop quickly.
+            # interval is float seconds from config; cast for the per-second
+            # tick loop and the final tail-sleep below.
+            _resolved_interval: float = float(interval) if interval is not None else _resolve_agent_cache_config()["sweep_interval_secs"]
+            _interval_int = max(1, int(_resolved_interval))
+            for _ in range(_interval_int):
                 if not self._running:
                     break
                 await asyncio.sleep(1)
+            # Final fractional tail-sleep so a 90.5s interval still hits
+            # the configured cadence rather than rounding down to 90s.
+            _tail = _resolved_interval - _interval_int
+            if _tail > 0 and self._running:
+                await asyncio.sleep(_tail)
 
     def _active_profile_name(self) -> str:
         """Return the profile name this gateway represents."""
@@ -14649,7 +14767,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # already-cached long-running one.  The cache may therefore stay
         # temporarily over cap; it will re-check on the next insert,
         # after active turns have finished.
-        excess = max(0, len(_cache) - _AGENT_CACHE_MAX_SIZE)
+        #
+        # The cap is read via _effective_agent_cache_cap() so it honours
+        # any ``gateway.agent_cache`` config override AND the RSS-based
+        # soft cap when memory pressure is high.
+        cap = _effective_agent_cache_cap()
+        excess = max(0, len(_cache) - cap)
         evict_plan: List[tuple] = []  # [(key, agent), ...]
         if excess > 0:
             ordered_keys = list(_cache.keys())
@@ -14663,12 +14786,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         for key, _ in evict_plan:
             _cache.pop(key, None)
 
-        remaining_over_cap = len(_cache) - _AGENT_CACHE_MAX_SIZE
+        remaining_over_cap = len(_cache) - cap
         if remaining_over_cap > 0:
             logger.warning(
                 "Agent cache over cap (%d > %d); %d excess slot(s) held by "
                 "mid-turn agents — will re-check on next insert.",
-                len(_cache), _AGENT_CACHE_MAX_SIZE, remaining_over_cap,
+                len(_cache), cap, remaining_over_cap,
             )
 
         for key, agent in evict_plan:
@@ -14706,6 +14829,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             for a in getattr(self, "_running_agents", {}).values()
             if a is not None and a is not _AGENT_PENDING_SENTINEL
         }
+        # Read the configured idle TTL via _resolve_agent_cache_config so
+        # operators can raise it (e.g. for high-traffic gateways) without a
+        # code change.  Falls through to _AGENT_CACHE_IDLE_TTL_SECS when
+        # the config block is absent or invalid.
+        idle_ttl = _resolve_agent_cache_config()["idle_ttl_secs"]
         with _lock:
             for key, entry in list(_cache.items()):
                 agent = entry[0] if isinstance(entry, tuple) and entry else None
@@ -14716,7 +14844,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 last_activity = getattr(agent, "_last_activity_ts", None)
                 if last_activity is None:
                     continue
-                if (now - last_activity) > _AGENT_CACHE_IDLE_TTL_SECS:
+                if (now - last_activity) > idle_ttl:
                     to_evict.append((key, agent))
             for key, _ in to_evict:
                 _cache.pop(key, None)
@@ -18097,6 +18225,26 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     from gateway.code_skew import record_boot_fingerprint
     record_boot_fingerprint()
 
+    # ── Periodic memory monitoring ────────────────────────────────────
+    # Spin up the RSS sampler + heap-dump-on-threshold thread early so it
+    # is alive across the gateway's full lifetime.  Configured via
+    # ``logging.memory_monitor`` in config.yaml — see gateway/memory_monitor.py.
+    # Idempotent: returns False if already running (e.g. tests / re-import).
+    # Also registered with atexit so the final snapshot + clean stop fires
+    # on every exit path (SIGTERM, SystemExit, KeyboardInterrupt, normal return).
+    try:
+        import atexit
+        from gateway.memory_monitor import (
+            start_memory_monitoring,
+            stop_memory_monitoring,
+        )
+        start_memory_monitoring()
+        # Idempotent — atexit only fires once even with multiple registrations,
+        # but stop_memory_monitoring itself is also idempotent.
+        atexit.register(stop_memory_monitoring)
+    except Exception as e:
+        logger.warning("[MEMORY] Failed to start memory monitor: %s", e)
+
     # ── Duplicate-instance guard ──────────────────────────────────────
     # Prevent two gateways from running under the same HERMES_HOME.
     # The PID file is scoped to HERMES_HOME, so future multi-profile
@@ -18600,6 +18748,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             "manager relaunches the gateway."
         )
         raise SystemExit(75)
+
+    # Final memory snapshot + monitor thread shutdown is handled by the
+    # atexit handler registered at the top of start_gateway.
 
     return True
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7811,10 +7811,20 @@ def _spawn_preflight_credentials(profile_arg: str) -> None:
         # No pool entries recorded — same as no auth.json.
         return
 
+    # Classify every provider in the pool:
+    #   "blocking"   - every entry on this provider is exhausted/dead
+    #   "healthy"    - at least one entry has a non-blocking status
+    #                   (None / missing / "ok") — the credential pool may
+    #                   pick that one.
+    # Only block the spawn when EVERY provider in the pool is blocking.
+    # If even one provider is healthy, the worker's credential-pool
+    # rotation can still succeed and the spawn should proceed.
     blocking_providers: list[str] = []
+    total_providers = 0
     for provider_name, entries in pool.items():
         if not isinstance(entries, list) or not entries:
             continue
+        total_providers += 1
         # A provider is "blocking" iff EVERY entry is exhausted/dead.
         # An entry with status=None or missing counts as healthy
         # (never failed yet).
@@ -7836,7 +7846,13 @@ def _spawn_preflight_credentials(profile_arg: str) -> None:
                 f"message={message!r})"
             )
 
-    if blocking_providers:
+    # Spawn-proceeds iff there is at least one healthy provider in the
+    # pool. Fix for kanban task t_e3e0256f (2026-06-29): the prior
+    # condition `if blocking_providers:` false-blocked any profile where
+    # one provider was all-dead, even when other healthy providers
+    # coexisted in the same pool. A profile with one healthy provider
+    # is usable; only a profile with NO healthy providers is doomed.
+    if total_providers > 0 and len(blocking_providers) >= total_providers:
         raise RuntimeError(
             f"spawn preflight: profile {profile_arg!r} has no usable "
             f"credentials — every pool entry is exhausted or dead. "

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -274,6 +274,39 @@ def _resolve_rate_limit_cooldown_seconds() -> int:
     return DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
 
 
+def _resolve_blocker_auth_window_seconds() -> int:
+    """Return the max age (seconds) of a ``last_failure_error`` after which
+    the ``blocker_auth`` respawn guard releases and the dispatcher attempts
+    a fresh probe.
+
+    Reads ``HERMES_KANBAN_BLOCKER_AUTH_WINDOW_SECONDS`` from the
+    environment; falls back to ``DEFAULT_RESPAWN_BLOCKER_WINDOW_SECONDS``
+    when absent, empty, non-integer, or negative. A value of 0 disables
+    the guard entirely (always allow a probe — useful for tests or for
+    operators who prefer to let the auto-block circuit breaker be the
+    sole gatekeeper).
+
+    Rationale: the regex-based ``blocker_auth`` guard is intentionally
+    silent — it does not bump ``consecutive_failures`` — so a one-time
+    stale failure parks a task in ``ready`` until either the operator
+    unblocks it or the breaker trips. Without this TTL the only way out
+    of ``blocker_auth`` was a manual ``hermes kanban unblock``. Reported
+    in t_7f4b0ff2 (2026-06-29): two ready tasks with stale ``429``
+    text sat for 21.9h while the live credential pool was healthy.
+    """
+    raw = os.environ.get(
+        "HERMES_KANBAN_BLOCKER_AUTH_WINDOW_SECONDS", ""
+    ).strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = -1
+        if parsed >= 0:
+            return parsed
+    return DEFAULT_RESPAWN_BLOCKER_WINDOW_SECONDS
+
+
 # Worker-context caps so build_worker_context() stays bounded on
 # pathological boards (retry-heavy tasks, comment storms, giant
 # summaries). Values chosen to fit a typical 100k-char LLM prompt with
@@ -1946,6 +1979,39 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "tasks",
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+
+    if "last_failure_at" not in cols:
+        # Timestamp of the most recent failure recorded by
+        # ``_record_task_failure``. NULL on legacy rows that predate the
+        # column. Used by ``check_respawn_guard`` to release the
+        # ``blocker_auth`` deferral after
+        # ``HERMES_KANBAN_BLOCKER_AUTH_WINDOW_SECONDS`` (default 1800s);
+        # without this timestamp the regex would defer a stale failure
+        # forever and the silent deferral would never bump
+        # ``consecutive_failures`` for the auto-block circuit breaker to
+        # trip (t_7f4b0ff2, 2026-06-29). Backfill from the latest
+        # ``spawn_failed`` ``task_events`` row when one exists, so old
+        # tasks unstick as soon as their failure ages past the window.
+        _add_column_if_missing(
+            conn, "tasks", "last_failure_at", "last_failure_at INTEGER"
+        )
+        conn.execute(
+            """
+            UPDATE tasks
+               SET last_failure_at = (
+                   SELECT MAX(e.created_at)
+                     FROM task_events e
+                    WHERE e.task_id = tasks.id
+                      AND e.kind IN ('spawn_failed', 'gave_up', 'crashed', 'timed_out')
+               )
+             WHERE last_failure_at IS NULL
+               AND EXISTS (
+                   SELECT 1 FROM task_events e
+                    WHERE e.task_id = tasks.id
+                      AND e.kind IN ('spawn_failed', 'gave_up', 'crashed', 'timed_out')
+               )
+            """
         )
 
     # Indexes over additive ``tasks`` columns must be created after the
@@ -5600,6 +5666,22 @@ DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 300  # 5 minutes
 # Within this window a GitHub PR URL in a comment blocks re-spawn.
 _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
 
+# Max age (seconds) of the last failure error before the ``blocker_auth``
+# guard releases and the dispatcher attempts a fresh probe. Without
+# this, a one-time preflight failure on a profile whose credentials
+# later recovered would park the task in ``ready`` indefinitely —
+# the regex never changes its mind on its own, and the deferral path
+# does not bump ``consecutive_failures`` so the auto-block circuit
+# breaker cannot trip either. Reported in t_7f4b0ff2 (2026-06-29):
+# two ready tasks with stale ``429`` text sat for 21.9h while the live
+# credential pool was healthy. Default 30 min — long enough to give a
+# quota window time to reset, short enough that an operator who
+# rotated keys sees the board recover on its own instead of having to
+# ``hermes kanban unblock`` every stuck task. Overridable via
+# ``HERMES_KANBAN_BLOCKER_AUTH_WINDOW_SECONDS``; 0 disables the
+# guard entirely (always allow a probe).
+DEFAULT_RESPAWN_BLOCKER_WINDOW_SECONDS = 1800  # 30 minutes
+
 # Pattern matching a GitHub PR URL in task comments.
 _RESPAWN_GUARD_PR_URL_RE = re.compile(
     r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+",
@@ -6524,6 +6606,11 @@ def _record_task_failure(
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     blocked = False
+    # Stamped onto ``tasks.last_failure_at`` in every branch below so the
+    # respawn guard can age out a stale ``blocker_auth`` deferral
+    # (t_7f4b0ff2). Captured once so all four UPDATEs share an exact
+    # timestamp rather than drifting by millisecond rounding.
+    failure_at = int(time.time())
     with write_txn(conn):
         row = conn.execute(
             "SELECT consecutive_failures, status, max_retries "
@@ -6553,9 +6640,10 @@ def _record_task_failure(
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
-                    "consecutive_failures = ?, last_failure_error = ? "
+                    "consecutive_failures = ?, last_failure_error = ?, "
+                    "last_failure_at = ? "
                     "WHERE id = ? AND status IN ('running', 'ready')",
-                    (failures, error[:500], task_id),
+                    (failures, error[:500], failure_at, task_id),
                 )
             else:
                 # Timeout/crash path: task is already at ``ready``
@@ -6563,9 +6651,10 @@ def _record_task_failure(
                 # counter fields.
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', "
-                    "consecutive_failures = ?, last_failure_error = ? "
+                    "consecutive_failures = ?, last_failure_error = ?, "
+                    "last_failure_at = ? "
                     "WHERE id = ? AND status IN ('ready', 'running')",
-                    (failures, error[:500], task_id),
+                    (failures, error[:500], failure_at, task_id),
                 )
             run_id = None
             if end_run:
@@ -6601,17 +6690,19 @@ def _record_task_failure(
                 conn.execute(
                     "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
-                    "consecutive_failures = ?, last_failure_error = ? "
+                    "consecutive_failures = ?, last_failure_error = ?, "
+                    "last_failure_at = ? "
                     "WHERE id = ? AND status = 'running'",
-                    (failures, error[:500], task_id),
+                    (failures, error[:500], failure_at, task_id),
                 )
             else:
                 # Timeout/crash path: task is already at ``ready`` via
                 # its own UPDATE. Just bookkeep the counter + last error.
                 conn.execute(
                     "UPDATE tasks SET consecutive_failures = ?, "
-                    "last_failure_error = ? WHERE id = ?",
-                    (failures, error[:500], task_id),
+                    "last_failure_error = ?, last_failure_at = ? "
+                    "WHERE id = ?",
+                    (failures, error[:500], failure_at, task_id),
                 )
             if end_run:
                 # Spawn path: close the open run with outcome.
@@ -6682,7 +6773,8 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
     with write_txn(conn):
         conn.execute(
             "UPDATE tasks SET consecutive_failures = 0, "
-            "last_failure_error = NULL WHERE id = ?",
+            "last_failure_error = NULL, last_failure_at = NULL "
+            "WHERE id = ?",
             (task_id,),
         )
 
@@ -6722,6 +6814,20 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         blocks via the normal path — but a transient 429 gets a few
         ticks of recovery first.
 
+        The deferral is bounded by ``_RESPAWN_BLOCKER_WINDOW_SECONDS``
+        (default 1800s, env-tunable via
+        ``HERMES_KANBAN_BLOCKER_AUTH_WINDOW_SECONDS``): if the failure
+        is older than that window, the guard releases and the
+        dispatcher attempts a fresh probe. Without this, a one-time
+        preflight failure on a profile whose credentials later
+        recovered would park the task in ``ready`` indefinitely —
+        the regex never changes its mind on its own, and the
+        deferral path does not bump ``consecutive_failures`` so the
+        auto-block circuit breaker cannot trip either. This was the
+        symptom reported in t_7f4b0ff2 (2026-06-29): two ready
+        tasks with stale ``429`` text sat for 21.9h while the live
+        credential pool was healthy.
+
     ``"recent_success"``
         A completed run exists within ``_RESPAWN_GUARD_SUCCESS_WINDOW``
         seconds.  Useful work already succeeded for this task; wait for
@@ -6738,7 +6844,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     genuinely dead (no live PID on this host).
     """
     row = conn.execute(
-        "SELECT last_failure_error FROM tasks WHERE id = ?",
+        "SELECT last_failure_error, last_failure_at, created_at FROM tasks "
+        "WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
@@ -6785,7 +6892,46 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     # 2. Quota / auth blocker: retrying immediately will not help.
     err = row["last_failure_error"]
     if err and _RESPAWN_BLOCKER_RE.search(err):
-        return "blocker_auth"
+        # Bounded by _RESPAWN_BLOCKER_WINDOW_SECONDS so a one-time
+        # preflight failure whose underlying credential problem later
+        # recovered cannot park the task in ``ready`` indefinitely.
+        # Without this, the regex would defer forever and the silent
+        # deferral would never bump ``consecutive_failures`` for the
+        # auto-block circuit breaker to trip (t_7f4b0ff2).
+        blocker_window = _resolve_blocker_auth_window_seconds()
+        if blocker_window <= 0:
+            # Guard disabled — always allow a probe.
+            err = None
+        else:
+            # ``last_failure_at`` is the source of truth; fall back to
+            # ``created_at`` only for legacy rows that predate the
+            # migration (NULL last_failure_at). The fallback is
+            # conservative: it uses the OLDER of the two, so we never
+            # release the guard sooner than either timestamp implies.
+            failed_at = row["last_failure_at"]
+            if failed_at is None:
+                fallback_at = row["created_at"]
+                age_source = "created_at"
+            else:
+                fallback_at = int(failed_at)
+                age_source = "last_failure_at"
+            if fallback_at is not None and (now - int(fallback_at)) >= blocker_window:
+                # Failure is older than the window — release the guard
+                # and let the dispatcher take a fresh probe. The probe
+                # itself will re-run ``_spawn_preflight_credentials``;
+                # if the credential pool is STILL broken, the next
+                # attempt raises and ``_record_spawn_failure`` will
+                # bump ``consecutive_failures`` toward the breaker
+                # threshold normally.
+                _log.debug(
+                    "kanban respawn_guard: releasing blocker_auth deferral "
+                    "for task=%s after %s window (age=%ds source=%s); "
+                    "allowing fresh probe",
+                    task_id, blocker_window, now - int(fallback_at), age_source,
+                )
+                err = None
+        if err:
+            return "blocker_auth"
 
     # 3. Completed run within guard window — proof of recent success.
     cutoff = now - _RESPAWN_GUARD_SUCCESS_WINDOW

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6421,11 +6421,21 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # ready → blocked with a ``gave_up`` event on top of the ``crashed``
     # event we already emitted.
     #
-    # Protocol-violation crashes force an immediate trip (failure_limit=1)
-    # because clean-exit-without-transition is deterministic: the next
-    # respawn will do exactly the same thing. Better to surface to a
-    # human with a clear reason than to loop ``DEFAULT_FAILURE_LIMIT``
-    # times first.
+    # Protocol-violation crashes (worker exited cleanly without calling
+    # kanban_complete / kanban_block) used to force ``failure_limit=1``
+    # on the assumption that the next respawn would do exactly the same
+    # thing. That's true for genuine worker-driver bugs, but it also
+    # locked out an entire class of *recoverable* failures — most notably
+    # upstream provider-auth exhaustion, where the next respawn runs
+    # *only* after the operator rotates the OpenRouter key (or the
+    # account cooldown elapses). One crash → permanent block on what is
+    # actually a credentials problem. We now let the global
+    # ``kanban.failure_limit`` (default 2) be the floor, so a transient
+    # recovery (key rotation) can land the retry before the breaker
+    # trips. The genuine-loop safety net is preserved via the
+    # ``is_systemic`` fingerprint check on the non-protocol-violation
+    # path — three same-fingerprint crashes still auto-block
+    # immediately, regardless of the failure_limit floor.
     auto_blocked: list[str] = []
     if crash_details:
         # Fingerprint errors to detect systemic failures.
@@ -6443,7 +6453,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 conn, tid,
                 error=error_text,
                 outcome="crashed",
-                failure_limit=1 if (protocol_violation or is_systemic) else None,
+                # Protocol-violation crashes respect the global
+                # ``kanban.failure_limit`` floor (default 2) instead of
+                # hard-coded 1 — see comment above. ``is_systemic``
+                # non-protocol-violation loops still trip on the first
+                # iteration above threshold (preserved).
+                failure_limit=1 if is_systemic else None,
                 release_claim=False,
                 end_run=False,
                 event_payload_extra={"pid": pid, "claimer": claimer},
@@ -7580,6 +7595,112 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         return None
 
 
+# Status values from ``agent/credential_pool.py`` that mean the credential
+# is permanently unusable for this run. ``exhausted`` (HTTP 401/402/429)
+# covers auth rejection, billing/quota, and rate-limit; ``dead`` covers
+# terminal OAuth states (token_revoked / token_invalidated). Other
+# ``last_status`` values (``None``/missing, ``ok``) are NOT terminal and
+# are not eligible for the spawn-preflight short-circuit.
+_SPAWN_PREFLIGHT_BLOCKING_STATUSES = frozenset({"exhausted", "dead"})
+
+
+def _spawn_preflight_credentials(profile_arg: str) -> None:
+    """Spawn-time gate: refuse to spawn a worker when every credential
+    entry on its profile is stamped with a blocking status.
+
+    Returns ``None`` when the profile is healthy (or has no auth.json on
+    disk yet — the worker may still pick up env-var auth). Raises
+    ``RuntimeError`` with a concrete remediation hint when ALL entries
+    on ALL providers are ``exhausted`` or ``dead`` — i.e. the worker
+    subprocess is going to die in <1s with the rc=0 protocol-violation
+    signature before reaching any tool loop. The dispatcher's existing
+    ``except Exception`` around ``_default_spawn`` catches this and
+    routes through ``_record_spawn_failure`` (``outcome='spawn_failed'``),
+    stamping ``last_failure_error`` with the reason and bumping
+    ``consecutive_failures`` — which gives Frank a concrete action to
+    take instead of a 60-second 401 → block dance.
+
+    Belt-and-braces with the protocol-violation floor raise at line 6149:
+    when this preflight passes (e.g. a profile with some healthy and
+    some exhausted entries), the worker still might crash cleanly, but
+    at least the spawn wasn't doomed from the start. The two patches
+    complement each other — the floor keeps a transient recovery (key
+    rotation) alive, the preflight short-circuits the obvious case
+    where the *first* attempt cannot succeed at all.
+
+    Fail-open semantics: any error reading or parsing auth.json is
+    swallowed and the spawn proceeds. The credential pool itself
+    re-reads auth.json on every entry selection, so the worst case is
+    "we didn't catch it pre-spawn" — not "we false-blocked a healthy
+    profile."
+    """
+    try:
+        from hermes_cli.profiles import resolve_profile_env
+        profile_home = resolve_profile_env(profile_arg)
+    except FileNotFoundError:
+        # Profile directory doesn't exist — defer to the worker.
+        return
+    except Exception:
+        # Any other resolution error (imports, env) — don't block spawn.
+        return
+
+    auth_path = os.path.join(profile_home, "auth.json")
+    if not os.path.isfile(auth_path):
+        # No auth.json means no credential pool entries on disk — the
+        # worker may still auth via env vars or interactive flows.
+        return
+
+    try:
+        with open(auth_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        # Corrupt or unreadable auth.json — don't block spawn, let the
+        # credential pool surface the real error inside the worker.
+        return
+    if not isinstance(data, dict):
+        return
+
+    pool = data.get("credential_pool")
+    if not isinstance(pool, dict) or not pool:
+        # No pool entries recorded — same as no auth.json.
+        return
+
+    blocking_providers: list[str] = []
+    for provider_name, entries in pool.items():
+        if not isinstance(entries, list) or not entries:
+            continue
+        # A provider is "blocking" iff EVERY entry is exhausted/dead.
+        # An entry with status=None or missing counts as healthy
+        # (never failed yet).
+        all_blocked = all(
+            isinstance(e, dict)
+            and e.get("last_status") in _SPAWN_PREFLIGHT_BLOCKING_STATUSES
+            for e in entries
+        )
+        if all_blocked:
+            # Surface the most informative error reason for the operator.
+            sample = next(
+                (e for e in entries if isinstance(e, dict)),
+                {},
+            )
+            code = sample.get("last_error_code")
+            message = sample.get("last_error_message") or "<no message>"
+            blocking_providers.append(
+                f"{provider_name} (last_error_code={code}, "
+                f"message={message!r})"
+            )
+
+    if blocking_providers:
+        raise RuntimeError(
+            f"spawn preflight: profile {profile_arg!r} has no usable "
+            f"credentials — every pool entry is exhausted or dead. "
+            f"Blocking providers: {'; '.join(blocking_providers)}. "
+            f"Remediate by running `hermes auth` (or rotating the key in "
+            f"~/.hermes/profiles/{profile_arg}/auth.json), then "
+            f"`hermes kanban unblock <task-id>` to retry."
+        )
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -7605,6 +7726,21 @@ def _default_spawn(
     from hermes_cli.profiles import normalize_profile_name
 
     profile_arg = normalize_profile_name(task.assignee)
+
+    # Spawn-time credential preflight. Belt-and-braces with the
+    # protocol-violation floor raise at line 6149: when the profile's
+    # credential pool is fully exhausted (every entry stamped
+    # ``last_status='exhausted'`` or ``'dead'``), the worker is going
+    # to die in <1s with the rc=0 protocol-violation signature before
+    # any tool loop runs. Surface that as a ``spawn_failed`` here
+    # instead of burning 60 seconds of grace + a worker budget on a
+    # doomed call. The dispatcher's existing ``except Exception``
+    # handler catches the RuntimeError, calls
+    # ``_record_spawn_failure`` (which writes a ``spawn_failed`` event
+    # + bumps ``consecutive_failures``), and lands the task in
+    # ``blocked`` with a ``last_failure_error`` that tells the
+    # operator exactly which profile + provider is broken.
+    _spawn_preflight_credentials(profile_arg)
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -27,9 +27,11 @@ Session context:
     that thread will include ``[session_id]`` for filtering/correlation.
 """
 
+import gzip
 import io
 import logging
 import os
+import shutil
 import sys
 import threading
 from pathlib import Path
@@ -304,13 +306,17 @@ def setup_logging(
     )
 
     # --- errors.log (WARNING+) — quick triage log --------------------------
+    # Rotates at 5 MiB keeping 5 compressed (.gz) backups — matches agent.log
+    # size/count defaults from config.yaml and bounds total disk usage to
+    # ~30 MiB (current + 5 backups at ~5 MiB each, gzipped typically <1 MiB).
     _add_rotating_handler(
         root,
         log_dir / "errors.log",
         level=logging.WARNING,
-        max_bytes=2 * 1024 * 1024,
-        backup_count=2,
+        max_bytes=max_bytes,
+        backup_count=backups,
         formatter=RedactingFormatter(_LOG_FORMAT),
+        compress_rotated=True,
     )
 
     # --- gateway.log (INFO+, gateway component only) ------------------------
@@ -413,9 +419,10 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         rotating handlers.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, compress_rotated: bool = False, **kwargs):
         from hermes_cli.config import is_managed
         self._managed = is_managed()
+        self._compress_rotated = compress_rotated
         super().__init__(*args, **kwargs)
         # Snapshot the inode of the currently open stream so emit() can
         # detect external rotation without an extra fstat per write.
@@ -500,11 +507,125 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         return stream
 
     def doRollover(self):
-        super().doRollover()
+        # When compression is enabled we can't rely on stdlib's rename chain
+        # (it walks .N→.N+1 in plain-text land, which would leave the OLD
+        # compressed .1.gz stranded with .2/.3 as plain-text and silently
+        # skip the .1→.2 step on the next rollover). Instead, do the shift
+        # ourselves across the .gz suffix and only fall through to stdlib
+        # for the plain-text case.
+        if self._compress_rotated:
+            self._doRolloverCompressed()
+        else:
+            super().doRollover()
         self._chmod_if_managed()
+
         # Our own rollover writes a new baseFilename; refresh the snapshot
         # so the next emit doesn't mistake it for external rotation.
         self._record_stream_stat()
+
+    def _doRolloverCompressed(self):
+        """Custom rollover path used when ``_compress_rotated`` is True.
+
+        Mirrors stdlib ``RotatingFileHandler.doRollover`` but operates over
+        the ``.gz`` suffix instead of the plain ``.N`` chain:
+
+        1. Close the live stream.
+        2. Shift ``baseFilename.(N-1).gz`` → ``baseFilename.N.gz`` in
+           reverse, deleting any existing tail first.
+        3. If ``baseFilename.1.gz`` exists, remove it (it's now in .2.gz).
+        4. Rename ``baseFilename`` → ``baseFilename.1`` and gzip that to
+           ``baseFilename.1.gz`` (the new head).
+        5. Reopen ``baseFilename`` if not ``delay=True``.
+
+        All exceptions here are swallowed and logged to stderr — rotation
+        is a maintenance path, and a partial rotation leaves the live
+        log functional even if the backup chain is one step out of sync.
+        """
+        try:
+            if self.stream:
+                self.stream.close()
+                self.stream = None
+
+            if self.backupCount > 0:
+                # Shift the .gz chain in reverse. The newest current .1.gz
+                # becomes the oldest .2.gz (etc.); old tails are unlinked
+                # so the rename always succeeds.
+                for i in range(self.backupCount - 1, 0, -1):
+                    src_gz = self.rotation_filename(
+                        "%s.%d.gz" % (self.baseFilename, i)
+                    )
+                    dst_gz = self.rotation_filename(
+                        "%s.%d.gz" % (self.baseFilename, i + 1)
+                    )
+                    if os.path.exists(src_gz):
+                        if os.path.exists(dst_gz):
+                            os.remove(dst_gz)
+                        os.rename(src_gz, dst_gz)
+
+                # Drop the head .1.gz if it survived the shift (defensive:
+                # rotation_filename may have written a stale one).
+                head_gz = self.rotation_filename(
+                    "%s.1.gz" % self.baseFilename
+                )
+                if os.path.exists(head_gz):
+                    os.remove(head_gz)
+
+                # Move the active log to .1 (plain text) then gzip it.
+                # stdlib's rotate() honors the configured suffix hook, so
+                # the resulting .1 is exactly what the plain-text path
+                # would have produced.
+                dfn = self.rotation_filename(self.baseFilename + ".1")
+                if os.path.exists(dfn):
+                    os.remove(dfn)
+                self.rotate(self.baseFilename, dfn)
+
+                self._gzip_file(dfn)
+
+            if not self.delay:
+                self.stream = self._open()
+        except Exception as exc:  # pragma: no cover — defensive only
+            try:
+                _safe_stderr().write(
+                    f"[hermes_logging] compressed rollover failed: {exc!r}\n"
+                )
+            except Exception:
+                pass
+
+    @staticmethod
+    def _gzip_file(path: str) -> None:
+        """Compress *path* in place, replacing it with ``<path>.gz``.
+
+        Atomic-ish: write to a sibling ``<path>.gz.tmp``, ``rename`` over
+        ``<path>.gz`` if it exists, then ``unlink`` the original.  If any
+        step fails the original plain-text backup is left intact and we
+        log a single warning to stderr — but we do not raise, because
+        rotation must never break the running gateway/CLI.
+        """
+        src = Path(path)
+        if not src.is_file():
+            return
+        dst = Path(f"{path}.gz")
+        tmp = Path(f"{path}.gz.tmp")
+        try:
+            with src.open("rb") as fin, gzip.open(tmp, "wb", compresslevel=6) as fout:
+                shutil.copyfileobj(fin, fout, length=1024 * 1024)
+            # If a prior .gz exists (shouldn't, but defensive), replace it.
+            if dst.exists():
+                dst.unlink()
+            tmp.rename(dst)
+            src.unlink()
+        except Exception as exc:  # pragma: no cover — defensive only
+            try:
+                if tmp.exists():
+                    tmp.unlink()
+            except Exception:
+                pass
+            try:
+                _safe_stderr().write(
+                    f"[hermes_logging] gzip of {src.name} failed: {exc!r}\n"
+                )
+            except Exception:
+                pass
 
 
 def _add_rotating_handler(
@@ -516,6 +637,7 @@ def _add_rotating_handler(
     backup_count: int,
     formatter: logging.Formatter,
     log_filter: Optional[logging.Filter] = None,
+    compress_rotated: bool = False,
 ) -> None:
     """Add a ``RotatingFileHandler`` to *logger*, skipping if one already
     exists for the same resolved file path (idempotent).
@@ -525,6 +647,13 @@ def _add_rotating_handler(
     log_filter
         Optional filter to attach to the handler (e.g. ``_ComponentFilter``
         for gateway.log).
+    compress_rotated
+        When ``True``, each freshly-rotated backup (``baseFilename.1``) is
+        gzip-compressed in place to ``baseFilename.1.gz`` after rollover.
+        Bounded-failure: any compression error leaves the plain-text
+        backup intact and writes a warning to stderr.  Used by errors.log
+        to keep disk usage bounded without changing on-disk semantics for
+        tools that grep the logs (which can ``zcat`` on demand).
     """
     resolved = path.resolve()
     for existing in logger.handlers:
@@ -538,6 +667,7 @@ def _add_rotating_handler(
     handler = _ManagedRotatingFileHandler(
         str(path), maxBytes=max_bytes, backupCount=backup_count,
         encoding="utf-8",
+        compress_rotated=compress_rotated,
     )
     handler.setLevel(level)
     handler.setFormatter(formatter)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -13,6 +13,7 @@ import inspect
 import json
 import logging
 import os
+import random
 import html as _html
 import re
 from datetime import datetime, timezone
@@ -195,6 +196,67 @@ def _strip_mdv2(text: str) -> str:
     # Remove MarkdownV2 spoiler markers (||text|| → text)
     cleaned = re.sub(r'\|\|([^|]+)\|\|', r'\1', cleaned)
     return cleaned
+
+
+# Find MarkdownV2 reserved characters that appear *unescaped* and *outside*
+# any protected region (code block, inline code, link text, link URL).
+# This is a best-effort static pre-flight; it does NOT replicate the full
+# Telegram parser, but catches the most common parse failures cheaply so
+# we can skip the doomed API call and fall through to plain text without
+# burning a round-trip + a flood-window second edit.
+_MDV2_PROTECTED_RE = re.compile(
+    r'```[\s\S]*?```'                              # fenced code block
+    r'|\\\`[^`\\]*(?:\\.[^`\\]*)*\\\`'             # escaped inline code: \`…\`
+    r'|`[^`\n]+`'                                  # raw inline code: `…`
+    r'|\[[^\]\n]*\]\(\S+'                          # link text [..]( …  URL prefix
+)
+_MDV2_RESERVED = set(r'_*[]()~`>#+\-=|{}.!\\')
+
+
+def _validate_markdown_v2(text: str) -> Optional[str]:
+    """Best-effort MarkdownV2 syntax check.
+
+    Returns ``None`` when ``text`` looks well-formed, or a short reason
+    string describing the first violation found (used in logs and to
+    skip the doomed API call). Heuristic only — Telegram's parser is
+    stricter than this and may still reject text we accept.
+    """
+    if not text:
+        return None
+    # Mask out protected regions so we only inspect "naked" text.
+    masked = _MDV2_PROTECTED_RE.sub(lambda m: ' ' * len(m.group(0)), text)
+    # Also mask out runs of backslashes that escape the next character —
+    # those are valid escapes, not violations.
+    masked = re.sub(r'\\.', '  ', masked)
+    # Find the first unescaped reserved character.
+    for i, ch in enumerate(masked):
+        if ch in _MDV2_RESERVED:
+            # Allow '(' / ')' / '[' / ']' only when they form part of a
+            # link body (the protected-region regex above already caught
+            # well-formed links; any leftovers here are orphan brackets).
+            return f"unescaped {ch!r} at offset {i}"
+    return None
+
+
+@dataclasses.dataclass
+class _PendingEdit:
+    """Per-chat pending edit for the streaming-edit coalescer.
+
+    Tracks the latest content for a chat plus the asyncio task that
+    will flush it after the coalesce window.  Lives only on the
+    adapter instance — there is no cross-process state involved.
+    """
+    message_id: str
+    content: str
+    metadata: Optional[Dict[str, Any]]
+    future: "asyncio.Future[SendResult]"
+    task: Optional["asyncio.Task[None]"]
+
+    # __post_init__ ensures the mutable defaults are per-instance (Python
+    # dataclasses already give per-instance field storage, but documenting
+    # intent here for future readers).
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        return
 
 
 _CHUNK_INDICATOR_ON_FENCE_RE = re.compile(
@@ -484,6 +546,25 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        # Per-chat edit coalescer (fix 1+2 in t_dbcec280): collapses rapid
+        # streaming ``edit_message`` calls within a short window into a single
+        # outbound ``editMessageText`` carrying the latest content. The
+        # gateway's progress loop already throttles to ~1.5s, but multiple
+        # adapters / consumers racing the same chat, or one consumer's
+        # post-finialize touches, can still pile up. Finalize edits bypass
+        # the coalescer (they MUST land immediately so the user sees the
+        # finished response, and the rich/MarkdownV2 finalize chain has its
+        # own backoff in the outer handler).
+        self._edit_coalesce_window_seconds: float = self._env_float_clamped(
+            "HERMES_TELEGRAM_EDIT_COALESCE_WINDOW_SECONDS",
+            1.0,
+            min_value=0.0,
+            max_value=5.0,
+        )
+        # chat_id -> PendingEdit (latest content + the asyncio task that
+        # will flush it). A single coalescer task per chat means bursts
+        # collapse to one outbound edit, no matter how many callers race.
+        self._pending_edits: Dict[str, "_PendingEdit"] = {}
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -1331,6 +1412,180 @@ class TelegramAdapter(BasePlatformAdapter):
             success=True,
             message_id=str(message_id) if message_id is not None else None,
         )
+
+    # ------------------------------------------------------------------
+    # Edit coalescer (fix 1+2 in t_dbcec280)
+    # ------------------------------------------------------------------
+    # Streaming replies call ``edit_message`` many times in quick
+    # succession.  Each call would otherwise issue its own ``editMessageText``
+    # — wasteful in the best case, flood-control territory in the worst
+    # case.  The coalescer holds the latest content for a chat in a single
+    # pending task and flushes it after a short quiescent window, so a
+    # burst of N edits collapses to 1 outbound API call carrying the
+    # final content.  Finalize edits bypass the coalescer (the user must
+    # see the finished reply immediately) and rich pre-flight edits go
+    # through the coalescer because they are still streaming.
+
+    async def _coalesced_edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Queue a streaming edit behind the per-chat coalescer.
+
+        The caller awaits a SendResult that reflects the actual outbound
+        edit (after the window has elapsed and no further content
+        superseded this one).  If a NEWER call for the same
+        (chat_id, message_id) comes in during the window, this call's
+        content is dropped — only the latest wins, which is exactly the
+        user-visible behavior we want for a streaming preview.
+        """
+        key = str(chat_id)
+        pending = self._pending_edits.get(key)
+        window = self._edit_coalesce_window_seconds
+        # Fast path: window disabled → behave like a direct call.
+        if window <= 0:
+            return await self._flush_pending_edit(
+                chat_id, message_id, content, metadata,
+            )
+        # Always record the latest content/metadata; create the flush
+        # task on the first request or when the previous one finished.
+        if pending is None or pending.message_id != str(message_id):
+            fut: asyncio.Future = asyncio.get_event_loop().create_future()
+            pending = _PendingEdit(
+                message_id=str(message_id),
+                content=content,
+                metadata=metadata,
+                future=fut,
+                task=None,
+            )
+            self._pending_edits[key] = pending
+        else:
+            pending.content = content
+            pending.metadata = metadata
+        # (Re)arm the window: cancel any in-flight flush task and start
+        # a fresh one.  Cancelling is safe — the task awaits sleep, so
+        # CancelledError wakes it immediately.
+        if pending.task is not None and not pending.task.done():
+            pending.task.cancel()
+        pending.task = asyncio.create_task(
+            self._coalescer_flush(key, window),
+            name=f"telegram-edit-coalescer:{key}",
+        )
+        # Await the future the flush task will resolve with the real
+        # SendResult.  ``asyncio.shield`` keeps the future from being
+        # cancelled when the caller's wait is cancelled.
+        try:
+            return await asyncio.shield(pending.future)
+        except asyncio.CancelledError:
+            return SendResult(success=True, message_id=message_id)
+
+    async def _coalescer_flush(self, chat_id_key: str, window: float) -> None:
+        """Wait ``window`` seconds, then flush the pending edit (if still current)."""
+        try:
+            await asyncio.sleep(window)
+        except asyncio.CancelledError:
+            return
+        pending = self._pending_edits.get(chat_id_key)
+        if pending is None:
+            return
+        # Only flush if the recorded task still matches — a newer
+        # _coalesced_edit_message call may have re-armed us.
+        if pending.task is not asyncio.current_task():
+            return
+        # Snapshot and clear before issuing the API call so a new
+        # coalesced call during the API round-trip starts a fresh
+        # window rather than chaining on this one.
+        self._pending_edits.pop(chat_id_key, None)
+        try:
+            result = await self._flush_pending_edit(
+                chat_id_key, pending.message_id, pending.content,
+                metadata=pending.metadata,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug(
+                "[%s] coalescer flush raised (will not retry): %s",
+                self.name, exc,
+            )
+            if not pending.future.done():
+                pending.future.set_result(
+                    SendResult(success=False, error=str(exc))
+                )
+            return
+        if not pending.future.done():
+            pending.future.set_result(result)
+
+    async def _flush_pending_edit(
+        self,
+        chat_id,
+        message_id: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Issue a single non-coalesced streaming edit (used by the coalescer)."""
+        return await self._edit_message_streaming(
+            chat_id, message_id, content, metadata=metadata,
+        )
+
+    async def _edit_message_streaming(
+        self,
+        chat_id,
+        message_id: str,
+        content: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Streaming-edit path: plain text, no MarkdownV2 / rich.
+
+        Lifted out of :meth:`edit_message` so the coalescer can issue
+        exactly one API call per coalesced batch.  Mirrors the legacy
+        ``if not finalize:`` branch that lived at adapter.py:3006-3012
+        and the streaming-overflow fallback at 3057-3062.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        # Overflow pre-flight (same rule as the streaming branch in
+        # edit_message): truncate, never split, to avoid the duplicate
+        # final-message loop (#48648).
+        if utf16_len(content) > self.MAX_MESSAGE_LENGTH:
+            content = self._truncate_stream_overflow_preview(content)
+        try:
+            await self._bot.edit_message_text(
+                chat_id=normalize_telegram_chat_id(chat_id),
+                message_id=int(message_id),
+                text=content,
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as e:
+            err_str = str(e).lower()
+            if "not modified" in err_str:
+                return SendResult(success=True, message_id=message_id)
+            if "message_too_long" in err_str or "too long" in err_str:
+                # Streaming-time overflow fallback: truncate, not split.
+                truncated = self._truncate_stream_overflow_preview(content)
+                try:
+                    await self._bot.edit_message_text(
+                        chat_id=normalize_telegram_chat_id(chat_id),
+                        message_id=int(message_id),
+                        text=truncated,
+                    )
+                    return SendResult(success=True, message_id=message_id)
+                except Exception as e2:
+                    return SendResult(success=False, error=str(e2))
+            # Flood / transient — surface as retryable so the stream
+            # consumer can keep streaming; the next coalesced window
+            # will pick up fresh content.
+            retry_after = getattr(e, "retry_after", None)
+            if retry_after is not None or "retry after" in err_str:
+                return SendResult(
+                    success=False,
+                    error=f"flood_control:{retry_after or 1.0}",
+                    retryable=True,
+                )
+            return SendResult(success=False, error=str(e), retryable=True)
 
     async def _try_edit_rich(
         self,
@@ -2971,6 +3226,18 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        # Streaming-edit coalescer (fix 1+2 in t_dbcec280).  Streaming
+        # replies fire many ``edit_message`` calls in quick succession;
+        # the coalescer collapses them into a single outbound edit per
+        # chat carrying the latest content.  ``finalize=True`` edits
+        # bypass the coalescer so the user sees the completed reply
+        # immediately (the rich/MarkdownV2 finalize chain has its own
+        # backoff in the outer handler).
+        if not finalize and self._edit_coalesce_window_seconds > 0:
+            return await self._coalesced_edit_message(
+                chat_id, message_id, content, metadata=metadata,
+            )
+
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet
         # lists, task lists, <details>, block math) and rich is available,
@@ -3012,6 +3279,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 return SendResult(success=True, message_id=message_id)
 
             formatted = self.format_message(content)
+            # MarkdownV2 pre-flight (fix 3a in t_dbcec280).  Skip the
+            # doomed API call when static analysis can detect an unescaped
+            # reserved character; fall through directly to the plain-text
+            # edit rather than edit-retry-storming on a parse failure.
+            mdv2_violation = _validate_markdown_v2(formatted)
+            if mdv2_violation is not None:
+                logger.warning(
+                    "[%s] MarkdownV2 pre-flight rejected edit (%s); "
+                    "sending plain text directly",
+                    self.name, mdv2_violation,
+                )
+                _plain = _strip_mdv2(content) if content else content
+                await self._bot.edit_message_text(
+                    chat_id=normalize_telegram_chat_id(chat_id),
+                    message_id=int(message_id),
+                    text=_plain,
+                )
+                return SendResult(success=True, message_id=message_id)
             try:
                 await self._bot.edit_message_text(
                     chat_id=normalize_telegram_chat_id(chat_id),
@@ -3020,21 +3305,35 @@ class TelegramAdapter(BasePlatformAdapter):
                     parse_mode=ParseMode.MARKDOWN_V2,
                 )
             except Exception as fmt_err:
+                # Catch-boundary split (fix 3b in t_dbcec280).  ``BadRequest``
+                # parse failures fall back to plain text; transient /
+                # flood-control errors re-raise so the outer handler
+                # (below) can sleep + retry with the existing
+                # ``retry_after`` branch.
+                try:
+                    from telegram.error import BadRequest as _BadReq
+                except ImportError:
+                    _BadReq = None  # type: ignore[assignment]
+                err_str = str(fmt_err).lower()
                 # "Message is not modified" is a no-op, not an error
-                if "not modified" in str(fmt_err).lower():
+                if "not modified" in err_str:
                     return SendResult(success=True, message_id=message_id)
-                # Fallback: strip MarkdownV2 escapes and retry as clean plain text
-                logger.warning(
-                    "[%s] MarkdownV2 edit failed, falling back to plain text: %s",
-                    self.name,
-                    fmt_err,
-                )
-                _plain = _strip_mdv2(content) if content else content
-                await self._bot.edit_message_text(
-                    chat_id=normalize_telegram_chat_id(chat_id),
-                    message_id=int(message_id),
-                    text=_plain,
-                )
+                if _BadReq is not None and isinstance(fmt_err, _BadReq):
+                    # Real parse failure → fallback to plain text.
+                    logger.warning(
+                        "[%s] MarkdownV2 edit failed (%s), falling back to plain text: %s",
+                        self.name, type(fmt_err).__name__, fmt_err,
+                    )
+                    _plain = _strip_mdv2(content) if content else content
+                    await self._bot.edit_message_text(
+                        chat_id=normalize_telegram_chat_id(chat_id),
+                        message_id=int(message_id),
+                        text=_plain,
+                    )
+                    return SendResult(success=True, message_id=message_id)
+                # Transient / flood / unknown — bubble up so the outer
+                # handler at line ~3293+ can apply backoff.
+                raise
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             err_str = str(e).lower()
@@ -3066,10 +3365,22 @@ class TelegramAdapter(BasePlatformAdapter):
             # to a normal final send instead of leaving a truncated partial.
             retry_after = getattr(e, "retry_after", None)
             if retry_after is not None or "retry after" in err_str:
-                wait = retry_after if retry_after else 1.0
+                base_wait = float(retry_after) if retry_after is not None else 1.0
+                # Add ±10% jitter (fix 4 in t_dbcec280) to avoid
+                # synchronized re-fire when many chats/edits were
+                # flooded at the same instant — Telegram's retry-after
+                # windows are global-per-chat, not per-connection, so a
+                # shared wall-clock deadline causes a thundering herd on
+                # recovery.  Clamp the floor so we never sleep less
+                # than 100ms (and never less than `base_wait`).
+                jitter = base_wait * 0.1
+                wait = max(
+                    base_wait,
+                    base_wait + random.uniform(-jitter, jitter),
+                )
                 logger.warning(
-                    "[%s] Telegram flood control, waiting %.1fs",
-                    self.name, wait,
+                    "[%s] Telegram flood control, waiting %.2fs (retry_after=%.2fs)",
+                    self.name, wait, base_wait,
                 )
                 if wait > 5.0:
                     return SendResult(success=False, error=f"flood_control:{wait}")

--- a/tests/gateway/test_memory_monitor.py
+++ b/tests/gateway/test_memory_monitor.py
@@ -1,14 +1,24 @@
-"""Tests for gateway.memory_monitor — periodic process memory logging.
+"""Tests for gateway.memory_monitor — heap-dump-on-threshold and config wiring.
 
-Ported from cline/cline#10343.  The module logs a structured
-``[MEMORY] rss=...MB ...`` line periodically so long-running gateway
-leaks show up as a time series in agent.log / gateway.log.
+Covers:
+  * /proc/self/statm RSS reading (Linux only).
+  * Threshold trigger fires a heap dump when crossed.
+  * Threshold=0 disables the trigger.
+  * Rotation evicts oldest dump past ``heap_dump_max_files``.
+  * Config block parsing reads ``logging.memory_monitor`` correctly.
+  * In-flight guard prevents re-entrant dumps.
+  * Peak RSS tracking across samples.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import pickle
+import sys
 import time
+from pathlib import Path
 
 import pytest
 
@@ -23,6 +33,11 @@ def _ensure_monitor_stopped():
     mm.stop_memory_monitoring(timeout=1.0)
 
 
+# ---------------------------------------------------------------------------
+# Baseline behavior (existing)
+# ---------------------------------------------------------------------------
+
+
 def test_log_memory_usage_emits_memory_line(caplog):
     caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
     mm.log_memory_usage()
@@ -34,13 +49,13 @@ def test_log_memory_usage_has_grep_friendly_format(caplog):
     caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
     mm.log_memory_usage()
     msg = caplog.records[-1].getMessage()
-    # Grep-friendly contract: line starts with [MEMORY] and carries RSS
-    # (or 'unavailable'), GC counts, thread count, uptime.
     assert msg.startswith("[MEMORY]"), msg
     assert "rss=" in msg
+    assert "peak=" in msg
     assert "gc=" in msg
     assert "threads=" in msg
     assert "uptime=" in msg
+    assert "pid=" in msg
 
 
 def test_log_memory_usage_with_prefix(caplog):
@@ -52,8 +67,6 @@ def test_log_memory_usage_with_prefix(caplog):
 
 def test_start_logs_baseline_and_returns_true(caplog):
     caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
-    # Large interval so the background timer never fires during the test —
-    # we're only checking the synchronous baseline behavior here.
     started = mm.start_memory_monitoring(interval_seconds=3600.0)
     assert started is True
     assert mm.is_running() is True
@@ -82,14 +95,12 @@ def test_stop_logs_shutdown_snapshot(caplog):
 
 
 def test_stop_without_start_is_noop():
-    # Must not raise, must not log shutdown snapshot.
     mm.stop_memory_monitoring(timeout=0.5)
     assert mm.is_running() is False
 
 
 def test_periodic_timer_fires(caplog):
     caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
-    # Short interval so we can observe multiple ticks inside the test budget.
     mm.start_memory_monitoring(interval_seconds=0.1)
     time.sleep(0.45)
     mm.stop_memory_monitoring(timeout=1.0)
@@ -98,25 +109,330 @@ def test_periodic_timer_fires(caplog):
         r for r in caplog.records
         if r.getMessage().startswith("[MEMORY] rss=") or r.getMessage().startswith("[MEMORY] rss=unavailable")
     ]
-    # baseline + at least 2 periodic + shutdown — but shutdown has the
-    # "shutdown " prefix so it won't match the strict "[MEMORY] rss=" start.
-    # We expect >= 3 bare "[MEMORY] rss=..." lines.
     assert len(periodic) >= 3, [r.getMessage() for r in caplog.records]
 
 
 def test_thread_is_daemon():
     mm.start_memory_monitoring(interval_seconds=3600.0)
     assert mm._monitor_thread is not None
-    assert mm._monitor_thread.daemon is True, (
-        "memory monitor thread must be daemon so it can never block process exit"
-    )
+    assert mm._monitor_thread.daemon is True
 
 
 def test_unavailable_rss_warns_and_does_not_start(caplog, monkeypatch):
-    # Force both backends to claim unavailable; start should bail.
     monkeypatch.setattr(mm, "_get_rss_mb", lambda: None)
     caplog.set_level(logging.WARNING, logger="gateway.memory_monitor")
     started = mm.start_memory_monitoring(interval_seconds=3600.0)
     assert started is False
     assert mm.is_running() is False
     assert any("Memory monitoring unavailable" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# /proc/self/statm RSS reading (Linux only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux-only /proc path")
+def test_read_proc_self_rss_kb_returns_positive_int():
+    kb = mm._read_proc_self_rss_kb()
+    assert kb is not None
+    # /proc/self/statm field 1 is RSS in pages; we multiply by 4 KiB.  Anything
+    # under 1 MiB would be suspicious for a Python process running tests.
+    assert kb > 1024
+
+
+def test_get_rss_mb_returns_positive_int_or_none():
+    rss = mm._get_rss_mb()
+    if rss is not None:
+        assert rss > 0
+        assert isinstance(rss, int)
+
+
+def test_get_peak_rss_mb_returns_positive_int():
+    peak = mm._get_peak_rss_mb()
+    if peak is not None:
+        assert peak > 0
+        # Peak must be in the same order of magnitude as current RSS.
+        # (High-water mark can be slightly behind a fresh allocation if
+        # the kernel hasn't updated ru_maxrss yet between the two reads —
+        # so allow up to 5 MB slack instead of strict >=.)
+        rss = mm._get_rss_mb()
+        if rss is not None:
+            assert peak >= max(0, rss - 5)
+
+
+def test_log_line_includes_pid_and_peak(caplog):
+    """Regression: /proc gives current RSS, resource gives peak — both must appear."""
+    caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
+    mm.log_memory_usage(prefix="rsscheck")
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("rsscheck " in m and "rss=" in m and "peak=" in m and "pid=" in m for m in msgs), msgs
+
+
+# ---------------------------------------------------------------------------
+# Heap-dump-on-threshold behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_zero_disables_trigger(tmp_path, caplog):
+    """With heap_dump_threshold_mb=0 the trigger must never fire."""
+    mm.configure_for_test(
+        threshold_mb=0,
+        dump_dir=tmp_path,
+        max_files=3,
+    )
+    caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
+    # Even an "infinite" RSS shouldn't fire.
+    mm._maybe_trigger_heap_dump(current_rss_mb=999_999_999)
+    assert not list(tmp_path.glob("heap-*.pkl")), "no dump should be written when threshold=0"
+
+
+def test_threshold_below_rss_fires_dump(tmp_path, caplog):
+    """Synthetic high-RSS condition — set threshold to 1 MB and report RSS > threshold."""
+    mm.configure_for_test(
+        threshold_mb=1,
+        dump_dir=tmp_path,
+        top_n=10,
+        max_files=3,
+    )
+    caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
+    mm._maybe_trigger_heap_dump(current_rss_mb=128)
+    dumps = list(tmp_path.glob("heap-*.pkl"))
+    assert len(dumps) == 1, f"expected 1 heap dump, got {len(dumps)}"
+    # Log line should mention path + size.
+    assert any("HEAP_DUMP path=" in r.getMessage() for r in caplog.records), [
+        r.getMessage() for r in caplog.records
+    ]
+    # Dump should be a loadable pickle with the expected schema.
+    # Note: rss_mb_at_dump captures the *live* RSS at dump time (via
+    # _get_rss_mb() inside _take_heap_dump), not the synthetic trigger
+    # value we passed in — the dump is the real state of the process.
+    with open(dumps[0], "rb") as f:
+        payload = pickle.load(f)
+    assert payload["rss_mb_at_dump"] is None or payload["rss_mb_at_dump"] > 0
+    # top_allocations may be empty if tracemalloc wasn't already running
+    # at the time of the dump — that's still a valid snapshot, just
+    # minimally useful.  Assert it is a list (any length).
+    assert isinstance(payload["top_allocations"], list)
+    assert "ts" in payload
+    assert payload["pid"] == os.getpid()
+
+
+def test_threshold_above_rss_does_not_fire(tmp_path, caplog):
+    mm.configure_for_test(threshold_mb=99999, dump_dir=tmp_path)
+    caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
+    mm._maybe_trigger_heap_dump(current_rss_mb=128)
+    assert not list(tmp_path.glob("heap-*.pkl"))
+
+
+def test_in_flight_guard_prevents_reentrant_dump(tmp_path):
+    """If a dump is already in flight, second crossing must not start another."""
+    mm.configure_for_test(threshold_mb=1, dump_dir=tmp_path, max_files=10)
+    # Manually flip the in-flight flag to simulate a slow dump.
+    mm._heap_dump_in_flight = True
+    try:
+        mm._maybe_trigger_heap_dump(current_rss_mb=128)
+        assert not list(tmp_path.glob("heap-*.pkl")), "in-flight dump should block re-entrance"
+    finally:
+        mm._heap_dump_in_flight = False
+    # After clearing the flag, the next crossing fires normally.
+    mm._maybe_trigger_heap_dump(current_rss_mb=128)
+    assert len(list(tmp_path.glob("heap-*.pkl"))) == 1
+
+
+def test_rotation_evicts_oldest_dumps(tmp_path, caplog):
+    """Past ``heap_dump_max_files``, oldest .pkl files are deleted."""
+    mm.configure_for_test(threshold_mb=1, dump_dir=tmp_path, max_files=3)
+    caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
+    # Fire 5 dumps; expect exactly 3 to remain (oldest 2 evicted).
+    for i in range(5):
+        # Reset in-flight so each fires cleanly.
+        mm._heap_dump_in_flight = False
+        # Stagger filenames so sort order is deterministic.
+        dump_path = tmp_path / f"heap-20260101-0000{i}-{os.getpid()}.pkl"
+        # Touch a file so rotation has something to evict.
+        dump_path.write_bytes(b"\x00")
+        # Force the dump to write a fresh file too — but the rotation
+        # pass will compare on sort-by-name.  Use the real path:
+        mm._heap_dump_in_flight = False
+        # Rotate inline to simulate accumulation:
+        mm._rotate_heap_dumps(tmp_path, max_files=3)
+    final = sorted(tmp_path.glob("heap-*.pkl"))
+    # After 5 rotations with max_files=3, only the 3 newest should remain.
+    assert len(final) <= 3, [p.name for p in final]
+
+
+def test_rotation_keeps_recent(tmp_path):
+    """Rotation does not evict when count <= max_files."""
+    mm.configure_for_test(threshold_mb=1, dump_dir=tmp_path, max_files=5)
+    # Pre-create 2 dummy dumps.
+    (tmp_path / "heap-20260101-000001-1.pkl").write_bytes(b"x")
+    (tmp_path / "heap-20260101-000002-1.pkl").write_bytes(b"y")
+    mm._rotate_heap_dumps(tmp_path, max_files=5)
+    assert len(list(tmp_path.glob("heap-*.pkl"))) == 2
+
+
+def test_configure_for_test_resets_state():
+    """configure_for_test must reset every knob (re-entrant)."""
+    mm.configure_for_test(threshold_mb=10, dump_dir=Path("/tmp/a"), top_n=3, max_files=7)
+    assert mm._heap_dump_threshold_mb == 10
+    assert mm._heap_dump_dir == Path("/tmp/a")
+    assert mm._heap_dump_top_n == 3
+    assert mm._heap_dump_max_files == 7
+    mm.configure_for_test(threshold_mb=20, dump_dir=None, top_n=50, max_files=5)
+    assert mm._heap_dump_threshold_mb == 20
+    assert mm._heap_dump_dir is None
+    assert mm._heap_dump_top_n == 50
+    assert mm._heap_dump_max_files == 5
+
+
+# ---------------------------------------------------------------------------
+# Config block parsing
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_config_defaults_when_missing(monkeypatch):
+    """With no logging.memory_monitor block, defaults are returned."""
+    # Force read_raw_config to return empty
+    import sys
+    class _Stub:
+        def read_raw_config(self_inner):
+            return {}
+    # Patch via module attribute (we can't easily mock the import; use sys.modules)
+    fake_mod = type(sys)("fake_config")
+    fake_mod.read_raw_config = lambda: {}
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", fake_mod)
+    cfg = mm._resolve_memory_monitor_config()
+    assert cfg["enabled"] is True
+    assert cfg["interval_seconds"] == 60
+    assert cfg["heap_dump_threshold_mb"] == 4096
+    assert cfg["heap_dump_top_n"] == 50
+    assert cfg["heap_dump_max_files"] == 5
+
+
+def test_resolve_config_parses_overrides(monkeypatch):
+    """All overrides from config.yaml are surfaced correctly."""
+    fake_mod = type(sys)("fake_config")
+    fake_mod.read_raw_config = lambda: {
+        "logging": {
+            "memory_monitor": {
+                "enabled": False,
+                "interval_seconds": 30,
+                "heap_dump_threshold_mb": 1024,
+                "heap_dump_dir": "/tmp/dumps",
+                "heap_dump_top_n": 25,
+                "heap_dump_max_files": 8,
+            }
+        }
+    }
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", fake_mod)
+    cfg = mm._resolve_memory_monitor_config()
+    assert cfg["enabled"] is False
+    assert cfg["interval_seconds"] == 30
+    assert cfg["heap_dump_threshold_mb"] == 1024
+    assert cfg["heap_dump_dir"] == "/tmp/dumps"
+    assert cfg["heap_dump_top_n"] == 25
+    assert cfg["heap_dump_max_files"] == 8
+
+
+def test_resolve_config_handles_missing_logging_block(monkeypatch):
+    fake_mod = type(sys)("fake_config")
+    fake_mod.read_raw_config = lambda: {"model": "x"}
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", fake_mod)
+    cfg = mm._resolve_memory_monitor_config()
+    assert cfg == {
+        "enabled": True,
+        "interval_seconds": 60,
+        "heap_dump_threshold_mb": 4096,
+        "heap_dump_dir": None,
+        "heap_dump_top_n": 50,
+        "heap_dump_max_files": 5,
+    }
+
+
+def test_resolve_config_never_raises_on_malformed(monkeypatch):
+    """A bad config must not crash the gateway — return defaults."""
+    fake_mod = type(sys)("fake_config")
+    fake_mod.read_raw_config = lambda: {"logging": "not a dict"}
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", fake_mod)
+    cfg = mm._resolve_memory_monitor_config()
+    assert cfg["enabled"] is True
+
+
+def test_apply_config_handles_bad_types():
+    """apply_config coerces bad types back to defaults."""
+    mm._apply_config({
+        "interval_seconds": "bogus",
+        "heap_dump_threshold_mb": None,
+        "heap_dump_dir": "/custom/path",
+        "heap_dump_top_n": -5,
+        "heap_dump_max_files": "lots",
+    })
+    # bad types fall through to defaults; negative top_n clamped to 1.
+    assert mm._interval_seconds == 60.0
+    assert mm._heap_dump_threshold_mb == 4096
+    assert mm._heap_dump_dir == Path("/custom/path")
+    assert mm._heap_dump_top_n == 1  # max(1, -5)
+    assert mm._heap_dump_max_files == 5
+
+
+# ---------------------------------------------------------------------------
+# Peak tracking
+# ---------------------------------------------------------------------------
+
+
+def test_peak_rss_tracks_high_water():
+    """Across multiple log_memory_usage calls, peak only goes up."""
+    mm._peak_rss_mb = 0
+    for _ in range(3):
+        mm.log_memory_usage()
+    assert mm._peak_rss_mb >= 0
+
+
+def test_peak_rss_monotonic():
+    """Even with RSS reporting anomalies, peak should be the running max."""
+    mm._peak_rss_mb = 0
+    mm.log_memory_usage()
+    p1 = mm._peak_rss_mb
+    mm.log_memory_usage()
+    p2 = mm._peak_rss_mb
+    assert p2 >= p1
+
+
+# ---------------------------------------------------------------------------
+# Synthetic verification — the acceptance test from the task body
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_high_rss_triggers_dump(tmp_path, caplog):
+    """End-to-end: configure_for_test + simulated sample fires the trigger.
+
+    This mirrors the field conditions the task spec calls out ("verify the
+    trigger fires correctly under a synthetic high-RSS condition if feasible
+    to test").
+    """
+    mm.configure_for_test(threshold_mb=4096, dump_dir=tmp_path, max_files=5)
+    caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
+
+    # Simulate the periodic sampler observing RSS above the 4 GB trigger.
+    # Patch _get_rss_mb so the log line shows the synthetic value too.
+    real_get_rss = mm._get_rss_mb
+    mm._get_rss_mb = lambda: 4500  # MB
+    try:
+        mm.log_memory_usage()
+    finally:
+        mm._get_rss_mb = real_get_rss
+
+    # Dump should have fired and a [MEMORY] HEAP_DUMP line emitted.
+    dumps = list(tmp_path.glob("heap-*.pkl"))
+    assert len(dumps) == 1
+    with open(dumps[0], "rb") as f:
+        payload = pickle.load(f)
+    # The dump captures the live-process RSS at the time tracemalloc ran,
+    # which is whatever _get_rss_mb returns when the dump code itself runs.
+    assert payload["pid"] == os.getpid()
+
+    # Trigger notice + path notice both emitted.
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("HEAP_DUMP_TRIGGERED" in m for m in msgs), msgs
+    assert any("HEAP_DUMP path=" in m for m in msgs), msgs

--- a/tests/gateway/test_telegram_flood_throttle.py
+++ b/tests/gateway/test_telegram_flood_throttle.py
@@ -1,0 +1,324 @@
+"""Tests for the Telegram adapter's flood-control / throttle fixes (t_dbcec280).
+
+Covers three independent fixes that together reduce flood-control
+violations without changing user-visible behavior:
+
+1. **MarkdownV2 pre-flight** (``_validate_markdown_v2``): a cheap static
+   check that catches the most common parse failures so the adapter
+   doesn't burn an API round-trip + a flood-window second edit on a
+   known-bad payload.
+
+2. **Edit coalescer** (``_coalesced_edit_message``): streaming
+   ``edit_message`` calls within a short window collapse into one
+   outbound edit carrying the latest content.
+
+3. **Catch-boundary split**: ``BadRequest`` parse failures fall back to
+   plain text, while flood / transient errors re-raise to the outer
+   handler that has the proper ``retry_after`` backoff.
+
+The tests stub the python-telegram-bot ``Bot`` instance so the unit
+boundary is the adapter (no real network), per AGENTS.md's "E2E
+validation, not just green unit mocks" guidance — these tests exercise
+the *real* adapter code path with a recording stub, not a mock that
+re-implements the logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from plugins.platforms.telegram.adapter import (
+    _validate_markdown_v2,
+    _strip_mdv2,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. _validate_markdown_v2 — static pre-flight
+# ---------------------------------------------------------------------------
+
+class TestValidateMarkdownV2:
+    """The pre-flight must accept well-formed MarkdownV2 and reject the
+    common parse failure modes.  Heuristic-only — Telegram's parser is
+    stricter than this and may still reject text we accept, but the
+    contract is *catches common mistakes cheaply*."""
+
+    def test_empty_text_is_ok(self):
+        assert _validate_markdown_v2("") is None
+
+    def test_already_escaped_text_is_ok(self):
+        # MarkdownV2-escaped text (period escaped) should validate.
+        assert _validate_markdown_v2(r"just a regular sentence\.") is None
+
+    def test_escaped_reserved_chars_are_ok(self):
+        # Already-escaped reserved chars should pass.
+        assert _validate_markdown_v2(r"escaped \* and \_") is None
+
+    def test_fenced_code_block_masks_contents(self):
+        # The reserved characters inside a fenced code block must NOT
+        # be flagged — they're protected by the fence.
+        assert _validate_markdown_v2("```\nunbalanced *paren (\n```") is None
+
+    def test_inline_code_masks_contents(self):
+        # Inline code protects its contents — periods / parens / etc.
+        # inside the backticks are masked out.
+        assert _validate_markdown_v2(r"use `my.var_name()` carefully") is None
+
+    def test_bare_asterisk_is_rejected(self):
+        # Markdown italic in plain text — not escaped → violation.
+        result = _validate_markdown_v2("this is *italic* but not escaped")
+        assert result is not None
+        assert "asterisk" in result or "*" in result or "offset" in result
+
+    def test_bare_period_is_rejected(self):
+        # Periods are reserved in MarkdownV2 — must be escaped.
+        result = _validate_markdown_v2("hello world.")
+        assert result is not None
+        assert "period" in result or "." in result or "offset" in result
+
+    def test_escaped_period_is_ok(self):
+        # The escape backslash itself is fine — `_validate_markdown_v2`
+        # only flags unescaped reserved chars.
+        assert _validate_markdown_v2(r"hello world\.") is None
+
+    def test_link_body_does_not_flag_brackets(self):
+        assert _validate_markdown_v2(r"[click](https://example.com)") is None
+
+    def test_orphan_bracket_is_rejected(self):
+        result = _validate_markdown_v2("text [orphan bracket")
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. Edit coalescer — collapses bursts to one outbound edit
+# ---------------------------------------------------------------------------
+
+class _RecordingBot:
+    """Stub ``Bot`` that records every ``edit_message_text`` call.
+
+    Behaves like a real PTB ``Bot`` for the small surface our adapter
+    touches (only ``edit_message_text`` and ``do_api_request``), but
+    with controllable behavior (success / failure / sleep).  Used by
+    the coalescer tests to assert that N rapid ``edit_message`` calls
+    produce K (K ≪ N) outbound API calls.
+    """
+
+    def __init__(self, *, fail_with: Optional[Exception] = None):
+        self.calls: List[Dict[str, Any]] = []
+        self.fail_with = fail_with
+
+    async def edit_message_text(self, **kwargs):
+        self.calls.append({"method": "edit_message_text", "kwargs": kwargs})
+        if self.fail_with is not None:
+            raise self.fail_with
+        # Return a fake message-like object.
+        return _FakeMessage(int(kwargs.get("message_id", 0)))
+
+    async def do_api_request(self, method, api_kwargs=None):
+        self.calls.append({"method": method, "api_kwargs": api_kwargs or {}})
+        return None
+
+
+class _FakeMessage:
+    def __init__(self, message_id: int):
+        self.message_id = message_id
+
+
+def _make_adapter(bot):
+    """Build a TelegramAdapter with a recording bot, skipping __init__ side effects."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    from gateway.config import Platform
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    # ``name`` is a property on the base class derived from ``platform``.
+    # Set the platform enum so ``adapter.name`` returns "Telegram".
+    adapter.platform = Platform.TELEGRAM
+    adapter._bot = bot
+    adapter._edit_coalesce_window_seconds = 1.0
+    adapter._pending_edits = {}
+    adapter._status_message_ids = {}
+    adapter._rich_messages_enabled = False
+    adapter._rich_drafts_enabled = False
+    adapter._rich_send_disabled = False
+    adapter._rich_draft_disabled = False
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    return adapter
+
+
+class TestEditCoalescer:
+    """Streaming edits within the window must collapse to a single
+    outbound edit carrying the LATEST content (the contract: a burst
+    of N edits → 1 outbound edit with the final content)."""
+
+    @pytest.mark.asyncio
+    async def test_burst_of_five_collapses_to_one_outbound_edit(self):
+        bot = _RecordingBot()
+        adapter = _make_adapter(bot)
+        # Shorten the coalesce window so the test doesn't take 1s.
+        adapter._edit_coalesce_window_seconds = 0.1
+        chat_id = "123"
+        message_id = "42"
+        # Five rapid streaming edits — only the LAST content should land.
+        tasks = [
+            asyncio.create_task(
+                adapter.edit_message(chat_id, message_id, f"draft v{i}")
+            )
+            for i in range(5)
+        ]
+        results = await asyncio.gather(*tasks)
+        # Every caller sees a successful SendResult for the SAME message_id.
+        assert all(r.success for r in results)
+        assert all(r.message_id == message_id for r in results)
+        # Exactly ONE outbound API call was made.
+        assert len(bot.calls) == 1
+        # And it carried the LATEST content (draft v4).
+        assert bot.calls[0]["kwargs"]["text"] == "draft v4"
+
+    @pytest.mark.asyncio
+    async def test_finalize_bypasses_coalescer(self):
+        bot = _RecordingBot()
+        adapter = _make_adapter(bot)
+        chat_id = "123"
+        message_id = "42"
+        # A finalize=True edit must go straight to the API, not through the coalescer.
+        result = await adapter.edit_message(
+            chat_id, message_id, "final", finalize=True,
+        )
+        assert result.success
+        assert len(bot.calls) >= 1
+        # The finalize path goes through MarkdownV2 / rich — we only
+        # assert it reached the API directly without coalescer
+        # bookkeeping left behind.
+        assert chat_id not in adapter._pending_edits
+
+    @pytest.mark.asyncio
+    async def test_window_disabled_is_direct(self):
+        bot = _RecordingBot()
+        adapter = _make_adapter(bot)
+        adapter._edit_coalesce_window_seconds = 0  # coalescer off
+        chat_id = "123"
+        message_id = "42"
+        results = await asyncio.gather(*[
+            asyncio.create_task(
+                adapter.edit_message(chat_id, message_id, f"v{i}")
+            )
+            for i in range(3)
+        ])
+        # Each call issued its own outbound edit (no coalescing).
+        assert len(bot.calls) == 3
+        assert all(r.success for r in results)
+
+
+# ---------------------------------------------------------------------------
+# 3. Catch-boundary split — BadRequest falls back, flood re-raises
+# ---------------------------------------------------------------------------
+
+class _FakeBadRequest(Exception):
+    """Mimics telegram.error.BadRequest enough for isinstance checks."""
+    pass
+
+
+class TestCatchBoundary:
+    """The inner try in the finalize path must distinguish:
+
+    - BadRequest parse failure → plain-text fallback (no re-raise).
+    - RetryAfter / TimedOut / NetworkError → re-raise so the outer
+      flood handler can sleep + retry.
+    """
+
+    @pytest.mark.asyncio
+    async def test_badrequest_falls_back_to_plain_text(self):
+        from telegram.error import BadRequest
+        # Configure the recording bot to fail the FIRST attempt with a
+        # real BadRequest; subsequent attempts succeed.
+        bot = _TwoPhaseBot(
+            fail_first_with=BadRequest("can't parse entities at byte 7"),
+        )
+        adapter = _make_adapter(bot)
+        # _rich_eligible gates the rich pre-flight; force-eligible here
+        # so we go down the rich → MarkdownV2 path. But rich is disabled
+        # at the adapter level, so we land in the MarkdownV2 path.
+        result = await adapter.edit_message(
+            "123", "42", "hello", finalize=True,
+        )
+        # The fallback edit (plain text) must have succeeded.
+        assert result.success
+        # We expect at least: 1st = MDV2 (failed with BadRequest),
+        # 2nd = plain text (succeeded).
+        methods = [c["method"] for c in bot.calls]
+        assert methods.count("edit_message_text") >= 2
+
+    @pytest.mark.asyncio
+    async def test_flood_error_does_not_fall_back_to_plain_text(self):
+        # A RetryAfter-style error must RE-RAISE out of the inner try
+        # so the outer flood handler can apply backoff. A plain-text
+        # fallback within the flood window would be a SECOND doomed
+        # edit, which is the bug we're fixing.
+        class _RetryAfterLike(Exception):
+            retry_after = 2.0  # short wait → outer handler retries (≤5s)
+            def __str__(self):
+                return "Flood control exceeded. Retry in 2 seconds"
+        bot = _TwoPhaseBot(fail_first_with=_RetryAfterLike())
+        adapter = _make_adapter(bot)
+        # The outer handler will sleep ~2s ± jitter. Patch asyncio.sleep
+        # so the test isn't gated on real wall-clock time.
+        import plugins.platforms.telegram.adapter as _adapter_mod
+        original_sleep = _adapter_mod.asyncio.sleep
+        async def _fast_sleep(_):
+            return None
+        _adapter_mod.asyncio.sleep = _fast_sleep
+        try:
+            result = await adapter.edit_message(
+                "123", "42", "hello", finalize=True,
+            )
+        finally:
+            _adapter_mod.asyncio.sleep = original_sleep
+        # Structural contract: after a flood error, the catch-boundary
+        # split must RE-RAISE out of the inner try. The outer handler
+        # then EITHER retries (one more edit_message_text call) OR
+        # returns flood_control:N. What MUST NOT happen: a plain-text
+        # fallback edit fired within the flood window — i.e., a call
+        # with parse_mode absent AND no preceding RetryAfter-class
+        # exception. We assert by call count: the rich path (disabled)
+        # + 1st MDV2 (failed) + 1 retry = 2 calls.
+        methods = [c["method"] for c in bot.calls]
+        assert methods.count("edit_message_text") == 2, (
+            f"expected MDV2 attempt + outer retry = 2 calls; "
+            f"got {methods!r}"
+        )
+        # The second call must NOT be a plain-text fallback triggered by
+        # the inner try — i.e., it must be the outer's retry attempt
+        # against the SAME formatted text. We verify by inspecting that
+        # the second call's text is the same as the first (no
+        # _strip_mdv2 transformation happened between them).
+        first_text = bot.calls[0]["kwargs"]["text"]
+        second_text = bot.calls[1]["kwargs"]["text"]
+        assert first_text == second_text, (
+            f"outer retry should reuse the formatted text; "
+            f"first={first_text!r} second={second_text!r}"
+        )
+        assert result.success is True
+
+
+class _TwoPhaseBot:
+    """Bot stub that fails the first edit and succeeds thereafter."""
+
+    def __init__(self, *, fail_first_with: Optional[Exception] = None):
+        self.calls: List[Dict[str, Any]] = []
+        self._fail_first = fail_first_with
+        self._attempt = 0
+
+    async def edit_message_text(self, **kwargs):
+        self.calls.append({"method": "edit_message_text", "kwargs": kwargs})
+        if self._attempt == 0 and self._fail_first is not None:
+            self._attempt += 1
+            raise self._fail_first
+        self._attempt += 1
+        return _FakeMessage(int(kwargs.get("message_id", 0)))
+
+    async def do_api_request(self, method, api_kwargs=None):
+        # Rich path is disabled in _make_adapter so this isn't exercised.
+        self.calls.append({"method": method, "api_kwargs": api_kwargs or {}})
+        return None

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1936,6 +1936,77 @@ def test_spawn_preflight_credentials_passes_healthy_profile(
     assert result is None
 
 
+def test_spawn_preflight_credentials_passes_mixed_pool(
+    kanban_home, monkeypatch,
+):
+    """Regression coverage for kanban task t_e3e0256f (2026-06-29).
+
+    The original ``if blocking_providers:`` check raised whenever ANY
+    provider had every entry blocked, even when OTHER providers in the
+    pool still had healthy entries. The fix: spawn proceeds iff at
+    least one provider in the pool is healthy. This test mirrors the
+    live repro — one provider fully exhausted (``openrouter``,
+    ``last_status='exhausted'``), another healthy
+    (``minimax-oauth``, ``last_status=None``/missing).
+    """
+    import hermes_cli.kanban_db as _kb
+
+    auth_path = kanban_home / "auth.json"
+    auth_path.write_text(
+        json.dumps({
+            "credential_pool": {
+                "openrouter": [
+                    {"key_id": "or-1", "last_status": "exhausted",
+                     "last_error_code": 401,
+                     "last_error_message": "Missing Authentication header"},
+                ],
+                "minimax-oauth": [
+                    # last_status missing → counts as healthy (never failed).
+                    {"key_id": "mmo-1"},
+                ],
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    # Must NOT raise — ``minimax-oauth`` has a healthy entry and the
+    # worker's credential pool can pick it.
+    result = _kb._spawn_preflight_credentials("default")
+    assert result is None
+
+
+def test_spawn_preflight_credentials_blocks_when_only_one_provider_and_blocked(
+    kanban_home, monkeypatch,
+):
+    """Edge case: a single-provider pool that is all-blocked must still
+    raise — sanity check that the fix didn't accidentally weaken the
+    all-dead-pools-still-block behavior. The earlier
+    ``blocks_exhausted_profile`` test covers the multi-provider all-dead
+    case; this one covers single-provider all-dead.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    auth_path = kanban_home / "auth.json"
+    auth_path.write_text(
+        json.dumps({
+            "credential_pool": {
+                "openrouter": [
+                    {"key_id": "or-1", "last_status": "exhausted",
+                     "last_error_code": 401},
+                ],
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _kb._spawn_preflight_credentials("default")
+
+    msg = str(exc_info.value)
+    assert "no usable credentials" in msg
+    assert "openrouter" in msg
+
+
 def test_spawn_preflight_credentials_passes_when_no_auth_json(
     kanban_home, monkeypatch,
 ):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2083,7 +2083,7 @@ def test_respawn_guard_blocker_auth_on_authentication_error(kanban_home):
 
 
 def test_respawn_guard_blocker_auth_on_authorization_error(kanban_home):
-    """Full word 'authorization' triggers blocker_auth (regex covers auth\\w*)."""
+    """Full word 'authorization' triggers blocker_auth (regex covers auth\w*)."""
     with kb.connect() as conn:
         t = kb.create_task(conn, title="authz-task", assignee="alice")
         conn.execute(
@@ -2092,6 +2092,230 @@ def test_respawn_guard_blocker_auth_on_authorization_error(kanban_home):
         )
         reason = kb.check_respawn_guard(conn, t)
     assert reason == "blocker_auth"
+
+
+# ------------------------------------------------------------------
+# Bounded deferral window for blocker_auth (t_7f4b0ff2, 2026-06-29)
+#
+# Without a TTL, the regex-based blocker_auth guard parks a task in
+# ``ready`` indefinitely when the last failure is stale but matches a
+# quota/auth pattern. The deferral path does not bump
+# ``consecutive_failures`` so the auto-block circuit breaker cannot
+# free the task either. The window (default 1800s, env-tunable via
+# ``HERMES_KANBAN_BLOCKER_AUTH_WINDOW_SECONDS``) gives a stale 429
+# room to clear and lets the dispatcher take a fresh probe once the
+# failure is old enough that the regex's verdict is no longer fresh.
+# ------------------------------------------------------------------
+
+
+def test_respawn_guard_blocker_auth_within_window_deferred(kanban_home):
+    """A quota error within the window stays deferred as blocker_auth.
+
+    The fresh-failure path must NOT release the guard: a real ongoing
+    quota wall still warrants deferring the spawn so the dispatcher
+    doesn't thrash on it every tick. Only stale failures (older than
+    the window) release.
+    """
+    now = int(time.time())
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="fresh-quota", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ?, last_failure_at = ? "
+            "WHERE id = ?",
+            ("quota exceeded", now - 60, t),  # 60s ago, well inside default 1800s
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "blocker_auth"
+
+
+def test_respawn_guard_blocker_auth_outside_window_released(kanban_home):
+    """A quota error older than the window releases the guard.
+
+    Regression test for t_7f4b0ff2: the dispatcher stuck at 0 spawned
+    for 21.9h on two ready tasks whose ``last_failure_error`` still
+    matched the 429 pattern from a credential issue that had already
+    been resolved hours earlier. With the bounded window the guard
+    releases and the dispatcher takes a fresh probe.
+    """
+    now = int(time.time())
+    window = kb.DEFAULT_RESPAWN_BLOCKER_WINDOW_SECONDS  # 1800
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="stale-quota", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ?, last_failure_at = ? "
+            "WHERE id = ?",
+            ("429 too many requests", now - (window + 60), t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_blocker_auth_exactly_at_window_released(kanban_home):
+    """A failure exactly at the window edge releases the guard.
+
+    The implementation uses ``>=`` (``now - failed_at >= window``) so
+    a failure of EXACTLY the window age should already be released.
+    Lock the boundary so a future flip to strict ``>`` doesn't
+    silently re-introduce the t_7f4b0ff2 stuck condition.
+    """
+    now = int(time.time())
+    window = kb.DEFAULT_RESPAWN_BLOCKER_WINDOW_SECONDS
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="boundary", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ?, last_failure_at = ? "
+            "WHERE id = ?",
+            ("403 forbidden", now - window, t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_blocker_auth_window_env_override(kanban_home, monkeypatch):
+    """HERMES_KANBAN_BLOCKER_AUTH_WINDOW_SECONDS overrides the default window.
+
+    Operators running a tight quota wall (sub-minute resets) want a
+    shorter window so the dispatcher probes again sooner. The helper
+    reads the env var on every call so monkeypatch.setenv works
+    without a process restart.
+    """
+    monkeypatch.setenv("HERMES_KANBAN_BLOCKER_AUTH_WINDOW_SECONDS", "120")
+    now = int(time.time())
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="tight-window", assignee="alice")
+        # 90s old — under the 120s env-overridden window → still deferred
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ?, last_failure_at = ? "
+            "WHERE id = ?",
+            ("quota exhausted", now - 90, t),
+        )
+        assert kb.check_respawn_guard(conn, t) == "blocker_auth"
+        # Bump age past the env-overridden window → released
+        conn.execute(
+            "UPDATE tasks SET last_failure_at = ? WHERE id = ?",
+            (now - 240, t),
+        )
+        assert kb.check_respawn_guard(conn, t) is None
+
+
+def test_respawn_guard_blocker_auth_window_zero_disables_guard(
+    kanban_home, monkeypatch
+):
+    """HERMES_KANBAN_BLOCKER_WINDOW_SECONDS=0 disables the guard entirely.
+
+    Tests and operators who prefer the auto-block circuit breaker as
+    the sole gatekeeper use 0 to disable the deferral. The guard must
+    always return None so the dispatcher attempts a fresh probe.
+    """
+    monkeypatch.setenv("HERMES_KANBAN_BLOCKER_AUTH_WINDOW_SECONDS", "0")
+    now = int(time.time())
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="disabled-guard", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ?, last_failure_at = ? "
+            "WHERE id = ?",
+            ("auth failure on every credential", now - 1, t),  # brand-new
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_blocker_auth_legacy_null_failure_at_uses_created_at(
+    kanban_home,
+):
+    """Legacy rows with last_failure_at=NULL fall back to created_at.
+
+    The migration backfills ``last_failure_at`` from the latest failure
+    event for tasks that already had a ``spawn_failed``/``gave_up`` row
+    — but the fallback path still matters for tests and for any future
+    rollback that re-introduces a NULL. The fallback must be
+    conservative: if ``created_at`` is ALSO newer than the window, the
+    guard still releases (the task is just old enough that the legacy
+    data should not trap it).
+    """
+    now = int(time.time())
+    window = kb.DEFAULT_RESPAWN_BLOCKER_WINDOW_SECONDS
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="legacy", assignee="alice")
+        # created_at is old (well past the window), last_failure_at is
+        # NULL to simulate a pre-migration row.
+        old_created = now - (window * 4)
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ?, last_failure_at = NULL, "
+            "created_at = ? WHERE id = ?",
+            ("quota wall", old_created, t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_blocker_auth_legacy_null_failure_at_recent_keeps_deferral(
+    kanban_home,
+):
+    """Recent created_at + NULL last_failure_at still defers.
+
+    Mirror of the test above: if the fallback anchor (``created_at``)
+    is itself inside the window, the guard should NOT release — we
+    have no better signal than ``created_at`` and a freshly-created
+    task with a quota-style error is almost certainly still under
+    the quota wall.
+    """
+    now = int(time.time())
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="fresh-legacy", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ?, last_failure_at = NULL, "
+            "created_at = ? WHERE id = ?",
+            ("429 rate limit hit", now - 30, t),  # created 30s ago, inside window
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "blocker_auth"
+
+
+def test_respawn_guard_blocker_auth_dispatch_once_integration(
+    kanban_home, monkeypatch
+):
+    """End-to-end: dispatch_once auto-spawns a task once the window elapses.
+
+    Without the bounded window the dispatcher would defer the task
+    forever (regression of t_7f4b0ff2). With the window, a task with a
+    stale failure older than the window appears in the spawned list on
+    the next dispatcher tick.
+    """
+    import hermes_cli.kanban_db as kb_mod
+
+    # Stub spawn_fn so we can drive dispatch_once without spawning a
+    # real subprocess. The stub records every (task_id, assignee,
+    # workspace) triple it would have spawned.
+    spawned_calls: list[tuple[str, str, str]] = []
+
+    def fake_spawn(task, workspace, *, board=None):  # noqa: ARG001
+        spawned_calls.append((task.id, task.assignee or "", workspace))
+        return 12345  # pretend PID
+
+    now = int(time.time())
+    window = kb.DEFAULT_RESPAWN_BLOCKER_WINDOW_SECONDS
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="integration", assignee="alice")
+        # Stamp a 429 error and age it past the window. Without the
+        # fix this task sits in ``ready`` forever; with the fix the
+        # next dispatch_once picks it up.
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ?, last_failure_at = ? "
+            "WHERE id = ?",
+            ("429 too many requests", now - (window + 120), t),
+        )
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=fake_spawn,
+            board=None,
+            max_in_progress_per_profile=None,
+        )
+
+    assert any(call[0] == t for call in spawned_calls), (
+        f"expected task to be auto-spawned after window elapsed; "
+        f"spawned={spawned_calls!r} result={result!r}"
+    )
 
 
 def test_respawn_guard_recent_success(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import subprocess
@@ -860,6 +861,115 @@ def test_resolve_crash_grace_seconds_handles_bad_env(monkeypatch):
         assert result == _kb.DEFAULT_CRASH_GRACE_SECONDS, (
             f"expected default for {bad_val!r}, got {result}"
         )
+
+
+def test_detect_crashed_workers_protocol_violation_respects_failure_limit_floor(
+    kanban_home, monkeypatch,
+):
+    """Single clean-exit (rc=0) protocol-violation crash must NOT auto-block
+    on the first occurrence — the dispatcher used to hard-code
+    ``failure_limit=1`` for the protocol-violation class, which meant one
+    provider-auth crash permanently blocked the card on a class of error
+    that's actually recoverable (rotate the OpenRouter key, the next
+    respawn succeeds). The fix lets the global ``kanban.failure_limit``
+    (default 2) be the floor for protocol-violation crashes; only
+    ``is_systemic`` (>=3 same-fingerprint NON-protocol-violation
+    crashes) still hard-codes failure_limit=1.
+
+    Regression coverage for the rc=0 crash loop observed on t_06f05fc8
+    and t_de062926 (2026-06-23 -> 2026-06-27) and the t_85354f34
+    reproducer (2026-06-27 10:40).
+    """
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="protocol-violation", assignee="a")
+        conn.execute(
+            "UPDATE tasks SET status='running', worker_pid=?, "
+            "claim_lock=? WHERE id=?",
+            (77777, f"{host}:w-pv1", tid),
+        )
+        conn.commit()
+
+        # First clean_exit crash: protocol_violation=True, error_text
+        # matches the exact string the dispatcher stamps.
+        _kb._record_worker_exit(77777, _exited_status(0))
+        crashed = kb.detect_crashed_workers(conn)
+        assert tid in crashed
+
+        # After ONE protocol-violation crash, task must stay in ready
+        # so the operator can rotate the key and the next respawn can
+        # succeed. The failure_limit floor (default 2) is now respected.
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready", (
+            f"protocol-violation floor fix: task should stay ready after "
+            f"1 crash (failure_limit={kb.DEFAULT_FAILURE_LIMIT}), got {task.status}"
+        )
+        assert task.consecutive_failures == 1
+        assert "protocol violation" in (task.last_failure_error or "").lower()
+
+    # Second clean_exit crash: counter reaches DEFAULT_FAILURE_LIMIT,
+    # breaker trips, task transitions to blocked. This is the same
+    # outcome the OLD hardcoded-failure_limit=1 path produced for the
+    # second crash — but now AFTER giving the operator one retry window.
+    with kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET status='running', worker_pid=?, "
+            "claim_lock=? WHERE id=?",
+            (77778, f"{host}:w-pv2", tid),
+        )
+        conn.commit()
+        _kb._record_worker_exit(77778, _exited_status(0))
+        kb.detect_crashed_workers(conn)
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked", (
+            f"breaker should trip on the 2nd protocol-violation crash "
+            f"(== DEFAULT_FAILURE_LIMIT), got {task.status}"
+        )
+        assert task.consecutive_failures >= kb.DEFAULT_FAILURE_LIMIT
+
+
+def test_detect_crashed_workers_systemic_non_protocol_violation_still_fast_blocks(
+    kanban_home, monkeypatch,
+):
+    """The ``is_systemic`` path (>=3 same-fingerprint NON-protocol-violation
+    crashes) must STILL hard-code failure_limit=1 — this is the genuine
+    loop safety net that survives the protocol-violation floor raise.
+    A genuine non-protocol-violation crash loop (e.g. a worker that
+    keeps dying on a permissions error before the tool loop runs but
+    after some bootstrap logging that produces a non-protocol signature)
+    must trip on the first iteration past threshold.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+    with kb.connect() as conn:
+        task_ids = []
+        for i in range(3):  # 3 same-fingerprint non-protocol crashes
+            tid = kb.create_task(conn, title=f"systemic-{i}", assignee="a")
+            host = _kb._claimer_id().split(":", 1)[0]
+            conn.execute(
+                "UPDATE tasks SET status='running', worker_pid=?, "
+                "claim_lock=? WHERE id=?",
+                (70000 + i, f"{host}:w-s{i}", tid),
+            )
+            task_ids.append(tid)
+            _kb._record_worker_exit(70000 + i, _exited_status(1))
+        conn.commit()
+
+        kb.detect_crashed_workers(conn)
+
+        for tid in task_ids:
+            task = kb.get_task(conn, tid)
+            assert task.status == "blocked", (
+                f"systemic fingerprint trip should auto-block immediately "
+                f"regardless of failure_limit floor; task {tid} status={task.status}"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -1740,6 +1850,125 @@ def test_dispatch_spawn_failure_releases_claim(kanban_home, all_assignees_spawna
         # Must return to ready so the next tick can retry.
         assert kb.get_task(conn, t).status == "ready"
         assert kb.get_task(conn, t).claim_lock is None
+
+
+def test_spawn_preflight_credentials_blocks_exhausted_profile(
+    kanban_home, monkeypatch,
+):
+    """When every credential entry on every provider for the assignee's
+    profile is ``last_status='exhausted'`` or ``'dead'``, the spawn-time
+    preflight must raise ``RuntimeError`` so the dispatcher's existing
+    ``except Exception`` handler routes through ``_record_spawn_failure``
+    with outcome='spawn_failed' — instant blocked with a remediation
+    hint, instead of the 60-second 401-then-protocol-violation dance.
+
+    Regression coverage for the t_85354f34 reproducer (2026-06-27 10:40)
+    where the ``main`` profile had every OpenRouter key stamped
+    ``last_status=exhausted, last_error_code=401`` and the worker died
+    in <1s with rc=0 before any tool loop.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    # Write a fake auth.json into the kanban_home fixture (== the
+    # 'default' profile dir per the resolve_profile_env resolution chain).
+    auth_path = kanban_home / "auth.json"
+    auth_path.write_text(
+        json.dumps({
+            "credential_pool": {
+                "openrouter": [
+                    {"key_id": "or-1", "last_status": "exhausted",
+                     "last_error_code": 401, "last_error_message": "Missing Authentication header"},
+                    {"key_id": "or-2", "last_status": "dead",
+                     "last_error_code": 403, "last_error_message": "token revoked"},
+                ],
+                "anthropic": [
+                    {"key_id": "ant-1", "last_status": "exhausted",
+                     "last_error_code": 429, "last_error_message": "rate limit"},
+                ],
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _kb._spawn_preflight_credentials("default")
+
+    msg = str(exc_info.value)
+    assert "no usable credentials" in msg
+    # Must surface at least one blocking provider so the operator knows
+    # which profile + provider to remediate.
+    assert "openrouter" in msg or "anthropic" in msg
+    # Must include the remediation hint that points at the auth file path.
+    assert "hermes auth" in msg or "auth.json" in msg
+    assert "rotate" in msg.lower() or "auth" in msg.lower()
+
+
+def test_spawn_preflight_credentials_passes_healthy_profile(
+    kanban_home, monkeypatch,
+):
+    """A profile with at least one healthy entry on at least one provider
+    must NOT trip the preflight — the credential pool may still pick a
+    working entry. Belt-and-braces with the protocol-violation floor:
+    even if the spawn does end up clean-exiting, the preflight didn't
+    false-block a profile that COULD have worked.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    auth_path = kanban_home / "auth.json"
+    auth_path.write_text(
+        json.dumps({
+            "credential_pool": {
+                "openrouter": [
+                    {"key_id": "or-1", "last_status": "exhausted",
+                     "last_error_code": 401},
+                    {"key_id": "or-2", "last_status": "ok"},
+                ],
+                "anthropic": [
+                    {"key_id": "ant-1"},  # missing last_status = healthy
+                ],
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    # Must NOT raise — every provider has at least one non-blocking entry.
+    result = _kb._spawn_preflight_credentials("default")
+    assert result is None
+
+
+def test_spawn_preflight_credentials_passes_when_no_auth_json(
+    kanban_home, monkeypatch,
+):
+    """Fail-open semantics: when no auth.json exists on disk, the worker
+    may still pick up env-var auth or interactive flows. Don't block
+    spawn; the credential pool inside the worker will surface any real
+    error.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    # kanban_home is fresh per fixture — no auth.json written.
+    assert not (kanban_home / "auth.json").exists()
+    result = _kb._spawn_preflight_credentials("default")
+    assert result is None
+
+
+def test_spawn_preflight_credentials_fails_open_on_corrupt_auth_json(
+    kanban_home, monkeypatch,
+):
+    """A corrupt or unreadable auth.json must NOT block the spawn. The
+    preflight is fail-open by design — its job is to short-circuit the
+    obvious exhaustion case, not to replace the credential pool's own
+    retry/auth logic. The pool re-reads auth.json on every entry selection,
+    so a real worker would still get a clean error if the file is actually
+    broken.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    auth_path = kanban_home / "auth.json"
+    auth_path.write_text("{this is not valid json", encoding="utf-8")
+
+    result = _kb._spawn_preflight_credentials("default")
+    assert result is None  # fail-open: corrupted file doesn't block spawn
 
 
 def test_dispatch_max_spawn_counts_existing_running_tasks(

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -1,4 +1,5 @@
 """Tests for hermes_logging — centralized logging setup."""
+import gzip
 import io
 import logging
 import os
@@ -1086,3 +1087,254 @@ class TestSafeStderr:
             logger.info("Session hygiene: 400 messages — auto-compressing")
         finally:
             logger.removeHandler(handler)
+
+
+class TestErrorsLogRotation:
+    """errors.log rotation policy matches agent.log (5 MiB / 5 backups) and
+    compressed backups are gzip-archived so disk usage stays bounded.
+
+    Regression test for t_91a20f01 — before the fix, errors.log rotated at
+    2 MiB / 2 backups with no compression, leaving 5 MiB+ of plain-text
+    WARNING/ERROR records on disk per cycle.
+    """
+
+    def test_errors_log_uses_default_max_bytes_and_backup_count(self, hermes_home):
+        """errors.log inherits the same 5 MiB / 3-backup defaults as agent.log
+        from config.yaml, matching the agent.log behavior the runbook expects.
+        """
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        root = logging.getLogger()
+
+        err_handlers = [
+            h for h in root.handlers
+            if isinstance(h, RotatingFileHandler)
+            and "errors.log" in getattr(h, "baseFilename", "")
+            and "errors.log." not in getattr(h, "baseFilename", "")
+        ]
+        assert len(err_handlers) == 1
+        assert err_handlers[0].maxBytes == 5 * 1024 * 1024
+        assert err_handlers[0].backupCount == 3
+
+    def test_errors_log_handler_has_compression_enabled(self, hermes_home):
+        """The errors.log handler is configured to gzip its .1 backup after
+        rollover.  Confirms the ``_compress_rotated`` flag is plumbed through
+        ``_ManagedRotatingFileHandler`` so doRollover() compresses instead
+        of leaving plain-text backups forever.
+        """
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        root = logging.getLogger()
+
+        err_handlers = [
+            h for h in root.handlers
+            if isinstance(h, RotatingFileHandler)
+            and "errors.log" in getattr(h, "baseFilename", "")
+            and "errors.log." not in getattr(h, "baseFilename", "")
+        ]
+        assert len(err_handlers) == 1
+        # Public API surface: this is the flag we plumbed through to enable
+        # gzip.  If the flag ever gets renamed, this test will fail and force
+        # an explicit decision instead of a silent regression.
+        assert getattr(err_handlers[0], "_compress_rotated", False) is True
+
+    def test_rollover_produces_gzipped_backup(self, hermes_home):
+        """Triggering a rollover on errors.log produces ``errors.log.1.gz``
+        (compressed) and NOT a plain ``errors.log.1`` — confirming the
+        end-to-end rotation+gzip path actually fires.
+
+        Flow: pre-size the log so a single warning pushes it past the
+        rotation threshold, then emit one more warning.  The first batch
+        gets pushed to ``errors.log.1.gz`` by the rollover; the trailing
+        warning lands in the fresh live ``errors.log``.  We then ``zcat``
+        the .gz and confirm the pre-rotation payload survived the
+        rename+gzip round-trip.
+        """
+        log_path = hermes_home / "logs" / "errors.log"
+        backup_path = log_path.parent / "errors.log.1"
+        backup_gz = Path(f"{backup_path}.gz")  # errors.log.1.gz
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        # Lower the rotation threshold on the errors.log handler only so we
+        # can trigger a rollover with a small payload, and raise
+        # backupCount so this single rollover doesn't get evicted by
+        # successive ones triggered by the trailing warning.
+        root = logging.getLogger()
+        errors_handler = None
+        for h in root.handlers:
+            if (
+                isinstance(h, RotatingFileHandler)
+                and Path(getattr(h, "baseFilename", "")).name == "errors.log"
+            ):
+                errors_handler = h
+                break
+        assert errors_handler is not None, "Could not find errors.log handler"
+        errors_handler.maxBytes = 400  # big enough for the sentinel, not for filler
+        errors_handler.backupCount = 20  # generous so we don't evict the .gz
+
+        # Prime the file: write a sentinel that we expect to find in the
+        # gzip after the upcoming rollover.
+        test_logger = logging.getLogger("test.rotation_compress")
+        sentinel = "ROTATE-COMPRESS-SENTINEL-XYZ-987654"
+        test_logger.warning(sentinel)
+
+        # Pre-fill errors.log so the NEXT emit triggers exactly one rollover.
+        # Using direct file write keeps this off the warning-rate-limiters
+        # in pytest.
+        with open(log_path, "ab") as f:
+            f.write(b"x" * 600)  # > maxBytes; one rollover on next emit
+
+        # Emit one warning — should trigger exactly one rollover: pre-rotation
+        # content (.1.gz) = sentinel; new errors.log = this warning.
+        test_logger.warning("post-rotation-trailing-warning")
+
+        for h in root.handlers:
+            try:
+                h.flush()
+            except Exception:
+                pass
+
+        assert backup_gz.exists(), (
+            f"Expected {backup_gz} to exist after rotation; "
+            f"saw plain backup at {backup_path}={backup_path.exists()}"
+        )
+        assert not backup_path.exists(), (
+            f"Plain-text {backup_path} should have been gzip-replaced, "
+            f"but it's still present."
+        )
+
+        # The sentinel must have made it through the rename+gzip round-trip.
+        with gzip.open(backup_gz, "rt", encoding="utf-8") as f:
+            content = f.read()
+        assert sentinel in content, (
+            f"Sentinel missing from gzipped backup — gzip lost data. "
+            f"Content head: {content[:300]!r}"
+        )
+
+        # The active errors.log should still exist and contain the trailing
+        # warning — the gateway/CLI continues to log without restart or
+        # loss.
+        assert log_path.exists()
+        live_content = log_path.read_text()
+        assert "post-rotation-trailing-warning" in live_content
+
+    def test_gzip_file_static_helper_replaces_source(self, tmp_path):
+        """Direct test of the gzip helper: source file is removed, .gz exists,
+        .gz content matches the original.  Catches off-by-one bugs in the
+        tmp-rename-unlink dance.
+        """
+        src = tmp_path / "test.log.1"
+        src.write_text("line1\nline2\n" * 100)
+
+        hermes_logging._ManagedRotatingFileHandler._gzip_file(str(src))
+
+        gz = tmp_path / "test.log.1.gz"
+        assert gz.exists()
+        assert not src.exists()
+        with gzip.open(gz, "rt", encoding="utf-8") as f:
+            assert f.read() == "line1\nline2\n" * 100
+
+    def test_gzip_file_silent_on_missing_source(self, tmp_path):
+        """Calling _gzip_file on a path that doesn't exist must NOT raise —
+        the rotation path is hot and a missing-file race during concurrent
+        rotation (e.g. external logrotate or another Hermes process) must
+        not break the caller's doRollover.
+        """
+        missing = tmp_path / "nope.log.1"
+        # Should be a no-op, no exception.
+        hermes_logging._ManagedRotatingFileHandler._gzip_file(str(missing))
+        assert not missing.exists()
+        assert not (tmp_path / "nope.log.1.gz").exists()
+
+    def test_rollover_chain_shifts_gz_backups_across_rotations(self, hermes_home):
+        """Multiple successive rollovers must shift the .gz backup chain
+        (``1.gz`` → ``2.gz`` → ``3.gz``) and never leave a plain-text
+        ``errors.log.N`` file behind.
+
+        Regression guard for the stdlib ``doRollover`` interaction:
+        stdlib's plain-text rename chain would leave ``errors.log.2`` and
+        ``errors.log.3`` as plain text while ``.1.gz`` was freshly gzipped,
+        and on the next rollover the .1→.2 plain rename would silently
+        no-op (the source ``.1`` was renamed-and-unlinked by the gzip step).
+        The compressed path has to do the .gz shift itself.
+        """
+        log_path = hermes_home / "logs" / "errors.log"
+        backups_gz = [log_path.parent / f"errors.log.{i}.gz" for i in (1, 2, 3)]
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        root = logging.getLogger()
+        test_logger = logging.getLogger("test.rotation_chain")
+
+        # Locate the errors.log handler and shrink maxBytes so we can drive
+        # rollovers with small payloads. Keep backupCount = 3 (the default)
+        # so the chain tests the full shift.
+        errors_handler = None
+        for h in root.handlers:
+            if (
+                isinstance(h, RotatingFileHandler)
+                and Path(getattr(h, "baseFilename", "")).name == "errors.log"
+            ):
+                errors_handler = h
+                break
+        assert errors_handler is not None
+        errors_handler.maxBytes = 200
+
+        # Drive 4 warnings each followed by filler large enough to trigger
+        # a rollover on the NEXT emit. After 4 warnings we get 3 rollovers
+        # (the 1st, 2nd, and 3rd warning each trigger a rollover of the
+        # PRIOR iteration's payload into .gz land; the 4th warning is the
+        # tail that lives in the active file).
+        sentinels = []
+        for i in range(4):
+            sentinel = f"chain-sentinel-{i}"
+            sentinels.append(sentinel)
+            test_logger.warning(sentinel)
+            with open(log_path, "ab") as f:
+                f.write(b"x" * 400)  # > maxBytes
+
+        for h in root.handlers:
+            try:
+                h.flush()
+            except Exception:
+                pass
+
+        # Plain-text backups must never exist — every rollover produced
+        # only .gz backups.
+        for n in (1, 2, 3):
+            plain = log_path.parent / f"errors.log.{n}"
+            assert not plain.exists(), (
+                f"Plain-text {plain.name} should have been gzipped and "
+                f"unlinked, but it remains."
+            )
+
+        # .1.gz holds the most-recent rolled payload (sentinel-2's payload,
+        # because the 3rd warning's rollover pushed sentinel-2's content
+        # into .1.gz; sentinel-3 is the trailing warning that lives in the
+        # live errors.log). .2.gz holds sentinel-1; .3.gz holds sentinel-0.
+        import gzip as _gzip
+        expected = {
+            1: "chain-sentinel-2",  # .1.gz
+            2: "chain-sentinel-1",  # .2.gz
+            3: "chain-sentinel-0",  # .3.gz
+        }
+        for n, expected_sentinel in expected.items():
+            gz = backups_gz[n - 1]
+            assert gz.exists(), f"{gz.name} missing after rotation chain"
+            with _gzip.open(gz, "rt", encoding="utf-8") as f:
+                content = f.read()
+            assert expected_sentinel in content, (
+                f"{gz.name} should contain {expected_sentinel!r}; "
+                f"got head: {content[:200]!r}"
+            )
+
+        # The live errors.log should hold the trailing sentinel (chain-sentinel-3)
+        # which has NOT yet been rolled — and must NOT contain the rolled
+        # sentinels that are now sitting in the .gz chain.
+        live = log_path.read_text()
+        assert "chain-sentinel-3" in live, (
+            "Trailing sentinel-3 should still be in the active errors.log"
+        )
+        for already_rolled in ("chain-sentinel-0", "chain-sentinel-1", "chain-sentinel-2"):
+            assert already_rolled not in live, (
+                f"{already_rolled} should have been rolled into the .gz "
+                f"chain but is still in the active errors.log"
+            )


### PR DESCRIPTION
Demote both fall-throughs from logger.warning to logger.debug with per-process dedup (Path 1 line ~4288, Path 2 line ~4489). First occurrence surfaces for real diagnostics; repeated retries stay silent. Verification harness at workspaces/t_aee2929f/verify_aux_demotion.py confirms both paths emit exactly 1 DEBUG record (no WARNING), with dedup suppressing repeats. Linked: t_aee2929f (parent), t_6650c6b5 (push-followup), t_4b28d6df (originating auth-boundary case). Note: branch diff includes the 10-commit batch already on local main HEAD 698f025d6; per-commit breakdown in t_aee2929f's REPORT.md.