### PR TITLE
fix: include Homebrew/Linuxbrew bin dirs in service PATH

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2615,6 +2615,29 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
+    # Package-manager bin dirs. launchd's default PATH
+    # (/usr/bin:/bin:/usr/sbin:/sbin) and systemd's minimal unit PATH both
+    # omit these, so CLI tools installed via Homebrew (gh, jq, ffmpeg, ...)
+    # or /usr/local (Linux tarball installs, Linuxbrew) are invisible to
+    # cron job scripts and any subprocess launched from the running gateway
+    # service — even though the same tools resolve fine in an interactive
+    # shell or when a tool is invoked manually from this codebase. Seen
+    # live: a cron job's `script` shelling out to `gh` raised
+    # FileNotFoundError under the gateway service despite `which gh`
+    # succeeding in every interactive terminal. Homebrew installs to
+    # /opt/homebrew on Apple Silicon and /usr/local on Intel Macs;
+    # Linuxbrew defaults to /home/linuxbrew/.linuxbrew.
+    for pm_dir in (
+        "/opt/homebrew/bin",
+        "/opt/homebrew/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/home/linuxbrew/.linuxbrew/bin",
+        "/home/linuxbrew/.linuxbrew/sbin",
+    ):
+        if _is_dir(Path(pm_dir)):
+            candidates.append(pm_dir)
+
     return candidates
 
 

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -28,3 +28,69 @@ def test_service_path_includes_hermes_home_node_modules(tmp_path):
     with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
         dirs = _build_service_path_dirs(project_root=tmp_path)
     assert str(hermes_nm) in dirs
+
+
+def test_service_path_includes_existing_package_manager_dirs(tmp_path):
+    """Homebrew/Linuxbrew/usr-local bin dirs must be on the service PATH when present.
+
+    launchd's default PATH (/usr/bin:/bin:/usr/sbin:/sbin) and systemd's
+    minimal unit PATH both omit these, so CLI tools installed via Homebrew
+    (gh, jq, ffmpeg, ...) are invisible to cron job scripts and any
+    subprocess launched from the running gateway service, even though the
+    same tools resolve fine in an interactive shell. Regression coverage
+    for the gap that made a cron job's `gh` call fail with
+    FileNotFoundError under the gateway service.
+    """
+    from pathlib import Path
+    import hermes_cli.gateway as gateway_module
+
+    real_is_dir = Path.is_dir
+    existing = {"/opt/homebrew/bin", "/usr/local/bin"}
+
+    def fake_is_dir(self):
+        if str(self) in existing:
+            return True
+        if str(self) in {
+            "/opt/homebrew/sbin",
+            "/usr/local/sbin",
+            "/home/linuxbrew/.linuxbrew/bin",
+            "/home/linuxbrew/.linuxbrew/sbin",
+        }:
+            return False
+        return real_is_dir(self)
+
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"), \
+         patch.object(Path, "is_dir", fake_is_dir):
+        dirs = gateway_module._build_service_path_dirs(project_root=tmp_path)
+
+    assert "/opt/homebrew/bin" in dirs
+    assert "/usr/local/bin" in dirs
+    assert "/opt/homebrew/sbin" not in dirs
+    assert "/home/linuxbrew/.linuxbrew/bin" not in dirs
+
+
+def test_service_path_omits_absent_package_manager_dirs(tmp_path):
+    """No package-manager dir should be added when none exist on disk."""
+    from pathlib import Path
+    import hermes_cli.gateway as gateway_module
+
+    pm_dirs = {
+        "/opt/homebrew/bin",
+        "/opt/homebrew/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/home/linuxbrew/.linuxbrew/bin",
+        "/home/linuxbrew/.linuxbrew/sbin",
+    }
+    real_is_dir = Path.is_dir
+
+    def fake_is_dir(self):
+        if str(self) in pm_dirs:
+            return False
+        return real_is_dir(self)
+
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"), \
+         patch.object(Path, "is_dir", fake_is_dir):
+        dirs = gateway_module._build_service_path_dirs(project_root=tmp_path)
+
+    assert not (set(dirs) & pm_dirs)


### PR DESCRIPTION
## Problem

Cron job scripts (and any subprocess launched from the running gateway service) can't see CLI tools installed via Homebrew (`gh`, `jq`, `ffmpeg`, ...) or `/usr/local`, even though the same tools resolve fine in an interactive shell.

Concretely: a cron job's `script` shelled out to `gh` and crashed with `FileNotFoundError: [Errno 2] No such file or directory: 'gh'`, despite `which gh` succeeding in every interactive terminal on the same machine (macOS, Apple Silicon, Homebrew-installed `gh`).

## Root cause

`_build_service_path_dirs()` (in `hermes_cli/gateway.py`) feeds both `generate_launchd_plist()` and the systemd unit generator. It only ever added `venv/bin`, `node_modules/.bin`, and Hermes-managed node dirs to the service PATH. launchd's default PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) and systemd's minimal unit PATH both omit package-manager install locations entirely, so any tool installed outside those defaults is invisible to processes spawned by the gateway service — including cron job scripts, which is how this was discovered.

## Fix

Append the standard Homebrew (`/opt/homebrew` on Apple Silicon, `/usr/local` on Intel Macs) and Linuxbrew (`/home/linuxbrew/.linuxbrew`) `bin`/`sbin` directories to the candidate list, each gated by an existence check exactly like the other entries in this function — so the generated PATH never grows with dead/non-existent entries on machines that don't have these installed.

## Tests

Added `test_service_path_includes_existing_package_manager_dirs` and `test_service_path_omits_absent_package_manager_dirs` to `tests/hermes_cli/test_gateway_service_paths.py`, covering both the present and absent cases with mocked `Path.is_dir`.

```bash
PYTHONPATH=$(pwd) venv/bin/python -m pytest tests/hermes_cli/test_gateway_service_paths.py -v
# 5 passed
```

Also ran the broader gateway/cron suite to check for regressions:

```bash
PYTHONPATH=$(pwd) venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_service_paths.py tests/hermes_cli/test_gateway_restart_loop.py tests/hermes_cli/test_web_server_cron_profiles.py tests/cron/ -q
# 878 passed, 6 pre-existing failures
```

The 6 failures are systemd/D-Bus tests requiring a Linux user D-Bus session (not runnable on macOS) — confirmed identical failure set on unmodified `origin/main` as baseline, so nothing was introduced by this change.