### PR TITLE
fix(compaction): skip compression when it cannot reduce the token count

### DIFF
--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -628,3 +628,67 @@ class TestCompressionToolPairIntegrity:
             {"from": "tool", "value": "<tool_response>a</tool_response>"},
         ]
         assert tc._snap_boundary(trajectory, 1, 0, 1) == 0
+
+
+# ---------------------------------------------------------------------------
+# TrajectoryCompressor — compression must never increase the token count
+# ---------------------------------------------------------------------------
+
+
+class TestCompressionNetSavingsGuard:
+    """When the compressible middle is no larger than the summary that would
+    replace it, compression cannot help — it must be skipped rather than grow
+    the trajectory (and burn a summarization call)."""
+
+    def _tiny_middle_trajectory(self):
+        # Large protected head (system+human), tiny compressible middle.
+        big = "w " * 400  # ~200 tokens each (1 token / 4 chars)
+        small = "ok " * 2
+        return [
+            {"from": "system", "value": big},  # protected (first_system)
+            {"from": "human", "value": big},  # protected (first_human)
+            {"from": "gpt", "value": small},  # protected (first_gpt)
+            {"from": "tool", "value": small},  # protected (first_tool)
+            {"from": "gpt", "value": small},  # compressible middle
+            {"from": "tool", "value": small},  # compressible middle
+            {"from": "gpt", "value": small},  # protected (last 2)
+            {"from": "human", "value": small},  # protected (last 2)
+        ]
+
+    def _config(self):
+        config = CompressionConfig()
+        config.protect_last_n_turns = 2
+        config.summary_target_tokens = 20
+        config.target_max_tokens = 100  # trajectory is far over this
+        return config
+
+    def test_sync_skips_compression_when_middle_smaller_than_summary(self):
+        tc = _make_compressor(self._config())
+        tc._generate_summary = MagicMock(
+            return_value="[CONTEXT SUMMARY]: " + "blah " * 30
+        )
+        trajectory = self._tiny_middle_trajectory()
+        before = sum(tc.count_turn_tokens(trajectory))
+
+        compressed, metrics = tc.compress_trajectory(trajectory)
+
+        assert metrics.was_compressed is False
+        assert compressed == trajectory
+        assert sum(tc.count_turn_tokens(compressed)) == before
+        tc._generate_summary.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_skips_compression_when_middle_smaller_than_summary(self):
+        tc = _make_compressor(self._config())
+        tc._generate_summary_async = AsyncMock(
+            return_value="[CONTEXT SUMMARY]: " + "blah " * 30
+        )
+        trajectory = self._tiny_middle_trajectory()
+        before = sum(tc.count_turn_tokens(trajectory))
+
+        compressed, metrics = await tc.compress_trajectory_async(trajectory)
+
+        assert metrics.was_compressed is False
+        assert compressed == trajectory
+        assert sum(tc.count_turn_tokens(compressed)) == before
+        tc._generate_summary_async.assert_not_called()

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -831,6 +831,18 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             metrics.still_over_limit = total_tokens > self.config.target_max_tokens
             return trajectory, metrics
 
+        # If the region we can safely compress is no larger than the summary
+        # that would replace it, compression cannot reduce the token count --
+        # it would grow the trajectory and still spend a summarization call.
+        if (
+            sum(turn_tokens[compress_start:compress_until])
+            <= self.config.summary_target_tokens
+        ):
+            metrics.compressed_tokens = total_tokens
+            metrics.compressed_turns = len(trajectory)
+            metrics.still_over_limit = total_tokens > self.config.target_max_tokens
+            return trajectory, metrics
+
         # Record compression region
         metrics.turns_compressed_start_idx = compress_start
         metrics.turns_compressed_end_idx = compress_until
@@ -941,6 +953,18 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         compress_until = self._snap_boundary(trajectory, compress_until, compress_start, compress_end)
         if compress_until <= compress_start:
             # Snapping collapsed the region; nothing can be safely compressed.
+            metrics.compressed_tokens = total_tokens
+            metrics.compressed_turns = len(trajectory)
+            metrics.still_over_limit = total_tokens > self.config.target_max_tokens
+            return trajectory, metrics
+
+        # If the region we can safely compress is no larger than the summary
+        # that would replace it, compression cannot reduce the token count --
+        # it would grow the trajectory and still spend a summarization call.
+        if (
+            sum(turn_tokens[compress_start:compress_until])
+            <= self.config.summary_target_tokens
+        ):
             metrics.compressed_tokens = total_tokens
             metrics.compressed_turns = len(trajectory)
             metrics.still_over_limit = total_tokens > self.config.target_max_tokens


### PR DESCRIPTION
## What does this PR do?

Skips trajectory compaction when it can't actually reduce the token count. `compress_trajectory` (and its async twin) replaced a compressible middle region with a summary without checking that the summary is smaller than what it replaces. When the region was already small, the "summary" came out larger than the original. So the trajectory grew while still being marked `was_compressed=True` (observed: 406 tokens went up to 465, `tokens_saved = -59`).

The fix adds a net-savings guard: when the compressible region's token count is `<=` the summary target, return the trajectory unchanged instead of expanding it. This applies to both the sync and async paths (sibling call path included).

## Related Issue

No separate issue filed; reproduces on current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `trajectory_compressor.py`: guard both `compress_trajectory` and `compress_trajectory_async` so they skip compression when `region_tokens <= summary_target_tokens`, returning the trajectory unchanged.
- `tests/test_trajectory_compressor.py`: sync and async tests asserting a tiny compressible region is left unchanged (no token growth, `was_compressed` not set).

## How to Test

1. On `main`: compressing a trajectory with a small compressible middle grows the token count yet reports `was_compressed=True`.
2. Apply this PR.
3. Run `scripts/run_tests.sh tests/test_trajectory_compressor.py -q`. The added net-savings tests pass (34 passed). Note: 3 tests (`*_omits_temperature`, kimi/moonshot) fail identically on unmodified `main`. They're unrelated to this change (temperature-omission for kimi models), not a regression from this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(compaction): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/test_trajectory_compressor.py`; the net-savings tests pass, and the only failures are the 3 pre-existing `*_omits_temperature` cases that also fail on `main`
- [x] I've added tests for my changes (sync + async)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Documentation: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact: N/A (pure token-count arithmetic)
- [x] Tool descriptions/schemas: N/A