### PR TITLE
fix(desktop): render sub-minute durations that round to 60s as "1m"

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatDurationSeconds } from './format'
+
+describe('formatDurationSeconds', () => {
+  it('renders sub-minute durations that round up to 60s as "1m"', () => {
+    // The sub-minute branch formats with toFixed(0), which rounds up. Gating on
+    // raw seconds let [59.5, 60) pass the "under a minute" gate yet render an
+    // out-of-range "60s" label. Round-then-gate keeps the boundary consistent.
+    expect(formatDurationSeconds(59.5)).toBe('1m')
+    expect(formatDurationSeconds(59.9)).toBe('1m')
+    expect(formatDurationSeconds(59.99)).toBe('1m')
+  })
+
+  it('keeps the existing labels below the rounding boundary', () => {
+    expect(formatDurationSeconds(0.5)).toBe('500ms')
+    expect(formatDurationSeconds(5.4)).toBe('5.4s')
+    expect(formatDurationSeconds(59.4)).toBe('59s')
+  })
+
+  it('keeps the minute and higher labels unchanged', () => {
+    expect(formatDurationSeconds(60)).toBe('1m')
+    expect(formatDurationSeconds(90)).toBe('1m 30s')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
@@ -114,7 +114,11 @@ export function formatDurationSeconds(seconds: number): string {
     return `${ms}ms`
   }
 
-  if (seconds < 60) {
+  // Gate on the value we will actually render. The sub-minute label rounds via
+  // toFixed(0) for >= 10s, so gating on raw `seconds` lets [59.5, 60) pass this
+  // branch yet render "60s" — an out-of-range seconds label the minute branch
+  // below exists to avoid. Rounding first keeps the boundary consistent.
+  if (Math.round(seconds) < 60) {
     return `${seconds.toFixed(seconds >= 10 ? 0 : 1)}s`
   }
 


### PR DESCRIPTION
## What does this PR do?

`formatDurationSeconds` in `apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts` gates its sub-minute branch on the **raw** `seconds` (`seconds < 60`) but formats the label with `toFixed(0)`, which rounds up. Any `seconds` in `[59.5, 60)` therefore passes the "under a minute" gate yet renders `"60s"` — an out-of-range seconds label the minute branch below exists to avoid.

The inconsistency is internal: the minute branch already rounds via `Math.round(seconds)`, so the two branches disagree on where the one-minute boundary is. Verified: `formatDurationSeconds(59.5) === "60s"`, `(59.9) === "60s"`, `(59.99) === "60s"`, whereas `(60) === "1m"`.

This label renders live as `view.durationLabel` on tool-card headers (`durationLabel` → `formatDurationSeconds(numberValue(resultRecord.duration_s))`); `duration_s` is a wall-clock float and the file already parses fractional durations, so the `[59.5, 60)` window is reachable in practice.

## Related Issue

N/A — found by reading the two duration branches against each other; the sub-minute gate uses raw seconds while the minute gate rounds.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts`: gate the sub-minute branch on `Math.round(seconds) < 60` so the same rounding governs which branch renders. `[59.5, 60)` now falls to the minute branch and renders `"1m"`. Sub-second (`< 1` → ms) and 1–9.9s one-decimal formatting are unchanged.
- `apps/desktop/src/components/assistant-ui/tool/fallback-model/format.test.ts` (new): vitest coverage for the boundary and the unchanged labels.

## How to Test

1. Before the fix, `formatDurationSeconds(59.5)` returns `"60s"` (and `59.9`, `59.99` likewise) — an out-of-range seconds label.
2. `format.test.ts` asserts `formatDurationSeconds(59.5) === "1m"` and `(59.99) === "1m"` (both **fail before** this change), plus unchanged guards `0.5 → "500ms"`, `5.4 → "5.4s"`, `59.4 → "59s"`, `60 → "1m"`, `90 → "1m 30s"`.
3. `npx vitest run --environment jsdom src/components/assistant-ui/tool/fallback-model/format.test.ts` (from `apps/desktop`) → 3 passed. Verified fail-before by reverting the gate to raw seconds.

Note: the sibling `fallback-model.test.ts` has 2 pre-existing `browser_navigate title` failures on clean `main` (URL-title formatting, unrelated to this change) — this PR adds a separate `format.test.ts` and does not touch them.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the fallback-model test folder and my new tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure numeric formatting)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A