### PR TITLE
fix(agent): gate restore_primary_runtime credential pool by provider

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -662,6 +662,42 @@ def strip_think_blocks(agent, content: str) -> str:
     return content
 
 
+def credential_pool_matches_agent(
+    pool,
+    agent,
+    *,
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> bool:
+    """Return True when *pool* belongs to the agent's current provider context.
+
+    Custom endpoints use ``custom`` on the agent while pools are keyed
+    ``custom:<name>``; match only when the agent's current base_url resolves
+    to that pool key so fallback leftovers cannot contaminate restore.
+    """
+    current_provider = (
+        provider if provider is not None else (getattr(agent, "provider", "") or "")
+    ).strip().lower()
+    pool_provider = (getattr(pool, "provider", "") or "").strip().lower()
+    if not current_provider or not pool_provider:
+        return True
+    if current_provider == pool_provider:
+        return True
+    agent_base = (
+        base_url if base_url is not None else (getattr(agent, "base_url", "") or "")
+    ).strip()
+    if current_provider == "custom" and pool_provider.startswith("custom:"):
+        try:
+            from agent.credential_pool import get_custom_provider_pool_key
+
+            return bool(agent_base) and (
+                (get_custom_provider_pool_key(agent_base) or "").strip().lower()
+                == pool_provider
+            )
+        except Exception:
+            return False
+    return False
+
 
 def recover_with_credential_pool(
     agent,
@@ -697,36 +733,16 @@ def recover_with_credential_pool(
     # subsequent request then goes to the wrong host and 404s (see #33163).
     # The pool should only act when the agent is still on the same provider
     # that seeded the pool.
-    current_provider = (getattr(agent, "provider", "") or "").strip().lower()
-    pool_provider = (getattr(pool, "provider", "") or "").strip().lower()
-    if current_provider and pool_provider and current_provider != pool_provider:
-        # Custom endpoints use two naming conventions for the SAME provider:
-        # the agent carries the generic ``custom`` label while the pool is
-        # keyed ``custom:<name>`` (see CUSTOM_POOL_PREFIX). A literal string
-        # compare treats them as a mismatch and skips recovery for every
-        # custom-provider user — 401s/429s then burn the full retry cycle
-        # with no rotation or refresh. Accept the pair as matching only when
-        # the agent's CURRENT base_url actually resolves to this pool key,
-        # so a fallback provider (or a different custom endpoint) still
-        # triggers the guard.
-        _custom_match = False
-        if current_provider == "custom" and pool_provider.startswith("custom:"):
-            try:
-                from agent.credential_pool import get_custom_provider_pool_key
-                _agent_base = (getattr(agent, "base_url", "") or "").strip()
-                _custom_match = bool(_agent_base) and (
-                    (get_custom_provider_pool_key(_agent_base) or "").strip().lower()
-                    == pool_provider
-                )
-            except Exception:
-                _custom_match = False
-        if not _custom_match:
-            _ra().logger.warning(
-                "Credential pool provider mismatch: pool=%s, agent=%s — "
-                "skipping pool mutation to avoid cross-provider contamination",
-                pool_provider, current_provider,
-            )
-            return False, has_retried_429
+    if not credential_pool_matches_agent(pool, agent):
+        pool_provider = (getattr(pool, "provider", "") or "").strip().lower()
+        current_provider = (getattr(agent, "provider", "") or "").strip().lower()
+        _ra().logger.warning(
+            "Credential pool provider mismatch: pool=%s, agent=%s — "
+            "skipping pool mutation to avoid cross-provider contamination",
+            pool_provider,
+            current_provider,
+        )
+        return False, has_retried_429
 
     effective_reason = classified_reason
     if effective_reason is None:
@@ -1182,22 +1198,30 @@ def restore_primary_runtime(agent) -> bool:
         # keep the snapshot key (the existing behavior).  Fixes #25205.
         pool = getattr(agent, "_credential_pool", None)
         if pool is not None and pool.has_available():
-            entry = pool.select()
-            if entry is not None:
-                entry_key = (
-                    getattr(entry, "runtime_api_key", None)
-                    or getattr(entry, "access_token", "")
-                )
-                if entry_key:
-                    # ``_swap_credential`` rebuilds the OpenAI/Anthropic client,
-                    # reapplies base-url-scoped headers, and carries the
-                    # accumulated base_url / OAuth-detection fixes (#33163).
-                    agent._swap_credential(entry)
-                    logger.info(
-                        "Restore re-selected pool entry %s (%s)",
-                        getattr(entry, "id", "?"),
-                        getattr(entry, "label", "?"),
+            if credential_pool_matches_agent(pool, agent):
+                entry = pool.select()
+                if entry is not None:
+                    entry_key = (
+                        getattr(entry, "runtime_api_key", None)
+                        or getattr(entry, "access_token", "")
                     )
+                    if entry_key:
+                        # ``_swap_credential`` rebuilds the OpenAI/Anthropic client,
+                        # reapplies base-url-scoped headers, and carries the
+                        # accumulated base_url / OAuth-detection fixes (#33163).
+                        agent._swap_credential(entry)
+                        logger.info(
+                            "Restore re-selected pool entry %s (%s)",
+                            getattr(entry, "id", "?"),
+                            getattr(entry, "label", "?"),
+                        )
+            else:
+                pool_provider = (getattr(pool, "provider", "") or "").strip().lower()
+                logger.warning(
+                    "Restore skipped credential pool reselect: pool=%s, agent=%s",
+                    pool_provider,
+                    (agent.provider or "").strip().lower(),
+                )
 
         # ── Reset fallback chain for the new turn ──
         agent._fallback_activated = False

--- a/tests/agent/test_credential_pool_matches_agent.py
+++ b/tests/agent/test_credential_pool_matches_agent.py
@@ -1,0 +1,33 @@
+# Copyright 2025 Nous Research (Licensed under the Apache License, Version 2.0)
+"""Tests for credential_pool_matches_agent provider gating."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.agent_runtime_helpers import credential_pool_matches_agent
+
+
+def test_matches_same_provider():
+    pool = SimpleNamespace(provider="openai-codex")
+    agent = SimpleNamespace(provider="openai-codex", base_url="https://example.com/v1")
+    assert credential_pool_matches_agent(pool, agent) is True
+
+
+def test_rejects_cross_provider_mismatch():
+    pool = SimpleNamespace(provider="deepseek")
+    agent = SimpleNamespace(
+        provider="custom",
+        base_url="https://primary-host.example.com/v1",
+    )
+    assert credential_pool_matches_agent(pool, agent) is False
+
+
+def test_accepts_custom_agent_with_matching_custom_pool_key():
+    pool = SimpleNamespace(provider="custom:together")
+    agent = SimpleNamespace(provider="custom", base_url="https://api.together.xyz/v1")
+
+    with patch(
+        "agent.credential_pool.get_custom_provider_pool_key",
+        return_value="custom:together",
+    ):
+        assert credential_pool_matches_agent(pool, agent) is True

--- a/tests/agent/test_restore_primary_pool_reselect.py
+++ b/tests/agent/test_restore_primary_pool_reselect.py
@@ -220,3 +220,36 @@ class TestRestorePrimaryPoolReselect:
         assert result is True
         assert "custom-endpoint.example.com" in agent.base_url
         assert "custom-endpoint.example.com" in agent._client_kwargs["base_url"]
+
+    def test_restore_skips_mismatched_fallback_pool(self):
+        """Do not swap a fallback-provider pool entry while restoring primary."""
+        entries = [
+            _make_entry("deepseek-1", "deepseek-key", priority=0),
+        ]
+        pool = _build_mock_pool(entries)
+        pool.provider = "deepseek"
+
+        agent = self._make_agent(pool)
+        agent.provider = "custom"
+        agent.model = "ornith-35b"
+        agent.base_url = "https://primary-host.example.com/v1"
+        agent.api_key = "primary-snapshot-key"
+        agent._client_kwargs["api_key"] = "primary-snapshot-key"
+        agent._client_kwargs["base_url"] = "https://primary-host.example.com/v1"
+        agent._primary_runtime["provider"] = "custom"
+        agent._primary_runtime["model"] = "ornith-35b"
+        agent._primary_runtime["base_url"] = "https://primary-host.example.com/v1"
+        agent._primary_runtime["api_key"] = "primary-snapshot-key"
+        agent._primary_runtime["client_kwargs"] = {
+            "api_key": "primary-snapshot-key",
+            "base_url": "https://primary-host.example.com/v1",
+        }
+        agent._swap_credential = MagicMock()
+
+        result = agent._restore_primary_runtime()
+
+        assert result is True
+        agent._swap_credential.assert_not_called()
+        assert agent.api_key == "primary-snapshot-key"
+        assert agent._client_kwargs["api_key"] == "primary-snapshot-key"
+        assert agent.base_url == "https://primary-host.example.com/v1"


### PR DESCRIPTION
## Summary

- Add shared `credential_pool_matches_agent()` and use it in both `recover_with_credential_pool()` and `restore_primary_runtime()`.
- When restoring the primary runtime at turn start, skip credential-pool reselect if the pool belongs to a different provider (e.g. leftover DeepSeek pool after custom-primary fallback).

Fixes #56374

## Problem

`restore_primary_runtime()` re-selected from `agent._credential_pool` without checking provider alignment. After cross-provider fallback, a leftover fallback pool could overwrite `api_key` / `base_url` while `agent.model` stayed on the primary model, sending the wrong model name to the wrong endpoint.

## Evidence

- `python -m pytest tests/agent/test_restore_primary_pool_reselect.py tests/agent/test_credential_pool_matches_agent.py` — 11/11 pass
- `python -m pytest tests/run_agent/test_fallback_credential_isolation.py` — pass

## Related

Complements open PR #52799 (provider-gated pools on model switch); this covers the remaining `restore_primary_runtime()` call site called out in #56374.

Made with [Cursor](https://cursor.com)