### PR TITLE
fix(auxiliary_client): dedup resolve_provider_client fall-through warnings (salvage #56283)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -121,6 +121,11 @@ logger = logging.getLogger(__name__)
 # them independently.
 _LOGGED_UNKNOWN_PROVIDER_KEYS: set = set()
 _LOGGED_UNHANDLED_AUTHTYPE_KEYS: set = set()
+# Same treatment for the two "registered provider, unsupported sub-branch"
+# routing dead-ends — external-process and OAuth providers that fall through
+# with no matching handler. Keyed by provider name.
+_LOGGED_UNSUPPORTED_EXTPROC_KEYS: set = set()
+_LOGGED_UNSUPPORTED_OAUTH_KEYS: set = set()
 
 
 def _openai_http_client_kwargs(
@@ -4495,8 +4500,10 @@ def resolve_provider_client(
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
-        logger.warning("resolve_provider_client: external-process provider %s not "
-                       "directly supported", provider)
+        if provider not in _LOGGED_UNSUPPORTED_EXTPROC_KEYS:
+            _LOGGED_UNSUPPORTED_EXTPROC_KEYS.add(provider)
+            logger.debug("resolve_provider_client: external-process provider %s not "
+                         "directly supported", provider)
         return None, None
 
     elif pconfig.auth_type == "aws_sdk":
@@ -4541,8 +4548,10 @@ def resolve_provider_client(
         if provider == "xai-oauth":
             return resolve_provider_client("xai-oauth", model, async_mode)
         # Other OAuth providers not directly supported
-        logger.warning("resolve_provider_client: OAuth provider %s not "
-                       "directly supported, try 'auto'", provider)
+        if provider not in _LOGGED_UNSUPPORTED_OAUTH_KEYS:
+            _LOGGED_UNSUPPORTED_OAUTH_KEYS.add(provider)
+            logger.debug("resolve_provider_client: OAuth provider %s not "
+                         "directly supported, try 'auto'", provider)
         return None, None
 
     # Demoted from logger.warning to debug; dedup keyed on (auth_type,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -110,6 +110,19 @@ from utils import base_url_host_matches, base_url_hostname, env_float, model_for
 logger = logging.getLogger(__name__)
 
 
+# ── resolve_provider_client fall-through dedup ───────────────────────────
+# Both fall-through warning sites in resolve_provider_client (the "unknown
+# provider" and "unhandled auth_type" branches) fire on every retry of a
+# misconfigured provider, spamming the logs. Demote them to logger.debug with
+# per-process dedup: the FIRST occurrence still surfaces (it carries real
+# diagnostic value — a provider-name typo or PROVIDER_REGISTRY/auth_type
+# drift), and identical repeats are suppressed for the lifetime of the
+# process. Two independent sets keep each branch linear and let tests clear
+# them independently.
+_LOGGED_UNKNOWN_PROVIDER_KEYS: set = set()
+_LOGGED_UNHANDLED_AUTHTYPE_KEYS: set = set()
+
+
 def _openai_http_client_kwargs(
     base_url: Optional[str],
     *,
@@ -4336,7 +4349,11 @@ def resolve_provider_client(
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig is None:
-        logger.warning("resolve_provider_client: unknown provider %r", provider)
+        # Demoted from logger.warning to debug; dedup keyed by provider name
+        # so the first occurrence surfaces but repeated retries stay silent.
+        if provider not in _LOGGED_UNKNOWN_PROVIDER_KEYS:
+            _LOGGED_UNKNOWN_PROVIDER_KEYS.add(provider)
+            logger.debug("resolve_provider_client: unknown provider %r", provider)
         return None, None
 
     if pconfig.auth_type == "api_key":
@@ -4528,8 +4545,14 @@ def resolve_provider_client(
                        "directly supported, try 'auto'", provider)
         return None, None
 
-    logger.warning("resolve_provider_client: unhandled auth_type %s for %s",
-                   pconfig.auth_type, provider)
+    # Demoted from logger.warning to debug; dedup keyed on (auth_type,
+    # provider) so the first occurrence surfaces (real schema-drift bug) but
+    # per-call retries stay silent.
+    _auth_dedup_key = (pconfig.auth_type, provider)
+    if _auth_dedup_key not in _LOGGED_UNHANDLED_AUTHTYPE_KEYS:
+        _LOGGED_UNHANDLED_AUTHTYPE_KEYS.add(_auth_dedup_key)
+        logger.debug("resolve_provider_client: unhandled auth_type %s for %s",
+                     pconfig.auth_type, provider)
     return None, None
 
 

--- a/tests/agent/test_auxiliary_client_resolve_dedup.py
+++ b/tests/agent/test_auxiliary_client_resolve_dedup.py
@@ -1,0 +1,52 @@
+"""Tests for resolve_provider_client fall-through log dedup (salvage #56283).
+
+Both fall-through branches (unknown provider, unhandled auth_type) were demoted
+from ``logger.warning`` to ``logger.debug`` with per-process dedup: the first
+occurrence surfaces for diagnostics; identical repeats are suppressed for the
+lifetime of the process so a retry loop can't spam the logs.
+"""
+
+import logging
+
+import agent.auxiliary_client as ac
+from agent.auxiliary_client import resolve_provider_client
+
+
+class TestUnknownProviderDedup:
+    def setup_method(self):
+        ac._LOGGED_UNKNOWN_PROVIDER_KEYS.clear()
+
+    def test_unknown_provider_logs_debug_once_not_warning(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+            client, model = resolve_provider_client("no_such_provider_xyz", "")
+        assert (client, model) == (None, None)
+        recs = [
+            r for r in caplog.records
+            if "unknown provider" in r.getMessage()
+        ]
+        # Exactly one record, and it is DEBUG (never WARNING).
+        assert len(recs) == 1
+        assert recs[0].levelno == logging.DEBUG
+        assert not any(r.levelno >= logging.WARNING for r in recs)
+
+    def test_unknown_provider_repeat_is_suppressed(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+            resolve_provider_client("no_such_provider_xyz", "")
+            resolve_provider_client("no_such_provider_xyz", "")
+            resolve_provider_client("no_such_provider_xyz", "")
+        recs = [
+            r for r in caplog.records
+            if "unknown provider" in r.getMessage()
+        ]
+        # Three calls, one log line — dedup suppressed the repeats.
+        assert len(recs) == 1
+
+    def test_distinct_unknown_providers_each_log_once(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+            resolve_provider_client("bogus_a", "")
+            resolve_provider_client("bogus_b", "")
+        recs = [
+            r for r in caplog.records
+            if "unknown provider" in r.getMessage()
+        ]
+        assert len(recs) == 2

--- a/tests/agent/test_auxiliary_client_resolve_dedup.py
+++ b/tests/agent/test_auxiliary_client_resolve_dedup.py
@@ -50,3 +50,69 @@ class TestUnknownProviderDedup:
             if "unknown provider" in r.getMessage()
         ]
         assert len(recs) == 2
+
+
+class TestUnhandledAuthTypeDedup:
+    def setup_method(self):
+        ac._LOGGED_UNHANDLED_AUTHTYPE_KEYS.clear()
+
+    def test_unhandled_auth_type_logs_debug_once_not_warning(self, caplog, monkeypatch):
+        import hermes_cli.auth as auth
+        from hermes_cli.auth import ProviderConfig
+
+        # A registered provider whose auth_type matches no handled branch →
+        # the terminal "unhandled auth_type" fall-through.
+        bogus = ProviderConfig(
+            id="bogus_authtype",
+            name="Bogus",
+            auth_type="totally_unhandled_scheme",
+        )
+        patched = dict(auth.PROVIDER_REGISTRY)
+        patched["bogus_authtype"] = bogus
+        monkeypatch.setattr(auth, "PROVIDER_REGISTRY", patched)
+
+        with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+            client, model = resolve_provider_client("bogus_authtype", "")
+            resolve_provider_client("bogus_authtype", "")  # repeat → suppressed
+
+        assert (client, model) == (None, None)
+        recs = [
+            r for r in caplog.records
+            if "unhandled auth_type" in r.getMessage()
+        ]
+        # Two calls, one DEBUG record, never WARNING.
+        assert len(recs) == 1
+        assert recs[0].levelno == logging.DEBUG
+        assert not any(r.levelno >= logging.WARNING for r in recs)
+
+
+class TestUnsupportedOAuthDedup:
+    def setup_method(self):
+        ac._LOGGED_UNSUPPORTED_OAUTH_KEYS.clear()
+
+    def test_unsupported_oauth_provider_logs_debug_once(self, caplog, monkeypatch):
+        import hermes_cli.auth as auth
+        from hermes_cli.auth import ProviderConfig
+
+        # A registered oauth_* provider that is not one of the directly-handled
+        # names (nous / openai-codex / xai-oauth) → the OAuth dead-end branch.
+        bogus = ProviderConfig(
+            id="bogus_oauth",
+            name="BogusOAuth",
+            auth_type="oauth_device_code",
+        )
+        patched = dict(auth.PROVIDER_REGISTRY)
+        patched["bogus_oauth"] = bogus
+        monkeypatch.setattr(auth, "PROVIDER_REGISTRY", patched)
+
+        with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+            resolve_provider_client("bogus_oauth", "")
+            resolve_provider_client("bogus_oauth", "")
+
+        recs = [
+            r for r in caplog.records
+            if "OAuth provider" in r.getMessage() and "not " in r.getMessage()
+        ]
+        assert len(recs) == 1
+        assert recs[0].levelno == logging.DEBUG
+        assert not any(r.levelno >= logging.WARNING for r in recs)


### PR DESCRIPTION
Salvage of the stated fix from #56283 (@fjventura20), rebased onto current main.

## Issue
The two fall-through branches in `resolve_provider_client` (unknown provider, unhandled auth_type) logged at `WARNING` on **every retry** of a misconfigured provider, spamming logs during retry loops.

## Fix
Demote both to `logger.debug` with per-process dedup: the **first** occurrence still surfaces (a provider-name typo or PROVIDER_REGISTRY/auth_type-drift bug is worth seeing once), while identical repeats are suppressed for the process lifetime. Two independent dedup sets keep each branch linear.

## Scope note
The original #56283 bundled **~2800 lines across 10 unrelated files** (AGENTS.md, memory_monitor, kanban_db, telegram adapter, hermes_logging + test files) under this title, with machine-authored (`kanban-worker@hermes.local`) commits and task-workspace paths in the body. This salvage extracts **only** the auxiliary_client log-demotion the title describes; the unrelated changes are dropped.

## Verification
New test file: unknown provider logs DEBUG once (never WARNING), repeats suppressed, distinct providers each log once. Mutation-checked: reverting the demotion+dedup fails the level and suppression assertions.

Supersedes #56283.

Co-authored-by: fjventura20 <fjventura20@users.noreply.github.com>