### PR TITLE
fix(tools): preserve integer precision and union order in tool-arg coercion

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -737,8 +737,14 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
         return None
 
     if isinstance(expected_type, list):
-        # Union type — try each in order, return first successful coercion
+        # Union type — try each in order, return first successful coercion.
+        # `value` is already a str, so a "string" member matches immediately;
+        # otherwise the string branch (which returns `value` unchanged) never
+        # counts as a success and the loop falls through to a numeric member,
+        # ignoring declared order (e.g. "007" under ["string", "integer"] -> 7).
         for t in expected_type:
+            if t == "string":
+                return value
             result = _coerce_value(value, t, schema=schema)
             if result is not value:
                 return result
@@ -814,6 +820,15 @@ def _coerce_json(value: str, expected_python_type: type):
 
 def _coerce_number(value: str, integer_only: bool = False):
     """Try to parse *value* as a number.  Returns original string on failure."""
+    if integer_only:
+        # Parse integers directly: float() cannot represent integers above
+        # 2**53 exactly, so int(float(value)) would silently corrupt large
+        # ids / timestamps / nonces. Non-integer strings ("3.5", "1e3") raise
+        # ValueError here and fall through to the float logic below.
+        try:
+            return int(value.strip(), 10)
+        except ValueError:
+            pass
     try:
         f = float(value)
     except (ValueError, OverflowError):

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -84,6 +84,17 @@ class TestCoerceNumber:
     def test_negative_float(self):
         assert _coerce_number("-2.5") == -2.5
 
+    def test_integer_only_preserves_large_int(self):
+        """Integers above 2**53 must survive without float round-trip loss."""
+        assert (
+            _coerce_number("1234567890123456789", integer_only=True)
+            == 1234567890123456789
+        )
+        assert (
+            _coerce_number("9007199254740993", integer_only=True)
+            == 9007199254740993
+        )
+
 
 class TestCoerceBoolean:
     """Unit tests for _coerce_boolean."""
@@ -145,6 +156,16 @@ class TestCoerceValue:
     def test_union_with_string_preserves_original(self):
         """A non-numeric string in [number, string] should stay a string."""
         assert _coerce_value("hello", ["number", "string"]) == "hello"
+
+    def test_union_string_first_preserves_numeric_string(self):
+        """A leading "string" member matches, honoring declared order."""
+        assert _coerce_value("007", ["string", "integer"]) == "007"
+        assert _coerce_value("42", ["string", "integer"]) == "42"
+        assert _coerce_value("3.14", ["string", "number"]) == "3.14"
+
+    def test_union_integer_first_still_coerces(self):
+        """Declared order is honored the other way too: integer-first coerces."""
+        assert _coerce_value("7", ["integer", "string"]) == 7
 
     def test_array_type_parsed_from_json_string(self):
         """Stringified JSON arrays are parsed into native lists."""


### PR DESCRIPTION
## Summary
Two correctness bugs in tool-argument coercion (`model_tools.py`), which runs on every tool call: `coerce_tool_args` calls `_coerce_value`, which calls `_coerce_number`.

### 1. Large integers corrupted by a float round-trip
`_coerce_number` did `f = float(value); ... return int(f)`. `float()` cannot represent integers above `2**53` exactly, so `int(float(value))` changes the number without any error:

```
'1234567890123456789'  -> 1234567890123456768
'9007199254740993'     -> 9007199254740992
```

Any `integer`-typed tool arg a model emits as a string (ids, snowflakes, timestamps, nonces, large offsets) is at risk. Fixed by parsing integer-typed values with `int(value, 10)` first, falling back to the existing float path for non-integer strings (`'3.5'`, `'1e3'`).

### 2. Union types ignored declared order
For `"type": ["string", "integer"]`, the loop tries each member "in order, return first successful coercion" (per its docstring). But the `string` branch returns the value unchanged, so the `result is not value` success check never counted it, and the loop always fell through to the numeric member:

```
"007"  under ["string", "integer"] -> 7      (leading zeros destroyed)
"42"   under ["string", "integer"] -> 42     (string-ness lost)
```

Fixed by treating a `string` member as an immediate match (the input is already a `str`), which honors declared order in both directions (`["integer", "string"]` still coerces).

## Testing
Extended `tests/run_agent/test_tool_arg_coercion.py` with regression tests for both; the two new assertions fail on the previous code. Full file: 64 passed. `ruff check --select PLW1514` clean.