### PR TITLE
fix(gateway): preserve session source on resume

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1648,15 +1648,20 @@ class SessionDB:
         chat_type: str = None,
         thread_id: str = None,
     ) -> None:
-        """Persist the gateway routing peer for an existing session row."""
+        """Persist the gateway routing peer for an existing session row.
+
+        ``source`` records where the session was originally created.  Resuming a
+        desktop/TUI/CLI session from a gateway should attach routing metadata for
+        that gateway peer without rewriting the original provenance.
+        """
         if not session_id or not session_key:
             return
 
         def _do(conn):
             conn.execute(
                 """UPDATE sessions
-                   SET session_key = ?, source = ?, user_id = ?, chat_id = ?,
-                       chat_type = ?, thread_id = ?
+                   SET session_key = ?, source = COALESCE(source, ?),
+                       user_id = ?, chat_id = ?, chat_type = ?, thread_id = ?
                    WHERE id = ?""",
                 (
                     session_key,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4793,6 +4793,26 @@ def test_gateway_session_peer_round_trip_and_recovery(db):
     assert recovered["id"] == "gw-session"
 
 
+def test_record_gateway_session_peer_preserves_original_source(db):
+    db.create_session("desktop-session", "tui", user_id="desktop-user")
+
+    db.record_gateway_session_peer(
+        "desktop-session",
+        source="telegram",
+        user_id="telegram-user",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+
+    row = db.get_session("desktop-session")
+    assert row["source"] == "tui"
+    assert row["session_key"] == "agent:main:telegram:dm:chat-1"
+    assert row["user_id"] == "telegram-user"
+    assert row["chat_id"] == "chat-1"
+    assert row["chat_type"] == "dm"
+
+
 def test_gateway_session_recovery_reopens_legacy_agent_close_rows(db):
     db.create_session(
         "closed-gw-session",


### PR DESCRIPTION
## Summary
- keep the original sessions.source when gateway /resume attaches peer routing metadata
- add regression coverage for preserving desktop/TUI provenance while updating gateway routing fields

Fixes #56439.

## Tests
- scripts/run_tests.sh tests/test_hermes_state.py -k record_gateway_session_peer_preserves_original_source