### PR TITLE
fix(gateway): align _split_text_chunks hard-split fallback to codepoint budget for UTF-16 (#55844)

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -754,7 +754,7 @@ class GatewayStreamConsumer:
             _cp_budget = _custom_unit_to_cp(remaining, limit, len_fn)
             split_at = remaining.rfind("\n", 0, _cp_budget)
             if split_at < limit // 2:
-                split_at = limit
+                split_at = _cp_budget
             chunks.append(remaining[:split_at])
             remaining = remaining[split_at:].lstrip("\n")
         if remaining:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1817,6 +1817,58 @@ class TestOnNewMessageCallback:
         assert consumer.already_sent is True
 
 
+class TestSplitTextChunks:
+    """Regression coverage for #55844 — _split_text_chunks must use the
+    codepoint-equivalent budget (not the raw limit) when falling back
+    to a hard split, so that emoji/supplementary characters don't produce
+    chunks that exceed the platform's UTF-16 limit."""
+
+    def test_ascii_text_hard_split_with_len(self):
+        """Plain ASCII text: len_fn=len, hard split should respect limit."""
+        text = "a" * 5000
+        chunks = GatewayStreamConsumer._split_text_chunks(text, 1000, len_fn=len)
+        for c in chunks:
+            assert len(c) <= 1000, f"chunk len {len(c)} > 1000"
+        assert "".join(chunks) == text
+
+    def test_emoji_text_hard_split_utf16(self):
+        """Emoji-only text with utf16_len: every chunk must be ≤ limit in
+        UTF-16 code units, even when no newlines exist to guide the split."""
+        from gateway.platforms.base import utf16_len
+
+        # 🚀 = 1 codepoint = 2 UTF-16 code units
+        text = "🚀" * 3000  # 3000 codepoints, 6000 UTF-16 units
+        limit = 1000       # 1000 UTF-16 units → at most 500 emoji per chunk
+        chunks = GatewayStreamConsumer._split_text_chunks(text, limit, len_fn=utf16_len)
+
+        for c in chunks:
+            actual = utf16_len(c)
+            assert actual <= limit, f"chunk utf16_len {actual} > {limit}"
+
+        # Concatenation must reproduce original
+        joined = "".join(chunks)
+        assert utf16_len(joined) == utf16_len(text)
+        assert joined == text
+
+    def test_mixed_text_hard_split_utf16(self):
+        """Mixed ASCII + emoji: each chunk respects the UTF-16 limit."""
+        from gateway.platforms.base import utf16_len
+
+        # Each segment: some ASCII chars then an emoji
+        segment = "Hello world! " + "🚀"
+        # segment utf16_len: 13 ASCII (13) + 1 emoji (2) = 15
+        # 200 segments = 200 * 15 = 3000 UTF-16 units
+        text = segment * 200
+        limit = 1000
+        chunks = GatewayStreamConsumer._split_text_chunks(text, limit, len_fn=utf16_len)
+
+        for c in chunks:
+            actual = utf16_len(c)
+            assert actual <= limit, f"chunk utf16_len {actual} > {limit}"
+
+        assert "".join(chunks) == text
+
+
 class TestUtf16OverflowDetection:
     """Regression coverage for #11170 — Telegram counts message length in
     UTF-16 code units, not Python codepoints. A response with supplementary

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -146,6 +146,35 @@ class TestCoerceValue:
         """A non-numeric string in [number, string] should stay a string."""
         assert _coerce_value("hello", ["number", "string"]) == "hello"
 
+    def test_union_integer_string_leading_zeros_preserved(self):
+        """Issue 55369: '007' in [integer, string] must stay as '007', not coerced to 7."""
+        result = _coerce_value("007", ["integer", "string"])
+        assert result == "007"
+        assert isinstance(result, str)
+
+    def test_union_integer_string_plain_int_still_coerced(self):
+        """Plain integer-like strings without formatting should still coerce."""
+        assert _coerce_value("42", ["integer", "string"]) == 42
+        assert isinstance(_coerce_value("42", ["integer", "string"]), int)
+
+    def test_union_integer_string_leading_zeros_reversed_order(self):
+        """Same behavior when union is [string, integer]."""
+        result = _coerce_value("007", ["string", "integer"])
+        assert result == "007"
+        assert isinstance(result, str)
+
+    def test_union_number_string_leading_zeros_preserved(self):
+        """"007" in [number, string] should also stay as "007"."""
+        result = _coerce_value("007", ["number", "string"])
+        assert result == "007"
+        assert isinstance(result, str)
+
+    def test_union_integer_string_trailing_dot_zero_preserved(self):
+        """"3.0" in [integer, string] should stay as string (round-trip lossy)."""
+        result = _coerce_value("3.0", ["integer", "string"])
+        assert result == "3.0"
+        assert isinstance(result, str)
+
     def test_array_type_parsed_from_json_string(self):
         """Stringified JSON arrays are parsed into native lists."""
         assert _coerce_value('["a", "b"]', "array") == ["a", "b"]
@@ -408,3 +437,25 @@ class TestCoerceToolArgs:
         assert isinstance(result["offset"], int)
         assert result["limit"] == 100
         assert isinstance(result["limit"], int)
+
+    def test_union_integer_string_leading_zeros_preserved(self):
+        """Issue 55369: union integer|string arg with leading zero is kept as string."""
+        schema = self._mock_schema({
+            "code": {"type": ["integer", "string"]},
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"code": "007"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["code"] == "007"
+            assert isinstance(result["code"], str)
+
+    def test_union_integer_string_plain_int_still_coerced(self):
+        """Union integer|string with plain int string still coerces to int."""
+        schema = self._mock_schema({
+            "limit": {"type": ["integer", "string"]},
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"limit": "42"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["limit"] == 42
+            assert isinstance(result["limit"], int)


### PR DESCRIPTION
Fixes #55844. Streaming fallback was using UTF-16 code units as Python codepoints, causing oversized chunks with emoji. This changes the hard-split fallback to use the codepoint-derived budget.