### PR TITLE
fix(moa): allow a user interrupt to abort the reference fan-out wait

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -762,6 +762,7 @@ def init_agent(
         agent.client = MoAClient(
             agent.model or "default",
             reference_callback=_moa_reference_relay,
+            agent=agent,
         )
         agent._client_kwargs = {}
         agent.api_key = api_key or "moa-virtual-provider"

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1733,7 +1733,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.api_key = api_key or "moa-virtual-provider"
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
-            agent.client = MoAClient(agent.model or "default")
+            agent.client = MoAClient(agent.model or "default", agent=agent)
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -856,6 +856,7 @@ def run_conversation(
                     aggregator=moa_config.get("aggregator") or {},
                     temperature=float(moa_config.get("reference_temperature", 0.6) or 0.6),
                     aggregator_temperature=float(moa_config.get("aggregator_temperature", 0.4) or 0.4),
+                    agent=agent,
                 )
                 if _moa_context:
                     for _msg in reversed(api_messages):

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, wait as _futures_wait
 from typing import Any
 
 from agent.auxiliary_client import call_llm
@@ -277,12 +277,16 @@ def _run_reference(
         )
 
 
+_REFERENCE_POLL_INTERVAL_S = 5.0
+
+
 def _run_references_parallel(
     reference_models: list[dict[str, str]],
     ref_messages: list[dict[str, Any]],
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    agent: Any = None,
 ) -> list[tuple[str, str, Any]]:
     """Fan out all reference models in parallel, returning outputs in order.
 
@@ -293,7 +297,22 @@ def _run_references_parallel(
     another MoA preset are skipped here (recursion guard) with a labelled note.
 
     Each element is ``(label, text, usage)`` where usage is a
-    ``CanonicalUsage`` (zeroed for skipped/failed references).
+    ``CanonicalUsage`` (zeroed for skipped/failed/interrupted references).
+
+    When *agent* is given, the fan-out is interruptible: waiting for the
+    batch is broken into ``_REFERENCE_POLL_INTERVAL_S``-second polls (instead
+    of one blocking ``future.result()`` per reference) so a user interrupt
+    mid-turn can abort the wait — mirroring the same interrupt check
+    ``agent.tool_executor`` already applies to its own concurrent tool
+    batch. This does not add or change any per-reference *timeout* (that is
+    ``auxiliary.moa_reference.timeout``, out of scope here) — it only lets
+    the caller stop waiting early. References already in flight cannot be
+    forcibly killed (``call_llm`` is a blocking HTTP call with no interrupt
+    hook of its own, same limitation tool_executor has for tools without an
+    interrupt check); an interrupted reference's own timeout still reaps its
+    thread independently. *agent* is optional and defaults to ``None``,
+    preserving today's uninterruptible blocking behavior for any caller that
+    doesn't pass it.
     """
     from agent.usage_pricing import CanonicalUsage
 
@@ -301,9 +320,11 @@ def _run_references_parallel(
         return []
 
     results: list[tuple[str, str, Any] | None] = [None] * len(reference_models)
-    futures = {}
+    futures: dict[Any, int] = {}
     workers = min(_MAX_REFERENCE_WORKERS, len(reference_models))
-    with ThreadPoolExecutor(max_workers=workers) as executor:
+    executor = ThreadPoolExecutor(max_workers=workers)
+    interrupted = False
+    try:
         for idx, slot in enumerate(reference_models):
             if slot.get("provider") == "moa":
                 results[idx] = (
@@ -321,10 +342,45 @@ def _run_references_parallel(
                     max_tokens=max_tokens,
                 )
             ] = idx
+
         # Collect every reference before returning — the aggregator needs the
-        # complete set, so there is no early-exit / first-completed path here.
-        for future, idx in futures.items():
-            results[idx] = future.result()
+        # complete set, so there is no early-exit / first-completed path
+        # here, other than a user interrupt.
+        pending = set(futures)
+        while pending:
+            done, pending = _futures_wait(pending, timeout=_REFERENCE_POLL_INTERVAL_S)
+            for future in done:
+                results[futures[future]] = future.result()
+            if not pending:
+                break
+            if agent is not None and getattr(agent, "_interrupt_requested", False):
+                interrupted = True
+                break
+
+        if interrupted:
+            for future, idx in futures.items():
+                if results[idx] is not None:
+                    continue
+                if future.cancel():
+                    results[idx] = (
+                        _slot_label(reference_models[idx]),
+                        "[skipped: interrupted by user]",
+                        _RefAccounting(CanonicalUsage()),
+                    )
+                elif future.done():
+                    # Finished between the interrupt check and now.
+                    results[idx] = future.result()
+                else:
+                    # Already running — cannot be force-killed (see
+                    # docstring); leave it be so the caller isn't blocked,
+                    # and note that its output was abandoned.
+                    results[idx] = (
+                        _slot_label(reference_models[idx]),
+                        "[skipped: interrupted by user]",
+                        _RefAccounting(CanonicalUsage()),
+                    )
+    finally:
+        executor.shutdown(wait=not interrupted, cancel_futures=interrupted)
 
     return [r for r in results if r is not None]
 
@@ -499,6 +555,7 @@ def aggregate_moa_context(
     temperature: float = 0.6,
     aggregator_temperature: float = 0.4,
     max_tokens: int | None = None,
+    agent: Any = None,
 ) -> str:
     """Run configured reference models and synthesize their advice.
 
@@ -510,6 +567,9 @@ def aggregate_moa_context(
     the parameter entirely when it is ``None`` (see its docstring), which also
     sidesteps providers that reject ``max_tokens`` outright. A hardcoded cap
     here previously truncated long aggregator syntheses.
+
+    ``agent``, when passed, lets the reference fan-out be aborted early on a
+    user interrupt — see ``_run_references_parallel``'s docstring.
     """
     reference_outputs: list[tuple[str, str, Any]] = []
     ref_messages = _reference_messages(api_messages)
@@ -518,6 +578,7 @@ def aggregate_moa_context(
         ref_messages,
         temperature=temperature,
         max_tokens=max_tokens,
+        agent=agent,
     )
 
     joined = "\n\n".join(
@@ -586,7 +647,7 @@ def _attach_reference_guidance(agg_messages: list[dict[str, Any]], guidance: str
 class MoAChatCompletions:
     """OpenAI-chat-compatible facade where the aggregator is the acting model."""
 
-    def __init__(self, preset_name: str, reference_callback: Any = None):
+    def __init__(self, preset_name: str, reference_callback: Any = None, agent: Any = None):
         self.preset_name = preset_name or "default"
         # Optional display hook. Called as reference outputs become available so
         # frontends can show each reference model's answer as a labelled block
@@ -597,6 +658,11 @@ class MoAChatCompletions:
         #   "moa.aggregating" kwargs: aggregator (label), ref_count
         # Never raises into the model call — display is best-effort.
         self.reference_callback = reference_callback
+        # Back-reference to the owning AIAgent, so the reference fan-out can
+        # check agent._interrupt_requested (see _run_references_parallel).
+        # Optional — a caller that doesn't pass it just keeps the fan-out
+        # uninterruptible, as it was before.
+        self._agent = agent
         # State-scoped reference cache. The agent loop calls create() once per
         # tool-loop iteration; references should re-run whenever the task STATE
         # advances — i.e. on every new user message AND every new tool result —
@@ -736,6 +802,7 @@ class MoAChatCompletions:
                 ref_messages,
                 temperature=temperature,
                 max_tokens=None,
+                agent=self._agent,
             )
             self._ref_cache_key = _cache_key
             self._ref_cache_outputs = list(reference_outputs)
@@ -873,9 +940,11 @@ class MoAChatCompletions:
 
 
 class MoAClient:
-    def __init__(self, preset_name: str, reference_callback: Any = None):
+    def __init__(self, preset_name: str, reference_callback: Any = None, agent: Any = None):
         self.chat = type("_MoAChat", (), {})()
-        self.chat.completions = MoAChatCompletions(preset_name, reference_callback=reference_callback)
+        self.chat.completions = MoAChatCompletions(
+            preset_name, reference_callback=reference_callback, agent=agent,
+        )
 
     def consume_reference_usage(self) -> Any:
         """Pop the pending reference-fan-out usage from the completions facade.

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -574,6 +574,82 @@ def test_references_run_in_parallel(monkeypatch):
     assert out[0][1] == "resp-p1"
 
 
+def test_references_parallel_without_agent_is_unaffected(monkeypatch):
+    """No agent passed (the pre-fix call shape) must behave exactly as
+    before: block until every reference completes, no interrupt check."""
+    import time
+
+    from agent import moa_loop
+
+    monkeypatch.setattr(moa_loop, "get_transport", lambda *_a, **_k: None)
+    # Poll interval shorter than the reference's own sleep so the assertion
+    # below would catch a regression that waits a whole poll cycle extra.
+    monkeypatch.setattr(moa_loop, "_REFERENCE_POLL_INTERVAL_S", 0.05)
+
+    def slow_call_llm(**kwargs):
+        time.sleep(0.2)
+        return _response(f"resp-{kwargs['provider']}")
+
+    monkeypatch.setattr(moa_loop, "call_llm", slow_call_llm)
+
+    refs = [{"provider": "p1", "model": "ok"}]
+    out = moa_loop._run_references_parallel(
+        refs, [{"role": "user", "content": "hi"}],
+    )
+
+    assert out[0][1] == "resp-p1"
+
+
+def test_references_parallel_interrupt_aborts_wait(monkeypatch):
+    """A user interrupt mid-fanout must stop the wait instead of blocking
+    until every reference (including a wedged one) finishes or times out on
+    its own — mirroring the interrupt check agent.tool_executor already
+    applies to its own concurrent tool batch."""
+    import threading
+    import time
+
+    from agent import moa_loop
+
+    monkeypatch.setattr(moa_loop, "get_transport", lambda *_a, **_k: None)
+    monkeypatch.setattr(moa_loop, "_REFERENCE_POLL_INTERVAL_S", 0.05)
+
+    fake_agent = SimpleNamespace(_interrupt_requested=False)
+    release_wedged = threading.Event()
+
+    def fake_call_llm(**kwargs):
+        if kwargs["provider"] == "fast":
+            # Simulate the interrupt arriving right after the fast reference
+            # finishes, while the wedged one is still in flight.
+            fake_agent._interrupt_requested = True
+            return _response("fast output")
+        # "wedged" — never returns within the test unless released, standing
+        # in for a reference whose own (possibly very long) timeout hasn't
+        # elapsed yet.
+        release_wedged.wait(timeout=5)
+        return _response("should not be observed")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+
+    refs = [
+        {"provider": "fast", "model": "m1"},
+        {"provider": "wedged", "model": "m2"},
+    ]
+    try:
+        start = time.monotonic()
+        out = moa_loop._run_references_parallel(
+            refs, [{"role": "user", "content": "hi"}], agent=fake_agent,
+        )
+        elapsed = time.monotonic() - start
+
+        # Must return promptly once interrupted, not block for the wedged
+        # reference's full (5s test-simulated) duration.
+        assert elapsed < 2.0, f"interrupt did not abort the wait (took {elapsed:.2f}s)"
+        assert out[0][1] == "fast output"
+        assert "interrupted" in out[1][1]
+    finally:
+        release_wedged.set()  # don't leak a blocked thread past the test
+
+
 def _ref_config(home):
     home.mkdir()
     (home / "config.yaml").write_text(


### PR DESCRIPTION
## Summary

`agent/tool_executor.py`'s concurrent tool-call batch checks `agent._interrupt_requested` on every poll cycle and aborts the wait early — but `agent/moa_loop.py::_run_references_parallel` (the MoA reference-model fan-out, whether references run alongside the main model via `aggregate_moa_context`, or the MoA preset itself is the acting model via `MoAClient`/`MoAChatCompletions`) had no equivalent. It blocked on `ThreadPoolExecutor` + `future.result()` per reference with no way to abort mid-wait — a user who wants to stop a live MoA turn (Ctrl-C / stop button) had to wait for every reference to finish or hit its own individual `auxiliary.moa_reference` timeout, which can mean minutes of an unresponsive turn.

## Fix

Threaded an optional `agent` parameter through the call chain so the fan-out can check `agent._interrupt_requested`:

- `agent/moa_loop.py::_run_references_parallel`: replaced the single blocking `future.result()` collection loop with a poll loop (`concurrent.futures.wait(..., timeout=_REFERENCE_POLL_INTERVAL_S)`, 5s slices) that checks `agent._interrupt_requested` each cycle. On interrupt: not-yet-started futures are cancelled, still-running ones are left alone (a blocking `call_llm` HTTP call can't be force-killed from another thread — same limitation `tool_executor.py` accepts for tools without their own interrupt hook) but no longer block the caller, and the executor is shut down with `cancel_futures=True`.
- `agent/moa_loop.py::aggregate_moa_context`: accepts and forwards `agent`.
- `agent/conversation_loop.py::run_conversation`: passes `agent=agent` to `aggregate_moa_context`.
- `agent/moa_loop.py::MoAChatCompletions`/`MoAClient`: accept and store an optional `agent` back-reference, forwarded to `_run_references_parallel` from `create()`.
- `agent/agent_init.py` / `agent/agent_runtime_helpers.py`: pass `agent=agent` at the two `MoAClient(...)` construction sites (main-model-is-MoA-preset path).

**Deliberately scoped to interrupt/cancel only** — no new or changed timeout value, so this doesn't overlap open PRs #53784 ("sanitize failed reference outputs and add per-preset timeout") or #53875 ("lower auxiliary default timeouts"), both of which only touch the per-reference timeout *value*, not interrupt handling. `agent` is optional and defaults to `None` everywhere, so any caller that doesn't pass it (existing tests included) keeps today's uninterruptible blocking behavior unchanged — this is a strictly additive, backward-compatible change.

## Test plan

- [x] `pytest tests/run_agent/test_moa_loop_mode.py -q -k "references_parallel or references_run_in_parallel"` — 4 passed: existing parallel-execution test unaffected, new "no agent passed → unaffected" regression test, new "interrupt mid-fanout aborts the wait without blocking for a wedged reference" test (asserts elapsed time and that the wedged slot gets an `"interrupted by user"` marker while the already-finished one keeps its real output)
- [x] `pytest tests/run_agent/test_moa_loop_mode.py tests/run_agent/test_moa_streaming.py -q` — 36 passed
- [x] `pytest tests/run_agent/ -q` (full suite, includes the real end-to-end `AIAgent` + `MoAClient` construction test) — 1857 passed, 3 skipped
- [x] `ruff check` on all changed files — clean