### PR TITLE
feat(delegate): add resolve_delegation_model plugin hook for per-delegation model/effort routing

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -163,6 +163,33 @@ VALID_HOOKS: Set[str] = {
     "on_session_reset",
     "subagent_start",
     "subagent_stop",
+    # Delegation model/effort router hook. Fired by tools/delegate_tool.py
+    # ONCE PER child task, right before the child AIAgent is constructed, so a
+    # plugin can OVERRIDE which (model, effort) pair that single delegation runs
+    # on. This is a cache-safe boundary: each child is a fresh context, so a
+    # route decision here never re-reads or invalidates the parent's prompt
+    # cache, and it never switches the main agent's model mid-turn.
+    #
+    # Kwargs:
+    #   goal: str               -- the child task's prompt/goal text
+    #   context: str | None     -- optional extra context block for the child
+    #   role: str               -- "leaf" | "orchestrator"
+    #   toolsets: list[str] | None -- toolsets the child will run with
+    #   parent_model: str | None   -- the model the delegating parent runs on
+    #   delegation_model: str | None  -- model from delegation config (None ->
+    #                                    child inherits the parent's model)
+    #   delegation_effort: str | None -- reasoning_effort from delegation config
+    #
+    # Return: a plugin returns a dict to override, or None to abstain. The
+    # FIRST non-None dict wins (invoke_hook preserves registration order).
+    #   {"model": "<model-id>", "effort": "low|medium|high|xhigh|max"}
+    # Both keys are optional: a plugin may set only "effort" (keep the model,
+    # change thinking depth) or only "model". An omitted/empty key leaves that
+    # axis at its configured default. SAFE DEFAULT: when no plugin registers
+    # this hook, or every callback returns None, delegate_task behaves
+    # byte-identically to a build without the hook (children inherit the
+    # parent / configured delegation creds).
+    "resolve_delegation_model",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -34,6 +34,7 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _resolve_delegation_model_override,
     _inherit_parent_base_url,
 )
 
