### PR TITLE
fix: simplify list(dict.keys()) to list(dict) (P2)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2919,7 +2919,7 @@ def _evict_cached_client_instance(target: Any) -> bool:
         return False
     evicted = False
     with _client_cache_lock:
-        for key in list(_client_cache.keys()):
+        for key in list(_client_cache):
             entry = _client_cache.get(key)
             if entry is None:
                 continue

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -495,11 +495,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             display_args = _redact_tool_args_for_display(name, args) or args
             args_str = json.dumps(display_args, ensure_ascii=False)
             if agent.verbose_logging:
-                print(f"  📞 Tool {i}: {name}({list(display_args.keys())})")
+                print(f"  📞 Tool {i}: {name}({list(display_args)})")
                 print(agent._wrap_verbose("Args: ", json.dumps(display_args, indent=2, ensure_ascii=False)))
             else:
                 args_preview = args_str[:agent.log_prefix_chars] + "..." if len(args_str) > agent.log_prefix_chars else args_str
-                print(f"  📞 Tool {i}: {name}({list(args.keys())}) - {args_preview}")
+                print(f"  📞 Tool {i}: {name}({list(args)}) - {args_preview}")
 
     for tc, name, args, middleware_trace, block_result, blocked_by_guardrail in parsed_calls:
         if block_result is not None:
@@ -1064,11 +1064,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             display_args = _redact_tool_args_for_display(function_name, function_args) or function_args
             args_str = json.dumps(display_args, ensure_ascii=False)
             if agent.verbose_logging:
-                print(f"  📞 Tool {i}: {function_name}({list(display_args.keys())})")
+                print(f"  📞 Tool {i}: {function_name}({list(display_args)})")
                 print(agent._wrap_verbose("Args: ", json.dumps(display_args, indent=2, ensure_ascii=False)))
             else:
                 args_preview = args_str[:agent.log_prefix_chars] + "..." if len(args_str) > agent.log_prefix_chars else args_str
-                print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}")
+                print(f"  📞 Tool {i}: {function_name}({list(function_args)}) - {args_preview}")
 
         if not _execution_blocked:
             agent._current_tool = function_name

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15269,7 +15269,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         excess = max(0, len(_cache) - _AGENT_CACHE_MAX_SIZE)
         evict_plan: List[tuple] = []  # [(key, agent), ...]
         if excess > 0:
-            ordered_keys = list(_cache.keys())
+            ordered_keys = list(_cache)
             for key in ordered_keys[:excess]:
                 entry = _cache.get(key)
                 agent = entry[0] if isinstance(entry, tuple) and entry else None
@@ -16083,7 +16083,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # detail.  Platform message-length limits handle the rest.
                     if _pl > 0 and len(args_str) > _pl:
                         args_str = args_str[:_pl - 3] + "..."
-                    msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
+                    msg = f"{emoji} {tool_name}({list(args)})\n{args_str}"
                 elif preview:
                     msg = f"{emoji} {tool_name}: \"{preview}\""
                 else:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -632,7 +632,7 @@ def _interactive_auth() -> None:
 
 def _pick_provider(prompt: str = "Provider") -> str:
     """Prompt for a provider name with auto-complete hints."""
-    known = sorted(set(list(PROVIDER_REGISTRY.keys()) + ["openrouter"]))
+    known = sorted(set(list(PROVIDER_REGISTRY) + ["openrouter"]))
     custom_names = _get_custom_provider_names()
     if custom_names:
         custom_display = [name for name, _key, _provider_key in custom_names]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5169,7 +5169,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 _persist_migration(config)
                 if not quiet:
                     print(f"  ✓ Migrated {migrated_count} custom provider(s) to providers: section")
-                    for key in list(providers_dict.keys())[-migrated_count:]:
+                    for key in list(providers_dict)[-migrated_count:]:
                         ep = providers_dict[key]
                         print(f"    → {key}: {ep.get('api', '')}")
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1726,7 +1726,7 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
         # Severity filter.
         sev = getattr(args, "severity", None)
         if sev:
