### PR TITLE
fix(subdirectory_hints): catch RuntimeError from Path.expanduser()

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -144,7 +144,7 @@ class SubdirectoryHintTracker:
                 if parent == p:
                     break  # filesystem root
                 p = parent
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
             pass
 
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):
@@ -241,11 +241,11 @@ class SubdirectoryHintTracker:
                 rel_path = str(hint_path)
                 try:
                     rel_path = str(hint_path.relative_to(self.working_dir))
-                except ValueError:
+                except (ValueError, RuntimeError):
                     try:
                         rel_path = str(hint_path.relative_to(Path.home()))
                         rel_path = "~/" + rel_path
-                    except ValueError:
+                    except (ValueError, RuntimeError):
                         pass  # keep absolute
                 found_hints.append((rel_path, content))
                 # First match wins per directory (like startup loading)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "ud@arubangles.com": "udatny",  # PR #29433 salvage (subdirectory_hints: catch RuntimeError from Path.expanduser()/Path.home() so a literal ~ in tool-call args — e.g. LLM "~500-700" or ~unknownuser — can't escape the hint walker and crash the conversation loop)
     "mac-studio@Fabios-Mac-Studio.local": "valenteff",  # PR #53277 salvage (macOS launchd reload: retry bootstrap via _launchctl_bootstrap until launchctl-list confirms registration or the restart-drain window elapses; retry TimeoutExpired not just CalledProcessError; log persistent orphans)
     "gary@bitcryptic.com": "bitcryptic-gw",  # PR #53997 salvage (Matrix E2EE: resolve device_id via query_keys({mxid: []}) when whoami returns none; guard verification call sites so query_keys is never sent [null]; reset _device_id_unverified at connect() start; disconnect before reconnect)
     "7698789+abchiaravalle@users.noreply.github.com": "abchiaravalle",  # PR #46997 salvage (recover resume_pending sessions: dual freshness signal + empty-turn safety net so restart auto-resume never sends a blank user turn)

--- a/tests/agent/test_subdirectory_hints_tilde.py
+++ b/tests/agent/test_subdirectory_hints_tilde.py
@@ -1,0 +1,54 @@
+"""Regression tests for the home-directory RuntimeError bug.
+
+Without the fix to ``agent/subdirectory_hints.py`` (add ``RuntimeError`` to
+the three ``except`` clauses around ``Path.expanduser()`` /
+``Path.home()``), the first two tests raise ``RuntimeError`` from inside
+the hint walker on POSIX systems.
+
+These tests use pytest's built-in ``tmp_path`` fixture and intentionally
+do not depend on the richer ``project`` fixture from
+``test_subdirectory_hints.py`` so the file is runnable standalone.
+"""
+
+from agent.subdirectory_hints import SubdirectoryHintTracker
+
+
+class TestSubdirectoryHintTrackerTildeRobustness:
+    """Regression: literal ``~`` in tool-call args must not crash the walker."""
+
+    def test_tilde_approximately_in_command_does_not_crash(self, tmp_path):
+        """LLMs use ``~`` for "approximately" (e.g. ``~500 agencies``).
+
+        ``pathlib.Path('~500-700').expanduser()`` raises ``RuntimeError`` —
+        the walker must catch this, not propagate it as a tool failure.
+        """
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        # Heredoc-style terminal command body containing "~500-700"
+        # used as "approximately 500-700"
+        cmd = (
+            "cat > out.md <<EOF\n"
+            "Segment size signal: ~500-700 agencies in DACH region.\n"
+            "CVE volume: ~45,000 disclosed in 2025.\n"
+            "Founder blended rate: ~80/hr.\n"
+            "EOF"
+        )
+        # Must not raise — return value can be None / empty
+        tracker.check_tool_call("terminal", {"command": cmd})
+
+    def test_tilde_with_unknown_user_does_not_crash(self, tmp_path):
+        """``~unknown_user`` similarly raises RuntimeError on POSIX systems
+        whose /etc/passwd does not contain that user.  Walker must absorb it."""
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        cmd = "echo path: ~nonexistent_user_xyzzy_12345/some/file"
+        # Must not raise
+        tracker.check_tool_call("terminal", {"command": cmd})
+
+    def test_valid_tilde_user_still_works(self, tmp_path):
+        """The fix must not regress the legitimate-tilde-user path.
+
+        ``~`` alone resolves to ``Path.home()`` and should still be
+        recognised as a candidate path (no exception either way).
+        """
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        tracker.check_tool_call("terminal", {"command": "ls ~/Documents"})
+        # No exception, no assertion required


### PR DESCRIPTION
## Summary
A literal `~` in a tool-call argument no longer crashes the conversation loop.

`pathlib.Path('~user').expanduser()` raises `RuntimeError: Could not determine home directory` when the tilde-user can't be resolved — e.g. `~500-700` (an LLM writing "approximately 500-700"), `~45,000`, or `~unknownuser`. The hint walker's `except (OSError, ValueError)` clauses didn't catch it, so it escaped `_add_path_candidate` → `_extract_directories` → `check_tool_call` and surfaced in the loop as a misleading "Could not determine home directory" API error.

## Changes
- `agent/subdirectory_hints.py`: add `RuntimeError` to three `except` clauses — the `_add_path_candidate` catch around `Path().expanduser()`, and the two `_load_hints_for_directory` catches around `hint_path.relative_to(Path.home())`.
- `tests/agent/test_subdirectory_hints_tilde.py`: 3 regression tests (tilde-as-approximately, `~unknownuser`, and a no-regression guard for legit `~/`).
- `scripts/release.py`: AUTHOR_MAP entry for @udatny.

## Validation
| | Before | After |
|---|---|---|
| `~500-700` in a command arg | RuntimeError crashes loop | absorbed, no crash |
| `~unknownuser/x` | RuntimeError crashes loop | absorbed, no crash |
| legit `~/Documents` | works | works (no regression) |
| tests | — | 28 pass (3 new + 25 existing) |

E2E-verified against a real `SubdirectoryHintTracker` on all three cases.

Salvages @udatny's #29433 (earliest of a 3-PR duplicate cluster; #49263 and #50926 fixed the same bug and will be closed with credit).

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa07f99/GJ7DId6vRikZRThC4Oul8_hKawRjjO.png)

Nous Research
