### PR TITLE
fix(gateway): parse compact reasoning commands

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1783,11 +1783,10 @@ class MessageEvent:
         """Check if this is a command message (e.g., /new, /reset)."""
         return self.text.startswith("/")
     
-    def get_command(self) -> Optional[str]:
-        """Extract command name if this is a command message."""
+    def _raw_command_token(self) -> Optional[str]:
+        """Return the normalized first slash-token without bot mention."""
         if not self.is_command():
             return None
-        # Split on space and get first word, strip the /
         parts = self.text.split(maxsplit=1)
         raw = parts[0][1:].lower() if parts else None
         if raw and "@" in raw:
@@ -1796,6 +1795,34 @@ class MessageEvent:
         if raw and "/" in raw:
             return None
         return raw
+
+    @staticmethod
+    def _compact_reasoning_arg(raw: Optional[str]) -> Optional[str]:
+        """Map compact Telegram commands like /reasoningmedium to args."""
+        if not raw or not raw.startswith("reasoning") or raw == "reasoning":
+            return None
+        suffix = raw[len("reasoning"):]
+        supported = {
+            "reset",
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "show",
+            "hide",
+            "on",
+            "off",
+        }
+        return suffix if suffix in supported else None
+
+    def get_command(self) -> Optional[str]:
+        """Extract command name if this is a command message."""
+        raw = self._raw_command_token()
+        if self._compact_reasoning_arg(raw):
+            return "reasoning"
+        return raw
     
     def get_command_args(self) -> str:
         """Get the arguments after a command."""
@@ -1803,6 +1830,9 @@ class MessageEvent:
             return self.text
         parts = self.text.split(maxsplit=1)
         args = parts[1] if len(parts) > 1 else ""
+        compact_reasoning_arg = self._compact_reasoning_arg(self._raw_command_token())
+        if compact_reasoning_arg:
+            args = f"{compact_reasoning_arg} {args}".strip()
         # iOS auto-corrects -- to — (em dash) and - to – (en dash)
         args = args.replace("\u2014\u2014", "--").replace("\u2014", "--").replace("\u2013", "-")
         return args

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -160,6 +160,14 @@ class TestMessageEventGetCommand:
         event = MessageEvent(text="/RESET@TigerNanoBot")
         assert event.get_command() == "reset"
 
+    def test_compact_reasoning_level_command(self):
+        event = MessageEvent(text="/reasoningmedium")
+        assert event.get_command() == "reasoning"
+
+    def test_compact_reasoning_level_command_with_at_botname(self):
+        event = MessageEvent(text="/reasoninghigh@TigerNanoBot")
+        assert event.get_command() == "reasoning"
+
 
 class TestMessageEventGetCommandArgs:
     def test_command_with_args(self):
@@ -173,6 +181,14 @@ class TestMessageEventGetCommandArgs:
     def test_not_a_command_returns_full_text(self):
         event = MessageEvent(text="hello world")
         assert event.get_command_args() == "hello world"
+
+    def test_compact_reasoning_level_command(self):
+        event = MessageEvent(text="/reasoningmedium")
+        assert event.get_command_args() == "medium"
+
+    def test_compact_reasoning_level_command_preserves_extra_args(self):
+        event = MessageEvent(text="/reasoningxhigh@TigerNanoBot --global")
+        assert event.get_command_args() == "xhigh --global"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- parse compact Telegram-style `/reasoning<level>` commands as `/reasoning <level>`
- preserve bot mentions and extra args, e.g. `/reasoningxhigh@BotName --global` -> `reasoning`, `xhigh --global`
- add regression coverage for compact reasoning command parsing

Fixes #56323.

## Test Plan

- `python -m pytest tests/gateway/test_platform_base.py::TestMessageEventGetCommand tests/gateway/test_platform_base.py::TestMessageEventGetCommandArgs -q -o 'addopts='`