### PR TITLE
fix(dashboard): redirect basic auth to /login instead of /auth/login?provider=basic

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -188,11 +188,19 @@ def _auto_sso_response(request: Request) -> Response | None:
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote
-    auth_login = f"{prefix}/auth/login?provider={quote(provider.name, safe='')}"
-    if next_param:
-        auth_login = f"{auth_login}&next={next_param}"
 
-    resp = RedirectResponse(url=auth_login, status_code=302)
+    # Password-only providers (basic auth) have no OAuth redirect;
+    # send the user directly to the login form instead.
+    if getattr(provider, "supports_password", False):
+        login_url = f"{prefix}/login"
+        if next_param:
+            login_url = f"{login_url}?next={next_param}"
+        resp = RedirectResponse(url=login_url, status_code=302)
+    else:
+        auth_login = f"{prefix}/auth/login?provider={quote(provider.name, safe='')}"
+        if next_param:
+            auth_login = f"{auth_login}&next={next_param}"
+        resp = RedirectResponse(url=auth_login, status_code=302)
     # Drop the one-shot marker so a return trip that's STILL unauthenticated
     # (portal had no session) trips the guard above next time instead of
     # looping. Detect HTTPS for the Secure flag the same way the auth routes


### PR DESCRIPTION
## Problem

When basic auth is the only interactive provider configured, `_auto_sso_response` redirects unauthenticated users to `/auth/login?provider=basic`. BasicAuthProvider does not support OAuth redirect flow (`start_login` raises `NotImplementedError`), it only supports password form login via `complete_password_login`. This causes a 500 error.

## Fix

In `_auto_sso_response`, check if the sole interactive provider has `supports_password = True`. If so, redirect to `/login` (the credential form) instead of `/auth/login?provider=<name>` (the OAuth initiation endpoint).

## Testing

1. Configure `dashboard.basic_auth` with username + password_hash
2. Visit the dashboard root path unauthenticated
3. Previously: 302 → `/auth/login?provider=basic` → 500
4. Now: 302 → `/login?next=%2F` → 200 (login page renders)
