### PR TITLE
fix(tools): don't apply host-mtime dedup/staleness on remote backends

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -994,3 +994,267 @@ class TestNotFoundCache:
         assert _check_not_found_cache("read", "/tmp/never-exists-notify", tid) is None, (
             "notify_other_tool_call must clear cached misses"
         )
+
+
+class TestIsHostLocalEnv:
+    """_is_host_local_env gates read-dedup and staleness detection to the
+    local backend only. Host os.path.getmtime is meaningless for a file
+    living inside a docker/singularity/ssh/modal/daytona sandbox, so those
+    backends must never be reported as host-local."""
+
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    def test_true_when_active_env_is_local(self, mock_active):
+        from tools.environments.local import LocalEnvironment
+        from tools.file_tools import _is_host_local_env
+
+        mock_active["default"] = MagicMock(spec=LocalEnvironment)
+        assert _is_host_local_env("default") is True
+
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    def test_false_when_active_env_is_not_local(self, mock_active):
+        from tools.environments.docker import DockerEnvironment
+        from tools.file_tools import _is_host_local_env
+
+        mock_active["default"] = MagicMock(spec=DockerEnvironment)
+        assert _is_host_local_env("default") is False
+
+    @patch("tools.terminal_tool._get_env_config")
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    def test_falls_back_to_config_when_no_active_env(self, mock_active, mock_config):
+        from tools.file_tools import _is_host_local_env
+
+        mock_config.return_value = {"env_type": "local"}
+        assert _is_host_local_env("default") is True
+
+        mock_config.return_value = {"env_type": "docker"}
+        assert _is_host_local_env("default") is False
+
+    @patch("tools.terminal_tool._get_env_config")
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    def test_falls_back_to_terminal_env_when_config_raises(
+        self, mock_active, mock_config, monkeypatch
+    ):
+        from tools.file_tools import _is_host_local_env
+
+        mock_config.side_effect = RuntimeError("no config available")
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        assert _is_host_local_env("default") is False
+
+        # Nothing configured anywhere: no remote backend exists to be wrong
+        # about, so the host filesystem is the right assumption.
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        assert _is_host_local_env("default") is True
+
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    def test_false_for_subagent_sharing_parent_container(self, mock_active, monkeypatch):
+        """A delegate_task subagent registers no env of its own — it shares
+        the parent's container under the collapsed "default" key.  Looking up
+        the raw subagent id finds nothing and would fall back to the global
+        config default ("local"), silently re-enabling host mtimes for a file
+        that only exists inside the container."""
+        from tools.environments.docker import DockerEnvironment
+        from tools.file_tools import _is_host_local_env
+
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        mock_active["default"] = MagicMock(spec=DockerEnvironment)
+        assert _is_host_local_env("subagent_1") is False
+
+
+class TestReadDedupHostLocalGate:
+    """Regression guard: read-dedup must only stub out a re-read when the
+    terminal backend is local. On a remote backend a host mtime "match" is
+    meaningless — skipping the real read would silently serve stale content
+    for a file the agent never actually re-checked."""
+
+    @staticmethod
+    def _seed_dedup(task_id, resolved_path, offset, limit, mtime):
+        from tools.file_tools import _read_tracker, _read_tracker_lock
+        with _read_tracker_lock:
+            task_data = _read_tracker.setdefault(task_id, {
+                "last_key": None, "consecutive": 0,
+                "read_history": set(), "dedup": {},
+                "dedup_hits": {}, "read_timestamps": {},
+            })
+            task_data["dedup"][(resolved_path, offset, limit)] = mtime
+
+    @patch("tools.file_tools._is_host_local_env", return_value=True)
+    @patch("tools.file_tools._get_file_ops")
+    def test_dedup_stub_fires_on_local_env(self, mock_get, mock_is_local, tmp_path):
+        from tools.file_tools import read_file_tool, _read_tracker
+
+        f = tmp_path / "a.txt"
+        f.write_text("hello\n")
+        task_id = "dedup-local"
+        _read_tracker.pop(task_id, None)
+        self._seed_dedup(task_id, str(f), 1, 500, f.stat().st_mtime)
+
+        result = json.loads(read_file_tool(str(f), 1, 500, task_id))
+
+        assert result.get("dedup") is True
+        assert result.get("status") == "unchanged"
+        mock_get.assert_not_called()
+        _read_tracker.pop(task_id, None)
+
+    @patch("tools.file_tools._is_host_local_env", return_value=False)
+    @patch("tools.file_tools._get_file_ops")
+    def test_dedup_skipped_on_remote_env_even_with_matching_mtime(
+        self, mock_get, mock_is_local, tmp_path
+    ):
+        from tools.file_tools import read_file_tool, _read_tracker
+
+        f = tmp_path / "b.txt"
+        f.write_text("hello\n")
+        task_id = "dedup-remote"
+        _read_tracker.pop(task_id, None)
+        self._seed_dedup(task_id, str(f), 1, 500, f.stat().st_mtime)
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "hello"
+        result_obj.to_dict.return_value = {"content": "hello", "total_lines": 1}
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        result = json.loads(read_file_tool(str(f), 1, 500, task_id))
+
+        assert result.get("dedup") is not True
+        assert result.get("content") == "hello"
+        mock_get.assert_called_once()
+        _read_tracker.pop(task_id, None)
+
+
+class TestCheckFileStalenessHostLocalGate:
+    """Regression guard: staleness warnings on write/patch must only compare
+    host mtimes when the backend is local. On a remote backend the host-side
+    mtime of a same-named path is unrelated to the sandboxed file, so a
+    "changed" comparison would be a false positive."""
+
+    @patch("tools.file_tools._is_host_local_env", return_value=False)
+    def test_returns_none_on_remote_env_even_when_mtime_differs(self, mock_is_local, tmp_path):
+        from tools.file_tools import _check_file_staleness, _read_tracker
+
+        f = tmp_path / "c.txt"
+        f.write_text("v1\n")
+        task_id = "staleness-remote"
+        _read_tracker[task_id] = {"read_timestamps": {str(f): -1.0}}  # deliberately stale
+
+        assert _check_file_staleness(str(f), task_id) is None
+        _read_tracker.pop(task_id, None)
+
+    @patch("tools.file_tools._is_host_local_env", return_value=True)
+    def test_warns_on_local_env_when_mtime_differs(self, mock_is_local, tmp_path):
+        from tools.file_tools import _check_file_staleness, _read_tracker
+
+        f = tmp_path / "d.txt"
+        f.write_text("v1\n")
+        task_id = "staleness-local"
+        _read_tracker[task_id] = {"read_timestamps": {str(f): -1.0}}  # older than real mtime
+
+        warning = _check_file_staleness(str(f), task_id)
+
+        assert warning is not None
+        assert "modified since you last read it" in warning
+        _read_tracker.pop(task_id, None)
+
+
+class TestFileStateRegistryRemoteGate:
+    """Public-tool coverage for the cross-agent registry on remote backends.
+
+    read_file → write_file and read_file → patch_tool run the registry, which
+    stamps a host mtime on read and re-stats the host path before the write.
+    On a remote backend that path is not the file the tools actually touched
+    — either a same-named host twin (ssh) or nothing at all (container) — so
+    those mtimes must not drive warnings.  The backend-agnostic half of the
+    registry (per-path locks, sibling-write coordination) must keep working.
+    """
+
+    @staticmethod
+    def _file_ops():
+        mock_ops = MagicMock()
+        read_obj = MagicMock()
+        read_obj.content = "sandbox v1"
+        read_obj.to_dict.return_value = {"content": "sandbox v1", "total_lines": 1}
+        mock_ops.read_file.return_value = read_obj
+        for _attr in ("write_file", "patch_replace"):
+            _obj = MagicMock()
+            _obj.to_dict.return_value = {"success": True}
+            getattr(mock_ops, _attr).return_value = _obj
+        return mock_ops
+
+    @patch("tools.file_tools._get_file_ops")
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    def test_read_then_write_ignores_host_twin_mtime(self, mock_active, mock_get, tmp_path):
+        import os
+        from tools import file_state
+        from tools.environments.ssh import SSHEnvironment
+        from tools.file_tools import read_file_tool, write_file_tool
+
+        file_state.get_registry().clear()
+        mock_active["default"] = MagicMock(spec=SSHEnvironment)
+        mock_get.return_value = self._file_ops()
+
+        # ssh resolves host-style paths, so a same-named file on the host is
+        # stat-able — and completely unrelated to the file over the wire.
+        twin = tmp_path / "app.py"
+        twin.write_text("host twin v1\n")
+        task_id = "remote-read-write"
+
+        read_file_tool(str(twin), 1, 500, task_id)
+        os.utime(twin, (0, 0))  # host-side churn on the twin only
+
+        result = json.loads(write_file_tool(str(twin), "sandbox v2", task_id))
+
+        assert "_warning" not in result, result.get("_warning")
+        file_state.get_registry().clear()
+
+    @patch("tools.file_tools._get_file_ops")
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    def test_read_then_patch_ignores_host_twin_mtime(self, mock_active, mock_get, tmp_path):
+        import os
+        from tools import file_state
+        from tools.environments.ssh import SSHEnvironment
+        from tools.file_tools import patch_tool, read_file_tool
+
+        file_state.get_registry().clear()
+        mock_active["default"] = MagicMock(spec=SSHEnvironment)
+        mock_get.return_value = self._file_ops()
+
+        twin = tmp_path / "mod.py"
+        twin.write_text("host twin v1\n")
+        task_id = "remote-read-patch"
+
+        read_file_tool(str(twin), 1, 500, task_id)
+        os.utime(twin, (0, 0))
+
+        result = json.loads(patch_tool(
+            mode="replace", path=str(twin), old_string="sandbox v1",
+            new_string="sandbox v2", task_id=task_id,
+        ))
+
+        assert "_warning" not in result, result.get("_warning")
+        file_state.get_registry().clear()
+
+    @patch("tools.file_tools._get_file_ops")
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    def test_sibling_write_coordination_survives_on_container_backend(
+        self, mock_active, mock_get, tmp_path
+    ):
+        """The gate must not disable the registry: a container path never
+        stats on the host, so dropping the read/write records entirely would
+        leave two subagents editing the same sandbox file unwarned."""
+        from tools import file_state
+        from tools.environments.docker import DockerEnvironment
+        from tools.file_tools import read_file_tool, write_file_tool
+
+        file_state.get_registry().clear()
+        mock_active["default"] = MagicMock(spec=DockerEnvironment)
+        mock_get.return_value = self._file_ops()
+
+        target = "/workspace/shared.py"  # exists only inside the container
+        read_file_tool(target, 1, 500, "agent-A")
+        write_file_tool(target, "sibling edit", "agent-B")
+
+        result = json.loads(write_file_tool(target, "stale edit", "agent-A"))
+
+        assert "sibling subagent" in result.get("_warning", ""), result
+        file_state.get_registry().clear()

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -45,7 +45,10 @@ from typing import Dict, Iterable, List, Optional, Tuple
 # (mtime, read_ts, partial).  partial=True when read_file returned a
 # windowed view (offset > 1 or limit < total_lines) — writes that happen
 # after a partial read should still warn so the model re-reads in full.
