### PR TITLE
fix: remove unused imports across 23 files (P2)

### DIFF
--- a/agent/billing_view.py
+++ b/agent/billing_view.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any, Optional
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -17,7 +17,6 @@ compatibility.
 from __future__ import annotations
 
 import logging
-import os
 import time
 from types import SimpleNamespace
 from typing import Any, Dict, List

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -18,20 +18,16 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import random
 import re
 import ssl
-import threading
 import time
-import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.conversation_compression import conversation_history_after_compression
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
-from agent.iteration_budget import IterationBudget
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -7,11 +7,11 @@ Usage:
 """
 
 from agent.transports.types import (
-    NormalizedResponse,
-    ToolCall,
-    Usage,
-    build_tool_call,
-    map_finish_reason,
+    NormalizedResponse as NormalizedResponse,
+    ToolCall as ToolCall,
+    Usage as Usage,
+    build_tool_call as build_tool_call,
+    map_finish_reason as map_finish_reason,
 )  # noqa: F401
 
 _REGISTRY: dict = {}

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -37,7 +37,7 @@ import re
 import subprocess
 import time
 from collections import deque
-from typing import Any, Deque, Dict, List, Optional
+from typing import Any, Deque, Dict, Optional
 
 try:
     from aiohttp import web

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -76,7 +76,6 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
-    SUPPORTED_DOCUMENT_TYPES,
 )
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
 from gateway import rich_sent_store

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -39,7 +39,6 @@ import signal
 import tempfile
 import threading
 import time
-import sqlite3
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -52,7 +51,6 @@ from typing import Callable, Dict, Optional, Any, List, Union
 # `gateway.run.fetch_account_usage` as a module-level attribute. The
 # gateway is a long-running daemon, so its boot cost matters less than
 # preserving the established test-patch surface.
-from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
 from hermes_cli.config import cfg_get
@@ -968,7 +966,6 @@ _AUTO_APPEND_MEDIA_TOOL_NAMES = {
 # implementation.  Re-exported under the historical private names so existing
 # call sites and tests keep working.
 from agent.replay_cleanup import (  # noqa: E402
-    is_interrupted_tool_result as _is_interrupted_tool_result,
     strip_interrupted_tool_tails as _strip_interrupted_tool_tails,
     strip_dangling_tool_call_tail as _strip_dangling_tool_call_tail,
 )
@@ -1261,7 +1258,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
-from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
+from utils import atomic_json_write, is_truthy_value
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -1663,8 +1660,6 @@ from gateway.config import (
     Platform,
     _BUILTIN_PLATFORM_VALUES,
     GatewayConfig,
-    HomeChannel,
-    PlatformConfig,
     load_gateway_config,
 )
 from gateway.session import (
@@ -1698,9 +1693,7 @@ from gateway.restart import (
 
 from gateway.whatsapp_identity import (
     canonical_whatsapp_identifier as _canonical_whatsapp_identifier,  # noqa: F401
-    expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
-    normalize_whatsapp_identifier as _normalize_whatsapp_identifier,
-)
+    )
 
 
 logger = logging.getLogger(__name__)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -19,7 +19,6 @@ import asyncio
 import inspect
 import logging
 import queue
-import re
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Optional

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -296,7 +296,6 @@ _EXTRA_ENV_KEYS = frozenset({
     "LANGFUSE_SECRET_KEY",
     "LANGFUSE_BASE_URL",
 })
-import yaml
 
 from hermes_cli.colors import Colors, color
 from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul
@@ -7802,7 +7801,6 @@ def _inject_platform_plugin_env_vars() -> None:
         return
     _platform_plugin_env_vars_injected = True
     try:
-        import yaml  # type: ignore
 
         # Resolve the bundled plugins dir from this file's location so the
         # injector works regardless of CWD.

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -19,7 +19,7 @@ import logging
 import threading
 import time
 from collections import defaultdict, deque
-from typing import Any, Deque, Dict, Tuple
+from typing import Any, Deque, Dict
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse

--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -15,7 +15,6 @@ browser tool needs agent-browser).
 """
 from __future__ import annotations
 
-import os
 import platform
 import shutil
 import subprocess

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -26,7 +26,6 @@ from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
-from hermes_cli.profiles import get_active_profile_name
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -265,7 +265,6 @@ from pathlib import Path
 from typing import Optional
 
 
