### PR TITLE
fix(model): prefer authenticated aggregators over unauthed vendor pins

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1102,7 +1102,16 @@ def switch_model(
             and not resolved_in_current_catalog
             and not config_routed
         ):
-            detected = detect_provider_for_model(new_model, current_provider)
+            authed = get_authenticated_provider_slugs(
+                current_provider=current_provider,
+                user_providers=user_providers,
+                custom_providers=custom_providers,
+            )
+            detected = detect_provider_for_model(
+                new_model,
+                current_provider,
+                authenticated_providers=authed,
+            )
             if detected:
                 target_provider, new_model = detected
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -206,6 +206,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "z-ai/glm-5.1",
         # Xiaomi
         "xiaomi/mimo-v2.5-pro",
+        "xiaomi/mimo-v2.5",
         # Tencent
         "tencent/hy3-preview",
         # StepFun
@@ -1871,6 +1872,72 @@ def _resolve_static_model_alias(
     return None
 
 
+def _aggregator_catalog_models(provider: str) -> list[str]:
+    """Return the model catalog for an aggregator provider."""
+    try:
+        from agent.models_dev import list_provider_models
+
+        catalog = list_provider_models(provider)
+    except Exception:
+        catalog = []
+    if not catalog:
+        catalog = list(_PROVIDER_MODELS.get(provider, []))
+    return catalog
+
+
+def _find_aggregator_catalog_match(
+    model_name: str,
+    aggregator_provider: str,
+) -> Optional[str]:
+    """Find a catalog entry for *model_name* on an aggregator provider."""
+    name = (model_name or "").strip()
+    if not name:
+        return None
+
+    from hermes_cli.model_normalize import _prepend_vendor
+
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def _add(cand: str) -> None:
+        key = cand.strip().lower()
+        if key and key not in seen:
+            seen.add(key)
+            candidates.append(cand.strip())
+
+    _add(name)
+    if "/" not in name:
+        prefixed = _prepend_vendor(name)
+        if prefixed != name:
+            _add(prefixed)
+
+    for mid in _aggregator_catalog_models(aggregator_provider):
+        mid_l = mid.lower()
+        for cand in candidates:
+            cl = cand.lower()
+            if mid_l == cl:
+                return mid
+            if "/" in mid:
+                _, bare = mid.split("/", 1)
+                if bare.lower() == cl:
+                    return mid
+    return None
+
+
+def _resolve_via_authenticated_aggregators(
+    model_name: str,
+    authenticated_providers: list[str],
+) -> Optional[tuple[str, str]]:
+    """Route a model through an authenticated aggregator when possible."""
+    for provider in authenticated_providers:
+        if provider not in _AGGREGATOR_PROVIDERS:
+            continue
+        matched = _find_aggregator_catalog_match(model_name, provider)
+        if matched:
+            return (provider, matched)
+    return None
+
+
 def detect_static_provider_for_model(
     model_name: str,
     current_provider: str,
@@ -1947,6 +2014,7 @@ def detect_static_provider_for_model(
 def detect_provider_for_model(
     model_name: str,
     current_provider: str,
+    authenticated_providers: Optional[list[str]] = None,
 ) -> Optional[tuple[str, str]]:
     """Auto-detect the best provider for a model name.
 
@@ -1958,6 +2026,11 @@ def detect_provider_for_model(
     0. Bare provider name → switch to that provider's default model
     1. Direct provider static catalog match
     2. OpenRouter catalog match
+
+    When *authenticated_providers* is supplied, a static match that would pin
+    the model to a native provider without credentials is skipped in favour of
+    an authenticated aggregator route (e.g. bare ``mimo-v2.5`` via Nous OAuth
+    instead of direct ``xiaomi``).
     """
     name = (model_name or "").strip()
     if not name:
@@ -1965,7 +2038,17 @@ def detect_provider_for_model(
 
     static_match = detect_static_provider_for_model(name, current_provider)
     if static_match:
-        return static_match
+        pid, mid = static_match
+        if authenticated_providers is not None:
+            authed = set(authenticated_providers)
+            if pid in authed:
+                return static_match
+            agg = _resolve_via_authenticated_aggregators(mid, list(authed))
+            if agg:
+                return agg
+            # Fall through — do not pin to an unauthenticated native provider.
+        else:
+            return static_match
     if _model_in_provider_catalog(name.lower(), _provider_keys(current_provider)):
         return None
 

--- a/tests/hermes_cli/test_model_switch_vendor_prefix_credentials.py
+++ b/tests/hermes_cli/test_model_switch_vendor_prefix_credentials.py
@@ -1,0 +1,80 @@
+"""Regression tests for #56465 — vendor-prefix models must not pin unauthed natives."""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import models
+from hermes_cli.model_switch import switch_model
+
+
+def test_detect_provider_for_model_prefers_authenticated_nous_over_xiaomi(monkeypatch):
+    monkeypatch.setattr(
+        models,
+        "_aggregator_catalog_models",
+        lambda provider: ["xiaomi/mimo-v2.5"] if provider == "nous" else [],
+    )
+
+    result = models.detect_provider_for_model(
+        "mimo-v2.5",
+        "nous",
+        authenticated_providers=["nous"],
+    )
+
+    assert result == ("nous", "xiaomi/mimo-v2.5")
+
+
+def test_detect_provider_for_model_skips_unauthed_xiaomi_when_nous_authed(monkeypatch):
+    monkeypatch.setattr(models, "_aggregator_catalog_models", lambda provider: [])
+
+    result = models.detect_provider_for_model(
+        "mimo-v2.5",
+        "nous",
+        authenticated_providers=["nous"],
+    )
+
+    assert result is None
+
+
+def test_detect_provider_for_model_keeps_xiaomi_when_authed():
+    result = models.detect_provider_for_model(
+        "mimo-v2.5",
+        "nous",
+        authenticated_providers=["nous", "xiaomi"],
+    )
+
+    assert result == ("xiaomi", "mimo-v2.5")
+
+
+def test_switch_model_mimo_v25_stays_on_nous_without_xiaomi_key():
+    runtime = {
+        "api_key": "nous-oauth-token",
+        "base_url": "https://api.nousresearch.com/v1",
+        "api_mode": "",
+    }
+
+    with patch(
+        "hermes_cli.model_switch.get_authenticated_provider_slugs",
+        return_value=["nous"],
+    ), patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value=runtime,
+    ), patch(
+        "hermes_cli.models.validate_requested_model",
+        return_value={
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": "",
+        },
+    ):
+        result = switch_model(
+            raw_input="mimo-v2.5",
+            current_provider="nous",
+            current_model="deepseek/deepseek-v4-flash",
+            is_global=False,
+        )
+
+    assert result.success, result.error_message
+    assert result.target_provider == "nous"
+    assert result.new_model == "xiaomi/mimo-v2.5"


### PR DESCRIPTION
## Summary

Fixes #56465.

- `detect_provider_for_model()` accepts `authenticated_providers` and no longer pins bare vendor-prefixed models (e.g. `mimo-v2.5` → `xiaomi`) when that native provider lacks credentials.
- When an authenticated aggregator (Nous, OpenRouter, Kilocode) lists the model, route there with the vendor-prefixed slug (e.g. `nous` + `xiaomi/mimo-v2.5`).
- `switch_model()` passes the authenticated provider list into detection so `/model mimo-v2.5` works with Nous OAuth and no `XIAOMI_API_KEY`.
- Add `xiaomi/mimo-v2.5` to the Nous static catalog.

## Test plan

- [x] `pytest tests/hermes_cli/test_model_switch_vendor_prefix_credentials.py`
- [x] `pytest tests/hermes_cli/test_models.py::TestDetectProviderForModel`
