### PR TITLE
fix(gateway): validate user authorization before auto-resume

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6068,6 +6068,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 continue
 
+            # Validate the session owner against the current allowlist
+            # before auto-resuming. A session created before
+            # TELEGRAM_ALLOWED_USERS (or equivalent) was configured, or
+            # before the owner was removed from it, must not silently
+            # receive a full agent response on gateway restart just
+            # because it has a resume-pending marker (issue #23778).
+            try:
+                if not self._is_user_authorized(source):
+                    logger.warning(
+                        "Skipping auto-resume for %s: session owner is no "
+                        "longer authorized under the current allowlist",
+                        entry.session_key,
+                    )
+                    continue
+            except Exception as exc:
+                logger.warning(
+                    "Skipping auto-resume for %s: authorization check failed: %s",
+                    entry.session_key, exc,
+                )
+                continue
+
             # Claim the session slot *before* spawning the task so that an
             # inbound message arriving between task creation and the task's
             # first await (where _process_message_background sets the real

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1192,6 +1192,84 @@ async def test_startup_auto_resume_skips_disallowed_reasons():
 
 
 @pytest.mark.asyncio
+async def test_startup_auto_resume_skips_unauthorized_owner():
+    """A resume-pending session whose owner is no longer authorized under the
+    current allowlist must not receive a synthesized agent turn on restart.
+
+    Auto-resume dispatches a full agent turn without going through the normal
+    inbound-message auth gate, so it re-checks _is_user_authorized here
+    (issue #23778).  An unauthorized owner is skipped WITHOUT claiming a
+    _running_agents slot or persisting one — the slot claim happens only
+    after this gate passes.
+    """
+    runner, adapter = make_restart_runner()
+    runner._is_user_authorized = lambda _source: False
+    runner._persist_active_agents = MagicMock()
+    source = make_restart_source(chat_id="revoked-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:revoked-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    # No slot was claimed and nothing was persisted for the skipped session.
+    assert pending_entry.session_key not in runner._running_agents
+    runner._persist_active_agents.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_fails_closed_on_auth_error():
+    """If the authorization check itself raises, the session is skipped
+    (fail-closed) rather than resumed — a broken auth check must never
+    default to granting a full agent turn.
+    """
+    runner, adapter = make_restart_runner()
+
+    def _boom(_source):
+        raise RuntimeError("allowlist backend down")
+
+    runner._is_user_authorized = _boom
+    runner._persist_active_agents = MagicMock()
+    source = make_restart_source(chat_id="err-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:err-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    assert pending_entry.session_key not in runner._running_agents
+    runner._persist_active_agents.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_startup_auto_resume_skips_when_adapter_unavailable():
     runner, adapter = make_restart_runner()
     source = make_restart_source(chat_id="resume-chat")


### PR DESCRIPTION
## Summary

Auto-resume of restart-interrupted gateway sessions now validates the session owner against the current allowlist before synthesizing a recovery turn. Previously the resume path dispatched a full agent turn with no authorization check, so a session whose owner was removed from `TELEGRAM_ALLOWED_USERS` (or created before the allowlist existed) still received a full agent response on gateway restart (#23778).

Salvage of #47761 by @ygd58 (itself a rebase of the earlier #23800), re-applied at the current `_schedule_resume_pending_sessions` site and covered with tests.

## Changes

- `gateway/run.py` `_schedule_resume_pending_sessions`: check `_is_user_authorized(source)` before auto-resuming. Unauthorized owners are skipped with a warning log; a raising auth check fails closed (session skipped, not resumed). The gate runs **after** the adapter-ready check and **before** the `_running_agents` slot claim, so a skipped session never claims a slot or persists one.
- `tests/gateway/test_restart_resume_pending.py`: two tests — unauthorized owner is skipped (no slot claimed, nothing persisted) and a raising auth check fails closed.

## Root cause

The normal inbound path enforces auth (`run.py` drop-in-active-session guard and the main dispatch gate), but the auto-resume path (startup + platform-reconnect) synthesizes an internal `MessageEvent` and runs a full turn directly — bypassing that gate. The merged adapter-level hardening (#28492) covers real inbound messages, not this synthetic-event path.

## Validation

| | Result |
|---|---|
| Targeted suite | 80/80 pass (`tests/gateway/test_restart_resume_pending.py`) |
| E2E — authorized | scheduled=1, turn dispatched (unchanged behavior) |
| E2E — unauthorized | scheduled=0, no slot claimed, nothing persisted, warning logged |
| E2E — auth raises | scheduled=0, fail-closed |

Fixes #23778 (auto-resume auth bypass). Closes #47761 — @ygd58's fix commit authorship preserved via rebase-merge.

## Infographic

![Auto-resume auth gate](https://v3b.fal.media/files/b/0aa07f75/5Gq2df2mcJFxZayrFW4eu_x5UxQhK4.png)
