### PR TITLE
fix(title): honor configured auxiliary.title_generation.timeout (salvage #41844, #32729)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -51,7 +51,7 @@ def _title_language() -> str:
 def generate_title(
     user_message: str,
     assistant_response: str,
-    timeout: float = 30.0,
+    timeout: Optional[float] = None,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
 ) -> Optional[str]:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -59,6 +59,37 @@ class TestGenerateTitle:
         with patch("hermes_cli.config.load_config", side_effect=RuntimeError("bad config")):
             assert _title_language() == ""
 
+    def test_default_timeout_delegates_to_auxiliary_config(self):
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Configured Timeout"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question", "answer") == "Configured Timeout"
+
+        assert captured_kwargs["task"] == "title_generation"
+        assert captured_kwargs["timeout"] is None
+
+    def test_explicit_timeout_still_overrides_config(self):
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Explicit Timeout"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question", "answer", timeout=123.0) == "Explicit Timeout"
+
+        assert captured_kwargs["timeout"] == 123.0
+
     def test_strips_quotes(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]


### PR DESCRIPTION
## Summary

Salvage of #41844 by @shandian64 (cherry-picked onto current `main`, authorship preserved). The minimal fix for #32729: `auxiliary.title_generation.timeout` was silently ignored.

## The bug

`agent/title_generator.py::generate_title` hardcoded `timeout: float = 30.0` in its signature. Its caller `auto_title_session` never passes an explicit timeout, so the hardcoded `30.0` always reached `call_llm` — and `call_llm` only resolves `auxiliary.title_generation.timeout` from config when it's called with `timeout=None` (`auxiliary_client.py:5842`: `effective_timeout = timeout if timeout is not None else _get_task_timeout(task)`). So a user who set a high title-generation timeout for a slow local LLM still saw `Request timed out.` at 30s every session. Confirmed on `main` (`title_generator.py:54`).

## The fix (one line)

```diff
-    timeout: float = 30.0,
+    timeout: Optional[float] = None,
```

`Optional` is already imported; the `None` default now flows to `call_llm`, which resolves `auxiliary.title_generation.timeout` (default 30) from config. An explicit `timeout=` still overrides. Plus two regression tests: default delegates to config (`task=="title_generation"`, `timeout is None`) and explicit timeout still forwards.

## Chosen over competing PRs (issue #32729)

This was a 4-way OPEN cluster. #41844 is the cleanest: the exact one-line default fix with focused, non-tautological tests and **no scope creep**. Superseded:
- **#56285** (Tranquil-Flow) — same core fix + a (harmless but unnecessary) type-annotation tidy on `call_llm`; thorough tests, but more surface than needed.
- **#41841** — re-implements the timeout resolution at the `gateway/run.py` call site that `call_llm` already does internally — redundant plumbing.
- **#39035** — contains the correct one-liner but **bundles an unrelated arm64 Docker CI rewrite** (`.github/workflows/docker.yml`), which disqualifies it as-is.

## Rebase note

The one-liner applied clean; only the test file conflicted (main added language tests in the same region). Resolved by keeping BOTH main's language tests and #41844's timeout tests.

## Review

Ran hermes-agent-dev + hermes-pr-review Phase 2c — 0 Critical / 0 Warnings. Confirmed the fix chain end-to-end, config key exists on main, no behavior change for explicit-timeout callers, tests non-tautological. Locally: 25 passed.

## Tests

```text
pytest tests/agent/test_title_generator.py -q   # 25 passed (CI runs the full suite)
```

Supersedes #41844 (and #56285 / #41841 / #39035). Full credit to @shandian64.
