### PR TITLE
fix(agent): make persist user-message override non-mutating

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1615,35 +1615,14 @@ class AIAgent:
         )
 
     def _apply_persist_user_message_override(self, messages: List[Dict]) -> None:
-        """Rewrite the current-turn user message before persistence/return.
+        """Legacy seam — persistence overrides are resolved in the flush chokepoint.
 
-        Some call paths need an API-only user-message variant without letting
-        that synthetic text leak into persisted transcripts or resumed session
-        history. When an override is configured for the active turn, mutate the
-        in-memory messages list in place so both persistence and returned
-        history stay clean.  A paired timestamp override preserves the platform
-        event time as message metadata, rather than embedding it in content.
+        ``_flush_messages_to_session_db`` applies ``_persist_user_message_override``
+        and ``_persist_user_message_timestamp`` only to the values written to
+        SQLite, never mutating the live message dicts used for API calls
+        (#48677, #56303). This method intentionally does not mutate *messages*.
         """
-        idx = getattr(self, "_persist_user_message_idx", None)
-        override = getattr(self, "_persist_user_message_override", None)
-        timestamp = getattr(self, "_persist_user_message_timestamp", None)
-        if idx is None or (override is None and timestamp is None):
-            return
-        if 0 <= idx < len(messages):
-            msg = messages[idx]
-            if isinstance(msg, dict) and msg.get("role") == "user":
-                # Text-only call paths may pass a synthetic API-facing prompt
-                # and a cleaner transcript string separately. Multimodal
-                # turns, however, keep image/audio blocks in the live
-                # messages list that is still used for the API request after
-                # early crash-resilience persistence. Do not replace those
-                # blocks with the text-only persistence override before the
-                # model call is built. The paired timestamp override still
-                # applies — it is metadata, not content.
-                if override is not None and not isinstance(msg.get("content"), list):
-                    msg["content"] = override
-                if timestamp is not None:
-                    msg["timestamp"] = timestamp
+        return
 
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state to both JSON log and SQLite on any exit path.

--- a/tests/gateway/test_message_timestamps.py
+++ b/tests/gateway/test_message_timestamps.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
 from gateway.message_timestamps import (
@@ -68,27 +69,32 @@ def test_coerce_message_timestamp_accepts_datetime_and_epoch():
     assert coerce_message_timestamp(dt.timestamp(), tz=BERLIN) == dt.timestamp()
 
 
-def test_persist_user_message_override_keeps_clean_content_and_timestamp_metadata():
+def test_persist_user_message_override_applies_only_on_db_flush():
+    from run_agent import AIAgent
+
     agent = AIAgent.__new__(AIAgent)
+    agent._session_db = MagicMock()
+    agent.session_id = "session-123"
+    agent._last_flushed_db_idx = 0
+    agent._session_db_created = True
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
     agent._persist_user_message_idx = 0
     agent._persist_user_message_override = "[Example User] Clean content"
     agent._persist_user_message_timestamp = _epoch(2026, 4, 28, 13, 40, 53)
-    messages = [
-        {
-            "role": "user",
-            "content": "[Tue 2026-04-28 13:40:53 CEST] [Example User] Clean content",
-        }
-    ]
+    augmented = "[Tue 2026-04-28 13:40:53 CEST] [Example User] Clean content"
+    messages = [{"role": "user", "content": augmented}]
 
     agent._apply_persist_user_message_override(messages)
+    assert messages == [{"role": "user", "content": augmented}]
 
-    assert messages == [
-        {
-            "role": "user",
-            "content": "[Example User] Clean content",
-            "timestamp": _epoch(2026, 4, 28, 13, 40, 53),
-        }
-    ]
+    agent._flush_messages_to_session_db(messages, [])
+
+    assert messages[0]["content"] == augmented
+    assert messages[0].get("_db_persisted") is True
+    first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
+    assert first_db_write["content"] == "[Example User] Clean content"
+    assert first_db_write["timestamp"] == _epoch(2026, 4, 28, 13, 40, 53)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_persist_override_non_mutating.py
+++ b/tests/run_agent/test_persist_override_non_mutating.py
@@ -1,0 +1,45 @@
+"""Regression tests for #56303 — persist override must not mutate live messages."""
+
+from unittest.mock import MagicMock
+
+from agent.tool_executor import _flush_session_db_after_tool_progress
+from run_agent import AIAgent
+
+
+def _bare_agent() -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent._session_db = MagicMock()
+    agent.session_id = "session-56303"
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._session_db_created = True
+    return agent
+
+
+def test_tool_loop_incremental_flush_preserves_augmented_user_content():
+    """Mid-tool-loop flush must not strip API-facing user prefixes (#56303)."""
+    agent = _bare_agent()
+    agent._persist_user_message_idx = 0
+    agent._persist_user_message_override = "hello"
+    augmented = "[Group context] hello"
+    messages = [
+        {"role": "user", "content": augmented},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "web_search", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "result"},
+    ]
+
+    _flush_session_db_after_tool_progress(agent, messages, stage="tool_result")
+
+    assert messages[0]["content"] == augmented
+    user_db_writes = [
+        call.kwargs
+        for call in agent._session_db.append_message.call_args_list
+        if call.kwargs.get("role") == "user"
+    ]
+    assert user_db_writes
+    assert user_db_writes[0]["content"] == "hello"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -116,14 +116,16 @@ def agent():
         return a
 
 
-def test_persist_user_message_override_rewrites_text_turns(agent):
-    messages = [{"role": "user", "content": "API-only synthetic prefix\nhello"}]
+def test_persist_user_message_override_is_non_mutating(agent):
+    """Override seam must not rewrite the live list — flush owns DB values (#56303)."""
+    original = "API-only synthetic prefix\nhello"
+    messages = [{"role": "user", "content": original}]
     agent._persist_user_message_idx = 0
     agent._persist_user_message_override = "hello"
 
     agent._apply_persist_user_message_override(messages)
 
-    assert messages == [{"role": "user", "content": "hello"}]
+    assert messages == [{"role": "user", "content": original}]
 
 
 def test_persist_user_message_override_preserves_multimodal_turns(agent):


### PR DESCRIPTION
## Summary

Fixes #56303.

`_flush_messages_to_session_db` already applied persist user-message overrides only to SQLite rows (#48677), but `_apply_persist_user_message_override` still mutated live message dicts if any caller invoked it directly. Make that seam a no-op so every path — including incremental tool-loop flushes — keeps augmented user content for subsequent API calls while the DB still receives the clean override.

## Test plan

- [x] `pytest tests/run_agent/test_persist_override_non_mutating.py`
- [x] `pytest tests/run_agent/test_run_agent.py::TestPersistUserMessageOverride`
- [x] `pytest tests/gateway/test_message_timestamps.py::test_persist_user_message_override_applies_only_on_db_flush`
