### PR TITLE
fix(webhook): make {__raw__} truncate length configurable per-use

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -851,11 +851,25 @@ class WebhookAdapter(BasePlatformAdapter):
         ``{pull_request.title}`` → ``payload["pull_request"]["title"]``
 
         Special token ``{__raw__}`` dumps the entire payload as indented
-        JSON (truncated to 4000 chars).  Useful for monitoring alerts or
-        any webhook where the agent needs to see the full payload.
+        JSON (truncated to 4000 chars by default). For large payloads from
+        CRMs / ERPs whose formatted JSON exceeds 4000 chars, the truncate
+        length can be overridden per-use with the ``{__raw__:N}`` form
+        where ``N`` is a non-negative integer; ``{__raw__:0}`` disables
+        truncation entirely. Useful for monitoring alerts or any webhook
+        where the agent needs to see the full payload.
         """
+        # Default truncate for the special ``{__raw__}`` token. Override per-use
+        # with the ``{__raw__:N}`` form (N=0 disables truncation entirely).
+        raw_default_max = 4000
+
+        def _truncate_raw(limit: int) -> str:
+            serialized = json.dumps(payload, indent=2)
+            if limit <= 0:
+                return serialized
+            return serialized[:limit]
+
         if not template:
-            truncated = json.dumps(payload, indent=2)[:4000]
+            truncated = _truncate_raw(raw_default_max)
             return (
                 f"Webhook event '{event_type}' on route "
                 f"'{route_name}':\n\n```json\n{truncated}\n```"
@@ -863,9 +877,14 @@ class WebhookAdapter(BasePlatformAdapter):
 
         def _resolve(match: re.Match) -> str:
             key = match.group(1)
-            # Special token: dump the entire payload as JSON
+            colon_size = match.group(2)
+            # Special token: dump the entire payload as JSON. An optional
+            # ``:N`` suffix overrides the default truncate length; ``:0``
+            # disables truncation entirely. Bare ``{__raw__}`` keeps the
+            # 4000-char default (backward-compatible).
             if key == "__raw__":
-                return json.dumps(payload, indent=2)[:4000]
+                limit = int(colon_size) if colon_size is not None else raw_default_max
+                return _truncate_raw(limit)
             value: Any = payload
             for part in key.split("."):
                 if isinstance(value, dict):
@@ -876,7 +895,10 @@ class WebhookAdapter(BasePlatformAdapter):
                 return json.dumps(value, indent=2)[:2000]
             return str(value)
 
-        return re.sub(r"\{([a-zA-Z0-9_.]+)\}", _resolve, template)
+        # Match ``{key}`` or ``{key:N}`` where ``key`` is alphanumeric/underscore/dot
+        # and ``:N`` is an optional non-negative integer override. The default
+        # ``[a-zA-Z0-9_.]+`` keeps dot-notation access working unchanged.
+        return re.sub(r"\{([a-zA-Z0-9_.]+)(?::(\d+))?\}", _resolve, template)
 
     def _render_delivery_extra(
         self, extra: dict, payload: dict

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -943,6 +943,46 @@ class TestRawTemplateToken:
         assert '"action": "closed"' in result
         assert '"number": 7' in result
 
+    def test_raw_with_explicit_size_param_truncates_to_provided(self):
+        """{__raw__:5000} overrides the default 4000-char truncate length."""
+        adapter = _make_adapter()
+        # Build a payload whose JSON repr is bigger than 4000 but smaller than 5000
+        # so we can observe the size-driven truncation target without ambiguity.
+        payload = {"data": "x" * 4500}
+        result = adapter._render_prompt("{__raw__:5000}", payload, "push", "test")
+        # The dumped JSON starts with '{'; it must be present, with length
+        # strictly greater than the bare default's 4000-char output but at
+        # most 5000 chars (the override).
+        assert result.startswith('{\n')
+        assert len(result) > 4000
+        assert len(result) <= 5000
+
+    def test_raw_with_zero_size_param_disables_truncation(self):
+        """{__raw__:0} disables truncation and emits the full payload."""
+        adapter = _make_adapter()
+        payload = {"data": "x" * 5000}
+        result = adapter._render_prompt("{__raw__:0}", payload, "push", "test")
+        # No truncation: result equals the full ``json.dumps(payload, indent=2)``.
+        assert result == json.dumps(payload, indent=2)
+        assert len(result) > 4000
+
+    def test_raw_size_param_only_applies_to_raw_token_not_nested_keys(self):
+        """The ``:N`` suffix must only affect the ``__raw__} token, not
+        arbitrary dotted keys — nested dict/list JSON still uses the
+        existing 2000-char cap for backwards compatibility."""
+        adapter = _make_adapter()
+        payload = {"item": {"field": "y" * 2500}}
+        # Bare ``{item}`` keeps the 2000-char nested-truncate behaviour.
+        bare = adapter._render_prompt("{item}", payload, "push", "test")
+        assert len(bare) <= 2000
+        # ``{item:99999}`` (suffix on a dot-notation key) does NOT take effect
+        # — the JSON value is still capped at 2000 chars, the ``:N`` group
+        # is consumed by the regex but ignored in the resolver.
+        suffixed = adapter._render_prompt(
+            "{item:99999}", payload, "push", "test"
+        )
+        assert suffixed == bare
+
 
 # ===================================================================
 # Cross-platform delivery thread_id passthrough


### PR DESCRIPTION
Closes #55829.

Operators can now use `{__raw__:5000}` or `{__raw__:0}` to override the hardcoded 4000-char truncate. Bare `{__raw__}` is unchanged. Backward compatible.