### PR TITLE
fix(utils): honor env_bool default when the variable is unset or empty

### DIFF
--- a/tests/test_utils_truthy_values.py
+++ b/tests/test_utils_truthy_values.py
@@ -1,6 +1,6 @@
 """Tests for shared truthy-value helpers."""
 
-from utils import env_var_enabled, is_truthy_value
+from utils import env_bool, env_var_enabled, is_truthy_value
 
 
 def test_is_truthy_value_accepts_common_truthy_strings():
@@ -27,3 +27,21 @@ def test_env_var_enabled_uses_shared_truthy_rules(monkeypatch):
 
     monkeypatch.setenv("HERMES_TEST_BOOL", "no")
     assert env_var_enabled("HERMES_TEST_BOOL") is False
+
+
+def test_env_bool_honors_default_when_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_TEST_BOOL", raising=False)
+    assert env_bool("HERMES_TEST_BOOL", default=True) is True
+    assert env_bool("HERMES_TEST_BOOL", default=False) is False
+
+
+def test_env_bool_honors_default_when_empty(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_BOOL", "   ")
+    assert env_bool("HERMES_TEST_BOOL", default=True) is True
+
+
+def test_env_bool_reads_set_value(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_BOOL", "yes")
+    assert env_bool("HERMES_TEST_BOOL", default=False) is True
+    monkeypatch.setenv("HERMES_TEST_BOOL", "off")
+    assert env_bool("HERMES_TEST_BOOL", default=True) is False

--- a/utils.py
+++ b/utils.py
@@ -393,8 +393,11 @@ def env_float(key: str, default: float = 0.0) -> float:
 
 
 def env_bool(key: str, default: bool = False) -> bool:
-    """Read an environment variable as a boolean."""
-    return is_truthy_value(os.getenv(key, ""), default=default)
+    """Read an environment variable as a boolean, with fallback."""
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default
+    return is_truthy_value(raw, default=default)
 
 
 # ─── Proxy Helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`env_bool` (`utils.py`) ignored its `default` when the environment variable was unset or empty:

```python
def env_bool(key, default=False):
    return is_truthy_value(os.getenv(key, ""), default=default)
```

`os.getenv(key, "")` returns `""` (not `None`) for an absent variable. `is_truthy_value` only applies its `default` for `None`, so `""` fell through to the string branch and returned `False`. The `default` got discarded entirely. `env_bool("SOME_FLAG", default=True)` returned `False` for an unset var.

The sibling helpers `env_int` / `env_float` already guard this correctly (`raw = os.getenv(...).strip(); if not raw: return default`). This brings `env_bool` in line:

```python
def env_bool(key, default=False):
    raw = os.getenv(key, "").strip()
    if not raw:
        return default
    return is_truthy_value(raw, default=default)
```

No current call site passes `default=True`, so there is no live regression today. The helper's contract was still broken, and the first default-on flag would have read as off.

## Testing
Added regression tests to `tests/test_utils_truthy_values.py` (default honored when unset / whitespace-only; set values still read correctly). The unset/empty cases fail on the previous code. `ruff check --select PLW1514` clean.