-ReadStamp = Tuple[float, float, bool]
+# mtime is None when the caller reported that no host mtime describes the
+# file (remote backend): the sibling/partial/never-read checks still apply,
+# only the mtime-drift comparison is skipped.
+ReadStamp = Tuple[Optional[float], float, bool]
 
 # Number of resolved-path entries retained per agent.  Bounded to keep
 # long sessions from accumulating unbounded state.  On overflow we drop
@@ -97,10 +100,18 @@ class FileStateRegistry:
         *,
         partial: bool = False,
         mtime: Optional[float] = None,
+        host_mtime: bool = True,
     ) -> None:
+        """Record that *task_id* has read *resolved*.
+
+        ``host_mtime=False`` means the path lives on a remote backend, so a
+        host ``getmtime`` would describe a different (or missing) file.  The
+        read is still recorded — sibling-write coordination keys off task ids
+        and timestamps, not mtimes — just without an mtime stamp.
+        """
         if _disabled():
             return
-        if mtime is None:
+        if mtime is None and host_mtime:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
@@ -108,7 +119,11 @@ class FileStateRegistry:
         now = time.time()
         with self._state_lock:
             agent_reads = self._reads[task_id]
-            agent_reads[resolved] = (float(mtime), now, bool(partial))
+            agent_reads[resolved] = (
+                float(mtime) if mtime is not None else None,
+                now,
+                bool(partial),
+            )
             _cap_dict(agent_reads, _MAX_PATHS_PER_AGENT)
 
     def note_write(
@@ -117,16 +132,18 @@ class FileStateRegistry:
         resolved: str,
         *,
         mtime: Optional[float] = None,
+        host_mtime: bool = True,
     ) -> None:
         """Record a successful write.
 
         Updates the global last-writer map AND this agent's own read stamp
         (a write is an implicit read — the agent now knows the current
-        content).
+        content).  ``host_mtime=False`` (remote backend) skips the host stat;
+        the last-writer entry is still recorded so siblings keep coordinating.
         """
         if _disabled():
             return
