### PR TITLE
fix(auxiliary_client): demote resolve_provider_client fall-throughs to debug with dedup (salvage #56283)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -110,6 +110,18 @@ from utils import base_url_host_matches, base_url_hostname, env_float, model_for
 logger = logging.getLogger(__name__)
 
 
+# ── resolve_provider_client dedup ────────────────────────────────────────
+# Both warning sites in resolve_provider_client (the "unknown provider" and
+# "unhandled auth_type" fall-throughs) are demoted to logger.debug so they
+# don't spam logs on every retry loop. The first occurrence still surfaces —
+# that one carries real diagnostic value (typo in a provider name, or a
+# PROVIDER_REGISTRY / auth_type drift bug). Subsequent identical messages are
+# suppressed for the lifetime of the process. Two independent sets keep each
+# per-call branch linear and let each be cleared independently by tests.
+_LOGGED_UNKNOWN_PROVIDER_KEYS: set = set()
+_LOGGED_UNHANDLED_AUTHTYPE_KEYS: set = set()
+
+
 def _openai_http_client_kwargs(
     base_url: Optional[str],
     *,
@@ -4336,7 +4348,11 @@ def resolve_provider_client(
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig is None:
-        logger.warning("resolve_provider_client: unknown provider %r", provider)
+        # Demoted from logger.warning to debug; dedup keyed by provider name
+        # so the first occurrence surfaces but repeated retries stay silent.
+        if provider not in _LOGGED_UNKNOWN_PROVIDER_KEYS:
+            _LOGGED_UNKNOWN_PROVIDER_KEYS.add(provider)
+            logger.debug("resolve_provider_client: unknown provider %r", provider)
         return None, None
 
     if pconfig.auth_type == "api_key":
@@ -4528,8 +4544,14 @@ def resolve_provider_client(
                        "directly supported, try 'auto'", provider)
         return None, None
 
-    logger.warning("resolve_provider_client: unhandled auth_type %s for %s",
-                   pconfig.auth_type, provider)
+    # Demoted from logger.warning to debug; dedup keyed on (auth_type,
+    # provider) so the first occurrence surfaces (real schema-drift bug)
+    # but per-call retries stay silent.
+    _auth_dedup_key = (pconfig.auth_type, provider)
+    if _auth_dedup_key not in _LOGGED_UNHANDLED_AUTHTYPE_KEYS:
+        _LOGGED_UNHANDLED_AUTHTYPE_KEYS.add(_auth_dedup_key)
+        logger.debug("resolve_provider_client: unhandled auth_type %s for %s",
+                     pconfig.auth_type, provider)
     return None, None
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4932,3 +4932,42 @@ class TestCompressionFallbackContextFilter:
         # Empty / unknown tasks have no minimum
         assert _task_minimum_context_length("") is None
         assert _task_minimum_context_length(None) is None
+
+
+class TestResolveProviderClientWarningDedup:
+    """resolve_provider_client fall-throughs are demoted to DEBUG + deduped so
+    they don't spam logs on every retry, but the first occurrence still surfaces
+    (regression salvage of #56283)."""
+
+    def _reset_dedup(self):
+        import agent.auxiliary_client as ac
+        ac._LOGGED_UNKNOWN_PROVIDER_KEYS.clear()
+        ac._LOGGED_UNHANDLED_AUTHTYPE_KEYS.clear()
+
+    def test_unknown_provider_debug_not_warning_and_deduped(self, caplog):
+        self._reset_dedup()
+        with patch("hermes_cli.auth.PROVIDER_REGISTRY", {}):
+            with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+                r1 = resolve_provider_client("totally-made-up-provider")
+                r2 = resolve_provider_client("totally-made-up-provider")
+        assert r1 == (None, None) and r2 == (None, None)
+        recs = [r for r in caplog.records if "unknown provider" in r.getMessage()]
+        # First occurrence surfaces at DEBUG; the repeat is suppressed.
+        assert len(recs) == 1
+        assert recs[0].levelno == logging.DEBUG
+        # No WARNING-level record for this path.
+        assert not [r for r in caplog.records
+                    if "unknown provider" in r.getMessage() and r.levelno >= logging.WARNING]
+
+    def test_unhandled_auth_type_debug_not_warning_and_deduped(self, caplog):
+        self._reset_dedup()
+        fake = SimpleNamespace(auth_type="some-unhandled-auth-type")
+        with patch("hermes_cli.auth.PROVIDER_REGISTRY", {"fakeprov": fake}):
+            with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+                resolve_provider_client("fakeprov")
+                resolve_provider_client("fakeprov")
+        recs = [r for r in caplog.records if "unhandled auth_type" in r.getMessage()]
+        assert len(recs) == 1
+        assert recs[0].levelno == logging.DEBUG
+        assert not [r for r in caplog.records
+                    if "unhandled auth_type" in r.getMessage() and r.levelno >= logging.WARNING]


### PR DESCRIPTION
## Summary

Salvage of #56283 by @fjventura20 — **extracted to the intended fix only**. The original branch carried +2864/-114 across 11 files (a 10-commit batch mixed in, `CONFLICTING`, and authored under a generic `Kanban Worker` identity). This salvage carries **only** the ~31-line `auxiliary_client.py` change the PR title describes, re-authored to @fjventura20, plus a regression test.

## The bug

`agent/auxiliary_client.py::resolve_provider_client` logs `logger.warning` on two graceful `return None, None` fall-throughs — "unknown provider" and "unhandled auth_type". Both are auxiliary paths (title generation, compression summaries) that the caller handles by degrading, and both fire on **every retry loop**, spamming logs. The real failure surfaces on the main client path (callers check the `None` return and raise/branch), so a per-retry WARNING here is noise, not signal.

## The fix

Demote both to `logger.debug` with per-process dedup — the **first** occurrence still surfaces at DEBUG (real diagnostic value: provider typo, `PROVIDER_REGISTRY`/auth_type drift), and repeats are suppressed. Two module-level sets: `_LOGGED_UNKNOWN_PROVIDER_KEYS` (keyed by provider) and `_LOGGED_UNHANDLED_AUTHTYPE_KEYS` (keyed by `(auth_type, provider)`).

## Review

Ran hermes-agent-dev + hermes-pr-review Phase 2c — 0 Critical / 0 Warnings:
- **Extraction faithful:** diff touches exactly 2 files (`auxiliary_client.py` + test); none of the 10 unrelated files from the tangled original.
- **Demotion correct:** verified both sites are graceful fall-throughs that don't swallow a fatal condition, and the real error still surfaces at all callers (openrouter_client raises `ValueError`; mini_swe_runner falls back; trajectory_compressor / chat_completion_helpers branch on `client is None`) — so demoting the aux log doesn't hide failure.
- **Dedup bounded/benign:** sets are keyed by a small, finite space (provider names / (auth_type, provider) pairs); a concurrent-`add` race worst-case emits one duplicate DEBUG line — harmless.
- **Test genuine (mutation-verified):** asserts first occurrence at DEBUG, repeat suppressed, no WARNING-level record; reverting the demotion fails the test.

Non-blocking follow-up noted for maintainers: a shared `log_once` util could dedupe this dedup pattern across the codebase.

## Tests

```text
pytest tests/agent/test_auxiliary_client.py -q   # 277 passed (CI runs the full suite)
```

Supersedes #56283 (carrying only the focused fix, not the 10-commit batch). Full credit to @fjventura20.
