### PR TITLE
fix(agent): retry 413 after stripping vision payloads (salvage #47397)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3244,6 +3244,16 @@ def run_conversation(
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
+                        if agent._try_strip_image_parts_from_tool_messages(
+                            api_messages,
+                            remember_model=False,
+                        ):
+                            agent._buffer_status(
+                                "📐 Compression could not reduce the request further — "
+                                "removed retained vision payloads and retrying..."
+                            )
+                            continue
+
                         # Terminal — surface buffered context so the user
                         # sees what compression attempts were made.
                         agent._flush_status_buffer()

--- a/run_agent.py
+++ b/run_agent.py
@@ -4932,17 +4932,27 @@ class AIAgent:
             max_dimension=max_dimension,
         )
 
-    def _try_strip_image_parts_from_tool_messages(self, api_messages: list) -> bool:
+    def _try_strip_image_parts_from_tool_messages(
+        self,
+        api_messages: list,
+        *,
+        remember_model: bool = True,
+    ) -> bool:
         """Downgrade list-type tool messages to text summaries in-place.
 
         Recovery path for providers that reject list-type tool message content
         (e.g. Xiaomi MiMo's 400 "text is not set"; see issue #27344).  Walks
         ``api_messages`` for any ``role: "tool"`` message whose ``content`` is
         a list containing image parts, replaces the content with the existing
-        text part(s) (or a minimal placeholder if none survive), and records
-        the active (provider, model) in ``self._no_list_tool_content_models``
-        so subsequent ``_tool_result_content_for_active_model`` calls in this
-        session preemptively downgrade screenshots without a round-trip.
+        text part(s) (or a minimal placeholder if none survive), and by default
+        records the active (provider, model) in
+        ``self._no_list_tool_content_models`` so subsequent
+        ``_tool_result_content_for_active_model`` calls in this session
+        preemptively downgrade screenshots without a round-trip.
+
+        413 payload-size recovery passes ``remember_model=False`` because that
+        error means this request body was too large, not that the provider/model
+        rejects list-type tool content in general.
 
         Returns True when at least one tool message was downgraded — the
         caller (the 400 recovery branch in ``agent.conversation_loop``) uses
@@ -4952,15 +4962,16 @@ class AIAgent:
         if not isinstance(api_messages, list):
             return False
 
-        # Record (provider, model) so we don't relearn this lesson.
-        key = (
-            (getattr(self, "provider", "") or "").strip().lower(),
-            (getattr(self, "model", "") or "").strip(),
-        )
-        if not hasattr(self, "_no_list_tool_content_models"):
-            self._no_list_tool_content_models = set()
-        if key[1]:  # only record when we actually have a model id
-            self._no_list_tool_content_models.add(key)
+        if remember_model:
+            # Record (provider, model) so we don't relearn this lesson.
+            key = (
+                (getattr(self, "provider", "") or "").strip().lower(),
+                (getattr(self, "model", "") or "").strip(),
+            )
+            if not hasattr(self, "_no_list_tool_content_models"):
+                self._no_list_tool_content_models = set()
+            if key[1]:  # only record when we actually have a model id
+                self._no_list_tool_content_models.add(key)
 
         changed = False
         for msg in api_messages:

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -227,6 +227,76 @@ class TestHTTP413Compression:
         mock_compress.assert_called_once()
         assert result["completed"] is True
 
+    def test_413_strips_vision_payloads_when_compression_cannot_reduce_messages(self, agent):
+        """If compression leaves image payloads behind, strip them and retry.
+
+        Browser vision tool results can contain base64 image parts. A 413 can
+        persist even after summarisation when the remaining recent tool result
+        still carries binary data; Hermes should evict the image payload and
+        keep the text/placeholder context instead of failing immediately.
+        """
+        err_413 = _make_413_error()
+        ok_resp = _mock_response(content="Recovered after image eviction", finish_reason="stop")
+        request_payloads = []
+
+        def _side_effect(**kwargs):
+            request_payloads.append(kwargs)
+            if len(request_payloads) == 1:
+                raise err_413
+            return ok_resp
+
+        agent.client.chat.completions.create.side_effect = _side_effect
+
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64," + ("a" * 2000)},
+        }
+        prefill = [
+            {"role": "user", "content": "please inspect this page"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_vision",
+                        "type": "function",
+                        "function": {"name": "browser_vision", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_vision",
+                "name": "browser_vision",
+                "content": [
+                    {"type": "text", "text": "Screenshot of the dashboard"},
+                    image_part,
+                ],
+            },
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            # Simulate the bad production case: compression ran, but the
+            # recent vision tool message survived so message count did not drop.
+            mock_compress.side_effect = lambda msgs, *_a, **_k: (msgs, "compressed prompt")
+            result = agent.run_conversation("continue", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after image eviction"
+        assert len(request_payloads) == 2
+        first_tool = next(m for m in request_payloads[0]["messages"] if m.get("role") == "tool")
+        retried_tool = next(m for m in request_payloads[1]["messages"] if m.get("role") == "tool")
+        assert "Screenshot of the dashboard" in str(first_tool["content"])
+        assert "data:image" not in str(retried_tool["content"])
+        assert "Screenshot of the dashboard" in str(retried_tool["content"])
+        assert not getattr(agent, "_no_list_tool_content_models", set())
+
     def test_413_clears_conversation_history_on_persist(self, agent):
         """After 413-triggered compression, _persist_session must receive None history.
 


### PR DESCRIPTION
## Summary

Salvage of #47397 by @Tranquil-Flow (cherry-picked onto current `main`, authorship preserved). On an HTTP 413 that can't compress further, strips retained tool-message image payloads from the retry so an oversized vision request recovers instead of hard-failing (#47339).

## The bug

Issue #47339: context compression doesn't evict image/vision payloads, so a request can 413 even at ~44k tokens. Confirmed still present on `main`: `_strip_historical_media` anchors on `role=="user"` images and the compressor only evicts tool-result image envelopes *outside the protected tail* — so a recent screenshot in the protected tail keeps its base64 bytes through every compression pass. When compression "can't reduce further," it still 413s.

## The fix

At the terminal else-branch of the 413/`payload_too_large` recovery (reached only when compression didn't reduce the request), strip retained tool-message image payloads:
- evicts `image_url` **and** `input_image` byte parts, preserves `text`/`input_text` (reassembled as joined text or a placeholder);
- adds a `remember_model=False` kwarg so a 413 (a size problem) does **not** permanently mark a vision-capable model as unable to accept list-type tool content — that learning stays scoped to genuine provider list-content rejections.

## Cluster context (#47339)

This is one of several approaches for #47339. It's the **413-retry-level backstop** — complementary to, not competing with:
- #47398 (root-cause eviction in `_strip_historical_media`) — currently closed;
- #42509 / #37412 (inline-image *shrink*) — open, orthogonal (shrink keeps the image; this strips as a last resort).

Verified as a sound standalone backstop: it addresses a real unfixed gap (protected-tail images survive compression) and doesn't collide with the shrink PRs. Ideally a compressor-level fix also lands so the tail case is handled before 413 fires; this remains valuable as the last-resort layer.

## Review

Ran hermes-agent-dev + hermes-pr-review Phase 2c — 0 Critical. Strip logic handles both image shapes, preserves text, only fires on the last-resort path; the `_no_list_tool_content_models` learning-separation is real and tested (non-tautological — the test verifies retry #2's wire payload drops the image bytes present in #1).

## Tests

```text
pytest tests/run_agent/test_413_compression.py -q   # 25 passed (CI runs the full suite)
```

Supersedes #47397. Full credit to @Tranquil-Flow.
