### PR TITLE
fix(telegram): preserve args after command bot suffix

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6546,8 +6546,22 @@ class TelegramAdapter(BasePlatformAdapter):
     def _clean_bot_trigger_text(self, text: Optional[str]) -> Optional[str]:
         if not text or not self._bot or not getattr(self._bot, "username", None):
             return text
-        username = re.escape(self._bot.username)
-        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
+        username = re.escape(str(self._bot.username).lstrip("@"))
+
+        # Telegram group command menus address bots as /cmd@BotName args.
+        # Removing the @BotName suffix plus following whitespace directly would
+        # collapse the command and its first argument into /cmdargs. Preserve one
+        # separator when there is text after the bot suffix.
+        command_suffix = re.compile(
+            rf"(?i)(?P<cmd>/[a-z0-9_]+)@{username}\b[,:\-]*\s*"
+        )
+
+        def _strip_command_suffix(match: re.Match) -> str:
+            rest = text[match.end():]
+            return f"{match.group('cmd')} " if rest.strip() else match.group("cmd")
+
+        cleaned = command_suffix.sub(_strip_command_suffix, text)
+        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", cleaned).strip()
         return cleaned or text
 
     def _should_observe_unmentioned_group_message(self, message: Message) -> bool:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -225,6 +225,24 @@ def test_observed_group_context_uses_shared_source_and_prompt_for_later_mentions
     asyncio.run(_run())
 
 
+def test_clean_bot_trigger_text_preserves_command_args_after_bot_suffix():
+    adapter = _make_adapter(bot_username="LynxBot")
+
+    assert adapter._clean_bot_trigger_text("/reasoning@LynxBot medium") == "/reasoning medium"
+
+
+def test_clean_bot_trigger_text_preserves_command_args_after_bot_suffix_with_punctuation():
+    adapter = _make_adapter(bot_username="LynxBot")
+
+    assert adapter._clean_bot_trigger_text("/reasoning@LynxBot: high --global") == "/reasoning high --global"
+
+
+def test_clean_bot_trigger_text_keeps_bare_command_suffix_compact():
+    adapter = _make_adapter(bot_username="LynxBot")
+
+    assert adapter._clean_bot_trigger_text("/new@LynxBot") == "/new"
+
+
 def test_observed_group_context_replays_as_current_message_context_not_user_turns():
     from gateway.run import (
         _build_gateway_agent_history,

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -243,6 +243,18 @@ def test_clean_bot_trigger_text_keeps_bare_command_suffix_compact():
     assert adapter._clean_bot_trigger_text("/new@LynxBot") == "/new"
 
 
+def test_clean_bot_trigger_text_keeps_other_bot_command_suffix():
+    adapter = _make_adapter(bot_username="LynxBot")
+
+    assert adapter._clean_bot_trigger_text("/reasoning@OtherBot medium") == "/reasoning@OtherBot medium"
+
+
+def test_clean_bot_trigger_text_still_strips_leading_bot_mention():
+    adapter = _make_adapter(bot_username="LynxBot")
+
+    assert adapter._clean_bot_trigger_text("@LynxBot what did Alice say?") == "what did Alice say?"
+
+
 def test_observed_group_context_replays_as_current_message_context_not_user_turns():
     from gateway.run import (
         _build_gateway_agent_history,


### PR DESCRIPTION
## Summary

- preserve a separator when Telegram command mentions are stripped from `/cmd@BotName args`
- keep bare command mentions unchanged (`/new@BotName` -> `/new`)
- add regression coverage for `/reasoning@BotName medium` and punctuation variants

Fixes #56337.

## Test Plan

- `python -m pytest tests/gateway/test_telegram_group_gating.py -q -o 'addopts='`