### PR TITLE
fix(moa): merge consecutive same-role turns in the reference advisory view

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -410,6 +410,22 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
     rendered: list[dict[str, Any]] = []
     last_user_content: str | None = None
+
+    def _append_or_merge(role: str, content: str) -> None:
+        # Strict providers (Anthropic, Bedrock, Mistral) reject any request whose
+        # messages[] has two consecutive same-role entries with
+        # ``400 ... roles must alternate``. Two ordinary history shapes produce
+        # consecutive ``user`` turns here — adjacent user turns in ``messages``,
+        # and an empty assistant turn dropped between two users, collapsing
+        # ``[user, assistant(empty), user]`` to ``[user, user]``. Merge adjacent
+        # same-role turns as the view is built so the advisory copy stays
+        # alternating (preserving the end-on-user + no-tool-role guarantees).
+        if rendered and rendered[-1]["role"] == role:
+            prior = rendered[-1]["content"]
+            rendered[-1]["content"] = f"{prior}\n\n{content}" if prior else content
+        else:
+            rendered.append({"role": role, "content": content})
+
     for msg in messages:
         role = msg.get("role")
         content = msg.get("content")
@@ -420,7 +436,7 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if role == "user":
             if text.strip():
                 last_user_content = text
-            rendered.append({"role": "user", "content": text})
+            _append_or_merge("user", text)
         elif role == "assistant":
             parts: list[str] = []
             if text.strip():
@@ -430,7 +446,7 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 parts.append(calls_text)
             # Empty assistant turns (no text, no calls) carry nothing advisory.
             if parts:
-                rendered.append({"role": "assistant", "content": "\n".join(parts)})
+                _append_or_merge("assistant", "\n".join(parts))
         elif role == "tool":
             # Fold the tool result into the preceding assistant turn as text so
             # the reference sees what came back, without emitting a tool-role
@@ -442,7 +458,7 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
             else:
                 # No assistant turn to attach to (e.g. a leading tool result);
                 # keep it as advisory context on its own assistant-role line.
-                rendered.append({"role": "assistant", "content": block})
+                _append_or_merge("assistant", block)
         # Any other role is ignored.
 
     # End on a user turn: append a synthetic advisory request rather than

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -355,6 +355,50 @@ def test_reference_messages_ends_with_user_not_assistant_prefill():
     assert "q1" in joined and "a1" in joined and "q2 current" in joined
 
 
+def test_reference_messages_merges_consecutive_user_turns():
+    """Adjacent same-role turns are merged so the advisory view alternates.
+
+    Strict providers (Anthropic, Bedrock, Mistral) reject any request whose
+    ``messages[]`` has two consecutive same-role entries with
+    ``400 ... roles must alternate``. Two ordinary history shapes produce
+    consecutive ``user`` turns in the view: (a) two adjacent user turns in
+    ``messages`` (e.g. an injected snapshot user turn), and (b) an empty
+    assistant turn between two users, which is dropped and collapses
+    ``[user, assistant(empty), user]`` to ``[user, user]``. Both must be merged,
+    with each turn's text preserved.
+    """
+    from agent.moa_loop import _reference_messages
+
+    # (a) adjacent user turns.
+    view_a = _reference_messages(
+        [
+            {"role": "user", "content": "reminder"},
+            {"role": "user", "content": "real q"},
+            {"role": "assistant", "content": "a"},
+        ]
+    )
+    assert all(
+        view_a[i]["role"] != view_a[i + 1]["role"] for i in range(len(view_a) - 1)
+    )
+    joined_a = "\n".join(m["content"] for m in view_a)
+    assert "reminder" in joined_a and "real q" in joined_a
+
+    # (b) empty assistant turn between two users collapses to consecutive users.
+    view_b = _reference_messages(
+        [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "a"},
+        ]
+    )
+    assert all(
+        view_b[i]["role"] != view_b[i + 1]["role"] for i in range(len(view_b) - 1)
+    )
+    joined_b = "\n".join(m["content"] for m in view_b)
+    assert "q1" in joined_b and "q2" in joined_b
+
+
 def test_reference_messages_truncates_large_tool_results():
     """Large tool results are previewed head+tail, not replayed verbatim."""
     from agent.moa_loop import _REFERENCE_TOOL_RESULT_BUDGET, _reference_messages


### PR DESCRIPTION
## What does this PR do?

`_reference_messages` in `agent/moa_loop.py` builds the disposable advisory view handed to the MoA reference (advisor) models. Its docstring promises that view is safe for strict providers (Mistral/Fireworks/Anthropic) and explicitly guards *end-on-user* and *no-tool-roles* — but it never guards **role alternation**.

Anthropic/Bedrock/Mistral reject any request whose `messages[]` has two consecutive same-role entries with `400 ... roles must alternate`. Two ordinary history shapes produce consecutive `user` turns that pass straight through the view builder:

- **(a) two adjacent user turns** in `messages` (e.g. an injected snapshot user turn, or tool-result-as-user history), and
- **(b) an empty assistant turn between two users** — dropped when it carries no advisory parts (`if parts:`), collapsing `[user, assistant(empty), user]` → `[user, user]`.

The view is handed to the reference models via `_run_references_parallel` with no alternation sanitization anywhere on the path. So on any non-trivial history against an Anthropic/Mistral advisor, the entire reference fan-out 400s and silently degrades to `[failed: 400 ...]` notes — defeating MoA exactly on the longer conversations where advisory input matters most.

## Related Issue

N/A — found by reading the reference-view builder against the strict-provider guarantees its own docstring makes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moa_loop.py`: introduce a small `_append_or_merge(role, content)` helper inside `_reference_messages` that concatenates content onto the last rendered entry when its role matches, instead of appending a new same-role turn. Route the `user`, `assistant`, and leading-tool-result appends through it. This merges adjacent same-role turns as the view is built, keeping it alternating while preserving the existing end-on-user and no-tool-role guarantees (merging users keeps the tail role `user`).
- `tests/run_agent/test_moa_loop_mode.py`: add `test_reference_messages_merges_consecutive_user_turns` covering both producing shapes and asserting the view alternates while both user texts survive.

## How to Test

1. Before the fix, `_reference_messages([{"role":"user","content":"reminder"},{"role":"user","content":"real q"},{"role":"assistant","content":"a"}])` yields roles `['user','user','assistant','user']` — a consecutive `user,user` pair a strict advisor 400s on. Same for `[{"role":"user"},{"role":"assistant","content":""},{"role":"user"},{"role":"assistant"}]`.
2. The new test asserts `all(view[i]["role"] != view[i+1]["role"])` for both shapes and that both user texts survive the merge. It **fails before** this change and **passes after** (verified by stashing the prod hunk).
3. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/run_agent/test_moa_loop_mode.py -q` → 28 passed (27 existing sibling reference-view tests + 1 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched test file and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (pure in-memory list transform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A