### PR TITLE
feat(power): add opt-in sleep prevention

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -20,6 +20,7 @@ import {
   nativeTheme,
   Notification,
   powerMonitor,
+  powerSaveBlocker,
   protocol,
   safeStorage,
   screen,
@@ -65,7 +66,6 @@ import {
 } from './desktop-uninstall'
 import { installEmbedReferer } from './embed-referer'
 import { readDirForIpc } from './fs-read-dir'
-import { resolvePickerDefaultPath } from './wsl-path-bridge'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { scanGitRepos } from './git-repo-scan'
 import {
@@ -96,6 +96,7 @@ import {
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import { createPowerSaveBlockerController, isPowerSaveRefreshAuthorized } from './power-save'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import {
   buildSessionWindowUrl,
@@ -131,6 +132,7 @@ import { buildPathExtCandidates, chooseUpdaterArgs, getVenvSitePackagesEntries, 
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
+import { resolvePickerDefaultPath } from './wsl-path-bridge'
 
 const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
 
@@ -4527,6 +4529,52 @@ function registerPowerResumeListeners() {
   }
 }
 
+const desktopPowerSaveController = createPowerSaveBlockerController(powerSaveBlocker)
+
+function desktopSleepPreventionStatus(ok: boolean, reason?: string) {
+  const current = desktopPowerSaveController.state()
+
+  return {
+    ok,
+    active: current.active,
+    mode: current.mode,
+    surfaces: current.surfaces,
+    ...(reason ? { reason } : {})
+  }
+}
+
+function refreshDesktopSleepPrevention(block: unknown) {
+  try {
+    const result = desktopPowerSaveController.refresh(block)
+
+    if (result.changed) {
+      rememberLog(
+        result.active
+          ? `[power] sleep prevention enabled for desktop (mode=${result.mode}; display sleep ${result.mode === 'display' ? 'blocked' : 'allowed'})`
+          : '[power] sleep prevention cleared for desktop'
+      )
+    }
+
+    return desktopSleepPreventionStatus(true)
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+
+    rememberLog(`[power] sleep prevention refresh failed: ${reason}`)
+
+    return desktopSleepPreventionStatus(false, reason)
+  }
+}
+
+function stopDesktopSleepPrevention() {
+  try {
+    if (desktopPowerSaveController.stop()) {
+      rememberLog('[power] sleep prevention cleared for desktop')
+    }
+  } catch (error) {
+    rememberLog(`[power] sleep prevention cleanup failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
 function getAppIconPath() {
   return APP_ICON_PATHS.find(fileExists)
 }
@@ -7600,6 +7648,17 @@ ipcMain.handle('hermes:bootstrap:cancel', async () => {
   return { ok: false, cancelled: false }
 })
 ipcMain.handle('hermes:boot-progress:get', async () => bootProgressState)
+ipcMain.handle('hermes:power:refresh', async (event, block) => {
+  const owner = mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents : null
+
+  if (!isPowerSaveRefreshAuthorized(event.sender, owner)) {
+    rememberLog('[power] ignored sleep prevention refresh from a non-primary renderer')
+
+    return desktopSleepPreventionStatus(false, 'unauthorized-renderer')
+  }
+
+  return refreshDesktopSleepPrevention(block)
+})
 ipcMain.handle('hermes:bootstrap:get', async () => getBootstrapState())
 ipcMain.handle('hermes:connection-config:get', async (_event, profile) =>
   sanitizeDesktopConnectionConfig(readDesktopConnectionConfig(), profile)
@@ -9128,6 +9187,8 @@ function configureSpellChecker() {
 }
 
 app.on('before-quit', () => {
+  stopDesktopSleepPrevention()
+
   // The always-on-top overlay isn't a "real" app window; close it so a stray
   // pet can't keep the process alive or float over a quit app.
   closePetOverlay()

--- a/apps/desktop/electron/power-save.test.ts
+++ b/apps/desktop/electron/power-save.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createPowerSaveBlockerController,
+  isPowerSaveRefreshAuthorized,
+  powerSaveTypeForMode,
+  resolvePreventSleepConfig
+} from './power-save'
+
+describe('resolvePreventSleepConfig', () => {
+  it('is disabled with system mode by default', () => {
+    expect(resolvePreventSleepConfig(undefined)).toEqual({
+      enabled: false,
+      mode: 'system',
+      surfaces: []
+    })
+  })
+
+  it('accepts the canonical resolved payload', () => {
+    expect(
+      resolvePreventSleepConfig({
+        enabled: true,
+        mode: 'display',
+        surfaces: ['desktop', 'gateway']
+      })
+    ).toEqual({
+      enabled: true,
+      mode: 'display',
+      surfaces: ['desktop', 'gateway']
+    })
+  })
+
+  it('fails closed instead of duplicating backend normalization', () => {
+    expect(resolvePreventSleepConfig({ enabled: 'true', surfaces: ['desktop'] }).enabled).toBe(false)
+    expect(resolvePreventSleepConfig(true, 'gateway').enabled).toBe(false)
+    expect(resolvePreventSleepConfig({ enabled: true, mode: 'invalid' }).mode).toBe('system')
+  })
+
+  it('treats an explicit empty surface list as disabled everywhere', () => {
+    expect(resolvePreventSleepConfig({ enabled: true, surfaces: [] }, 'desktop').enabled).toBe(false)
+    expect(resolvePreventSleepConfig({ enabled: true, surfaces: [] }, 'gateway').enabled).toBe(false)
+  })
+})
+
+describe('powerSaveTypeForMode', () => {
+  it('keeps the display awake only when explicitly requested', () => {
+    expect(powerSaveTypeForMode('system')).toBe('prevent-app-suspension')
+    expect(powerSaveTypeForMode('display')).toBe('prevent-display-sleep')
+  })
+})
+
+describe('isPowerSaveRefreshAuthorized', () => {
+  it('allows only the primary renderer that owns the machine-wide effect', () => {
+    const mainRenderer = {}
+
+    expect(isPowerSaveRefreshAuthorized(mainRenderer, mainRenderer)).toBe(true)
+    expect(isPowerSaveRefreshAuthorized({}, mainRenderer)).toBe(false)
+    expect(isPowerSaveRefreshAuthorized(mainRenderer, null)).toBe(false)
+  })
+})
+
+describe('createPowerSaveBlockerController', () => {
+  it('starts, avoids duplicate starts, switches mode, and stops', () => {
+    let nextId = 40
+    const active = new Set<number>()
+
+    const powerSaveBlocker = {
+      start: vi.fn((type: string) => {
+        void type
+        const id = ++nextId
+        active.add(id)
+
+        return id
+      }),
+      stop: vi.fn((id: number) => active.delete(id)),
+      isStarted: vi.fn((id: number) => active.has(id))
+    }
+
+    const controller = createPowerSaveBlockerController(powerSaveBlocker)
+
+    expect(controller.refresh({ enabled: true, surfaces: ['desktop'], mode: 'system' })).toMatchObject({
+      active: true,
+      changed: true,
+      mode: 'system'
+    })
+    expect(powerSaveBlocker.start).toHaveBeenCalledWith('prevent-app-suspension')
+
+    expect(controller.refresh({ enabled: true, surfaces: ['desktop'], mode: 'system' }).changed).toBe(false)
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1)
+
+    expect(controller.refresh({ enabled: true, surfaces: ['desktop'], mode: 'display' })).toMatchObject({
+      active: true,
+      changed: true,
+      mode: 'display'
+    })
+    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(41)
+    expect(powerSaveBlocker.start).toHaveBeenLastCalledWith('prevent-display-sleep')
+    expect(powerSaveBlocker.start.mock.invocationCallOrder[1]).toBeLessThan(
+      powerSaveBlocker.stop.mock.invocationCallOrder[0]
+    )
+
+    expect(controller.stop()).toBe(true)
+    expect(controller.stop()).toBe(false)
+    expect(controller.state().active).toBe(false)
+  })
+
+  it('is a no-op when disabled for the desktop surface', () => {
+    const powerSaveBlocker = {
+      start: vi.fn(() => 1),
+      stop: vi.fn(() => true),
+      isStarted: vi.fn(() => false)
+    }
+
+    const controller = createPowerSaveBlockerController(powerSaveBlocker)
+
+    expect(controller.refresh({ enabled: true, surfaces: ['gateway'] })).toMatchObject({
+      active: false,
+      changed: false
+    })
+    expect(powerSaveBlocker.start).not.toHaveBeenCalled()
+  })
+
+  it('recovers if Electron reports that the previous blocker is no longer active', () => {
+    let active = true
+
+    const powerSaveBlocker = {
+      start: vi.fn(() => {
+        active = true
+
+        return 7
+      }),
+      stop: vi.fn(() => true),
+      isStarted: vi.fn(() => active)
+    }
+
+    const controller = createPowerSaveBlockerController(powerSaveBlocker)
+
+    controller.refresh({ enabled: true, surfaces: ['desktop'] })
+    active = false
+    controller.refresh({ enabled: true, surfaces: ['desktop'] })
+
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the last-good blocker when replacement acquisition fails', () => {
+    const active = new Set<number>()
+
+    const powerSaveBlocker = {
+      start: vi
+        .fn()
+        .mockImplementationOnce(() => {
+          active.add(1)
+
+          return 1
+        })
+        .mockImplementationOnce(() => {
+          throw new Error('native start failed')
+        }),
+      stop: vi.fn((id: number) => active.delete(id)),
+      isStarted: vi.fn((id: number) => active.has(id))
+    }
+
+    const controller = createPowerSaveBlockerController(powerSaveBlocker)
+
+    controller.refresh({ enabled: true, mode: 'system', surfaces: ['desktop'] })
+
+    expect(() => controller.refresh({ enabled: true, mode: 'display', surfaces: ['desktop'] })).toThrow(
+      'native start failed'
+    )
+    expect(controller.state()).toMatchObject({ active: true, mode: 'system' })
+    expect(active).toEqual(new Set([1]))
+    expect(powerSaveBlocker.stop).not.toHaveBeenCalled()
+  })
+
+  it('keeps the last-good blocker when Electron returns an inactive replacement', () => {
+    const active = new Set<number>()
+
+    const powerSaveBlocker = {
+      start: vi
+        .fn()
+        .mockImplementationOnce(() => {
+          active.add(1)
+
+          return 1
+        })
+        .mockReturnValueOnce(2),
+      stop: vi.fn((id: number) => active.delete(id)),
+      isStarted: vi.fn((id: number) => active.has(id))
+    }
+
+    const controller = createPowerSaveBlockerController(powerSaveBlocker)
+
+    controller.refresh({ enabled: true, mode: 'system', surfaces: ['desktop'] })
+
+    expect(() => controller.refresh({ enabled: true, mode: 'display', surfaces: ['desktop'] })).toThrow('did not start')
+    expect(controller.state()).toMatchObject({ active: true, mode: 'system' })
+    expect(active).toEqual(new Set([1]))
+  })
+
+  it('rolls back a replacement when the previous blocker cannot be released', () => {
+    let nextId = 0
+    const active = new Set<number>()
+
+    const powerSaveBlocker = {
+      start: vi.fn(() => {
+        const id = ++nextId
+
+        active.add(id)
+
+        return id
+      }),
+      stop: vi.fn((id: number) => (id === 1 ? false : active.delete(id))),
+      isStarted: vi.fn((id: number) => active.has(id))
+    }
+
+    const controller = createPowerSaveBlockerController(powerSaveBlocker)
+
+    controller.refresh({ enabled: true, mode: 'system', surfaces: ['desktop'] })
+
+    expect(() => controller.refresh({ enabled: true, mode: 'display', surfaces: ['desktop'] })).toThrow(
+      'Failed to replace'
+    )
+    expect(controller.state()).toMatchObject({ active: true, mode: 'system' })
+    expect(active).toEqual(new Set([1]))
+  })
+
+  it('retains a failed blocker release so a later refresh can retry it', () => {
+    let canStop = false
+    const active = new Set([1])
+
+    const powerSaveBlocker = {
+      start: vi.fn(() => 1),
+      stop: vi.fn((id: number) => canStop && active.delete(id)),
+      isStarted: vi.fn((id: number) => active.has(id))
+    }
+
+    const controller = createPowerSaveBlockerController(powerSaveBlocker)
+
+    controller.refresh({ enabled: true, surfaces: ['desktop'] })
+
+    expect(() => controller.refresh({ enabled: false })).toThrow('Failed to stop')
+    expect(controller.state().active).toBe(true)
+
+    canStop = true
+    expect(controller.refresh({ enabled: false })).toMatchObject({ active: false, changed: true })
+    expect(powerSaveBlocker.stop).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/electron/power-save.ts
+++ b/apps/desktop/electron/power-save.ts
@@ -1,0 +1,214 @@
+export type PreventSleepMode = 'display' | 'system'
+export type PowerSaveBlockerType = 'prevent-app-suspension' | 'prevent-display-sleep'
+
+export interface ResolvedPreventSleepConfig {
+  enabled: boolean
+  mode: PreventSleepMode
+  surfaces: string[]
+}
+
+export interface PowerSaveBlockerLike {
+  isStarted: (id: number) => boolean
+  start: (type: PowerSaveBlockerType) => number
+  stop: (id: number) => boolean
+}
+
+export interface PowerSaveControllerState extends ResolvedPreventSleepConfig {
+  active: boolean
+}
+
+function normalizeSurface(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replaceAll('_', '-')
+}
+
+function normalizeSurfaces(value: unknown): string[] {
+  const items = Array.isArray(value) ? value : []
+
+  const surfaces: string[] = []
+
+  for (const item of items) {
+    const surface = normalizeSurface(item)
+
+    if (surface && !surfaces.includes(surface)) {
+      surfaces.push(surface)
+    }
+  }
+
+  return surfaces
+}
+
+export function resolvePreventSleepConfig(block: unknown, surface = 'desktop'): ResolvedPreventSleepConfig {
+  const record = block && typeof block === 'object' ? (block as Record<string, unknown>) : {}
+  const mode: PreventSleepMode = record.mode === 'display' ? 'display' : 'system'
+
+  const surfaces = normalizeSurfaces(record.surfaces)
+
+  return {
+    enabled: record.enabled === true && surfaces.includes(normalizeSurface(surface)),
+    mode,
+    surfaces
+  }
+}
+
+export function powerSaveTypeForMode(mode: PreventSleepMode): PowerSaveBlockerType {
+  return mode === 'display' ? 'prevent-display-sleep' : 'prevent-app-suspension'
+}
+
+export function isPowerSaveRefreshAuthorized(sender: unknown, owner: unknown): boolean {
+  return owner !== null && owner !== undefined && sender === owner
+}
+
+export function createPowerSaveBlockerController(powerSaveBlocker: PowerSaveBlockerLike, surface = 'desktop') {
+  const blockers = new Map<number, PowerSaveBlockerType>()
+  let config = resolvePreventSleepConfig(undefined, surface)
+
+  const activeBlockers = (): [number, PowerSaveBlockerType][] => {
+    for (const id of blockers.keys()) {
+      if (!powerSaveBlocker.isStarted(id)) {
+        blockers.delete(id)
+      }
+    }
+
+    return [...blockers.entries()]
+  }
+
+  const isStarted = () => activeBlockers().length > 0
+
+  const state = (): PowerSaveControllerState => {
+    const active = activeBlockers()
+
+    const mode = active.some(([, type]) => type === 'prevent-display-sleep')
+      ? 'display'
+      : active.length > 0
+        ? 'system'
+        : config.mode
+
+    return { ...config, active: active.length > 0, mode }
+  }
+
+  const release = (id: number): boolean => {
+    if (!blockers.has(id)) {
+      return true
+    }
+
+    if (!powerSaveBlocker.isStarted(id)) {
+      blockers.delete(id)
+
+      return true
+    }
+
+    const stopped = powerSaveBlocker.stop(id)
+
+    if (!stopped && powerSaveBlocker.isStarted(id)) {
+      return false
+    }
+
+    if (powerSaveBlocker.isStarted(id)) {
+      return false
+    }
+
+    blockers.delete(id)
+
+    return true
+  }
+
+  const releaseAll = (ids: number[]): number[] => {
+    const failed: number[] = []
+
+    for (const id of ids) {
+      try {
+        if (!release(id)) {
+          failed.push(id)
+        }
+      } catch {
+        failed.push(id)
+      }
+    }
+
+    return failed
+  }
+
+  const acquire = (type: PowerSaveBlockerType): number => {
+    const id = powerSaveBlocker.start(type)
+
+    if (!powerSaveBlocker.isStarted(id)) {
+      throw new Error(`Electron did not start power save blocker ${id}`)
+    }
+
+    blockers.set(id, type)
+
+    return id
+  }
+
+  const stop = (): boolean => {
+    const ids = activeBlockers().map(([id]) => id)
+
+    if (ids.length === 0) {
+      return false
+    }
+
+    const failed = releaseAll(ids)
+
+    if (failed.length > 0) {
+      throw new Error(`Failed to stop ${failed.length} Electron power save blocker(s)`)
+    }
+
+    config = resolvePreventSleepConfig(undefined, surface)
+
+    return true
+  }
+
+  const refresh = (block: unknown): PowerSaveControllerState & { changed: boolean } => {
+    const next = resolvePreventSleepConfig(block, surface)
+    const nextType = powerSaveTypeForMode(next.mode)
+    const active = activeBlockers()
+    const matching = active.filter(([, type]) => type === nextType)
+
+    if (!next.enabled) {
+      const failed = releaseAll(active.map(([id]) => id))
+
+      if (failed.length > 0) {
+        throw new Error(`Failed to stop ${failed.length} Electron power save blocker(s)`)
+      }
+
+      config = next
+
+      return { ...state(), changed: active.length > 0 }
+    }
+
+    if (matching.length > 0) {
+      const keepId = matching[0][0]
+      const failed = releaseAll(active.filter(([id]) => id !== keepId).map(([id]) => id))
+
+      if (failed.length > 0) {
+        throw new Error(`Failed to replace ${failed.length} Electron power save blocker(s)`)
+      }
+
+      config = next
+
+      return { ...state(), changed: active.length > 1 }
+    }
+
+    const nextId = acquire(nextType)
+    const failed = releaseAll(active.map(([id]) => id))
+
+    if (failed.length > 0) {
+      const rollbackFailed = releaseAll([nextId])
+
+      throw new Error(
+        rollbackFailed.length > 0
+          ? 'Failed to replace and roll back Electron power save blocker'
+          : `Failed to replace ${failed.length} Electron power save blocker(s)`
+      )
+    }
+
+    config = next
+
+    return { ...state(), changed: true }
+  }
+
+  return { isStarted, refresh, state, stop }
+}

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -36,6 +36,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     }
   },
   getBootProgress: () => ipcRenderer.invoke('hermes:boot-progress:get'),
+  refreshPowerSaveBlocker: block => ipcRenderer.invoke('hermes:power:refresh', block),
   getConnectionConfig: profile => ipcRenderer.invoke('hermes:connection-config:get', profile),
   saveConnectionConfig: payload => ipcRenderer.invoke('hermes:connection-config:save', payload),
   applyConnectionConfig: payload => ipcRenderer.invoke('hermes:connection-config:apply', payload),

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -401,8 +401,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   }, [freshSessionRequest, startFreshSessionDraft])
 
   // Swapping the live gateway to another profile must re-pull that profile's
-  // global model + active-profile pill (both are nanostores — the blanket
-  // invalidateQueries on swap doesn't touch them).
+  // global model, active-profile pill, and profile-scoped config. Nanostores
+  // are not touched by the blanket invalidateQueries on swap, while the power
+  // config also owns a machine-wide Electron effect.
   const activeGatewayProfile = useStore($activeGatewayProfile)
   const lastGatewayProfileRef = useRef(activeGatewayProfile)
 
@@ -416,7 +417,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     // composer already shows the previous profile's model.
     void refreshCurrentModel(true)
     void refreshActiveProfile()
-  }, [activeGatewayProfile, refreshCurrentModel])
+    void refreshHermesConfig()
+  }, [activeGatewayProfile, refreshCurrentModel, refreshHermesConfig])
 
   // New session anchored to a workspace (sidebar "+" on a project/worktree).
   // Seeds cwd + branch from the clicked workspace; an explicit worktree path

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -1,19 +1,21 @@
 // @vitest-environment jsdom
 import { act, renderHook } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getHermesConfig } from '@/hermes'
+import { getEffectivePreventSleepConfig, getHermesConfig } from '@/hermes'
 import { persistString } from '@/lib/storage'
 import { $currentCwd, setCurrentCwd } from '@/store/session'
 
 import { useHermesConfig } from './use-hermes-config'
 
 vi.mock('@/hermes', () => ({
+  getEffectivePreventSleepConfig: vi.fn(),
   getHermesConfig: vi.fn(),
   getHermesConfigDefaults: vi.fn().mockResolvedValue({})
 }))
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
+const refreshPowerSaveBlocker = vi.fn()
 
 const mockConfig = (config: Record<string, unknown>) =>
   vi.mocked(getHermesConfig).mockResolvedValue(config as Awaited<ReturnType<typeof getHermesConfig>>)
@@ -23,6 +25,104 @@ describe('useHermesConfig refreshHermesConfig', () => {
     // Reset atoms and localStorage between tests
     setCurrentCwd('')
     persistString(WORKSPACE_CWD_KEY, null)
+    vi.mocked(getEffectivePreventSleepConfig)
+      .mockReset()
+      .mockResolvedValue({
+        enabled: false,
+        mode: 'system',
+        surfaces: ['desktop', 'gateway']
+      })
+    vi.mocked(getHermesConfig).mockReset()
+    refreshPowerSaveBlocker.mockReset().mockResolvedValue({
+      active: false,
+      mode: 'system',
+      ok: true,
+      surfaces: ['desktop', 'gateway']
+    })
+    vi.stubGlobal('hermesDesktop', { refreshPowerSaveBlocker })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('refreshes Electron sleep prevention from the canonical backend decision', async () => {
+    const block = { enabled: true, mode: 'display' as const, surfaces: ['desktop'] }
+
+    mockConfig({})
+    vi.mocked(getEffectivePreventSleepConfig).mockResolvedValue(block)
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
+      })
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect(refreshPowerSaveBlocker).toHaveBeenCalledWith(block)
+  })
+
+  it('discards a stale config response after a newer profile refresh wins', async () => {
+    type Config = Awaited<ReturnType<typeof getHermesConfig>>
+
+    let resolveFirst!: (config: Config) => void
+
+    const firstResponse = new Promise<Config>(resolve => {
+      resolveFirst = resolve
+    })
+
+    const firstBlock = { enabled: true, mode: 'display', surfaces: ['desktop'] }
+    const latestBlock = { enabled: false, mode: 'system', surfaces: ['desktop'] }
+
+    vi.mocked(getHermesConfig)
+      .mockImplementationOnce(() => firstResponse)
+      .mockResolvedValueOnce({} as Config)
+    vi.mocked(getEffectivePreventSleepConfig)
+      .mockResolvedValueOnce(firstBlock as Awaited<ReturnType<typeof getEffectivePreventSleepConfig>>)
+      .mockResolvedValueOnce(latestBlock as Awaited<ReturnType<typeof getEffectivePreventSleepConfig>>)
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
+      })
+    )
+
+    const firstRefresh = result.current.refreshHermesConfig()
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+    await act(async () => {
+      resolveFirst({} as Config)
+      await firstRefresh
+    })
+
+    expect(refreshPowerSaveBlocker).toHaveBeenCalledTimes(1)
+    expect(refreshPowerSaveBlocker).toHaveBeenCalledWith(latestBlock)
+  })
+
+  it('preserves config refreshes when an older backend lacks the power endpoint', async () => {
+    vi.mocked(getEffectivePreventSleepConfig).mockRejectedValue(new Error('not found'))
+    mockConfig({ terminal: { cwd: '/workspace/from-config' } })
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
+      })
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect($currentCwd.get()).toBe('/workspace/from-config')
+    expect(refreshPowerSaveBlocker).not.toHaveBeenCalled()
   })
 
   it('applies terminal.cwd from config even when localStorage has a stale value', async () => {

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -1,6 +1,6 @@
-import { type MutableRefObject, useCallback, useState } from 'react'
+import { type MutableRefObject, useCallback, useRef, useState } from 'react'
 
-import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
+import { getEffectivePreventSleepConfig, getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import { normalize } from '@/lib/text'
 import {
@@ -47,10 +47,23 @@ interface HermesConfigOptions {
 export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: HermesConfigOptions) {
   const [voiceMaxRecordingSeconds, setVoiceMaxRecordingSeconds] = useState(DEFAULT_VOICE_SECONDS)
   const [sttEnabled, setSttEnabled] = useState(true)
+  const refreshGenerationRef = useRef(0)
 
   const refreshHermesConfig = useCallback(async () => {
+    const generation = ++refreshGenerationRef.current
+
     try {
-      const [config, defaults] = await Promise.all([getHermesConfig(), getHermesConfigDefaults().catch(() => ({}))])
+      const [config, defaults, preventSleep] = await Promise.all([
+        getHermesConfig(),
+        getHermesConfigDefaults().catch(() => ({})),
+        getEffectivePreventSleepConfig().catch(() => null)
+      ])
+
+      // Startup, saves, reconnects, and profile switches can overlap. Only the
+      // latest foreground-profile response may update local or machine state.
+      if (generation !== refreshGenerationRef.current) {
+        return
+      }
 
       const personality = normalizePersonalityValue(
         typeof config.display?.personality === 'string' ? config.display.personality : ''
@@ -88,6 +101,13 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
       setVoiceMaxRecordingSeconds(recordingLimit(config.voice?.max_recording_seconds))
       setSttEnabled(config.stt?.enabled !== false)
       applyAutoSpeakFromConfig(config)
+
+      // This narrow endpoint uses the same Python resolver as Gateway. Older
+      // backends may not expose it; in that case preserve the last-good native
+      // blocker instead of falling back to duplicate renderer semantics.
+      if (preventSleep) {
+        await window.hermesDesktop?.refreshPowerSaveBlocker?.(preventSleep).catch(() => undefined)
+      }
     } catch {
       // Config is nice-to-have; chat still works without it.
     }

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -21,7 +21,14 @@ import { PanelEmpty } from '../overlays/panel'
 import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS, SECTIONS } from './constants'
 import { FallbackModelsField } from './fallback-models-field'
 import { fieldCopyForSchemaKey } from './field-copy'
-import { enumOptionsFor, getNested, prettyName, setNested } from './helpers'
+import {
+  configBoolean,
+  enumOptionsFor,
+  getNested,
+  getSettingsConfigValue,
+  prettyName,
+  setSettingsConfigValue
+} from './helpers'
 import { MemoryConnect } from './memory/connect'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
 import { EmptyState, ListRow, LoadingState, SettingsContent } from './primitives'
@@ -111,7 +118,7 @@ function ConfigField({
   if (schema.type === 'boolean') {
     return row(
       <div className="flex items-center justify-end">
-        <Switch checked={Boolean(value)} onCheckedChange={onChange} />
+        <Switch checked={configBoolean(value)} onCheckedChange={onChange} />
       </div>
     )
   }
@@ -465,14 +472,19 @@ export function ConfigSettings({
                 }
                 enumOptions={
                   key === 'tts.elevenlabs.voice_id'
-                    ? enumOptionsFor(key, getNested(config, key), config, elevenLabsVoiceOptions ?? undefined)
-                    : enumOptionsFor(key, getNested(config, key), config)
+                    ? enumOptionsFor(
+                        key,
+                        getSettingsConfigValue(config, key),
+                        config,
+                        elevenLabsVoiceOptions ?? undefined
+                      )
+                    : enumOptionsFor(key, getSettingsConfigValue(config, key), config)
                 }
-                onChange={value => updateConfig(setNested(config, key, value))}
+                onChange={value => updateConfig(setSettingsConfigValue(config, key, value))}
                 optionLabels={key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : undefined}
                 schema={field}
                 schemaKey={key}
-                value={getNested(config, key)}
+                value={getSettingsConfigValue(config, key)}
               />
               {key === 'memory.provider' && typeof getNested(config, key) === 'string' && getNested(config, key) ? (
                 <ProviderConfigPanel provider={String(getNested(config, key))} />

--- a/apps/desktop/src/app/settings/constants.test.ts
+++ b/apps/desktop/src/app/settings/constants.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { ENUM_OPTIONS, SECTIONS } from './constants'
+
+describe('Power settings surface', () => {
+  it('exposes every prevent-sleep field in a dedicated section', () => {
+    const power = SECTIONS.find(section => section.id === 'power')
+
+    expect(power?.keys).toEqual([
+      'power.prevent_sleep.enabled',
+      'power.prevent_sleep.surfaces',
+      'power.prevent_sleep.mode'
+    ])
+  })
+
+  it('limits the mode control to supported values', () => {
+    expect(ENUM_OPTIONS['power.prevent_sleep.mode']).toEqual(['system', 'display'])
+  })
+})

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -270,7 +270,8 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'tts.elevenlabs.model_id': ['eleven_multilingual_v2', 'eleven_turbo_v2_5', 'eleven_flash_v2_5'],
   // NeuTTS local inference device.
   'tts.neutts.device': ['cpu', 'cuda', 'mps'],
-  'updates.non_interactive_local_changes': ['stash', 'discard']
+  'updates.non_interactive_local_changes': ['stash', 'discard'],
+  'power.prevent_sleep.mode': ['system', 'display']
 }
 
 export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
@@ -424,6 +425,13 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   },
   updates: {
     nonInteractiveLocalChanges: 'In-App Update Local Changes'
+  },
+  power: {
+    preventSleep: {
+      enabled: 'Prevent System Sleep',
+      surfaces: 'Prevent Sleep For',
+      mode: 'Sleep Prevention Mode'
+    }
   }
 })
 
@@ -495,6 +503,15 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   updates: {
     nonInteractiveLocalChanges:
       'When Hermes updates itself from the app (no terminal prompt), keep local source edits (stash) or throw them away (discard). Terminal updates always ask.'
+  },
+  power: {
+    preventSleep: {
+      enabled:
+        'Keep this computer awake while selected Hermes surfaces are running. Off by default to avoid unexpected battery drain.',
+      surfaces:
+        'Comma-separated surfaces that hold the sleep assertion: desktop, gateway. The foreground profile in the primary Desktop window owns the local Desktop assertion.',
+      mode: 'System prevents idle system sleep while allowing the display to turn off; Display also keeps the screen awake. Gateway support is currently Windows-only and changes apply after its next restart.'
+    }
   }
 })
 
@@ -603,6 +620,12 @@ export const SECTIONS: DesktopConfigSection[] = [
       'voice.record_key',
       'voice.max_recording_seconds'
     ]
+  },
+  {
+    id: 'power',
+    label: 'Power',
+    icon: Moon,
+    keys: ['power.prevent_sleep.enabled', 'power.prevent_sleep.surfaces', 'power.prevent_sleep.mode']
   },
   {
     id: 'advanced',

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -3,9 +3,44 @@ import { describe, expect, it } from 'vitest'
 import type { HermesConfigRecord } from '@/types/hermes'
 
 import { defineFieldCopy, fieldCopyForSchemaKey, schemaKeyToFieldCopyKey } from './field-copy'
-import { enumOptionsFor, getNested, providerGroup, setNested, stripToolsetLabel, toolsetDisplayLabel } from './helpers'
+import {
+  configBoolean,
+  enumOptionsFor,
+  getNested,
+  getSettingsConfigValue,
+  providerGroup,
+  setNested,
+  setSettingsConfigValue,
+  stripToolsetLabel,
+  toolsetDisplayLabel
+} from './helpers'
 
 describe('settings helpers', () => {
+  it('renders env-expanded boolean strings with their canonical meaning', () => {
+    expect(configBoolean('true')).toBe(true)
+    expect(configBoolean('on')).toBe(true)
+    expect(configBoolean('false')).toBe(false)
+    expect(configBoolean('0')).toBe(false)
+    expect(configBoolean('${UNRESOLVED_BOOL}')).toBe(false)
+    expect(configBoolean(false)).toBe(false)
+  })
+
+  it('renders and edits prevent-sleep boolean shorthand without changing its meaning', () => {
+    const shorthand: HermesConfigRecord = { power: { prevent_sleep: true } }
+
+    expect(getSettingsConfigValue(shorthand, 'power.prevent_sleep.enabled')).toBe(true)
+    expect(getSettingsConfigValue(shorthand, 'power.prevent_sleep.mode')).toBe('system')
+    expect(getSettingsConfigValue(shorthand, 'power.prevent_sleep.surfaces')).toEqual(['desktop', 'gateway'])
+
+    const next = setSettingsConfigValue(shorthand, 'power.prevent_sleep.mode', 'display')
+
+    expect(getNested(next, 'power.prevent_sleep')).toEqual({
+      enabled: true,
+      mode: 'display',
+      surfaces: ['desktop', 'gateway']
+    })
+  })
+
   it('lists Hindsight as a built-in desktop memory provider option', () => {
     const options = enumOptionsFor('memory.provider', '', {})
 

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -25,6 +25,30 @@ export const withoutKey = <T>(record: Record<string, T>, key: string) => {
 
 export const redactedValue = (v: string) => (v.length <= 8 ? '••••' : `${v.slice(0, 4)}...${v.slice(-4)}`)
 
+/** Interpret canonical config values after ${VAR} expansion without treating
+ * the strings "false" and "0" as truthy in boolean settings controls. */
+export function configBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+
+    if (['false', 'no', 'off', '0'].includes(normalized)) {
+      return false
+    }
+
+    if (['true', 'yes', 'on', '1'].includes(normalized)) {
+      return true
+    }
+
+    return false
+  }
+
+  return Boolean(value)
+}
+
 // Longest-prefix match so a more specific group like ``MINIMAX_CN_`` is
 // chosen over its shorter parent ``MINIMAX_``. Falls back to the bucket
 // "Other" used by the Keys settings view for un-grouped env vars.
@@ -121,6 +145,49 @@ export function setNested(obj: HermesConfigRecord, path: string, value: unknown)
   safeSet(cur, parts[parts.length - 1], value)
 
   return clone
+}
+
+const PREVENT_SLEEP_ROOT = 'power.prevent_sleep'
+
+const PREVENT_SLEEP_SHORTHAND_DEFAULTS = {
+  mode: 'system',
+  surfaces: ['desktop', 'gateway']
+}
+
+export function getSettingsConfigValue(config: HermesConfigRecord, path: string): unknown {
+  const shorthand = getNested(config, PREVENT_SLEEP_ROOT)
+
+  if (typeof shorthand !== 'boolean') {
+    return getNested(config, path)
+  }
+
+  if (path === `${PREVENT_SLEEP_ROOT}.enabled`) {
+    return shorthand
+  }
+
+  if (path === `${PREVENT_SLEEP_ROOT}.mode`) {
+    return PREVENT_SLEEP_SHORTHAND_DEFAULTS.mode
+  }
+
+  if (path === `${PREVENT_SLEEP_ROOT}.surfaces`) {
+    return [...PREVENT_SLEEP_SHORTHAND_DEFAULTS.surfaces]
+  }
+
+  return getNested(config, path)
+}
+
+export function setSettingsConfigValue(config: HermesConfigRecord, path: string, value: unknown): HermesConfigRecord {
+  const shorthand = getNested(config, PREVENT_SLEEP_ROOT)
+
+  const expanded =
+    typeof shorthand === 'boolean' && path.startsWith(`${PREVENT_SLEEP_ROOT}.`)
+      ? setNested(config, PREVENT_SLEEP_ROOT, {
+          enabled: shorthand,
+          ...PREVENT_SLEEP_SHORTHAND_DEFAULTS
+        })
+      : config
+
+  return setNested(expanded, path, value)
 }
 
 function personalityOptions(config: HermesConfigRecord): string[] {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -4,6 +4,7 @@ import type {
   PetOverlayOpenRequest,
   PetOverlayStatePayload
 } from './store/pet-overlay'
+import type { ResolvedPreventSleepConfig } from './types/hermes'
 
 export {}
 
@@ -48,6 +49,13 @@ declare global {
         onControl: (callback: (payload: PetOverlayControl) => void) => () => void
       }
       getBootProgress: () => Promise<DesktopBootProgress>
+      refreshPowerSaveBlocker?: (block: ResolvedPreventSleepConfig) => Promise<{
+        ok: boolean
+        active: boolean
+        mode: string
+        reason?: string
+        surfaces: string[]
+      }>
       getConnectionConfig: (profile?: null | string) => Promise<DesktopConnectionConfig>
       saveConnectionConfig: (payload: DesktopConnectionConfigInput) => Promise<DesktopConnectionConfig>
       applyConnectionConfig: (payload: DesktopConnectionConfigInput) => Promise<DesktopConnectionConfig>

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -42,6 +42,7 @@ import type {
   ProfileSetupCommand,
   ProfileSoul,
   ProfilesResponse,
+  ResolvedPreventSleepConfig,
   SessionInfo,
   SessionMessagesResponse,
   SessionSearchResponse,
@@ -481,6 +482,14 @@ export function getHermesConfig(): Promise<HermesConfig> {
   return window.hermesDesktop.api<HermesConfig>({
     ...profileScoped(),
     path: '/api/config',
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
+  })
+}
+
+export function getEffectivePreventSleepConfig(): Promise<ResolvedPreventSleepConfig> {
+  return window.hermesDesktop.api<ResolvedPreventSleepConfig>({
+    ...profileScoped(),
+    path: '/api/power/prevent-sleep',
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -383,6 +383,7 @@ export const en: Translations = {
       safety: 'Safety',
       memory: 'Memory & Context',
       voice: 'Voice',
+      power: 'Power',
       advanced: 'Advanced'
     },
     searchPlaceholder: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -270,6 +270,7 @@ export const ja = defineLocale({
       safety: '安全性',
       memory: 'メモリとコンテキスト',
       voice: '音声',
+      power: '電源',
       advanced: '詳細'
     },
     searchPlaceholder: {
@@ -425,6 +426,13 @@ export const ja = defineLocale({
         maxRecordingSeconds: '最大録音時間',
         autoTts: '応答を読み上げる'
       },
+      power: {
+        preventSleep: {
+          enabled: 'システムスリープを防止',
+          surfaces: 'スリープ防止を保持するサーフェス',
+          mode: 'スリープ防止モード'
+        }
+      },
       stt: {
         enabled: '音声認識',
         provider: '音声認識プロバイダー',
@@ -562,6 +570,15 @@ export const ja = defineLocale({
       },
       voice: {
         autoTts: 'アシスタントの応答を自動で読み上げます。'
+      },
+      power: {
+        preventSleep: {
+          enabled:
+            '選択した Hermes サーフェスの実行中、このコンピューターを起動状態に保ちます。意図しないバッテリー消費を避けるため、既定では無効です。',
+          surfaces:
+            'スリープ防止要求を保持するサーフェスのカンマ区切りリスト：desktop、gateway。ローカル Desktop の要求は、メインウィンドウで選択中のフォアグラウンドプロファイルが制御します。',
+          mode: 'System はアイドル時のシステムスリープのみを防ぎ、ディスプレイの消灯は許可します。Display は画面も起動状態に保ちます。Gateway は現在 Windows のみ対応し、次回の再起動後に反映されます。'
+        }
       },
       stt: {
         enabled: 'ローカルまたはプロバイダーによる音声文字起こしを有効にします。',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -263,6 +263,7 @@ export const zhHant = defineLocale({
       safety: '安全性',
       memory: '記憶與上下文',
       voice: '語音',
+      power: '電源',
       advanced: '進階'
     },
     searchPlaceholder: {
@@ -414,6 +415,13 @@ export const zhHant = defineLocale({
         maxRecordingSeconds: '最長錄音時間',
         autoTts: '朗讀回覆'
       },
+      power: {
+        preventSleep: {
+          enabled: '防止系統進入睡眠',
+          surfaces: '保持喚醒的執行介面',
+          mode: '防止睡眠模式'
+        }
+      },
       stt: {
         enabled: '語音轉文字',
         provider: '語音轉文字提供方',
@@ -550,6 +558,14 @@ export const zhHant = defineLocale({
       },
       voice: {
         autoTts: '自動朗讀助手回覆。'
+      },
+      power: {
+        preventSleep: {
+          enabled: '所選 Hermes 執行介面運作時保持此電腦喚醒。預設關閉，以避免非預期的電池消耗。',
+          surfaces:
+            '以逗號分隔可持有防止睡眠要求的執行介面：desktop、gateway。本機 Desktop 要求由主視窗目前選取的前景設定檔控制。',
+          mode: 'System 僅防止系統因閒置而睡眠，仍允許螢幕關閉；Display 也會保持螢幕喚醒。Gateway 目前僅支援 Windows，並在下次重新啟動後生效。'
+        }
       },
       stt: {
         enabled: '啟用本機或提供方支援的語音轉寫。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -373,6 +373,7 @@ export const zh: Translations = {
       safety: '安全',
       memory: '记忆与上下文',
       voice: '语音',
+      power: '电源',
       advanced: '高级'
     },
     searchPlaceholder: {
@@ -614,6 +615,13 @@ export const zh: Translations = {
       },
       updates: {
         nonInteractiveLocalChanges: '应用内更新本地更改'
+      },
+      power: {
+        preventSleep: {
+          enabled: '防止系统休眠',
+          surfaces: '防止休眠的运行界面',
+          mode: '防休眠模式'
+        }
       }
     }),
     fieldDescriptions: defineFieldCopy({
@@ -670,6 +678,14 @@ export const zh: Translations = {
       updates: {
         nonInteractiveLocalChanges:
           'Hermes 从应用内更新时（无终端提示），保留本地源码修改（暂存）或丢弃（放弃）。通过终端更新时始终会询问。'
+      },
+      power: {
+        preventSleep: {
+          enabled: '所选 Hermes 运行界面工作时保持本机唤醒。默认关闭，以避免意外耗电。',
+          surfaces:
+            '持有防休眠请求的运行界面，以逗号分隔：desktop、gateway。当前主窗口所选的前台配置文件控制本机 Desktop 请求。',
+          mode: 'System 仅防止系统空闲休眠，允许显示器关闭；Display 还会保持屏幕唤醒。Gateway 目前仅在 Windows 上支持，并在下次重启后生效。'
+        }
       }
     }),
     about: {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -210,6 +210,15 @@ export interface HermesConfig {
     personality?: string
     skin?: string
   }
+  power?: {
+    prevent_sleep?:
+      | boolean
+      | {
+          enabled?: unknown
+          mode?: unknown
+          surfaces?: unknown
+        }
+  }
   terminal?: {
     cwd?: string
   }
@@ -220,6 +229,12 @@ export interface HermesConfig {
     max_recording_seconds?: number
     auto_tts?: boolean
   }
+}
+
+export interface ResolvedPreventSleepConfig {
+  enabled: boolean
+  mode: 'display' | 'system'
+  surfaces: string[]
 }
 
 export type HermesConfigRecord = Record<string, unknown>

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2890,6 +2890,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._sleep_prevention_handle = None
 
         # Wire process registry into session store for reset protection.
         # A background process older than the configured threshold (default 24h,
@@ -6847,6 +6848,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         logger.info("Starting Hermes Gateway...")
         try:
+            from hermes_cli.power_sleep import start_prevent_sleep
+
+            self._sleep_prevention_handle = start_prevent_sleep(
+                "gateway",
+                log=logger,
+            )
+        except Exception:
+            logger.debug("sleep-prevention setup failed at gateway startup", exc_info=True)
+        try:
             self._gateway_loop = asyncio.get_running_loop()
         except RuntimeError:
             self._gateway_loop = None
@@ -8597,6 +8607,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._update_runtime_status("running", self._exit_reason)
             else:
                 self._update_runtime_status("stopped", self._exit_reason)
+            try:
+                sleep_handle = getattr(self, "_sleep_prevention_handle", None)
+                if sleep_handle is not None and sleep_handle.stop():
+                    logger.info("Sleep prevention cleared for gateway")
+            except Exception:
+                logger.debug("sleep-prevention cleanup failed during gateway shutdown", exc_info=True)
             logger.info("Gateway stopped (total teardown %.2fs)", _phase_elapsed())
 
         self._stop_task = asyncio.create_task(_stop_impl())

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2095,6 +2095,18 @@ DEFAULT_CONFIG = {
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
     },
+
+    # Host power management. Off by default because a long-running gateway or
+    # desktop app can otherwise keep a laptop awake indefinitely. ``system``
+    # prevents idle system sleep while allowing the display to turn off;
+    # ``display`` also keeps the screen awake.
+    "power": {
+        "prevent_sleep": {
+            "enabled": False,
+            "surfaces": ["desktop", "gateway"],
+            "mode": "system",
+        },
+    },
     
     # Text-to-speech configuration
     # Each provider supports an optional `max_text_length:` override for the

--- a/hermes_cli/power_sleep.py
+++ b/hermes_cli/power_sleep.py
@@ -1,0 +1,240 @@
+"""Thread-owned host sleep prevention for long-running Hermes surfaces.
+
+User-facing configuration lives under ``power.prevent_sleep`` in config.yaml.
+``system`` prevents idle system sleep while allowing the display to turn off;
+``display`` also keeps the display awake.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import sys
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+logger = logging.getLogger(__name__)
+
+ES_CONTINUOUS = 0x80000000
+ES_SYSTEM_REQUIRED = 0x00000001
+ES_DISPLAY_REQUIRED = 0x00000002
+
+_DEFAULT_SURFACES = ("desktop", "gateway")
+_VALID_MODES = {"system", "display"}
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def _parse_bool(value: Any, *, default: bool | None = None) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if text in _TRUE_VALUES:
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    return default
+
+
+def _normalize_surface(surface: str) -> str:
+    return str(surface or "").strip().lower().replace("_", "-")
+
+
+def _normalize_surfaces(value: Any) -> list[str]:
+    if value is None:
+        return list(_DEFAULT_SURFACES)
+    if isinstance(value, str):
+        raw = value.strip().strip("[]")
+        if not raw:
+            return []
+        items = raw.split(",") if "," in raw else raw.split()
+    elif isinstance(value, (list, tuple, set)):
+        items = list(value)
+    else:
+        items = [value]
+
+    surfaces: list[str] = []
+    for item in items:
+        normalized = _normalize_surface(str(item).strip().strip("'\""))
+        if normalized and normalized not in surfaces:
+            surfaces.append(normalized)
+    return surfaces
+
+
+def prevent_sleep_config(config: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return normalized ``power.prevent_sleep`` config."""
+    power = (config or {}).get("power", {}) if isinstance(config, Mapping) else {}
+    raw = power.get("prevent_sleep", {}) if isinstance(power, Mapping) else {}
+    if isinstance(raw, bool):
+        return {
+            "enabled": raw,
+            "surfaces": list(_DEFAULT_SURFACES),
+            "mode": "system",
+        }
+    if not isinstance(raw, Mapping):
+        return {
+            "enabled": False,
+            "surfaces": list(_DEFAULT_SURFACES),
+            "mode": "system",
+        }
+
+    enabled = _parse_bool(raw.get("enabled"), default=False)
+    mode = str(raw.get("mode") or "system").strip().lower()
+    if mode not in _VALID_MODES:
+        mode = "system"
+    return {
+        "enabled": bool(enabled),
+        "surfaces": _normalize_surfaces(raw.get("surfaces")),
+        "mode": mode,
+    }
+
+
+def resolve_prevent_sleep_config(
+    surface: str,
+    *,
+    config: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Return the normalized, surface-specific prevent-sleep decision."""
+    block = prevent_sleep_config(config)
+    return {
+        **block,
+        "enabled": bool(block["enabled"])
+        and _normalize_surface(surface) in block["surfaces"],
+    }
+
+
+def prevent_sleep_mode(*, config: Mapping[str, Any] | None = None) -> str:
+    """Return ``system`` or ``display`` for the current prevent-sleep config."""
+    return str(prevent_sleep_config(config).get("mode") or "system")
+
+
+def should_prevent_sleep(surface: str, *, config: Mapping[str, Any] | None = None) -> bool:
+    """Return whether ``surface`` should hold a sleep assertion."""
+    return bool(resolve_prevent_sleep_config(surface, config=config)["enabled"])
+
+
+def _execution_state_flags(mode: str) -> int:
+    flags = ES_CONTINUOUS | ES_SYSTEM_REQUIRED
+    if mode == "display":
+        flags |= ES_DISPLAY_REQUIRED
+    return flags
+
+
+def _set_thread_execution_state(flags: int) -> int:
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetThreadExecutionState.argtypes = [ctypes.c_uint]
+    kernel32.SetThreadExecutionState.restype = ctypes.c_uint
+    return int(kernel32.SetThreadExecutionState(flags))
+
+
+@dataclass
+class SleepPreventionHandle:
+    """A started or no-op sleep-prevention assertion."""
+
+    surface: str
+    mode: str = "system"
+    started: bool = False
+    reason: str = "disabled"
+    _set_thread_execution_state: Callable[[int], int] | None = None
+    _owner_thread_id: int | None = None
+    _previous_execution_state: int = ES_CONTINUOUS
+    _stopped: bool = False
+
+    def stop(self) -> bool:
+        """Restore the owner thread's prior execution state."""
+        if not self.started or self._stopped:
+            return False
+        if self._owner_thread_id is not None and threading.get_ident() != self._owner_thread_id:
+            logger.debug(
+                "Refusing to clear sleep prevention for %s from a non-owner thread",
+                self.surface,
+            )
+            return False
+        setter = self._set_thread_execution_state or _set_thread_execution_state
+        try:
+            result = setter(self._previous_execution_state)
+        except Exception:
+            logger.debug("Failed to clear sleep prevention for %s", self.surface, exc_info=True)
+            return False
+        if not result:
+            logger.debug(
+                "Failed to clear sleep prevention for %s: SetThreadExecutionState returned 0",
+                self.surface,
+            )
+            return False
+        self._stopped = True
+        self.started = False
+        self.reason = "stopped"
+        return True
+
+
+def start_prevent_sleep(
+    surface: str,
+    *,
+    config: Mapping[str, Any] | None = None,
+    platform: str | None = None,
+    set_thread_execution_state: Callable[[int], int] | None = None,
+    log: logging.Logger | None = None,
+) -> SleepPreventionHandle:
+    """Start thread-owned host sleep prevention when configured.
+
+    Windows uses ``SetThreadExecutionState``. Non-Windows platforms return an
+    inactive handle so gateway callers can remain platform-neutral; Desktop
+    uses Electron's cross-platform ``powerSaveBlocker`` instead.
+    """
+    normalized_surface = _normalize_surface(surface)
+    if config is None:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+    resolved = resolve_prevent_sleep_config(normalized_surface, config=config)
+    mode = str(resolved["mode"])
+    if not resolved["enabled"]:
+        return SleepPreventionHandle(surface=normalized_surface, mode=mode, reason="disabled")
+
+    current_platform = platform if platform is not None else sys.platform
+    if current_platform != "win32":
+        return SleepPreventionHandle(
+            surface=normalized_surface,
+            mode=mode,
+            reason=f"unsupported-platform:{current_platform}",
+        )
+
+    setter = set_thread_execution_state or _set_thread_execution_state
+    flags = _execution_state_flags(mode)
+    sink = log or logger
+    try:
+        result = setter(flags)
+    except Exception as exc:
+        sink.warning("Failed to enable sleep prevention for %s: %s", normalized_surface, exc)
+        return SleepPreventionHandle(surface=normalized_surface, mode=mode, reason="api-error")
+
+    if not result:
+        sink.warning(
+            "Failed to enable sleep prevention for %s: SetThreadExecutionState returned 0",
+            normalized_surface,
+        )
+        return SleepPreventionHandle(surface=normalized_surface, mode=mode, reason="api-failed")
+
+    handle = SleepPreventionHandle(
+        surface=normalized_surface,
+        mode=mode,
+        started=True,
+        reason="started",
+        _set_thread_execution_state=setter,
+        _owner_thread_id=threading.get_ident(),
+        _previous_execution_state=result,
+    )
+    atexit.register(handle.stop)
+    sink.info(
+        "Sleep prevention enabled for %s (mode=%s; display sleep %s)",
+        normalized_surface,
+        mode,
+        "blocked" if mode == "display" else "allowed",
+    )
+    return handle

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -736,6 +736,11 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         ),
         "options": ["stash", "discard"],
     },
+    "power.prevent_sleep.mode": {
+        "type": "select",
+        "description": "Host sleep-prevention mode",
+        "options": ["system", "display"],
+    },
     "updates.refresh_cua_driver": {
         "type": "bool",
         "description": (
@@ -777,7 +782,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
 
 # Display order for tabs — unlisted categories sort alphabetically after these.
 _CATEGORY_ORDER = [
-    "general", "agent", "terminal", "display", "delegation",
+    "general", "agent", "terminal", "display", "power", "delegation",
     "memory", "compression", "security", "browser", "voice",
     "tts", "stt", "logging", "discord", "auxiliary",
 ]
@@ -5387,6 +5392,19 @@ async def get_config(profile: Optional[str] = None):
         config = _normalize_config_for_web(load_config())
     # Strip internal keys that the frontend shouldn't see or send back
     return {k: v for k, v in config.items() if not k.startswith("_")}
+
+
+@app.get("/api/power/prevent-sleep")
+async def get_prevent_sleep_config(profile: Optional[str] = None):
+    """Return the canonical, profile-scoped Desktop sleep decision."""
+    from hermes_cli.config import load_config_readonly
+    from hermes_cli.power_sleep import resolve_prevent_sleep_config
+
+    with _profile_scope(profile):
+        return resolve_prevent_sleep_config(
+            "desktop",
+            config=load_config_readonly(),
+        )
 
 
 @app.get("/api/config/defaults")

--- a/tests/gateway/test_runtime_config_env_expansion.py
+++ b/tests/gateway/test_runtime_config_env_expansion.py
@@ -16,6 +16,7 @@ def _write_config(home, body: str) -> None:
 @pytest.fixture
 def gateway_home(monkeypatch, tmp_path):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
     monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE", raising=False)
@@ -118,3 +119,24 @@ def test_gateway_runtime_loaders_expand_env_var_templates(
     loader = getattr(gateway_run.GatewayRunner, loader_name)
 
     assert loader() == expected
+
+
+def test_gateway_sleep_prevention_uses_canonical_config(monkeypatch, gateway_home):
+    _write_config(
+        gateway_home,
+        "power:\n"
+        "  prevent_sleep:\n"
+        "    enabled: ${GW_PREVENT_SLEEP_ENABLED}\n"
+        "    surfaces: ${GW_PREVENT_SLEEP_SURFACES}\n"
+        "    mode: ${GW_PREVENT_SLEEP_MODE}\n",
+    )
+    monkeypatch.setenv("GW_PREVENT_SLEEP_ENABLED", "true")
+    monkeypatch.setenv("GW_PREVENT_SLEEP_SURFACES", "gateway")
+    monkeypatch.setenv("GW_PREVENT_SLEEP_MODE", "display")
+
+    from hermes_cli.power_sleep import start_prevent_sleep
+
+    handle = start_prevent_sleep("gateway", platform="linux")
+
+    assert handle.reason == "unsupported-platform:linux"
+    assert handle.mode == "display"

--- a/tests/hermes_cli/test_power_sleep.py
+++ b/tests/hermes_cli/test_power_sleep.py
@@ -1,0 +1,235 @@
+"""Tests for opt-in host sleep prevention while Hermes is running."""
+
+import threading
+
+from hermes_cli import power_sleep
+
+
+def test_default_config_exposes_disabled_power_setting():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert power_sleep.prevent_sleep_config(DEFAULT_CONFIG) == {
+        "enabled": False,
+        "mode": "system",
+        "surfaces": ["desktop", "gateway"],
+    }
+
+
+def test_prevent_sleep_disabled_by_default():
+    assert power_sleep.should_prevent_sleep("gateway", config={}) is False
+    assert power_sleep.should_prevent_sleep("desktop", config={"power": {}}) is False
+
+
+def test_prevent_sleep_enabled_for_configured_surfaces():
+    config = {
+        "power": {
+            "prevent_sleep": {
+                "enabled": True,
+                "surfaces": ["desktop", "gateway"],
+                "mode": "system",
+            }
+        }
+    }
+
+    assert power_sleep.should_prevent_sleep("desktop", config=config) is True
+    assert power_sleep.should_prevent_sleep("gateway", config=config) is True
+    assert power_sleep.should_prevent_sleep("cron", config=config) is False
+    assert power_sleep.prevent_sleep_mode(config=config) == "system"
+
+
+def test_boolean_shorthand_uses_default_surfaces():
+    config = {"power": {"prevent_sleep": True}}
+
+    assert power_sleep.should_prevent_sleep("desktop", config=config) is True
+    assert power_sleep.should_prevent_sleep("gateway", config=config) is True
+
+
+def test_explicit_empty_surfaces_disable_every_surface():
+    config = {"power": {"prevent_sleep": {"enabled": True, "surfaces": []}}}
+
+    assert power_sleep.should_prevent_sleep("desktop", config=config) is False
+    assert power_sleep.should_prevent_sleep("gateway", config=config) is False
+
+
+def test_env_expanded_config_uses_canonical_loader(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("PREVENT_SLEEP_ENABLED", "true")
+    monkeypatch.setenv("PREVENT_SLEEP_SURFACES", "desktop,gateway")
+    monkeypatch.setenv("PREVENT_SLEEP_MODE", "display")
+    (tmp_path / "config.yaml").write_text(
+        "power:\n"
+        "  prevent_sleep:\n"
+        "    enabled: ${PREVENT_SLEEP_ENABLED}\n"
+        "    surfaces: ${PREVENT_SLEEP_SURFACES}\n"
+        "    mode: ${PREVENT_SLEEP_MODE}\n",
+        encoding="utf-8",
+    )
+
+    from hermes_cli.config import load_config
+
+    config = load_config()
+    assert config["power"]["prevent_sleep"]["enabled"] == "true"
+    assert power_sleep.should_prevent_sleep("desktop", config=config) is True
+    assert power_sleep.should_prevent_sleep("gateway", config=config) is True
+    assert power_sleep.prevent_sleep_mode(config=config) == "display"
+
+
+def test_start_without_config_uses_canonical_readonly_loader(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("PREVENT_SLEEP_ENABLED", "true")
+    (tmp_path / "config.yaml").write_text(
+        "power:\n"
+        "  prevent_sleep:\n"
+        "    enabled: ${PREVENT_SLEEP_ENABLED}\n"
+        "    surfaces: [gateway]\n"
+        "    mode: display\n",
+        encoding="utf-8",
+    )
+
+    handle = power_sleep.start_prevent_sleep("gateway", platform="linux")
+
+    assert handle.reason == "unsupported-platform:linux"
+    assert handle.mode == "display"
+
+
+def test_canonical_loader_preserves_last_known_good_on_malformed_yaml(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "power:\n"
+        "  prevent_sleep:\n"
+        "    enabled: true\n"
+        "    surfaces: [gateway]\n"
+        "    mode: display\n",
+        encoding="utf-8",
+    )
+
+    first = power_sleep.start_prevent_sleep("gateway", platform="linux")
+    config_path.write_text("power: [\n", encoding="utf-8")
+    second = power_sleep.start_prevent_sleep("gateway", platform="linux")
+
+    assert first.reason == "unsupported-platform:linux"
+    assert second.reason == "unsupported-platform:linux"
+    assert second.mode == "display"
+
+
+def test_invalid_mode_falls_back_to_system():
+    config = {"power": {"prevent_sleep": {"enabled": True, "mode": "invalid"}}}
+
+    assert power_sleep.prevent_sleep_mode(config=config) == "system"
+
+
+def test_unresolved_boolean_template_fails_closed():
+    config = {"power": {"prevent_sleep": {"enabled": "${MISSING_BOOL}"}}}
+
+    assert power_sleep.should_prevent_sleep("gateway", config=config) is False
+
+
+def test_windows_execution_state_flags_are_started_and_cleared():
+    calls = []
+    previous_state = power_sleep.ES_CONTINUOUS | power_sleep.ES_DISPLAY_REQUIRED
+
+    def fake_set_thread_execution_state(flags):
+        calls.append(flags)
+        return previous_state
+
+    handle = power_sleep.start_prevent_sleep(
+        "gateway",
+        config={"power": {"prevent_sleep": {"enabled": True, "mode": "system"}}},
+        platform="win32",
+        set_thread_execution_state=fake_set_thread_execution_state,
+    )
+
+    assert handle.started is True
+    assert calls == [power_sleep.ES_CONTINUOUS | power_sleep.ES_SYSTEM_REQUIRED]
+    assert handle.stop() is True
+    assert calls[-1] == previous_state
+    assert handle.stop() is False
+
+
+def test_windows_handle_rejects_cross_thread_stop_and_retries_on_owner():
+    calls = []
+
+    def fake_set_thread_execution_state(flags):
+        calls.append(flags)
+        return power_sleep.ES_CONTINUOUS
+
+    handle = power_sleep.start_prevent_sleep(
+        "gateway",
+        config={"power": {"prevent_sleep": {"enabled": True}}},
+        platform="win32",
+        set_thread_execution_state=fake_set_thread_execution_state,
+    )
+    stopped = []
+    thread = threading.Thread(target=lambda: stopped.append(handle.stop()))
+
+    thread.start()
+    thread.join()
+
+    assert stopped == [False]
+    assert handle.started is True
+    assert len(calls) == 1
+    assert handle.stop() is True
+    assert len(calls) == 2
+
+
+def test_display_mode_adds_display_required_flag():
+    calls = []
+
+    handle = power_sleep.start_prevent_sleep(
+        "desktop",
+        config={"power": {"prevent_sleep": {"enabled": True, "mode": "display"}}},
+        platform="win32",
+        set_thread_execution_state=lambda flags: calls.append(flags) or 1,
+    )
+
+    assert handle.started is True
+    assert calls == [
+        power_sleep.ES_CONTINUOUS
+        | power_sleep.ES_SYSTEM_REQUIRED
+        | power_sleep.ES_DISPLAY_REQUIRED
+    ]
+
+
+def test_windows_api_zero_return_is_not_reported_as_started():
+    handle = power_sleep.start_prevent_sleep(
+        "gateway",
+        config={"power": {"prevent_sleep": {"enabled": True}}},
+        platform="win32",
+        set_thread_execution_state=lambda _flags: 0,
+    )
+
+    assert handle.started is False
+    assert handle.reason == "api-failed"
+
+
+def test_failed_clear_can_be_retried():
+    results = iter([1, 0, 1])
+    handle = power_sleep.start_prevent_sleep(
+        "gateway",
+        config={"power": {"prevent_sleep": {"enabled": True}}},
+        platform="win32",
+        set_thread_execution_state=lambda _flags: next(results),
+    )
+
+    assert handle.stop() is False
+    assert handle.started is True
+    assert handle.stop() is True
+    assert handle.started is False
+
+
+def test_non_windows_enabled_config_returns_inactive_handle_without_calling_api():
+    calls = []
+
+    handle = power_sleep.start_prevent_sleep(
+        "gateway",
+        config={"power": {"prevent_sleep": {"enabled": True}}},
+        platform="linux",
+        set_thread_execution_state=lambda flags: calls.append(flags) or 1,
+    )
+
+    assert handle.started is False
+    assert calls == []

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3760,6 +3760,14 @@ class TestBuildSchemaFromConfig:
             assert "options" in entry
             assert "local" in entry["options"]
 
+    def test_power_prevent_sleep_schema(self):
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        assert CONFIG_SCHEMA["power.prevent_sleep.enabled"]["type"] == "boolean"
+        assert CONFIG_SCHEMA["power.prevent_sleep.surfaces"]["type"] == "list"
+        assert CONFIG_SCHEMA["power.prevent_sleep.mode"]["type"] == "select"
+        assert CONFIG_SCHEMA["power.prevent_sleep.mode"]["options"] == ["system", "display"]
+
     def test_memory_provider_field_present_as_select(self):
         """memory.provider must stay in the config schema.
 
@@ -3872,6 +3880,47 @@ class TestConfigRoundTrip:
         config = self.client.get("/api/config").json()
         assert isinstance(config.get("model"), str), \
             f"model should be string, got {type(config.get('model'))}"
+
+    def test_get_config_expands_prevent_sleep_environment(self, monkeypatch):
+        """Config and effective-power APIs share canonical env expansion."""
+        from hermes_cli.config import save_config
+
+        monkeypatch.setenv("PREVENT_SLEEP_ENABLED", "false")
+        save_config(
+            {
+                "power": {
+                    "prevent_sleep": {
+                        "enabled": "${PREVENT_SLEEP_ENABLED}",
+                        "mode": "display",
+                        "surfaces": ["desktop"],
+                    }
+                }
+            }
+        )
+
+        config = self.client.get("/api/config").json()
+
+        assert config["power"]["prevent_sleep"] == {
+            "enabled": "false",
+            "mode": "display",
+            "surfaces": ["desktop"],
+        }
+        assert self.client.get("/api/power/prevent-sleep").json() == {
+            "enabled": False,
+            "mode": "display",
+            "surfaces": ["desktop"],
+        }
+
+    def test_effective_power_api_normalizes_boolean_shorthand(self):
+        from hermes_cli.config import save_config
+
+        save_config({"power": {"prevent_sleep": True}})
+
+        assert self.client.get("/api/power/prevent-sleep").json() == {
+            "enabled": True,
+            "mode": "system",
+            "surfaces": ["desktop", "gateway"],
+        }
 
     def test_round_trip_preserves_model_subkeys(self):
         """Save and reload should not lose model.provider, model.base_url, etc."""

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -71,6 +71,30 @@ class TestProfileScopedConfig:
         resp = client.get("/api/config")
         assert resp.json().get("timezone") != "Venus/Cloud"
 
+    def test_effective_power_get_reads_target_profile(self, client, isolated_profiles):
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "power:\n"
+            "  prevent_sleep:\n"
+            "    enabled: true\n"
+            "    surfaces: [desktop]\n"
+            "    mode: display\n",
+            encoding="utf-8",
+        )
+
+        worker = client.get(
+            "/api/power/prevent-sleep",
+            params={"profile": "worker_beta"},
+        )
+        default = client.get("/api/power/prevent-sleep")
+
+        assert worker.status_code == 200
+        assert worker.json() == {
+            "enabled": True,
+            "mode": "display",
+            "surfaces": ["desktop"],
+        }
+        assert default.json()["enabled"] is False
+
     def test_config_query_param_equivalent_to_body(self, client, isolated_profiles):
         """The SPA's fetchJSON injects ?profile= — must scope like body.profile."""
         resp = client.put(

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -91,6 +91,25 @@ You can also set `providers.<id>.stale_timeout_seconds` for the non-streaming st
 
 Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=90`s, native Anthropic 900s). The non-streaming stale detector is auto-disabled for local endpoints when left implicit and can scale upward for very large contexts. Not currently wired for AWS Bedrock (both `bedrock_converse` and AnthropicBedrock SDK paths use boto3 with its own timeout configuration). See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
 
+## Host Sleep Prevention
+
+Long-running Desktop and Gateway sessions can opt in to keeping the host awake. The setting is disabled by default to avoid unexpected battery drain:
+
+```yaml
+power:
+  prevent_sleep:
+    enabled: true
+    surfaces: [desktop, gateway]
+    mode: system  # system | display
+```
+
+- `system` prevents idle system sleep while still allowing the display to turn off.
+- `display` also keeps the display awake.
+- `surfaces` can contain `desktop`, `gateway`, or both. An empty list disables the assertion everywhere.
+- Desktop applies changes after its canonical config refresh. A running Gateway picks up changes on its next restart.
+
+Desktop uses Electron's cross-platform power blocker. The foreground profile in the primary Desktop window owns the local Desktop assertion; secondary session windows cannot change this machine-wide state. The standalone Gateway currently applies its host assertion on Windows through `SetThreadExecutionState`; on other platforms the Gateway setting is a safe no-op. Environment substitutions such as `enabled: ${PREVENT_SLEEP_ENABLED}` follow the same [canonical `${VAR}` rules](#environment-variable-substitution) as the rest of `config.yaml`.
+
 ## Update Behavior
 
 `hermes update` settings live under `updates` in `config.yaml`:


### PR DESCRIPTION
## Summary
- add an opt-in `power.prevent_sleep` config block for long-running Hermes surfaces
- surface `enabled`, `surfaces`, and `mode` in Desktop Settings → Power
- use Electron `powerSaveBlocker` for the Desktop lifecycle and Windows `SetThreadExecutionState` for the Gateway lifecycle
- keep the default disabled to avoid unexpected battery drain

## Sweeper feedback addressed
- ported the Electron implementation from the removed CJS/Jest surface to current `main.ts`, `preload.ts`, TypeScript, and Vitest
- removed the Electron YAML reader completely
- centralized normalization in Python `resolve_prevent_sleep_config()` over `load_config_readonly()`
- Gateway calls that canonical resolver directly; Desktop receives the same profile-scoped decision from `GET /api/power/prevent-sleep` and passes only the typed result over IPC
- retained version-skew safety: an older backend without the narrow endpoint leaves Electron's last-good blocker unchanged instead of falling back to duplicate renderer parsing
- added `${VAR}`, boolean shorthand, malformed-config last-known-good, and profile-scope coverage
- updated the latest Desktop `contrib/wiring.tsx` profile-swap path so the foreground profile refreshes the machine-wide local assertion

## Lifecycle hardening
- acquire and verify a replacement Electron blocker before releasing the last-good blocker
- retain failed releases for retry and report actual native state instead of assuming cleanup succeeded
- allow only the primary Desktop renderer to update the machine-wide assertion
- discard stale config responses after profile switches; the foreground profile owns the local Desktop assertion
- restore the Windows owner thread's prior execution state and reject cross-thread cleanup

## Configuration

```yaml
power:
  prevent_sleep:
    enabled: false
    surfaces:
      - desktop
      - gateway
    mode: system
```

- `system`: keep the host awake while allowing display sleep
- `display`: keep both the host and display awake
- Gateway host assertions are currently Windows-only; unsupported platforms safely no-op

## Verification
- rebased and verified on `main` at `dbf86b9234` (subsequent base-only commits may continue landing while this PR is open)
- canonical `scripts/run_tests.sh` power/Gateway/profile suites — 59 passed
- focused config schema/API tests — 3 passed
- `cd apps/desktop && npm run test:desktop:platforms -- electron/power-save.test.ts` — 13 passed
- targeted Desktop config/settings/boot UI suite — 36 passed
- `cd apps/desktop && npm run typecheck`
- targeted Electron/renderer ESLint + Prettier and changed-Python Ruff checks
- `cd apps/desktop && npm run build`
- `cd website && npx docusaurus build --locale en`
- real Windows API smoke: assertion started, prior state restored, and assertion cleared successfully