-        if mtime is None:
+        if mtime is None and host_mtime:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
@@ -136,10 +153,20 @@ class FileStateRegistry:
             self._last_writer[resolved] = (task_id, now)
             _cap_dict(self._last_writer, _MAX_GLOBAL_WRITERS)
             # Writer's own view is now up-to-date.
-            self._reads[task_id][resolved] = (float(mtime), now, False)
+            self._reads[task_id][resolved] = (
+                float(mtime) if mtime is not None else None,
+                now,
+                False,
+            )
             _cap_dict(self._reads[task_id], _MAX_PATHS_PER_AGENT)
 
-    def check_stale(self, task_id: str, resolved: str) -> Optional[str]:
+    def check_stale(
+        self,
+        task_id: str,
+        resolved: str,
+        *,
+        host_mtime: bool = True,
+    ) -> Optional[str]:
         """Return a model-facing warning if this write would be stale.
 
         Three staleness classes, in order of severity:
@@ -147,6 +174,11 @@ class FileStateRegistry:
           1. Sibling subagent wrote this file after this agent's last read.
           2. External/unknown change (mtime differs from our last read).
           3. Agent never read the file (write-without-read).
+
+        ``host_mtime=False`` (remote backend) drops case 2 only: the host path
+        is a different file from the sandboxed one, so comparing its mtime
+        invents drift that never happened.  Cases 1 and 3 are backend-agnostic
+        and still apply.
 
         Returns ``None`` when the write is safe.  Does not raise — callers
         decide whether to block or warn.
@@ -163,11 +195,13 @@ class FileStateRegistry:
         if stamp is None and last_writer is None:
             return None
 
-        try:
-            current_mtime = os.path.getmtime(resolved)
-        except OSError:
-            # File doesn't exist — write will create it; not stale.
-            return None
+        current_mtime: Optional[float] = None
+        if host_mtime:
+            try:
+                current_mtime = os.path.getmtime(resolved)
+            except OSError:
+                # File doesn't exist — write will create it; not stale.
+                return None
 
         # Case 1: sibling subagent modified after our last read.
         if last_writer is not None:
@@ -189,10 +223,15 @@ class FileStateRegistry:
                         "Re-read the file before writing."
                     )
 
-        # Case 2: external / unknown modification (mtime drifted).
+        # Case 2: external / unknown modification (mtime drifted).  Needs an
+        # mtime on both sides — a remote read/write leaves neither.
         if stamp is not None:
             read_mtime, _read_ts, partial = stamp
-            if current_mtime != read_mtime:
+            if (
+                current_mtime is not None
+                and read_mtime is not None
+                and current_mtime != read_mtime
+            ):
                 return (
                     f"{resolved} was modified since you last read it "
                     "on disk (external edit or unrecorded writer). "
@@ -292,16 +331,29 @@ def _cap_dict(d: dict, limit: int) -> None:
 
 
 # ── Convenience wrappers (short names used at call sites) ────────────
-def record_read(task_id: str, resolved_or_path: str | Path, *, partial: bool = False) -> None:
-    _registry.record_read(task_id, str(resolved_or_path), partial=partial)
+def record_read(
+    task_id: str,
+    resolved_or_path: str | Path,
+    *,
+    partial: bool = False,
+    host_mtime: bool = True,
+) -> None:
+    _registry.record_read(
+        task_id, str(resolved_or_path), partial=partial, host_mtime=host_mtime
+    )
 
 
-def note_write(task_id: str, resolved_or_path: str | Path) -> None:
-    _registry.note_write(task_id, str(resolved_or_path))
+def note_write(task_id: str, resolved_or_path: str | Path, *, host_mtime: bool = True) -> None:
+    _registry.note_write(task_id, str(resolved_or_path), host_mtime=host_mtime)
 
 
-def check_stale(task_id: str, resolved_or_path: str | Path) -> Optional[str]:
-    return _registry.check_stale(task_id, str(resolved_or_path))
+def check_stale(
+    task_id: str,
+    resolved_or_path: str | Path,
+    *,
+    host_mtime: bool = True,
+) -> Optional[str]:
+    return _registry.check_stale(task_id, str(resolved_or_path), host_mtime=host_mtime)
 
 
 def lock_path(resolved_or_path: str | Path):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1261,6 +1261,22 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
+def _is_host_local_env(task_id: str = "default") -> bool:
+    """Return True iff this task's file I/O runs on the host filesystem.
+
+    Read-dedup, staleness detection and the cross-agent file-state registry
+    all compare host-side os.path.getmtime values.  Those only describe the
+    file actually read when the terminal backend is local; on
+    docker/singularity/ssh/modal/daytona the file lives inside the sandbox,
+    so a host mtime belongs to an unrelated (or absent) path and must not
+    drive dedup/staleness.  Defers to _terminal_env_type_for_task so a
+    delegate_task subagent — whose env is registered under the collapsed
+    "default" container key — is classified by the container it actually
+    shares instead of falling back to the global config default.
+    """
+    return _terminal_env_type_for_task(task_id) == "local"
+
+
 def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
     """Read a file with pagination and line numbers."""
     try:
@@ -1387,7 +1403,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 task_data["read_timestamps"] = {}
             cached_mtime = task_data.get("dedup", {}).get(dedup_key)
 
-        if cached_mtime is not None:
+        if cached_mtime is not None and _is_host_local_env(task_id):
             try:
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
@@ -1546,7 +1562,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         # isn't nested under ours.
         try:
             _partial = (offset > 1) or bool(result_dict.get("truncated"))
-            file_state.record_read(task_id, resolved_str, partial=_partial)
+            file_state.record_read(
+                task_id, resolved_str, partial=_partial,
+                host_mtime=_is_host_local_env(task_id),
+            )
         except Exception:
             logger.debug("file_state.record_read failed", exc_info=True)
 
@@ -1696,6 +1715,9 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
     the last read_file call for this task), or None if the file is fresh
     or was never read.  Does not block — the write still proceeds.
     """
