### PR TITLE
fix(pet): reject unsafe petdex redirects

### DIFF
--- a/agent/pet/manifest.py
+++ b/agent/pet/manifest.py
@@ -25,6 +25,8 @@ import threading
 import time
 from dataclasses import dataclass
 
+from agent.pet.network import stream_petdex
+
 logger = logging.getLogger(__name__)
 
 MANIFEST_URL = "https://petdex.dev/api/manifest"
@@ -124,19 +126,12 @@ def fetch_manifest(*, timeout: float = _DEFAULT_TIMEOUT, force: bool = False) ->
         return _cache[1]
 
     try:
-        import httpx
+        with stream_petdex(MANIFEST_URL, timeout=timeout) as resp:
+            resp.raise_for_status()
+            resp.read()
+            payload = resp.json()
     except ImportError as exc:  # pragma: no cover - httpx is a core dep
         raise ManifestError("httpx is required to fetch the petdex manifest") from exc
-
-    try:
-        resp = httpx.get(
-            MANIFEST_URL,
-            timeout=timeout,
-            follow_redirects=True,
-            headers={"User-Agent": "hermes-agent-petdex"},
-        )
-        resp.raise_for_status()
-        payload = resp.json()
     except Exception as exc:  # noqa: BLE001 - normalize to one error type
         raise ManifestError(f"could not fetch petdex manifest: {exc}") from exc
 

--- a/agent/pet/network.py
+++ b/agent/pet/network.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from contextlib import ExitStack, contextmanager
+from urllib.parse import urlsplit
+
+_MAX_REDIRECTS = 20
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+_USER_AGENT = "hermes-agent-petdex"
+
+
+class PetdexNetworkError(RuntimeError):
+    pass
+
+
+def _is_petdex_url(url: str) -> bool:
+    import httpx
+
+    try:
+        parsed = httpx.URL(url)
+        raw = urlsplit(url)
+        port = raw.port
+    except (httpx.InvalidURL, TypeError, ValueError):
+        return False
+    host = parsed.host.lower()
+    return (
+        parsed.scheme == "https"
+        and (host == "petdex.dev" or host.endswith(".petdex.dev"))
+        and raw.username is None
+        and raw.password is None
+        and port in (None, 443)
+    )
+
+
+@contextmanager
+def stream_petdex(url: str, *, timeout: float):
+    import httpx
+
+    if not _is_petdex_url(url):
+        raise PetdexNetworkError("refusing non-petdex URL")
+
+    current_url = url
+    redirects = 0
+    with httpx.Client(
+        follow_redirects=False,
+        headers={"User-Agent": _USER_AGENT},
+    ) as client:
+        while True:
+            with ExitStack() as response_stack:
+                try:
+                    response = response_stack.enter_context(
+                        client.stream("GET", current_url, timeout=timeout)
+                    )
+                except httpx.RemoteProtocolError as exc:
+                    raise PetdexNetworkError(
+                        "refusing invalid petdex redirect"
+                    ) from exc
+                if response.status_code not in _REDIRECT_STATUSES:
+                    yield response
+                    return
+                location = response.headers.get("Location", "").strip()
+                if not location:
+                    raise PetdexNetworkError("petdex redirect missing Location")
+                if redirects >= _MAX_REDIRECTS:
+                    raise PetdexNetworkError("too many petdex redirects")
+                try:
+                    raw_location = urlsplit(location)
+                    if (
+                        raw_location.username is not None
+                        or raw_location.password is not None
+                    ):
+                        raise PetdexNetworkError("refusing non-petdex redirect")
+                    next_url = str(response.url.join(location))
+                except (httpx.InvalidURL, TypeError, ValueError) as exc:
+                    raise PetdexNetworkError(
+                        "refusing invalid petdex redirect"
+                    ) from exc
+                if not _is_petdex_url(next_url):
+                    raise PetdexNetworkError("refusing non-petdex redirect")
+                current_url = next_url
+                redirects += 1

