### PR TITLE
fix(voice): sanitize command provider subprocess env

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -370,6 +370,37 @@ class TestTranscribeOpenAIExtended:
 
 
 class TestTranscribeLocalCommand:
+    def test_command_provider_uses_sanitized_child_env(self, monkeypatch):
+        monkeypatch.setenv("AUXILIARY_VISION_API_KEY", "sk-vision")
+        monkeypatch.setenv("GATEWAY_RELAY_SECRET", "relay-secret")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        monkeypatch.setenv("MY_SAFE_STT_VAR", "keep")
+
+        captured = {}
+
+        class Proc:
+            returncode = 0
+
+            def communicate(self, timeout=None):
+                return "", ""
+
+        def fake_popen(command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return Proc()
+
+        monkeypatch.setattr("tools.transcription_tools.subprocess.Popen", fake_popen)
+
+        from tools.transcription_tools import _run_command_stt
+
+        result = _run_command_stt("echo hi", timeout=1)
+
+        assert result.returncode == 0
+        env = captured["env"]
+        assert "AUXILIARY_VISION_API_KEY" not in env
+        assert "GATEWAY_RELAY_SECRET" not in env
+        assert "OPENAI_API_KEY" not in env
+        assert env["MY_SAFE_STT_VAR"] == "keep"
+
     def test_auto_detects_local_whisper_binary(self, monkeypatch):
         monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
         monkeypatch.setattr("tools.transcription_tools._find_whisper_binary", lambda: "/opt/homebrew/bin/whisper")

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -37,6 +37,7 @@ from tools.tts_tool import (
     _render_command_tts_template,
     _resolve_command_provider_config,
     _resolve_max_text_length,
+    _run_command_tts,
     _shell_quote_context,
     check_tts_requirements,
     text_to_speech_tool,
@@ -112,6 +113,37 @@ class TestResolveCommandProviderConfig:
             },
         }
         assert _resolve_command_provider_config("piper", cfg) is None
+
+
+class TestCommandTtsEnv:
+    def test_command_provider_uses_sanitized_child_env(self, monkeypatch):
+        monkeypatch.setenv("AUXILIARY_VISION_API_KEY", "sk-vision")
+        monkeypatch.setenv("GATEWAY_RELAY_SECRET", "relay-secret")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        monkeypatch.setenv("MY_SAFE_TTS_VAR", "keep")
+
+        captured = {}
+
+        class Proc:
+            returncode = 0
+
+            def communicate(self, timeout=None):
+                return "", ""
+
+        def fake_popen(command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return Proc()
+
+        monkeypatch.setattr("tools.tts_tool.subprocess.Popen", fake_popen)
+
+        result = _run_command_tts("echo hi", timeout=1)
+
+        assert result.returncode == 0
+        env = captured["env"]
+        assert "AUXILIARY_VISION_API_KEY" not in env
+        assert "GATEWAY_RELAY_SECRET" not in env
+        assert "OPENAI_API_KEY" not in env
+        assert env["MY_SAFE_TTS_VAR"] == "keep"
 
 
 class TestGetNamedProviderConfig:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -546,11 +546,14 @@ def _run_command_stt(command: str, timeout: float) -> subprocess.CompletedProces
 
     Mirrors ``tools.tts_tool._run_command_tts``.
     """
+    from tools.environments.local import hermes_subprocess_env
+
     popen_kwargs: Dict[str, Any] = {
         "shell": True,
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
         "text": True,
+        "env": hermes_subprocess_env(inherit_credentials=False),
     }
     if os.name == "nt":
         popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -762,11 +762,14 @@ def _terminate_command_tts_process_tree(proc: subprocess.Popen) -> None:
 
 def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProcess:
     """Run a command-provider shell command with process-tree timeout cleanup."""
+    from tools.environments.local import hermes_subprocess_env
+
     popen_kwargs: Dict[str, Any] = {
         "shell": True,
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
         "text": True,
+        "env": hermes_subprocess_env(inherit_credentials=False),
     }
     if os.name == "nt":
         popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)


### PR DESCRIPTION
## Summary

This routes custom STT/TTS command-provider subprocesses through the centralized sanitized subprocess environment.

## Problem

Custom voice command providers run local shell commands through:

- `tools.transcription_tools._run_command_stt()`
- `tools.tts_tool._run_command_tts()`

Both used `subprocess.Popen(..., shell=True)` without an explicit `env`, so the child shell inherited the full Hermes process environment.

That bypasses the centralized subprocess secret filtering added for terminal/browser/ACP style child processes. In gateway sessions, the parent environment may contain dynamic Hermes-internal secrets such as `AUXILIARY_*_API_KEY`, `AUXILIARY_*_BASE_URL`, `GATEWAY_RELAY_*`, plus provider credentials. A configured voice command does not need those credentials by default.

## Changes

- Use `hermes_subprocess_env(inherit_credentials=False)` for STT command-provider subprocesses.
- Use `hermes_subprocess_env(inherit_credentials=False)` for TTS command-provider subprocesses.
- Add regression tests proving command-provider child envs strip:
  - `AUXILIARY_VISION_API_KEY`
  - `GATEWAY_RELAY_SECRET`
  - `OPENAI_API_KEY`
- Preserve normal non-secret environment variables.

## Tests

```text
python -m pytest tests/tools/test_tts_command_providers.py -k "CommandTtsEnv or command_provider_uses_sanitized" tests/tools/test_transcription_tools.py -k "command_provider_uses_sanitized_child_env" -q --timeout-method=thread
2 passed, 159 deselected

python -m pytest tests/tools/test_tts_command_providers.py tests/tools/test_transcription_tools.py -k "command" -q --timeout-method=thread
56 passed, 1 skipped, 104 deselected