### PR TITLE
fix(gateway): pairing store cannot bypass configured allowlist

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -417,10 +417,17 @@ class GatewayAuthorizationMixin:
         if getattr(source, "role_authorized", False) is True:
             return True
 
-        # Check pairing store (always checked, regardless of allowlists)
+        # Pairing store membership. Recorded here but NOT returned yet: if an
+        # allowlist is configured, a previously-paired user must STILL be in
+        # that allowlist to be honored. Otherwise a user who tapped "Always" on
+        # an approval button could permanently bypass TELEGRAM_ALLOWED_USERS (or
+        # equivalent) via the pairing store even after being removed from the
+        # allowlist (issue #23778). When no allowlist is configured, pairing is
+        # the intended access path and is honored in the no-allowlist branch
+        # below; when an allowlist IS configured, the pairing entry only counts
+        # if the user is also in it (folded into the final membership check).
         platform_name = source.platform.value if source.platform else ""
-        if self.pairing_store.is_approved(platform_name, user_id):
-            return True
+        is_paired = self.pairing_store.is_approved(platform_name, user_id)
 
         # Check platform-specific and global allowlists
         platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
@@ -432,6 +439,11 @@ class GatewayAuthorizationMixin:
         global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
+            # No env allowlist configured. A pairing-store entry is the intended
+            # access path here (the user completed the pairing handshake), so
+            # honor it — there is no allowlist to re-validate against.
+            if is_paired:
+                return True
             # No env allowlist configured. Adapters that own their own
             # config-driven access policy (dm_policy / group_policy /
             # allow_from / group_allow_from) gate access at intake, so for those

--- a/tests/gateway/test_pairing_allowlist_bypass.py
+++ b/tests/gateway/test_pairing_allowlist_bypass.py
@@ -1,0 +1,108 @@
+"""Regression guard: pairing store must not bypass a configured allowlist (#23778).
+
+A user who tapped "Always" on an approval button gets a pairing-store entry.
+Before the fix, ``_is_user_authorized()`` returned True from the pairing store
+BEFORE the allowlist was ever consulted, so a paired-but-not-allowed user
+permanently bypassed ``TELEGRAM_ALLOWED_USERS`` (or equivalent) even after being
+removed from the allowlist. The fix records pairing membership but only honors
+it when no allowlist is configured; when an allowlist IS configured, the paired
+user must still appear in it.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.session import Platform, SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for var in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_runner(*, paired: bool):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: paired)
+    return runner
+
+
+def _make_source(user_id: str = "attacker42", chat_type: str = "dm"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name="SomeHuman",
+        is_bot=False,
+    )
+
+
+def test_paired_user_denied_when_not_in_platform_allowlist(monkeypatch):
+    """The core bypass: paired but absent from TELEGRAM_ALLOWED_USERS → denied."""
+    runner = _make_runner(paired=True)
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1,owner2")
+
+    assert runner._is_user_authorized(_make_source("attacker42")) is False
+
+
+def test_paired_user_denied_when_not_in_global_allowlist(monkeypatch):
+    runner = _make_runner(paired=True)
+    monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "owner1,owner2")
+
+    assert runner._is_user_authorized(_make_source("attacker42")) is False
+
+
+def test_paired_user_allowed_when_still_in_platform_allowlist(monkeypatch):
+    """A paired user who is also in the allowlist stays authorized."""
+    runner = _make_runner(paired=True)
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1,attacker42")
+
+    assert runner._is_user_authorized(_make_source("attacker42")) is True
+
+
+def test_paired_user_allowed_when_still_in_global_allowlist(monkeypatch):
+    runner = _make_runner(paired=True)
+    monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "owner1,attacker42")
+
+    assert runner._is_user_authorized(_make_source("attacker42")) is True
+
+
+def test_paired_user_allowed_with_wildcard_allowlist(monkeypatch):
+    """A "*" allowlist means everyone; a paired user is honored."""
+    runner = _make_runner(paired=True)
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "*")
+
+    assert runner._is_user_authorized(_make_source("attacker42")) is True
+
+
+def test_paired_user_allowed_when_no_allowlist_configured(monkeypatch):
+    """No allowlist configured → pairing is the intended access path, honored."""
+    runner = _make_runner(paired=True)
+
+    assert runner._is_user_authorized(_make_source("attacker42")) is True
+
+
+def test_unpaired_user_denied_when_no_allowlist_configured(monkeypatch):
+    """No allowlist and not paired → default-deny (no fail-open)."""
+    runner = _make_runner(paired=False)
+
+    assert runner._is_user_authorized(_make_source("randouser")) is False
+
+
+def test_unpaired_user_in_allowlist_still_allowed(monkeypatch):
+    """Pairing changes did not regress the plain allowlist path."""
+    runner = _make_runner(paired=False)
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1")
+
+    assert runner._is_user_authorized(_make_source("owner1")) is True


### PR DESCRIPTION
## Summary

A configured allowlist can no longer be silently bypassed by a stale pairing-store entry — a paired user must still be in the allowlist to be authorized.

Root cause: `_is_user_authorized()` checked the pairing store BEFORE the allowlist and returned `True` unconditionally. A user who tapped **Always** on an approval button got a pairing entry that permanently bypassed `TELEGRAM_ALLOWED_USERS` (or equivalent) — even after being removed from the allowlist (#23778).

## Changes

- `gateway/authz_mixin.py`: record pairing membership (`is_paired`) instead of returning early. Honor it only in the no-allowlist branch (pairing is the intended access path on an open gateway). When an allowlist IS configured, the paired user must appear in the canonical `allowed_ids` set — reusing the existing logic that resolves WhatsApp aliases, SimpleX names, group allowlists, and the `*` wildcard. Pairing grants no extra access.
- `tests/gateway/test_pairing_allowlist_bypass.py`: 8 regression tests covering the bypass, wildcard, global allowlist, no-allowlist pairing, and no-fail-open cases.

## Validation

| Scenario | Before | After |
|---|---|---|
| Paired attacker, `TELEGRAM_ALLOWED_USERS=owner` | authorized (bypass) | **denied** |
| Paired owner, `TELEGRAM_ALLOWED_USERS=owner` | authorized | authorized |
| Paired user, no allowlist configured | authorized | authorized |
| Unpaired user, no allowlist configured | denied | denied (no fail-open) |

58/58 gateway pairing + auth-bypass tests pass; E2E replay of the exact #23778 scenario confirmed with real imports.

Salvaged from #47736 (rebase of #23805) by @ygd58; the inline membership check was rewritten to reuse the existing allowlist logic for a single source of truth.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa07f65/TMie47qqyjeOh7ZxxTdCO_EWhlnO0m.png)