+    # Host mtimes only describe the file when the backend is local.
+    if not _is_host_local_env(task_id):
+        return None
     try:
         resolved = str(_resolve_path_for_task(filepath, task_id))
     except (OSError, ValueError):
@@ -1805,7 +1827,10 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         with file_state.lock_path(_resolved):
             # Cross-agent staleness wins over per-task warning when both
             # fire — its message names the sibling subagent.
-            cross_warning = file_state.check_stale(task_id, _resolved)
+            _host_local = _is_host_local_env(task_id)
+            cross_warning = file_state.check_stale(
+                task_id, _resolved, host_mtime=_host_local
+            )
             stale_warning = _check_file_staleness(path, task_id)
             # Workspace-divergence warning: relative path resolving outside the
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
@@ -1827,7 +1852,7 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # writes by this task don't trigger false staleness warnings.
             _update_read_timestamp(path, task_id)
             if not result_dict.get("error"):
-                file_state.note_write(task_id, _resolved)
+                file_state.note_write(task_id, _resolved, host_mtime=_host_local)
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):
@@ -1928,13 +1953,17 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # then per-task tracker as a fallback.
             stale_warnings: list[str] = []
             _path_to_resolved: dict[str, str] = {}
+            _host_local = _is_host_local_env(task_id)
             for _p in _paths_to_check:
                 try:
                     _r = str(_resolve_path_for_task(_p, task_id))
                 except Exception:
                     _r = None
                 _path_to_resolved[_p] = _r
