### PR TITLE
fix(desktop): make MoA preset selection persistent, not one-shot

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -1,0 +1,92 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, findByText, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
+import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
+
+import { ModelMenuPanel } from './model-menu-panel'
+
+// Radix calls these on open; jsdom doesn't implement them.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const getMoaModels = vi.fn()
+const getGlobalModelOptions = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getGlobalModelOptions: (...args: unknown[]) => getGlobalModelOptions(...args),
+  getMoaModels: (...args: unknown[]) => getMoaModels(...args)
+}))
+
+function moaPreset() {
+  return {
+    aggregator: { provider: 'deepseek', model: 'deepseek-v4-pro' },
+    aggregator_temperature: 0.7,
+    enabled: true,
+    max_tokens: 4096,
+    reference_models: [{ provider: 'zai', model: 'glm-5.2' }],
+    reference_temperature: 0.7
+  }
+}
+
+beforeEach(() => {
+  $activeSessionId.set('runtime-1')
+  $currentModel.set('')
+  $currentProvider.set('')
+  getGlobalModelOptions.mockResolvedValue({ providers: [] })
+  getMoaModels.mockResolvedValue({
+    default_preset: 'default',
+    active_preset: 'default',
+    presets: { default: moaPreset(), BeastMode: moaPreset() }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function renderPanel(onSelectModel = vi.fn()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <DropdownMenu open>
+        <DropdownMenuContent>
+          <ModelMenuPanel onSelectModel={onSelectModel} requestGateway={vi.fn() as never} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </QueryClientProvider>
+  )
+
+  return onSelectModel
+}
+
+describe('ModelMenuPanel MoA presets', () => {
+  it('selecting a MoA preset switches PERSISTENTLY via onSelectModel (not the one-shot dispatch)', async () => {
+    const onSelectModel = renderPanel()
+
+    // moaOptions is async (useQuery) — wait for the preset row to mount.
+    const row = await findByText(document.body, 'MoA: BeastMode')
+    fireEvent.click(row)
+
+    // #54670: must route through the persistent model-switch path
+    // (config.set model="<preset> --provider moa"), i.e. onSelectModel with
+    // provider 'moa', NOT a one-shot command.dispatch that reverts after a turn.
+    expect(onSelectModel).toHaveBeenCalledWith({ model: 'BeastMode', provider: 'moa' })
+  })
+
+  it('shows the check on the preset that matches the current moa selection', async () => {
+    $currentProvider.set('moa')
+    $currentModel.set('BeastMode')
+    renderPanel()
+
+    const row = await findByText(document.body, 'MoA: BeastMode')
+    // The check codicon renders as a sibling within the same row item.
+    const item = row.closest('[role="menuitem"]') ?? row.parentElement
+    expect(item?.querySelector('.codicon-check')).not.toBeNull()
+  })
+})

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -69,7 +69,6 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
   const [search, setSearch] = useState('')
   const [refreshing, setRefreshing] = useState(false)
   const queryClient = useQueryClient()
-  const [activeMoaPreset, setActiveMoaPreset] = useState('')
   // Reactive session state is read from the stores here (not drilled in), so
   // toggling effort/fast/model re-renders this panel in place without forcing
   // the parent to rebuild the menu content (which would close the dropdown).
@@ -180,13 +179,18 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
     )
   }
 
-  const toggleMoaPreset = async (preset: string) => {
+  // Selecting a MoA preset switches the session to it PERSISTENTLY, using the
+  // same path real provider selections use (config.set model="<preset>
+  // --provider moa" via onSelectModel → the gateway's persistent switch_model).
+  // Previously this dispatched the one-shot `/moa` command, which ran a single
+  // turn through MoA and then silently reverted to the prior model (#54670) —
+  // the dropdown presented presets like persistent selections but they weren't.
+  const selectMoaPreset = async (preset: string) => {
     if (!activeSessionId) {
       return
     }
 
-    await requestGateway('command.dispatch', { name: 'moa', arg: preset, session_id: activeSessionId })
-    setActiveMoaPreset(current => (current === preset ? '' : preset))
+    await switchTo(preset, 'moa')
   }
 
   const groups = useMemo(
@@ -321,22 +325,26 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
       {moaOptions.data && Object.keys(moaOptions.data.presets ?? {}).length > 0 ? (
         <>
           <DropdownMenuLabel className={dropdownMenuSectionLabel}>MoA presets</DropdownMenuLabel>
-          {Object.keys(moaOptions.data.presets).map(preset => (
-            <DropdownMenuItem
-              className={dropdownMenuRow}
-              disabled={!activeSessionId}
-              key={`moa:${preset}`}
-              onSelect={event => {
-                event.preventDefault()
-                void toggleMoaPreset(preset)
-              }}
-            >
-              <span className="min-w-0 flex-1 truncate">MoA: {preset}</span>
-              {activeMoaPreset === preset ? (
-                <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" />
-              ) : null}
-            </DropdownMenuItem>
-          ))}
+          {Object.keys(moaOptions.data.presets).map(preset => {
+            const isCurrentMoa = currentProvider === 'moa' && currentModel === preset
+
+            return (
+              <DropdownMenuItem
+                className={dropdownMenuRow}
+                disabled={!activeSessionId}
+                key={`moa:${preset}`}
+                onSelect={event => {
+                  event.preventDefault()
+                  void selectMoaPreset(preset)
+                }}
+              >
+                <span className="min-w-0 flex-1 truncate">MoA: {preset}</span>
+                {isCurrentMoa ? (
+                  <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" />
+                ) : null}
+              </DropdownMenuItem>
+            )
+          })}
           <DropdownMenuSeparator className="mx-0" />
         </>
       ) : null}


### PR DESCRIPTION
## Summary
Selecting a MoA preset from the desktop composer's model dropdown now switches the session to it **persistently**, instead of running one turn through MoA and silently reverting.

Fixes #54670.

## Root cause
The MoA preset rows dispatched the one-shot `/moa` command (`command.dispatch name=moa`), which the gateway marks `_moa_disable_after_turn = True` — it runs a single turn through the preset and restores the prior model. But the rows sat in the same dropdown as real provider selections with no "one-shot" indicator, so the user saw MoA context for one message and then it silently vanished.

## Changes (`apps/desktop/src/app/shell/model-menu-panel.tsx`)
- MoA preset selection now calls `onSelectModel({ model: preset, provider: 'moa' })` — the same persistent path real provider selections use (`config.set model="<preset> --provider moa"` → the gateway's `switch_model`).
- The check mark reflects the real current selection (`currentProvider === 'moa' && currentModel === preset`) instead of transient local `activeMoaPreset` state, which is removed.

## Validation
| | Result |
|---|---|
| new `model-menu-panel.test.tsx` | 2/2 pass (selection routes through `onSelectModel` w/ provider `moa`; check renders on the active preset) |
| `tsc -b` (apps/desktop) | clean |
| `eslint` (changed files) | 0 errors |

## Infographic
![MoA preset persistent selection](https://v3b.fal.media/files/b/0aa0822e/3Kv7wT92lwJyj5cvEZgC8_UUPL1JoZ.png)
