### PR TITLE
fix(compaction): place END MARKER last in merge-into-tail summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -95,6 +95,15 @@ _SUMMARY_END_MARKER = (
     "respond to the message below, not the summary above ---"
 )
 
+# When the summary must be merged into the first tail message (the alternation
+# corner case where a standalone summary role would collide with both head and
+# tail), the tail message's own prior content is preserved BEFORE the summary,
+# wrapped in these delimiters so the model doesn't read it as a fresh message.
+# The summary prefix therefore lands AFTER _MERGED_SUMMARY_DELIMITER rather than
+# at the start of the message, so _is_context_summary_content must look past it.
+_MERGED_PRIOR_CONTEXT_HEADER = "[PRIOR CONTEXT — for reference only; not a new message]"
+_MERGED_SUMMARY_DELIMITER = "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]"
+
 # Handoff prefixes that shipped in earlier releases. A summary persisted under
 # one of these can be inherited into a resumed lineage (#35344); when it is
 # re-normalized on re-compaction we must strip the OLD prefix too, otherwise the
@@ -2007,6 +2016,13 @@ This compaction should PRIORITISE preserving all information related to the focu
         stale directive it carried stays embedded in the body.
         """
         text = (summary or "").strip()
+        # Merge-into-tail summaries wrap prior tail content before the summary
+        # body. Drop everything up to and including the delimiter so only the
+        # real summary body is carried forward on re-compaction — otherwise the
+        # [PRIOR CONTEXT] header and stale tail content leak into the next
+        # summarizer prompt.
+        if _MERGED_SUMMARY_DELIMITER in text:
+            text = text.split(_MERGED_SUMMARY_DELIMITER, 1)[1].strip()
         for prefix in (SUMMARY_PREFIX, LEGACY_SUMMARY_PREFIX, *_HISTORICAL_SUMMARY_PREFIXES):
             if text.startswith(prefix):
                 text = text[len(prefix):].lstrip()
@@ -2027,6 +2043,13 @@ This compaction should PRIORITISE preserving all information related to the focu
     @staticmethod
     def _is_context_summary_content(content: Any) -> bool:
         text = _content_text_for_contains(content).lstrip()
+        # Merge-into-tail summaries wrap prior tail content before the summary,
+        # so the handoff prefix lands after _MERGED_SUMMARY_DELIMITER rather than
+        # at the start. Detect the summary in that region too, otherwise callers
+        # (auto-focus skip, carry-forward summary find, last-real-user anchor)
+        # mistake a merged summary message for a real user turn.
+        if _MERGED_SUMMARY_DELIMITER in text:
+            text = text.split(_MERGED_SUMMARY_DELIMITER, 1)[1].lstrip()
         if text.startswith(SUMMARY_PREFIX) or text.startswith(LEGACY_SUMMARY_PREFIX):
             return True
         return any(text.startswith(p) for p in _HISTORICAL_SUMMARY_PREFIXES)
@@ -2898,13 +2921,13 @@ This compaction should PRIORITISE preserving all information related to the focu
                 # before the summary.
                 old_content = msg.get("content", "")
                 suffix = (
-                    "\n\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+                    "\n\n" + _MERGED_SUMMARY_DELIMITER + "\n\n"
                     + summary + "\n\n"
                     + _SUMMARY_END_MARKER
                 )
                 msg["content"] = _append_text_to_content(
                     _append_text_to_content(old_content, suffix, prepend=False),
-                    "[PRIOR CONTEXT — for reference only; not a new message]\n",
+                    _MERGED_PRIOR_CONTEXT_HEADER + "\n",
                     prepend=True,
                 )
                 # Mark the merged message so frontends can identify it as

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2886,10 +2886,25 @@ This compaction should PRIORITISE preserving all information related to the focu
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
             if _merge_summary_into_tail and i == compress_end:
-                merged_prefix = summary + "\n\n" + _SUMMARY_END_MARKER + "\n\n"
+                # Merge the summary into the first tail message, but place
+                # the END MARKER at the very end so the model sees an
+                # unambiguous boundary. Old tail content is preserved as
+                # reference material BEFORE the summary, clearly delimited
+                # so it is not mistaken for a new message to respond to.
+                # Uses _append_text_to_content to safely handle both
+                # string and multimodal-list content types.
+                # Fixes ghost-message leakage across compaction boundaries
+                # where old head messages survived verbatim and appeared
+                # before the summary.
+                old_content = msg.get("content", "")
+                suffix = (
+                    "\n\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+                    + summary + "\n\n"
+                    + _SUMMARY_END_MARKER
+                )
                 msg["content"] = _append_text_to_content(
-                    msg.get("content"),
-                    merged_prefix,
+                    _append_text_to_content(old_content, suffix, prepend=False),
+                    "[PRIOR CONTEXT — for reference only; not a new message]\n",
                     prepend=True,
                 )
                 # Mark the merged message so frontends can identify it as

--- a/tests/agent/test_compressor_assistant_tail_anchor.py
+++ b/tests/agent/test_compressor_assistant_tail_anchor.py
@@ -357,7 +357,10 @@ class TestCompactionRollupReproduction:
     in ``web/src/pages/SessionsPage.tsx``)."""
 
     def test_compress_keeps_visible_reply_text(self, compressor):
