### PR TITLE
fix(cli): flush un-persisted messages before /resume and /branch end the old session (salvage #48764)

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -712,6 +712,14 @@ class CLICommandsMixin:
             return
 
         old_session_id = self.session_id
+        # Flush un-persisted messages before ending the old session (#47202).
+        if self.agent:
+            try:
+                self.agent._flush_messages_to_session_db(
+                    self.conversation_history
+                )
+            except Exception:
+                pass
         # End current session
         try:
             self._session_db.end_session(self.session_id, "resumed_other")
@@ -850,6 +858,15 @@ class CLICommandsMixin:
 
         # Save the current session's state before branching
         parent_session_id = self.session_id
+
+        # Flush un-persisted messages before ending the old session (#47202).
+        if self.agent:
+            try:
+                self.agent._flush_messages_to_session_db(
+                    self.conversation_history
+                )
+            except Exception:
+                pass
 
         # End the old session
         try:

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -253,8 +253,18 @@ class TestBranchFlushesBeforeEndSession:
         agent = MagicMock()
         cli_instance.agent = agent
 
+        # Track relative ordering of the flush vs end_session via a shared
+        # parent mock — the flush MUST precede end_session (a flush after the
+        # session ends would be useless).
+        manager = MagicMock()
+        manager.attach_mock(agent._flush_messages_to_session_db, "flush")
+        cli_instance._session_db.end_session = manager.end_session
+
         HermesCLI._handle_branch_command(cli_instance, "/branch")
 
         agent._flush_messages_to_session_db.assert_called_once_with(
             cli_instance.conversation_history
         )
+        # Ordering invariant: flush is called before end_session.
+        ordered = [c[0] for c in manager.mock_calls if c[0] in ("flush", "end_session")]
+        assert ordered.index("flush") < ordered.index("end_session")

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -240,3 +240,21 @@ class TestBranchCommandDef:
         from hermes_cli.commands import COMMAND_REGISTRY
         branch = next(c for c in COMMAND_REGISTRY if c.name == "branch")
         assert branch.category == "Session"
+
+
+class TestBranchFlushesBeforeEndSession:
+    """Regression for #47202: /branch must flush un-persisted messages to
+    the session DB before ending the old session, just like /new and
+    compress_context() already do."""
+
+    def test_branch_flushes_when_agent_present(self, cli_instance, session_db):
+        from cli import HermesCLI
+
+        agent = MagicMock()
+        cli_instance.agent = agent
+
+        HermesCLI._handle_branch_command(cli_instance, "/branch")
+
+        agent._flush_messages_to_session_db.assert_called_once_with(
+            cli_instance.conversation_history
+        )

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -321,3 +321,33 @@ class TestRestoreSessionCwdMarkup:
             assert "Working directory" in printed or "working" in printed.lower()
         finally:
             os.chdir(original_cwd)
+
+
+class TestResumeFlushesBeforeEndSession:
+    """Regression for #47202: /resume must flush un-persisted messages to
+    the session DB before ending the old session, just like /new and
+    compress_context() already do."""
+
+    def test_resume_flushes_when_agent_present(self):
+        cli_obj = _make_cli()
+        cli_obj.conversation_history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        agent = MagicMock()
+        cli_obj.agent = agent
+
+        cli_obj._session_db.get_session.return_value = {"id": "target", "title": "T"}
+        cli_obj._session_db.get_messages_as_conversation.return_value = []
+        cli_obj._session_db.resolve_resume_session_id.return_value = "target"
+
+        with (
+            patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="target"),
+            patch("cli._cprint"),
+        ):
+            cli_obj._handle_resume_command("/resume target")
+
+        agent._flush_messages_to_session_db.assert_called_once_with(
+            [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
+        )
+        cli_obj._session_db.end_session.assert_called_once()

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -341,6 +341,11 @@ class TestResumeFlushesBeforeEndSession:
         cli_obj._session_db.get_messages_as_conversation.return_value = []
         cli_obj._session_db.resolve_resume_session_id.return_value = "target"
 
+        # Track flush vs end_session ordering — flush MUST precede end_session.
+        manager = MagicMock()
+        manager.attach_mock(agent._flush_messages_to_session_db, "flush")
+        manager.attach_mock(cli_obj._session_db.end_session, "end_session")
+
         with (
             patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="target"),
             patch("cli._cprint"),
@@ -351,3 +356,6 @@ class TestResumeFlushesBeforeEndSession:
             [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
         )
         cli_obj._session_db.end_session.assert_called_once()
+        # Ordering invariant: flush is called before end_session.
+        ordered = [c[0] for c in manager.mock_calls if c[0] in ("flush", "end_session")]
+        assert ordered.index("flush") < ordered.index("end_session")


### PR DESCRIPTION
Salvage of #48764 (@srojk34), rebased onto current main.

## Issue (#47202)
`/new` and `compress_context()` flush the live conversation to the session DB before ending/rotating the session, but `/resume` and `/branch` called `end_session()` **directly without flushing first** — so any messages not yet persisted (the tail of the current turn) were lost when the old session ended.

## Fix
Add the same guarded `_flush_messages_to_session_db(self.conversation_history)` call before `end_session` in both `_handle_resume_command` and `_handle_branch_command` — matching the established /new + compress behavior.

## Verification
Two regression tests: /resume and /branch each flush the conversation history before ending the old session (asserted via mock). Mutation-checked: removing either flush block fails its test. 35 cli session tests pass.

Closes #48764.

Co-authored-by: srojk34 <286497132+srojk34@users.noreply.github.com>