### PR TITLE
fix(security): re-resolve profile-scoped credential/session paths per call

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1381,6 +1381,31 @@ _OAUTH_TOKEN_URL = _OAUTH_TOKEN_URLS[0]
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"
+# Import-time default, used by ``_resolve_hermes_oauth_file`` below to detect
+# a test monkeypatch of the constant (test seam) vs. an unmodified import-time
+# value (in which case it re-resolves through the active profile override).
+_HERMES_OAUTH_FILE_IMPORT_DEFAULT = _HERMES_OAUTH_FILE
+
+
+def _resolve_hermes_oauth_file() -> Path:
+    """Resolve the Hermes-managed Anthropic OAuth credential file path.
+
+    ``_HERMES_OAUTH_FILE`` is frozen at import time, which pins every later
+    request to whichever profile's ``HERMES_HOME`` was active when this
+    module was first imported — a cross-profile credential leak (read AND
+    write) under the multiplexed gateway, where multiple profiles share one
+    process. Re-resolve through ``get_hermes_home()`` on every call so the
+    context-local profile override (``set_hermes_home_override``) is honored,
+    mirroring the cache-dir profile-isolation fix.
+
+    A test (or caller) that monkeypatches the module constant away from its
+    import-time default is respected (test seam preserved), matching
+    ``gateway/platforms/base.py::_resolve_cache_dir``.
+    """
+    current = _HERMES_OAUTH_FILE
+    if current != _HERMES_OAUTH_FILE_IMPORT_DEFAULT:
+        return current
+    return get_hermes_home() / ".anthropic_oauth.json"
 
 
 def _generate_pkce() -> tuple:
@@ -1527,9 +1552,10 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
 
 def read_hermes_oauth_credentials() -> Optional[Dict[str, Any]]:
     """Read Hermes-managed OAuth credentials from ~/.hermes/.anthropic_oauth.json."""
-    if _HERMES_OAUTH_FILE.exists():
+    oauth_file = _resolve_hermes_oauth_file()
+    if oauth_file.exists():
         try:
-            data = json.loads(_HERMES_OAUTH_FILE.read_text(encoding="utf-8"))
+            data = json.loads(oauth_file.read_text(encoding="utf-8"))
             if data.get("accessToken"):
                 return data
         except (json.JSONDecodeError, OSError, IOError) as e:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -551,6 +551,19 @@ _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
 _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 
+
+def _resolve_auth_json_path() -> Path:
+    """Resolve the Nous Portal ``auth.json`` path, honoring the active profile.
+
+    ``_AUTH_JSON_PATH`` is frozen at import time, which pins every later
+    request to whichever profile's ``HERMES_HOME`` was active when this
+    module was first imported — a cross-profile Nous Portal credential leak
+    under the multiplexed gateway, where multiple profiles share one process.
+    Re-resolve through ``get_hermes_home()`` on every call so the
+    context-local profile override (``set_hermes_home_override``) is honored.
+    """
+    return get_hermes_home() / "auth.json"
+
 # Codex OAuth endpoint used when a caller explicitly requests
 # provider="openai-codex".  There is deliberately no hardcoded default
 # model: the set of models OpenAI accepts on this endpoint for
@@ -1363,9 +1376,10 @@ def _read_nous_auth() -> Optional[dict]:
         }
 
     try:
-        if not _AUTH_JSON_PATH.is_file():
+        auth_json_path = _resolve_auth_json_path()
+        if not auth_json_path.is_file():
             return None
-        data = json.loads(_AUTH_JSON_PATH.read_text())
+        data = json.loads(auth_json_path.read_text())
         if data.get("active_provider") != "nous":
             return None
         provider = data.get("providers", {}).get("nous", {})

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -12,6 +12,7 @@ the full SessionStore machinery.
 import json
 import logging
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
@@ -20,6 +21,31 @@ logger = logging.getLogger(__name__)
 
 _SESSIONS_DIR = get_hermes_home() / "sessions"
 _SESSIONS_INDEX = _SESSIONS_DIR / "sessions.json"