-                _cross = file_state.check_stale(task_id, _r) if _r else None
+                _cross = (
+                    file_state.check_stale(task_id, _r, host_mtime=_host_local)
+                    if _r else None
+                )
                 _sw = _cross or _check_file_staleness(_p, task_id)
                 if not _sw and _r:
                     # Workspace-divergence warning (worktree-cwd bug): relative
@@ -1992,7 +2021,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     _update_read_timestamp(_p, task_id)
                     _r = _path_to_resolved.get(_p)
                     if _r:
-                        file_state.note_write(task_id, _r)
+                        file_state.note_write(task_id, _r, host_mtime=_host_local)
                 # Successful patch: clear any prior consecutive-failure
                 # counters for the touched paths so a future failure on
                 # the same path starts the escalation cycle fresh.


### PR DESCRIPTION
## What does this PR do?

Fixes #56380: `read_file`'s dedup stub and the write/patch staleness warning in
`tools/file_tools.py` compared `os.path.getmtime()` resolved on the **host**
filesystem, even when the task's `TERMINAL_ENV` is a remote backend (docker /
singularity / ssh / modal / daytona). Since the file actually lives inside the
sandboxed environment, a host mtime "match" is coincidental, so dedup could
silently serve stale content and the staleness warning never fired on any
non-local backend.