-        from agent.context_compressor import SUMMARY_PREFIX
+        from agent.context_compressor import (
+            SUMMARY_PREFIX,
+            COMPRESSED_SUMMARY_METADATA_KEY,
+        )
         c = compressor
         c.tail_token_budget = 10
         # ``_generate_summary`` normally wraps the LLM body in
@@ -392,10 +395,12 @@ class TestCompactionRollupReproduction:
             return_value=_mocked,
         ):
             result = c.compress(messages, current_tokens=90_000)
-        # 1. A summary message exists (compression actually ran).
+        # 1. A summary message exists (compression actually ran). Detect via
+        # the canonical metadata key rather than a content prefix: merge-into-
+        # tail summaries wrap prior content before the summary, so the prefix
+        # is no longer at the start of the message content (#56372).
         assert any(
-            isinstance(m.get("content"), str)
-            and m["content"].startswith(SUMMARY_PREFIX)
+            m.get(COMPRESSED_SUMMARY_METADATA_KEY)
             for m in result
         ), "compress() did not insert a summary message"
         # 2. The visible reply text must survive somewhere — either
@@ -419,7 +424,10 @@ class TestCompactionRollupReproduction:
         as its OWN assistant message — not merged with anything.
         This is the common case; the merge-into-tail path is the
         edge case for double-collision."""
-        from agent.context_compressor import SUMMARY_PREFIX
+        from agent.context_compressor import (
+            SUMMARY_PREFIX,
+            COMPRESSED_SUMMARY_METADATA_KEY,
+        )
         c = compressor
         c.tail_token_budget = 10
         _mocked = f"{SUMMARY_PREFIX}\nrolled-up middle summary"
@@ -449,11 +457,11 @@ class TestCompactionRollupReproduction:
             return_value=_mocked,
         ):
             result = c.compress(messages, current_tokens=90_000)
-        # Standalone summary present:
+        # Summary present (detect via the canonical metadata key — merge-into-
+        # tail summaries no longer start with SUMMARY_PREFIX after #56372):
         summary_rows = [
             m for m in result
-            if isinstance(m.get("content"), str)
-            and m["content"].startswith(SUMMARY_PREFIX)
+            if m.get(COMPRESSED_SUMMARY_METADATA_KEY)
         ]
         assert len(summary_rows) == 1
         # Visible reply as its OWN distinct assistant message
@@ -463,7 +471,7 @@ class TestCompactionRollupReproduction:
             if m.get("role") == "assistant"
             and isinstance(m.get("content"), str)
             and "THE VISIBLE REPLY THE USER JUST READ" in m["content"]
-            and not m["content"].startswith(SUMMARY_PREFIX)
+            and not m.get(COMPRESSED_SUMMARY_METADATA_KEY)
         ]
         assert len(reply_rows) == 1, (
             "REGRESSION (#29824): expected exactly one standalone "

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -8,6 +8,7 @@ from agent.context_compressor import (
     ContextCompressor,
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
+    COMPRESSED_SUMMARY_METADATA_KEY,
 )
 from hermes_state import SessionDB
 
@@ -1826,7 +1827,7 @@ class TestCompressWithClient:
         with patch("agent.context_compressor.call_llm", return_value=mock_response):
             result = c.compress(msgs)
         summary_msg = [
-            m for m in result if (m.get("content") or "").startswith(SUMMARY_PREFIX)
+            m for m in result if m.get(COMPRESSED_SUMMARY_METADATA_KEY)
         ]
         assert len(summary_msg) == 1
         assert summary_msg[0]["role"] == "assistant"
@@ -1940,11 +1941,73 @@ class TestCompressWithClient:
             if m.get("role") == "user" and isinstance(m.get("content"), list)
         )
         assert isinstance(merged_tail["content"], list)
-        assert "summary text" in merged_tail["content"][0]["text"]
+        # With the fixed merge format, summary text is in the last text block
+        # (after PRIOR CONTEXT and END OF PRIOR CONTEXT delimiters),
+        # not necessarily in block [0].
+        assert any(
+            "summary text" in (block.get("text") or "")
+            for block in merged_tail["content"]
+            if isinstance(block, dict)
+        )
         assert any(
             isinstance(block, dict) and block.get("text") == "msg 6"
             for block in merged_tail["content"]
         )
+
+    def test_merge_into_tail_end_marker_is_last(self):
+        """Regression for #56372: in a merge-into-tail summary, the END MARKER
+        must come AFTER the preserved prior tail content, not before it.
+
+        The old format was SUMMARY + END_MARKER + OLD_CONTENT, so the preserved
+        tail content landed after the marker and the model could read it as a
+        fresh message. The fix wraps old content in [PRIOR CONTEXT] delimiters
+        and always places the END MARKER last.
+
+        Mirrors test_double_collision_merges_summary_into_list_tail_content so
+        the merged tail message genuinely carries preserved content ("msg 6").
+        """
+        from agent.context_compressor import _SUMMARY_END_MARKER
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "SUMMARY_BODY"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=3)
+
+        msgs = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "msg 1"},
+            {"role": "assistant", "content": "msg 2"},
+            {"role": "user", "content": "msg 3"},
+            {"role": "assistant", "content": "msg 4"},
+            {"role": "user", "content": "msg 5"},
+            {"role": "user", "content": [{"type": "text", "text": "PRESERVED_TAIL_CONTENT"}]},
+            {"role": "assistant", "content": "msg 7"},
+            {"role": "user", "content": "msg 8"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        merged = next(m for m in result if m.get(COMPRESSED_SUMMARY_METADATA_KEY))
+        content = merged["content"]
+        text = (
+            content if isinstance(content, str)
+            else " ".join(
+                b.get("text", "") for b in content if isinstance(b, dict)
+            )
+        )
+        end = _SUMMARY_END_MARKER.strip()
+        # All three fragments present.
+        assert "PRESERVED_TAIL_CONTENT" in text
+        assert "SUMMARY_BODY" in text
+        assert end in text
+        # Ordering invariant: prior content BEFORE summary BEFORE end marker,
+        # and the end marker is the very last fragment.
+        assert text.index("PRESERVED_TAIL_CONTENT") < text.index("SUMMARY_BODY")
+        assert text.index("SUMMARY_BODY") < text.index(end)
+        assert text.rstrip().endswith(end)
 
     def test_double_collision_user_head_assistant_tail(self):
         """Reverse double collision: head ends with 'user', tail starts with 'assistant'.

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2009,6 +2009,42 @@ class TestCompressWithClient:
         assert text.index("SUMMARY_BODY") < text.index(end)
         assert text.rstrip().endswith(end)
 
