### PR TITLE
fix(gateway): resolve terminal.cwd placeholder for container backends

### DIFF
--- a/gateway/cwd_placeholder.py
+++ b/gateway/cwd_placeholder.py
@@ -1,0 +1,49 @@
+"""Resolve gateway ``terminal.cwd`` placeholder values to ``TERMINAL_CWD``.
+
+When ``terminal.cwd`` is unset or a placeholder (``.``, ``auto``, ``cwd``),
+the gateway must not blindly map host ``Path.home()`` into container backends.
+Docker with workspace mounting still needs an explicit host path signal
+(``MESSAGING_CWD`` or an absolute config path) for ``terminal_tool`` to map
+``/host/project`` → ``/workspace``.
+"""
+
+from __future__ import annotations
+
+CWD_PLACEHOLDERS = frozenset({".", "auto", "cwd"})
+
+
+def _truthy_env(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"true", "1", "yes"}
+
+
+def resolve_placeholder_terminal_cwd(
+    *,
+    configured_cwd: str,
+    terminal_backend: str,
+    messaging_cwd: str | None,
+    docker_mount_cwd_to_workspace: bool,
+    home_fallback: str,
+) -> str | None:
+    """Return the ``TERMINAL_CWD`` value to set, or ``None`` to leave it unset.
+
+    Cases:
+      - **local** + placeholder → ``MESSAGING_CWD`` or ``home_fallback``
+      - **docker** + placeholder + mount on + host ``MESSAGING_CWD`` → host path
+        (for ``terminal_tool`` ``/workspace`` mapping)
+      - **docker** + placeholder + mount off → ``None`` (sandbox default)
+      - other non-local backends + placeholder → ``None``
+    """
+    if configured_cwd and configured_cwd not in CWD_PLACEHOLDERS:
+        return configured_cwd
+
+    backend = (terminal_backend or "local").strip().lower()
+    if backend == "local":
+        messaging = (messaging_cwd or "").strip()
+        return messaging or home_fallback
+
+    if backend == "docker" and docker_mount_cwd_to_workspace:
+        messaging = (messaging_cwd or "").strip()
+        if messaging and messaging not in CWD_PLACEHOLDERS:
+            return messaging
+
+    return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1651,13 +1651,27 @@ os.environ["HERMES_EXEC_ASK"] = "1"
 
 # Set terminal working directory for messaging platforms.
 # config.yaml terminal.cwd is the canonical source (bridged to TERMINAL_CWD
-# by the config bridge above).  When it's unset or a placeholder, default
-# to home directory.  MESSAGING_CWD is accepted as a backward-compat
-# fallback (deprecated — the warning above tells users to migrate).
+# by the config bridge above).  Placeholder values are resolved per-backend —
+# see gateway/cwd_placeholder.py for the three-case contract (local vs docker
+# mount-off vs docker mount-on).  MESSAGING_CWD is a backward-compat fallback.
+from gateway.cwd_placeholder import CWD_PLACEHOLDERS, resolve_placeholder_terminal_cwd
+
 _configured_cwd = os.environ.get("TERMINAL_CWD", "")
