### PR TITLE
fix: honor suppressed Anthropic account sources

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6192,13 +6192,19 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
         read_hermes_oauth_credentials = None  # type: ignore
         _HERMES_OAUTH_FILE = None  # type: ignore
 
+    try:
+        from hermes_cli.auth import is_source_suppressed as _is_source_suppressed
+    except ImportError:
+        def _is_source_suppressed(provider_id: str, source: str) -> bool:  # type: ignore[misc]
+            return False
+
     hermes_creds = None
     if read_hermes_oauth_credentials:
         try:
             hermes_creds = read_hermes_oauth_credentials()
         except Exception:
             hermes_creds = None
-    if hermes_creds and hermes_creds.get("accessToken"):
+    if hermes_creds and hermes_creds.get("accessToken") and not _is_source_suppressed("anthropic", "hermes_pkce"):
         return {
             "logged_in": True,
             "source": "hermes_pkce",
@@ -6227,7 +6233,7 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
 
     for var in env_var_order:
         value = (get_env_value(var) if get_env_value else None) or os.getenv(var)
-        if not value:
+        if not value or _is_source_suppressed("anthropic", f"env:{var}"):
             continue
         suffix = format_secret_source_suffix(var) if format_secret_source_suffix else ""
         return {
@@ -6248,6 +6254,12 @@ def _claude_code_only_status() -> Dict[str, Any]:
     Claude Code subscription tokens are actively flowing into Hermes even
     when they also have a separate Hermes-managed PKCE login.
     """
+    try:
+        from hermes_cli.auth import is_source_suppressed
+        if is_source_suppressed("anthropic", "claude_code"):
+            return {"logged_in": False, "source": None}
+    except Exception:
+        pass
     try:
         from agent.anthropic_adapter import read_claude_code_credentials
         creds = read_claude_code_credentials()
@@ -6506,6 +6518,24 @@ def _oauth_provider_disconnect_hint(provider: Dict[str, Any], status: Dict[str, 
     return None
 
 
+def _oauth_provider_hidden_by_suppression(provider_id: str) -> bool:
+    """Return True when the user explicitly suppressed a synthetic Accounts row."""
+    try:
+        from hermes_cli.auth import is_source_suppressed
+    except ImportError:
+        return False
+    if provider_id == "claude-code":
+        return is_source_suppressed("anthropic", "claude_code")
+    if provider_id == "anthropic":
+        return (
+            is_source_suppressed("anthropic", "hermes_pkce")
+            and is_source_suppressed("anthropic", "env:ANTHROPIC_API_KEY")
+            and is_source_suppressed("anthropic", "env:ANTHROPIC_TOKEN")
+            and is_source_suppressed("anthropic", "env:CLAUDE_CODE_OAUTH_TOKEN")
+        )
+    return False
+
+
 def _build_oauth_catalog() -> list[Dict[str, Any]]:
     """Build the Accounts-tab provider list.
 
@@ -6583,6 +6613,8 @@ async def list_oauth_providers(profile: Optional[str] = None):
     with _profile_scope(profile):
         providers = []
         for p in _build_oauth_catalog():
+            if _oauth_provider_hidden_by_suppression(p["id"]):
+                continue
             status = _resolve_provider_status(p["id"], p.get("status_fn"))
             disconnect_hint = _oauth_provider_disconnect_hint(p, status)
             providers.append({

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -557,6 +557,50 @@ def test_env_sourced_oauth_status_is_not_disconnectable(monkeypatch):
     assert "Settings" in delete_resp.text
 
 
+def test_suppressed_anthropic_sources_hide_accounts_rows(monkeypatch):
+    """Removing Anthropic/Claude sources should make the Accounts tab stay clean.
+
+    The user can suppress env, Hermes PKCE, and Claude Code credential sources
+    after disconnecting. Once suppressed, the dashboard must neither report them
+    connected nor keep dangling Anthropic/Claude rows visible.
+    """
+    from agent import anthropic_adapter
+    from hermes_cli import web_server as ws
+    from hermes_cli.auth import suppress_credential_source
+
+    for source in (
+        "claude_code",
+        "hermes_pkce",
+        "env:ANTHROPIC_API_KEY",
+        "env:ANTHROPIC_TOKEN",
+        "env:CLAUDE_CODE_OAUTH_TOKEN",
+    ):
+        suppress_credential_source("anthropic", source)
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "read_hermes_oauth_credentials",
+        lambda: {"accessToken": "pkce-token", "refreshToken": "refresh"},
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "read_claude_code_credentials",
+        lambda: {"accessToken": "cc-token", "refreshToken": "refresh"},
+    )
+
+    assert ws._anthropic_oauth_status()["logged_in"] is False
+    assert ws._claude_code_only_status()["logged_in"] is False
+    assert ws._oauth_provider_hidden_by_suppression("anthropic") is True
+    assert ws._oauth_provider_hidden_by_suppression("claude-code") is True
+
+    resp = client.get("/api/providers/oauth", headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    providers = {p["id"] for p in resp.json()["providers"]}
+    assert "anthropic" not in providers
+    assert "claude-code" not in providers
+
+
 def test_xai_loopback_start_returns_authorize_url(monkeypatch):
     """Start MUST bind the loopback listener and hand back an xAI authorize URL."""
     from hermes_cli import auth as auth_mod


### PR DESCRIPTION
## Summary
- Respect suppressed Anthropic credential sources in Desktop Accounts status helpers
- Hide Anthropic / Claude Code Accounts rows after the user suppresses all Anthropic credential sources
- Add regression coverage so suppressed env, Hermes PKCE, and Claude Code credentials stay disconnected and hidden

## Test Plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_web_oauth_dispatch.py tests/hermes_cli/test_auth_commands.py -q`
- [x] `./venv/bin/python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_oauth_dispatch.py`
- [x] `git diff --check`
