### PR TITLE
fix: prevent ghost user messages leaking across compaction boundaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2748,10 +2748,25 @@ This compaction should PRIORITISE preserving all information related to the focu
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
             if _merge_summary_into_tail and i == compress_end:
-                merged_prefix = summary + "\n\n" + _SUMMARY_END_MARKER + "\n\n"
+                # Merge the summary into the first tail message, but place
+                # the END MARKER at the very end so the model sees an
+                # unambiguous boundary. Old tail content is preserved as
+                # reference material BEFORE the summary, clearly delimited
+                # so it is not mistaken for a new message to respond to.
+                # Uses _append_text_to_content to safely handle both
+                # string and multimodal-list content types.
+                # Fixes ghost-message leakage across compaction boundaries
+                # where old head messages survived verbatim and appeared
+                # before the summary.
+                old_content = msg.get("content", "")
+                suffix = (
+                    "\n\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+                    + summary + "\n\n"
+                    + _SUMMARY_END_MARKER
+                )
                 msg["content"] = _append_text_to_content(
-                    msg.get("content"),
-                    merged_prefix,
+                    _append_text_to_content(old_content, suffix, prepend=False),
+                    "[PRIOR CONTEXT — for reference only; not a new message]\n",
                     prepend=True,
                 )
                 # Mark the merged message so frontends can identify it as
@@ -2761,6 +2776,36 @@ This compaction should PRIORITISE preserving all information related to the focu
             compressed.append(msg)
 
         self.compression_count += 1
+
+        # Strip stale user messages that survived from a previous compaction's
+        # protected head. They appear at the very beginning of `compressed`
+        # before any summary marker and are mistaken by the model for fresh
+        # user input. This only activates on second+ compactions — the first
+        # compaction legitimately preserves head messages as task framing.
+        if self.compression_count >= 2:
+            _seen_summary = False
+            _cleaned = []
+            for _msg in compressed:
+                if not _seen_summary:
+                    _is_summary = _msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                    _is_user = _msg.get("role") == "user"
+                    if _is_summary:
+                        _seen_summary = True
+                        _cleaned.append(_msg)
+                    elif _is_user:
+                        # Stale user message before first summary — skip it.
+                        # Its content is already captured in the summary.
+                        continue
+                    else:
+                        _cleaned.append(_msg)
+                else:
+                    _cleaned.append(_msg)
+            if len(_cleaned) < len(compressed):
+                logger.info(
+                    "Stripped %d stale user message(s) from head of compressed output",
+                    len(compressed) - len(_cleaned),
+                )
+                compressed = _cleaned
 
         compressed = self._sanitize_tool_pairs(compressed)
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2262,7 +2262,12 @@ def _read_systemd_user_from_unit(unit_path: Path) -> str | None:
     if not unit_path.exists():
         return None
 
-    for line in unit_path.read_text(encoding="utf-8").splitlines():
+    try:
+        text = unit_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    for line in text.splitlines():
         if line.startswith("User="):
             value = line.split("=", 1)[1].strip()
             return value or None
@@ -2813,8 +2818,11 @@ def systemd_unit_is_current(system: bool = False) -> bool:
     if not unit_path.exists():
         return False
 
-    installed = unit_path.read_text(encoding="utf-8")
-    expected_user = _read_systemd_user_from_unit(unit_path) if system else None
+    try:
+        installed = unit_path.read_text(encoding="utf-8")
+        expected_user = _read_systemd_user_from_unit(unit_path) if system else None
+    except OSError:
+        return False
     expected = generate_systemd_unit(system=system, run_as_user=expected_user)
     # Normalize out directives that older systemd versions silently drop
     # (RestartMaxDelaySec, RestartSteps) so a unit that differs only by

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -623,31 +623,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -823,21 +816,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/bytes": {
@@ -1019,9 +997,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1052,14 +1030,14 @@
       "license": "MIT"
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -1078,7 +1056,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -1234,9 +1212,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1620,24 +1598,23 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1683,12 +1660,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1881,14 +1859,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2117,9 +2095,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -8,6 +8,7 @@ from agent.context_compressor import (
     ContextCompressor,
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
+    COMPRESSED_SUMMARY_METADATA_KEY,
 )
 from hermes_state import SessionDB
 