-from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
@@ -600,7 +599,6 @@ from hermes_cli import __version__, __release_date__
 # (god-file decomposition Phase 2). Re-imported here so select_provider_and_model and
 # existing test monkeypatches (hermes_cli.main._model_flow_*) keep resolving unchanged.
 from hermes_cli.model_setup_flows import (
-    _prompt_auth_credentials_choice,
     _model_flow_openrouter,
     _model_flow_nous,
     _model_flow_openai_codex,
@@ -614,7 +612,6 @@ from hermes_cli.model_setup_flows import (
     _model_flow_copilot_acp,
     _model_flow_kimi,
     _model_flow_stepfun,
-    _model_flow_bedrock_api_key,
     _model_flow_bedrock,
     _model_flow_api_key_provider,
     _model_flow_anthropic,

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import logging
 import os
 import platform
-import shutil
 import subprocess
 import tempfile
 from pathlib import Path

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List
 
 logger = logging.getLogger(__name__)
 

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -17,7 +17,6 @@ from utils import is_truthy_value
 from tools.tool_backend_helpers import (
     fal_key_is_configured,
     has_direct_modal_credentials,
-    managed_nous_tools_enabled,
     normalize_browser_cloud_provider,
     normalize_modal_mode,
     resolve_modal_backend_state,

--- a/hermes_cli/security_audit_startup.py
+++ b/hermes_cli/security_audit_startup.py
@@ -26,7 +26,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 logger = logging.getLogger("hermes.security_audit")
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -23,7 +23,6 @@ from typing import Optional, Dict, Any
 
 from hermes_cli.nous_subscription import get_nous_subscription_features
 from tools.tool_backend_helpers import managed_nous_tools_enabled
-from utils import base_url_hostname
 from hermes_constants import get_optional_skills_dir
 
 logger = logging.getLogger(__name__)
@@ -3094,7 +3093,6 @@ def _run_blank_slate_setup(config: dict, hermes_home, is_existing: bool):
 
     Either way nothing is enabled that the user did not explicitly choose.
     """
-    from hermes_cli.config import load_config
 
     print()
     print_header("Blank Slate Setup")

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -12,7 +12,7 @@ significant debugging to find. Surfacing invalid toolset names (and the
 zero-tools end state) loudly turns that silent failure into an actionable one.
 """
 
-from typing import Callable, Dict, List
+from typing import Callable, List
 
 
 def validate_platform_toolsets(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7639,7 +7639,6 @@ def _codex_full_login_worker(session_id: str) -> None:
         from hermes_cli.auth import (
             CODEX_OAUTH_CLIENT_ID,
             CODEX_OAUTH_TOKEN_URL,
-            DEFAULT_CODEX_BASE_URL,
         )
         issuer = "https://auth.openai.com"
 

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -20,7 +20,7 @@ import os
 import shutil
 import subprocess
 import sys
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 
 # Match the ALLOWED_STATUS_VALUES + ALLOWED_OVERALL_VALUES the cua-driver

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -33,7 +33,6 @@ import logging
 import os
 import shutil
 import subprocess
-import sys
 import threading
 from typing import Optional
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -10,9 +10,7 @@ import json
 import logging
 import os
 import re
-import ssl
 import time
-from email.utils import formatdate
 
 from agent.redact import redact_sensitive_text
 


### PR DESCRIPTION
## Summary

Remove 44 unused imports across 23 files, detected by ruff F401.

## Approach

- Used `ruff check --select F401 --fix` for auto-removal
- 4 remaining imports are intentional availability checks in try/except blocks (kept as-is)
- All modified files pass py_compile

## Files (23)

agent/billing_view.py, agent/codex_runtime.py, agent/conversation_loop.py, agent/transports/__init__.py, gateway/platforms/webhook.py, gateway/platforms/whatsapp_cloud.py, gateway/run.py, gateway/stream_consumer.py, hermes_cli/config.py, hermes_cli/dashboard_auth/routes.py, hermes_cli/dep_ensure.py, hermes_cli/kanban.py, hermes_cli/main.py, hermes_cli/managed_uv.py, hermes_cli/middleware.py, hermes_cli/nous_subscription.py, hermes_cli/security_audit_startup.py, hermes_cli/setup.py, hermes_cli/toolset_validation.py, hermes_cli/web_server.py, tools/computer_use/doctor.py, tools/env_probe.py, tools/send_message_tool.py