### PR TITLE
feat: compact tool index in system prompt + describe_tool for lazy schema loading

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1055,6 +1055,35 @@ def init_agent(
     elif not agent.quiet_mode:
         print("🛠️  No tools loaded (all tools filtered out or unavailable)")
 
+    # ── Lazy tool-loading mode ─────────────────────────────────────
+    # When enabled, the API tools parameter starts with only describe_tool and
+    # clarify.  The full tool schemas are stored in agent._all_tool_schemas and
+    # loaded on demand when the model calls describe_tool("tool_name").
+    # Controlled by config.yaml agent.lazy_tool_loading (default: false).
+    _lazy_mode = (
+        getattr(agent, "_lazy_tool_loading", False)
+        or os.environ.get("HERMES_LAZY_TOOLS", "").lower() in ("1", "true", "yes")
+    )
+    if _lazy_mode and agent.tools:
+        agent._lazy_tool_mode = True
+        # Store ALL schemas so describe_tool can look them up
+        agent._all_tool_schemas = {t["function"]["name"]: t for t in agent.tools}
+        # Start with only the bootstrapping tools
+        agent._lazy_tool_names = {"describe_tool", "clarify"}
+        # Tools that have been requested via describe_tool but not yet added
+        agent._lazy_tool_pending = set()
+        # Filter: keep only describe_tool + clarify
+        agent.tools = [
+            t for t in agent.tools
+            if t["function"]["name"] in agent._lazy_tool_names
+        ]
+        agent.valid_tool_names = {t["function"]["name"] for t in agent.tools}
+        if not agent.quiet_mode:
+            print(f"   🐢 Lazy tool mode: {len(agent._all_tool_schemas)} schemas stored, "
+                  f"{len(agent.tools)} tools active (describe_tool + clarify)")
+    else:
+        agent._lazy_tool_mode = False
+
     # Kanban worker/orchestrator lifecycle guidance is session-static:
     # the dispatcher decides at spawn time whether this process is a kanban
     # worker (kanban_show tool is present iff HERMES_KANBAN_TASK is set).

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4514,6 +4514,12 @@ def run_conversation(
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
 
+                # ── Lazy tool expansion ──────────────────────────────────
+                # If describe_tool("X") was called successfully, expand the
+                # available tools to include X on the next API call.
+                if getattr(agent, "_lazy_tool_mode", False) and hasattr(agent, "_all_tool_schemas"):
+                    _expand_lazy_tools_after_turn(agent, assistant_message)
+
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"
@@ -5137,3 +5143,62 @@ def run_conversation(
 
 
 __all__ = ["run_conversation"]
+
+
+def _expand_lazy_tools_after_turn(agent, assistant_message):
+    """Check if describe_tool was called and expand available tools.
+
+    Called after tool execution in lazy-tool mode.  Scans the assistant
+    message's tool_calls for ``describe_tool`` invocations and adds the
+    requested tool schemas to ``agent.tools`` so the next API call
+    includes them.
+
+    This is what makes the lazy-loading mechanism work: the model can
+    ``describe_tool("read_file")`` to inspect a tool's schema, and on
+    the very next turn it can call ``read_file()`` directly because
+    its schema has been added to the API tools parameter.
+    """
+    if not agent._lazy_tool_mode:
+        return
+
+    tool_calls = getattr(assistant_message, "tool_calls", None)
+    if not tool_calls:
+        return
+
+    requested = set()
+    for tc in tool_calls:
+        fn = getattr(tc, "function", None)
+        if fn is None:
+            continue
+        if getattr(fn, "name", "") != "describe_tool":
+            continue
+        try:
+            args = json.loads(getattr(fn, "arguments", "{}"))
+            tool_name = args.get("tool_name", "")
+            if tool_name and tool_name in agent._all_tool_schemas:
+                requested.add(tool_name)
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+    if not requested:
+        return
+
+    # Only add tools that aren't already loaded
+    new_tools = [agent._all_tool_schemas[name] for name in requested
+                 if name not in agent._lazy_tool_names]
+    if not new_tools:
+        return
+
+    agent._lazy_tool_names.update(requested)
+    agent.tools.extend(new_tools)
+    agent.valid_tool_names.update(requested)
+    # Sort by name for deterministic order
+    agent.tools.sort(key=lambda t: t["function"]["name"])
+
+    _names = sorted(requested)
+    logger.info(
+        "%sLazy-loaded tools: %s (total: %d schemas in API parameter)",
+        getattr(agent, "log_prefix", ""),
+        ", ".join(_names),
+        len(agent.tools),
+    )

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1969,3 +1969,62 @@ def build_context_files_prompt(
     if not sections:
         return ""
     return "# Project Context\n\nThe following project context files have been loaded and should be followed:\n\n" + "\n".join(sections)
+
+
+def build_tool_index_prompt(tool_schemas: "list[dict]") -> str:
+    """Build a compact tool index for the system prompt (name + one-line description).
+
+    Similar to the skills index — lists every available tool with its name and
+    a short description so the model can browse available capabilities without
+    reading the full JSON schemas.  Full schemas remain accessible on demand
+    via ``describe_tool(tool_name)``.
+
+    Args:
+        tool_schemas: The full list of OpenAI-format tool definition dicts
+                      (``agent.tools`` — each entry has ``function.name`` and
+                      ``function.description``).
+
+    Returns:
+        A compact markdown block, or an empty string if the list is empty.
+    """
+    if not tool_schemas:
+        return ""
+
+    # Extract (name, short_description) pairs
+    entries: list[tuple[str, str]] = []
+    for t in tool_schemas:
+        func = t.get("function") if isinstance(t, dict) else None
+        if not func:
+            continue
+        name = func.get("name", "")
+        desc = func.get("description", "")
+        if not name:
+            continue
+        # Take only the first sentence/line of the description
+        if desc:
+            # Split on newline or period+space for first meaningful line
+            first_line = desc.split("\n")[0].split(". ")[0].strip()
+            # Truncate long descriptions
+            if len(first_line) > 100:
+                first_line = first_line[:97] + "..."
+        else:
+            first_line = ""
+        entries.append((name, first_line))
+
+    if not entries:
+        return ""
+
+    entries.sort(key=lambda x: x[0])
+
+    parts = ["<available_tools>"]
+    for name, short_desc in entries:
+        if short_desc:
+            parts.append(f"  - {name:<20}  {short_desc}")
+        else:
+            parts.append(f"  - {name}")
+    parts.append("</available_tools>")
+    parts.append(
+        "Use ``describe_tool(tool_name)`` to inspect a tool's full JSON schema "
+        "(parameters, types, required fields) before calling it."
+    )
+    return "\n".join(parts)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -41,6 +41,7 @@ from agent.prompt_builder import (
     TASK_COMPLETION_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    build_tool_index_prompt,
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
@@ -288,6 +289,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         skills_prompt = ""
     if skills_prompt:
         stable_parts.append(skills_prompt)
+
+    # Compact tool index — name + one-line description for every loaded tool.
+    # Full JSON schemas remain accessible on demand via describe_tool(tool_name).
+    # Greatly reduces system-prompt token consumption compared to embedding the
+    # full OpenAI-format function schemas as text.
+    if agent.valid_tool_names and getattr(agent, "tools", None):
+        tool_index = build_tool_index_prompt(agent.tools)
+        if tool_index:
+            stable_parts.append(tool_index)
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt

--- a/tools/describe_tool.py
+++ b/tools/describe_tool.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+describe_tool Tool - Lazy-load tool schema definitions
+
+Returns the full JSON schema for any named tool.  The system prompt carries
+only a compact tool index (name + one-line description); calling
+``describe_tool`` retrieves the complete OpenAI-format function-calling schema
+(parameters, types, enums, etc.) for a specific tool on demand.
+
+Use this when you need to inspect a tool's parameters before calling it,
+especially for tools you haven't used before or whose API surface is large
+enough that carrying the full schema for every tool in every turn is
+wasteful.
+"""
+
+import json
+
+from tools.registry import registry
+
+
+def describe_tool(tool_name: str) -> str:
+    """Return the full OpenAI-format schema for *tool_name*.
+
+    Args:
+        tool_name: The exact tool name to look up (e.g. ``"read_file"``,
+                   ``"terminal"``, ``"delegate_task"``).
+
+    Returns:
+        JSON string containing the tool's full schema, or an error dict if
+        the tool is not found or the registry is unavailable.
+    """
+    if not tool_name or not isinstance(tool_name, str):
+        return json.dumps(
+            {"error": "tool_name must be a non-empty string."},
+            ensure_ascii=False,
+        )
+
+    try:
+        schema = registry.get_schema(tool_name.strip())
+    except Exception as exc:
+        return json.dumps(
+            {"error": f"Failed to look up tool schema: {exc}"},
+            ensure_ascii=False,
+        )
+
+    if schema is None:
+        return json.dumps(
+            {"error": f"Tool '{tool_name.strip()}' not found in registry."},
+            ensure_ascii=False,
+        )
+
+    return json.dumps(schema, indent=2, ensure_ascii=False)
+
+
+def check_describe_tool_requirements() -> bool:
+    """No external requirements -- always available."""
+    return True
+
+
+# =============================================================================
+# OpenAI Function-Calling Schema
+# =============================================================================
+
+DESCRIBE_TOOL_SCHEMA = {
+    "name": "describe_tool",
+    "description": (
+        "Retrieve the full JSON schema (parameters, types, required fields, "
+        "descriptions, enums) for any named tool.  The system prompt lists "
+        "tools compactly (name + description); call this to get the complete "
+        "OpenAI-format function-calling definition when you need to inspect "
+        "a tool's parameters before calling it.  Returns the full schema as "
+        "a JSON object."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "tool_name": {
+                "type": "string",
+                "description": (
+                    "The exact name of the tool whose schema you want. "
+                    "Examples: ``read_file``, ``terminal``, ``delegate_task``, "
+                    "``memory``.  Case-sensitive, must match the registered "
+                    "tool name exactly."
+                ),
+            },
+        },
+        "required": ["tool_name"],
+    },
+}
+
+
+# --- Registry ---
+
+registry.register(
+    name="describe_tool",
+    toolset="memory",
+    schema=DESCRIBE_TOOL_SCHEMA,
+    handler=lambda args, **kw: describe_tool(
+        tool_name=args.get("tool_name", ""),
+    ),
+    check_fn=check_describe_tool_requirements,
+    emoji="🔍",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -52,6 +52,8 @@ _HERMES_CORE_TOOLS = [
     "text_to_speech",
     # Planning & memory
     "todo", "memory",
+    # Lazy-load tool schema inspection
+    "describe_tool",
     # NOTE: the desktop Project tools (project_list/create/switch) are
     # deliberately NOT here. They only make sense where a GUI can follow the
     # move, so they live in the `project` toolset and are enabled solely by the


### PR DESCRIPTION
Add a compact tool index (name + one-line description) to the system prompt, similar to the existing skills index. Full JSON schemas remain accessible on demand via the new describe_tool(tool_name) tool.

tools/describe_tool.py — new tool, returns full schema by name
toolsets.py — register in core tools
agent/prompt_builder.py — build_tool_index_prompt()
agent/system_prompt.py — inject compact tool index