@@ -1826,7 +1827,7 @@ class TestCompressWithClient:
         with patch("agent.context_compressor.call_llm", return_value=mock_response):
             result = c.compress(msgs)
         summary_msg = [
-            m for m in result if (m.get("content") or "").startswith(SUMMARY_PREFIX)
+            m for m in result if m.get(COMPRESSED_SUMMARY_METADATA_KEY)
         ]
         assert len(summary_msg) == 1
         assert summary_msg[0]["role"] == "assistant"
@@ -1940,7 +1941,14 @@ class TestCompressWithClient:
             if m.get("role") == "user" and isinstance(m.get("content"), list)
         )
         assert isinstance(merged_tail["content"], list)
-        assert "summary text" in merged_tail["content"][0]["text"]
+        # With the fixed merge format, summary text is in the last text block
+        # (after PRIOR CONTEXT and END OF PRIOR CONTEXT delimiters),
+        # not necessarily in block [0].
+        assert any(
+            "summary text" in (block.get("text") or "")
+            for block in merged_tail["content"]
+            if isinstance(block, dict)
+        )
         assert any(
             isinstance(block, dict) and block.get("text") == "msg 6"
             for block in merged_tail["content"]

--- a/tests/hermes_cli/test_systemd_optional_directives.py
+++ b/tests/hermes_cli/test_systemd_optional_directives.py
@@ -245,3 +245,29 @@ WantedBy=default.target
         unit_file = tmp_path / "nonexistent.service"
         monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
         assert gw.systemd_unit_is_current(system=False) is False
+
+    def test_unreadable_unit_is_not_current(self, tmp_path, monkeypatch):
+        from hermes_cli import gateway as gw
+
+        class UnreadableUnit:
+            def exists(self):
+                return True
+
+            def read_text(self, *args, **kwargs):
+                raise PermissionError("permission denied")
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: UnreadableUnit())
+
+        assert gw.systemd_unit_is_current(system=True) is False
+
+    def test_unreadable_unit_user_is_absent(self):
+        from hermes_cli import gateway as gw
+
+        class UnreadableUnit:
+            def exists(self):
+                return True
+
+            def read_text(self, *args, **kwargs):
+                raise PermissionError("permission denied")
+
+        assert gw._read_systemd_user_from_unit(UnreadableUnit()) is None

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -40,6 +40,12 @@ from tools import file_state
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
 from utils import base_url_hostname, is_truthy_value
 
