### PR TITLE
fix(gateway): don't count live-process reconnects as restart-loop boots

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6099,7 +6099,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if drained:
             logger.info("Drained %d inbound message(s) queued during startup restore", drained)
 
-    def _schedule_resume_pending_sessions(self, platform=None) -> int:
+    def _restart_loop_should_skip_resume(self, count_as_boot: bool) -> bool:
+        """Whether the restart-loop breaker (#30719, defense-3) says to skip
+        auto-resume for this pass.
+
+        A startup pass (``count_as_boot=True``) RECORDS this
+        restart-interrupted boot into the rolling window and trips once too
+        many cluster inside the window. A live reconnect pass
+        (``count_as_boot=False``) must NOT record — a network blip recovered
+        within one already-running process is not a gateway boot, and counting
+        it would let ordinary reconnect churn trip the breaker (and pollute the
+        window for a later genuine startup). It still HONORS an already-tripped
+        breaker so a real SIGTERM-respawn loop is not resurrected by a
+        reconnect. Fails OPEN (returns False) on any error — a broken breaker
+        must never wedge a healthy gateway.
+        """
+        try:
+            from gateway import restart_loop_guard as _rlg
+
+            _max_restarts, _window = self._restart_loop_guard_config()
+            if count_as_boot:
+                return _rlg.check_and_record(_max_restarts, _window)
+            return _rlg.is_restart_loop_tripped(_max_restarts, _window)
+        except Exception as exc:  # noqa: BLE001 — breaker must fail OPEN
+            logger.debug("Restart-loop guard check skipped: %s", exc)
+            return False
+
+    def _schedule_resume_pending_sessions(self, platform=None, *, count_as_boot=True) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
 
         ``resume_pending`` already preserves the transcript AND the existing
@@ -6147,16 +6173,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # resume_pending, so a real user message can still continue it (a human
         # is now in the loop). Defenses 1-2 cover the cron/CLI/terminal paths;
         # this catches every other SIGTERM source (e.g. a raw `terminal(
-        # "launchctl kickstart ai.hermes.gateway")`).
-        if candidates:
-            try:
-                from gateway import restart_loop_guard as _rlg
-
-                _max_restarts, _window = self._restart_loop_guard_config()
-                if _rlg.check_and_record(_max_restarts, _window):
-                    return 0
-            except Exception as exc:  # noqa: BLE001 — breaker must fail OPEN
-                logger.debug("Restart-loop guard check skipped: %s", exc)
+        # "launchctl kickstart ai.hermes.gateway")`). ``count_as_boot`` is False
+        # on the live-process reconnect pass so a network blip does not accrue a
+        # phantom boot (it still honors an already-tripped breaker).
+        if candidates and self._restart_loop_should_skip_resume(count_as_boot):
+            return 0
 
         now = datetime.now()
         scheduled = 0
@@ -7488,7 +7509,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # auto-resume scoped to this platform so recovery
                         # doesn't silently wait for a manual user message.
                         try:
