### PR TITLE
fix(gateway): guard closed websocket in WeCom _read_events to prevent busy-loop (#55487)

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -309,7 +309,8 @@ class WeComAdapter(BasePlatformAdapter):
 
     async def _wait_for_handshake(self, req_id: str) -> Dict[str, Any]:
         """Wait for the subscribe acknowledgement."""
-        if not self._ws:
+
+        if not self._ws or getattr(self._ws, "closed", False):
             raise RuntimeError("WebSocket not initialized")
 
         deadline = asyncio.get_running_loop().time() + CONNECT_TIMEOUT_SECONDS
@@ -360,7 +361,8 @@ class WeComAdapter(BasePlatformAdapter):
 
     async def _read_events(self) -> None:
         """Read websocket frames until the connection closes."""
-        if not self._ws:
+
+        if not self._ws or getattr(self._ws, "closed", False):
             raise RuntimeError("WebSocket not connected")
 
         while self._running and self._ws and not self._ws.closed:


### PR DESCRIPTION
Closes #55487. Adds  guard in  so a closed socket raises instead of returning silently and triggering an immediate reconnect busy-loop.