### PR TITLE
fix(error-classifier): route 5xx context-overflow into compression (salvage #48038)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -964,9 +964,31 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
+        # Some local inference servers (notably llama.cpp / llama-server)
+        # report context overflow with an HTTP 500 instead of the standard
+        # 400/413. The request-validation guard above already ran, so any
+        # remaining explicit context-overflow signal routes into the
+        # compression-and-retry path (mirroring _classify_400) instead of
+        # blind server_error retries that exhaust and drop the turn.
+        if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
+            return result_fn(
+                FailoverReason.context_overflow,
+                retryable=True,
+                should_compress=True,
+            )
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:
+        # Same overflow-as-5xx variant (server busy / model-load OOM, or a
+        # Cloudflare/Tailscale hop relabeling the status). Route explicit
+        # overflow bodies into compression; otherwise treat as transient
+        # overload and retry.
+        if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
+            return result_fn(
+                FailoverReason.context_overflow,
+                retryable=True,
+                should_compress=True,
+            )
         return result_fn(FailoverReason.overloaded, retryable=True)
 
     # Other 4xx — non-retryable

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -469,6 +469,51 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.server_error
         assert result.retryable is True
 
+    # ── 5xx that are actually context overflow ──
+    # Some local inference servers (llama.cpp / llama-server, and vLLM/Ollama
+    # behind a Cloudflare/Tailscale hop) report context overflow with a 5xx
+    # status instead of the standard 400/413. These must route into the
+    # compression-and-retry path, not the blind server_error/overloaded retry
+    # that exhausts and drops the turn.
+
+    def test_500_context_overflow_routes_to_compression(self):
+        """A llama.cpp 500 'Context size has been exceeded.' must compress."""
+        e = MockAPIError(
+            "Context size has been exceeded.",
+            status_code=500,
+            body={"error": {"code": 500, "message": "Context size has been exceeded.", "type": "server_error"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+        assert result.retryable is True
+
+    def test_503_context_overflow_routes_to_compression(self):
+        """An overflow surfaced as 503 (busy / model-load OOM) must compress."""
+        e = MockAPIError(
+            "the request exceeds the available context size",
+            status_code=503,
+            body={"error": {"message": "the request exceeds the available context size"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
+    def test_500_plain_server_error_not_compressed(self):
+        """A genuine 500 crash without overflow wording must NOT be swallowed
+        into compression — it stays a retryable server_error."""
+        e = MockAPIError("Internal Server Error", status_code=500)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.should_compress is False
+
+    def test_503_plain_overloaded_not_compressed(self):
+        """A genuine 503 overload without overflow wording stays overloaded."""
+        e = MockAPIError("Service Unavailable", status_code=503)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_compress is False
+
     # ── Model not found ──
 
     def test_404_model_not_found(self):

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -476,28 +476,21 @@ class TestClassifyApiError:
     # compression-and-retry path, not the blind server_error/overloaded retry
     # that exhausts and drops the turn.
 
-    def test_500_context_overflow_routes_to_compression(self):
-        """A llama.cpp 500 'Context size has been exceeded.' must compress."""
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 529])
+    def test_5xx_context_overflow_routes_to_compression(self, status_code):
+        """Explicit context-overflow wording on any of the codes the fix covers
+        (500/502/503/529) must route to context_overflow + compression, not a
+        blind server_error/overloaded retry. Covers all four branches the code
+        touches (the original PR only asserted 500 and 503)."""
         e = MockAPIError(
             "Context size has been exceeded.",
-            status_code=500,
-            body={"error": {"code": 500, "message": "Context size has been exceeded.", "type": "server_error"}},
+            status_code=status_code,
+            body={"error": {"code": status_code, "message": "Context size has been exceeded.", "type": "server_error"}},
         )
         result = classify_api_error(e)
         assert result.reason == FailoverReason.context_overflow
         assert result.should_compress is True
         assert result.retryable is True
-
-    def test_503_context_overflow_routes_to_compression(self):
-        """An overflow surfaced as 503 (busy / model-load OOM) must compress."""
-        e = MockAPIError(
-            "the request exceeds the available context size",
-            status_code=503,
-            body={"error": {"message": "the request exceeds the available context size"}},
-        )
-        result = classify_api_error(e)
-        assert result.reason == FailoverReason.context_overflow
-        assert result.should_compress is True
 
     def test_500_plain_server_error_not_compressed(self):
         """A genuine 500 crash without overflow wording must NOT be swallowed


### PR DESCRIPTION
## Summary

Salvage of #48038 by @pefontana (applied onto current `main` + a test follow-up). Routes HTTP 5xx context-overflow into compression instead of a blind retry-then-drop.

## The bug

Local inference servers (llama.cpp/llama-server, vLLM/Ollama behind a Cloudflare/Tailscale hop) report context overflow with HTTP **500/502/503/529** instead of the standard 400/413. `_classify_by_status` returned `server_error`/`overloaded` for those and retried blindly 3× before dropping the turn with **no compaction** — what users report as "the LLM disconnects mid-session instead of compressing." Confirmed still present on current `main`: the 5xx branches return before any context-overflow pattern check.

## The fix

In `_classify_by_status`, after the request-validation guard, route explicit `_CONTEXT_OVERFLOW_PATTERNS` matches on 500/502/503/529 to `context_overflow` (`should_compress=True`, retryable). Narrowly scoped:
- plain 500 stays `server_error`, plain 503 stays `overloaded` (no pattern match);
- reuses the existing `_CONTEXT_OVERFLOW_PATTERNS` (single source of truth), consistent lowercase/raw+body+metadata matching;
- `FailoverReason.context_overflow` already routes into the compression-retry path downstream.

## Test follow-up (this salvage)

Reviewer helix4u noted the code covers 500/502/503/529 but the positive tests only asserted 500/503. Parametrized the positive test over **[500, 502, 503, 529]**; kept the plain-5xx negatives.

## Review

Member **rob-maron approved** the original. Ran hermes-agent-dev + hermes-pr-review Phase 2c on the final salvage — 0 Critical, non-tautological tests confirmed.

## Tests

```text
pytest tests/agent/test_error_classifier.py -q   # (CI runs the full suite)
```

Supersedes #48038. Full credit to @pefontana.