-                            self._schedule_resume_pending_sessions(platform=platform)
+                            self._schedule_resume_pending_sessions(
+                                platform=platform, count_as_boot=False
+                            )
                         except Exception:
                             logger.debug(
                                 "resume-pending reschedule after %s reconnect failed",

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -318,9 +318,67 @@ class TestPlatformReconnectWatcher:
                 await run_one_iteration()
 
         assert Platform.TELEGRAM in runner.adapters
+        # count_as_boot=False: a live-process reconnect is not a gateway boot,
+        # so it must not accrue toward the restart-loop breaker (#30719).
         runner._schedule_resume_pending_sessions.assert_called_once_with(
-            platform=Platform.TELEGRAM
+            platform=Platform.TELEGRAM, count_as_boot=False
         )
+
+
+class TestRestartLoopBootAccounting:
+    """The restart-loop breaker (#30719, defense-3) must count gateway boots,
+    not live-process platform reconnects."""
+
+    def _runner(self):
+        runner = object.__new__(GatewayRunner)
+        # Fixed config so the test doesn't depend on a user's config.yaml.
+        runner._restart_loop_guard_config = lambda: (3, 60)
+        return runner
+
+    def test_reconnect_pass_does_not_accrue_or_trip(self, monkeypatch, tmp_path):
+        """Repeated live reconnects within the window neither record a boot nor
+        trip the breaker — otherwise ordinary network churn would suppress
+        auto-resume and poison the window for a later genuine startup."""
+        import gateway.restart_loop_guard as rlg
+
+        monkeypatch.setattr(rlg, "get_hermes_home", lambda: tmp_path)
+        rlg.clear()
+        runner = self._runner()
+
+        for _ in range(5):
+            assert runner._restart_loop_should_skip_resume(count_as_boot=False) is False
+        # Nothing was recorded — the window is still empty.
+        assert rlg._load_boots() == []
+
+    def test_startup_pass_still_trips(self, monkeypatch, tmp_path):
+        """Regression guard: genuine restart-interrupted boots still trip on
+        the Nth boot inside the window."""
+        import gateway.restart_loop_guard as rlg
+
+        monkeypatch.setattr(rlg, "get_hermes_home", lambda: tmp_path)
+        rlg.clear()
+        runner = self._runner()
+
+        assert runner._restart_loop_should_skip_resume(count_as_boot=True) is False
+        assert runner._restart_loop_should_skip_resume(count_as_boot=True) is False
+        assert runner._restart_loop_should_skip_resume(count_as_boot=True) is True
+
+    def test_reconnect_honors_already_tripped_breaker(self, monkeypatch, tmp_path):
+        """A reconnect must still SKIP resume when a real SIGTERM loop has
+        already tripped the breaker — it just doesn't add to the count."""
+        import gateway.restart_loop_guard as rlg
+
+        monkeypatch.setattr(rlg, "get_hermes_home", lambda: tmp_path)
+        rlg.clear()
+        runner = self._runner()
+
+        # Three genuine boots trip the breaker.
+        for _ in range(3):
+            runner._restart_loop_should_skip_resume(count_as_boot=True)
+        before = list(rlg._load_boots())
+        # A subsequent reconnect honors the trip but records nothing new.
+        assert runner._restart_loop_should_skip_resume(count_as_boot=False) is True
+        assert rlg._load_boots() == before
 
     @pytest.mark.asyncio
     async def test_reconnect_nonretryable_removed_from_queue(self):


### PR DESCRIPTION
## What does this PR do?

The auto-resume restart-loop breaker (#30719, defense-3) keeps a rolling window of restart-interrupted gateway boots in `<HERMES_HOME>/gateway/restart_loop.json`. It trips when too many cluster inside the window, at which point `_schedule_resume_pending_sessions` skips auto-resume to break a suspected SIGTERM-respawn loop.

That method records a boot via `restart_loop_guard.check_and_record(...)` on two call paths:

- `gateway/run.py` startup pass, `_schedule_resume_pending_sessions()`. A genuine boot.
- the per-platform reconnect pass, `_schedule_resume_pending_sessions(platform=...)`, fired by the reconnect watcher within one already-running process after a network/DNS blip (`_connect_adapter_with_timeout(..., is_reconnect=True)`).

A live reconnect is not a gateway boot, yet it accrued one. Consequences:

1. **False trips.** A gateway with restart-interrupted sessions on a flaky platform that reconnects a few times inside the window (default 3 / 60s) reaches the threshold and suppresses auto-resume. Sessions stay `resume_pending` until the next real user message.
2. **Window poisoning.** Those non-boot timestamps persist and can trip a later genuine startup earlier than intended.

The module docstring and the TRIPPED warning both define the window strictly in terms of "restart-interrupted gateway boots". The reconnect path violated that contract.

## Related Issue

Fixes # <!-- no existing issue; found via source audit; relates to the #30719 breaker -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: extract the breaker decision into `_restart_loop_should_skip_resume(count_as_boot)`. Startup passes (`count_as_boot=True`, the default) still `check_and_record` (record + trip). The reconnect pass now calls `_schedule_resume_pending_sessions(platform=..., count_as_boot=False)`, which uses the read-only `is_restart_loop_tripped`. It still honors an already-tripped breaker (a real SIGTERM loop is not resurrected by a reconnect) but does not accrue a phantom boot. Fails OPEN on any error, unchanged.
- `tests/gateway/test_platform_reconnect.py`: assert the reconnect pass calls with `count_as_boot=False`; add `TestRestartLoopBootAccounting` covering (a) repeated reconnects neither record nor trip, (b) genuine startup boots still trip on the Nth, (c) a reconnect still skips resume when the breaker is already tripped without adding to the count.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_platform_reconnect.py`. All pass (36 tests).
2. To show the fix matters, temporarily make the `count_as_boot=False` branch call `check_and_record` (the old behavior) and rerun. `test_reconnect_honors_already_tripped_breaker` and `test_reconnect_pass_does_not_accrue_or_trip` fail because reconnects then grow the boot window.
3. `scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py`. The breaker's own unit tests (`TestRestartLoopBreaker`) still pass. Some `TestTerminalToolGatewayLifecycleGuard` and launchctl-blocking cases fail on macOS on a clean checkout too; that is pre-existing and unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all target tests pass (`scripts/run_tests.sh tests/gateway/test_platform_reconnect.py`)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15 (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings). The new method is documented; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A (no config keys; still reads the existing `gateway.restart_loop_guard` config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide, or N/A (pure control-flow; no platform-specific calls)