### PR TITLE
fix(acp): stop _persist from deleting compression-archived history

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -461,10 +461,31 @@ class SessionManager:
                 except Exception:
                     logger.debug("Failed to update ACP session metadata", exc_info=True)
 
-            # Replace stored messages with current history atomically so a
-            # mid-rewrite failure rolls back and the previously persisted
-            # conversation is preserved (salvaged from #13675).
-            db.replace_messages(state.session_id, state.history)
+            # When the agent owns persistence to this same SessionDB it has
+            # already flushed the live transcript incrementally during
+            # run_conversation (append_message), and it preserves pre-compaction
+            # turns non-destructively via archive_and_compact() — keeping them on
+            # disk as searchable active=0/compacted=1 rows. Calling
+            # replace_messages() here would then be a redundant double-write that
+            # DELETEs exactly those archived rows (and, after a compression-driven
+            # id rotation where agent.session_id no longer equals
+            # state.session_id, clobbers the ended parent transcript) — silent
+            # data loss for any ACP conversation long enough to compress.
+            #
+            # Only fall back to the destructive atomic replace when the agent is
+            # NOT persisting itself to this DB (e.g. a test agent factory, or a
+            # fresh create/fork whose copied history the agent has not flushed
+            # yet). That path still rolls back on a mid-rewrite failure so the
+            # previously persisted conversation survives (salvaged from #13675).
+            agent = state.agent
+            agent_db = getattr(agent, "_session_db", None)
+            agent_owns_persistence = (
+                agent_db is not None
+                and agent_db is db
+                and bool(getattr(agent, "_session_db_created", False))
+            )
+            if not agent_owns_persistence:
+                db.replace_messages(state.session_id, state.history)
         except Exception:
             logger.warning("Failed to persist ACP session %s", state.session_id, exc_info=True)
 

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -260,6 +260,76 @@ class TestListAndCleanup:
         assert messages[0]["content"] == "original"
         assert isinstance(messages[0].get("timestamp"), (int, float))
 
+    def test_save_session_preserves_agent_archived_history(self, tmp_path):
+        """Regression: ACP _persist must not destroy compression-archived rows.
+
+        When the agent owns persistence to the same SessionDB, it has already
+        flushed the transcript itself and used archive_and_compact() to keep
+        pre-compaction turns as searchable active=0/compacted=1 rows. A blind
+        replace_messages() here used to DELETE those archived rows (and the FTS
+        index entries with them) on every save — silent data loss for any ACP
+        conversation long enough to compress.
+        """
+        db = SessionDB(tmp_path / "state.db")
+
+        def factory():
+            # Mimic a live ACP agent: it persists to *this* db and has already
+            # created its session row / flushed at least one turn.
+            return SimpleNamespace(
+                model="test-model",
+                _session_db=db,
+                _session_db_created=True,
+            )
+
+        manager = SessionManager(agent_factory=factory, db=db)
+        state = manager.create_session(cwd="/work")
+
+        # Simulate the agent's own persistence: it flushed the live transcript,
+        # then compression archived the pre-compaction turns and inserted a
+        # compacted summary as the new active set.
+        db.append_message(
+            session_id=state.session_id, role="user", content="archived needle"
+        )
+        db.archive_and_compact(
+            state.session_id, [{"role": "user", "content": "compacted summary"}]
+        )
+
+        # ACP's in-memory history only tracks the post-compaction (active) set.
+        state.history = [{"role": "user", "content": "compacted summary"}]
+        manager.save_session(state.session_id)
+
+        # The archived pre-compaction turn must survive and stay discoverable.
+        contents = [
+            m["content"]
+            for m in db.get_messages(state.session_id, include_inactive=True)
+        ]
+        assert "archived needle" in contents
+        assert "compacted summary" in contents
+        hits = {r["session_id"] for r in db.search_messages("needle")}
+        assert state.session_id in hits
+
+    def test_save_session_still_replaces_when_agent_not_self_persisting(self, manager):
+        """Agents that don't own DB persistence keep ACP as the source of truth.
+
+        The default fixture's MagicMock agent has a ``_session_db`` that is *not*
+        the manager's db, so the destructive replace path stays active and ACP
+        history overwrites cleanly (no orphaned rows from a prior save).
+        """
+        state = manager.create_session()
+        db = manager._get_db()
+
+        state.history = [{"role": "user", "content": "v1"}]
+        manager.save_session(state.session_id)
+        assert [
+            m["content"] for m in db.get_messages_as_conversation(state.session_id)
+        ] == ["v1"]
+
+        state.history = [{"role": "user", "content": "v2 replaced"}]
+        manager.save_session(state.session_id)
+        assert [
+            m["content"] for m in db.get_messages_as_conversation(state.session_id)
+        ] == ["v2 replaced"]
+
     def test_cleanup_clears_all(self, manager):
         s1 = manager.create_session()
         s2 = manager.create_session()


### PR DESCRIPTION
## Summary

ACP editor sessions (VS Code / Zed / JetBrains) no longer silently lose their transcript once a conversation is long enough to compress. `SessionManager._persist` stops calling the destructive `db.replace_messages()` when the backing agent already owns persistence to the same `SessionDB`.

Root cause: the agent flushes turns incrementally (`append_message`) and preserves pre-compaction turns non-destructively via `archive_and_compact()` (kept on disk as searchable `active=0`/`compacted=1` rows). ACP's per-save `replace_messages()` was a redundant double-write that DELETEd exactly those archived rows (and their FTS entries). After a compression-driven id rotation the agent's live head id no longer equals the ACP session id, so the replace also clobbered the ended parent transcript while new turns flowed to the new id — split-brain corruption of one conversation.

## Changes

- `acp_adapter/session.py`: `_persist` skips `replace_messages` when `agent._session_db is db and agent._session_db_created`, deferring to the agent's own incremental + archival flush. Falls back to the atomic replace when the agent is not self-persisting (test factories, fresh create/fork whose copied history the agent hasn't flushed) — so the #13675 rollback guarantee still holds.
- `tests/acp/test_session.py`: regression test proving archived (`active=0`/`compacted=1`) rows survive a save when the agent self-persists and stay FTS-searchable; plus a test confirming the destructive replace path still runs for agents that don't own DB persistence.

## Validation

| | Before | After |
|---|---|---|
| Long ACP session compresses, then saves | archived turns DELETEd, FTS entries dropped | archived turns survive, stay FTS-searchable |
| Post-rotation save | ended parent clobbered, conversation split | parent intact, new turns flow to new id |
| Non-self-persisting agent (test factory / fresh create / fork) | replace | replace (unchanged, #13675 rollback intact) |

- `scripts/run_tests.sh tests/acp/test_session.py` → 44/44 pass.
- E2E (real `SessionDB` + real imports, temp `HERMES_HOME`): after `archive_and_compact` + a save, the archived turn is present in a full load, absent from the active load, and found by `search_messages`; the foreign-DB agent still gets a clean destructive replace with no orphans.

## Infographic

![ACP _persist archived-history fix](https://v3b.fal.media/files/b/0aa07faf/13SOsW5r2naMF5vGcAw_W_Z0eaxk2s.png)

---

Salvaged from #50405 by @sasquatch9818, cherry-picked onto current `main` with authorship preserved. Duplicate of #50306 by @mrparker0980 (submitted ~2h earlier) — both contributors credited; #50306 took the `replace_messages(active_only=True)` route, which still rewrites the active set every save and doesn't cover the id-rotation split-brain, so this implementation was chosen.

Nous Research
