### PR TITLE
fix(security): bind tool override gates to owner tokens

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -337,9 +337,10 @@ class LoadedPlugin:
 class PluginContext:
     """Facade given to plugins so they can register tools and hooks."""
 
-    def __init__(self, manifest: PluginManifest, manager: "PluginManager"):
+    def __init__(self, manifest: PluginManifest, manager: "PluginManager", tool_owner_token: object | None = None):
         self.manifest = manifest
         self._manager = manager
+        self._tool_owner_token = tool_owner_token
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
 
@@ -436,6 +437,7 @@ class PluginContext:
             description=description,
             emoji=emoji,
             override=override,
+            owner_token=self._tool_owner_token,
         )
         self._manager._plugin_tool_names.add(name)
         logger.debug(
@@ -1711,7 +1713,7 @@ class PluginManager:
         from tools.registry import registry as _registry
         _plugin_id = manifest.key or manifest.name
         _slug = _plugin_id.replace("/", "__").replace("-", "_")
-        _registry.register_plugin_override_policy(
+        _tool_owner_token = _registry.register_plugin_override_policy(
             f"{_NS_PARENT}.{_slug}",
             PluginContext(manifest, self)._tool_override_allowed(""),
         )
@@ -1729,7 +1731,7 @@ class PluginManager:
                 loaded.error = "no register() function"
                 logger.warning("Plugin '%s' has no register() function", manifest.name)
             else:
-                ctx = PluginContext(manifest, self)
+                ctx = PluginContext(manifest, self, tool_owner_token=_tool_owner_token)
                 # Snapshot registry state BEFORE register() so each registry's
                 # attribution counts only what THIS plugin actually added.
                 # The previous approach diffed names against all already-loaded

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1092,6 +1092,8 @@ class TestPluginContext:
             # And an ERROR was logged explaining why and how to opt in.
             assert any("override=True" in r.message for r in caplog.records)
         finally:
+            registry._plugin_override_policy.clear()
+            registry._plugin_override_tokens.clear()
             registry.deregister("shadow_target")
 
     def test_register_tool_override_replaces_existing(self, tmp_path, monkeypatch, caplog):
@@ -1147,6 +1149,8 @@ class TestPluginContext:
             # Plugin tracks it.
             assert "override_target" in mgr._plugin_tool_names
         finally:
+            registry._plugin_override_policy.clear()
+            registry._plugin_override_tokens.clear()
             registry.deregister("override_target")
 
     def test_register_tool_override_on_new_name_is_noop_path(self, tmp_path, monkeypatch):
@@ -1185,6 +1189,8 @@ class TestPluginContext:
             mgr.discover_and_load()
             assert "brand_new_override_tool" in registry._tools
         finally:
+            registry._plugin_override_policy.clear()
+            registry._plugin_override_tokens.clear()
             registry.deregister("brand_new_override_tool")
 
     def test_register_tool_override_blocked_without_operator_opt_in(self, tmp_path, monkeypatch):
@@ -1253,6 +1259,8 @@ class TestPluginContext:
             assert "allow_tool_override" in str(excinfo.value)
             assert "evil_override_plugin" in str(excinfo.value)
         finally:
+            registry._plugin_override_policy.clear()
+            registry._plugin_override_tokens.clear()
             registry.deregister("gated_override_target")
 
     def test_register_tool_override_blocked_via_direct_registry_import(self, tmp_path, monkeypatch):
@@ -1304,6 +1312,8 @@ class TestPluginContext:
             assert entry.toolset == "terminal", "built-in must NOT be overridden via direct registry import"
             assert entry.handler({}) == "built-in", "handler should still be the built-in one"
         finally:
+            registry._plugin_override_policy.clear()
+            registry._plugin_override_tokens.clear()
             registry.deregister("gated_override_target")
 
     def test_register_tool_override_blocked_via_delayed_callback(self, tmp_path, monkeypatch):
@@ -1368,6 +1378,8 @@ class TestPluginContext:
             assert entry.toolset == "terminal", "delayed override must NOT replace the built-in"
             assert entry.handler({}) == "built-in", "handler must still be the built-in one"
         finally:
+            registry._plugin_override_policy.clear()
+            registry._plugin_override_tokens.clear()
             registry.deregister("gated_override_target")
 
 
@@ -2200,4 +2212,6 @@ class TestDispatchToolWithoutCliRef:
             # parent_agent is not forced when there's no CLI agent to resolve.
             assert calls[0][1].get("parent_agent") is None
         finally:
+            registry._plugin_override_policy.clear()
+            registry._plugin_override_tokens.clear()
             registry.deregister("_test_dispatch_probe")

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -623,32 +623,33 @@ class TestDeregisterAuthorization:
 
     def test_plugin_cannot_deregister_unowned_tool_without_opt_in(self):
         reg = self._reg()
-        reg.register_plugin_override_policy("hermes_plugins.evil", False)
+        token = reg.register_plugin_override_policy("hermes_plugins.evil", False)
         with patch.object(ToolRegistry, "_caller_module", return_value="hermes_plugins.evil"):
             import pytest
             with pytest.raises(PermissionError, match="allow_tool_override"):
-                reg.deregister("protected")
+                reg.deregister("protected", owner_token=token)
         assert reg._tools.get("protected") is not None, "tool must survive the rejected deregister"
 
     def test_plugin_with_opt_in_can_deregister_unowned_tool(self):
         reg = self._reg()
-        reg.register_plugin_override_policy("hermes_plugins.allowed", True)
+        token = reg.register_plugin_override_policy("hermes_plugins.allowed", True)
         with patch.object(ToolRegistry, "_caller_module", return_value="hermes_plugins.allowed"):
-            reg.deregister("protected")
+            reg.deregister("protected", owner_token=token)
         assert reg._tools.get("protected") is None
 
     def test_plugin_can_deregister_its_own_tool(self):
         """Plugin deregistering a handler it defined itself — always allowed."""
         reg = ToolRegistry()
-        reg.register_plugin_override_policy("hermes_plugins.myplug", False)
+        token = reg.register_plugin_override_policy("hermes_plugins.myplug", False)
         handler = eval("lambda *a, **k: 'own'", {"__name__": "hermes_plugins.myplug"})
         reg.register(
             name="own_tool", toolset="myplug-ts",
             schema={"name": "own_tool", "description": "", "parameters": {"type": "object", "properties": {}}},
             handler=handler,
+            owner_token=token,
         )
         with patch.object(ToolRegistry, "_caller_module", return_value="hermes_plugins.myplug"):
-            reg.deregister("own_tool")
+            reg.deregister("own_tool", owner_token=token)
         assert reg._tools.get("own_tool") is None
 
     def test_plugin_root_module_can_deregister_submodule_handler(self):
@@ -661,17 +662,18 @@ class TestDeregisterAuthorization:
         module (egilewski review, #55840).
         """
         reg = ToolRegistry()
-        reg.register_plugin_override_policy("hermes_plugins.pkg", False)
+        token = reg.register_plugin_override_policy("hermes_plugins.pkg", False)
         handler = eval("lambda *a, **k: 'sub'", {"__name__": "hermes_plugins.pkg.handlers"})
         reg.register(
             name="sub_tool", toolset="pkg-ts",
             schema={"name": "sub_tool", "description": "", "parameters": {"type": "object", "properties": {}}},
             handler=handler,
+            owner_token=token,
         )
         # Caller is the plugin root (hermes_plugins.pkg), handler is in a
         # submodule (hermes_plugins.pkg.handlers) — must be allowed.
         with patch.object(ToolRegistry, "_caller_module", return_value="hermes_plugins.pkg"):
-            reg.deregister("sub_tool")
+            reg.deregister("sub_tool", owner_token=token)
         assert reg._tools.get("sub_tool") is None
 
     def test_opted_in_plugin_submodule_can_deregister(self):
@@ -691,9 +693,9 @@ class TestDeregisterAuthorization:
             schema={"name": "protected", "description": "", "parameters": {"type": "object", "properties": {}}},
             handler=lambda *a, **k: "built-in",
         )
-        reg.register_plugin_override_policy("hermes_plugins.allowed", True)
+        token = reg.register_plugin_override_policy("hermes_plugins.allowed", True)
         with patch.object(ToolRegistry, "_caller_module", return_value="hermes_plugins.allowed.cleanup"):
-            reg.deregister("protected")
+            reg.deregister("protected", owner_token=token)
         assert reg._tools.get("protected") is None
 
     def test_mcp_toolset_always_deregisterable(self):
@@ -716,6 +718,15 @@ class TestDeregisterAuthorization:
             reg.deregister("protected")
         assert reg._tools.get("protected") is None
 
+    def test_forged_core_caller_cannot_deregister_after_plugin_policy_loads(self):
+        reg = self._reg()
+        reg.register_plugin_override_policy("hermes_plugins.evil", False)
+        import pytest
+        with patch.object(ToolRegistry, "_caller_module", return_value="tools.mcp_tool"):
+            with pytest.raises(PermissionError, match="owner token"):
+                reg.deregister("protected")
+        assert reg._tools.get("protected") is not None
+
     def test_full_bypass_blocked(self):
         """The original bypass: deregister then plain register no longer works."""
         reg = self._reg()
@@ -730,3 +741,19 @@ class TestDeregisterAuthorization:
             evil_handler = eval("lambda *a, **k: 'hijacked'", {"__name__": "hermes_plugins.evil"})
             reg.register(name="protected", toolset="evil-ts", schema={}, handler=evil_handler, override=True)
         assert reg._tools["protected"].handler({}) == "built-in"
+
+    def test_forged_handler_module_cannot_override_without_owner_token(self):
+        reg = self._reg()
+        reg.register_plugin_override_policy("hermes_plugins.allowed", True)
+        forged_handler = eval("lambda *a, **k: 'hijacked'", {"__name__": "tools.mcp_tool"})
+        import pytest
+        with pytest.raises(PermissionError, match="owner token"):
+            reg.register(name="protected", toolset="evil-ts", schema={}, handler=forged_handler, override=True)
+        assert reg._tools["protected"].handler({}) == "built-in"
+
+    def test_opted_in_owner_token_can_override(self):
+        reg = self._reg()
+        token = reg.register_plugin_override_policy("hermes_plugins.allowed", True)
+        handler = eval("lambda *a, **k: 'plugin'", {"__name__": "hermes_plugins.allowed"})
+        reg.register(name="protected", toolset="allowed-ts", schema={}, handler=handler, override=True, owner_token=token)
+        assert reg._tools["protected"].handler({}) == "plugin"

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -82,11 +82,13 @@ class ToolEntry:
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
         "max_result_size_chars", "dynamic_schema_overrides",
+        "owner_namespace",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 owner_namespace=None):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -97,6 +99,7 @@ class ToolEntry:
         self.description = description
         self.emoji = emoji
         self.max_result_size_chars = max_result_size_chars
+        self.owner_namespace = owner_namespace
         # Optional zero-arg callable returning a dict of schema overrides
         # applied at get_definitions() time. Use for fields that depend on
         # runtime config (e.g. delegate_task's description must reflect the
@@ -216,6 +219,7 @@ class ToolRegistry:
         # code that defined the handler, independent of WHEN the register() call
         # happens (sync during load, or a delayed/threaded callback afterwards).
         self._plugin_override_policy: Dict[str, bool] = {}
+        self._plugin_override_tokens: Dict[object, str] = {}
         self._toolset_checks: Dict[str, Callable] = {}
         self._toolset_aliases: Dict[str, str] = {}
         # MCP dynamic refresh can mutate the registry while other threads are
@@ -304,14 +308,25 @@ class ToolRegistry:
     # Registration
     # ------------------------------------------------------------------
 
-    def register_plugin_override_policy(self, module_namespace: str, allowed: bool) -> None:
+    def register_plugin_override_policy(self, module_namespace: str, allowed: bool) -> object:
         """Bind a plugin module namespace to its operator opt-in for built-in
         override. Called once per plugin at load time. Durable: never cleared,
         so later (even threaded/delayed) register() calls from that module are
-        still gated by the same policy.
+        still gated by the same policy. Returns an opaque owner token that
+        trusted plugin-loading code passes back when registering or removing
+        tools; unlike module names or frame globals, the token is not forgeable
+        by changing ``__name__``.
         """
+        token = object()
         with self._lock:
             self._plugin_override_policy[module_namespace] = bool(allowed)
+            self._plugin_override_tokens[token] = module_namespace
+        return token
+
+    def _plugin_owner_from_token(self, owner_token: object | None) -> Optional[str]:
+        if owner_token is None:
+            return None
+        return self._plugin_override_tokens.get(owner_token)
 
     def _plugin_owner_of(self, handler: Callable) -> Optional[str]:
         """Return the plugin module namespace that defined *handler*, or None
@@ -367,6 +382,7 @@ class ToolRegistry:
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
         override: bool = False,
+        owner_token: object | None = None,
     ):
         """Register a tool.  Called at module-import time by each tool file.
 
@@ -378,6 +394,7 @@ class ToolRegistry:
         """
         with self._lock:
             existing = self._tools.get(name)
+            token_owner = self._plugin_owner_from_token(owner_token)
             if existing and existing.toolset != toolset:
                 # Allow MCP-to-MCP overwrites (legitimate: server refresh,
                 # or two MCP servers with overlapping tool names).
@@ -391,18 +408,28 @@ class ToolRegistry:
                         name, toolset, existing.toolset,
                     )
                 elif override:
-                    _owner = self._plugin_owner_of(handler)
-                    if _owner is not None and not self._plugin_override_policy.get(_owner, False):
+                    if token_owner is None:
+                        logger.error(
+                            "Tool registration REJECTED: override of built-in "
+                            "tool %r (existing toolset %r) requires a registry "
+                            "owner token.",
+                            name, existing.toolset,
+                        )
+                        raise PermissionError(
+                            f"Tool {name!r} cannot override built-in toolset "
+                            f"{existing.toolset!r} without a registry owner token."
+                        )
+                    if not self._plugin_override_policy.get(token_owner, False):
                         logger.error(
                             "Tool registration REJECTED: plugin %r attempted to "
                             "override built-in tool %r (existing toolset %r) without "
                             "operator opt-in. Set "
                             "plugins.entries.<plugin_id>.allow_tool_override: true "
                             "in config.yaml to allow it.",
-                            _owner, name, existing.toolset,
+                            token_owner, name, existing.toolset,
                         )
                         raise PermissionError(
-                            f"Plugin module {_owner!r} cannot override built-in "
+                            f"Plugin module {token_owner!r} cannot override built-in "
                             f"tool {name!r} without operator opt-in "
                             f"(allow_tool_override)."
                         )
@@ -436,6 +463,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                owner_namespace=token_owner or self._plugin_owner_of(handler),
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -447,7 +475,7 @@ class ToolRegistry:
                 self._toolset_checks[toolset] = check_fn
             self._generation += 1
 
-    def deregister(self, name: str) -> None:
+    def deregister(self, name: str, owner_token: object | None = None) -> None:
         """Remove a tool from the registry.
 
         Also cleans up the toolset check if no other tools remain in the
@@ -468,36 +496,50 @@ class ToolRegistry:
             if entry is None:
                 return
             if not entry.toolset.startswith("mcp-"):
-                caller_mod = self._caller_module()
-                owner = self._plugin_owner_of(entry.handler)
-                # Ownership check: bind to the plugin package root
-                # (``hermes_plugins.{name}``), not the exact module string.
-                # A handler defined in ``hermes_plugins.pkg.handlers`` is
-                # still owned by the ``hermes_plugins.pkg`` package — exact
-                # string equality would wrongly block root-module cleanup code
-                # from removing tools registered by a submodule of the same
-                # plugin (egilewski review on #55840).
-                caller_root = ".".join(caller_mod.split(".")[:2])
-                owner_root = ".".join(owner.split(".")[:2]) if owner else ""
-                same_plugin = bool(owner and caller_root == owner_root)
-                if (
-                    caller_mod.startswith("hermes_plugins.")
-                    and not same_plugin
-                    and not self._plugin_override_policy.get(caller_root, False)
-                ):
+                token_owner = self._plugin_owner_from_token(owner_token)
+                if token_owner is not None:
+                    owner = entry.owner_namespace
+                    token_root = ".".join(token_owner.split(".")[:2])
+                    owner_root = ".".join(owner.split(".")[:2]) if owner else ""
+                    same_plugin = bool(owner and token_root == owner_root)
+                    if not same_plugin and not self._plugin_override_policy.get(token_owner, False):
+                        logger.error(
+                            "Tool deregistration REJECTED: plugin %r attempted to "
+                            "remove tool %r (toolset %r) it does not own, without "
+                            "operator opt-in.",
+                            token_owner, name, entry.toolset,
+                        )
+                        raise PermissionError(
+                            f"Plugin module {token_owner!r} cannot deregister tool "
+                            f"{name!r} (toolset {entry.toolset!r}) without operator "
+                            f"opt-in (allow_tool_override)."
+                        )
+                elif self._plugin_override_policy:
                     logger.error(
-                        "Tool deregistration REJECTED: plugin %r attempted to "
-                        "remove tool %r (toolset %r) it does not own, without "
-                        "operator opt-in. Set "
-                        "plugins.entries.%s.allow_tool_override: true in "
-                        "config.yaml to allow it.",
-                        caller_mod, name, entry.toolset, caller_mod,
+                        "Tool deregistration REJECTED: removal of tool %r "
+                        "(toolset %r) requires a registry owner token while "
+                        "plugin override policies are loaded.",
+                        name, entry.toolset,
                     )
                     raise PermissionError(
-                        f"Plugin module {caller_mod!r} cannot deregister tool "
-                        f"{name!r} (toolset {entry.toolset!r}) without operator "
-                        f"opt-in (allow_tool_override)."
+                        f"Tool {name!r} cannot be deregistered without a registry "
+                        f"owner token while plugin override policies are loaded."
                     )
+                else:
+                    del self._tools[name]
+                    toolset_still_exists = any(
+                        e.toolset == entry.toolset for e in self._tools.values()
+                    )
+                    if not toolset_still_exists:
+                        self._toolset_checks.pop(entry.toolset, None)
+                        self._toolset_aliases = {
+                            alias: target
+                            for alias, target in self._toolset_aliases.items()
+                            if target != entry.toolset
+                        }
+                    self._generation += 1
+                    logger.debug("Deregistered tool: %s", name)
+                    return
             del self._tools[name]
             # Drop the toolset check and aliases if this was the last tool in
             # that toolset.


### PR DESCRIPTION
## Summary
- replace forgeable module/frame based plugin tool override authorization with an opaque registry owner token
- pass the token through PluginContext for legitimate plugin tool registration
- add regression coverage for forged handler modules and forged core caller deregistration

Fixes #56271.

## Tests
- python -m pytest tests/tools/test_registry.py tests/hermes_cli/test_plugins.py -q

## Notes
- scoped to upstream files only; no fork-only custom features or _docs files included