### PR TITLE
test(moa): loosen parallel-fan-out timing threshold to tolerate CI jitter

### DIFF
--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -566,7 +566,10 @@ def test_references_run_in_parallel(monkeypatch):
     elapsed = time.monotonic() - start
 
     # Two 0.5s sleeps run concurrently → well under the 1.0s serial floor.
-    assert elapsed < 0.9, f"references did not run in parallel (took {elapsed:.2f}s)"
+    # Threshold sits at 0.95s (not tight against 0.5s) to tolerate CI
+    # thread-pool startup jitter while still failing hard if the two calls
+    # ran serially (which would be ≥1.0s).
+    assert elapsed < 0.95, f"references did not run in parallel (took {elapsed:.2f}s)"
     # Output order matches input order (stable Reference N labelling).
     assert [label for label, _, _ in out] == ["p1:ok", "moa:preset", "p2:boom", "p3:ok"]
     assert "recursively reference MoA" in out[1][1]


### PR DESCRIPTION
## Summary

Fixes a flaky CI shard: `test_moa_loop_mode.py::test_references_run_in_parallel` intermittently fails on a wall-clock threshold under load.

## Root cause

The test dispatches four MoA references where two do `time.sleep(0.5)` concurrently, then asserts `elapsed < 0.9` to prove they ran in parallel (serial would be ≥1.0s). The `< 0.9` ceiling leaves only 0.4s of slack above the 0.5s of real work — on a loaded 8-worker CI runner, thread-pool startup jitter pushed wall time to `0.9001s`, a **0.14ms** miss, failing the shard.

## Changes

- `tests/run_agent/test_moa_loop_mode.py`: loosen the threshold `< 0.9` → `< 0.95`. Still well below the 1.0s serial floor, so a genuine serialization regression (≥1.0s) still fails hard; the assertion keeps its purpose while tolerating scheduling jitter.

## Validation

| | Before | After |
|---|---|---|
| Parallel run (~0.5s + jitter) | flakes near 0.9s ceiling | passes (< 0.95) |
| Serial regression (≥1.0s) | fails | fails (unchanged) |

Targeted test passes locally.

## Infographic

![Flaky timing test fixed](https://v3b.fal.media/files/b/0aa0807a/JYgFul-Q492oWgxS0pegb_HfaWdp7i.png)

Nous Research
