### PR TITLE
fix(docker): publish dashboard port for Docker Desktop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,13 +64,17 @@ services:
     image: hermes-agent
     container_name: hermes-dashboard
     restart: unless-stopped
-    network_mode: host
     depends_on:
       - gateway
+    ports:
+      - "127.0.0.1:9119:9119"
     volumes:
       - ~/.hermes:/opt/data
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}
-    # Localhost-only. For remote access, tunnel via `ssh -L 9119:localhost:9119`.
-    command: ["dashboard", "--host", "127.0.0.1", "--no-open"]
+    # Bind inside the container so Docker can publish the port, but only publish
+    # it on host loopback. This works on Docker Desktop macOS/Windows where
+    # network_mode: host targets the Linux VM, not the real host browser.
+    # For remote access, tunnel via `ssh -L 9119:localhost:9119`.
+    command: ["dashboard", "--host", "0.0.0.0", "--no-open"]


### PR DESCRIPTION
## Summary
- stop using host networking for the dashboard service in the default compose file
- publish 127.0.0.1:9119:9119 and bind the dashboard inside the container to 0.0.0.0 so macOS/Windows Docker Desktop host browsers can reach it
- keep host-loopback exposure only for the published port

Fixes #56401.

## Tests
- python YAML assertion for docker-compose.yml dashboard port mapping