### PR TITLE
fix(mcp): preserve sibling params when renaming arguments to tool_arguments

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -185,7 +185,42 @@ class TestSchemaConversion:
 
         assert schema["name"] == "mcp_filesystem_read_file"
         assert schema["description"] == "Read a file"
-        assert "properties" in schema["parameters"]
+        assert schema["parameters"]["type"] == "object"
+        assert "path" in schema["parameters"]["properties"]
+        assert "_mcp_input_schema" not in schema
+
+    def test_arguments_property_is_renamed_to_tool_arguments(self):
+        """A top-level `arguments` parameter collides with the tool-call envelope
+        and is renamed to `tool_arguments` in the model-facing schema.
+        """
+        from tools.mcp_tool import _convert_mcp_schema
+
+        mcp_tool = _make_mcp_tool(
+            name="call_tool",
+            description="Call an MCP tool",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "tool_name": {"type": "string"},
+                    "toolset_name": {"type": "string"},
+                    "arguments": {"type": "object", "description": "Nested args"},
+                },
+                "required": ["tool_name", "toolset_name", "arguments"],
+            },
+        )
+        schema = _convert_mcp_schema("unreal-engine", mcp_tool)
+
+        # The public schema renames `arguments` to `tool_arguments`.
+        params = schema["parameters"]
+        assert params["type"] == "object"
+        assert "arguments" not in params["properties"]
+        assert "tool_arguments" in params["properties"]
+        assert "tool_name" in params["properties"]
+        assert "toolset_name" in params["properties"]
+        assert params["required"] == ["tool_name", "toolset_name", "tool_arguments"]
+        # The original native schema is preserved under `_mcp_input_schema`.
+        assert schema["_mcp_input_schema"]["required"] == ["tool_name", "toolset_name", "arguments"]
+
 
     def test_empty_input_schema_gets_default(self):
         from tools.mcp_tool import _convert_mcp_schema
@@ -669,14 +704,74 @@ class TestToolHandler:
         try:
             handler = _make_tool_handler("test_srv", "greet", 120)
             with self._patch_mcp_loop():
-                result = json.loads(handler({"name": "world"}))
-            assert result["result"] == "hello world"
-            mock_session.call_tool.assert_called_once_with("greet", arguments={"name": "world"})
+                # Handler accepts the original MCP argument names when the
+                # schema does not need a wrapper, and accepts tool_arguments
+                # when the wrapper is applied.
+                result = handler({"path": "/tmp/foo"})
+            parsed = json.loads(result)
+            assert parsed["result"] == "hello world"
+            mock_session.call_tool.assert_called_once_with(
+                "greet", arguments={"path": "/tmp/foo"}
+            )
         finally:
             _servers.pop("test_srv", None)
 
-    def test_mcp_error_result(self):
+    def test_call_tool_handler_preserves_sibling_params(self):
+        """Wrapped `call_tool` schemas pass all params, not just tool_arguments."""
         from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            return_value=_make_call_result("ok", is_error=False)
