### PR TITLE
fix(cli): add display.editor_auto_submit toggle to restore pre-74f0dd6 Ctrl+G behavior

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1675,6 +1675,13 @@ display:
   #   false: Only keep/send the final response
   interim_assistant_messages: true
 
+  # External editor auto-submit behavior (classic CLI only).
+  # When true (default), the external editor auto-submits on close (Ctrl+G).
+  # When false, Ctrl+G opens the editor but you must explicitly save-and-exit
+  # to submit — restoring the pre-74f0dd6 behavior for users who prefer to
+  # review in-editor before sending.
+  editor_auto_submit: true
+
   # Gateway-only long-running status heartbeats.
   # When false, the platform does not receive periodic "⏳ Working — N min"
   # notifications even if agent.gateway_notify_interval is non-zero. The

--- a/cli.py
+++ b/cli.py
@@ -8674,13 +8674,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._skip_paste_collapse = True
             # Open the editor, then submit the saved draft on a clean exit —
             # matching the TUI's Ctrl+G (openEditor), which sends the buffer
-            # instead of requiring a second Enter. Submission in this CLI is
-            # driven by the custom `enter` keybinding, NOT the buffer's
-            # accept_handler, so validate_and_handle can't route through it;
-            # chain a done-callback on the returned Task that re-uses the
-            # real submit pipeline via _submit_editor_buffer().
+            # instead of requiring a second Enter. This behavior can be
+            # disabled via config.yaml: display.editor_auto_submit=false
+            # to return to the old behavior where the edited text loads back
+            # into the input area and requires Enter to send.
             task = target_buffer.open_in_editor(validate_and_handle=False)
-            if task is not None and hasattr(task, "add_done_callback"):
+            editor_auto_submit = (
+                (self.config or {}).get("display", {}).get("editor_auto_submit", True)
+            )
+            if editor_auto_submit and task is not None and hasattr(task, "add_done_callback"):
                 task.add_done_callback(
                     lambda _t, b=target_buffer: self._submit_editor_buffer(b)
                 )

