### PR TITLE
fix: route allowed Slack bot mentions

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -329,6 +329,7 @@ class GatewayAuthorizationMixin:
         platform_allow_bots_map = {
             Platform.DISCORD: "DISCORD_ALLOW_BOTS",
             Platform.FEISHU: "FEISHU_ALLOW_BOTS",
+            Platform.SLACK: "SLACK_ALLOW_BOTS",
             Platform.TELEGRAM: "TELEGRAM_ALLOW_BOTS",
         }
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3152,6 +3152,8 @@ class SlackAdapter(BasePlatformAdapter):
         user_name = await self._resolve_user_name(user_id, chat_id=channel_id)
 
         # Build source
+        is_bot_author = bool(event.get("bot_id") or event.get("subtype") == "bot_message")
+
         source = self.build_source(
             chat_id=channel_id,
             chat_name=channel_id,  # Will be resolved later if needed
@@ -3159,6 +3161,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_ts,
+            is_bot=is_bot_author,
         )
 
         # Per-channel ephemeral prompt

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -62,8 +62,10 @@ class _AuthRunner:
     def __init__(self, auth_fn=None):
         self._auth_fn = auth_fn or (lambda _source: True)
         self.seen_sources = []
+        self.seen_events = []
 
     async def handle(self, event):
+        self.seen_events.append(event)
         return None
 
     def _is_user_authorized(self, source):
@@ -75,6 +77,47 @@ def _attach_auth_runner(adapter, auth_fn=None):
     runner = _AuthRunner(auth_fn=auth_fn)
     adapter.set_message_handler(runner.handle)
     return runner
+
+
+# ===========================================================================
+# incoming bot-authored mentions
+# ===========================================================================
+
+class TestSlackBotAuthoredMentions:
+    """Bot-authored Slack messages should be routed when explicitly allowed and addressed."""
+
+    @pytest.mark.asyncio
+    async def test_allowed_bot_mention_marks_source_as_bot(self):
+        adapter = _make_adapter()
+        adapter.config.extra["allow_bots"] = "mentions"
+        adapter._user_name_cache["U_OTHER_BOT"] = "grainfs-dev"
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture
+
+        await adapter._handle_slack_message(
+            {
+                "type": "message",
+                "subtype": "bot_message",
+                "bot_id": "B_OTHER",
+                "user": "U_OTHER_BOT",
+                "username": "grainfs-dev",
+                "text": "<@U_BOT> PR #999 is ready for review",
+                "channel": "C1",
+                "channel_type": "channel",
+                "team": "T1",
+                "ts": "1000.1",
+            }
+        )
+
+        assert len(captured) == 1
+        source = captured[0].source
+        assert source.user_id == "U_OTHER_BOT"
+        assert source.is_bot is True
+        assert "<@U_BOT>" not in captured[0].text
 
 
 # ===========================================================================

--- a/tests/gateway/test_slack_bot_auth_bypass.py
+++ b/tests/gateway/test_slack_bot_auth_bypass.py
@@ -1,0 +1,55 @@
+"""Regression guard for Slack bot-origin authorization."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.session import Platform, SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _isolate_slack_env(monkeypatch):
+    for var in (
+        "SLACK_ALLOW_BOTS",
+        "SLACK_ALLOWED_USERS",
+        "SLACK_ALLOW_ALL_USERS",
+        "SLACK_GROUP_ALLOWED_USERS",
+        "SLACK_GROUP_ALLOWED_CHATS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_bare_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    return runner
+
+
+def _make_slack_bot_source(bot_id: str = "U_OTHER_BOT"):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C1",
+        chat_type="group",
+        user_id=bot_id,
+        user_name="grainfs-dev",
+        is_bot=True,
+    )
+
+
+def test_slack_bot_authorized_when_allow_bots_mentions(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_HUMAN")
+
+    assert runner._is_user_authorized(_make_slack_bot_source()) is True
+
+
+def test_slack_bot_not_authorized_when_allow_bots_unset(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_HUMAN")
+
+    assert runner._is_user_authorized(_make_slack_bot_source()) is False


### PR DESCRIPTION
## Summary
- Mark Slack bot-authored events as bot sources so gateway auth can apply bot-specific policy.
- Include Slack in the platform `{PLATFORM}_ALLOW_BOTS` auth bypass map.
- Add regression coverage for `SLACK_ALLOW_BOTS=mentions` and Slack bot-authored mention routing.

## Test Plan
- `pytest tests/gateway/test_slack_bot_auth_bypass.py tests/gateway/test_slack_approval_buttons.py -q`