-            for tid in list(diags_by_task.keys()):
+            for tid in list(diags_by_task):
                 kept = [d for d in diags_by_task[tid] if kd.SEVERITY_ORDER.index(d.severity) >= kd.SEVERITY_ORDER.index(sev)]
                 if kept:
                     diags_by_task[tid] = kept

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -507,7 +507,7 @@ def cmd_mcp_remove(args):
 
     if name not in existing:
         _error(f"Server '{name}' not found in config.")
-        servers = list(existing.keys())
+        servers = list(existing)
         if servers:
             _info(f"Available servers: {', '.join(servers)}")
         return
@@ -608,7 +608,7 @@ def cmd_mcp_test(args):
 
     if name not in servers:
         _error(f"Server '{name}' not found in config.")
-        available = list(servers.keys())
+        available = list(servers)
         if available:
             _info(f"Available: {', '.join(available)}")
         return
@@ -824,7 +824,7 @@ def cmd_mcp_configure(args):
 
     if name not in servers:
         _error(f"Server '{name}' not found in config.")
-        available = list(servers.keys())
+        available = list(servers)
         if available:
             _info(f"Available: {', '.join(available)}")
         return

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -161,7 +161,7 @@ def _model_flow_moa(config, current_model=""):
         print("No MoA presets configured. Run `hermes moa configure <name>` first.")
         return
 
-    names = list(presets.keys())
+    names = list(presets)
     default_name = moa.get("default_preset") or names[0]
 
     # Build labelled rows showing the aggregator so the picker is informative

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3920,7 +3920,7 @@ def validate_requested_model(
                     "message": None,
                 }
             # Auto-correct close matches (case-insensitive)
-            catalog_lower_list = list(catalog_lower.keys())
+            catalog_lower_list = list(catalog_lower)
             auto = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9)
             if auto:
                 corrected = catalog_lower[auto[0]]
@@ -4163,7 +4163,7 @@ def validate_requested_model(
                 "recognized": True,
                 "message": None,
             }
-        catalog_lower_list = list(catalog_lower.keys())
+        catalog_lower_list = list(catalog_lower)
         auto = get_close_matches(
             requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9
         )

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2665,7 +2665,7 @@ def _configure_imagegen_model(backend_name: str, config: dict) -> None:
     if current_model not in catalog:
         current_model = default_model
 
-    model_ids = list(catalog.keys())
+    model_ids = list(catalog)
     # Put current model at the top so the cursor lands on it by default.
     ordered = [current_model] + [m for m in model_ids if m != current_model]
 
@@ -2749,7 +2749,7 @@ def _configure_imagegen_model_for_plugin(plugin_name: str, config: dict) -> None
     if current_model not in catalog:
         current_model = default_model
 