+    def test_merged_tail_summary_still_detected_and_stripped(self):
+        """Regression for #56372 salvage: the merge-into-tail reorder moves the
+        summary prefix AFTER the [PRIOR CONTEXT] wrapper, so content-prefix
+        detection (_is_context_summary_content) and body extraction
+        (_strip_summary_prefix) must look past the delimiter. Otherwise a merged
+        summary is mistaken for a real user turn (breaking the last-real-user
+        anchor and carry-forward summary find) and the wrapper + stale tail
+        content leaks into the next summarizer prompt.
+        """
+        from agent.context_compressor import (
+            SUMMARY_PREFIX,
+            _SUMMARY_END_MARKER,
+            _MERGED_PRIOR_CONTEXT_HEADER,
+            _MERGED_SUMMARY_DELIMITER,
+        )
+
+        merged = (
+            _MERGED_PRIOR_CONTEXT_HEADER + "\n"
+            "old tail content here\n\n"
+            + _MERGED_SUMMARY_DELIMITER + "\n\n"
+            + SUMMARY_PREFIX + "\nTHE_SUMMARY_BODY\n\n"
+            + _SUMMARY_END_MARKER
+        )
+
+        # Detected as a summary despite the prefix not being at the start.
+        assert ContextCompressor._is_context_summary_content(merged) is True
+        # Stripping yields only the real summary body — no wrapper, no stale
+        # tail content, no prefix, no end marker.
+        body = ContextCompressor._strip_summary_prefix(merged)
+        assert body == "THE_SUMMARY_BODY"
+
+        # Standalone (non-merged) summaries still work unchanged.
+        standalone = SUMMARY_PREFIX + "\nSTANDALONE_BODY\n\n" + _SUMMARY_END_MARKER
+        assert ContextCompressor._is_context_summary_content(standalone) is True
+        assert ContextCompressor._strip_summary_prefix(standalone) == "STANDALONE_BODY"
+
     def test_double_collision_user_head_assistant_tail(self):
         """Reverse double collision: head ends with 'user', tail starts with 'assistant'.
         summary='assistant' collides with tail, 'user' collides with head → merge."""


