### PR TITLE
fix(gateway): normalize empty agent responses in inner runner early-return

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17611,9 +17611,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
             if not final_response:
-                error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
+                final_response = _normalize_empty_agent_response(
+                    result, final_response or "", history_len=len(agent_history),
+                )
+                final_response = _sanitize_gateway_final_response(source.platform, final_response)
+                if not final_response:
+                    final_response = f"⚠️ {result['error']}" if result.get("error") else ""
                 return {
-                    "final_response": error_msg,
+                    "final_response": final_response,
                     "messages": result.get("messages", []),
                     "api_calls": result.get("api_calls", 0),
                     "failed": result.get("failed", False),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "mac-studio@Fabios-Mac-Studio.local": "valenteff",  # PR #53277 salvage (macOS launchd reload: retry bootstrap via _launchctl_bootstrap until launchctl-list confirms registration or the restart-drain window elapses; retry TimeoutExpired not just CalledProcessError; log persistent orphans)
+    "info@djimit.nl": "djimit",  # PR #48034 salvage (normalize empty agent responses in the proxy/inner runner's not-final_response early return so gateways surface "⚠️ Processing stopped: … Try again." instead of a raw truncation error)
     "gary@bitcryptic.com": "bitcryptic-gw",  # PR #53997 salvage (Matrix E2EE: resolve device_id via query_keys({mxid: []}) when whoami returns none; guard verification call sites so query_keys is never sent [null]; reset _device_id_unverified at connect() start; disconnect before reconnect)
     "7698789+abchiaravalle@users.noreply.github.com": "abchiaravalle",  # PR #46997 salvage (recover resume_pending sessions: dual freshness signal + empty-turn safety net so restart auto-resume never sends a blank user turn)
     "swissly@users.noreply.github.com": "swissly",  # PR #47167 salvage (wrap cron delivery thread-pool fallback in its own try/except so a per-target failure can't escape the except-RuntimeError block and crash the multi-target delivery loop; #47163)

--- a/tests/gateway/test_run_progress_interrupt.py
+++ b/tests/gateway/test_run_progress_interrupt.py
@@ -106,6 +106,29 @@ class InterruptedAgent:
         return {"final_response": "interrupted", "messages": [], "api_calls": 1}
 
 
+class PartialTruncationAgent:
+    """Returns an incomplete turn with no visible assistant text."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+        self._interrupt_requested = False
+
+    @property
+    def is_interrupted(self) -> bool:
+        return self._interrupt_requested
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return {
+            "final_response": None,
+            "messages": [],
+            "api_calls": 2,
+            "completed": False,
+            "partial": True,
+            "error": "Response truncated due to output length limit",
+        }
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -179,6 +202,19 @@ async def test_baseline_non_interrupted_agent_renders_progress(monkeypatch, tmp_
         "baseline agent should render its tool-progress event — "
         "if this fails the test harness is broken, not the fix"
     )
+
+
+@pytest.mark.asyncio
+async def test_partial_empty_agent_response_is_normalized(monkeypatch, tmp_path):
+    """Messaging gateways should not echo raw truncation errors as final text."""
+    adapter, result = await _run_once(
+        monkeypatch, tmp_path, PartialTruncationAgent, "sess-partial-empty"
+    )
+
+    assert result["final_response"].startswith("⚠️ Processing stopped:")
+    assert "Response truncated due to output length limit" in result["final_response"]
+    assert result["final_response"] != "⚠️ Response truncated due to output length limit"
+    assert result["partial"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Gateways no longer echo the raw `⚠️ Response truncated due to output length limit` string to users when an agent turn ends with no visible text — they get the friendly `⚠️ Processing stopped: … Try again.` instead.

**Root cause:** `_run_agent_inner`'s `not final_response` early-return built its result dict with the raw `⚠️ {error}` string. That early-return path bypasses the normalization the outer `_handle_message_with_agent` already applies for the completed-turn path, so a truncation-with-no-text turn leaked the bare error to messaging users.

## Changes
- `gateway/run.py`: route the `not final_response` early-return through `_normalize_empty_agent_response` + `_sanitize_gateway_final_response` (the exact pair the main path uses), falling back to the raw `⚠️ {error}` only when normalization yields nothing.
- `tests/gateway/test_run_progress_interrupt.py`: `PartialTruncationAgent` + `test_partial_empty_agent_response_is_normalized` — drives `_run_agent` and asserts the normalized text is returned, not the raw error.
- `scripts/release.py`: AUTHOR_MAP entry for @djimit.

## Validation
| | Before | After |
|---|---|---|
| Final text on empty truncated turn | `⚠️ Response truncated due to output length limit` | `⚠️ Processing stopped: … Try again.` |

Regression test confirmed load-bearing: it fails on unpatched `main` (raw error surfaces) and passes with the fix. `tests/gateway/test_run_progress_interrupt.py` — 3 passed.

## Attribution
Salvaged from #48034 by @djimit, gateway-normalization half only. The retry-count bump (3→4) and linear→exponential token boost in `conversation_loop.py` were dropped as symptom-tuning of an already-working recovery loop rather than a root-cause fix.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa07f7a/VSJpcW2Uk-VeYD3Qu3RkF_UzzjuHIc.png)
