### PR TITLE
fix(gateway): make WeCom _cleanup_ws defensive against partially-initialized adapters (#55491)

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -270,13 +270,23 @@ class WeComAdapter(BasePlatformAdapter):
 
     async def _cleanup_ws(self) -> None:
         """Close the live websocket/session, if any."""
+        pending_tasks = getattr(self, "_pending_text_batch_tasks", None)
+        if pending_tasks is not None:
+            for task in pending_tasks.values():
+                if not task.done():
+                    task.cancel()
+            pending_tasks.clear()
+        pending_events = getattr(self, "_pending_text_batches", None)
+        if pending_events is not None:
+            pending_events.clear()
         if self._ws and not self._ws.closed:
             await self._ws.close()
         self._ws = None
 
-        if self._session and not self._session.closed:
+        session = getattr(self, "_session", None)
+        if session is not None and not session.closed:
             await self._session.close()
-        self._session = None
+            self._session = None
 
     async def _open_connection(self) -> None:
         """Open and authenticate a websocket connection."""

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -953,3 +953,21 @@ class TestTextBatchFlushRace:
         assert adapter._pending_text_batches.get(key) is None, (
             "active task must pop the event after processing"
         )
+
+
+def test_cleanup_ws_clears_pending_batch_state_without_assuming_full_init():
+    from gateway.platforms.wecom import WeComAdapter
+
+    adapter = WeComAdapter.__new__(WeComAdapter)
+    adapter._running = False
+    adapter._ws = None
+    adapter._session = None
+    adapter._pending_text_batch_tasks = {}
+    adapter._pending_text_batches = {}
+
+    async def _drive():
+        await adapter._cleanup_ws()
+
+    asyncio.run(_drive())
+    assert adapter._pending_text_batch_tasks == {}
+    assert adapter._pending_text_batches == {}


### PR DESCRIPTION
Closes #55491. Makes _cleanup_ws tolerate partially-initialized adapters by using getattr/defaults for session and pending batch state.