### PR TITLE
fix(slack): don't italicize intra-word underscores in Block Kit rendering

### DIFF
--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -71,8 +71,26 @@ def _indent_level(spaces: str) -> int:
 _INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 _LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^()\s]+(?:\([^()]*\)[^()\s]*)*)\)")
 _BOLD_RE = re.compile(r"(?:\*\*|__)(.+?)(?:\*\*|__)")
-_ITALIC_RE = re.compile(r"(?<![\*_])(?:\*|_)(?![\*_\s])(.+?)(?<![\*_\s])(?:\*|_)(?![\*_])")
+# Italic is split by marker because the two markers have different intra-word
+# rules. Per CommonMark, ``*`` emphasis may open/close intra-word ("a*b*c" is
+# emphasis), but ``_`` emphasis may NOT — an underscore inside a word is
+# literal, so snake_case identifiers like ``max_tokens`` must never open an
+# italic span. A single combined pattern applied the permissive ``*`` boundary
+# rules to ``_`` too, italicizing across intra-word underscores.
+_ITALIC_STAR_RE = re.compile(r"(?<!\*)\*(?![\*\s])(.+?)(?<![\*\s])\*(?!\*)")
+# ``_`` requires a non-word boundary on both sides (left: not preceded by a
+# word char or another ``_``; right: not followed by a word char or ``_``).
+_ITALIC_UNDERSCORE_RE = re.compile(r"(?<![\w_])_(?![_\s])(.+?)(?<![_\s])_(?![\w_])")
 _STRIKE_RE = re.compile(r"~~(.+?)~~")
+
+
+def _search_italic(s: str) -> Optional["re.Match[str]"]:
+    """Earliest italic match across the ``*``-intra-word and ``_``-boundary rules."""
+    star = _ITALIC_STAR_RE.search(s)
+    under = _ITALIC_UNDERSCORE_RE.search(s)
+    if star and under:
+        return star if star.start() <= under.start() else under
+    return star or under
 
 
 def _inline_elements(text: str) -> List[Dict[str, Any]]:
@@ -121,8 +139,15 @@ def _inline_elements(text: str) -> List[Dict[str, Any]]:
         if not s:
             return
         # Try bold, then strike, then italic, recursing into the inner span.
-        for rx, key in ((_BOLD_RE, "bold"), (_STRIKE_RE, "strike"), (_ITALIC_RE, "italic")):
-            m = rx.search(s)
+        # Italic uses ``_search_italic`` so the ``*``-intra-word and
+        # ``_``-boundary rules are considered together (earliest match wins),
+        # preserving the bold > strike > italic precedence.
+        for search, key in (
+            (_BOLD_RE.search, "bold"),
+            (_STRIKE_RE.search, "strike"),
+            (_search_italic, "italic"),
+        ):
+            m = search(s)
             if m:
                 _walk_emphasis(s[:m.start()], style)
                 inner_style = dict(style)

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -12,6 +12,25 @@ def _types(blocks):
     return [b["type"] for b in blocks]
 
 
+def _italic_texts(node):
+    """Recursively collect ``text`` values of every element carrying
+    ``style.italic`` anywhere in a Block Kit structure."""
+    found = []
+    if isinstance(node, dict):
+        style = node.get("style")
+        # ``style`` is a dict on inline text elements ({"italic": True}) but a
+        # bare string on list containers ("bullet"/"ordered") — only inspect
+        # the dict form.
+        if isinstance(style, dict) and style.get("italic"):
+            found.append(node.get("text", ""))
+        for value in node.values():
+            found.extend(_italic_texts(value))
+    elif isinstance(node, list):
+        for item in node:
+            found.extend(_italic_texts(item))
+    return found
+
+
 class TestRenderBlocksBasics:
     def test_empty_returns_none(self):
         assert render_blocks("") is None
@@ -96,8 +115,10 @@ class TestInlineFormatting:
         # italic regex ran from the ``_`` in ``max_tokens`` to the ``_`` in
         # ``top_p``, italicizing ``tokens and top``.
         blocks = render_blocks("- set max_tokens and top_p")
