### PR TITLE
fix: replace bare assert with proper exceptions in production code (P0)

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -396,7 +396,8 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+            raise RuntimeError("Codex session not properly initialized")
         result.thread_id = self._thread_id
 
         self._interrupt_event.clear()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4463,7 +4463,8 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
-            assert self._app is not None
+            if self._app is None:
+                raise RuntimeError("Failed to create web application")
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -217,13 +217,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return text
 
     async def _api_get(self, path: str) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("HTTP client not initialized")
         res = await self.client.get(self._api_url(path))
         res.raise_for_status()
         return res.json()
 
     async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("HTTP client not initialized")
         res = await self.client.post(self._api_url(path), json=payload)
         res.raise_for_status()
         return res.json()

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1335,7 +1335,8 @@ class WeixinAdapter(BasePlatformAdapter):
         logger.info("[%s] Disconnected", self.name)
 
     async def _poll_loop(self) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("Poll session not initialized")
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
         timeout_ms = LONG_POLL_TIMEOUT_MS
         consecutive_failures = 0
@@ -1401,7 +1402,8 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] unhandled inbound error from=%s: %s", self.name, _safe_id(message.get("from_user_id")), exc, exc_info=True)
 
     async def _process_message(self, message: Dict[str, Any]) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("Poll session not initialized")
         sender_id = str(message.get("from_user_id") or "").strip()
         if not sender_id:
             return
@@ -1813,7 +1815,8 @@ class WeixinAdapter(BasePlatformAdapter):
                 )
                 if wait > 0:
                     await asyncio.sleep(wait)
-        assert last_error is not None
+        if last_error is None:
+            raise RuntimeError("Unexpected state: no error recorded after retries")
         raise last_error
 
     async def send(
@@ -2068,7 +2071,8 @@ class WeixinAdapter(BasePlatformAdapter):
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
-        assert self._send_session is not None
+        if self._send_session is None:
+            raise RuntimeError("Send session not initialized")
         # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
         # "Timeout context manager should be used inside a task" errors.
         async def _do_fetch():
@@ -2088,7 +2092,8 @@ class WeixinAdapter(BasePlatformAdapter):
         caption: str,
         force_file_attachment: bool = False,
     ) -> str:
-        assert self._send_session is not None and self._token is not None
+        if self._send_session is None or self._token is None:
+            raise RuntimeError("Send session or token not initialized")
         plaintext = Path(path).read_bytes()
         media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey = secrets.token_hex(16)

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -548,7 +548,8 @@ class WebSocketRelayTransport:
         await self._ws.send(json.dumps(frame) + "\n")
 
     async def _read_loop(self) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected")
         buf = ""
         try:
             async for chunk in self._ws:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4654,7 +4654,8 @@ def _run_with_idle_timeout(
 
     def _reader() -> None:
         nonlocal last_output_ts
-        assert proc.stdout is not None
+        if proc.stdout is None:
+            return
         for line in proc.stdout:
             try:
                 print(f"{indent}{line.rstrip()}", flush=True)

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -374,7 +374,8 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
 def _do_git_install(entry: CatalogEntry) -> Path:
     """Clone the entry's repo into ``~/.hermes/mcp-installs/<name>`` and run
     bootstrap commands. Returns the install directory."""
-    assert entry.install is not None and entry.install.type == "git"
+    if entry.install is None or entry.install.type != "git":
+        raise CatalogError(f"Entry '{entry.name}' does not have a git install configuration")
     install = entry.install
     dest = _install_root() / entry.name
 

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -219,7 +219,8 @@ def _handle_row(row: _Row) -> None:
                 print(color(f"  '{row.name}' was not installed", Colors.DIM))
     elif choice == 3:
         try:
-            assert row.entry is not None
+            if row.entry is None:
+                raise CatalogError("No entry available for reinstall")
             install_entry(row.entry, enable=True)
         except CatalogError as exc:
             print(color(f"  ✗ reinstall failed: {exc}", Colors.RED))

--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -221,12 +221,14 @@ class RealtimeSession:
             return False
 
     def _send_json(self, payload: dict) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected")
         with self._send_lock:
             self._ws.send(json.dumps(payload))
 
     def _recv(self, timeout: Optional[float] = None):
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected")
         try:
             if timeout is None:
                 return self._ws.recv()

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -200,7 +200,8 @@ def _list_block(items: List[Tuple[int, bool, str]]) -> Block:
             }
             elements.append(cur)
             cur_key = key
