### PR TITLE
fix(env-probe): compare interpreter versions by major.minor, not string prefix

### DIFF
--- a/tests/tools/test_env_probe.py
+++ b/tests/tools/test_env_probe.py
@@ -69,6 +69,33 @@ class TestEmitsOnRealProblems:
         # Points at the right escape hatch
         assert "venv" in line or "uv" in line
 
+    def test_prefix_collision_version_mismatch_is_detected(self, monkeypatch):
+        """python3 is 3.12.4 but pip on PATH is bound to python 3.1 — a real
+        mismatch that a raw ``startswith`` check misses because
+        ``"3.12.4".startswith("3.1")`` is True. The probe must still flag it.
+        """
+        monkeypatch.setattr(env_probe, "_python_version_of",
+                            lambda b: {"python3": "3.12.4", "python": None}.get(b))
+        monkeypatch.setattr(env_probe, "_has_pip_module", lambda b: True)
+        monkeypatch.setattr(env_probe, "_detect_pep668", lambda b: False)
+        monkeypatch.setattr(env_probe, "_pip_python_version", lambda: "3.1")
+        monkeypatch.setattr(env_probe.shutil, "which", lambda name: None)
+
+        line = env_probe.get_environment_probe_line()
+        assert line  # must not be silent
+        assert "mismatch" in line
+
+    def test_micro_only_difference_is_not_a_mismatch(self, monkeypatch):
+        """python3=3.12.4 vs pip→3.12 differ only in micro — same feature
+        release, so NOT a mismatch (stays silent when otherwise healthy)."""
+        monkeypatch.setattr(env_probe, "_python_version_of",
+                            lambda b: "3.12.4" if b == "python3" else None)
+        monkeypatch.setattr(env_probe, "_has_pip_module", lambda b: True)
+        monkeypatch.setattr(env_probe, "_detect_pep668", lambda b: False)
+        monkeypatch.setattr(env_probe, "_pip_python_version", lambda: "3.12")
+        monkeypatch.setattr(env_probe.shutil, "which", lambda name: None)
+        assert env_probe.get_environment_probe_line() == ""
+
     def test_missing_python3_is_named(self, monkeypatch):
         """If python3 isn't installed at all, say so."""
         monkeypatch.setattr(env_probe, "_python_version_of", lambda b: None)

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -136,6 +136,13 @@ def _pip_python_version() -> Optional[str]:
     return None
 
 
+def _major_minor(version: str) -> str:
+    """Return the ``major.minor`` prefix of a version string (``3.12.4`` →
+    ``3.12``).  Used to compare interpreter versions by feature release
+    rather than by raw-string prefix."""
+    return ".".join(version.split(".")[:2])
+
+
 def _build_probe_line() -> str:
     """Build the one-liner.  Returns "" when nothing notable is detected.
 
@@ -159,7 +166,15 @@ def _build_probe_line() -> str:
     # version mismatch between `pip` and `python3` → environment is
     # clean enough to stay silent.  The model can discover details by
     # running commands if it cares.
-    mismatch = bool(pip_bound_to and py3_ver and not py3_ver.startswith(pip_bound_to))
+    # Compare on major.minor, not raw-string prefix: a plain
+    # ``py3_ver.startswith(pip_bound_to)`` treats python3=3.12.4 vs pip→3.1
+    # as a match (``"3.12.4".startswith("3.1")`` is True), silently hiding a
+    # real interpreter mismatch.
+    mismatch = bool(
+        pip_bound_to
+        and py3_ver
+        and _major_minor(py3_ver) != _major_minor(pip_bound_to)
+    )
     silent_conditions = (
         py3_ver is not None
         and py3_has_pip


### PR DESCRIPTION
## What does this PR do?

`tools/env_probe.py` emits a one-line toolchain hint when `pip` on PATH resolves to a different interpreter than `python3`. That's one of the failure modes the probe exists to catch. The mismatch test uses raw string-prefix matching:

```python
mismatch = bool(pip_bound_to and py3_ver and not py3_ver.startswith(pip_bound_to))
```

`py3_ver` is a full `major.minor.micro` string (e.g. `3.12.4`), while `pip_bound_to` is `major.minor` (e.g. `3.1`, parsed from the trailing `(python X.Y)` in `pip --version`). Because `startswith` compares raw text, a real mismatch gets swallowed whenever the pip-bound version is a textual prefix of `python3`'s version:

```
>>> "3.12.4".startswith("3.1")   # python3=3.12.4, pip→python3.1
True                              # → treated as "not a mismatch", probe stays silent
```

So the model never gets warned that `pip install` and `python3 -m pip` target different interpreters. That's the exact split the probe is supposed to catch.

The fix compares the `major.minor` release components instead. Now `3.12.4` vs `3.1` is correctly a mismatch, and `3.12.4` vs `3.12` (a micro-only difference, same feature release) is not.

## Related Issue

Fixes # <!-- no existing issue; found via source audit -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/env_probe.py`: add a small `_major_minor()` helper and use it in `_build_probe_line()`, so the pip vs. python3 version mismatch is computed on `major.minor` components rather than a raw-string prefix.
- `tests/tools/test_env_probe.py`: add `test_prefix_collision_version_mismatch_is_detected` (fails on the old code) and `test_micro_only_difference_is_not_a_mismatch` (guards against over-flagging a micro-only difference).

## How to Test

1. `scripts/run_tests.sh tests/tools/test_env_probe.py`. All 12 tests pass.
2. To show the fix matters, revert `env_probe.py` only and rerun. `test_prefix_collision_version_mismatch_is_detected` fails (`assert line` on an empty probe line), because the old `startswith` check emits no probe line for python3=3.12.4 with pip bound to 3.1.
3. Sanity check: `python3 -c "print('3.12.4'.startswith('3.1'))"` prints `True`, which is the root cause.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all pass (`scripts/run_tests.sh tests/tools/test_env_probe.py`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A (new helper is documented in its docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide, or N/A (pure string math, platform-independent)