### PR TITLE
docs: sync tool_use_enforcement model list with code; document local-model tool-calls-as-text cause

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -964,6 +964,15 @@ The model outputs something like `{"name": "web_search", "arguments": {...}}` as
 | **Ollama** | Tool calling is enabled by default — make sure your model supports it (check with `ollama show model-name`) |
 | **LM Studio** | Update to 0.3.6+ and use a model with native tool support |
 
+**Second cause — system-prompt guidance on small/quantized models:** If the parser flags above are already correct and the model *still* emits tool calls as text (most often a small or quantized local model), the cause may be prompt volume rather than the parser. Hermes injects tool-use / task-completion / parallel-tool-call guidance into the system prompt (see [Tool-Use Enforcement](../user-guide/configuration.md#tool-use-enforcement)); on a fragile model the extra volume can displace the native tool-call format. Disable it and retest:
+
+```yaml
+agent:
+  tool_use_enforcement: false
+  task_completion_guidance: false
+  parallel_tool_call_guidance: false
+```
+
 #### Model seems to forget context or give incoherent responses
 
 **Cause:** Context window is too small. When the conversation exceeds the context limit, most servers silently drop older messages. Hermes's system prompt + tool schemas alone can use 4k–8k tokens.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1316,7 +1316,7 @@ agent:
 
 | Value | Behavior |
 |-------|----------|
-| `"auto"` (default) | Enabled for models matching: `gpt`, `codex`, `gemini`, `gemma`, `grok`. Disabled for all others (Claude, DeepSeek, Qwen, etc.). |
+| `"auto"` (default) | Enabled for models whose name matches `TOOL_USE_ENFORCEMENT_MODELS` (in `agent/prompt_builder.py`): `gpt`, `codex`, `gemini`, `gemma`, `grok`, `glm`, `qwen`, `deepseek`. Disabled for all others (e.g. Claude, which uses tools reliably without it). |
 | `true` | Always enabled, regardless of model. Useful if you notice your current model describing actions instead of performing them. |
 | `false` | Always disabled, regardless of model. |
 | `["gpt", "codex", "qwen", "llama"]` | Enabled only when the model name contains one of the listed substrings (case-insensitive). |
@@ -1327,7 +1327,7 @@ When enabled, three layers of guidance may be added to the system prompt:
 
 1. **General tool-use enforcement** (all matched models) — instructs the model to make tool calls immediately instead of describing intentions, keep working until the task is complete, and never end a turn with a promise of future action.
 
-2. **OpenAI execution discipline** (GPT and Codex models only) — additional guidance addressing GPT-specific failure modes: abandoning work on partial results, skipping prerequisite lookups, hallucinating instead of using tools, and declaring "done" without verification.
+2. **OpenAI execution discipline** (GPT, Codex, and Grok models) — additional guidance addressing failure modes common to these families: abandoning work on partial results, skipping prerequisite lookups, hallucinating instead of using tools, and declaring "done" without verification.
 
 3. **Google operational guidance** (Gemini and Gemma models only) — conciseness, absolute paths, parallel tool calls, and verify-before-edit patterns.
 
@@ -1341,6 +1341,17 @@ If you're using a model not in the default auto list and notice it frequently de
 agent:
   tool_use_enforcement: ["gpt", "codex", "gemini", "grok", "my-custom-model"]
 ```
+
+:::caution Small or quantized local models
+On a small or quantized local model (e.g. a heavily-quantized Qwen / GLM / DeepSeek served through vLLM or llama.cpp), this guidance can have the **opposite** effect. The extra system-prompt volume can push the model off its native tool-call format, so it emits the call as **text** instead of a structured `tool_calls` — the same symptom as [Tool calls appear as text](../integrations/providers.md#tool-calls-appear-as-text-instead-of-executing), but caused by the prompt rather than a missing parser flag. Because `qwen`, `gemma`, `glm`, and `deepseek` are matched by `"auto"`, this can happen at the default setting. If your `--tool-call-parser` flags are already correct and you still see text tool calls, disable the guidance:
+
+```yaml
+agent:
+  tool_use_enforcement: false
+  task_completion_guidance: false
+  parallel_tool_call_guidance: false
+```
+:::
 
 ## Tool-Loop Guardrails
 


### PR DESCRIPTION
## What

Two documentation fixes around `tool_use_enforcement` and the "tool calls appear as text" symptom, prompted by #56360.

### 1. Sync the `"auto"` model list with the code

`configuration.md` states `tool_use_enforcement: "auto"` is *"Disabled for ... DeepSeek, Qwen"*, but `TOOL_USE_ENFORCEMENT_MODELS` in `agent/prompt_builder.py` matches `qwen`, `glm`, and `deepseek` as well:

```python
TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm", "qwen", "deepseek")
```

Also, `OPENAI_MODEL_EXECUTION_GUIDANCE` is applied to Grok in addition to GPT/Codex (`agent/system_prompt.py`), which the docs listed as "GPT and Codex only." Updated both to match the code.

### 2. Document the reverse "tool calls as text" cause

The existing **Tool calls appear as text instead of executing** troubleshooting entry only covers the missing-parser-flags cause. But on small/quantized local models *with correct parser flags*, the system-prompt guidance itself (tool-use / task-completion / parallel-tool-call) can displace the native tool-call format, so the model emits calls as text. Added a second-cause note there + a caution in the Tool-Use Enforcement section, both pointing at the config to disable.

## Why

From #56360: with `Qwen/Qwen3.6-35B-A3B` (NVFP4, served by vLLM with a correct `qwen3_xml` parser), replaying the full system prompt at the model gives **0/8 structured** tool calls; swapping to a minimal prompt gives **6/6**. Disabling the three guidance flags fixes it end-to-end. The docs currently point the opposite way — they say `"auto"` excludes Qwen (it doesn't), and recommend `tool_use_enforcement: true` for the very symptom the guidance causes on these models.

## Scope

Docs only — no behavior change. The code-level question (should this guidance be capability-gated for local/`custom`-provider models?) is left to maintainers; it's discussed in #56360.
