### PR TITLE
fix(gateway): prune video and screenshot caches

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -785,15 +785,10 @@ async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2) ->
                 raise
 
 
-def cleanup_image_cache(max_age_hours: int = 24) -> int:
-    """
-    Delete cached images older than *max_age_hours*.
-
-    Returns the number of files removed.
-    """
+def _cleanup_cache_dir(cache_dir: Path, max_age_hours: int = 24) -> int:
+    """Delete files in ``cache_dir`` older than *max_age_hours*."""
     import time
 
-    cache_dir = get_image_cache_dir()
     cutoff = time.time() - (max_age_hours * 3600)
     removed = 0
     for f in cache_dir.iterdir():
@@ -804,6 +799,15 @@ def cleanup_image_cache(max_age_hours: int = 24) -> int:
             except OSError:
                 pass
     return removed
+
+
+def cleanup_image_cache(max_age_hours: int = 24) -> int:
+    """
+    Delete cached images older than *max_age_hours*.
+
+    Returns the number of files removed.
+    """
+    return _cleanup_cache_dir(get_image_cache_dir(), max_age_hours=max_age_hours)
 
 
 # ---------------------------------------------------------------------------
@@ -938,6 +942,15 @@ def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
     filepath = cache_dir / filename
     filepath.write_bytes(data)
     return str(filepath)
+
+
+def cleanup_video_cache(max_age_hours: int = 24) -> int:
+    """
+    Delete cached videos older than *max_age_hours*.
+
+    Returns the number of files removed.
+    """
+    return _cleanup_cache_dir(get_video_cache_dir(), max_age_hours=max_age_hours)
 
 
 # ---------------------------------------------------------------------------
@@ -1565,19 +1578,23 @@ def cleanup_document_cache(max_age_hours: int = 24) -> int:
 
     Returns the number of files removed.
     """
-    import time
+    return _cleanup_cache_dir(get_document_cache_dir(), max_age_hours=max_age_hours)
 
-    cache_dir = get_document_cache_dir()
-    cutoff = time.time() - (max_age_hours * 3600)
-    removed = 0
-    for f in cache_dir.iterdir():
-        if f.is_file() and f.stat().st_mtime < cutoff:
-            try:
-                f.unlink()
-                removed += 1
-            except OSError:
-                pass
-    return removed
+
+def get_screenshot_cache_dir() -> Path:
+    """Return the browser screenshot cache directory, creating it if needed."""
+    d = _resolve_cache_dir("SCREENSHOT_CACHE_DIR", "cache/screenshots", "browser_screenshots")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def cleanup_screenshot_cache(max_age_hours: int = 24) -> int:
+    """
+    Delete cached browser screenshots older than *max_age_hours*.
+
+    Returns the number of files removed.
+    """
+    return _cleanup_cache_dir(get_screenshot_cache_dir(), max_age_hours=max_age_hours)
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18934,7 +18934,12 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     hour, and polls the curator hourly (its inner gate enforces the real
     weekly cadence).
     """
-    from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.platforms.base import (
+        cleanup_document_cache,
+        cleanup_image_cache,
+        cleanup_screenshot_cache,
+        cleanup_video_cache,
+    )
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -18978,6 +18983,18 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
                     logger.info("Document cache cleanup: removed %d stale file(s)", removed)
             except Exception as e:
                 logger.debug("Document cache cleanup error: %s", e)
+            try:
+                removed = cleanup_video_cache(max_age_hours=24)
+                if removed:
+                    logger.info("Video cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Video cache cleanup error: %s", e)
+            try:
+                removed = cleanup_screenshot_cache(max_age_hours=24)
+                if removed:
+                    logger.info("Screenshot cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Screenshot cache cleanup error: %s", e)
 
         if tick_count % PASTE_SWEEP_EVERY == 0:
             try:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -13,6 +13,8 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
+    cleanup_screenshot_cache,
+    cleanup_video_cache,
     safe_url_for_log,
     utf16_len,
     validate_inbound_media_size,
@@ -70,6 +72,42 @@ class TestInboundMediaSizeCap:
         validate_inbound_media_size(100, media_type="image", max_bytes=200)  # ok
         with pytest.raises(ValueError, match="too large"):
             validate_inbound_media_size(300, media_type="image", max_bytes=200)
+
+
+class TestCacheCleanup:
+    def test_video_cache_cleanup_removes_only_stale_files(self, tmp_path, monkeypatch):
+        import gateway.platforms.base as base
+
+        cache_dir = tmp_path / "videos"
+        monkeypatch.setattr(base, "VIDEO_CACHE_DIR", cache_dir)
+        old_file = cache_dir / "video_old.mp4"
+        fresh_file = cache_dir / "video_fresh.mp4"
+        old_file.parent.mkdir(parents=True)
+        old_file.write_bytes(b"old")
+        fresh_file.write_bytes(b"fresh")
+        old_mtime = time.time() - (25 * 3600)
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        assert cleanup_video_cache(max_age_hours=24) == 1
+        assert not old_file.exists()
+        assert fresh_file.exists()
+
+    def test_screenshot_cache_cleanup_removes_only_stale_files(self, tmp_path, monkeypatch):
+        import gateway.platforms.base as base
+
+        cache_dir = tmp_path / "screenshots"
+        monkeypatch.setattr(base, "SCREENSHOT_CACHE_DIR", cache_dir)
+        old_file = cache_dir / "browser_screenshot_old.png"
+        fresh_file = cache_dir / "browser_screenshot_fresh.png"
+        old_file.parent.mkdir(parents=True)
+        old_file.write_bytes(b"old")
+        fresh_file.write_bytes(b"fresh")
+        old_mtime = time.time() - (25 * 3600)
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        assert cleanup_screenshot_cache(max_age_hours=24) == 1
+        assert not old_file.exists()
+        assert fresh_file.exists()
 
 
 class TestSecretCaptureGuidance:


### PR DESCRIPTION
## Summary
- add mtime-based cleanup for gateway video and screenshot caches
- run both cleanup passes from the existing hourly gateway housekeeping tick
- add regression coverage that stale video/screenshot files are removed while fresh files remain

Fixes #56427.

## Tests
- scripts/run_tests.sh tests/gateway/test_platform_base.py -k 'CacheCleanup'