### PR TITLE
fix(mcp): preserve OAuth provider on initial token mtime

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -115,10 +115,14 @@ async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
     mgr = MCPOAuthManager()
     provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
     assert provider is not None
+    provider._initialized = True
 
-    # First call: records mtime (zero -> real) -> returns True
+    # First call: records mtime (zero -> real) as baseline, returns False.
+    # Forcing a reload on first observation tears down the streamable-http
+    # connection before tools register (NousResearch/hermes-agent#39551).
     changed1 = await mgr.invalidate_if_disk_changed("srv")
-    assert changed1 is True
+    assert changed1 is False
+    assert provider._initialized is True
 
     # No file change -> False
     changed2 = await mgr.invalidate_if_disk_changed("srv")
@@ -127,6 +131,7 @@ async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
     # Touch file with a newer mtime
     future_mtime = time.time() + 10
     os.utime(tokens_file, (future_mtime, future_mtime))
+    provider._initialized = True
 
     changed3 = await mgr.invalidate_if_disk_changed("srv")
     assert changed3 is True

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -599,6 +599,19 @@ class MCPOAuthManager:
             if mtime_ns != entry.last_mtime_ns:
                 old = entry.last_mtime_ns
                 entry.last_mtime_ns = mtime_ns
+                # First observation of an existing tokens file: record the
+                # baseline mtime and DO NOT force a reload. Forcing a reload
+                # here resets _initialized in the middle of the first auth
+                # flow and tears the streamable-http connection down before
+                # tools register (NousResearch/hermes-agent#39551). A reload
+                # is only meaningful for catching external refreshes after
+                # the baseline already exists.
+                if old == 0:
+                    logger.debug(
+                        "MCP OAuth '%s': baseline tokens mtime recorded (%d)",
+                        server_name, mtime_ns,
+                    )
+                    return False
                 # Force the SDK's OAuthClientProvider to reload from storage
                 # on its next auth flow. `_initialized` is private API but
                 # stable across the MCP SDK versions we pin (>=1.26.0).


### PR DESCRIPTION
## Summary
- avoid invalidating the MCP OAuth provider on the first observed token-file mtime
- keep real later token-file changes invalidating the provider so external refreshes still reload from disk
- update the disk-watch test to cover both the baseline observation and real-change paths

## Root cause
`invalidate_if_disk_changed()` treated `last_mtime_ns == 0 -> current mtime` as an external token-file change. For HTTP/StreamableHTTP OAuth MCP servers that already have cached tokens, that first baseline observation reset the SDK provider `_initialized` state during startup, which can tear down the connection before tools register.

## Validation
- `uv run --extra dev pytest tests/tools/test_mcp_oauth_manager.py -q`
- Result: `16 passed in 6.72s`
- Note: pytest emitted a Windows temp cleanup `PermissionError` from its atexit cleanup after the successful run; the command exited 0 and all targeted tests passed.

Refs #39551