### PR TITLE
fix(matrix): reset _encryption to config-derived value on every connect()

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1153,6 +1153,16 @@ class MatrixAdapter(BasePlatformAdapter):
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to the Matrix homeserver and start syncing."""
         self._device_id_unverified = False
+        # Reset to the config-derived value on every (re)connect attempt, not
+        # just __init__. A transient E2EE setup failure (missing deps import
+        # race, a locked crypto-store sqlite file, etc.) downgrades this to
+        # False below; without resetting here first, that downgrade is
+        # permanent for the adapter's lifetime — every later reconnect
+        # silently skips the whole E2EE setup block instead of retrying,
+        # even though the transient cause may have cleared. Same "stale
+        # one-shot flag across reconnect" bug class _device_id_unverified
+        # above was just fixed for.
+        self._encryption = self._e2ee_mode != "off"
         if self._client is not None:
             try:
                 await self.disconnect()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5276,3 +5276,150 @@ class TestDeviceIdRecoveryOnReconnect:
         assert None not in _verify_call.args[0]["@bot:example.org"]
 
         await adapter.disconnect()
+
+
+class TestEncryptionRecoveryOnReconnect:
+    """_encryption must reset to the config-derived value on every connect()
+    call, same as _device_id_unverified — a transient E2EE setup failure must
+    not permanently disable encryption for the adapter's lifetime."""
+
+    @staticmethod
+    def _basic_mock_client():
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123")
+        )
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.crypto = None
+        mock_client.sync_store = mock_sync_store
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}, "next_batch": "s1"})
+        mock_client.get_account_data = AsyncMock(return_value=MagicMock(content={}))
+        mock_client.add_dispatcher = MagicMock()
+        mock_client.add_event_handler = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        return mock_client
+
+    @pytest.mark.asyncio
+    async def test_flag_recovers_when_second_connect_has_deps(self):
+        """Same adapter: first connect hits a transient _check_e2ee_deps
+        failure (_encryption downgraded to False); second connect must get a
+        fresh attempt, not inherit the stale False from the first."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "e2ee_mode": "optional",
+            },
+        )
+        adapter = MatrixAdapter(config)
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        # --- first connect: deps check fails (transient) → downgraded ---
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(
+            return_value=self._basic_mock_client()
+        )
+        with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False):
+            with patch.dict("sys.modules", fake_mautrix_mods):
+                with patch.object(matrix_mod, "_create_matrix_session", return_value=MagicMock()):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                        result1 = await adapter.connect()
+
+        assert result1 is True
+        assert adapter._encryption is False
+        await adapter.disconnect()
+
+        # --- second connect (same adapter instance): deps now available →
+        #     _encryption must be back to True, the config-derived value,
+        #     not stuck at the first connect's downgraded False. Full
+        #     working E2EE mock (mirrors test_connect_with_access_token_and_
+        #     encryption) since this connect now actually reaches the crypto
+        #     setup + device-key-verification path.
+        mock_client2 = MagicMock()
+        mock_client2.mxid = "@bot:example.org"
+        mock_client2.device_id = None
+        mock_client2.state_store = MagicMock()
+        mock_client2.sync_store = MagicMock()
+        mock_client2.crypto = None
+        mock_client2.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123")
+        )
+        mock_client2.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
+        mock_client2.add_event_handler = MagicMock()
+        mock_client2.handle_sync = MagicMock(return_value=[])
+        mock_client2.query_keys = AsyncMock(return_value=MagicMock(device_keys={
+            "@bot:example.org": {"DEV123": MagicMock(keys={"ed25519:DEV123": "fake_ed25519_key"})},
+        }))
+        mock_client2.api = MagicMock()
+        mock_client2.api.token = "syt_test_access_token"
+        mock_client2.api.session = MagicMock()
+        mock_client2.api.session.close = AsyncMock()
+
+        mock_olm2 = MagicMock()
+        mock_olm2.load = AsyncMock()
+        mock_olm2.share_keys = AsyncMock()
+        mock_olm2.share_keys_min_trust = None
+        mock_olm2.send_keys_min_trust = None
+        mock_olm2.account = MagicMock()
+        mock_olm2.account.identity_keys = {"ed25519": "fake_ed25519_key"}
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client2)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(return_value=mock_olm2)
+
+        with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
+            with patch.dict("sys.modules", fake_mautrix_mods):
+                with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                        result2 = await adapter.connect(is_reconnect=True)
+
+        assert result2 is True
+        assert adapter._encryption is True
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_encryption_off_stays_off_across_reconnect(self):
+        """Regression guard: e2ee_mode=off must not be "recovered" into True
+        by the reset — the reset restores the CONFIG-derived value, not a
+        hardcoded True."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "encryption": False,
+            },
+        )
+        adapter = MatrixAdapter(config)
+        assert adapter._encryption is False
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(
+            return_value=self._basic_mock_client()
+        )
+        with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
+            with patch.dict("sys.modules", fake_mautrix_mods):
+                with patch.object(matrix_mod, "_create_matrix_session", return_value=MagicMock()):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                        result = await adapter.connect()
+
+        assert result is True
+        assert adapter._encryption is False


### PR DESCRIPTION
## Summary

A commit merged earlier today fixed `self._device_id_unverified` in `plugins/platforms/matrix/adapter.py` — a flag that was set once and never reset on reconnect, so a failed device-id resolution on one connect attempt permanently disabled server-side key verification for the adapter's lifetime, even after a later reconnect could have resolved cleanly. The fix: reset the flag at the top of `connect()`.

`self._encryption` has the exact same bug shape and wasn't covered by that fix:

- Initialized once in `__init__` from the config-derived `self._e2ee_mode != "off"`.
- Inside `connect()`, if `e2ee_mode == "optional"` and E2EE setup hits a transient failure (`_check_e2ee_deps()` returns `False` due to a missing-deps import race, or the crypto client import / `Database.create`/`crypto_store.open()` raises due to e.g. a locked sqlite file), `self._encryption` is downgraded to `False`.
- The entire E2EE setup block is gated on `if self._encryption:` — since nothing ever resets it back, once downgraded, **every later reconnect silently skips E2EE setup entirely** instead of retrying, even after the transient cause has cleared (dependency import race resolved, sqlite lock released, etc.).

## Fix

Reset `self._encryption = self._e2ee_mode != "off"` at the top of `connect()`, right alongside the existing `self._device_id_unverified = False` reset, so every (re)connect attempt gets a fresh shot at E2EE setup instead of inheriting a stale downgrade from a previous attempt.

## Test plan

- [x] New `TestEncryptionRecoveryOnReconnect` class in `tests/gateway/test_matrix.py`:
  - `test_flag_recovers_when_second_connect_has_deps` — first connect hits a simulated transient `_check_e2ee_deps() == False` (downgrades to `False`), second connect on the **same adapter instance** has deps available and must end with `_encryption is True`, not stuck at `False`.
  - `test_encryption_off_stays_off_across_reconnect` — regression guard: `e2ee_mode: off` must stay `False` across reconnect (the reset restores the *config-derived* value, not a hardcoded `True`).
- [x] `pytest tests/gateway/test_matrix.py -q` — 252 passed (250 pre-existing + 2 new)
- [x] `ruff check` on all changed files — clean