-        assert cur is not None
+        if cur is None:
+            raise ValueError("No rich text block to append elements to")
         cur["elements"].append(
             {"type": "rich_text_section", "elements": _inline_elements(text)}
         )

--- a/plugins/security-guidance/patterns.py
+++ b/plugins/security-guidance/patterns.py
@@ -350,7 +350,8 @@ _RULE_NAME_TO_ID = {
 
 # Fail loudly at import time if a pattern is added without a RuleId.
 # This fires in pytest on every PR, so desync is caught before merge.
-assert set(_RULE_NAME_TO_ID) == {p["ruleName"] for p in SECURITY_PATTERNS}, (
+if set(_RULE_NAME_TO_ID) != {p["ruleName"] for p in SECURITY_PATTERNS}:
+    raise RuntimeError(
     f"RuleId enum out of sync with SECURITY_PATTERNS: "
     f"missing={set(p['ruleName'] for p in SECURITY_PATTERNS) - set(_RULE_NAME_TO_ID)}, "
     f"extra={set(_RULE_NAME_TO_ID) - set(p['ruleName'] for p in SECURITY_PATTERNS)}"

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -841,7 +841,8 @@ class CDPSupervisor:
 
     async def _read_loop(self) -> None:
         """Continuously dispatch incoming CDP frames."""
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected")
         try:
             async for raw in self._ws:
                 if self._stop_requested:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1019,7 +1019,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+            raise RuntimeError("Container not started")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -928,7 +928,8 @@ def _patch_skill(
         target, err = _resolve_skill_target(skill_dir, file_path)
         if err:
             return {"success": False, "error": err}
-        assert target is not None
+        if target is None:
+            return {"success": False, "error": "Failed to resolve skill target"}
     else:
         # Patching SKILL.md
         target = skill_dir / "SKILL.md"
@@ -1146,7 +1147,8 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+        return {"success": False, "error": "Failed to resolve skill target"}
     if target.exists():
         read_guard = _background_review_read_before_write_guard(
             name, target, "write_file", file_path
@@ -1192,7 +1194,8 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(skill_dir, file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+        return {"success": False, "error": "Failed to resolve skill target"}
     if not target.exists():
         # List what's actually there for the model to see
         available = []


### PR DESCRIPTION
## Summary

Replace 22 bare `assert` statements across 14 production files with explicit `if/raise` guards. Bare asserts are silently stripped when Python runs with `-O` flag, disabling critical precondition checks at runtime.

## Severity: P0

When Python runs optimized (`python -O`), all `assert` statements are removed. This means:
- WebSocket connection checks silently pass → runtime crashes on None
- Container-started checks silently pass → subprocess errors
- Session initialization checks silently pass → NoneType attribute errors

## Changes (14 files, 22 asserts → proper exceptions)

| File | Assert | Replacement |
|------|--------|-------------|
| `tools/skill_manager_tool.py` | 3× `assert target is not None` | `return {"success": False, "error": ...}` |
| `tools/environments/docker.py` | `assert self._container_id` | `raise RuntimeError` |
| `tools/browser_supervisor.py` | `assert self._ws is not None` | `raise RuntimeError` |
| `agent/transports/codex_app_server_session.py` | `assert self._client and self._thread_id` | `raise RuntimeError` |
| `gateway/platforms/api_server.py` | `assert self._app is not None` | `raise RuntimeError` |
| `gateway/platforms/weixin.py` | 5× session/token asserts | `raise RuntimeError` |
| `gateway/platforms/bluebubbles.py` | 2× `assert self.client` | `raise RuntimeError` |
| `gateway/relay/ws_transport.py` | `assert self._ws is not None` | `raise RuntimeError` |
| `plugins/platforms/slack/block_kit.py` | `assert cur is not None` | `raise ValueError` |
| `plugins/google_meet/realtime/openai_client.py` | 2× ws assert | `raise RuntimeError` |
| `plugins/security-guidance/patterns.py` | module-level assert | `raise RuntimeError` |
| `hermes_cli/mcp_catalog.py` | `assert entry.install` | `raise CatalogError` |
| `hermes_cli/mcp_picker.py` | `assert row.entry` | `raise CatalogError` |
| `hermes_cli/main.py` | `assert proc.stdout` | early `return` |

## Testing

All 14 files pass `python3 -m py_compile` verification.