--- a/agent/pet/store.py
+++ b/agent/pet/store.py
@@ -22,6 +22,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from agent.pet.network import PetdexNetworkError, stream_petdex
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
@@ -355,16 +356,9 @@ def thumbnail_png(slug: str, *, source_url: str = "", timeout: float = 30.0) -> 
 
     if sheet_bytes is None and source_url and _is_petdex_host(source_url):
         try:
-            import httpx
-
-            resp = httpx.get(
-                source_url,
-                timeout=timeout,
-                follow_redirects=True,
-                headers={"User-Agent": "hermes-agent-petdex"},
-            )
-            resp.raise_for_status()
-            sheet_bytes = resp.content
+            with stream_petdex(source_url, timeout=timeout) as resp:
+                resp.raise_for_status()
+                sheet_bytes = resp.read()
         except Exception as exc:  # noqa: BLE001 - cosmetic, degrade to placeholder
             logger.debug("thumb fetch failed for %s: %s", slug, exc)
 
@@ -469,16 +463,8 @@ def rename_pet(slug: str, display_name: str) -> str | None:
 
 
 def _download(url: str, dest: Path, *, timeout: float) -> None:
-    import httpx
-
     try:
-        with httpx.stream(
-            "GET",
-            url,
-            timeout=timeout,
-            follow_redirects=True,
-            headers={"User-Agent": "hermes-agent-petdex"},
-        ) as resp:
+        with stream_petdex(url, timeout=timeout) as resp:
             resp.raise_for_status()
             tmp = dest.with_suffix(dest.suffix + ".part")
             with tmp.open("wb") as fh:
@@ -490,14 +476,11 @@ def _download(url: str, dest: Path, *, timeout: float) -> None:
 
 
 def _download_json(url: str, *, timeout: float) -> dict:
-    import httpx
-
-    resp = httpx.get(
-        url,
-        timeout=timeout,
-        follow_redirects=True,
-        headers={"User-Agent": "hermes-agent-petdex"},
-    )
-    resp.raise_for_status()
-    data = resp.json()
-    return data if isinstance(data, dict) else {}
+    try:
+        with stream_petdex(url, timeout=timeout) as resp:
+            resp.raise_for_status()
+            resp.read()
+            data = resp.json()
+            return data if isinstance(data, dict) else {}
+    except PetdexNetworkError as exc:
+        raise PetStoreError(str(exc)) from exc

