### PR TITLE
fix(tools): preserve array/object default and const values in schema_sanitizer

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -275,6 +275,101 @@ def test_none_tools_returns_none():
     assert sanitize_tool_schemas(None) is None
 
 
+def test_array_default_value_preserved_as_literal():
+    """Issue #55077: array-valued ``default`` siblings must NOT be walked as schemas.
+
+    The literal ``default: ["read", "write"]`` on a property is a hint to the
+    model, not a JSON Schema sub-document. Walking it through _sanitize_node
+    replaces each bare string with ``{"type": "object", "properties": {}}``
+    and silently corrupts the advertised default.
+    """
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "perms": {
+                "type": "array",
+                "items": {"type": "string"},
+                "default": ["read", "write"],
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    perms = out[0]["function"]["parameters"]["properties"]["perms"]
+    assert perms["default"] == ["read", "write"]
+
+
+def test_object_default_value_preserved_as_literal():
+    """Object-valued ``default`` siblings must survive as-is."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "cfg": {
+                "type": "object",
+                "default": {"nested": ["a", "b"]},
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    cfg = out[0]["function"]["parameters"]["properties"]["cfg"]
+    assert cfg["default"] == {"nested": ["a", "b"]}
+
+
+def test_string_default_preserved_as_literal():
+    """Scalar string ``default`` was already passing — confirm it still does."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "tier": {"type": "string", "const": "gold", "default": "gold"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    tier = out[0]["function"]["parameters"]["properties"]["tier"]
+    assert tier["default"] == "gold"
+    assert tier["const"] == "gold"
+
+
+def test_array_const_preserved_as_literal():
+    """Array-valued ``const`` siblings must NOT be walked as schemas."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "const": ["a", "b"],
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    tags = out[0]["function"]["parameters"]["properties"]["tags"]
+    assert tags["const"] == ["a", "b"]
+
+
+def test_default_with_ref_still_stripped():
+    """Allowing ``default`` as a literal must NOT bypass the $ref-sibling strip.
+
+    The strict-backend rule that ``default`` cannot sit alongside ``$ref``
+    is enforced separately by ``_strip_ref_siblings``. Adding ``default`` to
+    the literal-value allow-list only affects the recursive schema walk;
+    the $ref-sibling strip remains authoritative.
+    """
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "payload": {"$ref": "#/$defs/Payload", "default": ["x", "y"]},
+        },
+        "$defs": {
+            "Payload": {
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    payload = out[0]["function"]["parameters"]["properties"]["payload"]
+    assert payload == {"$ref": "#/$defs/Payload"}
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # strip_pattern_and_format — reactive recovery when llama.cpp rejects a
 # schema with an HTTP 400 grammar-parse error. Must be opt-in (only

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -314,6 +314,17 @@ def _sanitize_node(node: Any, path: str) -> Any:
             # literal strings like "path" as bare-string schemas and replace
             # them with {"type": "object"} dicts. Pass through unchanged.
             out[key] = copy.deepcopy(value) if isinstance(value, (list, dict)) else value
+        elif key in {"default", "const"}:
+            # Annotation siblings whose values are literal instances (any JSON
+            # type, including arrays and objects) rather than schemas. Treat
+            # them the same as ``enum`` / ``examples`` so a default like
+            # ``["read", "write"]`` is not walked as a sub-schema and turned
+            # into ``[{"type": "object", "properties": {}}, ...]``.
+            #
+            # NOTE: ``default`` siblings of ``$ref`` are still removed by the
+            # separate ``_strip_ref_siblings`` pass below — strict backends
+            # (Fireworks, draft-07 validators) reject that combination.
+            out[key] = copy.deepcopy(value) if isinstance(value, (list, dict)) else value
         else:
             out[key] = _sanitize_node(value, f"{path}.{key}") if isinstance(value, (dict, list)) else value
 


### PR DESCRIPTION
## Summary

The `schema_sanitizer` walked literal annotation values for `default` and
`const` through `_sanitize_node`, which corrupts them: a bare string
inside a default/const list was replaced with
`{"type": "object", "properties": {}}` because the walker treats stray
strings as malformed bare-string schemas.

This silently rewrote tool definitions whose advertised defaults used
non-empty arrays (e.g. `default: ["read", "write"]`) or array-bearing
objects, so the model saw an empty-object default instead of the real
literal value.

`default` and `const` now join the existing allow-list alongside
`required`, `enum`, and `examples` — all of them are sibling keywords
whose values are literal instances rather than sub-schemas.

`_strip_ref_siblings` continues to remove `default` from nodes that
carry `$ref`; the $ref-strip runs after the recursive walk and is
unaffected by this change.

## Reproduction (before the fix)

```python
from tools.schema_sanitizer import sanitize_tool_schemas

tool = {"type": "function", "function": {"name": "demo", "parameters": {
    "type": "object",
    "properties": {
        "perms": {"type": "array", "items": {"type": "string"},
                  "default": ["read", "write"]},
        "cfg":   {"type": "object", "default": {"nested": ["a", "b"]}},
    },
    "required": ["perms"],
}}}

props = sanitize_tool_schemas([tool])[0]["function"]["parameters"]["properties"]
print(props["perms"]["default"])
# Before: [{"type": "object", "properties": {}}, {"type": "object", "properties": {}}]
# After:  ["read", "write"]
```

## Test Plan

- [x] Added 5 new tests in `tests/tools/test_schema_sanitizer.py`
      covering array/object `default`, scalar `default`, array `const`,
      and the `$ref`-sibling-strip invariant.
- [x] Full `tests/tools/test_schema_sanitizer.py` suite: 48/48 passed
- [x] Adjacent suites (`tests/test_model_tools.py`,
      `tests/tools/test_todo_tool_type_coercion.py`): 92/92 passed total
- [x] No new files, no scope creep outside the sanitizer and its tests

Closes #55077