--- a/cli.py
+++ b/cli.py
@@ -8680,8 +8680,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # into the input area and requires Enter to send.
             task = target_buffer.open_in_editor(validate_and_handle=False)
             editor_auto_submit = (
-                (self.config or {}).get("display", {}).get("editor_auto_submit", True)
-            )
+                getattr(self, "config", None) or {}
+            ).get("display", {}).get("editor_auto_submit", True)
             if editor_auto_submit and task is not None and hasattr(task, "add_done_callback"):
                 task.add_done_callback(
                     lambda _t, b=target_buffer: self._submit_editor_buffer(b)
@@ -13122,7 +13122,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         result = resolve_plugin_command_result(
                             plugin_handler(user_args)
                         )
-                        if result:
+                        if isinstance(result, dict) and result.get("action") == "inject":
+                            msg = result.get("content", "")
+                            if msg:
+                                if hasattr(self, "_pending_input"):
+                                    self._pending_input.put(msg)
+                                else:
+                                    _cprint(msg)
+                        elif result:
                             _cprint(str(result))
                     except Exception as e:
                         _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")

--- a/cli.py
+++ b/cli.py
@@ -13122,14 +13122,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         result = resolve_plugin_command_result(
                             plugin_handler(user_args)
                         )
-                        if isinstance(result, dict) and result.get("action") == "inject":
-                            msg = result.get("content", "")
-                            if msg:
-                                if hasattr(self, "_pending_input"):
-                                    self._pending_input.put(msg)
-                                else:
-                                    _cprint(msg)
-                        elif result:
+                        if result:
                             _cprint(str(result))
                     except Exception as e:
                         _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1099,7 +1099,6 @@ def _ensure_hermes_home_managed(home: Path):
 # =============================================================================
 
 from hermes_cli.config_defaults import DEFAULT_CONFIG, OPTIONAL_ENV_VARS  # noqa: F401
-
 # =============================================================================
 # Config Migration System
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1488,6 +1488,7 @@ DEFAULT_CONFIG = {
         #   "off"     — no watcher messages at all
         "background_process_notifications": "concise",
         "streaming": False,
+        "editor_auto_submit": True,  # Auto-submit on Ctrl+G in external editor (False = Ctrl+G exits without submit)
         "timestamps": False,      # Show message timestamps (CLI labels, TUI rows, desktop transcript)
         "timestamp_format": "%H:%M",  # strftime format for timestamps (e.g. "%b-%d %H:%M")
         "final_response_markdown": "strip",  # render | strip | raw

--- a/tests/cli/test_cli_external_editor.py
+++ b/tests/cli/test_cli_external_editor.py
@@ -107,3 +107,45 @@ def test_inline_pastes_missing_file_keeps_placeholder(tmp_path):
 
     assert buffer.text == placeholder
     assert cli_obj._skip_paste_collapse is False
+
+
+def test_editor_auto_submit_true_attaches_callback():
+    """When editor_auto_submit is True, the done callback is attached."""
+    cli_obj = _make_cli()
+    cli_obj.config = {"display": {"editor_auto_submit": True}}
+
+    from unittest.mock import MagicMock
+    task = MagicMock()
+    buffer = _FakeBuffer()
+    buffer.open_in_editor = lambda validate_and_handle=False: task
+
+    assert cli_obj._open_external_editor(buffer=buffer) is True
+    task.add_done_callback.assert_called_once()
+
+
+def test_editor_auto_submit_false_skips_callback():
+    """When editor_auto_submit is False, no done callback is attached."""
+    cli_obj = _make_cli()
+    cli_obj.config = {"display": {"editor_auto_submit": False}}
+
+    from unittest.mock import MagicMock
+    task = MagicMock()
+    buffer = _FakeBuffer()
+    buffer.open_in_editor = lambda validate_and_handle=False: task
+
+    assert cli_obj._open_external_editor(buffer=buffer) is True
+    task.add_done_callback.assert_not_called()
+
+
+def test_editor_auto_submit_defaults_true_when_config_missing():
+    """Without config, editor_auto_submit defaults to True."""
+    cli_obj = _make_cli()
+    # No config set — _make_cli doesn't set config
+
+    from unittest.mock import MagicMock
+    task = MagicMock()
+    buffer = _FakeBuffer()
+    buffer.open_in_editor = lambda validate_and_handle=False: task
+
+    assert cli_obj._open_external_editor(buffer=buffer) is True
+    task.add_done_callback.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Commit 74f0dd6 changed Ctrl+G (open in $EDITOR) so that save-and-quit immediately submits the draft. Before that commit, saving the editor loaded the text back into the input area and the user could continue editing before pressing Enter to send.

This change **removed the old behavior entirely** with no config toggle, which is **very rude** to users who relied on being able to save intermediate versions in the editor and then add more text before sending.

This PR adds `display.editor_auto_submit` (default: `true`, preserving the current behavior). When set to `false`, Ctrl+G returns to the pre-74f0dd6 behavior: save-and-quit loads the edited text back into the input buffer, and the user presses Enter to send.

## Related Issue

Fixes the regression introduced by 74f0dd6, which removed the old editor workflow without a migration path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: Check `self.config["display"]["editor_auto_submit"]` (default `true`) before chaining the `_submit_editor_buffer()` done-callback on the Ctrl+G editor task. When `false`, falls through to `open_in_editor(validate_and_handle=False)` which loads the text back into the input area.

## How to Test

1. Set `display.editor_auto_submit: false` in config.yaml
2. Type a partial message in the CLI
3. Press Ctrl+G, edit in $EDITOR, save and quit
4. Verify the text appears in the input area (not sent)
5. Add more text, press Enter to send

## Checklist

- [x] My commit messages follow Conventional Commits (`feat(cli): add display.editor_auto_submit config toggle for Ctrl+G`)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have tested the change manually
- [x] I have updated `cli-config.yaml.example` with the new config key

## Notes

The config key lives under `display` to match the convention of UI/display-related settings.