### PR TITLE
fix(telegram): preserve slash-command args after @bot mention

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6569,6 +6569,19 @@ class TelegramAdapter(BasePlatformAdapter):
         if not text or not self._bot or not getattr(self._bot, "username", None):
             return text
         username = re.escape(self._bot.username)
+        # Telegram group menus send slash commands as /cmd@BotName args. Strip
+        # only our bot suffix from the command token so args stay separated
+        # (/reasoning@LynxBot medium -> /reasoning medium, not /reasoningmedium).
+        slash_cmd = re.match(
+            rf"^(/[\w-]+)@{username}\b[,:\-]*\s*(.*)$",
+            text,
+            re.IGNORECASE | re.DOTALL,
+        )
+        if slash_cmd:
+            command, args = slash_cmd.group(1), slash_cmd.group(2)
+            if args:
+                return f"{command} {args}".strip()
+            return command
         cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
         return cleaned or text
 

--- a/tests/plugins/platforms/telegram/test_clean_bot_trigger_text.py
+++ b/tests/plugins/platforms/telegram/test_clean_bot_trigger_text.py
@@ -1,0 +1,43 @@
+"""Regression tests for Telegram /command@BotName argument parsing (#56337)."""
+
+from types import SimpleNamespace
+
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _adapter_with_bot(username: str = "LynxBot") -> TelegramAdapter:
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = SimpleNamespace(username=username)
+    return adapter
+
+
+def test_slash_command_preserves_args_after_bot_mention():
+    adapter = _adapter_with_bot()
+    assert adapter._clean_bot_trigger_text("/reasoning@LynxBot medium") == "/reasoning medium"
+
+
+def test_slash_command_strips_punctuation_after_bot_mention():
+    adapter = _adapter_with_bot()
+    assert (
+        adapter._clean_bot_trigger_text("/reasoning@LynxBot: high --global")
+        == "/reasoning high --global"
+    )
+
+
+def test_bare_slash_command_mention_stays_compact():
+    adapter = _adapter_with_bot()
+    assert adapter._clean_bot_trigger_text("/new@LynxBot") == "/new"
+
+
+def test_leading_mention_trigger_still_strips_bot_prefix():
+    adapter = _adapter_with_bot("hermes_bot")
+    assert adapter._clean_bot_trigger_text("@hermes_bot what did Alice say?") == (
+        "what did Alice say?"
+    )
+
+
+def test_other_bot_mention_in_slash_command_is_unchanged():
+    adapter = _adapter_with_bot("LynxBot")
+    assert adapter._clean_bot_trigger_text("/reasoning@OtherBot medium") == (
+        "/reasoning@OtherBot medium"
+    )


### PR DESCRIPTION
## Summary

Fixes #56337.

Telegram group command menus send `/command@BotName args`. `_clean_bot_trigger_text` stripped `@BotName` with trailing whitespace globally, which glued the command name to its first argument (`/reasoning@LynxBot medium` → `/reasoningmedium`).

Now slash commands parse the `@BotName` suffix on the command token separately, preserving args and optional `:,-` punctuation separators.

## Test plan

- [x] `pytest tests/plugins/platforms/telegram/test_clean_bot_trigger_text.py`
