### PR TITLE
fix(agent): append assistant reply when max-iterations summary fails

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1708,6 +1708,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         logger.warning(f"Failed to get summary response: {e}")
         final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
 
+    if (
+        messages
+        and messages[-1].get("role") == "user"
+        and messages[-1].get("content") == summary_request
+    ):
+        messages.append({"role": "assistant", "content": final_response})
+
     return final_response
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3663,6 +3663,19 @@ class TestHandleMaxIterations:
         assert isinstance(result, str)
         assert "error" in result.lower()
         assert "API down" in result
+        assert messages[-1]["role"] == "assistant"
+        assert messages[-1]["content"] == result
+        assert messages[-2]["role"] == "user"
+        assert "maximum number of tool-calling iterations" in messages[-2]["content"]
+
+    def test_empty_summary_appends_assistant_fallback(self, agent):
+        agent.client.chat.completions.create.return_value = _mock_response(content="")
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+        result = agent._handle_max_iterations(messages, 60)
+        assert messages[-1]["role"] == "assistant"
+        assert messages[-1]["content"] == result
+        assert "couldn't generate a summary" in result.lower()
 
     def test_summary_skips_reasoning_for_unsupported_openrouter_model(self, agent):
         agent.base_url = "https://openrouter.ai/api/v1"


### PR DESCRIPTION
## Summary

- When `handle_max_iterations` injects the synthetic summary user message but the summary API call fails (or returns empty after retry), append an assistant reply with the error/fallback text before returning.
- Keeps resumed sessions valid for strict providers (Gemini, Claude) that reject consecutive user messages.

Fixes #56056

## Test plan

- [x] `pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations` (13/13)
- [x] Extended `test_api_failure_returns_error` to assert role alternation in `messages`
- [x] Added `test_empty_summary_appends_assistant_fallback`