Adds `_is_host_local_env()`, mirroring the existing
`ShellFileOperations._lsp_local_only()` precedent, and gates both the dedup
stub and `_check_file_staleness` on it so they only compare host mtimes when
the backend is actually local.

The same host-local gate also covers the cross-agent
`FileStateRegistry`, which the two legacy helpers alone did not reach:
`read_file`'s `record_read`, and the `check_stale` calls that `write_file` and
`patch_tool` run before every write, no longer stat the host path on remote
backends (there it is a same-named host twin under ssh, or absent under a
container). `_is_host_local_env` now classifies through the shared
`_terminal_env_type_for_task` resolver, so a `delegate_task` subagent sharing
its parent's container is no longer misread as host-local. Per-path locking,
sibling-write coordination and the never-read check stay backend-agnostic and
keep running.

## Related Issue

Fixes #56380

**Neighbouring PRs, not duplicates.** #56658 fixes the same class of bug on the remote backend (cross-agent file-state coordination) and touches the same module; the two are independent, but if both land, taking this one first keeps the other's pick clean. #62591 moves the mtime capture in the same `record_read` wrapper this PR touches, so whichever lands second needs a trivial rebase there.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py`: add `_is_host_local_env()` (classifying through
  `_terminal_env_type_for_task`); gate the read-dedup stub in `read_file_tool`,
  `_check_file_staleness`, and the `record_read` / `check_stale` calls into the
  `FileStateRegistry` on it