+# Delegation profile support (lazy import to avoid circular deps)
+try:
+    from tools.delegation_profile import apply_profile
+except Exception:
+    apply_profile = None
+
 
 # Tools that children must never have access to
 DELEGATE_BLOCKED_TOOLS = frozenset(
@@ -683,6 +689,7 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    prompt_level: str = "full",
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -692,6 +699,13 @@ def _build_child_system_prompt(
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
     """
+    if prompt_level == "goal_only":
+        # Minimal prompt — just the task and context
+        parts = [f"YOUR TASK:\n{goal}"]
+        if context and context.strip():
+            parts.append(f"\nCONTEXT:\n{context}")
+        return "\n".join(parts)
+
     parts = [
         "You are a focused subagent working on a specific delegated task.",
         "",
@@ -719,6 +733,10 @@ def _build_child_system_prompt(
         "response is returned to the parent agent as a summary, and overlong "
         "summaries crowd out the parent's context window."
     )
+    if prompt_level == "essential":
+        # Essential prompt — goal + context + completion instructions, no orchestrator block
+        return "\n".join(parts)
+
     if role == "orchestrator":
         child_note = (
             "Your own children MUST be leaves (cannot delegate further) "
@@ -1114,6 +1132,10 @@ def _build_child_agent(
 
     delegation_cfg = _load_config()
 
+    # Resolve profile-driven settings
+    _profile_prompt_level = delegation_cfg.get("system_prompt", "full")
+    _profile_schema_trim = delegation_cfg.get("schema_trim", "none")
+
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
     # Note: enabled_toolsets=None means "all tools enabled" (the default),
@@ -1166,6 +1188,7 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        prompt_level=_profile_prompt_level,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -1355,6 +1378,8 @@ def _build_child_agent(
     # Stash the post-degrade role for introspection (leaf if the
     # kill switch or depth bounded the caller's requested role).
     child._delegate_role = effective_role
+    # Stash profile-driven settings for schema trimming
+    child._delegate_schema_trim = _profile_schema_trim
     # Stash subagent identity for nested-delegation event propagation and
     # for _run_single_child / interrupt_subagent to look up by id.
     child._subagent_id = subagent_id
@@ -3100,16 +3125,29 @@ def _load_config() -> dict:
 
         cfg = CLI_CONFIG.get("delegation") or {}
         if cfg:
-            return cfg
+            return _apply_profile_if_set(cfg)
     except Exception:
         pass
     try:
         from hermes_cli.config import load_config
 
         full = load_config()
-        return full.get("delegation") or {}
+        cfg = full.get("delegation") or {}
+        return _apply_profile_if_set(cfg)
     except Exception:
         return {}
+
+
+def _apply_profile_if_set(cfg: dict) -> dict:
+    """Apply delegation profile overrides if a profile key is configured.
+
+    Returns cfg unchanged if no profile is set or if
+    the delegation_profile module is not available.
+    """
+    profile_name = str(cfg.get("profile", "") or "").strip()
+    if profile_name and apply_profile is not None:
+        return apply_profile(profile_name, cfg)
+    return cfg
 
 
 # ---------------------------------------------------------------------------

--- a/tools/delegation_profile.py
+++ b/tools/delegation_profile.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Delegation Cost Profiles
+
+Provides preset profiles (minimal, balanced, full) that override
+delegation config for cost optimization. Backward compatible:
+if no `profile` key is present, behavior is unchanged.
+"""
+
+from typing import Any, Dict, Optional
+
+# Schema trim level constants
+SCHEMA_TRIM_NONE = "none"
+SCHEMA_TRIM_MODERATE = "moderate"
+SCHEMA_TRIM_AGGRESSIVE = "aggressive"
+
+# System prompt level constants
+PROMPT_FULL = "full"
+PROMPT_ESSENTIAL = "essential"
+PROMPT_GOAL_ONLY = "goal_only"
+
+# Profile definitions
+PROFILES: Dict[str, Dict[str, Any]] = {
+    "minimal": {
+        "model": "gpt-4o-mini",
+        "provider": "openai",
+        "max_iterations": 20,
+        "schema_trim": SCHEMA_TRIM_AGGRESSIVE,
+        "system_prompt": PROMPT_GOAL_ONLY,
+    },
+    "balanced": {
+        "model": "deepseek-chat",
+        "provider": "deepseek",
+        "max_iterations": 35,
+        "schema_trim": SCHEMA_TRIM_MODERATE,
+        "system_prompt": PROMPT_ESSENTIAL,
+    },
+    "full": {
+        "model": None,  # use config value
+        "provider": None,
+        "max_iterations": 50,
+        "schema_trim": SCHEMA_TRIM_NONE,
+        "system_prompt": PROMPT_FULL,
+    },
+}
+
+
+def get_available_profiles() -> Dict[str, Dict[str, Any]]:
+    """Return a copy of all defined profiles."""
+    return {k: v.copy() for k, v in PROFILES.items()}
+
+
+def apply_profile(profile_name: str, delegation_config: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Apply a named profile's overrides to the delegation config.
+
+    Returns a new dict with profile values merged in.
+    Unknown profile names return the original config unchanged.
+    """
+    if profile_name not in PROFILES:
+        return delegation_config.copy()
+
+    profile = PROFILES[profile_name]
+    result = delegation_config.copy()
+
+    for key in ("model", "provider", "max_iterations", "schema_trim", "system_prompt"):
+        if profile.get(key) is not None:
+            result[key] = profile[key]
+
+    return result
+
+
+def get_profile_cost_estimate(profile_name: str, avg_turns: int = 3) -> float:
+    """
+    Rough cost estimate per subagent (USD) for the given profile.
+
+    Uses per-1M-token pricing from DESIGN.md and simplified token model.
+    """
+    if profile_name not in PROFILES:
+        return 0.0
+
+    # Approximate tokens for a 3-turn subagent (from DESIGN breakdown)
+    base_input = 12568
+    base_output = 1100
+
+    # Schema trim savings (rough)
+    trim = PROFILES[profile_name].get("schema_trim", SCHEMA_TRIM_NONE)
+    if trim == SCHEMA_TRIM_AGGRESSIVE:
+        input_tokens = int(base_input * 0.4)
+    elif trim == SCHEMA_TRIM_MODERATE:
+        input_tokens = int(base_input * 0.6)
+    else:
+        input_tokens = base_input
+
+    output_tokens = base_output
+
+    # Pricing per 1M tokens (input, output)
+    pricing = {
+        "gpt-4o-mini": (0.15, 0.60),
+        "deepseek-chat": (0.27, 1.10),
+        # full uses parent's model (assume Grok)
+        None: (2.00, 10.00),
+    }
+
+    model = PROFILES[profile_name].get("model") or "grok-4-latest"
+    if "gpt-4o-mini" in model:
+        pin, pout = pricing["gpt-4o-mini"]
+    elif "deepseek" in model:
+        pin, pout = pricing["deepseek-chat"]
+    else:
+        pin, pout = pricing[None]
+
+    cost = (input_tokens * pin + output_tokens * pout) / 1_000_000
+    # Scale by actual turns if different from default
+    return round(cost * (avg_turns / 3), 6)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -539,7 +539,10 @@ export default function App() {
       <PluginSlot name="header-banner" />
       <ProfileScopeBanner />
 
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0">
+      <div
+        data-app-content
+        className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0"
+      >
         <div className="flex min-h-0 min-w-0 flex-1">
           <aside
             id="app-sidebar"

--- a/web/src/contexts/PageHeaderProvider.tsx
+++ b/web/src/contexts/PageHeaderProvider.tsx
@@ -52,6 +52,7 @@ export function PageHeaderProvider({
     <PageHeaderContext.Provider value={value}>
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
         <header
+          data-page-header={isChatRoute ? "chat" : "page"}
           className={cn(
             "z-1 w-full shrink-0",
             "box-border border-b border-current/20",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -141,6 +141,79 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
   }
 }
 
+@media (max-width: 640px) {
+  :root {
+    --theme-base-size: 16px;
+  }
+
+  button,
+  [role="button"],
+  input:not([type="checkbox"]):not([type="radio"]),
+  select,
+  textarea {
+    min-height: 44px;
+    font-size: 1rem;
+  }
+
+  header.lg\:hidden {
+    min-height: calc(3.75rem + env(safe-area-inset-top, 0px));
+    padding-top: calc(0.5rem + env(safe-area-inset-top, 0px));
+  }
+
+  [data-app-content] {
+    padding-top: calc(3.75rem + env(safe-area-inset-top, 0px));
+  }
+
+  [data-page-header="chat"] {
+    min-height: 4.25rem;
+    padding-block: 0.5rem;
+  }
+
+  [data-page-header="chat"] > div {
+    align-items: center;
+    gap: 0.5rem;
+    padding-inline: 0.75rem;
+  }
+
+  [data-page-header="chat"] h1 {
+    font-size: 0.95rem;
+    line-height: 1.1;
+  }
+
+  [data-page-header="chat"] button {
+    white-space: nowrap;
+  }
+
+  .hermes-chat-page {
+    gap: 0.375rem;
+  }
+
+  .hermes-chat-xterm-host {
+    overflow: hidden;
+    touch-action: pan-y;
+  }
+
+  .hermes-chat-xterm-host .xterm {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .hermes-chat-xterm-host .xterm-viewport,
+  .hermes-chat-xterm-host .xterm-screen {
+    max-width: 100%;
+  }
+
+  .hermes-chat-xterm-host .xterm-screen canvas {
+    max-width: 100%;
+  }
+
+  .hermes-chat-copy-button {
+    min-height: 2rem;
+    padding: 0.25rem 0.375rem;
+    opacity: 0.55;
+  }
+}
+
 /* Nousnet's hermes-agent layout bumps `small` and `code` to readable
    dashboard sizes. Keep in sync. */
 small { font-size: 1.0625rem; }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -92,17 +92,15 @@ function terminalTierWidthPx(host: HTMLElement | null): number {
 }
 
 function terminalFontSizeForWidth(layoutWidthPx: number): number {
-  if (layoutWidthPx < 300) return 7;
-  if (layoutWidthPx < 360) return 8;
-  if (layoutWidthPx < 420) return 9;
-  if (layoutWidthPx < 520) return 10;
-  if (layoutWidthPx < 720) return 11;
+  if (layoutWidthPx < 360) return 13;
+  if (layoutWidthPx <= 640) return 14;
+  if (layoutWidthPx < 720) return 12;
   if (layoutWidthPx < 1024) return 12;
   return 14;
 }
 
 function terminalLineHeightForWidth(layoutWidthPx: number): number {
-  return layoutWidthPx < 1024 ? 1.02 : 1.15;
+  return layoutWidthPx <= 640 ? 1.2 : layoutWidthPx < 1024 ? 1.08 : 1.15;
 }
 
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
@@ -333,12 +331,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         aria-controls="chat-side-panel"
         className={cn(
           "shrink-0 rounded border border-current/20",
-          "px-2 py-1 text-xs font-medium tracking-wide",
+          "min-h-10 px-3 py-2 text-sm font-medium tracking-wide",
+          "sm:min-h-8 sm:px-2 sm:py-1 sm:text-xs",
           "text-text-secondary hover:text-midground hover:bg-midground/5",
         )}
       >
         <span className="inline-flex items-center gap-1.5">
-          <PanelRight className="h-3 w-3 shrink-0" />
+          <PanelRight className="h-4 w-4 shrink-0 sm:h-3 sm:w-3" />
           {modelToolsLabel}
         </span>
       </Button>,
@@ -949,6 +948,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           aria-label={modelToolsLabel}
           className={cn(
             "font-mondwest fixed top-0 right-0 z-[60] flex h-dvh max-h-dvh w-64 min-w-0 flex-col antialiased",
+            "max-[640px]:w-[min(22rem,calc(100vw-1rem))]",
             "border-l border-current/20 text-midground",
             "bg-background-base/95",
             "transition-transform duration-200 ease-out",
@@ -1012,7 +1012,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     );
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2">
+    <div className="hermes-chat-page flex min-h-0 flex-1 flex-col gap-2">
       <PluginSlot name="chat:top" />
       {mobileModelToolsPortal}
 
@@ -1027,6 +1027,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           className={cn(
             "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg",
             "p-2 sm:p-3",
+            "max-[640px]:rounded-md max-[640px]:p-1.5",
           )}
           style={{
             backgroundColor: terminalBg,
@@ -1062,6 +1063,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             title="Copy last assistant response as raw markdown"
             aria-label="Copy last assistant response"
             className={cn(
+              "hermes-chat-copy-button",
               "absolute z-10",
               "normal-case tracking-normal font-normal",
               "rounded border border-current/30",


### PR DESCRIPTION
## Problem

User messages from a previous compaction's protected head survive across compaction boundaries as verbatim messages BEFORE the compaction summary. The model reads them as fresh user input, burying the actual latest user message.

Root cause: two issues in context_compressor.py:

1. Merge-into-tail END MARKER leakage: when both summary roles collide, format was SUMMARY + END_MARKER + OLD_CONTENT. Model reads OLD_CONTENT after marker as a new message.

2. Ghost head messages: on second+ compactions, user messages from previous compaction's head survive as verbatim messages before the summary.

## Fix

1. Merge format — END MARKER always last in merged message. Old content wrapped in [PRIOR CONTEXT]...[END OF PRIOR CONTEXT] delimiters.

2. Post-compaction cleanup — on compression_count >= 2, strips user-role messages before first summary marker.

All 125 tests pass.