### PR TITLE
fix(gateway): preserve sessions.source on /resume from different platform

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1126,22 +1126,34 @@ class SessionStore:
         session_key: str,
         source: Optional[SessionSource],
     ) -> None:
-        """Persist the routing peer for an existing gateway session row."""
-        if not self._db or not source:
+        """Persist the routing peer for an existing gateway session row.
+
+        When *source* is ``None`` (e.g. ``/resume`` from a different
+        platform), the routing fields are still updated but
+        ``sessions.source`` is left untouched to preserve the original
+        platform provenance.
+        """
+        if not self._db:
             return
         recorder = getattr(self._db, "record_gateway_session_peer", None)
         if not callable(recorder):
             return
         try:
-            recorder(
-                session_id,
-                source=source.platform.value,
-                user_id=source.user_id,
-                session_key=session_key,
-                chat_id=source.chat_id,
-                chat_type=source.chat_type,
-                thread_id=source.thread_id,
-            )
+            if source is not None:
+                recorder(
+                    session_id,
+                    source=source.platform.value,
+                    user_id=source.user_id,
+                    session_key=session_key,
+                    chat_id=source.chat_id,
+                    chat_type=source.chat_type,
+                    thread_id=source.thread_id,
+                )
+            else:
+                recorder(
+                    session_id,
+                    session_key=session_key,
+                )
         except Exception as exc:
             logger.debug("Gateway session peer record failed for %s: %s", session_key, exc)
     

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1641,33 +1641,54 @@ class SessionDB:
         self,
         session_id: str,
         *,
-        source: str,
+        source: str = None,
         user_id: str = None,
         session_key: str = None,
         chat_id: str = None,
         chat_type: str = None,
         thread_id: str = None,
     ) -> None:
-        """Persist the gateway routing peer for an existing session row."""
+        """Persist the gateway routing peer for an existing session row.
+
+        When *source* is ``None`` the ``sessions.source`` column is left
+        untouched so that ``/resume`` does not overwrite the original
+        platform provenance.
+        """
         if not session_id or not session_key:
             return
 
         def _do(conn):
-            conn.execute(
-                """UPDATE sessions
-                   SET session_key = ?, source = ?, user_id = ?, chat_id = ?,
-                       chat_type = ?, thread_id = ?
-                   WHERE id = ?""",
-                (
-                    session_key,
-                    source,
-                    user_id,
-                    chat_id,
-                    chat_type,
-                    thread_id,
-                    session_id,
-                ),
-            )
+            if source is not None:
+                conn.execute(
+                    """UPDATE sessions
+                       SET session_key = ?, source = ?, user_id = ?, chat_id = ?,
+                           chat_type = ?, thread_id = ?
+                       WHERE id = ?""",
+                    (
+                        session_key,
+                        source,
+                        user_id,
+                        chat_id,
+                        chat_type,
+                        thread_id,
+                        session_id,
+                    ),
+                )
+            else:
+                conn.execute(
+                    """UPDATE sessions
+                       SET session_key = ?, user_id = ?, chat_id = ?,
+                           chat_type = ?, thread_id = ?
+                       WHERE id = ?""",
+                    (
+                        session_key,
+                        user_id,
+                        chat_id,
+                        chat_type,
+                        thread_id,
+                        session_id,
+                    ),
+                )
 
         self._execute_write(_do)
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4793,6 +4793,56 @@ def test_gateway_session_peer_round_trip_and_recovery(db):
     assert recovered["id"] == "gw-session"
 
 
+def test_record_gateway_session_peer_preserves_source_when_none(db):
+    """Passing source=None to record_gateway_session_peer must leave
+    the existing sessions.source column untouched (#56439)."""
+    db.create_session(
+        "resume-test",
+        "tui",
+        user_id="user-1",
+        session_key="agent:main:tui:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+    row = db.get_session("resume-test")
+    assert row["source"] == "tui"
+
+    # Simulate /resume from telegram: update routing fields but NOT source
+    db.record_gateway_session_peer(
+        "resume-test",
+        source=None,
+        session_key="agent:main:telegram:dm:chat-1",
+        user_id="user-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+    row = db.get_session("resume-test")
+    assert row["source"] == "tui", "source must not be overwritten when source=None"
+    assert row["session_key"] == "agent:main:telegram:dm:chat-1"
+
+
+def test_record_gateway_session_peer_updates_source_when_provided(db):
+    """Passing source=<value> must still update the source column."""
+    db.create_session(
+        "src-update",
+        "tui",
+        user_id="user-1",
+        session_key="agent:main:tui:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+    db.record_gateway_session_peer(
+        "src-update",
+        source="telegram",
+        session_key="agent:main:telegram:dm:chat-1",
+        user_id="user-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+    row = db.get_session("src-update")
+    assert row["source"] == "telegram"
+
+
 def test_gateway_session_recovery_reopens_legacy_agent_close_rows(db):
     db.create_session(
         "closed-gw-session",


### PR DESCRIPTION
## What does this PR do?

`record_gateway_session_peer()` unconditionally overwrites the `sessions.source` column in `state.db`. When a user resumes a session from a different platform via `/resume` (e.g. resuming a TUI-created session from Telegram), the source gets overwritten to the resuming platform, destroying the original provenance.

This fix makes `source` optional in both `SessionDB.record_gateway_session_peer()` and `SessionStore._record_gateway_session_peer()`. When `source=None`, the UPDATE skips the `source` column entirely, preserving the original platform value.

## Related Issue

Fixes #56439

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: Make `source` parameter optional (default `None`) in `record_gateway_session_peer()`. When `source is None`, emit an UPDATE that excludes the `source` column.
- `gateway/session.py`: Remove the early-return guard on `source is None` in `_record_gateway_session_peer()`. When source is None, call the DB method with only `session_key` (routing fields only, no source overwrite).
- `tests/test_hermes_state.py`: Add two regression tests — one verifying source is preserved when `None`, one verifying source is still updated when a value is provided.

## How to Test

1. Run the new tests:
   ```bash
   python -m pytest tests/test_hermes_state.py::test_record_gateway_session_peer_preserves_source_when_none tests/test_hermes_state.py::test_record_gateway_session_peer_updates_source_when_provided -xvs
   ```
2. Run the full `test_hermes_state.py` suite (305 tests) to confirm no regressions:
   ```bash
   python -m pytest tests/test_hermes_state.py -q
   ```
3. All tests should pass. Observed result: 305 passed in 9.95s.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1

### Documentation and Housekeeping

- [x] I've updated relevant documentation or N/A
- [x] I've updated cli-config.yaml.example or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md or N/A
