### PR TITLE
fix(gateway): add cleanup for video and screenshot cache directories

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -940,6 +940,27 @@ def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
     return str(filepath)
 
 
+def cleanup_video_cache(max_age_hours: int = 24) -> int:
+    """
+    Delete cached videos older than *max_age_hours*.
+
+    Returns the number of files removed.
+    """
+    import time
+
+    cache_dir = get_video_cache_dir()
+    cutoff = time.time() - (max_age_hours * 3600)
+    removed = 0
+    for f in cache_dir.iterdir():
+        if f.is_file() and f.stat().st_mtime < cutoff:
+            try:
+                f.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed
+
+
 # ---------------------------------------------------------------------------
 # Document cache utilities
 #
@@ -949,6 +970,35 @@ def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
 
 DOCUMENT_CACHE_DIR = get_hermes_dir("cache/documents", "document_cache")
 SCREENSHOT_CACHE_DIR = get_hermes_dir("cache/screenshots", "browser_screenshots")
+
+
+def get_screenshot_cache_dir() -> Path:
+    """Return the screenshot cache directory, creating it if it doesn't exist."""
+    d = _resolve_cache_dir("SCREENSHOT_CACHE_DIR", "cache/screenshots", "browser_screenshots")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def cleanup_screenshot_cache(max_age_hours: int = 24) -> int:
+    """
+    Delete cached screenshots older than *max_age_hours*.
+
+    Returns the number of files removed.
+    """
+    import time
+
+    cache_dir = get_screenshot_cache_dir()
+    cutoff = time.time() - (max_age_hours * 3600)
+    removed = 0
+    for f in cache_dir.iterdir():
+        if f.is_file() and f.stat().st_mtime < cutoff:
+            try:
+                f.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed
+
 
 # Import-time defaults; _resolve_cache_dir compares against these to tell a
 # test monkeypatch from an unmodified constant.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18934,7 +18934,12 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     hour, and polls the curator hourly (its inner gate enforces the real
     weekly cadence).
     """
-    from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.platforms.base import (
+        cleanup_document_cache,
+        cleanup_image_cache,
+        cleanup_screenshot_cache,
+        cleanup_video_cache,
+    )
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -18978,6 +18983,18 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
                     logger.info("Document cache cleanup: removed %d stale file(s)", removed)
             except Exception as e:
                 logger.debug("Document cache cleanup error: %s", e)
+            try:
+                removed = cleanup_video_cache(max_age_hours=24)
+                if removed:
+                    logger.info("Video cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Video cache cleanup error: %s", e)
+            try:
+                removed = cleanup_screenshot_cache(max_age_hours=24)
+                if removed:
+                    logger.info("Screenshot cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Screenshot cache cleanup error: %s", e)
 
         if tick_count % PASTE_SWEEP_EVERY == 0:
             try:

--- a/tests/gateway/test_video_screenshot_cache_cleanup.py
+++ b/tests/gateway/test_video_screenshot_cache_cleanup.py
@@ -1,0 +1,156 @@
+"""
+Tests for video and screenshot cache cleanup in gateway/platforms/base.py.
+
+Covers: cleanup_video_cache, cleanup_screenshot_cache, get_screenshot_cache_dir.
+"""
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from gateway.platforms.base import (
+    cleanup_screenshot_cache,
+    cleanup_video_cache,
+    get_screenshot_cache_dir,
+    get_video_cache_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: redirect cache dirs to temp directories
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _redirect_video_cache(tmp_path, monkeypatch):
+    """Point VIDEO_CACHE_DIR to a fresh tmp_path."""
+    monkeypatch.setattr(
+        "gateway.platforms.base.VIDEO_CACHE_DIR", tmp_path / "video_cache"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _redirect_screenshot_cache(tmp_path, monkeypatch):
+    """Point SCREENSHOT_CACHE_DIR to a fresh tmp_path."""
+    monkeypatch.setattr(
+        "gateway.platforms.base.SCREENSHOT_CACHE_DIR", tmp_path / "screenshot_cache"
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestCleanupVideoCache
+# ---------------------------------------------------------------------------
+
+class TestCleanupVideoCache:
+    def test_removes_old_files(self):
+        cache_dir = get_video_cache_dir()
+        old_file = cache_dir / "old_video.mp4"
+        old_file.write_bytes(b"\x00" * 64)
+        # Set modification time to 48 hours ago
+        old_mtime = time.time() - 48 * 3600
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        removed = cleanup_video_cache(max_age_hours=24)
+        assert removed == 1
+        assert not old_file.exists()
+
+    def test_keeps_recent_files(self):
+        cache_dir = get_video_cache_dir()
+        recent = cache_dir / "recent_video.mp4"
+        recent.write_bytes(b"\x00" * 64)
+
+        removed = cleanup_video_cache(max_age_hours=24)
+        assert removed == 0
+        assert recent.exists()
+
+    def test_returns_removed_count(self):
+        cache_dir = get_video_cache_dir()
+        old_time = time.time() - 48 * 3600
+        for i in range(3):
+            f = cache_dir / f"old_{i}.mp4"
+            f.write_bytes(b"\x00" * 64)
+            os.utime(f, (old_time, old_time))
+
+        assert cleanup_video_cache(max_age_hours=24) == 3
+
+    def test_empty_cache_dir(self):
+        assert cleanup_video_cache(max_age_hours=24) == 0
+
+    def test_ignores_directories(self):
+        cache_dir = get_video_cache_dir()
+        subdir = cache_dir / "subdir"
+        subdir.mkdir()
+        old_mtime = time.time() - 48 * 3600
+        os.utime(subdir, (old_mtime, old_mtime))
+
+        removed = cleanup_video_cache(max_age_hours=24)
+        assert removed == 0
+        assert subdir.exists()
+
+
+# ---------------------------------------------------------------------------
+# TestCleanupScreenshotCache
+# ---------------------------------------------------------------------------
+
+class TestCleanupScreenshotCache:
+    def test_removes_old_files(self):
+        cache_dir = get_screenshot_cache_dir()
+        old_file = cache_dir / "browser_screenshot_old.png"
+        old_file.write_bytes(b"\x89PNG")
+        old_mtime = time.time() - 48 * 3600
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        removed = cleanup_screenshot_cache(max_age_hours=24)
+        assert removed == 1
+        assert not old_file.exists()
+
+    def test_keeps_recent_files(self):
+        cache_dir = get_screenshot_cache_dir()
+        recent = cache_dir / "browser_screenshot_new.png"
+        recent.write_bytes(b"\x89PNG")
+
+        removed = cleanup_screenshot_cache(max_age_hours=24)
+        assert removed == 0
+        assert recent.exists()
+
+    def test_returns_removed_count(self):
+        cache_dir = get_screenshot_cache_dir()
+        old_time = time.time() - 48 * 3600
+        for i in range(4):
+            f = cache_dir / f"browser_screenshot_{i}.png"
+            f.write_bytes(b"\x89PNG")
+            os.utime(f, (old_time, old_time))
+
+        assert cleanup_screenshot_cache(max_age_hours=24) == 4
+
+    def test_empty_cache_dir(self):
+        assert cleanup_screenshot_cache(max_age_hours=24) == 0
+
+    def test_ignores_directories(self):
+        cache_dir = get_screenshot_cache_dir()
+        subdir = cache_dir / "subdir"
+        subdir.mkdir()
+        old_mtime = time.time() - 48 * 3600
+        os.utime(subdir, (old_mtime, old_mtime))
+
+        removed = cleanup_screenshot_cache(max_age_hours=24)
+        assert removed == 0
+        assert subdir.exists()
+
+
+# ---------------------------------------------------------------------------
+# TestGetScreenshotCacheDir
+# ---------------------------------------------------------------------------
+
+class TestGetScreenshotCacheDir:
+    def test_creates_directory(self):
+        cache_dir = get_screenshot_cache_dir()
+        assert cache_dir.exists()
+        assert cache_dir.is_dir()
+
+    def test_returns_existing_directory(self):
+        first = get_screenshot_cache_dir()
+        second = get_screenshot_cache_dir()
+        assert first == second
+        assert first.exists()


### PR DESCRIPTION
## What does this PR do?

Adds periodic cleanup for `cache/videos/` and `cache/screenshots/` directories, which currently grow indefinitely with no sweep logic.

`cache_video_from_bytes()` in `gateway/platforms/base.py` writes platform-downloaded video files that are never removed. The screenshot cache has a local `_cleanup_old_screenshots()` in `browser_tool.py` but it's not wired into the gateway housekeeping ticker alongside the existing image and document cache cleanup.

This PR adds `cleanup_video_cache()`, `get_screenshot_cache_dir()`, and `cleanup_screenshot_cache()` following the exact same mtime-based sweep pattern as the existing `cleanup_image_cache()` and `cleanup_document_cache()`, and wires both into the hourly housekeeping ticker in `gateway/run.py`.

## Related Issue

Fixes #56427

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Added `cleanup_video_cache(max_age_hours=24)` — mtime-based sweep of `cache/videos/` directory, same pattern as `cleanup_image_cache`.
- `gateway/platforms/base.py`: Added `get_screenshot_cache_dir()` — accessor for the screenshot cache directory using `_resolve_cache_dir()`.
- `gateway/platforms/base.py`: Added `cleanup_screenshot_cache(max_age_hours=24)` — mtime-based sweep of `cache/screenshots/` directory.
- `gateway/run.py`: Imported `cleanup_video_cache` and `cleanup_screenshot_cache` and wired them into the `IMAGE_CACHE_EVERY` ticker block alongside image and document cleanup.
- `tests/gateway/test_video_screenshot_cache_cleanup.py`: 12 regression tests covering old-file removal, recent-file retention, empty directory, and directory-ignoring behavior.

## How to Test

1. Run `python -m pytest tests/gateway/test_video_screenshot_cache_cleanup.py -v` — all 12 tests should pass.
2. Run `python -m pytest tests/gateway/test_document_cache.py -v` — existing cache tests should still pass (no regressions).
3. Manual verification: create files in `~/.hermes/cache/videos/` and `~/.hermes/cache/screenshots/` with old mtimes, start the gateway, and confirm they are removed after the hourly ticker fires.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