-        blob = str(blocks)
-        assert "'italic': True" not in blob and '"italic": true' not in blob
+        # Walk the rendered rich_text elements (like the bold/boundary tests)
+        # rather than substring-matching ``str(blocks)``: no element anywhere
+        # in the structure may carry ``style.italic`` for this input.
+        assert _italic_texts(blocks) == []
 
     def test_boundary_underscore_still_italic(self):
         # ``_`` at word boundaries is legitimate emphasis and must still render.

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -90,6 +90,27 @@ class TestInlineFormatting:
         ]
         assert styled, "expected a bold-styled text element in the list item"
 
+    def test_intraword_underscore_not_italic(self):
+        # CommonMark forbids ``_`` emphasis at intra-word positions, so
+        # snake_case identifiers must never open an italic span. Previously the
+        # italic regex ran from the ``_`` in ``max_tokens`` to the ``_`` in
+        # ``top_p``, italicizing ``tokens and top``.
+        blocks = render_blocks("- set max_tokens and top_p")
+        blob = str(blocks)
+        assert "'italic': True" not in blob and '"italic": true' not in blob
+
+    def test_boundary_underscore_still_italic(self):
+        # ``_`` at word boundaries is legitimate emphasis and must still render.
+        blocks = render_blocks("- a _real italic_ here")
+        rich = [b for b in blocks if b["type"] == "rich_text"][0]
+        section = rich["elements"][0]["elements"][0]
+        styled = [
+            el for el in section["elements"]
+            if el.get("style", {}).get("italic")
+        ]
+        assert styled, "expected an italic-styled element for boundary underscores"
+        assert any("real italic" in el.get("text", "") for el in styled)
+
 
 class TestTables:
     def test_pipe_table_renders_native_table_block(self):


### PR DESCRIPTION
## What does this PR do?

The Block Kit inline renderer in `plugins/platforms/slack/block_kit.py` used a single italic regex whose opening lookbehind `(?<![\*_])` blocked a preceding `*`/`_` but **not** a word character. So an underscore in the middle of an identifier opened an italic span:

- `_inline_elements("use max_tokens and top_p params")` → italic `"tokens and top"` (the span runs from the `_` in `max_tokens` to the `_` in `top_p`)
- `_inline_elements("the file_name_here var")` → italic `"name"`
- `_inline_elements("call get_user_id()")` → italic `"user"`

This hits any agent message containing snake_case identifiers, param names, or file names — extremely common in code discussions. It is reachable end-to-end via `render_blocks` list items and table cells (both call `_inline_elements` on raw markdown), in the opt-in `slack.extra.rich_blocks` Block Kit renderer.

CommonMark forbids `_`-emphasis at intra-word positions — only `*` may open or close emphasis inside a word. The single regex wrongly applied the permissive `*` boundary rules to `_` as well.

## Related Issue

N/A — found by reading `_ITALIC_RE` against the CommonMark intra-word-emphasis rule.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/block_kit.py`: split the single `_ITALIC_RE` into `_ITALIC_STAR_RE` (intra-word `*` legal, unchanged permissiveness) and `_ITALIC_UNDERSCORE_RE` (requires a non-word boundary on both ends: `(?<![\w_])_(?![_\s])` … `(?<![_\s])_(?![\w_])`). Add `_search_italic` which returns the earliest match across both, and route the italic tier of `_walk_emphasis` through it — preserving the existing bold → strike → italic precedence.
- `tests/gateway/test_slack_block_kit.py`: add `test_intraword_underscore_not_italic` (fails before) and `test_boundary_underscore_still_italic` (guards over-correction).

## How to Test

1. Before the fix, `render_blocks("- set max_tokens and top_p")` produces a list item containing a spurious `style.italic` element spanning `"tokens and top"`.
2. `test_intraword_underscore_not_italic` asserts no `italic` style is present for that input (**fails before**, passes after). `test_boundary_underscore_still_italic` asserts `_real italic_` still renders italic (passes before and after — guards against over-correction).
3. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_slack_block_kit.py -q` → 21 passed (19 existing + 2 new). Also manually verified `*starred*`, intra-word `a*b*c`, and bold `**…**`/`__…__` are unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full `tests/gateway/test_slack_block_kit.py` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure regex/string transform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A