### PR TITLE
fix(gateway): suppress duplicate send after failed finalize

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1668,18 +1668,15 @@ class GatewayStreamConsumer:
                         if (
                             finalize
                             and is_turn_final
-                            and self.cfg.cursor
-                            and self._last_sent_text.endswith(self.cfg.cursor)
                             and self._visible_prefix() == text
                         ):
-                            # The final clean-up edit failed, but the complete
-                            # answer is already visible from the last streaming
-                            # frame (usually with only the cursor still stuck on
-                            # screen).  Mark the content delivered so the
-                            # gateway suppresses its normal full final send;
-                            # otherwise users see the same long answer twice
-                            # when Telegram/Discord rate-limit this cosmetic
-                            # final edit (#36965, #25349).
+                            # The final finalize/clean-up edit failed, but the
+                            # complete answer is already visible from an earlier
+                            # streaming frame.  Mark the content delivered so
+                            # the gateway suppresses its normal full final send;
+                            # otherwise users see the same answer twice when
+                            # Telegram/Discord rate-limit or reject the
+                            # cosmetic final edit (#36965, #25349, #55761).
                             self._final_content_delivered = True
                         raw_response = getattr(result, "raw_response", None)
                         if isinstance(raw_response, dict) and raw_response.get("partial_overflow"):

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -132,6 +132,32 @@ class TestFinalizeCapabilityGate:
         picky.edit_message.assert_called_once()
         assert picky.edit_message.call_args[1]["finalize"] is True
 
+    @pytest.mark.asyncio
+    async def test_failed_turn_final_finalize_confirms_already_visible_text(self):
+        """If final text is already visible, a failed finalize edit must not
+        make the gateway resend the same answer as a duplicate (#55761)."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = True
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(
+            success=False, error="telegram flood control",
+        ))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        consumer = GatewayStreamConsumer(adapter, "chat_1")
+
+        await consumer._send_or_edit("final answer")
+        delivered = await consumer._send_or_edit(
+            "final answer",
+            finalize=True,
+            is_turn_final=True,
+        )
+
+        assert delivered is False
+        assert consumer.final_response_sent is False
+        assert consumer.final_content_delivered is True
+
 
 class TestEditMessageFinalizeSignature:
     """Every concrete platform adapter must accept the ``finalize`` kwarg.


### PR DESCRIPTION
## What does this PR do?

Fixes a Telegram streaming duplicate-send path where the user already sees the
complete assistant reply through streaming edits, but the final Telegram
`finalize=True` cleanup edit fails or is rate-limited. Before this change the
stream consumer kept `final_content_delivered=False`, so the gateway believed
the reply had not reached the user and sent the same final text again through
the normal final-send path.

The fix is deliberately narrow: on a turn-final finalize failure, the stream
consumer marks final content as delivered only when the currently visible text
exactly matches the final text. Partial/tool-progress streams still fall back to
the gateway final send.

## Related Issue

Fixes #55761

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/stream_consumer.py`: when a turn-final finalize edit fails but the
  visible streamed prefix already equals the final text, mark
  `final_content_delivered=True` so `gateway/run.py` suppresses the duplicate
  normal final send.
- `tests/gateway/test_stream_consumer.py`: adds a regression test for the
  Telegram-style `REQUIRES_EDIT_FINALIZE=True` failure path.

## How to Test

1. Verified the new regression test fails on unpatched `origin/main` because
   `consumer.final_content_delivered` stays `False`.
2. Ran:
   `uv run pytest tests/gateway/test_stream_consumer.py::TestFinalizeCapabilityGate::test_failed_turn_final_finalize_confirms_already_visible_text tests/gateway/test_stream_consumer.py::TestFinalizeCapabilityGate tests/gateway/test_duplicate_reply_suppression.py -q`
   Result: `26 passed`.
3. Ran:
   `uv run pytest tests/gateway/test_stream_consumer.py tests/gateway/test_duplicate_reply_suppression.py -q`
   Result: `147 passed`.
4. Ran repository gate:
   `scripts/check.sh`
   Result: all blocking gates passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant pytest coverage and `scripts/check.sh`; the full repository matrix remains covered by CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing docs changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Relevant local proof:

```text
uv run pytest tests/gateway/test_stream_consumer.py tests/gateway/test_duplicate_reply_suppression.py -q
147 passed in 15.49s

scripts/check.sh
All blocking gates passed.
```
