### PR TITLE
fix(agent): copy messages in _flush_messages_to_session_db to prevent persist-override mutation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1747,10 +1747,19 @@ class AIAgent:
         # tool-execution loop re-uses that list for subsequent API calls
         # where the original user text must remain intact. (#56303)
         idx = getattr(self, "_persist_user_message_idx", None)
+        _original_override_msg = None
         if idx is not None and 0 <= idx < len(messages):
+            _original_override_msg = messages[idx]
             messages = list(messages)
             messages[idx] = dict(messages[idx])
         self._apply_persist_user_message_override(messages)
+        # Mark the *original* message so repeated flushes skip it.
+        # The copy above isolates the override rewrite, but the persist
+        # loop stamps _DB_PERSISTED_MARKER on the copy, not the caller's
+        # live dict.  Without this, a second flush sees the original as
+        # unmarked and appends it a second time.  (#56318)
+        if _original_override_msg is not None:
+            _original_override_msg[_DB_PERSISTED_MARKER] = True
         try:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1742,6 +1742,14 @@ class AIAgent:
             return
         if not self._session_db:
             return
+        # Deep-copy the override target so the persist-override rewrite
+        # doesn't mutate the caller's live messages list — the
+        # tool-execution loop re-uses that list for subsequent API calls
+        # where the original user text must remain intact. (#56303)
+        idx = getattr(self, "_persist_user_message_idx", None)
+        if idx is not None and 0 <= idx < len(messages):
+            messages = list(messages)
+            messages[idx] = dict(messages[idx])
         self._apply_persist_user_message_override(messages)
         try:
             # Retry row creation if the earlier attempt failed transiently.

--- a/tests/run_agent/test_flush_override_mutation.py
+++ b/tests/run_agent/test_flush_override_mutation.py
@@ -84,3 +84,28 @@ class TestFlushOverrideMutation:
 
         # Caller's message must NOT have the timestamp injected
         assert "timestamp" not in messages[0]
+
+    def test_repeated_flush_does_not_duplicate_user_message(self):
+        """Second flush of the same messages list must not re-persist the
+        override target.  (#56318)
+
+        Before the fix, the _DB_PERSISTED_MARKER was stamped on the copy
+        (not the caller's live dict), so a second flush saw the original
+        as unmarked and appended it to the DB again.
+        """
+        agent = self._make_agent()
+        messages = [
+            {"role": "user", "content": "synthetic clean"},
+        ]
+
+        agent._flush_messages_to_session_db(messages, [])
+        agent._flush_messages_to_session_db(messages, [])
+
+        user_calls = [
+            c
+            for c in agent._session_db.append_message.call_args_list
+            if c.kwargs.get("role") == "user"
+        ]
+        assert len(user_calls) == 1, (
+            f"Expected exactly 1 user DB write, got {len(user_calls)}"
+        )

--- a/tests/run_agent/test_flush_override_mutation.py
+++ b/tests/run_agent/test_flush_override_mutation.py
@@ -1,0 +1,86 @@
+"""Regression: _flush_messages_to_session_db must not mutate the caller's
+live messages list when a persist-override is configured. (#56303)
+
+The tool-execution loop re-uses the same ``messages`` list for subsequent
+API calls — if the override rewrites ``content`` in-place, later iterations
+see the transcript-clean text instead of the original API-facing prompt.
+"""
+
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent
+
+
+class TestFlushOverrideMutation:
+    """Persist-override in _flush_messages_to_session_db must not leak back."""
+
+    def _make_agent(self):
+        agent = AIAgent.__new__(AIAgent)
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_override = "Hello there"
+        agent._persist_user_message_timestamp = None
+        agent._session_db = MagicMock()
+        agent._session_db_created = True
+        agent._last_flushed_db_idx = 0
+        agent.session_id = "session-123"
+        agent._flushed_db_message_session_id = "session-123"
+        agent._flushed_db_message_ids = set()
+        agent._persist_disabled = False
+        return agent
+
+    def test_flush_does_not_mutate_caller_messages(self):
+        """Caller's messages list must retain original content after flush."""
+        agent = self._make_agent()
+        original_content = (
+            "[Voice input - respond concisely and conversationally, "
+            "2-3 sentences max. No code blocks or markdown.] Hello there"
+        )
+        messages = [
+            {"role": "user", "content": original_content},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+
+        agent._flush_messages_to_session_db(messages, [])
+
+        # The live messages list used by the tool-execution loop must
+        # retain the original content — override should only affect
+        # the persisted copy.
+        assert messages[0]["content"] == original_content
+
+    def test_flush_still_persists_override_content(self):
+        """DB writes must still receive the override content."""
+        agent = self._make_agent()
+        original_content = (
+            "[Voice input - respond concisely and conversationally, "
+            "2-3 sentences max.] Hello there"
+        )
+        messages = [
+            {"role": "user", "content": original_content},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+
+        agent._flush_messages_to_session_db(messages, [])
+
+        # DB should receive the overridden content
+        calls = agent._session_db.append_message.call_args_list
+        user_writes = [c for c in calls if c.kwargs.get("role") == "user"]
+        assert len(user_writes) >= 1
+        assert user_writes[0].kwargs["content"] == "Hello there"
+
+    def test_flush_timestamp_override_does_not_mutate_caller(self):
+        """Timestamp override must also not leak into caller's messages."""
+        from datetime import datetime, timezone
+
+        agent = self._make_agent()
+        agent._persist_user_message_timestamp = datetime(
+            2026, 4, 28, 13, 40, 53, tzinfo=timezone.utc
+        )
+        messages = [
+            {"role": "user", "content": "Hello there"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+
+        agent._flush_messages_to_session_db(messages, [])
+
+        # Caller's message must NOT have the timestamp injected
+        assert "timestamp" not in messages[0]


### PR DESCRIPTION
## What does this PR do?

Prevents `_flush_messages_to_session_db` from mutating the caller's live `messages` list when applying the persist-override rewrite. The tool-execution loop (`conversation_loop.py:4473`, `tool_executor.py:109`) re-uses that same list for subsequent API calls — the override's in-place rewrite of `msg["content"]` to the transcript-clean variant silently replaced the API-facing prompt for later tool-loop iterations, causing the same class of silent context drop as #48677 but on the incremental-persist path.

## Related Issue

Fixes #56303

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: In `_flush_messages_to_session_db`, shallow-copy the messages list and deep-copy the override-target message dict before calling `_apply_persist_user_message_override`, so the caller's live list is never mutated. `_persist_session` (the final exit-path persist) still mutates in place — it owns the list and no subsequent API call uses it.
- `tests/run_agent/test_flush_override_mutation.py`: 3 regression tests covering content override isolation, DB write correctness, and timestamp override isolation.

## How to Test

1. Run the new regression tests:
   ```bash
   python -m pytest tests/run_agent/test_flush_override_mutation.py -v
   ```
   All 3 tests should pass.

2. Run existing persist-override tests to confirm no regression:
   ```bash
   python -m pytest tests/run_agent/test_run_agent.py::TestPersistUserMessageOverride -v
   python -m pytest tests/run_agent/test_empty_response_recovery_persistence.py -v
   python -m pytest tests/run_agent/test_tool_call_incremental_persistence.py -v
   ```
   All should pass.

3. Manual verification: start a session with a platform adapter that sets `_persist_user_message_override` (e.g. Telegram with voice input). The API-facing prompt should not be overwritten during tool-loop iterations.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (in-memory list copy, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
