### PR TITLE
fix(gateway): don't resolve node symlink into profile dir (multi-profile flap)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2655,7 +2655,15 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     path_entries = _build_service_path_dirs()
     resolved_node = shutil.which("node")
     if resolved_node:
-        resolved_node_dir = str(Path(resolved_node).resolve().parent)
+        # Use the directory where ``node`` is *found on PATH*, NOT the
+        # symlink's resolved target. ``~/.local/bin/node`` is often a symlink
+        # into a specific profile's node install (e.g. profiles/jarvis/node/
+        # bin/node); calling .resolve() here would chase that symlink and bake
+        # one profile's node path into *every* profile's service unit. That
+        # cross-profile leak makes systemd_unit_is_current() perpetually false,
+        # so each gateway rewrites its unit + daemon-reload on every boot. Using
+        # the symlink's own parent keeps the generated unit profile-agnostic.
+        resolved_node_dir = str(Path(resolved_node).parent)
         if resolved_node_dir not in path_entries:
             path_entries.append(resolved_node_dir)
 
@@ -3807,7 +3815,13 @@ def generate_launchd_plist() -> str:
     priority_dirs = _build_service_path_dirs()
     resolved_node = shutil.which("node")
     if resolved_node:
-        resolved_node_dir = str(Path(resolved_node).resolve().parent)
+        # Use the directory where ``node`` is *found on PATH*, NOT the symlink's
+        # resolved target. ``~/.local/bin/node`` is often a symlink into a
+        # specific profile's node install; calling .resolve() would chase it and
+        # bake one profile's path into every profile's service definition,
+        # breaking profile isolation and causing perpetual unit rewrites. See
+        # the matching fix in generate_systemd_unit().
+        resolved_node_dir = str(Path(resolved_node).parent)
         if resolved_node_dir not in priority_dirs:
             priority_dirs.append(resolved_node_dir)
     sane_path = ":".join(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -233,6 +233,7 @@ AUTHOR_MAP = {
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
     "153708448+hunjaiboy@users.noreply.github.com": "yyzquwu",  # PR #47567 salvage (Matrix: register inbound handlers with wait_sync=True so _dispatch_sync's gather awaits them; without it mautrix fire-and-forgets and inbound intake has no completion point)
+    "jearnest@velocityenergy.com": "jearnest11",  # PR #48700 salvage (multi-profile gateway flap: use node symlink's own parent, not .resolve() target, when building systemd/launchd service PATH so one profile's node path can't leak into every unit and force a perpetual daemon-reload restart loop)
     "tgmerritt@gmail.com": "tgmerritt",  # PR #43553 salvage (parse vLLM's token-based output-cap error format so over-cap max_tokens 400s reduce the output cap instead of death-looping into compression)
     "13277570+justin-cyhuang@users.noreply.github.com": "justin-cyhuang",
     "agent@tranquil-flow.dev": "Tranquil-Flow",

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -447,6 +447,48 @@ class TestGeneratedSystemdUnits:
 
         assert "/home/test/.nvm/versions/node/v24.14.0/bin" in unit
 
+    def test_user_unit_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
+        # Regression for the multi-profile gateway restart-loop flap (#48700):
+        # ~/.local/bin/node is often a symlink into a *specific* profile's node
+        # install. The generated unit's PATH must contain the symlink's own
+        # directory (~/.local/bin), NOT the resolved profile target — otherwise
+        # one profile's node path leaks into every profile's unit, making
+        # systemd_unit_is_current() perpetually false and forcing a
+        # daemon-reload restart loop on every boot.
+        local_bin = tmp_path / ".local" / "bin"
+        profile_node_bin = tmp_path / ".hermes" / "profiles" / "jarvis" / "node" / "bin"
+        local_bin.mkdir(parents=True)
+        profile_node_bin.mkdir(parents=True)
+        real_node = profile_node_bin / "node"
+        real_node.write_text("#!/bin/sh\n")
+        link_node = local_bin / "node"
+        link_node.symlink_to(real_node)
+
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: str(link_node) if cmd == "node" else None)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert str(local_bin) in unit
+        assert str(profile_node_bin) not in unit
+
+    def test_launchd_plist_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
+        # Same #48700 regression for the macOS twin generate_launchd_plist().
+        local_bin = tmp_path / ".local" / "bin"
+        profile_node_bin = tmp_path / ".hermes" / "profiles" / "jarvis" / "node" / "bin"
+        local_bin.mkdir(parents=True)
+        profile_node_bin.mkdir(parents=True)
+        real_node = profile_node_bin / "node"
+        real_node.write_text("#!/bin/sh\n")
+        link_node = local_bin / "node"
+        link_node.symlink_to(real_node)
+
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: str(link_node) if cmd == "node" else None)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert str(local_bin) in plist
+        assert str(profile_node_bin) not in plist
+
     def test_user_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
         monkeypatch.setenv(


### PR DESCRIPTION
## Summary

Multi-profile gateway installs no longer crash-loop: the generated systemd/launchd unit's PATH stays profile-agnostic instead of baking one profile's node install into every profile's unit.

Root cause: `generate_systemd_unit()` (and its macOS twin `generate_launchd_plist()`) built the service PATH from `shutil.which("node")` and then called `.resolve()` on it. On multi-profile installs `~/.local/bin/node` is a symlink into a *specific* profile's node install (`~/.hermes/profiles/<profile>/node/bin/node`), so `.resolve()` chased the symlink and leaked that profile's path into **every** profile's unit. `systemd_unit_is_current()` then compared installed-vs-generated, saw the leaked path mismatch, returned False on every boot, and `refresh_systemd_unit_if_needed()` rewrote the unit + `daemon-reload` — the restart loop (observed `NRestarts` ~1600 on two gateways).

## Changes
- `hermes_cli/gateway.py`: use `Path(node).parent` (the dir where node is *found on PATH*, e.g. `~/.local/bin`) instead of `.resolve().parent`, at **both** sites — `generate_systemd_unit` and `generate_launchd_plist`.
- `tests/hermes_cli/test_gateway_service.py`: real-symlink regression tests for both generators — assert the symlink's own parent is in the unit and the profile target is not.
- `scripts/release.py`: AUTHOR_MAP entry for @jearnest11.

## Validation

Live E2E on a real filesystem (real `~/.local/bin/node → profiles/jarvis/node/bin/node` symlink, real imports, both generators):

| | Before (`.resolve().parent`) | After (`.parent`) |
|---|---|---|
| `profiles/jarvis/node/bin` in generated PATH | leaked (True) | gone (False) |
| `systemd_unit_is_current()` after write | False (perpetual rewrite) | True (no daemon-reload) |
| result | restart-loop flap | stable |

Pinning test flipped both ways: with the buggy `.resolve()` both new regression tests FAIL; with the fix both PASS. Full `test_gateway_service.py` class: 185 passed.

Salvage of #48700 by @jearnest11 — original fix commit authored by Jack Earnest, preserved via rebase-merge.

## Infographic

![PR 48700 infographic](https://v3b.fal.media/files/b/0aa07fc2/5nIz-0gigh1vLK2pfyNZP_NdwrWsqA.png)
