### PR TITLE
fix(agent): coordinate truncated tool call argument repair

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -249,6 +249,8 @@ def sanitize_tool_call_arguments(
     session_id: str = None,
 ) -> int:
     """Repair corrupted assistant tool-call argument JSON in-place."""
+    from agent.message_sanitization import repair_tool_call_arguments_with_status
+
     log = logger or logging.getLogger(__name__)
     if not isinstance(messages, list):
         return 0
@@ -308,6 +310,7 @@ def sanitize_tool_call_arguments(
             except json.JSONDecodeError:
                 tool_call_id = tool_call.get("id")
                 function_name = function.get("name", "?")
+                repair = repair_tool_call_arguments_with_status(arguments, function_name)
                 preview = arguments[:80]
                 log.warning(
                     "Corrupted tool_call arguments repaired before request "
@@ -318,7 +321,7 @@ def sanitize_tool_call_arguments(
                     function_name,
                     preview,
                 )
-                function["arguments"] = "{}"
+                function["arguments"] = repair.arguments
 
                 existing_tool_msg = None
                 scan_index = message_index + 1

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -32,7 +32,7 @@ from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
 from agent.message_sanitization import (
     _sanitize_surrogates,
-    _repair_tool_call_arguments,
+    repair_tool_call_arguments_with_status,
 )
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
@@ -2234,12 +2234,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # commas, unclosed brackets, Python None, etc.
                         # Without repair, these hit the truncation handler
                         # and kill the session.  _repair_tool_call_arguments
-                        # returns "{}" for unrepairable args, which is far
-                        # better than a crashed session.
-                        repaired = _repair_tool_call_arguments(arguments, tool_name)
-                        if repaired != "{}":
+                        # reports unrepairable args separately from legitimate
+                        # empty-object normalization, so only genuine failures
+                        # hit the truncation handler.
+                        repair = repair_tool_call_arguments_with_status(arguments, tool_name)
+                        if repair.success:
                             # Successfully repaired — use the fixed args
-                            arguments = repaired
+                            arguments = repair.arguments
                         else:
                             # Unrepairable — flag for truncation handling
                             has_truncated_tool_args = True

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -37,7 +37,7 @@ from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
-    _repair_tool_call_arguments,
+    repair_tool_call_arguments_with_status,
     _sanitize_messages_non_ascii,
     _sanitize_messages_surrogates,
     _sanitize_structure_non_ascii,
@@ -932,10 +932,10 @@ def run_conversation(
                             ),
                         }}
                     except Exception:
-                        tc["function"]["arguments"] = _repair_tool_call_arguments(
+                        tc["function"]["arguments"] = repair_tool_call_arguments_with_status(
                             tc["function"]["arguments"],
                             tc["function"].get("name", "?"),
-                        )
+                        ).arguments
                 new_tcs.append(tc)
             am["tool_calls"] = new_tcs
 
