### PR TITLE
fix(gateway): fallback lock dir when HOME is unwritable

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from typing import Any, Optional
 from utils import atomic_json_write
 
@@ -62,12 +62,27 @@ def _get_runtime_status_path() -> Path:
 
 
 def _get_lock_dir() -> Path:
-    """Return the machine-local directory for token-scoped gateway locks."""
+    """Return the machine-local directory for token-scoped gateway locks.
+
+    Prefer XDG_STATE_HOME when the operator configured it.  Otherwise avoid
+    blindly using ``$HOME/.local/state`` when HOME is inherited from a root-owned
+    container init context: non-root gateway services cannot create files there,
+    which disables token-scoped platform locks.  In that case, fall back to the
+    writable Hermes root (``HERMES_HOME`` / profile root in Docker installs).
+    """
     override = os.getenv("HERMES_GATEWAY_LOCK_DIR")
     if override:
         return Path(override)
-    state_home = Path(os.getenv("XDG_STATE_HOME", Path.home() / ".local" / "state"))
-    return state_home / "hermes" / _LOCKS_DIRNAME
+
+    xdg_state_home = os.getenv("XDG_STATE_HOME")
+    if xdg_state_home:
+        return Path(xdg_state_home) / "hermes" / _LOCKS_DIRNAME
+
+    home = Path.home()
+    if home.exists() and os.access(home, os.W_OK):
+        return home / ".local" / "state" / "hermes" / _LOCKS_DIRNAME
+
+    return get_default_hermes_root() / _LOCKS_DIRNAME
 
 
 def _utc_now_iso() -> str:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -9,6 +9,28 @@ from types import SimpleNamespace
 from gateway import status
 
 
+class TestGatewayLockDir:
+    def test_lock_dir_falls_back_to_hermes_root_when_home_unwritable(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "data"
+        root_home = tmp_path / "root"
+        hermes_home.mkdir()
+        root_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: root_home)
+        monkeypatch.setattr(status.os, "access", lambda path, mode: False)
+
+        assert status._get_lock_dir() == hermes_home / "gateway-locks"
+
+    def test_lock_dir_honors_xdg_state_home(self, tmp_path, monkeypatch):
+        state_home = tmp_path / "state"
+        monkeypatch.setenv("XDG_STATE_HOME", str(state_home))
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+
+        assert status._get_lock_dir() == state_home / "hermes" / "gateway-locks"
+
+
 class TestGatewayPidState:
     def test_write_pid_file_records_gateway_metadata(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary
- avoid placing token-scoped gateway locks under an unwritable HOME-derived XDG path when HOME is inherited from a root-owned container init context
- preserve explicit HERMES_GATEWAY_LOCK_DIR / XDG_STATE_HOME behavior
- fall back to the Hermes root so non-root container gateways can write platform lock files

Fixes #56402.

## Tests
- scripts/run_tests.sh tests/gateway/test_status.py -k GatewayLockDir