### PR TITLE
fix(gateway): fall back from unwritable lock state home

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -83,7 +83,20 @@ def _get_lock_dir() -> Path:
     if override:
         return Path(override)
     state_home = Path(os.getenv("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+    if "XDG_STATE_HOME" not in os.environ and not _has_writable_ancestor(state_home):
+        state_home = _get_process_hermes_home() / ".local" / "state"
     return state_home / "hermes" / _LOCKS_DIRNAME
+
+
+def _has_writable_ancestor(path: Path) -> bool:
+    """Return True when *path* can plausibly be created by this process."""
+    current = path
+    while not current.exists():
+        parent = current.parent
+        if parent == current:
+            return False
+        current = parent
+    return os.access(current, os.W_OK | os.X_OK)
 
 
 def _utc_now_iso() -> str:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway import status
 
 
@@ -157,6 +158,68 @@ class TestGatewayPidState:
         status.release_gateway_runtime_lock()
 
         assert status.is_gateway_runtime_lock_active() is False
+
+    def test_lock_dir_falls_back_to_hermes_home_when_home_state_unwritable(self, tmp_path, monkeypatch):
+        """Container regression: HOME=/root under a non-root UID must not send
+        gateway-locks into an unwritable HOME-derived state directory (#56402)."""
+        bad_home = tmp_path / "root"
+        hermes_home = tmp_path / "data"
+        bad_home.mkdir()
+        hermes_home.mkdir()
+
+        monkeypatch.setenv("HOME", str(bad_home))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+        monkeypatch.setattr(status.Path, "home", classmethod(lambda cls: bad_home))
+        monkeypatch.setattr(
+            status.os,
+            "access",
+            lambda path, mode: not str(path).startswith(str(bad_home)),
+        )
+
+        assert status._get_lock_dir() == (
+            hermes_home / ".local" / "state" / "hermes" / "gateway-locks"
+        )
+
+    def test_lock_dir_honors_explicit_xdg_state_home(self, tmp_path, monkeypatch):
+        xdg_state = tmp_path / "xdg-state"
+        hermes_home = tmp_path / "data"
+        hermes_home.mkdir()
+
+        monkeypatch.setenv("XDG_STATE_HOME", str(xdg_state))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+        monkeypatch.setattr(status.os, "access", lambda path, mode: False)
+
+        assert status._get_lock_dir() == xdg_state / "hermes" / "gateway-locks"
+
+    def test_lock_dir_fallback_ignores_context_hermes_home_override(self, tmp_path, monkeypatch):
+        bad_home = tmp_path / "root"
+        process_home = tmp_path / "process-home"
+        profile_home = tmp_path / "profile-home"
+        bad_home.mkdir()
+        process_home.mkdir()
+        profile_home.mkdir()
+
+        monkeypatch.setenv("HOME", str(bad_home))
+        monkeypatch.setenv("HERMES_HOME", str(process_home))
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+        monkeypatch.setattr(status.Path, "home", classmethod(lambda cls: bad_home))
+        monkeypatch.setattr(
+            status.os,
+            "access",
+            lambda path, mode: not str(path).startswith(str(bad_home)),
+        )
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            assert status._get_lock_dir() == (
+                process_home / ".local" / "state" / "hermes" / "gateway-locks"
+            )
+        finally:
+            reset_hermes_home_override(token)
 
     def test_get_running_pid_treats_pid_file_as_stale_without_runtime_lock(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

Fixes the gateway scoped-lock path when the process inherits an unwritable
HOME-derived state directory, for example `HOME=/root` while the gateway runs as
a non-root UID in a container.

Before this change, `_get_lock_dir()` always derived token-scoped gateway locks
from `Path.home()/.local/state/hermes/gateway-locks` unless
`HERMES_GATEWAY_LOCK_DIR` or `XDG_STATE_HOME` was explicitly set. In the reported
container setup that resolves under `/root/.local/state/...`, so platform lock
acquisition can raise `PermissionError` and leave Telegram-style integrations
paused.

The fix keeps the existing precedence intact:

- `HERMES_GATEWAY_LOCK_DIR` still wins.
- Explicit `XDG_STATE_HOME` still wins.
- Only the implicit HOME-derived state path falls back, and only when its
  nearest existing ancestor is not writable.

The fallback uses the Hermes root's `.local/state/hermes/gateway-locks`, matching
the documented `HOME=$HERMES_HOME` workaround while preserving a root-scoped lock
directory for profile homes.

## Related Issue

Fixes #56402

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/status.py`: falls back from an unwritable implicit HOME-derived state
  path to `get_default_hermes_root()/.local/state`.
- `tests/gateway/test_status.py`: adds regression coverage for the unwritable
  HOME case and a guard that explicit `XDG_STATE_HOME` is not overridden.

## How to Test

1. Verified the new regression test fails against the old `gateway/status.py`
   behavior because `_get_lock_dir()` returns the fake-unwritable
   `HOME/.local/state/hermes/gateway-locks` path.
2. Ran:
   `uv run pytest tests/gateway/test_status.py -q`
   Result: `93 passed`.
3. Ran:
   `uv run ruff check gateway/status.py tests/gateway/test_status.py`
   Result: all checks passed.
4. Ran repository gate:
   `scripts/check.sh`
   Result: all blocking gates passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant pytest coverage and `scripts/check.sh`; the full repository matrix remains covered by CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing docs changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Relevant local proof:

```text
uv run pytest tests/gateway/test_status.py -q
93 passed in 2.46s

scripts/check.sh
All blocking gates passed.
```
