### PR TITLE
fix(gateway): add cleanup_audio_cache() and wire it into gateway housekeeping

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -905,6 +905,27 @@ async def cache_audio_from_url(url: str, ext: str = ".ogg", retries: int = 2) ->
                 raise
 
 
+def cleanup_audio_cache(max_age_hours: int = 24) -> int:
+    """
+    Delete cached audio files older than *max_age_hours*.
+
+    Returns the number of files removed.
+    """
+    import time
+
+    cache_dir = get_audio_cache_dir()
+    cutoff = time.time() - (max_age_hours * 3600)
+    removed = 0
+    for f in cache_dir.iterdir():
+        if f.is_file() and f.stat().st_mtime < cutoff:
+            try:
+                f.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed
+
+
 # ---------------------------------------------------------------------------
 # Video cache utilities
 #

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18934,7 +18934,11 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     hour, and polls the curator hourly (its inner gate enforces the real
     weekly cadence).
     """
-    from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.platforms.base import (
+        cleanup_audio_cache,
+        cleanup_document_cache,
+        cleanup_image_cache,
+    )
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -18978,6 +18982,12 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
                     logger.info("Document cache cleanup: removed %d stale file(s)", removed)
             except Exception as e:
                 logger.debug("Document cache cleanup error: %s", e)
+            try:
+                removed = cleanup_audio_cache(max_age_hours=24)
+                if removed:
+                    logger.info("Audio cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Audio cache cleanup error: %s", e)
 
         if tick_count % PASTE_SWEEP_EVERY == 0:
             try:

--- a/tests/gateway/test_audio_cache.py
+++ b/tests/gateway/test_audio_cache.py
@@ -1,0 +1,129 @@
+"""
+Tests for audio cache utilities in gateway/platforms/base.py.
+
+Covers: get_audio_cache_dir, cache_audio_from_bytes, cleanup_audio_cache.
+"""
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from gateway.platforms.base import (
+    cache_audio_from_bytes,
+    cleanup_audio_cache,
+    get_audio_cache_dir,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture: redirect AUDIO_CACHE_DIR to a temp directory for every test
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _redirect_cache(tmp_path, monkeypatch):
+    """Point the module-level AUDIO_CACHE_DIR to a fresh tmp_path."""
+    monkeypatch.setattr(
+        "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestGetAudioCacheDir
+# ---------------------------------------------------------------------------
+
+class TestGetAudioCacheDir:
+    def test_creates_directory(self):
+        cache_dir = get_audio_cache_dir()
+        assert cache_dir.exists()
+        assert cache_dir.is_dir()
+
+    def test_returns_existing_directory(self):
+        first = get_audio_cache_dir()
+        second = get_audio_cache_dir()
+        assert first == second
+        assert first.exists()
+
+
+# ---------------------------------------------------------------------------
+# TestCacheAudioFromBytes
+# ---------------------------------------------------------------------------
+
+class TestCacheAudioFromBytes:
+    def test_basic_caching(self):
+        data = b"fake-ogg-bytes"
+        path = cache_audio_from_bytes(data)
+        assert os.path.exists(path)
+        assert Path(path).read_bytes() == data
+
+    def test_default_extension(self):
+        path = cache_audio_from_bytes(b"data")
+        assert path.endswith(".ogg")
+
+    def test_custom_extension(self):
+        path = cache_audio_from_bytes(b"data", ext=".mp3")
+        assert path.endswith(".mp3")
+
+    def test_unique_filenames(self):
+        p1 = cache_audio_from_bytes(b"a")
+        p2 = cache_audio_from_bytes(b"b")
+        assert p1 != p2
+
+    def test_file_written_inside_cache_dir(self):
+        path = cache_audio_from_bytes(b"data")
+        cache_dir = get_audio_cache_dir()
+        assert Path(path).resolve().is_relative_to(cache_dir.resolve())
+
+
+# ---------------------------------------------------------------------------
+# TestCleanupAudioCache
+# ---------------------------------------------------------------------------
+
+class TestCleanupAudioCache:
+    def test_removes_old_files(self):
+        cache_dir = get_audio_cache_dir()
+        old_file = cache_dir / "old.ogg"
+        old_file.write_text("old")
+        # Set modification time to 48 hours ago
+        old_mtime = time.time() - 48 * 3600
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        removed = cleanup_audio_cache(max_age_hours=24)
+        assert removed == 1
+        assert not old_file.exists()
+
+    def test_keeps_recent_files(self):
+        cache_dir = get_audio_cache_dir()
+        recent = cache_dir / "recent.ogg"
+        recent.write_text("fresh")
+
+        removed = cleanup_audio_cache(max_age_hours=24)
+        assert removed == 0
+        assert recent.exists()
+
+    def test_returns_removed_count(self):
+        cache_dir = get_audio_cache_dir()
+        old_time = time.time() - 48 * 3600
+        for i in range(3):
+            f = cache_dir / f"old_{i}.ogg"
+            f.write_text("old")
+            os.utime(f, (old_time, old_time))
+
+        removed = cleanup_audio_cache(max_age_hours=24)
+        assert removed == 3
+
+    def test_ignores_subdirectories(self):
+        cache_dir = get_audio_cache_dir()
+        subdir = cache_dir / "subdir"
+        subdir.mkdir()
+        old_time = time.time() - 48 * 3600
+        os.utime(subdir, (old_time, old_time))
+
+        # Should not raise or attempt to remove the directory as a file.
+        removed = cleanup_audio_cache(max_age_hours=24)
+        assert removed == 0
+        assert subdir.exists()
+
+    def test_empty_cache_returns_zero(self):
+        removed = cleanup_audio_cache(max_age_hours=24)
+        assert removed == 0


### PR DESCRIPTION
## What does this PR do?

Adds `cleanup_audio_cache()` to `gateway/platforms/base.py` and wires it into `_start_gateway_housekeeping()` in `gateway/run.py`, removing cached audio files older than 24h on the existing hourly tick — the same cadence already used for the image and document cache cleanup in that function.

## Related Issue

Related: #39744 (audio-cache-cleanup request, closed in June as "addressed by #16473"; that PR has since stalled and now conflicts with `main`). Related: #16473 (the stalled PR this replaces).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: add `cleanup_audio_cache(max_age_hours: int = 24) -> int`, matching the existing `cleanup_image_cache()`/`cleanup_document_cache()` shape
- `gateway/run.py`: add `cleanup_audio_cache` to `_start_gateway_housekeeping()`'s import and sweep it in the existing `IMAGE_CACHE_EVERY` tick block
- `tests/gateway/test_audio_cache.py` (new): covers `get_audio_cache_dir`, `cache_audio_from_bytes`, and `cleanup_audio_cache`

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_audio_cache.py` — 12/12 pass
2. `scripts/run_tests.sh tests/gateway/` — full directory; two failures present (`test_agent_cache.py::test_honcho_cache_busting_config_memoized_by_mtime`, `test_matrix.py` timeout), both reproduced independently on a clean `main` with this diff stashed out, confirming they predate this change

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/` and reviewed all results
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Debian 13)

### Documentation & Housekeeping

- [x] N/A — no config keys, README, or tool schema changes
- [x] N/A — no architecture/workflow change to CONTRIBUTING.md/AGENTS.md
- [x] N/A — gateway-only background thread, no platform-specific behavior

## Background

This re-implements the fix proposed in #16473 (@nftpoetrist), open since April 27 and now conflicting with `main`; it hasn't advanced since May 29. #16473 wires into `_start_cron_ticker()`, which is now a deprecated shim — gateway housekeeping moved to `_start_gateway_housekeeping()` after that PR was opened. This PR targets the current hook instead of rebasing the original, since the target function no longer has the same shape.

Separately, #56427 tracks the adjacent video/screenshot cache gap; three PRs (#56432, #56445, #56453) are already open for that scope, so this PR is limited to audio only.

Credit: `cleanup_audio_cache()` follows the approach @nftpoetrist proposed in #16473.

*Drafted with AI assistance, reviewed by @vb3.*
