### PR TITLE
fix(agent): build Anthropic client before mutating agent state in try…

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1273,6 +1273,27 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         ):
             fb_api_mode = "bedrock_converse"
 
+        # Honor per-provider / per-model request_timeout_seconds for the
+        # fallback target (same knob the primary client uses).  None = use
+        # SDK default.  Resolved before the state commit below since the
+        # anthropic_messages client build needs it.
+        _fb_timeout = get_provider_request_timeout(fb_provider, fb_model)
+
+        # Build the native Anthropic client before committing agent state
+        # below.  A failure here (e.g. ImportError when the SDK isn't
+        # installed) must not leave agent.model/provider/api_mode already
+        # pointing at a fallback whose client was never built.
+        _fb_anthropic_key = None
+        _fb_anthropic_client = None
+        _fb_anthropic_oauth = False
+        if fb_api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
+            _fb_anthropic_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
+            _fb_anthropic_client = build_anthropic_client(
+                _fb_anthropic_key, fb_base_url, timeout=_fb_timeout,
+            )
+            _fb_anthropic_oauth = _is_oauth_token(_fb_anthropic_key) if fb_provider == "anthropic" else False
+
         old_model = agent.model
 
         # Clear the per-config context_length override so the fallback
@@ -1324,22 +1345,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                     fb_provider, fb_model, exc,
                 )
 
-        # Honor per-provider / per-model request_timeout_seconds for the
-        # fallback target (same knob the primary client uses).  None = use
-        # SDK default.
-        _fb_timeout = get_provider_request_timeout(fb_provider, fb_model)
-
         if fb_api_mode == "anthropic_messages":
-            # Build native Anthropic client instead of using OpenAI client
-            from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
-            effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
-            agent.api_key = effective_key
-            agent._anthropic_api_key = effective_key
+            # Native Anthropic client, built above.
+            agent.api_key = _fb_anthropic_key
+            agent._anthropic_api_key = _fb_anthropic_key
             agent._anthropic_base_url = fb_base_url
-            agent._anthropic_client = build_anthropic_client(
-                effective_key, agent._anthropic_base_url, timeout=_fb_timeout,
-            )
-            agent._is_anthropic_oauth = _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
+            agent._anthropic_client = _fb_anthropic_client
+            agent._is_anthropic_oauth = _fb_anthropic_oauth
             agent.client = None
             agent._client_kwargs = {}
         else:

--- a/tests/run_agent/test_anthropic_fallback_client_build_failure.py
+++ b/tests/run_agent/test_anthropic_fallback_client_build_failure.py
@@ -1,0 +1,136 @@
+"""Regression test — anthropic fallback must not commit agent state before
+the native Anthropic client is successfully built.
+
+``try_activate_fallback`` used to swap ``agent.model`` / ``agent.provider`` /
+``agent.base_url`` / ``agent.api_mode`` *before* calling
+``build_anthropic_client()`` for the ``anthropic_messages`` branch. When that
+call raised (e.g. ``ImportError`` because the ``anthropic`` package isn't
+installed), the agent was left half-switched: pointing at the fallback
+provider with no working client. See fix in this same PR.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_agent(fallback_model=None):
+    """Create a minimal AIAgent with optional fallback config."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+def _mock_client(base_url="https://api.anthropic.com/v1", api_key="sk-ant-test"):
+    mock = MagicMock()
+    mock.base_url = base_url
+    mock.api_key = api_key
+    return mock
+
+
+# ── Client build failure must not mutate agent state ───────────────────────
+
+
+class TestAnthropicFallbackClientBuildFailure:
+    def test_anthropic_fallback_does_not_mutate_agent_state_on_client_build_failure(self):
+        fbs = [{"provider": "anthropic", "model": "claude-sonnet-4-6"}]
+        agent = _make_agent(fallback_model=fbs)
+
+        original_model = agent.model
+        original_provider = agent.provider
+        original_base_url = agent.base_url
+        original_api_mode = agent.api_mode
+        original_client = agent.client
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(), None),
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                side_effect=ImportError("anthropic package missing"),
+            ),
+            patch("agent.anthropic_adapter.resolve_anthropic_token", return_value=None),
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is False
+        assert agent.model == original_model
+        assert agent.provider == original_provider
+        assert agent.base_url == original_base_url
+        assert agent.api_mode == original_api_mode
+        assert agent.client is original_client
+        assert agent._anthropic_client is None
+        assert agent._fallback_activated is False
+
+    def test_broken_entry_then_working_entry_still_activates(self):
+        fbs = [
+            {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        ]
+        agent = _make_agent(fallback_model=fbs)
+
+        def _client_for(provider, **kwargs):
+            if provider == "anthropic":
+                return (_mock_client(), None)
+            return (
+                _mock_client(base_url="https://openrouter.ai/api/v1", api_key="sk-or-test"),
+                None,
+            )
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                side_effect=lambda provider, **kw: _client_for(provider, **kw),
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                side_effect=ImportError("anthropic package missing"),
+            ),
+            patch("agent.anthropic_adapter.resolve_anthropic_token", return_value=None),
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.api_mode == "chat_completions"
+        assert agent.provider == "openrouter"
+        assert agent._anthropic_client is None
+        assert agent.client is not None
+
+    def test_successful_anthropic_fallback_unchanged_behavior(self):
+        fbs = [{"provider": "anthropic", "model": "claude-sonnet-4-6"}]
+        agent = _make_agent(fallback_model=fbs)
+        built_client = MagicMock()
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(), None),
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=built_client,
+            ) as mock_build,
+            patch("agent.anthropic_adapter.resolve_anthropic_token", return_value=None),
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.api_mode == "anthropic_messages"
+        assert agent._anthropic_client is built_client
+        assert agent.client is None
+        assert agent._fallback_activated is True
+        mock_build.assert_called_once()