@@ -3153,6 +3154,228 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+
+class TestResolveDelegationModelHook(unittest.TestCase):
+    """The resolve_delegation_model plugin hook: a router plugin can override
+    the (model, effort) pair for a single delegation, and the absence of the
+    hook is byte-identical to pre-hook behavior."""
+
+    # -- helper-level: _resolve_delegation_model_override --------------------
+
+    @patch("hermes_cli.plugins.invoke_hook")
+    @patch("hermes_cli.plugins.has_hook", return_value=False)
+    def test_no_registered_hook_is_noop(self, _has_hook, mock_invoke):
+        """No plugin registered -> (None, None) and the hook is never invoked
+        (the cache-safe, identical-to-before path)."""
+        m, e = _resolve_delegation_model_override(
+            goal="anything",
+            context=None,
+            role="leaf",
+            toolsets=None,
+            parent_agent=_make_mock_parent(),
+            creds={"model": "claude-opus-4-8"},
+            cfg={},
+        )
+        self.assertEqual((m, e), (None, None))
+        mock_invoke.assert_not_called()
+
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[{"model": "claude-haiku-4-5", "effort": "low"}],
+    )
+    @patch("hermes_cli.plugins.has_hook", return_value=True)
+    def test_plugin_override_wins(self, _has_hook, _invoke):
+        m, e = _resolve_delegation_model_override(
+            goal="summarize this changelog",
+            context=None,
+            role="leaf",
+            toolsets=["read"],
+            parent_agent=_make_mock_parent(),
+            creds={"model": "claude-opus-4-8"},
+            cfg={"reasoning_effort": "medium"},
+        )
+        self.assertEqual((m, e), ("claude-haiku-4-5", "low"))
+
+    @patch("hermes_cli.plugins.invoke_hook", return_value=[{"effort": "xhigh"}])
+    @patch("hermes_cli.plugins.has_hook", return_value=True)
+    def test_effort_only_override(self, _has_hook, _invoke):
+        """A plugin may set only effort (keep the model)."""
+        m, e = _resolve_delegation_model_override(
+            goal="debug this race condition",
+            context=None,
+            role="leaf",
+            toolsets=None,
+            parent_agent=_make_mock_parent(),
+            creds={"model": "claude-opus-4-8"},
+            cfg={},
+        )
+        self.assertEqual((m, e), (None, "xhigh"))
+
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        # First dict carries no usable key -> skipped; second one wins.
+        return_value=[{}, {"model": "claude-sonnet-4-5"}],
+    )
+    @patch("hermes_cli.plugins.has_hook", return_value=True)
+    def test_first_usable_dict_wins(self, _has_hook, _invoke):
+        m, e = _resolve_delegation_model_override(
+            goal="refactor the auth module",
+            context=None,
+            role="leaf",
+            toolsets=None,
+            parent_agent=_make_mock_parent(),
+            creds={"model": None},
+            cfg={},
+        )
+        self.assertEqual((m, e), ("claude-sonnet-4-5", None))
+
+    @patch("hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("boom"))
+    @patch("hermes_cli.plugins.has_hook", return_value=True)
+    def test_hook_exception_is_swallowed(self, _has_hook, _invoke):
+        """A misbehaving router must not break delegation."""
+        m, e = _resolve_delegation_model_override(
+            goal="x",
+            context=None,
+            role="leaf",
+            toolsets=None,
+            parent_agent=_make_mock_parent(),
+            creds={"model": "claude-opus-4-8"},
+            cfg={},
+        )
+        self.assertEqual((m, e), (None, None))
+
+    # -- build-level: _build_child_agent override_effort --------------------
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_applies_override_effort(self, _cfg):
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "medium"}
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="hard task",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_effort="xhigh",
+            )
+        self.assertEqual(
+            MockAgent.call_args[1]["reasoning_config"],
+            {"enabled": True, "effort": "xhigh"},
+        )
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_override_effort_supports_max(self, _cfg):
+        """'max' must survive — it bypasses the legacy xhigh-capped parser."""
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "medium"}
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="hardest task",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_effort="max",
+            )
+        self.assertEqual(
+            MockAgent.call_args[1]["reasoning_config"],
+            {"enabled": True, "effort": "max"},
+        )
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_no_override_inherits_parent_reasoning(self, _cfg):
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "medium"}
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="ordinary task",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_effort=None,
+            )
+        self.assertEqual(
+            MockAgent.call_args[1]["reasoning_config"],
+            {"enabled": True, "effort": "medium"},
+        )
+
+    # -- end-to-end: delegate_task wires the hook into child construction ----
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[{"model": "claude-haiku-4-5", "effort": "low"}],
+    )
+    @patch("hermes_cli.plugins.has_hook", return_value=True)
+    def test_delegate_task_applies_hook_override(
+        self, _has_hook, _invoke, _cfg, mock_run
+    ):
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "ok",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "medium"}
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            delegate_task(goal="summarize this file", parent_agent=parent)
+
+        self.assertEqual(MockAgent.call_args[1]["model"], "claude-haiku-4-5")
+        self.assertEqual(
+            MockAgent.call_args[1]["reasoning_config"],
+            {"enabled": True, "effort": "low"},
+        )
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("hermes_cli.plugins.invoke_hook")
+    @patch("hermes_cli.plugins.has_hook", return_value=False)
+    def test_delegate_task_without_hook_is_unchanged(
+        self, _has_hook, mock_invoke, _cfg, mock_run
+    ):
+        """No router registered -> child inherits the parent's model exactly as
+        before, and the hook is never invoked."""
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "ok",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            delegate_task(goal="do the thing", parent_agent=parent)
+
+        # creds["model"] is None (empty cfg) -> child inherits parent.model.
+        self.assertEqual(MockAgent.call_args[1]["model"], parent.model)
+        # invoke_hook fires for unrelated hooks (subagent_start/stop), but the
+        # router hook must never be invoked when has_hook() reports it absent.
+        router_calls = [
+            c
+            for c in mock_invoke.call_args_list
+            if c.args and c.args[0] == "resolve_delegation_model"
+        ]
+        self.assertEqual(router_calls, [])
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1060,6 +1060,10 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Per-task reasoning-effort override from the resolve_delegation_model hook.
+    # None => fall back to delegation.reasoning_effort / parent inheritance
+    # (unchanged behavior). A value here wins over both.
+    override_effort: Optional[str] = None,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1272,6 +1276,23 @@ def _build_child_agent(
                 )
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
+
+    # Per-task effort override from the resolve_delegation_model hook wins over
+    # both the delegation-config effort and parent inheritance. Built directly
+    # (not via parse_reasoning_effort) so the full adaptive range incl. "max"
+    # is honored — the adapter's ADAPTIVE_EFFORT_MAP accepts max/xhigh even
+    # though the legacy config parser caps at xhigh.
+    if override_effort:
+        _eff = override_effort.strip().lower()
+        if _eff in {"low", "medium", "high", "xhigh", "max"}:
+            child_reasoning = {"enabled": True, "effort": _eff}
+        elif _eff == "none":
+            child_reasoning = {"enabled": False}
+        else:
+            logger.warning(
+                "resolve_delegation_model: unknown effort '%s', keeping default",
+                override_effort,
+            )
 
     # Inherit the parent's fallback provider chain so subagents can recover
     # from rate-limits and credential exhaustion exactly like the top-level
