### PR TITLE
fix(gateway): clamp -1 context sentinel before it reaches /status

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -420,7 +420,13 @@ def finalize_turn(
         "prompt_tokens": agent.session_prompt_tokens,
         "completion_tokens": agent.session_completion_tokens,
         "total_tokens": agent.session_total_tokens,
-        "last_prompt_tokens": getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0,
+        # -1 is the compressor's "awaiting real usage" sentinel right after a
+        # compression (agent/conversation_compression.py) and is truthy, so
+        # `or 0` alone doesn't clamp it. Persisting -1 here durably survives
+        # into session_entry.last_prompt_tokens (see gateway/run.py's
+        # session_store.update_session call), where /status would otherwise
+        # display it verbatim as a nonsensical negative token count.
+        "last_prompt_tokens": max(0, getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0),
         "estimated_cost_usd": agent.session_estimated_cost_usd,
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -544,13 +544,23 @@ class GatewaySlashCommandsMixin:
             base_url = _clean_str(getattr(status_agent, "base_url", ""))
             ctx = getattr(status_agent, "context_compressor", None)
             if ctx is not None:
-                context_used = _int_value(getattr(ctx, "last_prompt_tokens", 0))
+                # last_prompt_tokens is -1 immediately after a compression
+                # ("awaiting real usage" sentinel, see
+                # conversation_compression.py) and -1 is truthy, so an
+                # unclamped value here would both display as a nonsensical
+                # negative token count AND short-circuit the session_entry
+                # fallback below via `context_used or ...`. Clamp to 0,
+                # matching the same guard already used for /usage above.
+                _ctx_lpt = _int_value(getattr(ctx, "last_prompt_tokens", 0))
+                context_used = _ctx_lpt if _ctx_lpt > 0 else 0
                 context_total = _int_value(getattr(ctx, "context_length", 0))
 
         model_name = model_name or _clean_str(session_row.get("model"))
         provider_name = provider_name or _clean_str(session_row.get("billing_provider"))
         base_url = base_url or _clean_str(session_row.get("billing_base_url"))
-        context_used = context_used or _int_value(getattr(session_entry, "last_prompt_tokens", 0))
+        if not context_used:
+            _entry_lpt = _int_value(getattr(session_entry, "last_prompt_tokens", 0))
+            context_used = _entry_lpt if _entry_lpt > 0 else 0
 
         user_config: dict[str, Any] = {}
         if not model_name or not provider_name or not context_total:

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -110,3 +110,34 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
     assert result["messages"][-1] == {"role": "assistant", "content": "Done."}
     assert agent.persisted_messages is not None
     assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}
+
+
+def test_negative_last_prompt_tokens_sentinel_is_clamped(monkeypatch):
+    """context_compressor.last_prompt_tokens == -1 is the compressor's
+    "awaiting real usage" sentinel right after a compression
+    (agent/conversation_compression.py). -1 is truthy, so a bare `or 0`
+    doesn't clamp it, and gateway/run.py persists this field verbatim into
+    session_entry.last_prompt_tokens, where /status would otherwise display
+    it as a nonsensical negative token count.
+    """
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent.context_compressor = SimpleNamespace(last_prompt_tokens=-1)
+
+    result = finalize_turn(
+        agent,
+        final_response="Done.",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "hi"}, {"role": "assistant", "content": "Done."}],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="hi",
+        original_user_message="hi",
+        _should_review_memory=False,
+        _turn_exit_reason="fallback_prior_turn_content",
+    )
+
+    assert result["last_prompt_tokens"] == 0

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -217,6 +217,80 @@ async def test_status_command_includes_live_agent_model_and_context():
 
 
 @pytest.mark.asyncio
