### PR TITLE
fix(gateway): prune stale video and screenshot caches

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -791,9 +791,12 @@ def cleanup_image_cache(max_age_hours: int = 24) -> int:
 
     Returns the number of files removed.
     """
+    return _cleanup_cache_dir(get_image_cache_dir(), max_age_hours=max_age_hours)
+
+
+def _cleanup_cache_dir(cache_dir: Path, max_age_hours: int = 24) -> int:
     import time
 
-    cache_dir = get_image_cache_dir()
     cutoff = time.time() - (max_age_hours * 3600)
     removed = 0
     for f in cache_dir.iterdir():
@@ -938,6 +941,10 @@ def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
     filepath = cache_dir / filename
     filepath.write_bytes(data)
     return str(filepath)
+
+
+def cleanup_video_cache(max_age_hours: int = 24) -> int:
+    return _cleanup_cache_dir(get_video_cache_dir(), max_age_hours=max_age_hours)
 
 
 # ---------------------------------------------------------------------------
@@ -1565,19 +1572,13 @@ def cleanup_document_cache(max_age_hours: int = 24) -> int:
 
     Returns the number of files removed.
     """
-    import time
+    return _cleanup_cache_dir(get_document_cache_dir(), max_age_hours=max_age_hours)
 
-    cache_dir = get_document_cache_dir()
-    cutoff = time.time() - (max_age_hours * 3600)
-    removed = 0
-    for f in cache_dir.iterdir():
-        if f.is_file() and f.stat().st_mtime < cutoff:
-            try:
-                f.unlink()
-                removed += 1
-            except OSError:
-                pass
-    return removed
+
+def cleanup_screenshot_cache(max_age_hours: int = 24) -> int:
+    cache_dir = _resolve_cache_dir("SCREENSHOT_CACHE_DIR", "cache/screenshots", "browser_screenshots")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return _cleanup_cache_dir(cache_dir, max_age_hours=max_age_hours)
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18934,7 +18934,12 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     hour, and polls the curator hourly (its inner gate enforces the real
     weekly cadence).
     """
-    from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.platforms.base import (
+        cleanup_document_cache,
+        cleanup_image_cache,
+        cleanup_screenshot_cache,
+        cleanup_video_cache,
+    )
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -18978,6 +18983,18 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
                     logger.info("Document cache cleanup: removed %d stale file(s)", removed)
             except Exception as e:
                 logger.debug("Document cache cleanup error: %s", e)
+            try:
+                removed = cleanup_video_cache(max_age_hours=24)
+                if removed:
+                    logger.info("Video cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Video cache cleanup error: %s", e)
+            try:
+                removed = cleanup_screenshot_cache(max_age_hours=24)
+                if removed:
+                    logger.info("Screenshot cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Screenshot cache cleanup error: %s", e)
 
         if tick_count % PASTE_SWEEP_EVERY == 0:
             try:

--- a/tests/gateway/test_media_cache_cleanup.py
+++ b/tests/gateway/test_media_cache_cleanup.py
@@ -1,0 +1,39 @@
+import os
+import time
+
+from gateway.platforms.base import (
+    cleanup_screenshot_cache,
+    cleanup_video_cache,
+    get_video_cache_dir,
+)
+
+
+def test_cleanup_video_cache_removes_only_stale_files(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.platforms.base.VIDEO_CACHE_DIR", tmp_path / "videos")
+    cache_dir = get_video_cache_dir()
+    old_file = cache_dir / "old.mp4"
+    fresh_file = cache_dir / "fresh.mp4"
+    old_file.write_bytes(b"old")
+    fresh_file.write_bytes(b"fresh")
+    old_time = time.time() - 48 * 3600
+    os.utime(old_file, (old_time, old_time))
+
+    assert cleanup_video_cache(max_age_hours=24) == 1
+    assert not old_file.exists()
+    assert fresh_file.exists()
+
+
+def test_cleanup_screenshot_cache_removes_only_stale_files(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.platforms.base.SCREENSHOT_CACHE_DIR", tmp_path / "screenshots")
+    cache_dir = tmp_path / "screenshots"
+    cache_dir.mkdir()
+    old_file = cache_dir / "old.png"
+    fresh_file = cache_dir / "fresh.png"
+    old_file.write_bytes(b"old")
+    fresh_file.write_bytes(b"fresh")
+    old_time = time.time() - 48 * 3600
+    os.utime(old_file, (old_time, old_time))
+
+    assert cleanup_screenshot_cache(max_age_hours=24) == 1
+    assert not old_file.exists()
+    assert fresh_file.exists()


### PR DESCRIPTION
## Summary
- share the existing stale-file cache cleanup helper across media cache types
- add video and screenshot cache cleanup helpers
- wire the gateway hourly housekeeping loop to prune video and screenshot caches

Fixes #56427.

## Tests
- python -m pytest tests/gateway/test_media_cache_cleanup.py tests/gateway/test_document_cache.py -q

## Notes
- scoped to upstream gateway files only; no fork-only custom features or _docs files included