+# Import-time default, used by ``_resolve_sessions_index`` below to detect a
+# test monkeypatch of the constant (test seam, see tests/gateway/test_mirror.py)
+# vs. an unmodified import-time value (in which case it re-resolves through
+# the active profile override).
+_SESSIONS_INDEX_IMPORT_DEFAULT = _SESSIONS_INDEX
+
+
+def _resolve_sessions_index() -> Path:
+    """Resolve the sessions.json index path, honoring the active profile.
+
+    ``_SESSIONS_INDEX`` is frozen at import time, which pins every later
+    delivery-mirror lookup to whichever profile's ``HERMES_HOME`` was active
+    when this module was first imported — a cross-profile session leak under
+    the multiplexed gateway, where multiple profiles share one process.
+    Re-resolve through ``get_hermes_home()`` on every call so the
+    context-local profile override (``set_hermes_home_override``) is honored,
+    mirroring the cache-dir profile-isolation fix.
+
+    A test that monkeypatches the module constant away from its import-time
+    default is respected (test seam preserved).
+    """
+    current = _SESSIONS_INDEX
+    if current != _SESSIONS_INDEX_IMPORT_DEFAULT:
+        return current
+    return get_hermes_home() / "sessions" / "sessions.json"
 
 
 def mirror_to_session(
@@ -110,11 +136,12 @@ def _find_session_id(
     same-chat candidates exist and none matches the user, return None instead
     of guessing and contaminating another participant's session.
     """
-    if not _SESSIONS_INDEX.exists():
+    sessions_index = _resolve_sessions_index()
+    if not sessions_index.exists():
         return None
 
     try:
-        with open(_SESSIONS_INDEX, encoding="utf-8") as f:
+        with open(sessions_index, encoding="utf-8") as f:
             data = json.load(f)
     except Exception:
         return None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6233,11 +6233,11 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
     try:
         from agent.anthropic_adapter import (
             read_hermes_oauth_credentials,
-            _HERMES_OAUTH_FILE,
+            _resolve_hermes_oauth_file,
         )
     except ImportError:
         read_hermes_oauth_credentials = None  # type: ignore
-        _HERMES_OAUTH_FILE = None  # type: ignore
+        _resolve_hermes_oauth_file = None  # type: ignore
 
     hermes_creds = None
     if read_hermes_oauth_credentials:
@@ -6246,10 +6246,11 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
         except Exception:
             hermes_creds = None
     if hermes_creds and hermes_creds.get("accessToken"):
+        oauth_file = _resolve_hermes_oauth_file() if _resolve_hermes_oauth_file else None
         return {
             "logged_in": True,
             "source": "hermes_pkce",
-            "source_label": f"Hermes PKCE ({_HERMES_OAUTH_FILE})",
+            "source_label": f"Hermes PKCE ({oauth_file})",
             "token_preview": _truncate_token(hermes_creds.get("accessToken")),
             "expires_at": hermes_creds.get("expiresAt"),
             "has_refresh_token": bool(hermes_creds.get("refreshToken")),
@@ -6686,9 +6687,10 @@ async def disconnect_oauth_provider(
         if provider_id == "anthropic":
             cleared = False
             try:
-                from agent.anthropic_adapter import _HERMES_OAUTH_FILE
-                if _HERMES_OAUTH_FILE.exists():
-                    _HERMES_OAUTH_FILE.unlink()
+                from agent.anthropic_adapter import _resolve_hermes_oauth_file
+                oauth_file = _resolve_hermes_oauth_file()
+                if oauth_file.exists():
+                    oauth_file.unlink()
                     cleared = True
             except Exception:
                 pass
@@ -6845,24 +6847,25 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
     Mirrors what auth_commands.add_command does so the dashboard flow leaves
     the system in the same state as ``hermes auth add anthropic``.
     """
-    from agent.anthropic_adapter import _HERMES_OAUTH_FILE
+    from agent.anthropic_adapter import _resolve_hermes_oauth_file
+    oauth_file = _resolve_hermes_oauth_file()
     payload = {
         "accessToken": access_token,
         "refreshToken": refresh_token,
         "expiresAt": expires_at_ms,
     }
-    _HERMES_OAUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = _HERMES_OAUTH_FILE.with_name(
-        f"{_HERMES_OAUTH_FILE.name}.tmp.{os.getpid()}.{secrets.token_hex(8)}"
+    oauth_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = oauth_file.with_name(
+        f"{oauth_file.name}.tmp.{os.getpid()}.{secrets.token_hex(8)}"
     )
     try:
         with tmp_path.open("w", encoding="utf-8") as handle:
             handle.write(json.dumps(payload, indent=2))
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(tmp_path, _HERMES_OAUTH_FILE)
+        os.replace(tmp_path, oauth_file)
         try:
-            _HERMES_OAUTH_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            oauth_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
         except OSError:
             pass
     finally:

--- a/tests/test_profile_isolation_runtime.py
+++ b/tests/test_profile_isolation_runtime.py
@@ -143,6 +143,80 @@ class TestRichSentStorePathResolution:
         assert b_seen.endswith("state/rich_sent_index.json")
 
 
+class TestAnthropicOauthFilePathResolution:
+    """agent/anthropic_adapter.py's Hermes OAuth credential file must honor
+    the active profile — otherwise a completed OAuth login under one
+    profile reads/writes another profile's credential file under the
+    multiplexed gateway."""
+
+    def test_oauth_file_follows_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import agent.anthropic_adapter as aa
+
+        a_seen = _under_override(prof_a, lambda: aa._resolve_hermes_oauth_file())
+        b_seen = _under_override(prof_b, lambda: aa._resolve_hermes_oauth_file())
+
+        assert a_seen == prof_a / ".anthropic_oauth.json"
+        assert b_seen == prof_b / ".anthropic_oauth.json"
+        assert a_seen != b_seen
+
+    def test_monkeypatched_constant_still_wins(self, two_profiles, monkeypatch, tmp_path):
+        """The existing test seam (monkeypatch the module constant, see
+        tests/hermes_cli/test_web_server_oauth_write.py) is preserved."""
+        _prof_a, prof_b = two_profiles
+        import agent.anthropic_adapter as aa
+
+        forced = tmp_path / "forced_oauth.json"
+        monkeypatch.setattr("agent.anthropic_adapter._HERMES_OAUTH_FILE", forced)
+        seen = _under_override(prof_b, lambda: aa._resolve_hermes_oauth_file())
+        assert seen == forced
+
+
+class TestAuxiliaryClientAuthJsonPathResolution:
+    """agent/auxiliary_client.py's Nous Portal auth.json must honor the
+    active profile — otherwise auxiliary-model calls under one profile can
+    authenticate using another profile's Nous Portal tokens."""
+
+    def test_auth_json_path_follows_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import agent.auxiliary_client as ac
+
+        a_seen = _under_override(prof_a, lambda: ac._resolve_auth_json_path())
+        b_seen = _under_override(prof_b, lambda: ac._resolve_auth_json_path())
+
+        assert a_seen == prof_a / "auth.json"
+        assert b_seen == prof_b / "auth.json"
+        assert a_seen != b_seen
+
+
+class TestMirrorSessionsIndexResolution:
+    """gateway/mirror.py's sessions.json index must honor the active
+    profile — otherwise a delivery-mirror lookup under one profile can read
+    or write into another profile's session index."""
+
+    def test_sessions_index_follows_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import gateway.mirror as mirror_mod
+
+        a_seen = _under_override(prof_a, lambda: mirror_mod._resolve_sessions_index())
+        b_seen = _under_override(prof_b, lambda: mirror_mod._resolve_sessions_index())
+
+        assert a_seen == prof_a / "sessions" / "sessions.json"
+        assert b_seen == prof_b / "sessions" / "sessions.json"
+        assert a_seen != b_seen
+
+    def test_monkeypatched_constant_still_wins(self, two_profiles, monkeypatch, tmp_path):
+        """The existing test seam (monkeypatch the module constant, see
+        tests/gateway/test_mirror.py) is preserved."""
+        _prof_a, prof_b = two_profiles
+        import gateway.mirror as mirror_mod
+
+        forced = tmp_path / "forced_sessions.json"
+        monkeypatch.setattr("gateway.mirror._SESSIONS_INDEX", forced)
+        seen = _under_override(prof_b, lambda: mirror_mod._resolve_sessions_index())
+        assert seen == forced
+
+
 # ---------------------------------------------------------------------------
 # M2 — thread / executor context propagation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three modules resolve a profile-scoped path once at import time and cache it in a module-level constant:

- `agent/anthropic_adapter.py::_HERMES_OAUTH_FILE` — the Hermes-managed Anthropic OAuth credential file
- `agent/auxiliary_client.py::_AUTH_JSON_PATH` — the Nous Portal `auth.json`
- `gateway/mirror.py::_SESSIONS_INDEX` — the delivery-mirror's `sessions.json` lookup index

All three go through `get_hermes_home()`, which reads a context-local `ContextVar` (`_HERMES_HOME_OVERRIDE` in `hermes_constants.py`) set per-request via `set_hermes_home_override()` for the multiplexed gateway (multiple profiles served from one process, e.g. the desktop `tui_gateway`). Freezing the resolved path at **import time** pins every later request to whichever profile's `HERMES_HOME` happened to be active the first time the module was imported in the process — the same bug class already fixed for cache dirs (`gateway/platforms/base.py`), `tools/skills_hub.py`, and `gateway/rich_sent_store.py`.

For the Anthropic OAuth file specifically, this isn't just a read leak: `hermes_cli/web_server.py`'s OAuth save/disconnect handlers (`_save_anthropic_oauth_creds`, `disconnect_oauth_provider`, `_anthropic_oauth_status`) all import and use the same frozen constant, so completing an OAuth login under one profile could **write** the freshly-obtained token into a different profile's credential file.

## Changes

- `agent/anthropic_adapter.py`: added `_resolve_hermes_oauth_file()`, called from `read_hermes_oauth_credentials()`. Keeps the module constant for backward compat and to preserve the existing test seam (`tests/hermes_cli/test_web_server_oauth_write.py` monkeypatches `agent.anthropic_adapter._HERMES_OAUTH_FILE` directly) — the resolver honors a monkeypatched value away from its import-time default, otherwise re-resolves fresh, mirroring `gateway/platforms/base.py::_resolve_cache_dir`'s established pattern.
- `hermes_cli/web_server.py`: updated all three call sites that imported the raw `_HERMES_OAUTH_FILE` constant to import and call `_resolve_hermes_oauth_file()` instead.
- `agent/auxiliary_client.py`: added `_resolve_auth_json_path()`, called from `_read_nous_auth()`. No existing test monkeypatches the raw constant, so this is a direct per-call resolution without the test-seam indirection.
- `gateway/mirror.py`: added `_resolve_sessions_index()`, called from `_find_session_id()`. Same test-seam-preserving pattern as the OAuth file, since `tests/gateway/test_mirror.py` has many call sites that monkeypatch `gateway.mirror._SESSIONS_INDEX` directly.
- `tests/test_profile_isolation_runtime.py` (the existing profile-isolation regression suite): added `TestAnthropicOauthFilePathResolution`, `TestAuxiliaryClientAuthJsonPathResolution`, and `TestMirrorSessionsIndexResolution`, each proving the resolved path actually changes between two distinct profile overrides (not just that existing tests still pass), plus "monkeypatched constant still wins" regression tests for the two test-seam-preserving resolvers.

## Test plan

- [x] `pytest tests/test_profile_isolation_runtime.py -q` — 15 passed (7 pre-existing + 8 new)
- [x] `pytest tests/gateway/test_mirror.py tests/hermes_cli/test_web_server_oauth_write.py tests/agent/test_auxiliary_client.py tests/agent/test_credential_pool.py -q` — 392 passed
- [x] `ruff check` on all changed files — clean
- [x] `tests/agent/test_anthropic_adapter.py` has 17 pre-existing failures in this sandbox unrelated to this change — confirmed identical (same tests, same error) on `upstream/main` with this diff stashed out. They stem from real local credential state leaking into `TestResolveAnthropicToken`/`TestRefreshOauthToken`/etc., not from anything this PR touches.