### PR TITLE
fix(web): refresh active session rows when metadata changes

### DIFF
--- a/web/src/lib/session-refresh.test.ts
+++ b/web/src/lib/session-refresh.test.ts
@@ -2,20 +2,54 @@ import { describe, it, expect } from "vitest";
 import { shouldRefreshSessions } from "./session-refresh";
 
 describe("shouldRefreshSessions", () => {
+  const session = {
+    id: "s1",
+    title: "Active chat",
+    last_active: 1_782_902_400,
+    is_active: true,
+    message_count: 0,
+    tool_call_count: 0,
+    preview: "",
+  };
+
   it("returns false on the first poll (no baseline yet)", () => {
-    expect(shouldRefreshSessions(null, "s2")).toBe(false);
+    expect(shouldRefreshSessions(null, [{ ...session, id: "s2" }])).toBe(
+      false,
+    );
   });
 
   it("returns false when the current response has no sessions", () => {
-    expect(shouldRefreshSessions("s1", null)).toBe(false);
-    expect(shouldRefreshSessions(null, null)).toBe(false);
+    expect(shouldRefreshSessions([session], [])).toBe(false);
+    expect(shouldRefreshSessions(null, [])).toBe(false);
   });
 
   it("returns false when the newest session id is unchanged", () => {
-    expect(shouldRefreshSessions("s1", "s1")).toBe(false);
+    expect(shouldRefreshSessions([session], [{ ...session }])).toBe(false);
   });
 
   it("returns true when a new session appears at the head of the list", () => {
-    expect(shouldRefreshSessions("s1", "s2")).toBe(true);
+    expect(
+      shouldRefreshSessions([session], [{ ...session, id: "s2" }]),
+    ).toBe(true);
+  });
+
+  it("returns true when sessions appear after an empty baseline", () => {
+    expect(shouldRefreshSessions([], [session])).toBe(true);
+  });
+
+  it("returns true when an active session changes without a new newest id", () => {
+    expect(
+      shouldRefreshSessions(
+        [session],
+        [
+          {
+            ...session,
+            message_count: 2,
+            preview: "Hello there",
+            last_active: 1_782_902_460,
+          },
+        ],
+      ),
+    ).toBe(true);
   });
 });

--- a/web/src/lib/session-refresh.ts
+++ b/web/src/lib/session-refresh.ts
@@ -6,21 +6,71 @@
  * processes that share the same SQLite session DB. There is no
  * inter-process push channel, so the Sessions page polls the 50 newest
  * sessions every few seconds (the "overview" poll). When that poll
- * surfaces a session id at the head of the list that we have not seen
- * before, a new session was created in another process and the
- * paginated list is stale — refresh it.
+ * surfaces a new session at the head of the list, or detects visible
+ * changes to an active session already in the list, the paginated list
+ * is stale and should be refreshed silently.
  *
- * Returns false on the very first poll (no baseline yet) and when
- * either id is null (empty DB / transient empty response), so we never
- * trigger a spurious reload on mount or while the DB is empty.
+ * Returns false on the very first poll (no baseline yet) and when the
+ * current response is empty, so we never trigger a spurious reload on
+ * mount or while the DB is empty.
  */
+export interface SessionRefreshSnapshotItem {
+  id: string;
+  title?: string | null;
+  last_active?: number | null;
+  ended_at?: number | null;
+  is_active?: boolean;
+  message_count?: number | null;
+  tool_call_count?: number | null;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  preview?: string | null;
+}
+
 export function shouldRefreshSessions(
-  prevNewestId: string | null,
-  currentNewestId: string | null,
+  prevSessions: readonly SessionRefreshSnapshotItem[] | null,
+  currentSessions: readonly SessionRefreshSnapshotItem[],
+): boolean {
+  if (prevSessions === null || currentSessions.length === 0) {
+    return false;
+  }
+  if (prevSessions.length === 0) {
+    return true;
+  }
+
+  const prevNewestId = prevSessions[0]?.id ?? null;
+  const currentNewestId = currentSessions[0]?.id ?? null;
+  if (prevNewestId === null || currentNewestId === null) {
+    return false;
+  }
+  if (prevNewestId !== currentNewestId) {
+    return true;
+  }
+
+  const prevById = new Map(prevSessions.map((session) => [session.id, session]));
+  return currentSessions.some((current) => {
+    const previous = prevById.get(current.id);
+    if (!previous || (!previous.is_active && !current.is_active)) {
+      return false;
+    }
+
+    return hasVisibleSessionChange(previous, current);
+  });
+}
+
+function hasVisibleSessionChange(
+  previous: SessionRefreshSnapshotItem,
+  current: SessionRefreshSnapshotItem,
 ): boolean {
   return (
-    prevNewestId !== null &&
-    currentNewestId !== null &&
-    prevNewestId !== currentNewestId
+    previous.title !== current.title ||
+    previous.last_active !== current.last_active ||
+    previous.ended_at !== current.ended_at ||
+    previous.is_active !== current.is_active ||
+    previous.message_count !== current.message_count ||
+    previous.tool_call_count !== current.tool_call_count ||
+    previous.input_tokens !== current.input_tokens ||
+    previous.output_tokens !== current.output_tokens ||
+    previous.preview !== current.preview
   );
 }

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -31,6 +31,7 @@ import {
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { shouldRefreshSessions } from "@/lib/session-refresh";
+import type { SessionRefreshSnapshotItem } from "@/lib/session-refresh";
 import type {
   SessionInfo,
   SessionMessage,
@@ -835,12 +836,15 @@ export default function SessionsPage() {
     loadStats();
   }, [loadStats]);
 
-  // Refs for the overview poll's new-session detection. The poll effect
+  // Refs for the overview poll's stale-list detection. The poll effect
   // below is mounted once with stable deps, so it reads the current page
-  // and the last-seen newest session id through refs instead of capturing
-  // stale values. ``newestSeenRef`` starts null so the first poll sets a
-  // baseline without triggering a redundant reload (mount already loads).
-  const newestSeenRef = useRef<string | null>(null);
+  // and the last overview snapshot through refs instead of capturing
+  // stale values. ``overviewSnapshotRef`` starts null so the first poll
+  // sets a baseline without triggering a redundant reload (mount already
+  // loads).
+  const overviewSnapshotRef = useRef<
+    readonly SessionRefreshSnapshotItem[] | null
+  >(null);
   const pageRef = useRef(page);
   pageRef.current = page;
 
@@ -861,16 +865,13 @@ export default function SessionsPage() {
           setOverviewSessions(r.sessions);
           // The dashboard server and a terminal CLI are separate
           // processes sharing one session DB — there is no push channel,
-          // so we detect sessions created in another process here. The
-          // overview poll already fetches the 50 newest sessions, so we
-          // reuse its head id as a cheap change signal: when it changes,
-          // silently refresh the paginated list so the new session shows
-          // up in real time without a visible loading flicker.
-          const newest = r.sessions[0]?.id ?? null;
-          if (shouldRefreshSessions(newestSeenRef.current, newest)) {
+          // so we detect new sessions and active-session changes from the
+          // overview poll and silently refresh the paginated list without
+          // a visible loading flicker.
+          if (shouldRefreshSessions(overviewSnapshotRef.current, r.sessions)) {
             loadSessions(pageRef.current, true);
           }
-          newestSeenRef.current = newest;
+          overviewSnapshotRef.current = r.sessions;
         })
         .catch(() => {});
     };