@@ -2512,6 +2533,18 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Let a router plugin override (model, effort) for THIS task based
+            # on its goal text. No plugin registered -> (None, None) -> creds
+            # are used unchanged (byte-identical to pre-hook behavior).
+            _model_override, _effort_override = _resolve_delegation_model_override(
+                goal=t["goal"],
+                context=t.get("context"),
+                role=effective_role,
+                toolsets=t.get("toolsets"),
+                parent_agent=parent_agent,
+                creds=creds,
+                cfg=cfg,
+            )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
@@ -2519,7 +2552,8 @@ def delegate_task(
                 # Subagents always inherit the parent's toolsets; the model
                 # cannot choose or narrow them (no model-facing toolsets arg).
                 toolsets=None,
-                model=creds["model"],
+                model=_model_override or creds["model"],
+                override_effort=_effort_override,
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
@@ -3022,6 +3056,78 @@ def _resolve_child_credential_pool(
             exc,
         )
     return None
+
+
+def _resolve_delegation_model_override(
+    *,
+    goal: str,
+    context: Optional[str],
+    role: Optional[str],
+    toolsets: Optional[List[str]],
+    parent_agent,
+    creds: dict,
+    cfg: dict,
+):
+    """Fire the ``resolve_delegation_model`` plugin hook for ONE delegation.
+
+    Lets a router plugin override the (model, effort) pair that this single
+    child task runs on, using the task ``goal`` text + parent/config context.
+    Returns ``(model_override, effort_override)`` — both ``None`` when no
+    plugin registers the hook or every callback abstains (returns ``None``).
+
+    SAFE DEFAULT / cache-safety: when the hook is unregistered this is a cheap
+    ``has_hook`` lookup that returns ``(None, None)``, so the caller keeps the
+    configured delegation creds and ``delegate_task`` behaves byte-identically
+    to a build without the hook. The hook fires at the delegation boundary
+    only (fresh child context) — it never switches the main agent's model
+    mid-turn and never touches the parent's prompt cache.
+
+    The FIRST callback returning a dict with a non-empty ``model`` or
+    ``effort`` wins; later callbacks are ignored. A bad return shape (non-dict,
+    or a dict with neither usable key) is skipped, not fatal.
+    """
+    try:
+        from hermes_cli.plugins import has_hook, invoke_hook as _invoke_hook
+    except Exception:
+        return None, None
+
+    # No registered router -> provably no-op (identical-to-before behavior).
+    try:
+        if not has_hook("resolve_delegation_model"):
+            return None, None
+    except Exception:
+        return None, None
+
+    try:
+        results = _invoke_hook(
+            "resolve_delegation_model",
+            goal=goal or "",
+            context=context,
+            role=role,
+            toolsets=list(toolsets) if toolsets else None,
+            parent_model=getattr(parent_agent, "model", None),
+            delegation_model=creds.get("model"),
+            delegation_effort=str(cfg.get("reasoning_effort") or "").strip() or None,
+        )
+    except Exception:
+        logger.debug("resolve_delegation_model hook invocation failed", exc_info=True)
+        return None, None
+
+    for ret in results:
+        if not isinstance(ret, dict):
+            continue
+        raw_model = ret.get("model")
+        raw_effort = ret.get("effort")
+        model = str(raw_model).strip() if raw_model else None
+        effort = str(raw_effort).strip().lower() if raw_effort else None
+        if model or effort:
+            logger.debug(
+                "resolve_delegation_model: plugin override model=%s effort=%s "
+                "(was model=%s)",
+                model, effort, creds.get("model"),
+            )
+            return model or None, effort or None
+    return None, None
 
 
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:


### PR DESCRIPTION
## Summary

Adds a single plugin hook, `resolve_delegation_model`, that lets a plugin
override the `(model, effort)` pair for an individual subagent delegation. This
is the minimal, generic surface a delegation-time model router needs — the
router logic itself ships as an out-of-tree plugin, so the core gains one small,
concrete extension point and no router-specific code.

## Motivation

Delegations are a natural place to route work to a cheaper/stronger model:
each child is a fresh context, so a per-child model choice never re-reads or
invalidates the parent's prompt cache and never switches the main agent's model
mid-turn. Today `delegate_task` resolves credentials statically via
`_resolve_delegation_credentials`; there is no way for a plugin to say "this
particular child is mechanical — send it to a cheaper tier" or "this one is
hard — raise effort".

This is a real, stated use case (a quota-aware router built as a standalone
plugin), not speculative infrastructure — the consumer exists and ships
separately, matching the "hook is not speculative if a contributor has a real
use case" bar in the contribution rubric.

## What it does

- **`hermes_cli/plugins.py`**: registers `resolve_delegation_model` in
  `VALID_HOOKS` with a full kwargs/return-shape docstring.
- **`tools/delegate_tool.py`**: `_resolve_delegation_model_override()` fires the
  hook via the existing `invoke_hook` plumbing (guarded by `has_hook`), collects
  returns, **first non-None dict wins** (`{"model", "effort"}`, both optional).
  The build loop threads the model + a new `override_effort` param into
  `_build_child_agent`. `override_effort` is built directly (not via
  `parse_reasoning_effort`) so the full adaptive range incl. `"max"` is honored.

## Safety / no-regression

- **No hook registered → byte-identical to today.** `has_hook` is False →
  `(None, None)` → `model=_model_override or creds["model"]`, `override_effort`
  None → the existing effort path is untouched.
- A callback that raises is swallowed → inherit (a plugin can't break the
  delegate loop).
- Delegation boundary only — **no** main-agent mid-conversation model switching,
  so prompt caching is preserved.

## Tests

`tests/tools/test_delegate.py::TestResolveDelegationModelHook` (10 new):
helper no-op / override / effort-only / first-dict-wins / exception-swallowed,
`override_effort` incl. `max`, no-override-inherits, plus e2e override-applied
and e2e no-hook-unchanged. All green alongside the existing 144 delegate tests.

```
tests/tools/test_delegate.py ...... 154 passed
```

## Notes

Returns are collected through the standard `invoke_hook` path; the "first
non-None dict wins" contract mirrors the existing `pre_llm_call` return
convention. No new core tool, no new env var, no change to default behavior.
