### PR TITLE
fix: use Pythonic idioms for emptiness and membership checks (P2)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1153,7 +1153,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # _fallback_index=0 and re-marshaling the whole context across every
         # provider again.  Guards the cross-turn replay storm in #24996.
         if (
-            len(agent._fallback_chain) > 0
+            bool(agent._fallback_chain)
             and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}
         ):
             _existing_cooldown = getattr(agent, "_rate_limited_until", 0) or 0

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1730,7 +1730,7 @@ class ExtractContentMiddleware(InboundMiddleware):
                 # Prefer medium image (index 1), fallback to index 0
                 if len(image_info_array) > 1 and isinstance(image_info_array[1], dict):
                     image_info = image_info_array[1]
-                elif len(image_info_array) > 0 and isinstance(image_info_array[0], dict):
+                elif image_info_array and isinstance(image_info_array[0], dict):
                     image_info = image_info_array[0]
                 image_url = str((image_info or {}).get("url") or "").strip()
                 rid = cls._parse_resource_id(image_url)
@@ -1830,7 +1830,7 @@ class ExtractContentMiddleware(InboundMiddleware):
                 image_info = None
                 if len(image_info_array) > 1 and isinstance(image_info_array[1], dict):
                     image_info = image_info_array[1]
-                elif len(image_info_array) > 0 and isinstance(image_info_array[0], dict):
+                elif image_info_array and isinstance(image_info_array[0], dict):
                     image_info = image_info_array[0]
                 image_url = str((image_info or {}).get("url") or "").strip()
                 if image_url:
@@ -4813,7 +4813,7 @@ class MessageSender:
         Returns:
             Error description (str) if validation fails, otherwise None.
         """
-        if file_bytes is None or len(file_bytes) == 0:
+        if not file_bytes:
             return f"Empty file: {filename}"
         max_bytes = max_size_mb * 1024 * 1024
         if len(file_bytes) > max_bytes:

--- a/gateway/relay/auth.py
+++ b/gateway/relay/auth.py
@@ -67,7 +67,7 @@ def verify_signature(payload: str, sig_hex: str, secrets: Sequence[str]) -> bool
         sig_buf = bytes.fromhex(sig_hex)
     except (ValueError, TypeError):
         return False
-    if len(sig_buf) == 0:
+    if not sig_buf:
         return False
     for secret in secrets:
         if not secret:

--- a/gateway/scale_to_zero.py
+++ b/gateway/scale_to_zero.py
@@ -80,7 +80,7 @@ def messaging_is_relay_only_or_absent(platforms: Iterable[Any]) -> bool:
     """
     names = {_platform_name(p) for p in platforms}
     names.discard("relay")
-    return len(names) == 0
+    return not names
 
 
 def _platform_name(platform: Any) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1726,7 +1726,7 @@ class SlashCommandCompleter(Completer):
         trailing_space = sub_text.endswith(" ")
 
         # Subcommand stage: zero words typed, or completing the first word.
-        if len(parts) == 0 or (len(parts) == 1 and not trailing_space):
+        if not parts or (len(parts) == 1 and not trailing_space):
             partial = sub_text if not trailing_space else ""
             for sub in SUBS:
                 if sub.startswith(partial.lower()) and sub != partial.lower():

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5279,9 +5279,9 @@ def _is_service_running() -> bool:
         if gateway_windows.is_installed():
             # "installed" doesn't necessarily mean "running" on Windows. The
             # canonical check is whether a gateway process actually exists.
-            return len(find_gateway_pids()) > 0
+            return bool(find_gateway_pids())
     # Check for manual processes
-    return len(find_gateway_pids()) > 0
+    return bool(find_gateway_pids())
 
 
 def _setup_weixin():

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3091,7 +3091,7 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
                 kind=r["kind"],
                 payload=payload,
                 created_at=r["created_at"],
-                run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+                run_id=(int(r["run_id"]) if "run_id" in r and r["run_id"] is not None else None),
             )
         )
     return out
@@ -4586,10 +4586,10 @@ def block_task(
         ).fetchone()
         if cur_row is None:
             return False
