### PR TITLE
fix(dingtalk): avoid pre-auth media side effects

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -483,6 +483,21 @@ class DingTalkAdapter(BasePlatformAdapter):
         candidates.discard("")
         return bool(candidates & self._allowed_users)
 
+    def _is_source_authorized_by_gateway(self, source) -> bool:
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        auth_fn = getattr(runner, "_is_user_authorized", None)
+        if not callable(auth_fn):
+            return True
+        try:
+            return bool(auth_fn(source))
+        except Exception:
+            logger.debug(
+                "[%s] Gateway auth check failed before DingTalk side effects",
+                self.name,
+                exc_info=True,
+            )
+            return False
+
     def _message_mentions_bot(self, message: "ChatbotMessage") -> bool:
         """True if the bot was @-mentioned in a group message.
 
@@ -632,11 +647,21 @@ class DingTalkAdapter(BasePlatformAdapter):
             )
             return
 
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=getattr(message, "conversation_title", None),
+            chat_type=chat_type,
+            user_id=sender_id,
+            user_name=sender_nick,
+            user_id_alt=sender_staff_id if sender_staff_id else None,
+        )
+        source_authorized = self._is_source_authorized_by_gateway(source)
+
         # Stash the incoming message keyed by chat_id so concurrent
         # conversations don't clobber each other's context.  Also reset
         # the per-chat "Done emoji fired" marker so a new inbound message
         # gets its own Thinking→Done cycle.
-        if chat_id:
+        if source_authorized and chat_id:
             self._message_contexts[chat_id] = message
             self._done_emoji_fired.discard(chat_id)
 
@@ -645,7 +670,12 @@ class DingTalkAdapter(BasePlatformAdapter):
         session_webhook_expired_time = (
             getattr(message, "session_webhook_expired_time", 0) or 0
         )
-        if session_webhook and chat_id and _DINGTALK_WEBHOOK_RE.match(session_webhook):
+        if (
+            source_authorized
+            and session_webhook
+            and chat_id
+            and _DINGTALK_WEBHOOK_RE.match(session_webhook)
+        ):
             if len(self._session_webhooks) >= _SESSION_WEBHOOKS_MAX:
                 try:
                     self._session_webhooks.pop(next(iter(self._session_webhooks)))
@@ -657,7 +687,8 @@ class DingTalkAdapter(BasePlatformAdapter):
             )
 
         # Resolve media download codes to URLs so vision tools can use them
-        await self._resolve_media_codes(message)
+        if source_authorized:
+            await self._resolve_media_codes(message)
 
         # Extract text content
         text = self._extract_text(message)
@@ -668,15 +699,6 @@ class DingTalkAdapter(BasePlatformAdapter):
         if not text and not media_urls:
             logger.debug("[%s] Empty message, skipping", self.name)
             return
-
-        source = self.build_source(
-            chat_id=chat_id,
-            chat_name=getattr(message, "conversation_title", None),
-            chat_type=chat_type,
-            user_id=sender_id,
-            user_name=sender_nick,
-            user_id_alt=sender_staff_id if sender_staff_id else None,
-        )
 
         # Parse timestamp
         create_at = getattr(message, "create_at", None)

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -682,6 +682,52 @@ class TestAllowedUsersGate:
         assert adapter._is_user_allowed("alice", "") is True
         assert adapter._is_user_allowed("dave", "") is False
 
+    @pytest.mark.asyncio
+    async def test_unauthorized_sender_does_not_trigger_pre_auth_side_effects(
+        self, monkeypatch
+    ):
+        adapter = _make_gating_adapter(monkeypatch)
+
+        class Runner:
+            def _is_user_authorized(self, source):
+                return False
+
+            async def handle(self, event):
+                self.event = event
+
+        runner = Runner()
+        adapter._message_handler = runner.handle
+        adapter.handle_message = AsyncMock()
+        adapter._resolve_media_codes = AsyncMock()
+
+        msg = _FakeChatbotMessage(
+            message_id="msg-preauth",
+            conversation_id="chat-preauth",
+            conversation_type="1",
+            sender_id="sender-preauth",
+            sender_staff_id="staff-preauth",
+            sender_nick="Sender",
+            text={"content": "please inspect this"},
+            rich_text=None,
+            rich_text_content=None,
+            session_webhook="https://api.dingtalk.com/robot/sendBySession?session=preauth",
+            session_webhook_expired_time=9999999999999,
+            create_at=0,
+            at_users=[],
+            is_in_at_list=False,
+        )
+        msg.image_content = SimpleNamespace(download_code="download-code")
+
+        await adapter._on_message(msg)
+
+        adapter._resolve_media_codes.assert_not_awaited()
+        assert "chat-preauth" not in adapter._session_webhooks
+        assert "chat-preauth" not in adapter._message_contexts
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.user_id == "sender-preauth"
+        assert event.media_urls == ["download-code"]
+
 
 class TestMentionPatterns:
 


### PR DESCRIPTION
## Summary

This prevents DingTalk messages from triggering pre-auth side effects before the gateway authorization boundary has accepted the sender.

## Problem

`DingTalkAdapter._on_message()` performed DingTalk-specific side effects before handing the event to `BasePlatformAdapter.handle_message()`, where the gateway runner performs the canonical `_is_user_authorized()` check.

In particular, a sender who is later rejected by gateway auth could still cause the adapter to:

- cache the incoming `session_webhook` for the chat
- stash the raw incoming message in `_message_contexts`
- resolve media `download_code` values through DingTalk Robot file-download APIs

That means unauthorized DingTalk users could trigger external file-resolution/API work before the central auth gate rejected the message.

## Changes

- Build the DingTalk `SessionSource` before side-effectful processing.
- Ask the attached gateway runner’s `_is_user_authorized()` gate before DingTalk-only side effects.
- Skip session webhook caching, message context caching, and media download-code resolution when the sender is unauthorized.
- Still pass the event to the normal gateway path so existing unauthorized/pairing behavior is preserved.

## Tests

Added regression coverage proving an unauthorized DingTalk sender does not trigger media resolution or cache session webhooks before gateway auth.

```text
python -m pytest tests/gateway/test_dingtalk.py -q --timeout-method=thread
69 passed