### PR DESCRIPTION
## What does this PR do?

The web Sessions page can show stale metadata for a live session when another Hermes process appends messages to the same session. The overview poll already runs every few seconds, but it only used the newest session id as its change signal. If the active session remains the newest row, the id does not change, so the paginated Sessions list can keep showing an old message count, preview, timestamp, or active state until a manual refresh.

This PR changes the overview-poll decision from a newest-id-only check to a lightweight snapshot comparison. The page still avoids a visible loading spinner, but it now silently refreshes the paginated list when active-session fields that are visible in the UI change while the session id stays the same.

## Related Issue

No upstream issue number. This was found while watching a live Hermes session continue receiving messages from another process while the web Sessions page still showed stale zero-message/old-preview state.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/lib/session-refresh.ts`: compare overview session snapshots instead of only the newest session id.
- `web/src/lib/session-refresh.ts`: trigger a silent paginated-list refresh when:
  - a new newest session appears,
  - sessions appear after a known empty baseline,
  - or a still-active/recently-active session changes visible fields such as message count, tool call count, token counts, title, preview, timestamps, or active state.
- `web/src/pages/SessionsPage.tsx`: keep the last overview snapshot in a ref and use it for stale-list detection during the existing overview poll.
- `web/src/lib/session-refresh.test.ts`: add regression coverage for first poll, empty responses, unchanged snapshots, new sessions, sessions appearing after an empty baseline, and same-id active-session updates.

## How to Test

1. `cd web && npm test -- --run src/lib/session-refresh.test.ts` — passed, 6 tests.
2. `cd web && npm test` — passed, 5 files / 33 tests.
3. `cd web && npm run typecheck` — passed.
4. `cd web && npm run build` — passed, with the existing Vite large-chunk warning.
5. `cd web && npx eslint src/lib/session-refresh.ts src/lib/session-refresh.test.ts` — passed.
6. `cd web && npm run lint` — fails on existing repo-wide React compiler/hook findings outside this patch, including pre-existing `SessionsPage` hook/ref findings. The changed helper/test files lint cleanly.
7. `pytest tests/ -q` — attempted after installing the full Python dev/test extras in a Python 3.11 venv. It does not pass in this checkout; failures are in existing Python tests unrelated to this web patch. The clearest isolated failure is `tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken` on macOS, where the test's global `subprocess.run` mock is also seen by the macOS keychain credential reader and produces `TypeError: the JSON object must be str, bytes or bytearray, not MagicMock`.
8. `scripts/run_tests.sh -j 8 tests/ -q` — attempted because the repo documents this as the canonical per-file pytest runner. It also fails before completion on existing Python-suite failures unrelated to this patch; after isolating `HOME`, the Bedrock local-region failure disappears, but the Anthropic OAuth mock/keychain failures remain.

## Duplicate Check

Searched open PRs for active/session refresh overlap before opening this PR.

- #53592 updates `apps/desktop` active-chat hydration for external messages. It does not change the web Sessions page paginated-list refresh path.
- #44465 is an older web Sessions polling PR. Current `main` already contains the silent-load/overview-polling structure, but the remaining refresh decision still keys off only the newest id. This PR narrows in on that same-id active-session metadata gap.
- #37766 is also a desktop active-session refresh path, not this web Sessions page path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (attempted; current checkout fails in unrelated Python tests, see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout, Node/npm web workspace

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

Regression evidence:

- Before the implementation, the focused test failed because the old helper could not correctly evaluate overview snapshots; unchanged same-id snapshots and empty current snapshots were treated as changed by reference.
- After the implementation, focused and full web tests pass.
