### PR TITLE
chore: AUTHOR_MAP entries for session-persistence salvage batch

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -61,6 +61,8 @@ AUTHOR_MAP = {
     "214165399+kernel-t1@users.noreply.github.com": "kernel-t1",  # PR #41349 salvage (.env sanitizer: only split when line starts with a known KEY= and preceding values are plain tokens; keep URL/query/whitespace secrets verbatim)
     "290858493+sasquatch9818@users.noreply.github.com": "sasquatch9818",  # PR #41198 salvage (defang untrusted-tool-result delimiter against tag injection; drop forgeable startswith fast-path)
     "jnibarger01@gmail.com": "jnibarger01",  # PR #35130 salvage (ReDoS-bound threat-pattern filler + FTS5 query cap + V4A Move-File approval/traversal targets)
+    "info@djimit.nl": "djimit",  # PR #48034 salvage (recover from truncated gateway responses: 4 continuation retries + exponential token headroom + normalize empty partials)
+    "lubos@komfi.health": "lubosxyz",  # PR #49225 salvage (persist codex app-server turns to session DB via agent_persisted=False so session_search/distill see gateway conversations)
     "290868363+petrichor-op@users.noreply.github.com": "petrichor-op",  # PR #41281 salvage (never persist ephemeral empty-response recovery scaffolding to the SQLite session store / JSON log; filter by flag not position)
     "283494121+redactdeveloper@users.noreply.github.com": "redactdeveloper",  # PR #36897 salvage (route /sessions & /history through prompt_toolkit-safe print; filter doctor missing-key summary to CLI-enabled toolsets)
     "charleneleong84@gmail.com": "charleneleong-ai",  # PR #11736 salvage (classify Anthropic "out of extra usage" 400 as billing)


### PR DESCRIPTION
## Summary
Adds AUTHOR_MAP mappings for the two plain-email contributors in the session-persistence salvage batch so `contributor_audit.py` (check-attribution CI) passes when their salvage PRs land.

## Changes
- `scripts/release.py`: `info@djimit.nl` -> `djimit` (PR #48034), `lubos@komfi.health` -> `lubosxyz` (PR #49225)

The other two PRs in the batch (#50405 sasquatch9818, #48764 srojk34) use `users.noreply.github.com` emails, which check-attribution auto-skips — no entry needed.

Merged first so the attribution audit against main is green before the salvage PRs.