### PR TITLE
fix(auxiliary): treat explicit model:auto sentinel, not just cfg_model

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5272,6 +5272,15 @@ def _resolve_task_provider_model(
     # which downstream consumers like ContextCompressor accept as the task output.
     # The provider-side 'auto' is handled in _resolve_auto() via main_runtime
     # fallback, so dropping cfg_model to None here lets that path do its job.
+    #
+    # The explicit `model` kwarg needs the identical normalization: MoA slots
+    # (agent/moa_loop.py's _slot_runtime) forward a preset's `model:` field as
+    # this explicit argument rather than through auxiliary.<task> config, so a
+    # user-configured `model: auto` on a MoA reference/aggregator slot reaches
+    # this function here, not as cfg_model. Only normalizing cfg_model let that
+    # literal "auto" slip through via `model or cfg_model` below.
+    if model and model.lower() == "auto":
+        model = None
     if cfg_model and cfg_model.lower() == "auto":
         cfg_model = None
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -168,6 +168,55 @@ class TestResolveTaskProviderModel:
         assert api_key == "sk-test"
         assert api_mode is None
 
+    def test_explicit_model_auto_sentinel_is_normalized(self):
+        """MoA slots (agent/moa_loop.py's _slot_runtime) forward a preset's
+        `model:` field as the explicit `model` kwarg here, not through
+        auxiliary.<task> config. Only cfg_model was normalized before, so a
+        MoA reference/aggregator slot configured with `model: auto` sent the
+        literal string "auto" to the wire as a model id."""
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            provider="anthropic",
+            model="auto",
+        )
+
+        assert resolved_provider == "anthropic"
+        assert model is None
+
+    def test_explicit_model_auto_sentinel_case_insensitive(self):
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            provider="anthropic",
+            model="AUTO",
+        )
+
+        assert model is None
+
+    def test_explicit_model_auto_falls_back_to_cfg_model(self, monkeypatch):
+        """When the explicit model is the "auto" sentinel, it must not shadow
+        a real configured task model — the `model or cfg_model` fallback
+        chain should still reach cfg_model exactly as if model had been
+        omitted entirely."""
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda _task: {"provider": "openai", "model": "gpt-real-model"},
+        )
+
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="moa_reference",
+            model="auto",
+        )
+
+        assert model == "gpt-real-model"
+
+    def test_non_auto_model_is_unaffected(self):
+        """Regression guard: a real model name must not be touched by the
+        sentinel normalization."""
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            provider="openai",
+            model="gpt-4o-mini",
+        )
+
+        assert model == "gpt-4o-mini"
+
 
 class TestBuildCallKwargsMaxTokens:
     """_build_call_kwargs should not cap output by default (#34530).


### PR DESCRIPTION
## Summary

`'auto'` is a documented sentinel meaning "inherit from main runtime / auto-detect", not a literal model id. `agent/auxiliary_client.py::_resolve_task_provider_model` already normalizes this for `cfg_model` (the config-derived value from `auxiliary.<task>.model`):

```python
if cfg_model and cfg_model.lower() == "auto":
    cfg_model = None
```

But `resolved_model = model or cfg_model` never applied the same normalization to the **explicit** `model` argument. MoA reference/aggregator slots (`agent/moa_loop.py::_slot_runtime`) forward a preset's `model:` field as this explicit `model` kwarg — not through `auxiliary.<task>` config — so a MoA preset configured with `model: auto` (a natural thing to try, given the existing `auxiliary.*.model: auto` convention documented elsewhere) reaches `_resolve_task_provider_model` as the explicit arg, takes the `model or cfg_model` branch, and the literal string `"auto"` gets sent to the wire as a model id — exactly the failure mode (`200 OK` with an error-text body that downstream consumers like `ContextCompressor` accept as valid output) the original `cfg_model` fix was written to prevent.

## Fix

Normalize both `model` and `cfg_model` at the same chokepoint, so this is fixed for MoA and any other current/future caller that might pass an explicit `model="auto"` — no changes needed in `moa_loop.py` itself, since every caller already routes through this single resolver.

## Test plan

- [x] `pytest tests/agent/test_auxiliary_client.py::TestResolveTaskProviderModel -q` — 16 passed (12 pre-existing + 4 new: explicit-auto normalized, case-insensitive, falls back to a real `cfg_model` correctly, non-auto model unaffected)
- [x] `pytest tests/agent/test_auxiliary_client.py tests/run_agent/test_moa_streaming.py tests/run_agent/test_moa_loop_mode.py tests/agent/test_vision_routing_31179.py tests/agent/test_vision_resolved_args.py tests/agent/test_auxiliary_main_first.py -q` — 346 passed
- [x] `pytest tests/hermes_cli/test_moa_config.py tests/agent/test_moa_switch_api_mode.py tests/agent/test_moa_slot_api_mode.py tests/cli/test_moa_command.py tests/tui_gateway/test_moa_reference_emit.py tests/gateway/test_moa_one_shot_restore.py -q` — 36 passed
- [x] `ruff check` on all changed files — clean