### PR TITLE
fix(tools): honor per-session cwd override in execute_code project mode

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -30,6 +30,7 @@ def _force_local_terminal(monkeypatch):
     monkeypatch.setenv("TERMINAL_ENV", "local")
 
 
+from tools import terminal_tool
 from tools.code_execution_tool import (
     SANDBOX_ALLOWED_TOOLS,
     DEFAULT_EXECUTION_MODE,
@@ -214,7 +215,18 @@ class TestResolveChildCwd(unittest.TestCase):
         with patch.dict(os.environ, {"TERMINAL_CWD": "/does/not/exist/anywhere"}):
             self.assertEqual(_resolve_child_cwd("project", "/tmp/staging"), os.getcwd())
 
-    def test_project_expands_tilde(self):
+    def test_project_uses_per_session_override_before_terminal_cwd(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as session_dir, tempfile.TemporaryDirectory() as other_dir:
+            terminal_tool.register_task_env_overrides(
+                "sess-override", {"cwd": session_dir}
+            )
+            with patch.dict(os.environ, {"TERMINAL_CWD": other_dir}):
+                self.assertEqual(
+                    _resolve_child_cwd("project", "/tmp/staging", task_id="sess-override"),
+                    session_dir,
+                )
+
         import pathlib
         home = str(pathlib.Path.home())
         with patch.dict(os.environ, {"TERMINAL_CWD": "~"}):

--- a/tests/tools/test_gateway_cwd_contract.py
+++ b/tests/tools/test_gateway_cwd_contract.py
@@ -67,3 +67,22 @@ def test_execute_code_project_mode_falls_back_when_terminal_cwd_missing(monkeypa
 
     assert Path(resolved).is_dir()
     assert Path(resolved) != tmp_path / "missing"
+
+
+def test_execute_code_project_mode_uses_per_session_cwd_override(monkeypatch, tmp_path):
+    """Per-session cwd overrides (session.cwd.set) must win over TERMINAL_CWD."""
+    session_workspace = tmp_path / "session-a"
+    other_workspace = tmp_path / "session-b"
+    staging = tmp_path / "staging"
+    session_workspace.mkdir()
+    other_workspace.mkdir()
+    staging.mkdir()
+
+    monkeypatch.setenv("TERMINAL_CWD", str(other_workspace))
+    terminal_tool.register_task_env_overrides("session-a", {"cwd": str(session_workspace)})
+
+    resolved = code_execution_tool._resolve_child_cwd(
+        "project", str(staging), task_id="session-a"
+    )
+
+    assert Path(resolved) == session_workspace

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1328,7 +1328,7 @@ def execute_code(
         # Env scrubbing and tool whitelist apply identically in both modes.
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir)
+        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id or "")
         _script_path = os.path.join(tmpdir, "script.py")
 
         proc = subprocess.Popen(
@@ -1734,17 +1734,26 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
+def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
-    - ``project``: the session's TERMINAL_CWD (same as the terminal tool), or
-      ``os.getcwd()`` if TERMINAL_CWD is unset or doesn't point at a real dir.
-      Falls back to the staging tmpdir as a last resort so we never invoke
-      Popen with a nonexistent cwd.
+    - ``project``: the per-session cwd override (``session.cwd.set``), then
+      ``TERMINAL_CWD`` (same as the terminal tool), or ``os.getcwd()`` if
+      unset. Falls back to the staging tmpdir as a last resort so we never
+      invoke Popen with a nonexistent cwd.
     """
     if mode != "project":
         return staging_dir
+    if task_id:
+        try:
+            from tools.file_tools import _registered_task_cwd_override
+
+            sess_cwd = _registered_task_cwd_override(task_id)
+            if sess_cwd and os.path.isdir(sess_cwd):
+                return sess_cwd
+        except Exception:
+            pass
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)


### PR DESCRIPTION
## Summary

- Pass `task_id` into `_resolve_child_cwd()` for project-mode `execute_code`.
- Resolve the per-session cwd override from `session.cwd.set` before falling back to `TERMINAL_CWD` / `getcwd()`, matching `write_file` and `terminal`.

Fixes #56047

## Test plan

- [x] `pytest tests/tools/test_gateway_cwd_contract.py` (5/5)
- [x] `pytest tests/tools/test_code_execution_modes.py::TestResolveChildCwd` (6/6)