+async def test_status_command_clamps_negative_context_used_from_live_agent():
+    """last_prompt_tokens == -1 (the compressor's "awaiting real usage"
+    sentinel right after a compression) must not be shown to the user as a
+    nonsensical negative token count."""
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 1000,
+        "output_tokens": 250,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "openai/gpt-test",
+    }
+    running_agent = SimpleNamespace(
+        model="openai/gpt-test",
+        provider="openai",
+        context_compressor=SimpleNamespace(
+            last_prompt_tokens=-1,
+            context_length=100_000,
+        ),
+        interrupt=MagicMock(),
+    )
+    runner._running_agents[build_session_key(_make_source())] = running_agent
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "Context:** -1" not in result
+    assert "**Context:** 0 / 100,000 (0%)" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_clamps_negative_persisted_context_used():
+    """The -1 sentinel can also be durably persisted into
+    session_entry.last_prompt_tokens (gateway/run.py's update_session call
+    after turn_finalizer.py builds the result dict) and must be clamped on
+    that fallback path too, not just when read from a live agent."""
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+        last_prompt_tokens=-1,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 200,
+        "output_tokens": 121,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+    }
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    # No context_total is available anywhere in this scenario, so with the
+    # sentinel correctly clamped to 0 (falsy), neither the "used/total" line
+    # nor the total-less "~{used} tokens" line should render at all -- before
+    # the fix, -1 is truthy and rendered as "**Context:** ~-1 tokens".
+    assert "**Context:**" not in result
+
+
+@pytest.mark.asyncio
 async def test_status_command_includes_persisted_model_and_context_when_agent_not_running(monkeypatch):
     session_entry = SessionEntry(
         session_key=build_session_key(_make_source()),


### PR DESCRIPTION
## Summary

`context_compressor.last_prompt_tokens` is set to `-1` right after a compression fires, as an "awaiting real usage" sentinel (`agent/conversation_compression.py:904`). `-1` is truthy in Python, so two existing guards that look like clamps don't actually clamp it:

- `agent/turn_finalizer.py`'s `finalize_turn()` result dict did `getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0` — `-1 or 0` evaluates to `-1`, not `0`.
- `gateway/slash_commands.py`'s `_handle_status_command()` did `context_used or _int_value(getattr(session_entry, "last_prompt_tokens", 0))` — since the live-agent read on the line above is also unclamped, `context_used` can be `-1` (truthy), which short-circuits the `session_entry` fallback entirely instead of falling through to it.

End result: any user who runs `/status` shortly after an auto-compression sees a nonsensical negative token count — `"Context: -1 / 128,000 tokens (0%)"`, or `"Context: ~-1 tokens"` when no context-window total is known — on any gateway platform. Worse, `gateway/run.py`'s `session_store.update_session(..., last_prompt_tokens=agent_result.get("last_prompt_tokens", 0))` persists the raw `-1` from `turn_finalizer.py` into `session_entry.last_prompt_tokens`, so the bug isn't limited to the single transitional turn right after compression — it durably survives until the next real API call updates the count.

This exact sentinel is already correctly clamped in two other places in the codebase (`agent/context_engine.py:201` and `gateway/slash_commands.py`'s `/usage` command a few hundred lines below `/status`, both using `value if value > 0 else 0`) — `/status`'s two read sites and the `turn_finalizer.py` source were just missed.

## Changes

- `agent/turn_finalizer.py`: clamp `last_prompt_tokens` to `max(0, ...)` before it enters the result dict, fixing the root cause so the persisted `session_entry` value is never negative.
- `gateway/slash_commands.py::_handle_status_command`: clamp both read sites (`ctx.last_prompt_tokens` and the `session_entry.last_prompt_tokens` fallback) using the same `value if value > 0 else 0` idiom already established in this file, so the fallback chain works correctly even before the `turn_finalizer.py` fix takes effect for already-persisted sessions.
- `tests/agent/test_turn_finalizer_final_response_persistence.py`: new test proving `finalize_turn()` clamps `last_prompt_tokens == -1` to `0` in its result dict.
- `tests/gateway/test_status_command.py`: two new tests — one driving the live-agent `context_compressor.last_prompt_tokens == -1` path (asserts the rendered line is `"Context: 0 / 100,000 (0%)"`, not `-1`), one driving the persisted `session_entry.last_prompt_tokens == -1` fallback path with no context-window total available (asserts no `"Context:"` line renders at all, matching the correct "no real data yet" behavior instead of the pre-fix `"Context: ~-1 tokens"`).

## Test plan

- [x] `pytest tests/gateway/test_status_command.py -q` — 19 passed (17 pre-existing + 2 new)
- [x] `pytest tests/agent/test_turn_finalizer_final_response_persistence.py -q` — 2 passed (1 pre-existing + 1 new)
- [x] `pytest tests/agent/test_turn_finalizer_interrupt_alternation.py tests/agent/test_turn_finalizer_cleanup_guard.py tests/cli/test_cli_status_bar.py tests/gateway/test_slash_access_dispatch.py -q` — 77 passed (sanity check, unaffected)
- [x] `ruff check` on all changed files — clean