### PR TITLE
fix(gateway): preserve sessions.source on /resume peer updates

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1648,23 +1648,30 @@ class SessionDB:
         chat_type: str = None,
         thread_id: str = None,
     ) -> None:
-        """Persist the gateway routing peer for an existing session row."""
+        """Persist the gateway routing peer for an existing session row.
+
+        ``source`` records where the conversation was *created* (billing,
+        analytics, memory scoping). Gateway ``/resume`` and cross-platform
+        routing may update ``session_key``/chat metadata without overwriting
+        that creation source.
+        """
         if not session_id or not session_key:
             return
 
         def _do(conn):
             conn.execute(
                 """UPDATE sessions
-                   SET session_key = ?, source = ?, user_id = ?, chat_id = ?,
-                       chat_type = ?, thread_id = ?
+                   SET session_key = ?, user_id = ?, chat_id = ?,
+                       chat_type = ?, thread_id = ?,
+                       source = COALESCE(source, ?)
                    WHERE id = ?""",
                 (
                     session_key,
-                    source,
                     user_id,
                     chat_id,
                     chat_type,
                     thread_id,
+                    source,
                     session_id,
                 ),
             )
@@ -1693,20 +1700,24 @@ class SessionDB:
         """
         if not session_key:
             return None
-        with self._lock:
-            row = self._conn.execute(
-                """
-                SELECT * FROM sessions
-                WHERE session_key = ?
-                  AND source = ?
+        recoverable_clause = """
                   AND (ended_at IS NULL OR end_reason = 'agent_close')
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
-                  ))
+                  ))"""
+        with self._lock:
+            # ``session_key`` is the durable routing index. After cross-platform
+            # ``/resume`` the creation ``source`` may differ from the resuming
+            # platform, so key-based lookup must not filter on ``source``.
+            row = self._conn.execute(
+                f"""
+                SELECT * FROM sessions
+                WHERE session_key = ?
+                {recoverable_clause}
                 ORDER BY started_at DESC
                 LIMIT 1
                 """,
-                (session_key, source),
+                (session_key,),
             ).fetchone()
             if row is not None:
                 return dict(row)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4766,6 +4766,42 @@ class TestListCronJobRuns:
         assert "idx_sessions_source" in detail, detail
 
 
+def test_gateway_session_peer_preserves_creation_source_on_resume(db):
+    db.create_session(
+        "cross-platform-session",
+        "tui",
+        user_id="user-1",
+        session_key="agent:main:tui:dm:local",
+        chat_id="local",
+        chat_type="dm",
+    )
+    db.append_message("cross-platform-session", "user", "started in tui")
+
+    db.record_gateway_session_peer(
+        "cross-platform-session",
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-99",
+        chat_id="chat-99",
+        chat_type="dm",
+    )
+
+    row = db.get_session("cross-platform-session")
+    assert row["source"] == "tui"
+    assert row["session_key"] == "agent:main:telegram:dm:chat-99"
+    assert row["chat_id"] == "chat-99"
+
+    recovered = db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-99",
+        chat_id="chat-99",
+        chat_type="dm",
+    )
+    assert recovered["id"] == "cross-platform-session"
+    assert recovered["source"] == "tui"
+
+
 def test_gateway_session_peer_round_trip_and_recovery(db):
     db.create_session(
         "gw-session",


### PR DESCRIPTION
## Summary

Fixes #56439.

- `record_gateway_session_peer` no longer overwrites `sessions.source` when gateway `/resume` or `switch_session` updates routing metadata; uses `COALESCE(source, ?)` so bare rows can still be backfilled once.
- `find_latest_gateway_session_for_peer` resolves recoverable sessions by `session_key` alone so cross-platform resume still works when creation source differs from the resuming platform.

## Test plan

- [x] `pytest tests/test_hermes_state.py::test_gateway_session_peer_preserves_creation_source_on_resume`
- [x] `pytest tests/test_hermes_state.py::test_gateway_session_peer_round_trip_and_recovery`
- [x] `pytest tests/test_hermes_state.py::test_gateway_session_recovery_reopens_legacy_agent_close_rows`
- [x] `pytest tests/gateway/test_session.py::TestSessionStoreSwitchSession`
