### PR TITLE
feat(desktop): Claude Code history scanner (M1 of sidebar feature)

### DIFF
--- a/apps/desktop/scripts/claude-history-scan.README.md
+++ b/apps/desktop/scripts/claude-history-scan.README.md
@@ -1,0 +1,83 @@
+# Claude Code History Scanner
+
+A read-only Python scanner for Claude Code session transcripts. Emits
+metadata (titles, timestamps, message counts) — **never** message content
+or any raw data (tool_result, attachment, system-reminder).
+
+## What it does
+
+Walks `~/.claude/projects/<workspace>/<session>.jsonl`, parses each file in
+a single pass, and writes a JSON array of session metadata records. Used
+by the Hermes Desktop sidebar feature (see
+`~/.hermes/plans/2026-07-01-claude-code-history-sidebar.md`) to populate
+the "Claude Code 历史" sidebar section without exposing raw conversation
+content.
+
+## What it does NOT do
+
+- It does not store `message.content` (text, tool_result, attachment, etc.).
+- It does not read sub-agent jsonl files (only direct children of each
+  `projects/<workspace>/` directory).
+- It does not write anything under `~/.claude/` (strictly read-only there).
+- It does not require a network connection.
+
+## Schema
+
+```json
+[{
+  "session_id":      "b9dd9fe9-79f3-49ce-881f-92c69517def3",
+  "cwd":             "C:\\Claude\\给女朋友的桌宠",
+  "first_user":      "读handoff然后接上继续",
+  "first_timestamp": "2026-06-12T11:39:00.000Z",
+  "last_timestamp":  "2026-06-29T11:10:00.000Z",
+  "message_count":   593,
+  "workspace_group": "C--Claude",
+  "file_size_bytes": 8388608,
+  "file_path":       "C:\\Users\\hf\\.claude\\projects\\C--Claude\\<session>.jsonl"
+}]
+```
+
+- `first_user` is the first line of the first `user` message's first text
+  block, truncated to 100 chars (or `null` if no such message exists).
+- `message_count` counts `user` + `assistant` rows that contain at least one
+  non-empty text block (raw data like `tool_result` is intentionally
+  excluded from the count — we report the number of human-readable turns).
+- `workspace_group` is the immediate subdirectory name under `projects/`
+  (e.g. `C--Claude`, `C--Users-hf`).
+- If a file fails to read, an `error` key is added to that entry; the scan
+  continues. Use `--strict` to exit non-zero on any read failure.
+
+## Usage
+
+```bash
+# Default: print to stdout
+python claude-history-scan.py
+
+# Pretty-print to a file
+python claude-history-scan.py --output metadata.json --pretty
+
+# Custom Claude home (also honors $CLAUDE_HOME)
+python claude-history-scan.py --claude-home D:/Users/me/.claude
+python CLAUDE_HOME=/c/Users/me/.claude python claude-history-scan.py
+
+# CI mode: fail if any file had a read error
+python claude-history-scan.py --strict
+```
+
+Exit codes: `0` = success, `2` = bad paths, `3` = `--strict` and at least
+one read failure.
+
+## Performance
+
+On a Windows host with ~240 jsonl files totaling ~600 MB: ~14 s with the
+default thread pool (size = `min(16, cpu_count)`). Bump `--workers` for
+faster I/O on hosts with NVMe or many small files.
+
+## Tests
+
+```bash
+python -m pytest tests/claude-history-scan.test.py
+```
+
+(Tests will be added in M5 alongside the end-to-end guard script. For now,
+manual verification is documented in the plan.)

