### PR TITLE
fix(mcp): stop EventBridge silently dropping sessions.json-only changes

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -356,7 +356,10 @@ class EventBridge:
         Uses mtime checks on sessions.json and state.db to skip work
         when nothing has changed — makes 200ms polling essentially free.
         """
-        # Check if sessions.json has changed (mtime check is ~1μs)
+        # Check if sessions.json has changed (mtime check is ~1μs).
+        # Capture the previously-seen mtime *before* refreshing the cache so the
+        # skip guard below can still tell whether sessions.json changed this tick.
+        prev_sessions_json_mtime = self._sessions_json_mtime
         sessions_file = _get_sessions_dir() / "sessions.json"
         try:
             sj_mtime = sessions_file.stat().st_mtime if sessions_file.exists() else 0.0
@@ -379,7 +382,16 @@ class EventBridge:
         except OSError:
             db_mtime = 0.0
 
-        if db_mtime == self._state_db_mtime and sj_mtime == self._sessions_json_mtime:
+        # Skip only when NEITHER file changed since the last poll. Comparing
+        # against ``prev_sessions_json_mtime`` (not the freshly-stored
+        # ``self._sessions_json_mtime``) is essential: the latter was just set to
+        # ``sj_mtime`` above, so using it would make the sessions.json term
+        # always true and collapse the guard to a db-only check. That would
+        # discard a tick where only sessions.json changed — e.g. a brand-new
+        # conversation registered after its first message already landed in
+        # state.db on an earlier tick — and the new chat's messages would never
+        # be emitted until state.db happened to change again.
+        if db_mtime == self._state_db_mtime and sj_mtime == prev_sessions_json_mtime:
             return  # Nothing changed since last poll — skip entirely
 
         self._state_db_mtime = db_mtime

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1232,6 +1232,63 @@ class TestEventBridgePollE2E:
         assert len(r2["events"]) == 1
         assert r2["events"][0]["content"] == "New reply!"
 
+    def test_poll_picks_up_new_conversation_when_only_sessions_json_changed(
+        self, tmp_path, monkeypatch
+    ):
+        """A conversation registered in sessions.json *after* its first message
+        already landed in state.db must still be picked up, even when state.db's
+        mtime did not move on this tick.
+
+        Regression guard: the skip-when-unchanged check must compare against the
+        sessions.json mtime seen on the *previous* poll. If it instead compares
+        against the just-refreshed value, the sessions.json term is always true,
+        the guard collapses to a db-only check, and a sessions.json-only change
+        is silently dropped — the new chat's messages never reach MCP clients.
+        """
+        import mcp_serve
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        # _poll_once reads <HERMES_HOME>/state.db for its mtime gate; the autouse
+        # fixture points HERMES_HOME at tmp_path.
+        db_path = tmp_path / "state.db"
+        db_path.write_text("placeholder")
+
+        session_id = "20260329_150000_late_register"
+        sessions_json = sessions_dir / "sessions.json"
+        sessions_json.write_text(json.dumps({
+            "agent:main:telegram:dm:late": {
+                "session_id": session_id,
+                "platform": "telegram",
+                "origin": {"platform": "telegram", "chat_id": "late"},
+            }
+        }))
+
+        class DB:
+            def get_messages(self, sid):
+                return [{
+                    "id": 1, "role": "user",
+                    "content": "Hello from a freshly-registered conversation",
+                    "timestamp": "2026-03-29T15:00:00",
+                }]
+
+        bridge = mcp_serve.EventBridge()
+        # Simulate the boundary state: state.db has NOT changed since the last
+        # poll (its message landed on an earlier tick), but sessions.json was
+        # only updated with this conversation now — the bridge has not yet seen
+        # the current sessions.json content.
+        bridge._state_db_mtime = db_path.stat().st_mtime
+        bridge._sessions_json_mtime = 0.0
+
+        bridge._poll_once(DB())
+
+        result = bridge.poll_events(after_cursor=0)
+        assert len(result["events"]) == 1
+        assert result["events"][0]["session_key"] == "agent:main:telegram:dm:late"
+        assert result["events"][0]["content"].startswith("Hello from a freshly")
+
     def test_poll_interval_is_200ms(self):
         """Verify the poll interval constant."""
         from mcp_serve import POLL_INTERVAL


### PR DESCRIPTION
## Summary
The MCP serve EventBridge now processes ticks where only `sessions.json` changed, so freshly-registered conversations reach MCP clients instead of being silently dropped.

Root cause: in `EventBridge._poll_once` (`mcp_serve.py`), the skip-when-unchanged guard compared `sj_mtime == self._sessions_json_mtime` — but that attribute was refreshed to `sj_mtime` two lines earlier, so the term was always true. The guard collapsed to a state.db-only check and discarded any tick where only `sessions.json` moved (e.g. a conversation registered on tick N+1 after its first message already landed in state.db on tick N). Those messages never reached `events_poll` / `events_wait` until state.db happened to change again.

## Changes
- `mcp_serve.py`: snapshot `prev_sessions_json_mtime` before the cache refresh and compare against that in the skip guard, so it skips only when NEITHER file changed. Hot-path mtime short-circuit preserved.
- `tests/test_mcp_serve.py`: regression test reproducing the boundary state (state.db unchanged, sessions.json newly updated) asserting the new conversation's message is emitted.

## Validation
| | Before | After |
|---|---|---|
| sessions.json-only tick | dropped (0 events) | processed (1 event) |
| test_mcp_serve.py | — | 86 passed, 0 failed |
| ruff | — | clean |
| E2E (real EventBridge, temp HERMES_HOME) | — | emits new chat |

## Attribution
Salvage of #50406 (@rrevenanttt) — cleanest implementation + strongest regression test. This bug was independently reported by four contributors; @Dusk1e submitted the same fix first in #8925 (Apr 13). Also duplicated by #41688 (@entropy-0x) and #41915 (@sasquatch9818). All credited; dupes closed pointing here.

## Infographic
![EventBridge fix infographic](https://v3b.fal.media/files/b/0aa07fb2/usgjXmq4bVlhztn9QqIbJ_oryKcL8Y.png)
