### PR TITLE
fix(gateway): cancel pending WhatsApp text-batch tasks on disconnect (#55866)

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -839,6 +839,19 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 pass
         self._poll_task = None
 
+
+        # Cancel any in-flight text-batch tasks and clear buffers so
+        # disconnect does not retain references across reconnects (#55866).
+        pending_tasks = getattr(self, "_pending_text_batch_tasks", None)
+        if pending_tasks is not None:
+            for task in pending_tasks.values():
+                if not task.done():
+                    task.cancel()
+            pending_tasks.clear()
+        pending_events = getattr(self, "_pending_text_batches", None)
+        if pending_events is not None:
+            pending_events.clear()
+
         # Close the persistent HTTP session
         if self._http_session and not self._http_session.closed:
             await self._http_session.close()

--- a/tests/gateway/test_whatsapp_text_batching.py
+++ b/tests/gateway/test_whatsapp_text_batching.py
@@ -105,3 +105,24 @@ def test_lone_message_dispatched_alone():
 
     asyncio.run(_drive())
     assert dispatched == ["solo"]
+
+
+def test_disconnect_cancels_pending_batch_tasks():
+    adapter = _make_adapter(
+        text_batch_delay_seconds=0.1,
+        text_batch_split_delay_seconds=0.2,
+    )
+
+    async def _noop(event):
+        return None
+
+    adapter.handle_message = _noop
+
+    async def _drive():
+        adapter._enqueue_text_event(_event("keep"))
+        await asyncio.sleep(0.05)
+        await adapter.disconnect()
+
+    asyncio.run(_drive())
+    assert adapter._pending_text_batch_tasks == {}
+    assert adapter._pending_text_batches == {}


### PR DESCRIPTION
Closes #55866. Adds cleanup in disconnect() so reconnect cycles don't accumulate finished or failed batch tasks or message buffers across the adapter lifetime.