@@ -4346,7 +4346,14 @@ def run_conversation(
                     try:
                         json.loads(args)
                     except json.JSONDecodeError as e:
-                        invalid_json_args.append((tc.function.name, str(e)))
+                        repair = repair_tool_call_arguments_with_status(
+                            args,
+                            tc.function.name,
+                        )
+                        if repair.success:
+                            tc.function.arguments = repair.arguments
+                            continue
+                        invalid_json_args.append((tc, str(e)))
                 
                 if invalid_json_args:
                     # Check if the invalid JSON is due to truncation rather
@@ -4357,31 +4364,39 @@ def run_conversation(
                     # (after stripping whitespace) are cut off mid-stream.
                     _truncated = any(
                         not (tc.function.arguments or "").rstrip().endswith(("}", "]"))
-                        for tc in assistant_message.tool_calls
-                        if tc.function.name in {n for n, _ in invalid_json_args}
+                        for tc, _ in invalid_json_args
                     )
                     if _truncated:
                         agent._vprint(
                             f"{agent.log_prefix}⚠️  Truncated tool call arguments detected "
-                            f"(finish_reason={finish_reason!r}) — refusing to execute.",
+                            f"(finish_reason={finish_reason!r}) — returning tool error.",
                             force=True,
                         )
                         agent._invalid_json_retries = 0
-                        agent._cleanup_task_resources(effective_task_id)
-                        agent._persist_session(messages, conversation_history)
-                        return {
-                            "final_response": "Response truncated due to output length limit",
-                            "messages": messages,
-                            "api_calls": api_call_count,
-                            "completed": False,
-                            "partial": True,
-                            "error": "Response truncated due to output length limit",
-                        }
+                        recovery_assistant = agent._build_assistant_message(assistant_message, finish_reason)
+                        messages.append(recovery_assistant)
+                        invalid_call_ids = {tc.id for tc, _ in invalid_json_args}
+                        for tc in assistant_message.tool_calls:
+                            if tc.id in invalid_call_ids:
+                                tool_result = (
+                                    "Error: Tool call arguments were truncated due to the "
+                                    "output length limit and could not be repaired. Please "
+                                    "shorten the content or split it into multiple tool calls."
+                                )
+                            else:
+                                tool_result = "Skipped: other tool call in this response had truncated arguments."
+                            messages.append({
+                                "role": "tool",
+                                "name": tc.function.name,
+                                "tool_call_id": tc.id,
+                                "content": tool_result,
+                            })
+                        continue
 
                     # Track retries for invalid JSON arguments
                     agent._invalid_json_retries += 1
 
-                    tool_name, error_msg = invalid_json_args[0]
+                    tool_name, error_msg = invalid_json_args[0][0].function.name, invalid_json_args[0][1]
                     agent._buffer_vprint(f"⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
 
                     if agent._invalid_json_retries < 3:
@@ -4399,10 +4414,10 @@ def run_conversation(
                         messages.append(recovery_assistant)
                         
                         # Respond with tool error results for each tool call
-                        invalid_names = {name for name, _ in invalid_json_args}
+                        invalid_call_ids = {tc.id for tc, _ in invalid_json_args}
                         for tc in assistant_message.tool_calls:
-                            if tc.function.name in invalid_names:
-                                err = next(e for n, e in invalid_json_args if n == tc.function.name)
+                            if tc.id in invalid_call_ids:
+                                err = next(e for invalid_tc, e in invalid_json_args if invalid_tc.id == tc.id)
                                 tool_result = (
                                     f"Error: Invalid JSON arguments. {err}. "
                                     f"For tools with no required parameters, use an empty object: {{}}. "

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -17,9 +17,19 @@ from __future__ import annotations
 import json
 import logging
 import re
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ToolCallArgumentsRepair:
+    """Result of a tool-call argument repair attempt."""
+
+    arguments: str
+    repaired: bool
+    success: bool
 
 # Lone surrogate code points are invalid in UTF-8 and crash json.dumps
 # inside the OpenAI SDK.  Used by every surrogate-sanitization helper
@@ -182,26 +192,31 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     return "".join(out)
 
 
-def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
+def repair_tool_call_arguments_with_status(
+    raw_args: str,
+    tool_name: str = "?",
+) -> ToolCallArgumentsRepair:
     """Attempt to repair malformed tool_call argument JSON.
 
     Models like GLM-5.1 via Ollama can produce truncated JSON, trailing
     commas, Python ``None``, etc.  The API proxy rejects these with HTTP 400
-    "invalid tool call arguments".  This function applies common repairs;
-    if all fail it returns ``"{}"`` so the request succeeds (better than
-    crashing the session).  All repairs are logged at WARNING level.
+    "invalid tool call arguments".  This function applies common repairs and
+    reports whether repair actually succeeded. Empty argument strings and
+    Python ``None`` are successful normalisations to ``{}``; unrepairable
+    non-empty JSON returns ``{}`` with ``success=False`` so callers can surface
+    a model-visible tool error instead of executing an empty call.
     """
     raw_stripped = raw_args.strip() if isinstance(raw_args, str) else ""
 
     # Fast-path: empty / whitespace-only -> empty object
     if not raw_stripped:
         logger.warning("Sanitized empty tool_call arguments for %s", tool_name)
-        return "{}"
+        return ToolCallArgumentsRepair("{}", True, True)
 
     # Python-literal None -> normalise to {}
     if raw_stripped == "None":
         logger.warning("Sanitized Python-None tool_call arguments for %s", tool_name)
-        return "{}"
+        return ToolCallArgumentsRepair("{}", True, True)
 
     # Repair pass 0: llama.cpp backends sometimes emit literal control
     # characters (tabs, newlines) inside JSON string values. json.loads
@@ -216,7 +231,11 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 "Repaired unescaped control chars in tool_call arguments for %s",
                 tool_name,
             )
-        return reserialised
+        return ToolCallArgumentsRepair(
+            reserialised,
+            reserialised != raw_stripped,
+            True,
+        )
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 
@@ -224,6 +243,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     fixed = raw_stripped
     # 1. Strip trailing commas before } or ]
     fixed = re.sub(r',\s*([}\]])', r'\1', fixed)
+    fixed = re.sub(r',\s*$', '', fixed)
     # 2. Close unclosed structures
     open_curly = fixed.count('{') - fixed.count('}')
     open_bracket = fixed.count('[') - fixed.count(']')
@@ -250,7 +270,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
             "Repaired malformed tool_call arguments for %s: %s → %s",
             tool_name, raw_stripped[:80], fixed[:80],
         )
-        return fixed
+        return ToolCallArgumentsRepair(fixed, fixed != raw_stripped, True)
     except json.JSONDecodeError:
         pass
 
@@ -265,7 +285,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 "Repaired control-char-laced tool_call arguments for %s: %s → %s",
                 tool_name, raw_stripped[:80], escaped[:80],
             )
-            return escaped
+            return ToolCallArgumentsRepair(escaped, True, True)
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 
@@ -276,7 +296,12 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
         "replaced with empty object (was: %s)",
         tool_name, raw_stripped[:80],
     )
-    return "{}"
+    return ToolCallArgumentsRepair("{}", True, False)
+
+
+def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
+    """Backward-compatible wrapper returning only repaired argument JSON."""
+    return repair_tool_call_arguments_with_status(raw_args, tool_name).arguments
 
 
 def close_interrupted_tool_sequence(messages: list, final_response: Any = None) -> bool:
@@ -468,6 +493,8 @@ __all__ = [
     "_sanitize_structure_surrogates",
     "_sanitize_messages_surrogates",
     "_escape_invalid_chars_in_json_strings",
+    "ToolCallArgumentsRepair",
+    "repair_tool_call_arguments_with_status",
     "_repair_tool_call_arguments",
     "_strip_non_ascii",
     "_sanitize_messages_non_ascii",

--- a/run_agent.py
+++ b/run_agent.py
@@ -410,7 +410,7 @@ class AIAgent:
 
     _TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER = (
         "[hermes-agent: tool call arguments were corrupted in this session and "
-        "have been dropped to keep the conversation alive. See issue #15236.]"
+        "were repaired or dropped to keep the conversation alive. See issue #15236.]"
     )
 
     @property

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -2,6 +2,7 @@
 
 import json
 
+from agent.message_sanitization import repair_tool_call_arguments_with_status
 from run_agent import _repair_tool_call_arguments
 
 
@@ -80,6 +81,18 @@ class TestRepairToolCallArguments:
         # Truncated in the middle of a string key — bracket closing won't help
         assert _repair_tool_call_arguments('{"truncated": "val', "t") == "{}"
 
+    def test_unrepairable_partial_reports_failure(self):
+        result = repair_tool_call_arguments_with_status('{"truncated": "val', "t")
+        assert result.arguments == "{}"
+        assert result.repaired is True
+        assert result.success is False
+
+    def test_legitimate_empty_object_reports_success(self):
+        result = repair_tool_call_arguments_with_status("   \n\t  ", "t")
+        assert result.arguments == "{}"
+        assert result.repaired is True
+        assert result.success is True
+
     # -- Valid JSON passthrough (this path is via except, but still works) --
 
     def test_already_valid_json_passes_through(self):
@@ -97,6 +110,12 @@ class TestRepairToolCallArguments:
         # Trailing comma stripped first, then closing brace added.
         # May or may not fully recover — verify valid JSON at minimum.
         json.loads(result)
+
+    def test_repairable_truncation_reports_success(self):
+        result = repair_tool_call_arguments_with_status('{"a": 1, "b": 2,', "t")
+        assert json.loads(result.arguments) == {"a": 1, "b": 2}
+        assert result.repaired is True
+        assert result.success is True
 
     def test_real_world_glm_truncation(self):
         """Simulates GLM-5.1 truncating mid-argument."""
@@ -139,4 +158,3 @@ class TestRepairToolCallArguments:
         result = _repair_tool_call_arguments(raw, "t")
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
-

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5186,10 +5186,10 @@ class TestRunConversation:
         mock_hfc.assert_called_once()
         assert result["final_response"] == "Done!"
 
-    def test_truncated_tool_args_detected_when_finish_reason_not_length(self, agent):
+    def test_unrepairable_truncated_tool_args_return_tool_error_when_finish_reason_not_length(self, agent):
         """When a router rewrites finish_reason from 'length' to 'tool_calls',
-        truncated JSON arguments should still be detected and refused rather
-        than wasting 3 retry attempts."""
+        unrepairable truncated JSON arguments should return a tool error to
+        the model instead of executing an empty-argument tool call."""
         self._setup_agent(agent)
         agent.valid_tool_names.add("write_file")
         bad_tc = _mock_tool_call(
@@ -5200,7 +5200,7 @@ class TestRunConversation:
         resp = _mock_response(
             content="", finish_reason="tool_calls", tool_calls=[bad_tc],
         )
-        agent.client.chat.completions.create.return_value = resp
+        final_resp = _mock_response(content="I will split the write.", finish_reason="stop")
 
         with (
             patch("run_agent.handle_function_call") as mock_handle_function_call,
@@ -5208,12 +5208,45 @@ class TestRunConversation:
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
+            agent.client.chat.completions.create.side_effect = [resp, final_resp]
             result = agent.run_conversation("write the report")
 
-        assert result["completed"] is False
-        assert result["partial"] is True
-        assert "truncated due to output length limit" in result["error"]
+        assert result["final_response"] == "I will split the write."
+        assert any(
+            msg.get("role") == "tool"
+            and "Tool call arguments were truncated" in msg.get("content", "")
+            for msg in result["messages"]
+        )
         mock_handle_function_call.assert_not_called()
+
+    def test_repairable_truncated_tool_args_continue_when_finish_reason_not_length(self, agent):
+        """Router-mislabeled tool-call truncation gets one repair attempt before
+        falling back to a tool error."""
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("write_file")
+        repaired_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial"',
+            call_id="c1",
+        )
+        resp = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[repaired_tc],
+        )
+        final_resp = _mock_response(content="Done!", finish_reason="stop")
+
+        with (
+            patch("run_agent.handle_function_call", return_value='{"success":true}') as mock_hfc,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.client.chat.completions.create.side_effect = [resp, final_resp]
+            result = agent.run_conversation("write the report")
+
+        mock_hfc.assert_called_once()
+        args, _kwargs = mock_hfc.call_args
+        assert args[1] == {"path": "report.md", "content": "partial"}
+        assert result["final_response"] == "Done!"
 
     def test_kanban_block_called_on_iteration_exhaustion(self, agent, monkeypatch):
         """Regression: kanban worker must signal the dispatcher when its

--- a/tests/run_agent/test_tool_call_args_sanitizer.py
+++ b/tests/run_agent/test_tool_call_args_sanitizer.py
@@ -125,7 +125,7 @@ def test_multiple_corrupted_tool_calls_in_one_message():
     assert repaired == 2
     assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
     assert messages[0]["tool_calls"][1]["function"]["arguments"] == '{"path":"/tmp/bar"}'
-    assert messages[0]["tool_calls"][2]["function"]["arguments"] == "{}"
+    assert messages[0]["tool_calls"][2]["function"]["arguments"] == '{"mode":"tail"}'
     assert messages[1]["tool_call_id"] == "call_1"
     assert messages[1]["content"] == marker
     assert messages[2]["tool_call_id"] == "call_3"


### PR DESCRIPTION
## What does this PR do?

Coordinates truncated tool-call argument handling around one repair contract: repairable malformed JSON continues normally, while unrepairable truncated JSON is reported back to the model as a tool error instead of executing with `{}` or aborting prematurely.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Shared root cause

- `agent/message_sanitization.py` returned only repaired argument text, so callers could not distinguish a legitimate empty `{}` from the last-resort `{}` used after failed repair.
- `agent/conversation_loop.py` had a separate invalid-JSON truncation branch that rejected router-mislabeled truncated tool calls before trying the shared repair routine.
- Streaming and pre-request transcript sanitation therefore made inconsistent decisions for the same broken tool-call arguments.

## How this fixes each issue

- #35151: unrepairable truncated tool-call arguments now produce a tool-result error telling the model to shorten or split the content; Hermes no longer executes the tool with silent empty arguments on that path.
- #35574: router-mislabeled truncated tool-call arguments are passed through the existing repair routine before being treated as invalid, so simple missing braces/brackets and dangling commas are repaired and continue normally.

## Changes Made

- Added `repair_tool_call_arguments_with_status()` so callers can tell whether repair succeeded even when the returned JSON is `{}`.
- Reused that status-bearing repair in the conversation loop, streaming assembly, and pre-request tool-call argument sanitizer.
- Converted unrepairable truncated live tool calls into assistant/tool recovery messages instead of a partial abort.
- Added regression coverage for repair success/failure status, pre-request sanitizer behavior, and router-mislabeled truncated tool calls.

## How to Test

1. `HERMES_HOME=/private/tmp/hermes-test-home /opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_tool_call_args_sanitizer.py tests/run_agent/test_run_agent.py -q -x --timeout=60'`
2. `BASE=$(git merge-base origin/main HEAD); { git diff --name-only --diff-filter=d "$BASE"; git ls-files --others --exclude-standard; } | grep -E '\.pyi?$' | sort -u | xargs ruff check`
3. `python scripts/check-windows-footguns.py run_agent.py agent/message_sanitization.py agent/agent_runtime_helpers.py agent/chat_completion_helpers.py agent/conversation_loop.py tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_tool_call_args_sanitizer.py tests/run_agent/test_run_agent.py`
4. Broad suite attempted with `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`; it aborted during collection because `fastapi`/`uvicorn` are not installed and this Homebrew Python is externally managed, so the lazy dependency installer cannot install them.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide / AGENTS instructions
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched the provided issue cluster context for duplicate/member PRs
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass; broad collection is blocked locally by missing dashboard dependencies as noted above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered; changed-file Windows footgun scan passed
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

- Focused tests: 446 passed
- Ruff changed files: passed (with a pre-existing warning about `run_agent.py:107` `# noqa` directive format)
- Windows footgun scan: passed

Refs #35151
Refs #35574

<!-- autocontrib:worker-id=pr-spanning-d94217c8 kind=pr-open -->