### PR TITLE
fix(agent): prioritize id over call_id in tool_call ID extraction

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2097,10 +2097,18 @@ This compaction should PRIORITISE preserving all information related to the focu
 
     @staticmethod
     def _get_tool_call_id(tc) -> str:
-        """Extract the call ID from a tool_call entry (dict or SimpleNamespace)."""
+        """Extract the call ID from a tool_call entry (dict or SimpleNamespace).
+
+        Priority: ``id`` (OpenAI standard, also used by
+        ``make_tool_result_message`` for ``tool_call_id``), then
+        ``call_id`` (Codex Responses API format).  Must match
+        ``AIAgent._get_tool_call_id_static`` so both the compressor and
+        the pre-API-call sanitizer agree on the same ID for each tool
+        call (#55626).
+        """
         if isinstance(tc, dict):
-            return tc.get("call_id", "") or tc.get("id", "") or ""
-        return getattr(tc, "call_id", "") or getattr(tc, "id", "") or ""
+            return tc.get("id", "") or tc.get("call_id", "") or ""
+        return getattr(tc, "id", "") or getattr(tc, "call_id", "") or ""
 
     def _sanitize_tool_pairs(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Fix orphaned tool_call / tool_result pairs after compression.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3640,10 +3640,17 @@ class AIAgent:
 
     @staticmethod
     def _get_tool_call_id_static(tc) -> str:
-        """Extract call ID from a tool_call entry (dict or object)."""
+        """Extract call ID from a tool_call entry (dict or object).
+
+        Priority: ``id`` (OpenAI standard, also used by
+        ``make_tool_result_message`` for ``tool_call_id``), then
+        ``call_id`` (Codex Responses API format).  Using ``call_id``
+        first caused ``[Result unavailable]`` stubs for providers that
+        set *both* fields with different values (#55626).
+        """
         if isinstance(tc, dict):
-            return (tc.get("call_id", "") or tc.get("id", "") or "").strip()
-        return (getattr(tc, "call_id", "") or getattr(tc, "id", "") or "").strip()
+            return (tc.get("id", "") or tc.get("call_id", "") or "").strip()
+        return (getattr(tc, "id", "") or getattr(tc, "call_id", "") or "").strip()
 
     @staticmethod
     def _get_tool_call_name_static(tc) -> str:


### PR DESCRIPTION
## What

Swap the field priority in `AIAgent._get_tool_call_id_static` and `ContextCompressor._get_tool_call_id` from `call_id → id` to `id → call_id`.

## Why

The two ID extractors used `call_id` as the primary key, but
`make_tool_result_message()` constructs the matching `tool_call_id`
field from `tool_call.id` (the `id` key).

When a provider such as Codex Responses API sets **both** `call_id`
and `id` keys with **different values** on the same tool_call object,
the two ID sources diverge permanently. The pre-API-call sanitizer
(`sanitize_api_messages`) then sees the assistant tool_call as having
no matching result and injects a `[Result unavailable]` stub, even
though the tool executed successfully and returned real data.

This caused memory-provider tools (`mnemosyne_recall`,
`mnemosyne_remember`, `cronjob list`, etc.) to consistently show
`[Result unavailable]` on affected providers.

Fixes: #55626

## Changes

- `run_agent.py`: `_get_tool_call_id_static` — swap `tc.get("call_id")`
  and `tc.get("id")` order (2 lines)
- `agent/context_compressor.py`: `_get_tool_call_id` — same swap (2
  lines)
- Both docstrings updated to document the priority reason and link
  issue #55626

## How to test

1. Configure a provider that uses Codex Responses API format (or any
   provider that emits both `call_id` and `id` on tool_call objects)
2. Use a memory provider such as mnemosyne
3. Send a prompt that triggers `mnemosyne_recall`
4. Before the fix: result shows `[Result unavailable]`
5. After the fix: result shows actual memory content

**Unit test (standalone):**
```python
# Verify id priority
assert get_tool_call_id_static({"call_id": "c1", "id": "c2"}) == "c2"
assert get_tool_call_id_static({"id": "call_123"}) == "call_123"
```

## Platforms tested

- macOS (arm64)
- The fix is a pure data-lookup priority change; no OS-specific logic