### PR TITLE
fix(agent): bound context compression summary stalls (salvage #49905)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1607,8 +1607,12 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             return future.result(timeout=hard_timeout)
         except concurrent.futures.TimeoutError as exc:
             future.cancel()
+            # Message MUST contain the substring "timeout" so the caller's
+            # _is_timeout check (which matches `"timeout" in err_str`) routes
+            # this into the existing timeout fallback path — the whole point of
+            # the hard timeout is to fall back to the deterministic summary.
             raise TimeoutError(
-                f"Context compression hard-timed out after {hard_timeout:g}s"
+                f"Context compression summary timeout: hard-timed out after {hard_timeout:g}s"
             ) from exc
         finally:
             # Do not wait for a stuck network stack to unwind in the caller's
@@ -1939,7 +1943,16 @@ This compaction should PRIORITISE preserving all information related to the focu
             # transient network events; treat them like a timeout so we fall
             # back to the main model instead of entering a 60-second cooldown.
             # See issue #18458.
-            _is_streaming_closed = _is_connection_error(e)
+            # A genuine mid-stream connection drop. Deliberately exclude
+            # timeouts: our own hard-timeout (``_call_summary_llm_with_hard_timeout``)
+            # raises a builtin ``TimeoutError`` whose type name contains
+            # "Timeout", which ``_is_connection_error`` reports as a connection
+            # error. That is NOT a network stream-close — it is us abandoning a
+            # slow summary — and must not set ``_last_summary_network_failure``
+            # (which would make compress() ABORT instead of taking the intended
+            # deterministic-fallback path). Timeouts are already handled by
+            # ``_is_timeout`` above.
+            _is_streaming_closed = _is_connection_error(e) and not _is_timeout
             # Authentication / permission failures (401/403) are NOT transient
             # and NOT fixable by retrying the same request: the credential is
             # invalid/blocked/expired or the endpoint is wrong (e.g. a prod

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -16,6 +16,7 @@ Improvements over v2:
   - Richer tool call/result detail in summarizer input
 """
 
+import concurrent.futures
 import hashlib
 import json
 import logging
@@ -24,7 +25,7 @@ import re
 import time
 from typing import Any, Dict, List, Optional
 
-from agent.auxiliary_client import call_llm, _is_connection_error, aux_interrupt_protection
+from agent.auxiliary_client import call_llm, _get_task_timeout, _is_connection_error, aux_interrupt_protection
 from agent.context_engine import ContextEngine
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
@@ -1590,6 +1591,31 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self.summary_model = ""  # empty = use main model
         self._clear_compression_failure_cooldown()  # no cooldown — retry immediately
 
+    def _call_summary_llm_with_hard_timeout(self, call_kwargs: Dict[str, Any]) -> Any:
+        """Bound how long compression summary generation can block the caller.
+
+        ``call_llm()`` already forwards ``auxiliary.compression.timeout`` to
+        the provider client, but the dashboard/gateway still waits
+        synchronously for that call to return. Run it in a worker thread and
+        stop waiting after the configured compression timeout so the normal
+        fallback summary path can keep the process responsive.
+        """
+        hard_timeout = max(1.0, float(_get_task_timeout("compression")))
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(call_llm, **call_kwargs)
+        try:
+            return future.result(timeout=hard_timeout)
+        except concurrent.futures.TimeoutError as exc:
+            future.cancel()
+            raise TimeoutError(
+                f"Context compression hard-timed out after {hard_timeout:g}s"
+            ) from exc
+        finally:
+            # Do not wait for a stuck network stack to unwind in the caller's
+            # thread. The timed-out summary attempt is being abandoned in
+            # favor of the existing deterministic compression fallback.
+            pool.shutdown(wait=False, cancel_futures=True)
+
     def _generate_summary(
         self,
         turns_to_summarize: List[Dict[str, Any]],
@@ -1799,13 +1825,22 @@ This compaction should PRIORITISE preserving all information related to the focu
             }
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
-            # Compression is atomic: protect the in-flight summary call from a
-            # mid-turn gateway interrupt. Without this, an incoming user message
-            # aborts the summary and compression falls back to a degraded static
-            # marker, losing the real handoff (#23975). Re-entrant: a main-model
-            # retry (_generate_summary recursion) re-enters harmlessly.
+            # Compression is atomic: protect the summary path from a mid-turn
+            # gateway interrupt so an incoming user message can't abort it and
+            # drop us to a degraded static marker (#23975).
+            #
+            # NOTE on composition: aux_interrupt_protection() is a threading.local
+            # flag, so it guards work on THIS thread — the response unpacking
+            # below — but does NOT propagate into the worker thread that
+            # _call_summary_llm_with_hard_timeout runs call_llm on. That is
+            # intentional here: the hard worker-thread timeout (#49768) is the
+            # stronger guarantee — a wedged socket / SDK that ignores its own
+            # read timeout can't block the gateway loop forever; on timeout the
+            # helper raises, caught below and routed to the deterministic
+            # fallback summary path. The two mechanisms are complementary, not
+            # nested.
             with aux_interrupt_protection():
-                response = call_llm(**call_kwargs)
+                response = self._call_summary_llm_with_hard_timeout(call_kwargs)
             # ``_validate_llm_response`` only guarantees ``choices[0].message``
             # exists, not that it's an object with ``.content``. Some
             # OpenAI-compatible proxies / local backends return a dict- or

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,5 +1,7 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
+import concurrent.futures
+
 import pytest
 import time
 from unittest.mock import patch, MagicMock
@@ -1366,6 +1368,61 @@ class TestSummaryFailureTrackingForGatewayWarning:
         assert len(fallback) <= 8300
         assert "deterministic fallback" in fallback
         assert "important detail" in fallback
+
+    def test_compress_hard_timeout_uses_existing_fallback_path(self):
+        events = {"shutdown_calls": []}
+
+        class _TimeoutFuture:
+            def cancel(self):
+                events["cancel_called"] = True
+                return False
+
+            def result(self, timeout=None):
+                events["result_timeout"] = timeout
+                raise concurrent.futures.TimeoutError("timed out")
+
+        class _FakeExecutor:
+            def __init__(self, max_workers=1):
+                events["max_workers"] = max_workers
+
+            def submit(self, fn, *args, **kwargs):
+                events["submitted_fn"] = getattr(fn, "__name__", repr(fn))
+                events["submitted_kwargs"] = kwargs
+                return _TimeoutFuture()
+
+            def shutdown(self, wait=True, cancel_futures=False):
+                events["shutdown_calls"].append((wait, cancel_futures))
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "msg 1"},
+            {"role": "assistant", "content": "msg 2"},
+            {"role": "user", "content": "msg 3"},
+            {"role": "assistant", "content": "msg 4"},
+            {"role": "user", "content": "msg 5"},
+            {"role": "assistant", "content": "msg 6"},
+            {"role": "user", "content": "msg 7"},
+        ]
+
+        with patch("agent.context_compressor._get_task_timeout", return_value=12.5), \
+             patch("agent.context_compressor.concurrent.futures.ThreadPoolExecutor", _FakeExecutor):
+            result = c.compress(msgs)
+
+        assert events["max_workers"] == 1
+        assert events["submitted_fn"] == "call_llm"
+        assert events["submitted_kwargs"]["task"] == "compression"
+        assert events["result_timeout"] == 12.5
+        assert events["cancel_called"] is True
+        assert events["shutdown_calls"] == [(False, True)]
+        assert c._last_summary_fallback_used is True
+        assert "hard-timed out after 12.5s" in (c._last_summary_error or "")
+        assert any(
+            isinstance(m.get("content"), str) and "Summary generation was unavailable" in m["content"]
+            for m in result
+        )
 
     def test_compress_clears_fallback_flag_on_subsequent_success(self):
         mock_response = MagicMock()


### PR DESCRIPTION
## Summary

Salvage of #49905 by @LeonSGP43 (rebased onto current `main` + a rebase-follow-up fixing a production gap the rebase exposed). Bounds context-compression summary generation with a hard timeout so a wedged summary call can't block the gateway loop indefinitely (#49768).

## The bug

`call_llm` forwards `auxiliary.compression.timeout` to the provider client as a socket/read timeout only — it does **not** bound the caller's wait if the network stack wedges or the SDK ignores it. The synchronous summary call in `context_compressor.py` was wrapped only in `aux_interrupt_protection()` (which suppresses interrupts — the opposite of a timeout), so compression summary generation could block the gateway loop forever. Confirmed still present on `main`.

## The fix

@LeonSGP43's fix: run the summary `call_llm` in a `ThreadPoolExecutor(max_workers=1)` worker and stop waiting after `auxiliary.compression.timeout` (`future.result(timeout=...)`, `shutdown(wait=False, cancel_futures=True)`). On timeout it raises, caught by the existing handler and routed into the deterministic fallback summary path — the gateway stays responsive.

## Rebase + production-gap fix (this salvage)

The PR was ~592 commits behind; the compressor drifted (two cosmetic conflicts). Resolved by composing main's `aux_interrupt_protection` wrapper + defensive message coercion with the PR's timeout call (documented the thread-local interaction honestly: the protection guards caller-thread unpacking, the hard timeout is the stronger guarantee for the wedged-socket case — complementary, not nested).

Fixing the rebase surfaced a real **production gap**: the hard timeout raises a builtin `TimeoutError`, but `_generate_summary`'s handler set `_is_streaming_closed = _is_connection_error(e)` — and `_is_connection_error` classifies **any** exception whose type name contains "Timeout" as a network close. That set `_last_summary_network_failure=True`, making `compress()` take the network-failure **ABORT** branch (return messages unchanged) instead of the deterministic fallback — the opposite of the PR's intent. Gated it: `_is_streaming_closed = _is_connection_error(e) and not _is_timeout`. Mutation-verified against the contributor's own `test_compress_hard_timeout_uses_existing_fallback_path` (reverting the gate fails it). Genuine streaming-closes don't carry "timeout" wording, so they're unaffected.

## Review

Ran hermes-agent-dev + hermes-pr-review Phase 2c — 0 Critical. The executor pattern is correct, the abandoned-thread trade-off is bounded/documented, `auxiliary.compression.timeout` confirmed in `DEFAULT_CONFIG`, and the false-suppression edge for the `_is_timeout` gate was independently checked (genuine mid-stream closes are correctly preserved).

## Tests

```text
pytest tests/agent/test_context_compressor.py -q   # 142 passed (CI runs the full suite)
```

Supersedes #49905. Full credit to @LeonSGP43.
