### PR TITLE
fix(terminal): force Git for Windows bash + convert native CWD for bash cd

### DIFF
--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -26,6 +26,7 @@ from tools.environments.local import (
     LocalEnvironment,
     _msys_to_windows_path,
     _resolve_safe_cwd,
+    _windows_to_msys_path,
 )
 
 
@@ -68,6 +69,35 @@ class TestMsysToWindowsPath:
     def test_empty_string(self, monkeypatch):
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         assert _msys_to_windows_path("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _windows_to_msys_path — reverse translation for bash builtin cd
+# ---------------------------------------------------------------------------
+
+class TestWindowsToMsysPath:
+    def test_noop_on_non_windows(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        assert _windows_to_msys_path(r"C:\Users\NVIDIA") == r"C:\Users\NVIDIA"
+
+    def test_translates_backslash_path(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _windows_to_msys_path(r"C:\Users\NVIDIA") == "/c/Users/NVIDIA"
+        assert _windows_to_msys_path(r"D:\Projects\foo bar") == "/d/Projects/foo bar"
+
+    def test_translates_forward_slash_native_path(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _windows_to_msys_path("C:/Users/NVIDIA") == "/c/Users/NVIDIA"
+
+    def test_translates_drive_root(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _windows_to_msys_path(r"C:\\") == "/c/"
+        assert _windows_to_msys_path("D:/") == "/d/"
+
+    def test_does_not_translate_non_drive_path(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _windows_to_msys_path("/tmp/foo") == "/tmp/foo"
+        assert _windows_to_msys_path(r"\\server\share") == r"\\server\share"
 
 
 # ---------------------------------------------------------------------------
@@ -196,3 +226,23 @@ class TestExtractCwdFromOutputWindowsMsys:
             env._extract_cwd_from_output(result)
 
         assert env.cwd == str(new_dir)
+
+
+# ---------------------------------------------------------------------------
+# Command wrapping — native Windows cwd must be Git Bash-friendly for cd
+# ---------------------------------------------------------------------------
+
+class TestWrapCommandWindowsNativeCwd:
+    def test_wrap_command_converts_native_cwd_for_builtin_cd(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        with patch.object(
+            LocalEnvironment, "init_session", autospec=True, return_value=None
+        ):
+            env = LocalEnvironment(cwd=r"C:\Users\liush", timeout=10)
+
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("pwd", r"C:\Users\liush")
+
+        assert "builtin cd -- /c/Users/liush || exit 126" in wrapped
+        assert r"builtin cd -- C:\Users\liush || exit 126" not in wrapped

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -246,3 +246,24 @@ class TestWrapCommandWindowsNativeCwd:
 
         assert "builtin cd -- /c/Users/liush || exit 126" in wrapped
         assert r"builtin cd -- C:\Users\liush || exit 126" not in wrapped
+
+    def test_init_session_bootstrap_converts_native_cwd_for_cd(self, monkeypatch):
+        """The snapshot bootstrap ``cd`` must also use the Git-Bash path form,
+        not just ``_wrap_command`` — otherwise ``pwd -P`` captures the login
+        shell's directory instead of ``terminal.cwd`` on Windows."""
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        captured = {}
+
+        def fake_run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+            captured["script"] = cmd_string
+            raise RuntimeError("stop after capturing bootstrap")
+
+        monkeypatch.setattr(LocalEnvironment, "_run_bash", fake_run_bash)
+
+        # init_session swallows the exception and falls back; we only need the
+        # captured bootstrap script to assert the cd target was converted.
+        LocalEnvironment(cwd=r"C:\Users\liush", timeout=10)
+
+        assert "builtin cd -- /c/Users/liush 2>/dev/null || true" in captured["script"]
+        assert r"C:\Users\liush" not in captured["script"]

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -361,7 +361,12 @@ class BaseEnvironment(ABC):
         # Restore configured cwd after login shell profile scripts, which may
         # change the working directory (e.g. bashrc `cd ~`).  Without this,
         # pwd -P captures the profile's directory, not terminal.cwd.
-        _quoted_cwd = shlex.quote(self.cwd)
+        # Route through ``_quote_cwd_for_cd`` (not a bare ``shlex.quote``) so
+        # the Windows subclass override converts a native ``C:\Users\x`` cwd to
+        # the Git-Bash ``/c/Users/x`` form the bootstrap ``cd`` can resolve.
+        # Without this the snapshot bootstrap ``cd`` below fails on Windows and
+        # ``pwd -P`` captures the login shell's directory, not ``terminal.cwd``.
+        _quoted_cwd = self._quote_cwd_for_cd(self.cwd)
         # Quote the snapshot / cwd-file paths so Git Bash on Windows handles
         # ``C:/Users/...``-shaped paths without glob-splitting the colon or
         # tripping on drive letters.  On POSIX this is a no-op (no colons /
@@ -413,7 +418,7 @@ class BaseEnvironment(ABC):
             # Publish atomically only if assembly succeeded; otherwise drop the
             # partial temp rather than leave it to be sourced or orphaned.
             f"mv -f {_snap_tmp} {_quoted_snap} || rm -f {_snap_tmp}\n"
-            f"builtin cd {_quoted_cwd} 2>/dev/null || true\n"
+            f"builtin cd -- {_quoted_cwd} 2>/dev/null || true\n"
             f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
         )

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -40,6 +40,24 @@ def _msys_to_windows_path(cwd: str) -> str:
     return f"{drive}:{tail or chr(92)}"  # chr(92) = backslash, avoid raw-string escape
 
 
+def _windows_to_msys_path(cwd: str) -> str:
+    """Translate a native Windows path (``C:\\Users\\x``) to Git Bash /
+    MSYS form (``/c/Users/x``) so ``builtin cd`` resolves it reliably.
+
+    No-ops on non-Windows hosts or for paths that aren't drive-qualified
+    native Windows paths. Returns the input unchanged when no translation
+    applies.
+    """
+    if not _IS_WINDOWS or not cwd:
+        return cwd
+    m = re.match(r'^([a-zA-Z]):[\\/]*(.*)$', cwd)
+    if not m:
+        return cwd
+    drive = m.group(1).lower()
+    tail = (m.group(2) or "").replace('\\', '/').lstrip('/')
+    return f"/{drive}/{tail}" if tail else f"/{drive}/"
+
+
 def _resolve_safe_cwd(cwd: str) -> str:
     """Return ``cwd`` if it exists as a directory, else the nearest existing
     ancestor.  Falls back to ``tempfile.gettempdir()`` only if walking up the
@@ -920,6 +938,11 @@ class LocalEnvironment(BaseEnvironment):
             return candidate.rstrip("/") or "/"
 
         return "/tmp"
+
+    @staticmethod
+    def _quote_cwd_for_cd(cwd: str) -> str:
+        """Use native paths for Python, but Git Bash-friendly paths for cd."""
+        return BaseEnvironment._quote_cwd_for_cd(_windows_to_msys_path(cwd))
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -509,10 +509,10 @@ def _find_bash() -> str:
             if os.path.isfile(candidate):
                 return candidate
 
-    found = shutil.which("bash")
-    if found:
-        return found
-
+    # Check known Git for Windows install locations before PATH lookup.
+    # On machines with both WSL and Git for Windows, shutil.which("bash")
+    # may return WSL's bash (which doesn't understand Windows paths and
+    # will fail silently).  Explicit Git-for-Windows paths avoid that.
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
         os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
@@ -520,6 +520,10 @@ def _find_bash() -> str:
     ):
         if candidate and os.path.isfile(candidate):
             return candidate
+
+    found = shutil.which("bash")
+    if found:
+        return found
 
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"


### PR DESCRIPTION
## Summary

Windows terminal commands launched from PowerShell/cmd now work instead of failing with exit 126 — fixed at the root by forcing one canonical bash, not by translating around whichever shell PATH happened to resolve.

Root cause was two-layered:
1. `_find_bash()` called `shutil.which("bash")` *before* checking Git-for-Windows install paths. On any machine with WSL installed, PATH returns `C:\Windows\System32\bash.exe` (the WSL shim), so Hermes silently ran WSL bash instead of Git Bash — a different drive-mount dialect (`/mnt/c` vs `/c`).
2. Native cwd (`C:\Users\x`) was embedded verbatim into bash `cd`, which no bash dialect can resolve → `cd: C:\Users\...: No such file or directory` → `exit 126` on the first command of every session.

## Changes

- `tools/environments/local.py` (@Icather): reorder `_find_bash()` so explicit Git-for-Windows paths win over `shutil.which("bash")`. Git Bash always beats the WSL shim → one canonical MSYS shell, one path dialect. Fixes #47837.
- `tools/environments/local.py` (@LeonSGP43): add `_windows_to_msys_path()` (`C:\Users\x` → `/c/Users/x`) + a `LocalEnvironment._quote_cwd_for_cd` override that applies it. No-op on non-Windows.
- `tools/environments/base.py` (follow-up): route the `init_session` snapshot bootstrap `cd` through `_quote_cwd_for_cd` too — the override previously only reached `_wrap_command`, so the bootstrap `cd` still leaked the raw Windows path and `pwd -P` captured the login shell's dir instead of `terminal.cwd`. Also add `--` for hyphen-safety to match `_wrap_command`.
- Tests: cover `_windows_to_msys_path`, the `_wrap_command` cd conversion, and the `init_session` bootstrap conversion.

## Why force one shell instead of dialect-detecting

Several competing PRs proposed detecting whether the resolved bash is Git Bash or WSL and emitting `/c/` vs `/mnt/c/` accordingly. That translates around the symptom. The design intent (`_find_bash`'s own error: "requires Git for Windows") is one canonical shell. Fixing the resolution order makes the whole `/mnt/c` dialect-mismatch bug class impossible rather than handling it downstream.

## Validation

| | Before | After |
|---|---|---|
| `_find_bash()` w/ WSL on PATH + Git for Windows | returns WSL shim | returns Git for Windows bash |
| `cd` in `_wrap_command` on Windows | `cd C:\Users\x` → exit 126 | `cd -- /c/Users/x` ✓ |
| `cd` in `init_session` bootstrap | `cd C:\Users\x` (fails silently) | `cd -- /c/Users/x` ✓ |
| Non-Windows | unchanged | unchanged (no-op) |

E2E tested with real imports against a simulated Windows env (fake Git-for-Windows + WSL shim on PATH); both layers verified. Targeted suite: 17/17 green.

Supersedes #50596, #42105 (same MSYS conversion, less complete), #53475 (wrong premise — WSL is not always the shell), #54321 (dialect detection unnecessary once the shell is forced; also bundled an unrelated coding_context change), #13397 (mistitled — never converted paths), #47920 (duplicate of the `_find_bash` reorder).

Fixes #50594, #35459, #47837.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa080a7/Gw69sco-X5lpTO_8KYEFJ_sLBqSfXq.png)
