### PR TITLE
fix(docker): add macOS Docker Desktop compose override for bridge networking

### DIFF
--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -1,0 +1,33 @@
+1|#
+2|# docker-compose.macos.yml — macOS Docker Desktop compatible
+3|#
+4|# Docker Desktop for Mac runs containers inside a Linux VM.  Unlike native
+5|# Linux Docker, `network_mode: host` maps to the *VM's* network namespace,
+6|# not the Mac host.  Ports bound inside the VM are invisible to the Mac
+7|# browser, and `ports:` mappings are silently ignored when host networking
+8|# is active.
+9|#
+10|# This override removes `network_mode: host` and uses explicit port
+11|# mappings so the dashboard is reachable from the Mac at
+12|# http://localhost:9119.
+13|#
+14|# Usage:
+15|#   HERMES_UID=$(id -u) HERMES_GID=$(id -g) \
+16|#     docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d
+17|#
+18|
+19|services:
+20|  gateway:
+21|    network_mode: bridge
+22|    # Uncomment to expose the OpenAI-compatible API server on the Mac host:
+23|    # ports:
+24|    #   - "127.0.0.1:9090:9090"
+25|
+26|  dashboard:
+27|    network_mode: bridge
+28|    environment:
+29|      - HERMES_DASHBOARD_HOST=0.0.0.0
+30|    ports:
+31|      - "127.0.0.1:9119:9119"
+32|    command: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open"]
+33|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,13 @@
 #
 # docker-compose.yml for Hermes Agent
 #
-# Usage:
+# Usage (Linux):
 #   HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose up -d
+#
+# Usage (macOS — Docker Desktop):
+#   HERMES_UID=$(id -u) HERMES_GID=$(id -g) \
+#     docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d
+# See docker-compose.macos.yml for why the override is needed.
 #
 # Set HERMES_UID / HERMES_GID to the host user that owns ~/.hermes so
 # files created inside the container stay readable/writable on the host.


### PR DESCRIPTION
## What does this PR do?

Adds a `docker-compose.macos.yml` override that replaces `network_mode: host` with bridge networking and explicit port mappings. On macOS Docker Desktop, `network_mode: host` maps to the Linux VM's network namespace (not the Mac host), so the dashboard port `9119` is invisible to the Mac browser. The override fixes this by using bridge mode with `ports: "127.0.0.1:9119:9119"`.

Also updates the main `docker-compose.yml` usage comment to point macOS users to the override file.

## Related Issue

Fixes #56401

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `docker-compose.yml` — Added macOS Docker Desktop usage comment pointing to the override file
- `docker-compose.macos.yml` — New override file that removes `network_mode: host` for both gateway and dashboard services, adds explicit `127.0.0.1:9119:9119` port mapping for the dashboard, and binds the dashboard to `0.0.0.0` inside the container (same pattern as the existing `docker-compose.windows.yml`)

## How to Test

1. On macOS with Docker Desktop installed, clone hermes-agent
2. Run: `HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d`
3. Open http://localhost:9119 in the Mac browser — Observed result: dashboard loads successfully (previously "connection refused" with the base `docker-compose.yml` alone)
4. On Linux, verify the original `docker compose up -d` still works unchanged — Observed result: dashboard accessible at localhost:9119 as before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A (compose config only)
- [x] I've tested on my platform: macOS 15 (Docker Desktop)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — usage comment in docker-compose.yml
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — follows same pattern as existing `docker-compose.windows.yml`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
