### PR TITLE
fix(gateway): route queued follow-ups to compression child

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18543,13 +18543,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # new message).
 
                 updated_history = result.get("messages", history)
+                followup_session_id = session_id
+                if isinstance(response, dict):
+                    followup_session_id = response.get("session_id") or followup_session_id
                 next_source = source
                 next_message = pending
                 next_message_id = None
                 next_channel_prompt = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
-                    if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
+                    if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(followup_session_id):
                         logger.info(
                             "Discarding stale goal continuation for session %s — goal is no longer active",
                             session_key or "?",
@@ -18589,17 +18592,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # prefix #46237 was merged to preserve.  The existing
                 # re-baseline in _handle_message_with_agent only runs after the
                 # whole _run_agent chain unwinds — too late for the in-band
-                # follow-up.  Use the same (session_key, session_id) the
-                # recursive call runs under so the snapshot matches exactly
+                # follow-up.  Use the same (session_key, followup_session_id)
+                # the recursive call runs under so the snapshot matches exactly
                 # what the follow-up's guard will consult.  Fail-safe in helper.
-                await self._refresh_agent_cache_message_count(session_key, session_id)
+                await self._refresh_agent_cache_message_count(session_key, followup_session_id)
 
                 followup_result = await self._run_agent(
                     message=next_message,
                     context_prompt=context_prompt,
                     history=updated_history,
                     source=next_source,
-                    session_id=session_id,
+                    session_id=followup_session_id,
                     session_key=session_key,
                     run_generation=run_generation,
                     _interrupt_depth=_interrupt_depth + 1,

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import gateway.run as gateway_run
 from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
 
@@ -54,6 +55,22 @@ class _CompressionThenFailureAgent:
         pass
 
 
+class _CompressionThenInterruptedAgent(_CompressionThenFailureAgent):
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, **_kwargs):
+        self.session_id = "session-after-compression"
+        return {
+            "final_response": "",
+            "interrupted": True,
+            "interrupt_message": "queued follow-up",
+            "session_id": self.session_id,
+            "messages": [
+                {"role": "user", "content": "[compressed summary]"},
+                {"role": "user", "content": user_message},
+            ],
+            "api_calls": 1,
+        }
+
+
 class _StreamConsumer:
     final_response_sent = False
 
@@ -69,9 +86,14 @@ class _StreamConsumer:
 
 class _Adapter:
     SUPPORTS_MESSAGE_EDITING = True
-    _pending_messages = {}
 
-    def get_pending_message(self, _session_key):
+    def __init__(self):
+        self._pending_messages = {}
+
+    def get_pending_message(self, session_key):
+        return self._pending_messages.pop(session_key, None)
+
+    async def send(self, *_args, **_kwargs):
         return None
 
     async def send_typing(self, *_args, **_kwargs):
@@ -158,3 +180,63 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
     runner._sync_telegram_topic_binding.assert_called_once_with(
         source, session_store.entry, reason="agent-run-compression"
     )
+
+
+def test_queued_followup_after_compression_uses_rotated_session(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CompressionThenInterruptedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "0")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr("gateway.stream_consumer.GatewayStreamConsumer", _StreamConsumer)
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda *_args, **_kwargs: {"core"})
+
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+    queued = MessageEvent(
+        text="queued follow-up",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="queued-1",
+    )
+    runner.adapters[Platform.TELEGRAM]._pending_messages[SESSION_KEY] = queued
+    runner._prepare_inbound_message_text = AsyncMock(return_value="queued follow-up")
+
+    original_run_agent = runner._run_agent
+    followup_session_ids = []
+
+    async def spy_run_agent(*args, **kwargs):
+        if kwargs.get("_interrupt_depth", 0) > 0:
+            followup_session_ids.append(kwargs.get("session_id"))
+            return {
+                "final_response": "follow-up done",
+                "messages": [],
+                "api_calls": 1,
+                "history_offset": 0,
+                "session_id": kwargs.get("session_id"),
+            }
+        return await original_run_agent(*args, **kwargs)
+
+    runner._run_agent = spy_run_agent
+
+    result = asyncio.run(
+        asyncio.wait_for(
+            runner._run_agent(
+                message="continue",
+                context_prompt="",
+                history=[{"role": "user", "content": "old question"}],
+                source=source,
+                session_id="session-before-compression",
+                session_key=SESSION_KEY,
+            ),
+            timeout=2,
+        )
+    )
+
+    assert result["final_response"] == "follow-up done"
+    assert followup_session_ids == ["session-after-compression"]


### PR DESCRIPTION
## Summary

This is a supplemental fix for the remaining queued-follow-up half of #56391.

#56416 merged the useful demotion half from #56404: while a compression lock is held, gateway `busy_input_mode: interrupt` now behaves like queue mode. Current `main` still leaves the in-band queued-follow-up drain using the original parent `session_id` after the just-finished turn has already returned a rotated compression child.

## Root cause

`_run_agent()` propagates compression splits in the result it returns to the gateway. The outer `_handle_message_with_agent()` path uses that returned session id, but the recursive queued-follow-up path inside `_run_agent()` still re-entered cache refresh, goal-continuation checks, and the next `_run_agent()` call with the original parent id.

That means a follow-up drained immediately after a compression split can still resume the stale parent row even though the completed turn already knows the child id.

## Changes

- Use the completed turn's returned `session_id` when draining a pending in-band follow-up.
- Use that same follow-up session id for the goal-continuation liveness check and cached-agent message-count refresh.
- Add a regression that forces compression rotation plus a queued follow-up and asserts the recursive turn receives the child id.

## Relationship to related PRs

- #56404 partially addressed #56391 by adding the compression-lock demotion and a broader tip-healing helper.
- #56416 landed the demotion half from #56404 and intentionally dropped the tip-healing helper.
- This PR keeps that scope split and covers the adjacent post-lock-release queued-follow-up path instead of reintroducing the dropped tip-healing helper.

## Validation

- Replayed this patch onto current `main` after #56416.
- `pytest tests/gateway/test_compression_failure_session_sync.py tests/agent/test_compression_concurrent_fork.py tests/gateway/test_compression_concurrent_sessions.py -q` -> 17 passed
- `pytest tests/gateway/test_busy_session_ack.py tests/gateway/test_compression_interrupt_demotion_56391.py -q` -> 30 passed
- `python -m py_compile gateway/run.py tests/gateway/test_compression_failure_session_sync.py`
- `ruff check gateway/run.py tests/gateway/test_compression_failure_session_sync.py`
- CodeRabbit on the current-main replay diff -> no findings

Part of #56391
Supplements #56404
Supplements #56416

---

Created by GPT-5.5-xhigh in Codex. Human involvement: general issue selection and resolution guidelines; commit signing; checking notifications.