- `tools/file_state.py`: thread a `host_mtime` kwarg through
  `record_read` / `note_write` / `check_stale`; remote callers skip the host
  stat and the mtime-drift comparison while per-path locking and sibling-write
  coordination keep running; `note_write` records `mtime=None` on the
  container's `OSError` instead of bailing and dropping sibling coordination
- `tests/tools/test_file_tools.py`: add `TestIsHostLocalEnv`,
  `TestReadDedupHostLocalGate`, `TestCheckFileStalenessHostLocalGate`,
  `TestFileStateRegistryRemoteGate` (12 new tests)

## How to Test

1. Set `TERMINAL_ENV` to a non-local backend (docker/singularity/ssh/modal/daytona), read a file, then change it inside that environment while any host-side copy at the same path keeps a stale/absent mtime.
2. Before this fix: a re-read returns the stale `"File unchanged since last read"` dedup stub, `_check_file_staleness` never warns, and a subsequent `write_file` / `patch_tool` instead raises a false `"modified since you last read it"` off the host twin's mtime.
3. After this fix: `_is_host_local_env(task_id)` is `False` for non-local backends, so the dedup stub, the staleness check and the FileStateRegistry host stat are all skipped and the real remote content is always returned.
4. `pytest tests/tools/test_file_tools.py -q -k "TestIsHostLocalEnv or TestReadDedupHostLocalGate or TestCheckFileStalenessHostLocalGate or TestFileStateRegistryRemoteGate"` -- the 12 new tests, all passing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched suite -- rebased on current `main`, `pytest tests/tools/test_file_tools.py` shows 52 passed / 7 pre-existing platform failures unrelated to this change, and the 12 new tests all pass. The 7 failures are confirmed pre-existing by checking out `tests/tools/test_file_tools.py`, `tools/file_tools.py` and `tools/file_state.py` from `upstream/main`: the same 7 fail (40 passed) and only the 12 new tests flip. Reverting just the two production files while keeping the new tests turns all 12 red, e.g. `test_read_then_write_ignores_host_twin_mtime` fails with the exact false warning this PR removes (`app.py was modified since you last read it on disk (external edit or unrecorded writer)`). The full matrix runs on CI.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A, no doc changes needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A, no config keys touched
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A, no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) -- fix only changes which backend-selection branch runs (host-local vs remote check); no OS-specific paths touched
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A, tool behavior/schema is unchanged; this is an internal correctness fix

## Screenshots / Logs

New tests, isolated:

```
$ pytest tests/tools/test_file_tools.py -q -k "TestIsHostLocalEnv or TestReadDedupHostLocalGate or TestCheckFileStalenessHostLocalGate or TestFileStateRegistryRemoteGate"
............                                                             [100%]
12 passed, 47 deselected in 1.05s
```

Same tests with `tools/file_tools.py` and `tools/file_state.py` checked out from
`upstream/main` (production code reverted, tests kept):

```
$ git checkout upstream/main -- tools/file_tools.py tools/file_state.py
$ pytest tests/tools/test_file_tools.py -q -k "TestIsHostLocalEnv or TestReadDedupHostLocalGate or TestCheckFileStalenessHostLocalGate or TestFileStateRegistryRemoteGate"
12 failed, 47 deselected in 0.85s

$ pytest "tests/tools/test_file_tools.py::TestFileStateRegistryRemoteGate::test_read_then_write_ignores_host_twin_mtime" -q
>       assert "_warning" not in result, result.get("_warning")
E       AssertionError: ...\app.py was modified since you last read it on disk
E       (external edit or unrecorded writer). Re-read the file before writing.
```

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31055685139