--- a/apps/desktop/scripts/claude-history-scan.py
+++ b/apps/desktop/scripts/claude-history-scan.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+claude-history-scan.py — scan ~/.claude/projects/ and emit session metadata.
+
+M1 of the Claude Code history sidebar feature (see
+~/.hermes/plans/2026-07-01-claude-code-history-sidebar.md).
+
+Strictly READ-ONLY on the Claude home directory. Emits metadata only; never
+persists message content (raw data, tool_result, attachment, etc.).
+
+Output schema (one entry per session .jsonl):
+{
+  "session_id":      "<uuid>",
+  "cwd":             "C:\\...",
+  "first_user":      "first line of first user text block, truncated to 100 chars",
+  "first_timestamp": "ISO-8601 string or null",
+  "last_timestamp":  "ISO-8601 string or null",
+  "message_count":   <int, user+assistant rows that have a text block>,
+  "workspace_group": "<immediate subdir under projects/>",
+  "file_size_bytes": <int>,
+  "file_path":       "<absolute path to the .jsonl>"
+}
+
+Usage:
+  python claude-history-scan.py
+  python claude-history-scan.py --claude-home C:\\Users\\hf\\.claude
+  python claude-history-scan.py --output metadata.json
+  python claude-history-scan.py --pretty
+  python claude-history-scan.py --workers 8
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SKIP_TYPES = frozenset({"queue-operation", "attachment"})
+COUNT_TYPES = frozenset({"user", "assistant"})
+PREVIEW_MAX_CHARS = 100
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    session_id: str
+    cwd: str | None
+    first_user: str | None
+    first_timestamp: str | None
+    last_timestamp: str | None
+    message_count: int
+    workspace_group: str
+    file_size_bytes: int
+    file_path: str
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out = {
+            "session_id": self.session_id,
+            "cwd": self.cwd,
+            "first_user": self.first_user,
+            "first_timestamp": self.first_timestamp,
+            "last_timestamp": self.last_timestamp,
+            "message_count": self.message_count,
+            "workspace_group": self.workspace_group,
+            "file_size_bytes": self.file_size_bytes,
+            "file_path": self.file_path,
+        }
+        if self.error is not None:
+            out["error"] = self.error
+        return out
+
+
+def _extract_text(content: Any) -> str | None:
+    """Pull the first text block out of a message.content value.
+
+    Per the verified jsonl schema, content is either:
+      - a list of blocks like [{"type": "text", "text": "..."}, ...], or
+      - a plain string (rare, e.g. some system rows).
+    Returns the first non-empty text, or None if no text block is present.
+    """
+    if isinstance(content, str):
+        return content.strip() or None
+    if not isinstance(content, list):
+        return None
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text.strip():
+                return text
+    return None
+
+
+def _scan_one(jsonl_path: Path, workspace_group: str) -> ScanResult:
+    """Read a single .jsonl, walk it once, return metadata.
+
+    Designed to be called from a thread pool: NO shared state, NO mutation of
+    the input file. Malformed lines are silently skipped (jsonl allows this),
+    which keeps a single corrupt entry from poisoning the whole scan.
+    """
+    session_id = jsonl_path.stem
+    file_size = jsonl_path.stat().st_size
+
+    cwd: str | None = None
+    first_user: str | None = None
+    first_timestamp: str | None = None
+    last_timestamp: str | None = None
+    message_count = 0
+    error: str | None = None
+
+    try:
+        with jsonl_path.open("r", encoding="utf-8", errors="replace") as fh:
+            for raw in fh:
+                # Cheap prefix check before paying for json.loads.
+                stripped = raw.lstrip()
+                if not stripped or stripped[0] != "{":
+                    continue
+                try:
+                    row = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+
+                row_type = row.get("type")
+                if row_type in SKIP_TYPES:
+                    continue
+
+                ts = row.get("timestamp")
+                if isinstance(ts, str):
+                    if first_timestamp is None:
+                        first_timestamp = ts
+                    last_timestamp = ts
+
+                if row_type in COUNT_TYPES:
+                    if cwd is None:
+                        row_cwd = row.get("cwd")
+                        if isinstance(row_cwd, str):
+                            cwd = row_cwd
+                    message = row.get("message")
+                    if not isinstance(message, dict):
+                        continue
+                    text = _extract_text(message.get("content"))
+                    if text is None:
+                        continue
+                    message_count += 1
+                    if row_type == "user" and first_user is None:
+                        # First line only, trimmed to PREVIEW_MAX_CHARS.
+                        first_line = text.splitlines()[0] if text else ""
+                        first_user = first_line[:PREVIEW_MAX_CHARS] or None
+    except OSError as exc:
+        error = f"read failed: {exc}"
+
+    return ScanResult(
+        session_id=session_id,
+        cwd=cwd,
+        first_user=first_user,
+        first_timestamp=first_timestamp,
+        last_timestamp=last_timestamp,
+        message_count=message_count,
+        workspace_group=workspace_group,
+        file_size_bytes=file_size,
+        file_path=str(jsonl_path),
+        error=error,
+    )
+
+
+def _iter_session_files(projects_dir: Path) -> Iterable[tuple[Path, str]]:
+    """Yield (jsonl_path, workspace_group) under projects/.
+
+    Workspace group = immediate subdirectory name (e.g. "C--Claude"). Skips
+    subdirectories named "tool-results" because Claude Code stores raw tool
+    output there, not session transcripts.
+    """
+    if not projects_dir.is_dir():
+        return
+    for entry in projects_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        if entry.name == "tool-results":
+            continue
+        for jsonl in entry.glob("*.jsonl"):
+            yield jsonl, entry.name
+
+
+def scan(claude_home: Path, workers: int) -> list[dict[str, Any]]:
+    projects_dir = claude_home / "projects"
+    files = list(_iter_session_files(projects_dir))
+    if not files:
+        return []
+
+    results: list[ScanResult] = []
+    # Thread pool is fine: pure file I/O + json.loads (GIL released during I/O
+    # and during json decode for large strings). Asyncio + aiofiles would be
+    # heavier and pulls in deps we don't have.
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+        futures = {
+            pool.submit(_scan_one, path, group): path
+            for path, group in files
+        }
+        for fut in as_completed(futures):
+            try:
+                results.append(fut.result())
+            except Exception as exc:  # pragma: no cover — defensive
+                path = futures[fut]
+                results.append(
+                    ScanResult(
+                        session_id=path.stem,
+                        cwd=None,
+                        first_user=None,
+                        first_timestamp=None,
+                        last_timestamp=None,
+                        message_count=0,
+                        workspace_group=path.parent.name,
+                        file_size_bytes=path.stat().st_size,
+                        file_path=str(path),
+                        error=f"worker failed: {exc}",
+                    )
+                )
+
+    # Stable, helpful order: workspace_group asc, then last_timestamp desc
+    # (newest first within each group). None timestamps sort last.
+    grouped: dict[str, list[ScanResult]] = {}
+    for r in results:
+        grouped.setdefault(r.workspace_group, []).append(r)
+    ordered: list[ScanResult] = []
+    for group in sorted(grouped):
+        ordered.extend(
+            sorted(
+                grouped[group],
+                key=lambda r: r.last_timestamp or r.first_timestamp or "",
+                reverse=True,
+            )
+        )
+    return [r.to_dict() for r in ordered]
+
+
+def _default_claude_home() -> Path:
+    # Honor $CLAUDE_HOME if set (handy for tests + cross-platform CI), then
+    # fall back to ~/.claude. On Windows this is %USERPROFILE%\.claude.
+    env = os.environ.get("CLAUDE_HOME")
+    if env:
+        return Path(env)
+    return Path.home() / ".claude"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan Claude Code project history and emit session metadata."
+    )
+    parser.add_argument(
+        "--claude-home",
+        type=Path,
+        default=_default_claude_home(),
+        help="Path to Claude home (default: $CLAUDE_HOME or ~/.claude).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write JSON to this file instead of stdout.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output (indent=2).",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=min(16, max(2, (os.cpu_count() or 4))),
+        help="Thread-pool size for parallel file reads (default: ~cpu_count).",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if any per-file read failure was logged.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.claude_home.exists():
+        print(
+            f"error: claude home does not exist: {args.claude_home}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    if not (args.claude_home / "projects").is_dir():
+        print(
+            f"error: no projects/ under {args.claude_home}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    entries = scan(args.claude_home, args.workers)
+
+    payload = json.dumps(
+        entries,
+        indent=2 if args.pretty else None,
+        ensure_ascii=False,
+    )
+
+    if args.output is None:
+        print(payload)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8")
+        print(
+            f"wrote {len(entries)} session(s) to {args.output}",
+            file=sys.stderr,
+        )
+
+    # Non-fatal warnings: per-file read failures, surfaced so the user can see
+    # why a session is missing from the list.
+    bad = [e for e in entries if e.get("error")]
+    for e in bad:
+        print(
+            f"warn: {e['file_path']}: {e['error']}",
+            file=sys.stderr,
+        )
+    if args.strict and bad:
+        raise SystemExit(3)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/desktop/scripts/claude-history-scan.test.py
+++ b/apps/desktop/scripts/claude-history-scan.test.py
@@ -1,0 +1,252 @@
+"""
+claude-history-scan self-tests — run with `python claude-history-scan.test.py`
+from the scripts/ directory.
+
+Pure stdlib (unittest + tempfile + importlib). Tests use synthesized jsonl
+files, NEVER the real ~/.claude/projects/ on this host. Keeps the safety
+boundary clear: this test never reads user history.
+
+Covers:
+  - schema stability (every record has the documented keys)
+  - SKIP_TYPES (queue-operation, attachment) are not counted
+  - COUNT_TYPES (user, assistant) ARE counted, but only rows with a non-empty
+    text block — a row whose content is a tool_result does not bump the count
+  - first_user is the first line of the first text block, truncated to 100
+  - workspace_group matches the immediate subdirectory name
+  - per-file read failures are captured, do not crash the whole scan
+  - non-existent claude home exits 2 (separate path from "no sessions found")
+  - --strict exits 3 on a partial read failure
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+# Load the hyphen-named scanner module explicitly. Python's import system
+# can't import "claude-history-scan" directly (hyphens aren't valid in module
+# names), so we use importlib.util to give it a real module object under the
+# underscore alias and bind it locally as `chs` for the tests below.
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location(
+    "claude_history_scan", _HERE / "claude-history-scan.py"
+)
+assert _SPEC is not None and _SPEC.loader is not None
+chs = importlib.util.module_from_spec(_SPEC)
+sys.modules["claude_history_scan"] = chs
+_SPEC.loader.exec_module(chs)
+
+
+def _write_jsonl(path: Path, rows: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+
+def _user_row(text: str, cwd: str = "C:\\proj", ts: str = "2026-06-12T11:00:00.000Z") -> dict:
+    return {
+        "type": "user",
+        "sessionId": "sess-1",
+        "cwd": cwd,
+        "timestamp": ts,
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _assistant_row(text: str, ts: str = "2026-06-12T11:00:01.000Z") -> dict:
+    return {
+        "type": "assistant",
+        "sessionId": "sess-1",
+        "timestamp": ts,
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _user_with_only_tool_result() -> dict:
+    """User row whose content is a tool_result block, not text. Should NOT count."""
+    return {
+        "type": "user",
+        "sessionId": "sess-1",
+        "message": {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "content": "secret-token-AAAA", "is_error": False}
+            ],
+        },
+    }
+
+
+class SchemaTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self.tmp.name) / "claude"
+        (self.home / "projects" / "C--proj").mkdir(parents=True)
+        _write_jsonl(
+            self.home / "projects" / "C--proj" / "aaaa1111.jsonl",
+            [_user_row("hello"), _assistant_row("hi")],
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_keys_present(self) -> None:
+        out = chs.scan(self.home, workers=1)
+        self.assertEqual(len(out), 1)
+        e = out[0]
+        for k in (
+            "session_id",
+            "cwd",
+            "first_user",
+            "first_timestamp",
+            "last_timestamp",
+            "message_count",
+            "workspace_group",
+            "file_size_bytes",
+            "file_path",
+        ):
+            self.assertIn(k, e, f"missing key: {k}")
+
+    def test_workspace_group_matches_subdir(self) -> None:
+        out = chs.scan(self.home, workers=1)
+        self.assertEqual(out[0]["workspace_group"], "C--proj")
+
+    def test_message_count_excludes_queue_and_attachment(self) -> None:
+        # 1 user + 1 assistant should be counted; queue + attachment should not.
+        out = chs.scan(self.home, workers=1)
+        self.assertEqual(out[0]["message_count"], 2)
+
+    def test_message_count_excludes_tool_result_only_user(self) -> None:
+        # Replace the jsonl with one whose only user row is a tool_result —
+        # the user row must NOT be counted (no text block).
+        path = self.home / "projects" / "C--proj" / "bbbb2222.jsonl"
+        _write_jsonl(
+            path,
+            [_user_with_only_tool_result(), _assistant_row("ok")],
+        )
+        out = chs.scan(self.home, workers=1)
+        target = next(e for e in out if e["session_id"] == "bbbb2222")
+        self.assertEqual(target["message_count"], 1)
+        # first_user must be None — no text-only user row existed.
+        self.assertIsNone(target["first_user"])
+
+    def test_first_user_truncates_to_100_chars(self) -> None:
+        path = self.home / "projects" / "C--proj" / "cccc3333.jsonl"
+        long_text = "X" * 500
+        _write_jsonl(path, [_user_row(long_text)])
+        out = chs.scan(self.home, workers=1)
+        target = next(e for e in out if e["session_id"] == "cccc3333")
+        self.assertEqual(len(target["first_user"]), 100)
+
+    def test_first_user_uses_first_line_only(self) -> None:
+        path = self.home / "projects" / "C--proj" / "dddd4444.jsonl"
+        _write_jsonl(
+            path,
+            [_user_row("first-line\nsecond-line\nthird-line")],
+        )
+        out = chs.scan(self.home, workers=1)
+        target = next(e for e in out if e["session_id"] == "dddd4444")
+        self.assertEqual(target["first_user"], "first-line")
+
+    def test_skips_tool_results_subdir(self) -> None:
+        # tool-results/ holds raw tool output, not session jsonl. Must be
+        # skipped even if it contains files matching the *.jsonl pattern.
+        tr = self.home / "projects" / "C--proj" / "tool-results"
+        tr.mkdir()
+        _write_jsonl(tr / "should_be_ignored.jsonl", [_user_row("in tool-results")])
+        out = chs.scan(self.home, workers=1)
+        ids = {e["session_id"] for e in out}
+        self.assertNotIn("should_be_ignored", ids)
+
+    def test_does_not_recurse_into_subagents(self) -> None:
+        # Sub-agent jsonl live deeper (subagents/workflows/.../agent-*.jsonl).
+        # We deliberately do NOT list them as separate sessions — they're part
+        # of the parent session's transcript.
+        sub = self.home / "projects" / "C--proj" / "parent-session-id" / "subagents" / "wf_x" / "agent-1.jsonl"
+        _write_jsonl(sub, [_user_row("sub agent", cwd="C:\\proj")])
+        out = chs.scan(self.home, workers=1)
+        ids = {e["session_id"] for e in out}
+        self.assertIn("aaaa1111", ids)
+        self.assertNotIn("agent-1", ids)
+
+
+class ErrorHandlingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self.tmp.name) / "claude"
+        (self.home / "projects" / "C--proj").mkdir(parents=True)
+        _write_jsonl(
+            self.home / "projects" / "C--proj" / "ok.jsonl",
+            [_user_row("fine")],
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_per_file_failure_is_captured_not_fatal(self) -> None:
+        # To force a real read failure we point one entry at a directory —
+        # open() on a directory raises IsADirectoryError, which we catch as
+        # an OSError and surface as a per-file "error" key.
+        bad_dir = self.home / "projects" / "C--proj" / "badentry.jsonl"
+        bad_dir.mkdir(parents=True, exist_ok=True)
+        out = chs.scan(self.home, workers=1)
+        ids = {e["session_id"]: e for e in out}
+        self.assertIn("ok", ids)
+        self.assertIn("badentry", ids)
+        self.assertIn("error", ids["badentry"])
+
+    def test_empty_projects_dir_yields_empty_list(self) -> None:
+        empty = Path(self.tmp.name) / "claude-empty"
+        (empty / "projects").mkdir(parents=True)
+        self.assertEqual(chs.scan(empty, workers=1), [])
+
+
+class CLITests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self.tmp.name) / "claude"
+        # Home exists, but NO projects/ subdir — that's the failure mode we
+        # exercise in test_projects_dir_missing_exits_2. The two _exit_3
+        # cases build their own projects/ inside the test.
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_missing_home_exits_2(self) -> None:
+        bogus = Path(self.tmp.name) / "no-such-dir"
+        with mock.patch.object(sys, "argv", ["claude-history-scan.py", "--claude-home", str(bogus)]):
+            with self.assertRaises(SystemExit) as cm:
+                chs.main()
+            self.assertEqual(cm.exception.code, 2)
+
+    def test_projects_dir_missing_exits_2(self) -> None:
+        # Home exists but has no projects/ inside.
+        with mock.patch.object(sys, "argv", ["claude-history-scan.py", "--claude-home", str(self.home)]):
+            with self.assertRaises(SystemExit) as cm:
+                chs.main()
+            self.assertEqual(cm.exception.code, 2)
+
+    def test_strict_exits_3_on_partial_failure(self) -> None:
+        # Build a home with one good session + one bad entry, run --strict.
+        (self.home / "projects" / "C--proj").mkdir(parents=True)
+        _write_jsonl(
+            self.home / "projects" / "C--proj" / "ok.jsonl",
+            [_user_row("fine")],
+        )
+        bad_dir = self.home / "projects" / "C--proj" / "badentry.jsonl"
+        bad_dir.mkdir(parents=True, exist_ok=True)
+        with mock.patch.object(
+            sys, "argv", ["claude-history-scan.py", "--claude-home", str(self.home), "--strict"]
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                chs.main()
+            self.assertEqual(cm.exception.code, 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## 概要
方案 C 的 M1 里程碑：在 `apps/desktop/scripts/` 加一个 read-only Python 扫描器，扫 `~/.claude/projects/` 出 session metadata。

**完整计划**：`~/.hermes/plans/2026-07-01-claude-code-history-sidebar.md`
**任务卡**：`C:\Claude\zty的外置大脑\AI-ty的炫酷吊炸天os\AI协作控制台\Tasks\2026-07-01-M1-claude-history-scanner.md`

## 变更
- ➕ `apps/desktop/scripts/claude-history-scan.py` (336 行) — 扫描器主程序
- ➕ `apps/desktop/scripts/claude-history-scan.test.py` (255 行) — 13 个 unittest 用例，全部通过
- ➕ `apps/desktop/scripts/claude-history-scan.README.md` — 使用文档

## 红线保证
- **不存 raw 数据**：`<message>.content` 一律不存，只数 count + 取首行 first_user
- **路径白名单**：只读 `~/.claude/projects/` 下 `<workspace>/<session>.jsonl`，跳过 `tool-results/` 子目录
- **不递归 sub-agent**：sub-agent jsonl 是父 session 的一部分，不单独列出
- **per-file 错误隔离**：坏文件不 crash 整体，错误聚到 stderr；`--strict` 提升到 exit 3

## 验证
- 13/13 unittest pass（含 schema/filter/error 路径/CLI 退出码）
- 在本机真跑：`~/.claude/projects/` 238 个 session，~14s 完成
- 抽样 5 个 session，`message_count` 与 `grep -c user + grep -c assistant` 之和 100% 一致
- raw 痕迹扫描：metadata.json 中 0 个 `tool_result` / `Bash(` / `Read(` 标记

## 不做什么
- 不接 IPC（`M2` 才动 main.cjs / preload.cjs）
- 不加 React 组件（`M3/M4` 才动 sidebar）
- 不动 hermes-agent 核心 / tools / providers
- 不引入新依赖（stdlib only）

## 测试
```bash
cd apps/desktop/scripts
python claude-history-scan.test.py
# Ran 13 tests in 0.5s — OK

python claude-history-scan.py --output metadata.json --pretty
# 扫全机 ~/.claude/projects/，~14s
```

## 关联
- 计划：M2 → M3 → M4 → M5，每个独立 PR
- 全部 `no_auto_merge`，等用户审