### PR DESCRIPTION
## Summary
Compaction summaries that get merged into the first tail message no longer place surviving tail content *after* the END MARKER, where the model could read it as a fresh message.

**Root cause:** in the merge-into-tail branch (the alternation corner case where a standalone summary role would collide with both head and tail), the format was `SUMMARY + END_MARKER + OLD_TAIL_CONTENT`. The preserved tail content landed after the "respond to the message below" marker, so weak models treated it as fresh user input.

## Changes
- `agent/context_compressor.py`:
  - Reorder the merged-message format so the END MARKER is always last. Prior tail content is wrapped in `[PRIOR CONTEXT — for reference only]` … `[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]` delimiters, then the summary, then the END MARKER. Uses the existing `_append_text_to_content` helper (string + multimodal-list safe).
  - Follow-up (my commit): because the reorder moves the summary prefix past the `[PRIOR CONTEXT]` wrapper, `_is_context_summary_content` (prefix-at-start) and `_strip_summary_prefix` are taught to look past the new `_MERGED_SUMMARY_DELIMITER`. Without this, a merged-tail summary was mistaken for a real user turn — breaking the last-real-user tail anchor (active-task loss), the carry-forward summary find, and the auto-focus skip — and the wrapper + stale tail content leaked into the next summarizer prompt. The two delimiter strings are now shared constants so the writer and detector stay in sync.
- `tests/agent/test_context_compressor.py`: adapt two existing merge-tail assertions to the new format; add `test_merge_into_tail_end_marker_is_last` (ordering invariant) and `test_merged_tail_summary_still_detected_and_stripped` (detection + body-extraction across the delimiter, standalone unchanged).

## Salvage note
Salvaged from #56372 by @Gromykoss, cherry-picked to preserve authorship (commit 1). Follow-up detection/strip fix + tests are a separate commit under kshitijk4poor. Only the END-MARKER reorder half of the original PR was carried over. The PR's second change — a post-compaction pass stripping user-role messages before the first summary marker on `compression_count >= 2` — was intentionally **dropped**:
- On 2nd+ compactions the protected head decays to system-only (`_effective_protect_first_n → 0`, #11996), so the targeted "ghost head user" does not occur in the standard path.
- Where the strip *does* fire (a summary merged into a deep tail message), it deletes legitimate recent user turns (data loss) and can leave two consecutive `assistant` messages (role-alternation violation).

## Validation
| Check | Result |
|---|---|
| `tests/agent/test_context_compressor.py` | 143/143 pass (incl. 2 new regression tests) |
| Live E2E — merge-into-tail ordering | prior content → summary → END MARKER last ✓ |
| Live E2E — 2 full compaction cycles | alternation preserved, no wrapper leak, summary carried forward correctly ✓ |
| Regression tests mutation-checked | fail on the pre-fix behavior, pass on the fix |
| ruff | clean |

Closes #56372
