### PR TITLE
docs(env): mark HERMES_MAX_ITERATIONS as deprecated in environment-variables reference

### DIFF
--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -710,7 +710,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_MAX_ITERATIONS` | Max tool-calling iterations per conversation (default: 90) |
+| `HERMES_MAX_ITERATIONS` | Deprecated compatibility alias for the iteration budget. Prefer `agent.max_turns` in `config.yaml`; the setup wizard removes this variable automatically to avoid silent shadowing. |
 | `HERMES_INFERENCE_MODEL` | Override model name at process level (takes priority over `config.yaml` for the session). Also settable via `-m`/`--model` flag. |
 | `HERMES_YOLO_MODE` | Set to `1` to bypass dangerous-command approval prompts. Equivalent to `--yolo`. |
 | `HERMES_ACCEPT_HOOKS` | Auto-approve any unseen shell hooks declared in `config.yaml` without a TTY prompt. Equivalent to `--accept-hooks` or `hooks_auto_accept: true`. |


### PR DESCRIPTION
﻿## What does this PR do?

Corrects a stale entry in the environment-variables reference. `HERMES_MAX_ITERATIONS` is currently documented as a first-class, user-settable variable:

> | `HERMES_MAX_ITERATIONS` | Max tool-calling iterations per conversation (default: 90) |

But the codebase treats it as a deprecated backward-compat bridge, not a supported knob:

- `hermes_cli/setup.py` — the setup wizard actively **removes** `HERMES_MAX_ITERATIONS` from `.env`.
- `hermes_cli/doctor.py` — flags a stale `HERMES_MAX_ITERATIONS` in `.env` as a "ghost" shadowing `agent.max_turns` in `config.yaml`.
- Tests assert `HERMES_MAX_ITERATIONS` must **not** be in `OPTIONAL_ENV_VARS` (issue #17534).

The iteration budget is configured via `agent.max_turns` in `config.yaml`. Documenting the env var as a supported setting sends users toward a value the wizard will silently delete.

## The fix

One line, aligned with how other deprecated variables are already documented in the same file (e.g. `TERMINAL_CWD`, `MESSAGING_CWD`, `HERMES_TOOL_PROGRESS`):

```diff
-| `HERMES_MAX_ITERATIONS` | Max tool-calling iterations per conversation (default: 90) |
+| `HERMES_MAX_ITERATIONS` | Deprecated compatibility alias for the iteration budget. Prefer `agent.max_turns` in `config.yaml`; the setup wizard removes this variable automatically to avoid silent shadowing. |
```

## Type of Change

- [x] Documentation update

## Notes

- Docs-only. Zero runtime/behavior change.
- 1 file, 1 line changed.
- Provable by direct file comparison against `hermes_cli/setup.py`, `hermes_cli/doctor.py`, and `hermes_cli/config.py`.