-if not _configured_cwd or _configured_cwd in {".", "auto", "cwd"}:
-    _fallback = os.getenv("MESSAGING_CWD") or str(Path.home())
-    os.environ["TERMINAL_CWD"] = _fallback
+if not _configured_cwd or _configured_cwd in CWD_PLACEHOLDERS:
+    _resolved_cwd = resolve_placeholder_terminal_cwd(
+        configured_cwd=_configured_cwd,
+        terminal_backend=os.environ.get("TERMINAL_ENV", ""),
+        messaging_cwd=os.getenv("MESSAGING_CWD"),
+        docker_mount_cwd_to_workspace=os.getenv(
+            "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false"
+        ).lower()
+        in {"true", "1", "yes"},
+        home_fallback=str(Path.home()),
+    )
+    if _resolved_cwd is None:
+        os.environ.pop("TERMINAL_CWD", None)
+    else:
+        os.environ["TERMINAL_CWD"] = _resolved_cwd
 
 from gateway.config import (
     Platform,

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -12,6 +12,8 @@ asserting the expected env var outcomes.
 import os
 import json
 
+from gateway.cwd_placeholder import CWD_PLACEHOLDERS, resolve_placeholder_terminal_cwd
+
 
 def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
     """Simulate the gateway config bridge logic from gateway/run.py.
@@ -37,6 +39,7 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
             "container_cpu": "TERMINAL_CONTAINER_CPU",
             "container_memory": "TERMINAL_CONTAINER_MEMORY",
             "container_disk": "TERMINAL_CONTAINER_DISK",
+            "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         }
         for cfg_key, env_var in terminal_env_map.items():
             if cfg_key in terminal_cfg:
@@ -67,11 +70,23 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
                     alias_val = os.path.expanduser(alias_val)
                 env[alias_env] = alias_val.strip()
 
-    # --- Replicate lines 144-147: MESSAGING_CWD fallback ---
+    # --- Replicate gateway/run.py placeholder TERMINAL_CWD resolution ---
     configured_cwd = env.get("TERMINAL_CWD", "")
-    if not configured_cwd or configured_cwd in {".", "auto", "cwd"}:
-        messaging_cwd = env.get("MESSAGING_CWD") or "/root"  # Path.home() for root
-        env["TERMINAL_CWD"] = messaging_cwd
+    if not configured_cwd or configured_cwd in CWD_PLACEHOLDERS:
+        resolved = resolve_placeholder_terminal_cwd(
+            configured_cwd=configured_cwd,
+            terminal_backend=env.get("TERMINAL_ENV", ""),
+            messaging_cwd=env.get("MESSAGING_CWD"),
+            docker_mount_cwd_to_workspace=env.get(
+                "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false"
+            ).lower()
+            in {"true", "1", "yes"},
+            home_fallback="/root",
+        )
+        if resolved is None:
+            env.pop("TERMINAL_CWD", None)
+        else:
+            env["TERMINAL_CWD"] = resolved
 
     return env
 
@@ -214,7 +229,44 @@ class TestNestedTerminalCwdPlaceholderSkip:
         result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/from/env"})
         assert result["TERMINAL_ENV"] == "docker"
         assert result["TERMINAL_TIMEOUT"] == "300"
-        assert result["TERMINAL_CWD"] == "/from/env"
+        assert result.get("TERMINAL_CWD") is None
+
+    def test_docker_placeholder_does_not_inherit_host_home(self):
+        """terminal.cwd: '.' + docker + mount off must not resolve to host home."""
+        cfg = {
+            "terminal": {
+                "cwd": ".",
+                "backend": "docker",
+                "docker_mount_cwd_to_workspace": False,
+            },
+        }
+        result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/home/user"})
+        assert "TERMINAL_CWD" not in result
+
+    def test_docker_placeholder_mount_on_preserves_messaging_cwd(self):
+        """Mount-enabled docker still needs the host cwd signal for /workspace."""
+        cfg = {
+            "terminal": {
+                "cwd": ".",
+                "backend": "docker",
+                "docker_mount_cwd_to_workspace": True,
+            },
+        }
+        result = _simulate_config_bridge(
+            cfg, {"MESSAGING_CWD": "/host/project"}
+        )
+        assert result["TERMINAL_CWD"] == "/host/project"
+        assert result["TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE"] == "True"
+
+    def test_ssh_placeholder_does_not_inherit_host_home(self):
+        cfg = {"terminal": {"cwd": "auto", "backend": "ssh"}}
+        result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/home/user"})
+        assert "TERMINAL_CWD" not in result
+
+    def test_local_placeholder_still_falls_back_to_messaging_cwd(self):
+        cfg = {"terminal": {"cwd": ".", "backend": "local"}}
+        result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/home/user"})
+        assert result["TERMINAL_CWD"] == "/home/user"
 
     def test_terminal_home_mode_bridges_to_env(self):
         cfg = {"terminal": {"home_mode": "profile"}}

--- a/tests/gateway/test_cwd_placeholder.py
+++ b/tests/gateway/test_cwd_placeholder.py
@@ -1,0 +1,68 @@
+"""Unit tests for gateway.cwd_placeholder.resolve_placeholder_terminal_cwd."""
+
+from gateway.cwd_placeholder import resolve_placeholder_terminal_cwd
+
+
+class TestResolvePlaceholderTerminalCwd:
+    def test_local_placeholder_uses_messaging_cwd(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd=".",
+            terminal_backend="local",
+            messaging_cwd="/home/user/project",
+            docker_mount_cwd_to_workspace=False,
+            home_fallback="/home/user",
+        ) == "/home/user/project"
+
+    def test_local_placeholder_falls_back_to_home(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd="auto",
+            terminal_backend="local",
+            messaging_cwd=None,
+            docker_mount_cwd_to_workspace=False,
+            home_fallback="/home/user",
+        ) == "/home/user"
+
+    def test_docker_placeholder_mount_off_unset(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd=".",
+            terminal_backend="docker",
+            messaging_cwd="/home/user",
+            docker_mount_cwd_to_workspace=False,
+            home_fallback="/home/user",
+        ) is None
+
+    def test_docker_placeholder_mount_on_preserves_host_path(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd=".",
+            terminal_backend="docker",
+            messaging_cwd="/host/project",
+            docker_mount_cwd_to_workspace=True,
+            home_fallback="/home/user",
+        ) == "/host/project"
+
+    def test_docker_placeholder_mount_on_without_messaging_cwd_unset(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd=".",
+            terminal_backend="docker",
+            messaging_cwd=None,
+            docker_mount_cwd_to_workspace=True,
+            home_fallback="/home/user",
+        ) is None
+
+    def test_ssh_placeholder_unset(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd="cwd",
+            terminal_backend="ssh",
+            messaging_cwd="/home/user",
+            docker_mount_cwd_to_workspace=False,
+            home_fallback="/home/user",
+        ) is None
+
+    def test_explicit_configured_cwd_passthrough(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd="/explicit/path",
+            terminal_backend="docker",
+            messaging_cwd="/home/user",
+            docker_mount_cwd_to_workspace=False,
+            home_fallback="/home/user",
+        ) == "/explicit/path"


### PR DESCRIPTION
## Summary
- When `terminal.cwd` is a placeholder (`"."`, `"auto"`, `"cwd"`) and `terminal.backend` is non-local (`docker`, `ssh`, `modal`, …), stop falling back to host `Path.home()` in the gateway config bridge.
- Leave `TERMINAL_CWD` unset so `terminal_tool` applies the sandbox default (`/root`, `~`, `/workspace`) — matching the CLI/TUI path in `cli.py`.

## Context
Discord report: docker backend shell tried to `cd` the host user's home because the default `terminal.cwd: "."` was resolved to `Path.home()` on the gateway startup path.

## Test plan
- [x] `tests/gateway/test_config_cwd_bridge.py` — docker/ssh placeholders no longer inherit `MESSAGING_CWD`; local backend still does