-        prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
+        prev_kind = cur_row["block_kind"] if "block_kind" in cur_row else None
         prev_recurrences = (
             int(cur_row["block_recurrences"])
-            if "block_recurrences" in cur_row.keys()
+            if "block_recurrences" in cur_row
             and cur_row["block_recurrences"] is not None
             else 0
         )
@@ -6394,7 +6394,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             # Skip liveness check inside the launch-window grace period
             # so a freshly-spawned worker isn't reclaimed before its PID
             # is visible on /proc.
-            started_at = row["started_at"] if "started_at" in row.keys() else None
+            started_at = row["started_at"] if "started_at" in row else None
             if started_at is not None:
                 grace = _resolve_crash_grace_seconds()
                 if time.time() - started_at < grace:
@@ -6601,7 +6601,7 @@ def _record_task_failure(
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
         task_override = (
-            row["max_retries"] if "max_retries" in row.keys() else None
+            row["max_retries"] if "max_retries" in row else None
         )
         if task_override is not None:
             effective_limit = int(task_override)
@@ -8341,7 +8341,7 @@ def unseen_events_for_sub(
         out.append(Event(
             id=r["id"], task_id=r["task_id"], kind=r["kind"],
             payload=payload, created_at=r["created_at"],
-            run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+            run_id=(int(r["run_id"]) if "run_id" in r and r["run_id"] is not None else None),
         ))
         max_id = max(max_id, int(r["id"]))
     return max_id, out

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -136,7 +136,7 @@ def _task_field(task, name, default=None):
     try:
         # Row raises IndexError if the key isn't a column in the query;
         # dicts return default via .get. Handle both.
-        if hasattr(task, "keys") and name in task.keys():
+        if hasattr(task, "keys") and name in task:
             return task[name]
     except Exception:
         pass

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -17,7 +17,7 @@ def _has_configured_mcp_servers() -> bool:
         from hermes_cli.config import read_raw_config
 
         mcp_servers = (read_raw_config() or {}).get("mcp_servers")
-        return isinstance(mcp_servers, dict) and len(mcp_servers) > 0
+        return isinstance(mcp_servers, dict) and bool(mcp_servers)
     except Exception:
         # Be conservative: if config probing fails, try discovery in the
         # background so startup still can't block.

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -898,7 +898,7 @@ def image_generate_tool(
     start_time = datetime.datetime.now()
 
     try:
-        if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
+        if not prompt or not isinstance(prompt, str) or not prompt.strip():
             raise ValueError("Prompt is required and must be a non-empty string")
 
         if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):


### PR DESCRIPTION
## Summary

Replace 16 non-Pythonic patterns with idiomatic equivalents across 10 files.

## Changes

### 1. `len(x) == 0` → `not x` (5 instances)

```python
# Before
if len(parts) == 0:
if file_bytes is None or len(file_bytes) == 0:

# After
if not parts:
if not file_bytes:
```

### 2. `len(x) > 0` → `bool(x)` (4 instances)

```python
# Before
return len(find_gateway_pids()) > 0
elif len(image_info_array) > 0 and isinstance(...):

# After
return bool(find_gateway_pids())
elif image_info_array and isinstance(...):
```

### 3. `x in dict.keys()` → `x in dict` (7 instances)

```python
# Before
if "run_id" in r.keys():

# After
if "run_id" in r:
```

## Files (10)

| File | Changes |
|------|---------|
| `agent/chat_completion_helpers.py` | 1 |
| `gateway/platforms/yuanbao.py` | 3 |
| `gateway/relay/auth.py` | 1 |
| `gateway/scale_to_zero.py` | 1 |
| `hermes_cli/commands.py` | 1 |
| `hermes_cli/gateway.py` | 2 |
| `hermes_cli/kanban_db.py` | 6 |
| `hermes_cli/kanban_diagnostics.py` | 1 |
| `hermes_cli/mcp_startup.py` | 1 |
| `tools/image_generation_tool.py` | 1 |

## Testing

All 10 files pass `python3 -m py_compile`.
