### PR TITLE
fix(approval): detect Windows destructive shell commands (salvage #56272)

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -124,6 +124,41 @@ class TestWindowsShellDestructiveCommands:
         assert key is not None
         assert desc == "PowerShell encoded command execution"
 
+    def test_powershell_bare_remove_item_requires_approval(self):
+        # Regression: PowerShell runs the verb as the default positional arg,
+        # so `powershell Remove-Item ...` with NO explicit -Command must still
+        # be gated (the original pattern required -Command and missed this).
+        dangerous, key, desc = detect_dangerous_command(
+            r"powershell Remove-Item -Recurse -Force C:\tmp\hermes-victim"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows PowerShell destructive delete"
+
+    def test_pwsh_bare_remove_item_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"pwsh Remove-Item -Recurse C:\tmp\x"
+        )
+        assert dangerous is True
+        assert "delete" in (desc or "").lower()
+
+    def test_powershell_ri_alias_requires_approval(self):
+        # `ri` is the canonical Remove-Item alias.
+        dangerous, key, desc = detect_dangerous_command(
+            r"powershell ri -Recurse -Force C:\tmp\x"
+        )
+        assert dangerous is True
+        assert desc == "Windows PowerShell destructive delete"
+
+    def test_powershell_benign_path_containing_del_not_flagged(self):
+        # A benign file path that merely contains "del" must NOT trip the guard
+        # (verb-position anchoring prevents matching inside a -File arg).
+        dangerous, key, desc = detect_dangerous_command(
+            r"powershell -File C:\del-logs\run.ps1"
+        )
+        assert dangerous is False
+        assert key is None
+
     def test_plain_text_does_not_trigger_windows_delete(self):
         dangerous, key, desc = detect_dangerous_command(
             "echo remember to del old notes"

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -83,6 +83,56 @@ class TestDetectDangerousRm:
         assert "delete" in desc.lower()
 
 
+class TestWindowsShellDestructiveCommands:
+    def test_cmd_del_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"cmd /c del /f /q C:\tmp\hermes-victim\file.txt"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows cmd destructive delete"
+
+    def test_cmd_rmdir_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"cmd.exe /k rmdir /s /q C:\tmp\hermes-victim"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows cmd destructive delete"
+
+    def test_powershell_remove_item_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"powershell -NoProfile -Command Remove-Item -Recurse -Force C:\tmp\hermes-victim"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows PowerShell destructive delete"
+
+    def test_pwsh_rm_alias_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"pwsh -c rm -Recurse -Force C:\tmp\hermes-victim"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_powershell_encoded_command_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "powershell -EncodedCommand SQBFAFgA"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "PowerShell encoded command execution"
+
+    def test_plain_text_does_not_trigger_windows_delete(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "echo remember to del old notes"
+        )
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+
 class TestDetectDangerousSudo:
     def test_shell_via_c_flag(self):
         is_dangerous, key, desc = detect_dangerous_command("bash -c 'echo pwned'")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -503,7 +503,13 @@ DANGEROUS_PATTERNS = [
     # Unix `rm`. Gate only when they are executed through cmd/powershell so
     # ordinary prose or filenames containing "del"/"rd" do not trip the guard.
     (r'\bcmd(?:\.exe)?\s+/(?:c|k)\s+.*\b(?:del|erase|rd|rmdir)\b', "Windows cmd destructive delete"),
-    (r'\b(?:powershell|pwsh)(?:\.exe)?\b.*\s-(?:command|c)\b.*\b(?:remove-item|del|erase|rd|rmdir|rm)\b', "Windows PowerShell destructive delete"),
+    # PowerShell/pwsh: the destructive verb runs as the default positional
+    # argument, so `powershell Remove-Item ...` needs NO explicit -Command.
+    # Anchor the verb to the command position (right after the shell name,
+    # after any leading `-Flag` switches, and optionally after -Command/-c)
+    # so bare invocations are caught while a benign path arg containing
+    # "del"/"rm" (e.g. `-File c:\del-logs\run.ps1`) is not.
+    (r'\b(?:powershell|pwsh)(?:\.exe)?\b(?:\s+-\S+)*\s+(?:-(?:command|c)\s+)?["\']?(?:remove-item|rmdir|erase|del|rd|ri|rm)\b', "Windows PowerShell destructive delete"),
     (r'\b(?:powershell|pwsh)(?:\.exe)?\b.*\s-(?:encodedcommand|enc|e)\b', "PowerShell encoded command execution"),
     (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),
     (r'\bchmod\s+--recursive\b.*(777|666|o\+[rwx]*w|a\+[rwx]*w)', "recursive world/other-writable (long flag)"),

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -499,6 +499,12 @@ DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
+    # Windows shell front-ends have destructive built-ins that do not look like
+    # Unix `rm`. Gate only when they are executed through cmd/powershell so
+    # ordinary prose or filenames containing "del"/"rd" do not trip the guard.
+    (r'\bcmd(?:\.exe)?\s+/(?:c|k)\s+.*\b(?:del|erase|rd|rmdir)\b', "Windows cmd destructive delete"),
+    (r'\b(?:powershell|pwsh)(?:\.exe)?\b.*\s-(?:command|c)\b.*\b(?:remove-item|del|erase|rd|rmdir|rm)\b', "Windows PowerShell destructive delete"),
+    (r'\b(?:powershell|pwsh)(?:\.exe)?\b.*\s-(?:encodedcommand|enc|e)\b', "PowerShell encoded command execution"),
     (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),
     (r'\bchmod\s+--recursive\b.*(777|666|o\+[rwx]*w|a\+[rwx]*w)', "recursive world/other-writable (long flag)"),
     (r'\bchown\s+(-[^\s]*)?R\s+root', "recursive chown to root"),


### PR DESCRIPTION
## Summary

Salvage of #56272 by @necoweb3 (cherry-picked onto current `main` + a rework follow-up closing a false-negative). Adds Windows destructive-shell-command detection to the dangerous-command approval gate.

## The bug (approval-gate gap)

`tools/approval.py` caught Unix deletion (`rm -rf`), interpreter execution, and encoded-to-shell bypasses, but had **zero** Windows shell detection — so equivalent destructive commands ran without an approval prompt:
- `cmd /c del /f /q C:\...`, `cmd /c rmdir /s /q C:\...`
- `powershell -Command Remove-Item -Recurse -Force C:\...`
- `powershell -EncodedCommand ...`

Confirmed on current `main` (`detect_dangerous_command` returned safe for all of these).

## The fix

Three additions to `DANGEROUS_PATTERNS`, scoped through the cmd/powershell front-ends so ordinary prose or filenames containing "del"/"rd" don't trip the guard:
- `cmd(.exe) /c|/k ... del|erase|rd|rmdir`
- PowerShell/pwsh destructive verbs (`Remove-Item` + aliases)
- PowerShell `-EncodedCommand`/`-enc`/`-e`

## Rework in this salvage (the original was NOT sound as-shipped)

The original PowerShell pattern **required** an explicit `-Command`/`-c` before the verb — but PowerShell runs the verb as the default **positional** argument, so **bare `powershell Remove-Item -Recurse -Force C:\x` slipped through** (the exact case the PR body claims to close), and the canonical `ri` alias was missing. Its test used `-Command`, masking the gap.

Reworked the PowerShell pattern to a **command-position-anchored** form (verb right after the shell name, after any leading `-Flag` switches, and optionally after `-Command`/`-c`), added the `ri` alias, and added mutation-verified regression tests for the bare invocation, the `ri` alias, and a benign-path negative.

## Review

Ran hermes-agent-dev + hermes-pr-review Phase 2c — security-focused, regex stress-tested with real `re` (0 Critical / 0 Warnings on the final form):
- **Catches (14/14):** bare `powershell Remove-Item`, `pwsh Remove-Item`, `.exe`, mixed case, leading-switch-then-verb, `-Command Remove-Item`, `-c ri`, bare `ri`, all aliases, quoted.
- **Benign not flagged (6/6):** `-File C:\del-logs\run.ps1`, `-File C:\rm-backups\go.ps1`, `-Command Get-ChildItem`, `Compress-Archive`, `-ExecutionPolicy Bypass -File x.ps1`, and critically `powershell Get-Item C:\remove-item-notes.txt` (dangerous string only in a path arg — correctly NOT matched, because the anchor requires the verb in command position).
- Matching is doubly case-insensitive (input lowercased + `re.IGNORECASE`). Additive; no conflict with existing Unix `rm` patterns. 285 tests pass.

## Tests

```text
pytest tests/tools/test_approval.py -q   # 285 passed (CI runs the full suite)
```

Supersedes #56272. Full credit to @necoweb3.
