### PR TITLE
fix(tools): honor declared union order for string members

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -737,8 +737,16 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
         return None
 
     if isinstance(expected_type, list):
-        # Union type — try each in order, return first successful coercion
+        # Union type — try each member in declared order, return first match.
+        # `value` is already a str, so a "string" member is always a valid
+        # representation and must match immediately. Without this short-circuit
+        # the string branch returns `value` unchanged, the `is not value`
+        # success check never fires for it, and the loop falls through to a
+        # later numeric member — ignoring the declared order (e.g. "007" under
+        # ["string", "integer"] would wrongly coerce to 7).
         for t in expected_type:
+            if t == "string":
+                return value
             result = _coerce_value(value, t, schema=schema)
             if result is not value:
                 return result

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -146,6 +146,16 @@ class TestCoerceValue:
         """A non-numeric string in [number, string] should stay a string."""
         assert _coerce_value("hello", ["number", "string"]) == "hello"
 
+    def test_union_string_first_preserves_numeric_string(self):
+        """A leading "string" member matches, honoring declared order."""
+        assert _coerce_value("007", ["string", "integer"]) == "007"
+        assert _coerce_value("42", ["string", "integer"]) == "42"
+        assert _coerce_value("3.14", ["string", "number"]) == "3.14"
+
+    def test_union_integer_first_still_coerces(self):
+        """Declared order is honored the other way too: integer-first coerces."""
+        assert _coerce_value("7", ["integer", "string"]) == 7
+
     def test_array_type_parsed_from_json_string(self):
         """Stringified JSON arrays are parsed into native lists."""
         assert _coerce_value('["a", "b"]', "array") == ["a", "b"]


### PR DESCRIPTION
## What does this PR do?

Fixes a union-type coercion bug in `_coerce_value`. A declared `"string"` member gets skipped, so a numeric-looking argument that was typed string-first is coerced to a number instead.

A union type is tried member by member. The first member whose coercion succeeds wins, and success is defined as `result is not value`. The string branch returns `value` unchanged, so `result is not value` is never true for a `"string"` member. The loop skips past a leading `"string"`, falls through to a later numeric member, and ignores the declared order:

```python
_coerce_value("007", ["string", "integer"])   # -> 7   (should be "007")
_coerce_value("42",  ["string", "integer"])    # -> 42  (should be "42")
```

For a parameter that is explicitly declared string-first, this drops leading zeros and corrupts ids/codes/nonces that look numeric. The fix goes in the one central union-dispatch site, `_coerce_value`, which covers the whole bug class. `coerce_tool_args` delegates here, so there is no sibling call path.

This is split out from #56408. That PR bundled two independent fixes, and its large-integer `_coerce_number` half overlaps #40763, so this PR carries only the union-order fix (as suggested in triage on #56408).

## Related Issue

Split from #56408 (union-order half). No separate issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `model_tools.py`: in `_coerce_value`, short-circuit on a `"string"` union member. `value` is already a `str`, so it is always a valid string representation and should match immediately. Declared order now wins in both directions.
- `tests/run_agent/test_tool_arg_coercion.py`: added `test_union_string_first_preserves_numeric_string` and `test_union_integer_first_still_coerces`.

## How to Test

1. On `main`: `_coerce_value("007", ["string", "integer"])` returns `7` (the bug).
2. Apply this PR.
3. Run `scripts/run_tests.sh tests/run_agent/test_tool_arg_coercion.py -q`. You get 63 passed, 0 failed. The new string-first test fails on `main` (`assert 7 == '007'`) and passes here. `["integer", "string"]` still coerces to `7`, so existing behavior is preserved.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(tools): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the tests via `scripts/run_tests.sh` and all pass (63/63)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Documentation: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact: N/A (pure-Python string logic, no OS calls)
- [x] Tool descriptions/schemas: N/A