### PR TITLE
fix(tui): guard slash_worker sys.path against local package shadowing (#51286)

### DIFF
--- a/tests/tui_gateway/test_slash_worker_sys_path.py
+++ b/tests/tui_gateway/test_slash_worker_sys_path.py
@@ -1,0 +1,60 @@
+"""Regression tests for tui_gateway/slash_worker.py sys.path hardening (issue #51286).
+
+The slash-command worker is spawned as ``-m tui_gateway.slash_worker`` and
+inherits the user's CWD. A local package (e.g. ``utils/``) in that CWD shadows
+the installed hermes ``utils`` module and crashes the worker on ``import cli``
+(``ImportError: cannot import name 'atomic_replace' from 'utils'``).
+
+#15989 added this guard to the sibling entrypoint ``tui_gateway/entry.py`` but
+missed this child, so the crash still reproduced. slash_worker.py must sanitize
+sys.path before its first non-stdlib import.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_slash_worker_imports_from_cwd_with_colliding_utils(tmp_path):
+    """Importing the worker from a CWD that ships its own ``utils/`` package
+    must succeed — the guard strips CWD so the installed module wins."""
+    # Mimic the user's project (tg-ws-proxy ships utils/, proxy/, ui/).
+    for pkg in ("utils", "proxy", "ui"):
+        (tmp_path / pkg).mkdir()
+        (tmp_path / pkg / "__init__.py").write_text("")  # no atomic_replace, etc.
+
+    env = {k: v for k, v in os.environ.items() if k != "HERMES_PYTHON_SRC_ROOT"}
+    # Keep the source importable via PYTHONPATH; CWD ('') still precedes it on
+    # sys.path for ``-c``, so the shadow (and thus the guard) is still exercised.
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import tui_gateway.slash_worker"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, (
+        "slash_worker failed to import from a CWD containing a colliding "
+        "utils/ package — sys.path guard regressed (issue #51286).\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def test_sys_path_guard_runs_before_cli_import():
+    """The guard must execute before ``import cli`` — reordering it below the
+    import would re-introduce the shadowing crash."""
+    src = (PROJECT_ROOT / "tui_gateway" / "slash_worker.py").read_text()
+    guard = 'sys.path = [p for p in sys.path if p not in {"", "."}]'
+    cli_import = "import cli as cli_mod"
+    assert guard in src, "sys.path shadowing guard missing from slash_worker.py"
+    assert cli_import in src, "expected 'import cli as cli_mod' in slash_worker.py"
+    assert src.index(guard) < src.index(cli_import), (
+        "sys.path guard must run before 'import cli' (issue #51286)"
+    )

--- a/tests/tui_gateway/test_slash_worker_sys_path.py
+++ b/tests/tui_gateway/test_slash_worker_sys_path.py
@@ -5,11 +5,13 @@ inherits the user's CWD. A local package (e.g. ``utils/``) in that CWD shadows
 the installed hermes ``utils`` module and crashes the worker on ``import cli``
 (``ImportError: cannot import name 'atomic_replace' from 'utils'``).
 
-#15989 added this guard to the sibling entrypoint ``tui_gateway/entry.py`` but
-missed this child, so the crash still reproduced. slash_worker.py must sanitize
-sys.path before its first non-stdlib import.
+#51693 added this guard to the sibling entrypoints ``tui_gateway/entry.py`` and
+``acp_adapter/entry.py`` (via the shared ``hermes_bootstrap.harden_import_path``
+helper) but missed this child, so the crash still reproduced. slash_worker.py
+must run the guard before its first non-stdlib import.
 """
 
+import ast
 import os
 import subprocess
 import sys
@@ -49,12 +51,42 @@ def test_slash_worker_imports_from_cwd_with_colliding_utils(tmp_path):
 
 def test_sys_path_guard_runs_before_cli_import():
     """The guard must execute before ``import cli`` — reordering it below the
-    import would re-introduce the shadowing crash."""
+    import would re-introduce the shadowing crash. Assert via AST that the
+    ``hermes_bootstrap.harden_import_path()`` call precedes ``import cli``."""
     src = (PROJECT_ROOT / "tui_gateway" / "slash_worker.py").read_text()
-    guard = 'sys.path = [p for p in sys.path if p not in {"", "."}]'
-    cli_import = "import cli as cli_mod"
-    assert guard in src, "sys.path shadowing guard missing from slash_worker.py"
-    assert cli_import in src, "expected 'import cli as cli_mod' in slash_worker.py"
-    assert src.index(guard) < src.index(cli_import), (
-        "sys.path guard must run before 'import cli' (issue #51286)"
+    tree = ast.parse(src)
+
+    harden_call_line = None
+    cli_import_line = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "harden_import_path"
+        ):
+            if harden_call_line is None:
+                harden_call_line = node.lineno
+        if isinstance(node, ast.Import) and any(a.name == "cli" for a in node.names):
+            if cli_import_line is None:
+                cli_import_line = node.lineno
+
+    assert harden_call_line is not None, (
+        "slash_worker.py must call hermes_bootstrap.harden_import_path()"
+    )
+    assert cli_import_line is not None, "slash_worker.py must 'import cli'"
+    assert harden_call_line < cli_import_line, (
+        "harden_import_path() must run before 'import cli' (issue #51286)"
+    )
+
+
+def test_guard_delegates_to_shared_helper_not_inline():
+    """slash_worker should delegate to the shared guard, not re-implement the
+    old inline ``{"", "."}`` sys.path filter that #51693 replaced."""
+    src = (PROJECT_ROOT / "tui_gateway" / "slash_worker.py").read_text()
+    assert '{"", "."}' not in src and "{'', '.'}" not in src, (
+        "slash_worker.py should delegate to hermes_bootstrap.harden_import_path, "
+        "not re-implement the guard inline"
+    )
+    assert "hermes_bootstrap.harden_import_path()" in src, (
+        "slash_worker.py must call the shared hermes_bootstrap.harden_import_path guard"
     )

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -3,25 +3,25 @@
 Protocol: reads JSON lines from stdin {id, command}, writes {id, ok, output|error} to stdout.
 """
 
-import os
-import sys
+# Stop a ``utils/`` (or ``proxy/``, ``ui/``) package in the launch directory
+# from shadowing Hermes's own top-level modules.  This worker is spawned as
+# ``-m tui_gateway.slash_worker`` and inherits the user's CWD, so the ``import
+# cli`` below would otherwise resolve ``utils`` to a colliding local package
+# and crash the child in a retry loop (issue #51286).  ``hermes_bootstrap``
+# lives at the repo root, so importing it is safe before the guard runs (its
+# name won't collide with a user package), and it owns the canonical
+# path-hardening logic shared with the other entry points — #51693 added the
+# guard to ``entry.py``/``acp_adapter/entry.py`` but missed this child.
+import hermes_bootstrap
 
-# Guard against a local ``utils/`` (or other) package in the spawn CWD shadowing
-# installed hermes modules. This worker is spawned as ``-m tui_gateway.slash_worker``
-# and inherits the user's CWD, so the ``import cli`` below would otherwise resolve
-# ``utils`` to a colliding local package and crash the child (issue #51286). The
-# sibling entrypoint ``tui_gateway/entry.py`` applies the same guard; #15989 added
-# it there but missed this child.
-_src_root = os.environ.get("HERMES_PYTHON_SRC_ROOT", "")
-if _src_root and _src_root not in sys.path:
-    sys.path.insert(0, _src_root)
-# '' and '.' both resolve to CWD at import time and can shadow installed packages.
-sys.path = [p for p in sys.path if p not in {"", "."}]
+hermes_bootstrap.harden_import_path()
 
 import argparse
 import contextlib
 import io
 import json
+import os
+import sys
 import threading
 import time
 

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -3,12 +3,25 @@
 Protocol: reads JSON lines from stdin {id, command}, writes {id, ok, output|error} to stdout.
 """
 
+import os
+import sys
+
+# Guard against a local ``utils/`` (or other) package in the spawn CWD shadowing
+# installed hermes modules. This worker is spawned as ``-m tui_gateway.slash_worker``
+# and inherits the user's CWD, so the ``import cli`` below would otherwise resolve
+# ``utils`` to a colliding local package and crash the child (issue #51286). The
+# sibling entrypoint ``tui_gateway/entry.py`` applies the same guard; #15989 added
+# it there but missed this child.
+_src_root = os.environ.get("HERMES_PYTHON_SRC_ROOT", "")
+if _src_root and _src_root not in sys.path:
+    sys.path.insert(0, _src_root)
+# '' and '.' both resolve to CWD at import time and can shadow installed packages.
+sys.path = [p for p in sys.path if p not in {"", "."}]
+
 import argparse
 import contextlib
 import io
 import json
-import os
-import sys
 import threading
 import time
 


### PR DESCRIPTION
## Summary
Applies the sys.path shadowing guard to `tui_gateway/slash_worker.py` so a cwd package named `utils`/`proxy`/`ui` can no longer crash the spawned slash-command worker on `import cli`.

Root cause: the worker is spawned as `-m tui_gateway.slash_worker` with `cwd=os.getcwd()` and does an unguarded `import cli` at module top. Python seeds `sys.path` with the cwd, so a colliding local `utils/` package resolves before the installed hermes module → `ImportError: cannot import name 'atomic_replace' from 'utils'` → child exits 1 and the parent retries in a crash loop. #51693 hardened the sibling entry points (`entry.py`, `acp_adapter/entry.py`) via the shared `hermes_bootstrap.harden_import_path()` helper but missed this separately-spawned child.

## Changes
- `tui_gateway/slash_worker.py`: run `hermes_bootstrap.harden_import_path()` before the first non-stdlib import, matching `entry.py`/`acp_adapter/entry.py`. Salvaged from @Christopher-Schulze's PR; modernized from the older inline `{"", "."}` filter to the shared helper, which additionally relocates the Hermes source root ahead of an *absolute* cwd path on `sys.path` (venv/PYTHONPATH case the inline filter missed).
- `tests/tui_gateway/test_slash_worker_sys_path.py`: regression test — subprocess import from a cwd shipping colliding `utils/`/`proxy/`/`ui/` packages must not crash; AST check that the guard runs before `import cli`; check it delegates to the shared helper rather than re-inlining.

## Validation
| | Before (unguarded) | After |
|---|---|---|
| Import from colliding cwd | `ImportError: cannot import name 'atomic_replace' from 'utils'`, rc 1 | imports clean, rc 0 |
| Targeted tests | — | 3/3 pass |

E2E reproduced the exact reported failure on the unguarded path and confirmed the fixed worker imports cleanly.

Fixes #51286.

## Infographic
![PR #51484 infographic](https://v3b.fal.media/files/b/0aa08085/NM7YWDWXaSlK1yuCOFHUp_NTRGNVCd.png)

---
Nous Research · NousResearch/hermes-agent