--- a/tests/agent/test_pet_store_security.py
+++ b/tests/agent/test_pet_store_security.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import base64
+
+import httpx
+import pytest
+
+from agent.pet import manifest, store
+
+
+_PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+_UNSAFE_URL = "http://169.254.169.254/latest/meta-data"
+
+
+@pytest.fixture
+def blocked_redirect_transport(monkeypatch):
+    real_client = httpx.Client
+    requested: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested.append(str(request.url))
+        if request.url.host == "169.254.169.254":
+            return httpx.Response(200, content=_PNG_1X1, request=request)
+        return httpx.Response(302, headers={"Location": _UNSAFE_URL}, request=request)
+
+    transport = httpx.MockTransport(handler)
+    legacy_client = real_client(transport=transport)
+
+    def client_factory(**kwargs):
+        return real_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", client_factory)
+    monkeypatch.setattr(httpx, "get", legacy_client.get)
+    monkeypatch.setattr(httpx, "stream", legacy_client.stream)
+    yield requested
+    legacy_client.close()
+
+
+def _patch_client(monkeypatch, handler):
+    real_client = httpx.Client
+    requested: list[str] = []
+
+    def recording_handler(request: httpx.Request) -> httpx.Response:
+        requested.append(str(request.url))
+        return handler(request)
+
+    transport = httpx.MockTransport(recording_handler)
+
+    def client_factory(**kwargs):
+        return real_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", client_factory)
+    return requested
+
+
+def test_download_blocks_non_petdex_redirect_before_request(
+    blocked_redirect_transport,
+    tmp_path,
+):
+    source_url = "https://assets.petdex.dev/sprite.webp"
+    dest = tmp_path / "sprite.webp"
+
+    with pytest.raises(store.PetStoreError, match="non-petdex"):
+        store._download(source_url, dest, timeout=1)
+
+    assert blocked_redirect_transport == [source_url]
+    assert not dest.exists()
+
+
+def test_download_json_blocks_non_petdex_redirect_before_request(
+    blocked_redirect_transport,
+):
+    source_url = "https://assets.petdex.dev/pet.json"
+
+    with pytest.raises(store.PetStoreError, match="non-petdex"):
+        store._download_json(source_url, timeout=1)
+
+    assert blocked_redirect_transport == [source_url]
+
+
+def test_thumbnail_blocks_non_petdex_redirect_before_request(
+    blocked_redirect_transport,
+    monkeypatch,
+    tmp_path,
+):
+    source_url = "https://assets.petdex.dev/sprite.png"
+    monkeypatch.setattr(store, "get_hermes_home", lambda: tmp_path)
+
+    assert store.thumbnail_png("demo", source_url=source_url, timeout=1) is None
+    assert blocked_redirect_transport == [source_url]
+    assert not (tmp_path / "pets" / ".thumbs" / "demo.png").exists()
+
+
+def test_manifest_blocks_non_petdex_redirect_before_request(
+    blocked_redirect_transport,
+):
+    manifest.clear_cache()
+
+    with pytest.raises(manifest.ManifestError, match="non-petdex"):
+        manifest.fetch_manifest(timeout=1, force=True)
+
+    assert blocked_redirect_transport == [manifest.MANIFEST_URL]
+
+
+@pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])
+def test_download_json_follows_relative_petdex_redirect(monkeypatch, status_code):
+    real_client = httpx.Client
+    requested: list[str] = []
+    source_url = "https://assets.petdex.dev/pets/demo/pet.json"
+    redirected_url = "https://assets.petdex.dev/pets/shared/pet.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested.append(str(request.url))
+        if str(request.url) == source_url:
+            return httpx.Response(
+                status_code,
+                headers={"Location": "../shared/pet.json"},
+                request=request,
+            )
+        return httpx.Response(200, json={"id": "demo"}, request=request)
+
+    transport = httpx.MockTransport(handler)
+    legacy_client = real_client(transport=transport)
+
+    def client_factory(**kwargs):
+        return real_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", client_factory)
+    monkeypatch.setattr(httpx, "get", legacy_client.get)
+    try:
+        assert store._download_json(source_url, timeout=1) == {"id": "demo"}
+    finally:
+        legacy_client.close()
+
+    assert requested == [source_url, redirected_url]
+
+
+def test_download_json_stops_after_redirect_limit(monkeypatch):
+    real_client = httpx.Client
+    requested: list[str] = []
+    source_url = "https://assets.petdex.dev/pet.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested.append(str(request.url))
+        return httpx.Response(302, headers={"Location": source_url}, request=request)
+
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(**kwargs):
+        return real_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", client_factory)
+
+    with pytest.raises(store.PetStoreError, match="too many"):
+        store._download_json(source_url, timeout=1)
+
+    assert requested == [source_url] * 21
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        "http://assets.petdex.dev/pet.json",
+        "https://petdex.dev.evil.example/pet.json",
+        "//evil.example/pet.json",
+        "https://user@assets.petdex.dev/pet.json",
+        "https://@assets.petdex.dev/pet.json",
+        "https://assets.petdex.dev:8443/pet.json",
+    ],
+)
+def test_download_json_rejects_unsafe_petdex_url_forms(monkeypatch, location):
+    source_url = "https://assets.petdex.dev/pet.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"Location": location}, request=request)
+
+    requested = _patch_client(monkeypatch, handler)
+
+    with pytest.raises(store.PetStoreError, match="non-petdex"):
+        store._download_json(source_url, timeout=1)
+
+    assert requested == [source_url]
+
+
+def test_download_json_rejects_redirect_without_location(monkeypatch):
+    source_url = "https://assets.petdex.dev/pet.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, request=request)
+
+    requested = _patch_client(monkeypatch, handler)
+
+    with pytest.raises(store.PetStoreError, match="missing Location"):
+        store._download_json(source_url, timeout=1)
+
+    assert requested == [source_url]
+
+
+def test_download_json_does_not_follow_304(monkeypatch):
+    source_url = "https://assets.petdex.dev/pet.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(304, headers={"Location": "/other.json"}, request=request)
+
+    requested = _patch_client(monkeypatch, handler)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        store._download_json(source_url, timeout=1)
+
+    assert requested == [source_url]
+
+
+def test_download_json_allows_twenty_redirects(monkeypatch):
+    source_url = "https://assets.petdex.dev/pet.json?hop=0"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hop = int(request.url.params["hop"])
+        if hop < 20:
+            return httpx.Response(
+                302,
+                headers={"Location": f"/pet.json?hop={hop + 1}"},
+                request=request,
+            )
+        return httpx.Response(200, json={"id": "demo"}, request=request)
+
+    requested = _patch_client(monkeypatch, handler)
+
+    assert store._download_json(source_url, timeout=1) == {"id": "demo"}
+    assert len(requested) == 21
+    assert requested[-1] == "https://assets.petdex.dev/pet.json?hop=20"
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        "https://petdex.dev:bad/pet.json",
+        "https://petdex.dev/\x00pet.json",
+    ],
+)
+def test_download_json_normalizes_invalid_redirect_errors(monkeypatch, location):
+    source_url = "https://assets.petdex.dev/pet.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"Location": location}, request=request)
+
+    requested = _patch_client(monkeypatch, handler)
+
+    with pytest.raises(store.PetStoreError, match="invalid petdex redirect"):
+        store._download_json(source_url, timeout=1)
+
+    assert requested == [source_url]
+
+
+def test_download_json_rejects_unsafe_initial_url_without_request(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id": "unexpected"}, request=request)
+
+    requested = _patch_client(monkeypatch, handler)
+
+    with pytest.raises(store.PetStoreError, match="non-petdex"):
+        store._download_json("http://assets.petdex.dev/pet.json", timeout=1)
+
+    assert requested == []
+
+
+def test_download_json_follows_protocol_relative_petdex_redirect(monkeypatch):
+    source_url = "https://petdex.dev/pet.json"
+    redirected_url = "https://assets.petdex.dev/shared/pet.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == source_url:
+            return httpx.Response(
+                302,
+                headers={"Location": "//assets.petdex.dev/shared/pet.json"},
+                request=request,
+            )
+        return httpx.Response(200, json={"id": "demo"}, request=request)
+
+    requested = _patch_client(monkeypatch, handler)
+
+    assert store._download_json(source_url, timeout=1) == {"id": "demo"}
+    assert requested == [source_url, redirected_url]


### PR DESCRIPTION
## What does this PR do?

Petdex asset downloads now reject redirects that leave `petdex.dev` / `*.petdex.dev` before reading response bodies. The initial manifest and asset URLs were host-pinned, but the actual `httpx` requests followed redirects without checking the final URL, so a petdex asset URL could be redirected to an internal/private host and still be consumed.

## Related Issue

N/A — found via merged-PR echo scan of recent redirect/SSRF hardening.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/pet/store.py`: add a shared final-response host check for petdex fetches.
- `agent/pet/store.py`: apply the check to spritesheet downloads, pet JSON downloads, and thumbnail fetches.
- `tests/agent/test_pet_store_security.py`: cover redirects from petdex URLs to a non-petdex metadata host for all three fetch paths.

## How to Test

1. Run `python -m pytest tests/agent/test_pet_store_security.py -q`.
2. Run `python -m pytest tests/agent/test_pet_store_security.py tests/agent/test_pet_generate.py -q`.
3. Run `python -m ruff check agent/pet/store.py tests/agent/test_pet_store_security.py`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ python -m pytest tests/agent/test_pet_store_security.py -q
...                                                                      [100%]
3 passed in 0.18s

$ python -m pytest tests/agent/test_pet_store_security.py tests/agent/test_pet_generate.py -q
...ssssssssssssssssssssssssssssssssssss                                  [100%]
3 passed, 36 skipped in 0.29s

$ python -m ruff check agent/pet/store.py tests/agent/test_pet_store_security.py
All checks passed!
```