### PR DESCRIPTION
## Summary
Prevents `try_activate_fallback` from leaving the agent in a half-switched
state when building the native Anthropic client fails. Before this fix, a
failure in `build_anthropic_client()` after agent state was already
committed to the anthropic fallback entry crashed the next completion call
instead of cleanly advancing to the next fallback entry or leaving the
agent on its previous working configuration.

---

## Root cause
`try_activate_fallback()` in `agent/chat_completion_helpers.py` committed
`agent.model`, `agent.provider`, `agent.base_url`, `agent.api_mode`, and
`agent._fallback_activated` for the `anthropic_messages` branch before
calling `build_anthropic_client()`. That call can raise, for example
`ImportError` when the `anthropic` package is not installed, or an error
from a malformed base_url or key. The existing `except Exception` handler
caught the failure and recursed to the next fallback entry, but the
already-committed fields were never rolled back.

If the chain was exhausted after this failure, `restore_primary_runtime()`
also did not restore the primary provider, since `_fallback_activated` was
already `True` and `_rate_limited_until` (an existing cooldown from the
same failure path) was still in the future. The agent was left with
`provider="anthropic"` and `api_mode="anthropic_messages"` while
`_anthropic_client` stayed `None`, so the next completion call raised
`AttributeError: 'NoneType' object has no attribute 'messages'`.

The OpenAI-compatible branch does not have this problem, since `fb_client`
is already verified through `resolve_provider_client()` earlier in the
function, before any state is touched.

---

## Behavioral change
Before: a failure in `build_anthropic_client()` left the agent pointing at
the anthropic fallback with no working client, crashing the following
completion call.

After: the Anthropic client is built before any agent state is committed.
On success, the resulting state is identical to before. On failure, agent
state is left untouched and the function proceeds to the next fallback
entry, or exhausts the chain without ever having mutated state for the
entry that failed.

---

## What changed
**`agent/chat_completion_helpers.py`**: moved the `_fb_timeout` computation
and the native Anthropic client build into a block that runs before the
state commit inside `try_activate_fallback`. The block resolves the
effective key, builds the client, and resolves the oauth flag, storing the
results in local variables. The post-commit `anthropic_messages` branch now
only assigns these already-resolved values instead of calling
`build_anthropic_client()` itself.

**`tests/run_agent/test_anthropic_fallback_client_build_failure.py`**: added
`TestAnthropicFallbackClientBuildFailure` with three tests. One asserts
that agent state stays untouched when the client build raises. One asserts
that a broken anthropic entry followed by a working entry still activates
the working one cleanly. One asserts that the successful anthropic fallback
path is unchanged.

---

## What is NOT changed
- The OpenAI-compatible branch (`chat_completions`, `codex_responses`, `bedrock_converse`) is untouched
- Credential pool rebind logic is untouched
- Prompt caching policy, context compressor update, and `rewrite_prompt_model_identity` are untouched
- Fallback chain advancement and dedup logic is untouched
- All existing fallback and anthropic adapter tests pass