+        )
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "call_tool", 120)
+            with self._patch_mcp_loop():
+                result = handler({
+                    "tool_name": "InnerTool",
+                    "toolset_name": "Inner.Toolset",
+                    "tool_arguments": {"foo": 1},
+                })
+            parsed = json.loads(result)
+            assert parsed["result"] == "ok"
+            args = mock_session.call_tool.call_args
+            assert args.kwargs["arguments"]["tool_name"] == "InnerTool"
+            assert args.kwargs["arguments"]["toolset_name"] == "Inner.Toolset"
+            assert args.kwargs["arguments"]["arguments"] == {"foo": 1}
+            assert "tool_arguments" not in args.kwargs["arguments"]
+        finally:
+            _servers.pop("test_srv", None)
+
+    def test_call_tool_handler_accepts_legacy_arguments(self):
+        """Backward-compatible: native `arguments` still works for wrapped schemas."""
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            return_value=_make_call_result("ok", is_error=False)
+        )
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "call_tool", 120)
+            with self._patch_mcp_loop():
+                result = handler({
+                    "tool_name": "InnerTool",
+                    "toolset_name": "Inner.Toolset",
+                    "arguments": {"foo": 1},
+                })
+            parsed = json.loads(result)
+            assert parsed["result"] == "ok"
+            args = mock_session.call_tool.call_args
+            assert args.kwargs["arguments"]["tool_name"] == "InnerTool"
+            assert args.kwargs["arguments"]["toolset_name"] == "Inner.Toolset"
+            assert args.kwargs["arguments"]["arguments"] == {"foo": 1}
+        finally:
+            _servers.pop("test_srv", None)
 
         mock_session = MagicMock()
         mock_session.call_tool = AsyncMock(
@@ -2136,8 +2231,9 @@ class TestUtilitySchemas:
         params = gp["schema"]["parameters"]
         assert "name" in params["properties"]
         assert params["properties"]["name"]["type"] == "string"
-        assert "arguments" in params["properties"]
-        assert params["properties"]["arguments"]["type"] == "object"
+        assert "prompt_arguments" in params["properties"]
+        assert params["properties"]["prompt_arguments"]["type"] == "object"
+        assert "arguments" not in params["properties"]
         assert params["required"] == ["name"]
 
     def test_schemas_have_descriptions(self):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3389,7 +3389,21 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    # The native schema may rename its inner `arguments` field to
+                    # `tool_arguments` to avoid colliding with the outer tool call
+                    # envelope. Accept either name and fall back to the raw args
+                    # for direct/internal callers.  Preserve every sibling
+                    # parameter (e.g. tool_name / toolset_name for VibeUE's
+                    # call_tool wrapper) so the rename is not lossy.
+                    if isinstance(args, dict):
+                        tool_args = dict(args)
+                        if "tool_arguments" in tool_args:
+                            tool_args["arguments"] = tool_args.pop("tool_arguments")
+                        if "arguments" in tool_args and "tool_arguments" not in tool_args:
+                            pass  # already native shape
+                        result = await server.session.call_tool(tool_name, arguments=tool_args)
+                    else:
+                        result = await server.session.call_tool(tool_name, arguments=args)
                 finally:
                     server._pending_call_context = None
             # MCP CallToolResult has .content (list of content blocks) and .isError
@@ -3688,7 +3702,17 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
         name = args.get("name")
         if not name:
             return tool_error("Missing required parameter 'name'")
-        arguments = args.get("arguments", {})
+        # Name and arguments are the canonical MCP prompt parameters. Some
+        # prompt schemas expose the arguments under a top-level `arguments`
+        # property; Hermes' tool dispatch layer uses `arguments` for the whole
+        # tool-call envelope, so that parameter is renamed to `prompt_arguments`
+        # in the schema. Accept both names for backward compatibility.
+        if isinstance(args, dict) and "prompt_arguments" in args:
+            arguments = args["prompt_arguments"]
+        elif isinstance(args, dict) and "arguments" in args:
+            arguments = args["arguments"]
+        else:
+            arguments = {}
 
         async def _call():
             async with server._rpc_lock:
@@ -3923,10 +3947,43 @@ def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
     safe_tool_name = sanitize_mcp_name_component(mcp_tool.name)
     safe_server_name = sanitize_mcp_name_component(server_name)
     prefixed_name = f"mcp_{safe_server_name}_{safe_tool_name}"
+    normalized = _normalize_mcp_input_schema(getattr(mcp_tool, "inputSchema", None))
+
+    # NOTE: Targeted wrapper for MCP tools whose native schema uses a top-level
+    # `arguments` parameter. Hermes' tool dispatch path uses `arguments` as
+    # the JSON-encoded string for the whole tool call, so a tool parameter
+    # literally named `arguments` collides with that envelope and can be
+    # dropped or mis-routed. For affected schemas we rename the user-facing
+    # parameter to `tool_arguments`; the handler maps it back before calling
+    # the server.
+    #
+    # Only apply the wrapper when the normalized schema has a top-level
+    # property named `arguments`; otherwise keep the original schema so the
+    # model sees the real parameters and descriptions.
+    properties = normalized.get("properties", {})
+    if "arguments" in properties:
+        wrapped_props = {**properties}
+        wrapped_props["tool_arguments"] = wrapped_props.pop("arguments")
+        required = list(normalized.get("required", []))
+        if "arguments" in required:
+            required = ["tool_arguments" if p == "arguments" else p for p in required]
+        wrapped = {
+            "type": "object",
+            "properties": wrapped_props,
+        }
+        if required:
+            wrapped["required"] = required
+        return {
+            "name": prefixed_name,
+            "description": mcp_tool.description or f"MCP tool {mcp_tool.name} from {server_name}",
+            "parameters": wrapped,
+            "_mcp_input_schema": dict(normalized),
+        }
+
     return {
         "name": prefixed_name,
         "description": mcp_tool.description or f"MCP tool {mcp_tool.name} from {server_name}",
-        "parameters": _normalize_mcp_input_schema(getattr(mcp_tool, "inputSchema", None)),
+        "parameters": normalized,
     }
 
 
@@ -3988,10 +4045,14 @@ def _build_utility_schemas(server_name: str) -> List[dict]:
                             "type": "string",
                             "description": "Name of the prompt to retrieve",
                         },
-                        "arguments": {
+                        "prompt_arguments": {
                             "type": "object",
-                            "description": "Optional arguments to pass to the prompt",
-                            "properties": {},
+                            "description": (
+                                "Optional arguments to pass to the prompt. "
+                                "Renamed from `arguments` to avoid colliding with the "
+                                "tool-call envelope used by the dispatch layer."
+                            ),
+                            "default": {},
                             "additionalProperties": True,
                         },
                     },


### PR DESCRIPTION
## Problem
MCP tools with a top-level `arguments` parameter collide with Hermes' tool-call envelope. The schema wrapper renames the parameter to `tool_arguments`, but the handler was extracting only the `tool_arguments` value and dropping sibling parameters like `tool_name` and `toolset_name`. This caused tools like Unreal MCP's `call_tool` to fail with `Missing required parameter: tool_name`.

## Fix
- `_convert_mcp_schema()` now applies the `arguments` → `tool_arguments` rename only to MCP tools that actually have a top-level `arguments` property.
- `_make_tool_handler()` maps `tool_arguments` back to `arguments` in place while preserving every sibling parameter, so the full argument dict reaches the MCP server.
- Applied the same collision-safe rename to prompt utility tools (`arguments` → `prompt_arguments`) and accept both names in `_make_get_prompt_handler()`.
- Updated tests to cover the wrapped `call_tool` dispatch path.

## Verification
- `pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py -p anyio`: **214 passed, 1 failed** (pre-existing Windows env test `TestBuildSafeEnv.test_windows_location_vars_passed_without_secrets`).
- End-to-end against a live Unreal MCP server:
  - `mcp_unreal_engine_call_tool(tool_name="IsPIERunning", toolset_name="EditorToolset.EditorAppToolset")` → `{"returnValue":false}`
  - Direct MCP call: `session.call_tool("call_tool", {"toolset_name": "EditorToolset.EditorAppToolset", "tool_name": "IsPIERunning", "arguments": {}})` → `{"returnValue":false}`

Fixes the `arguments` envelope collision end-to-end.