-    model_ids = list(catalog.keys())
+    model_ids = list(catalog)
     ordered = [current_model] + [m for m in model_ids if m != current_model]
 
     widths = {
@@ -2888,7 +2888,7 @@ def _configure_videogen_model_for_plugin(plugin_name: str, config: dict) -> None
     if current_model not in catalog:
         current_model = default_model
 
-    model_ids = list(catalog.keys())
+    model_ids = list(catalog)
     ordered = [current_model] + [m for m in model_ids if m != current_model]
 
     widths = {

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4008,7 +4008,7 @@ def _cleanup_single_browser_session(task_id: str) -> None:
             logger.debug("Camofox cleanup for task %s: %s", task_id, e)
 
     logger.debug("cleanup_browser called for task_id: %s", task_id)
-    logger.debug("Active sessions: %s", list(_active_sessions.keys()))
+    logger.debug("Active sessions: %s", list(_active_sessions))
 
     # Check if session exists (under lock), but don't remove yet -
     # _run_browser_command needs it to build the close command.
@@ -4073,7 +4073,7 @@ def cleanup_all_browsers() -> None:
     Useful for cleanup on shutdown.
     """
     with _cleanup_lock:
-        task_ids = list(_active_sessions.keys())
+        task_ids = list(_active_sessions)
     for task_id in task_ids:
         cleanup_browser(task_id)
 

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -155,7 +155,7 @@ def _drive_health_report(
 
     raise RuntimeError(
         "health_report response carried neither structuredContent nor a parseable "
-        f"JSON text block. Result keys: {list(result.keys())}"
+        f"JSON text block. Result keys: {list(result)}"
     )
 
 

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -849,7 +849,7 @@ def _run_discord_action(
     if not action_fn:
         return json.dumps({
             "error": f"Unknown action: {action}",
-            "available_actions": list(valid_actions.keys()),
+            "available_actions": list(valid_actions),
         })
 
     # Config-level allowlist gate (defense in depth — schema already filtered,
@@ -934,10 +934,10 @@ def _make_handler(handler_fn):
 
 
 _STATIC_CORE_SCHEMA = _build_schema(
-    list(_CORE_ACTIONS.keys()), caps={"detected": False}, tool_name="discord",
+    list(_CORE_ACTIONS), caps={"detected": False}, tool_name="discord",
 )
 _STATIC_ADMIN_SCHEMA = _build_schema(
-    list(_ADMIN_ACTIONS.keys()), caps={"detected": False}, tool_name="discord_admin",
+    list(_ADMIN_ACTIONS), caps={"detected": False}, tool_name="discord_admin",
 )
 
 registry.register(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4272,7 +4272,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         return await _discover_and_register_server(name, cfg)
 
     async def _discover_all():
-        server_names = list(new_servers.keys())
+        server_names = list(new_servers)
         # Connect to all servers in PARALLEL
         results = await asyncio.gather(
             *(_discover_one(name, cfg) for name, cfg in new_servers.items()),
@@ -4507,7 +4507,7 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     probed_servers: List[MCPServerTask] = []
 
     async def _probe_all():
-        names = list(enabled.keys())
+        names = list(enabled)
         coros = []
         for name, cfg in enabled.items():
             ct = cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -382,7 +382,7 @@ def strip_pattern_and_format(tools: list[dict]) -> tuple[list[dict], int]:
             # named "pattern" (search_files.pattern, etc.) because those live
             # inside a ``properties`` dict, not as siblings of ``type``.
             is_schema_node = "type" in node or "anyOf" in node or "oneOf" in node or "allOf" in node
-            for key in list(node.keys()):
+            for key in list(node):
                 if is_schema_node and key in _STRIP_ON_RECOVERY_KEYS:
                     node.pop(key, None)
                     stripped += 1

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1528,7 +1528,7 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     # background processes (their _last_activity gets refreshed to keep them alive).
     try:
         from tools.process_registry import process_registry
-        for task_id in list(_last_activity.keys()):
+        for task_id in list(_last_activity):
             if process_registry.has_active_processes(task_id):
                 _last_activity[task_id] = current_time  # Keep sandbox alive
     except ImportError:
@@ -1647,7 +1647,7 @@ def is_persistent_env(task_id: str) -> bool:
 
 def cleanup_all_environments():
     """Clean up ALL active environments. Use with caution."""
-    task_ids = list(_active_environments.keys())
+    task_ids = list(_active_environments)
     cleaned = 0
     
     for task_id in task_ids:


### PR DESCRIPTION
## Summary

Replace `list(d.keys())` with `list(d)` — 30 instances across 16 files.

## Rationale

`list(d.keys())` creates an intermediate dict_keys view then materializes it. `list(d)` does the same thing in one step. Both return a list of keys.

```python
# Before
names = list(d.keys())
for key in list(d.keys()):

# After
names = list(d)
for key in list(d):  # or just: for key in d
```

Note: `for key in list(d)` is intentionally kept (not simplified to `for key in d`) when the loop body mutates the dict — snapshot via list() prevents RuntimeError.

## Files (16)

| File | Count |
|------|-------|
| agent/tool_executor.py | 4 |
| tools/discord_tool.py | 3 |
| hermes_cli/mcp_config.py | 3 |
| hermes_cli/tools_config.py | 3 |
| tools/browser_tool.py | 2 |
| tools/terminal_tool.py | 2 |
| tools/mcp_tool.py | 2 |
| gateway/run.py | 2 |
| hermes_cli/models.py | 2 |
| agent/auxiliary_client.py | 1 |
| tools/schema_sanitizer.py | 1 |
| tools/computer_use/doctor.py | 1 |
| hermes_cli/kanban.py | 1 |
| hermes_cli/config.py | 1 |
| hermes_cli/model_setup_flows.py | 1 |
| hermes_cli/auth_commands.py | 1 |