### PR TITLE
feat(telegram): add adaptive interactive tool progress

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -51,6 +51,33 @@ from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context
 logger = logging.getLogger(__name__)
 
 
+def _emit_tool_progress_callback(
+    agent,
+    event_type: str,
+    tool_name: str | None = None,
+    preview: Any = None,
+    args: Any = None,
+    **kwargs: Any,
+) -> None:
+    """Emit tool progress while preserving the legacy 4-argument callback shape."""
+    callback = getattr(agent, "tool_progress_callback", None)
+    if not callback:
+        return
+    try:
+        callback(event_type, tool_name, preview, args, **kwargs)
+    except TypeError as cb_err:
+        if kwargs:
+            try:
+                callback(event_type, tool_name, preview, args)
+                return
+            except Exception as legacy_err:
+                logging.debug("Tool progress callback error: %s", legacy_err)
+                return
+        logging.debug("Tool progress callback error: %s", cb_err)
+    except Exception as cb_err:
+        logging.debug("Tool progress callback error: %s", cb_err)
+
+
 def _budget_for_agent(agent) -> BudgetConfig:
     """Resolve a tool-result BudgetConfig scaled to the agent's context window.
 
@@ -508,7 +535,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             try:
                 display_args = _redact_tool_args_for_display(name, args) or args
                 preview = _build_tool_preview(name, display_args)
-                agent.tool_progress_callback("tool.started", name, preview, display_args)
+                _emit_tool_progress_callback(
+                    agent,
+                    "tool.started",
+                    name,
+                    preview,
+                    display_args,
+                    tool_call_id=getattr(tc, "id", "") or "",
+                )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
 
@@ -868,10 +902,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
             if not blocked and agent.tool_progress_callback:
                 try:
-                    agent.tool_progress_callback(
+                    _emit_tool_progress_callback(
+                        agent,
                         "tool.completed", function_name, None, None,
-                        duration=tool_duration, is_error=is_error,
+                        duration=tool_duration,
+                        is_error=is_error,
                         result=function_result,
+                        tool_call_id=getattr(tc, "id", "") or "",
                     )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
@@ -1088,7 +1125,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             try:
                 display_args = _redact_tool_args_for_display(function_name, function_args) or function_args
                 preview = _build_tool_preview(function_name, display_args)
-                agent.tool_progress_callback("tool.started", function_name, preview, display_args)
+                _emit_tool_progress_callback(
+                    agent,
+                    "tool.started",
+                    function_name,
+                    preview,
+                    display_args,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
 
@@ -1536,10 +1580,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         if not _execution_blocked and agent.tool_progress_callback:
             try:
-                agent.tool_progress_callback(
+                _emit_tool_progress_callback(
+                    agent,
                     "tool.completed", function_name, None, None,
-                    duration=tool_duration, is_error=_is_error_result,
+                    duration=tool_duration,
+                    is_error=_is_error_result,
                     result=function_result,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
                 )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -33,6 +33,15 @@ from typing import Any
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
     "tool_progress_grouping": "accumulate",  # "accumulate" = edit one bubble; "separate" = one msg per tool
+    # Minimum seconds between visible progress-message sends/edits.  This
+    # protects Telegram and other edit-based surfaces from flood-control churn
+    # when a turn fires many tool events in quick succession.
+    "tool_progress_update_interval": 1.5,
+    # Adaptive/interactive tool progress: show details inline for at most this
+    # many calls, then collapse to counts + sequence with drill-down buttons on
+    # platforms that support them (currently Telegram).
+    "tool_progress_interactive_inline_limit": 2,
+    "tool_progress_interactive_detail_chars": 1200,
     "show_reasoning": False,
     # How a reasoning/thinking summary is rendered when show_reasoning is on.
     #   "code"      -> 💭 **Reasoning:** + fenced code block (legacy default)
@@ -251,6 +260,19 @@ def _normalise(setting: str, value: Any) -> Any:
     if setting == "tool_progress_grouping":
         val = str(value).lower()
         return val if val in ("accumulate", "separate") else "accumulate"
+    if setting == "tool_progress_update_interval":
+        try:
+            return max(0.25, float(value))
+        except (TypeError, ValueError):
+            return _GLOBAL_DEFAULTS["tool_progress_update_interval"]
+    if setting in {
+        "tool_progress_interactive_inline_limit",
+        "tool_progress_interactive_detail_chars",
+    }:
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            return _GLOBAL_DEFAULTS[setting]
     if setting == "reasoning_style":
         val = str(value).lower()
         return val if val in ("code", "blockquote", "subtext") else "code"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -32,6 +32,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import shlex
 import site
 import sys
@@ -15980,10 +15981,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
+        progress_update_interval = resolve_display_setting(
+            user_config, platform_key, "tool_progress_update_interval"
+        )
+        try:
+            progress_update_interval = max(0.25, float(progress_update_interval))
+        except (TypeError, ValueError):
+            progress_update_interval = 1.5
+        _interactive_inline_limit = resolve_display_setting(
+            user_config, platform_key, "tool_progress_interactive_inline_limit"
+        )
+        try:
+            _interactive_inline_limit = max(0, int(_interactive_inline_limit))
+        except (TypeError, ValueError):
+            _interactive_inline_limit = 2
+        _interactive_detail_chars = resolve_display_setting(
+            user_config, platform_key, "tool_progress_interactive_detail_chars"
+        )
+        try:
+            _interactive_detail_chars = max(0, int(_interactive_detail_chars))
+        except (TypeError, ValueError):
+            _interactive_detail_chars = 1200
+        progress_mode_normalized = str(progress_mode or "").lower()
+        interactive_tool_progress = progress_mode_normalized in {"interactive", "adaptive"}
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
-        tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
+        tool_progress_enabled = progress_mode_normalized != "off" and source.platform != Platform.WEBHOOK
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
@@ -16015,6 +16039,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if needs_progress_queue else None
+        tool_progress_trace = None
+        if interactive_tool_progress and tool_progress_enabled and progress_queue is not None:
+            try:
+                from gateway.tool_progress_trace import ToolProgressTrace
+
+                trace_seed = secrets.token_urlsafe(12)
+                tool_progress_trace = ToolProgressTrace(
+                    trace_seed,
+                    max_args_chars=_interactive_detail_chars,
+                    max_result_chars=_interactive_detail_chars,
+                    redact=_redact_gateway_user_facing_secrets,
+                )
+            except Exception as _trace_err:
+                logger.debug("interactive tool-progress trace disabled: %s", _trace_err)
+                tool_progress_trace = None
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
@@ -16091,6 +16130,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not progress_queue or not _run_still_current():
                 return
 
+            if tool_progress_trace is not None and event_type == "tool.completed":
+                try:
+                    tool_progress_trace.completed(
+                        tool_name or "tool",
+                        duration=kwargs.get("duration"),
+                        is_error=kwargs.get("is_error"),
+                        result=kwargs.get("result"),
+                        call_id=kwargs.get("tool_call_id"),
+                    )
+                    _snapshot = tool_progress_trace.snapshot()
+                    _snapshot["inline_limit"] = _interactive_inline_limit
+                    progress_queue.put(("__tool_trace__", _snapshot))
+                except Exception as _trace_err:
+                    logger.debug("interactive tool-progress completion failed: %s", _trace_err)
+
             # First-touch onboarding: the first time a tool takes longer than
             # _LONG_TOOL_THRESHOLD_S during a run that's streaming every tool
             # (progress_mode == "all"), append a one-time hint suggesting
@@ -16100,7 +16154,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if event_type == "tool.completed" and not long_tool_hint_fired[0]:
                 try:
                     duration = kwargs.get("duration") or 0
-                    if duration >= _LONG_TOOL_THRESHOLD_S and progress_mode == "all":
+                    if duration >= _LONG_TOOL_THRESHOLD_S and progress_mode_normalized == "all":
                         from agent.onboarding import (
                             TOOL_PROGRESS_FLAG,
                             is_seen,
@@ -16159,8 +16213,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
+            if tool_progress_trace is not None:
+                try:
+                    tool_progress_trace.started(
+                        tool_name or "tool",
+                        preview,
+                        args,
+                        call_id=kwargs.get("tool_call_id"),
+                    )
+                    _snapshot = tool_progress_trace.snapshot()
+                    _snapshot["inline_limit"] = _interactive_inline_limit
+                    progress_queue.put(("__tool_trace__", _snapshot))
+                except Exception as _trace_err:
+                    logger.debug("interactive tool-progress start failed: %s", _trace_err)
+                return
+
             # "new" mode: only report when tool changes
-            if progress_mode == "new" and tool_name == last_tool[0]:
+            if progress_mode_normalized == "new" and tool_name == last_tool[0]:
                 return
             last_tool[0] = tool_name
             
@@ -16216,7 +16285,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _code_block_short = f"{_block_header}```\n{_cmd_short}\n```"
 
             # Verbose mode: show detailed arguments, respects tool_preview_length
-            if progress_mode == "verbose":
+            if progress_mode_normalized == "verbose":
                 if _code_block_full is not None:
                     last_was_terminal_block[0] = True
                     progress_queue.put(_code_block_full)
@@ -16338,7 +16407,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             progress_msg_id = None   # ID of the current progress message to edit
             can_edit = progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
-            _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
+            _PROGRESS_EDIT_INTERVAL = progress_update_interval  # Minimum seconds between edits/sends
+            _pending_tool_trace_snapshot = None
+            _pending_tool_trace_summary = None
+            _progress_aux_lines = []
 
             _progress_len_fn = (
                 adapter.message_len_fn
@@ -16372,7 +16444,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except (TypeError, ValueError):
                     _edit_accepts_metadata = False
 
-            async def _edit_progress_message(message_id: str, content: str):
+            async def _edit_progress_message(message_id: str, content: str, tool_trace: dict | None = None):
+                if tool_trace is not None and hasattr(adapter, "edit_tool_progress_message"):
+                    return await adapter.edit_tool_progress_message(
+                        chat_id=source.chat_id,
+                        message_id=message_id,
+                        content=content,
+                        tool_trace=tool_trace,
+                    )
                 kwargs = {
                     "chat_id": source.chat_id,
                     "message_id": message_id,
@@ -16386,6 +16465,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             def _progress_text(lines: list) -> str:
                 return "\n".join(str(line) for line in lines)
+
+            def _interactive_progress_lines() -> list:
+                lines = list(_progress_aux_lines)
+                if _pending_tool_trace_summary:
+                    lines.append(_pending_tool_trace_summary)
+                return lines
 
             def _split_progress_groups(lines: list) -> list[list]:
                 """Partition progress lines into platform-sized editable bubbles."""
@@ -16410,13 +16495,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ):
                     _cleanup_msg_ids.append(str(result.message_id))
 
-            async def _send_progress_text(text: str):
-                result = await adapter.send(
-                    chat_id=source.chat_id,
-                    content=text,
-                    reply_to=_progress_reply_to,
-                    metadata=_progress_metadata,
-                )
+            async def _send_progress_text(text: str, tool_trace: dict | None = None):
+                if tool_trace is not None and hasattr(adapter, "send_tool_progress_message"):
+                    result = await adapter.send_tool_progress_message(
+                        chat_id=source.chat_id,
+                        content=text,
+                        reply_to=_progress_reply_to,
+                        metadata=_progress_metadata,
+                        tool_trace=tool_trace,
+                    )
+                else:
+                    result = await adapter.send(
+                        chat_id=source.chat_id,
+                        content=text,
+                        reply_to=_progress_reply_to,
+                        metadata=_progress_metadata,
+                    )
                 _track_progress_result(result)
                 return result
 
@@ -16484,8 +16578,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     except Exception:
                         pass
 
+                    # Handle adaptive/interactive tool trace snapshots: replace
+                    # the current editable bubble with the latest compact
+                    # summary, while the platform adapter stores the detail
+                    # payload for button drill-down.
+                    if isinstance(raw, tuple) and len(raw) >= 2 and raw[0] == "__tool_trace__":
+                        _old_tool_trace_summary = _pending_tool_trace_summary
+                        try:
+                            from gateway.tool_progress_trace import format_tool_progress_summary
+
+                            _pending_tool_trace_snapshot = raw[1] if isinstance(raw[1], dict) else None
+                            _pending_tool_trace_summary = format_tool_progress_summary(
+                                _pending_tool_trace_snapshot or {},
+                                inline_limit=_interactive_inline_limit,
+                                max_chars=_PROGRESS_TEXT_LIMIT,
+                            )
+                            msg = _pending_tool_trace_summary
+                        except Exception as _format_err:
+                            logger.debug("interactive tool-progress format failed: %s", _format_err)
+                            _pending_tool_trace_snapshot = None
+                            _pending_tool_trace_summary = None
+                            msg = "🛠️ Tools updated"
+                        if can_edit:
+                            if progress_lines:
+                                _progress_aux_lines = [
+                                    line for line in progress_lines
+                                    if line != _old_tool_trace_summary
+                                ]
+                            progress_lines = _interactive_progress_lines() or [msg]
+                        else:
+                            progress_lines.append(msg)
                     # Handle dedup messages: update last line with repeat counter
-                    if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
+                    elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                         _, base_msg, count = raw
                         if progress_lines:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
@@ -16501,12 +16625,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # linearization regression after PR #7885.)
                         progress_msg_id = None
                         progress_lines = []
+                        _pending_tool_trace_snapshot = None
+                        _pending_tool_trace_summary = None
+                        _progress_aux_lines = []
                         last_progress_msg[0] = None
                         repeat_count[0] = 0
                         continue
                     else:
                         msg = raw
-                        progress_lines.append(msg)
+                        if _pending_tool_trace_snapshot is not None and can_edit:
+                            _progress_aux_lines.append(msg)
+                            progress_lines = _interactive_progress_lines()
+                        else:
+                            progress_lines.append(msg)
 
                     if await _roll_progress_overflow_if_needed():
                         _last_edit_ts = time.monotonic()
@@ -16534,7 +16665,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if can_edit and progress_msg_id is not None:
                         # Try to edit the existing progress message
                         full_text = "\n".join(progress_lines)
-                        result = await _edit_progress_message(progress_msg_id, full_text)
+                        result = await _edit_progress_message(progress_msg_id, full_text, _pending_tool_trace_snapshot)
                         if not result.success:
                             _err = (getattr(result, "error", "") or "").lower()
                             # Transient network errors (ConnectError, timeouts)
@@ -16558,40 +16689,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 _last_edit_ts = time.monotonic()
                             else:
                                 can_edit = False
-                            _flood_result = await adapter.send(
-                                chat_id=source.chat_id,
-                                content=msg,
-                                reply_to=_progress_reply_to,
-                                metadata=_progress_metadata,
-                            )
-                            if (
-                                _cleanup_progress
-                                and getattr(_flood_result, "success", False)
-                                and getattr(_flood_result, "message_id", None)
-                            ):
-                                _cleanup_msg_ids.append(str(_flood_result.message_id))
+                            await _send_progress_text(msg, _pending_tool_trace_snapshot)
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
                             full_text = "\n".join(progress_lines)
-                            result = await adapter.send(
-                                chat_id=source.chat_id,
-                                content=full_text,
-                                reply_to=_progress_reply_to,
-                                metadata=_progress_metadata,
-                            )
+                            result = await _send_progress_text(full_text, _pending_tool_trace_snapshot)
                         else:
                             # Editing unsupported: send just this line
-                            result = await adapter.send(
-                                chat_id=source.chat_id,
-                                content=msg,
-                                reply_to=_progress_reply_to,
-                                metadata=_progress_metadata,
-                            )
+                            result = await _send_progress_text(msg, _pending_tool_trace_snapshot)
                         if result.success and result.message_id:
                             progress_msg_id = result.message_id
-                            if _cleanup_progress:
-                                _cleanup_msg_ids.append(str(result.message_id))
 
                     _last_edit_ts = time.monotonic()
 
@@ -16607,7 +16715,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     while not progress_queue.empty():
                         try:
                             raw = progress_queue.get_nowait()
-                            if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
+                            if isinstance(raw, tuple) and len(raw) >= 2 and raw[0] == "__tool_trace__":
+                                _old_tool_trace_summary = _pending_tool_trace_summary
+                                try:
+                                    from gateway.tool_progress_trace import format_tool_progress_summary
+
+                                    _pending_tool_trace_snapshot = raw[1] if isinstance(raw[1], dict) else None
+                                    _pending_tool_trace_summary = format_tool_progress_summary(
+                                        _pending_tool_trace_snapshot or {},
+                                        inline_limit=_interactive_inline_limit,
+                                        max_chars=_PROGRESS_TEXT_LIMIT,
+                                    )
+                                    msg = _pending_tool_trace_summary
+                                except Exception:
+                                    _pending_tool_trace_snapshot = None
+                                    _pending_tool_trace_summary = None
+                                    msg = "🛠️ Tools updated"
+                                if can_edit:
+                                    if progress_lines:
+                                        _progress_aux_lines = [
+                                            line for line in progress_lines
+                                            if line != _old_tool_trace_summary
+                                        ]
+                                    progress_lines = _interactive_progress_lines() or [msg]
+                                else:
+                                    progress_lines.append(msg)
+                                await _roll_progress_overflow_if_needed()
+                            elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                                 _, base_msg, count = raw
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
@@ -16620,15 +16754,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 if can_edit and progress_lines and progress_msg_id:
                                     _pending_text = _progress_text(progress_lines)
                                     try:
-                                        await _edit_progress_message(progress_msg_id, _pending_text)
+                                        await _edit_progress_message(progress_msg_id, _pending_text, _pending_tool_trace_snapshot)
                                     except Exception:
                                         pass
                                 progress_msg_id = None
                                 progress_lines = []
+                                _pending_tool_trace_snapshot = None
+                                _pending_tool_trace_summary = None
+                                _progress_aux_lines = []
                                 last_progress_msg[0] = None
                                 repeat_count[0] = 0
                             else:
-                                progress_lines.append(raw)
+                                if _pending_tool_trace_snapshot is not None and can_edit:
+                                    _progress_aux_lines.append(raw)
+                                    progress_lines = _interactive_progress_lines()
+                                else:
+                                    progress_lines.append(raw)
                                 await _roll_progress_overflow_if_needed()
                         except Exception:
                             break
@@ -16638,7 +16779,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if can_edit and progress_lines and progress_msg_id:
                         full_text = _progress_text(progress_lines)
                         try:
-                            await _edit_progress_message(progress_msg_id, full_text)
+                            await _edit_progress_message(progress_msg_id, full_text, _pending_tool_trace_snapshot)
                         except Exception:
                             pass
                     return

--- a/gateway/tool_progress_trace.py
+++ b/gateway/tool_progress_trace.py
@@ -1,0 +1,355 @@
+"""Presentation helpers for adaptive gateway tool-progress traces.
+
+This module is intentionally presentation-only: traces are never written back to
+agent history and never affect model context.  The gateway uses them to render a
+compact progress summary while keeping redacted per-tool details available to
+platform UIs that support an interactive drill-down (Telegram inline buttons).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+
+_STATUS_ORDER = {"running": 0, "completed": 1, "failed": 2}
+
+
+def _clip(text: str, max_chars: int) -> str:
+    text = str(text or "")
+    if max_chars <= 0:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    return text[: max(0, max_chars - 1)].rstrip() + "…"
+
+
+def _value_preview(value: Any, *, max_chars: int = 1000) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return _clip(value, max_chars)
+    try:
+        rendered = json.dumps(value, ensure_ascii=False, default=str, indent=2)
+    except Exception:
+        rendered = str(value)
+    return _clip(rendered, max_chars)
+
+
+def _status_symbol(status: str, ok: Optional[bool] = None) -> str:
+    if status == "running":
+        return "…"
+    if status == "failed" or ok is False:
+        return "✗"
+    return "✓"
+
+
+def _duration_text(duration: Optional[float]) -> str:
+    if duration is None:
+        return ""
+    try:
+        value = float(duration)
+    except (TypeError, ValueError):
+        return ""
+    if value < 1:
+        return f"{value * 1000:.0f}ms"
+    if value < 60:
+        return f"{value:.1f}s"
+    minutes = int(value // 60)
+    seconds = int(value % 60)
+    return f"{minutes}m{seconds:02d}s"
+
+
+def _tool_emoji(tool_name: str) -> str:
+    try:
+        from agent.display import get_tool_emoji
+
+        return get_tool_emoji(tool_name, default="⚙️")
+    except Exception:
+        return "⚙️"
+
+
+@dataclass
+class ToolTraceCall:
+    """One presentation-layer tool invocation."""
+
+    index: int
+    name: str
+    preview: str = ""
+    args_preview: str = ""
+    status: str = "running"
+    ok: Optional[bool] = None
+    duration: Optional[float] = None
+    result_preview: str = ""
+    call_id: str = ""
+    started_at: float = field(default_factory=time.monotonic)
+    completed_at: Optional[float] = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "name": self.name,
+            "preview": self.preview,
+            "args_preview": self.args_preview,
+            "status": self.status,
+            "ok": self.ok,
+            "duration": self.duration,
+            "duration_text": _duration_text(self.duration),
+            "result_preview": self.result_preview,
+            "call_id": self.call_id,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+        }
+
+
+class ToolProgressTrace:
+    """Collect redacted tool-progress events for one gateway turn."""
+
+    def __init__(
+        self,
+        trace_id: str,
+        *,
+        max_args_chars: int = 1200,
+        max_result_chars: int = 1600,
+        redact: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        self.trace_id = str(trace_id)
+        self.max_args_chars = max_args_chars
+        self.max_result_chars = max_result_chars
+        self._redact = redact or (lambda text: text)
+        self._calls: list[ToolTraceCall] = []
+        self._next_index = 1
+        self.created_at = time.monotonic()
+        self.updated_at = self.created_at
+
+    def started(
+        self,
+        name: str,
+        preview: Any = None,
+        args: Any = None,
+        *,
+        call_id: Any = None,
+    ) -> ToolTraceCall:
+        call = ToolTraceCall(
+            index=self._next_index,
+            name=str(name or "tool"),
+            preview=_clip(str(preview or ""), 240),
+            args_preview=self._redacted_preview(args, self.max_args_chars),
+            call_id=str(call_id or ""),
+        )
+        self._next_index += 1
+        self._calls.append(call)
+        self.updated_at = time.monotonic()
+        return call
+
+    def completed(
+        self,
+        name: str,
+        *,
+        duration: Any = None,
+        is_error: Any = False,
+        result: Any = None,
+        call_id: Any = None,
+    ) -> ToolTraceCall:
+        call = self._find_open_call(str(name or "tool"), call_id=call_id)
+        if call is None:
+            call = self.started(str(name or "tool"), call_id=call_id)
+        failed = bool(is_error)
+        call.status = "failed" if failed else "completed"
+        call.ok = not failed
+        try:
+            call.duration = float(duration) if duration is not None else None
+        except (TypeError, ValueError):
+            call.duration = None
+        call.result_preview = self._redacted_preview(result, self.max_result_chars)
+        call.completed_at = time.monotonic()
+        self.updated_at = call.completed_at
+        return call
+
+    def snapshot(self) -> dict[str, Any]:
+        calls = [call.to_payload() for call in self._calls]
+        counts = Counter(call["name"] for call in calls)
+        running = sum(1 for call in calls if call.get("status") == "running")
+        failed = sum(1 for call in calls if call.get("status") == "failed")
+        completed = sum(1 for call in calls if call.get("status") == "completed")
+        return {
+            "trace_id": self.trace_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "calls": calls,
+            "counts": dict(counts),
+            "total": len(calls),
+            "running": running,
+            "completed": completed,
+            "failed": failed,
+        }
+
+    def _find_open_call(self, name: str, *, call_id: Any = None) -> Optional[ToolTraceCall]:
+        call_id_text = str(call_id or "")
+        if call_id_text:
+            for call in self._calls:
+                if call.call_id == call_id_text and call.status == "running":
+                    return call
+            return None
+        for call in self._calls:
+            if call.name == name and call.status == "running":
+                return call
+        return None
+
+    def _redacted_preview(self, value: Any, max_chars: int) -> str:
+        rendered = _value_preview(value, max_chars=max_chars)
+        if not rendered:
+            return ""
+        try:
+            rendered = self._redact(rendered)
+        except Exception:
+            pass
+        return _clip(rendered, max_chars)
+
+
+def format_tool_progress_summary(
+    snapshot: dict[str, Any],
+    *,
+    inline_limit: int = 2,
+    max_chars: int = 3900,
+) -> str:
+    """Return the default compact/adaptive progress message."""
+
+    calls = list(snapshot.get("calls") or [])
+    total = len(calls)
+    if total == 0:
+        return "🛠️ Tools: starting…"
+
+    completed = int(snapshot.get("completed") or 0)
+    failed = int(snapshot.get("failed") or 0)
+    running = int(snapshot.get("running") or 0)
+    status_bits: list[str] = []
+    if completed:
+        status_bits.append(f"✓ {completed}")
+    if running:
+        status_bits.append(f"… {running}")
+    if failed:
+        status_bits.append(f"✗ {failed}")
+    status = f" ({', '.join(status_bits)})" if status_bits else ""
+
+    header = f"🛠️ Tools: {total} call{'s' if total != 1 else ''}{status}"
+    inline_limit = max(0, int(inline_limit or 0))
+
+    if total <= inline_limit:
+        lines = [header]
+        for call in calls:
+            lines.extend(_summary_call_lines(call, include_args=True))
+        return _clip("\n".join(lines), max_chars)
+
+    counts = snapshot.get("counts") or {}
+    count_line = ", ".join(
+        f"{name}×{count}" if count > 1 else str(name)
+        for name, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:8]
+    )
+    sequence = " → ".join(str(call.get("name") or "tool") for call in calls[:10])
+    if total > 10:
+        sequence += " → …"
+
+    lines = [header]
+    if count_line:
+        lines.append(f"Counts: {count_line}")
+    lines.append(f"Sequence: {sequence}")
+    lines.append("Tap Details for arguments and output previews.")
+    return _clip("\n".join(lines), max_chars)
+
+
+def format_tool_progress_detail(
+    snapshot: dict[str, Any],
+    *,
+    max_chars: int = 3900,
+) -> str:
+    """Return an expanded all-calls detail view."""
+
+    calls = list(snapshot.get("calls") or [])
+    if not calls:
+        return "🛠️ No tool calls yet."
+    lines = [f"🛠️ Tool details: {len(calls)} call{'s' if len(calls) != 1 else ''}"]
+    for call in calls:
+        lines.extend(_summary_call_lines(call, include_args=True, include_output=True))
+    return _clip("\n".join(lines), max_chars)
+
+
+def format_tool_progress_call(
+    snapshot: dict[str, Any],
+    index: int,
+    *,
+    section: str = "call",
+    max_chars: int = 3900,
+) -> str:
+    """Return a single-call drill-down view."""
+
+    call = _find_payload_call(snapshot, index)
+    if call is None:
+        return f"🛠️ Tool call #{index} is no longer available."
+
+    symbol = _status_symbol(str(call.get("status") or ""), call.get("ok"))
+    duration = call.get("duration_text") or _duration_text(call.get("duration"))
+    title = f"{symbol} #{call.get('index')} {_tool_emoji(str(call.get('name') or ''))} {call.get('name') or 'tool'}"
+    if duration:
+        title += f" · {duration}"
+
+    args = str(call.get("args_preview") or "").strip()
+    output = str(call.get("result_preview") or "").strip()
+    preview = str(call.get("preview") or "").strip()
+    lines = [title]
+    if preview:
+        lines.append(f"Preview: {preview}")
+
+    if section == "args":
+        lines.append("Args:")
+        lines.append(args or "(empty)")
+    elif section == "output":
+        lines.append("Output preview:")
+        lines.append(output or "(not available yet)")
+    else:
+        if args:
+            lines.append("Args:")
+            lines.append(args)
+        if output:
+            lines.append("Output preview:")
+            lines.append(output)
+        if not args and not output:
+            lines.append("No details available yet.")
+    return _clip("\n".join(lines), max_chars)
+
+
+def _summary_call_lines(
+    call: dict[str, Any],
+    *,
+    include_args: bool = False,
+    include_output: bool = False,
+) -> list[str]:
+    symbol = _status_symbol(str(call.get("status") or ""), call.get("ok"))
+    duration = call.get("duration_text") or _duration_text(call.get("duration"))
+    suffix = f" · {duration}" if duration else ""
+    lines = [f"{symbol} #{call.get('index')} {_tool_emoji(str(call.get('name') or ''))} {call.get('name') or 'tool'}{suffix}"]
+    preview = str(call.get("preview") or "").strip()
+    if preview:
+        lines.append(f"  preview: {preview}")
+    if include_args:
+        args = str(call.get("args_preview") or "").strip()
+        if args:
+            lines.append(f"  args: {_clip(args, 500)}")
+    if include_output:
+        output = str(call.get("result_preview") or "").strip()
+        if output:
+            lines.append(f"  output: {_clip(output, 500)}")
+    return lines
+
+
+def _find_payload_call(snapshot: dict[str, Any], index: int) -> Optional[dict[str, Any]]:
+    for call in snapshot.get("calls") or []:
+        try:
+            if int(call.get("index")) == int(index):
+                return call
+        except (TypeError, ValueError):
+            continue
+    return None

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -15,6 +15,7 @@ import logging
 import os
 import html as _html
 import re
+from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -438,6 +439,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # While True, send() short-circuits to a failure so callers
         # (cron live-adapter branch) fall through to standalone delivery.
         self._send_path_degraded: bool = False
+        # In-memory interactive tool-progress payloads keyed by short trace_id.
+        # They are presentation state only: not durable, not injected into model
+        # context, and bounded to avoid unbounded growth in long-lived gateways.
+        self._tool_progress_state: OrderedDict[str, dict] = OrderedDict()
         self._general_request_drain_lock = asyncio.Lock()
         # DM Topics: map of topic_name -> message_thread_id (populated at startup)
         self._dm_topics: Dict[str, int] = {}
@@ -922,6 +927,23 @@ class TelegramAdapter(BasePlatformAdapter):
             return isinstance(error, BadRequest)
         except ImportError:
             return False
+
+    @classmethod
+    def _is_markdown_parse_error(cls, error: Exception) -> bool:
+        if not cls._is_bad_request_error(error):
+            return False
+        err_lower = str(error).lower()
+        return any(
+            marker in err_lower
+            for marker in (
+                "can't parse entities",
+                "can't parse message text",
+                "can't find end of",
+                "parse entities",
+                "unsupported start tag",
+                "entity",
+            )
+        )
 
     @classmethod
     def _should_retry_without_dm_topic_reply_anchor(
@@ -3595,6 +3617,347 @@ class TelegramAdapter(BasePlatformAdapter):
             self._status_message_ids[key] = str(result.message_id)
         return result
 
+    def _tool_progress_states(self) -> OrderedDict:
+        state = getattr(self, "_tool_progress_state", None)
+        if state is None:
+            state = OrderedDict()
+            self._tool_progress_state = state
+        return state
+
+    def _remember_tool_progress_trace(
+        self,
+        snapshot: Optional[dict],
+        *,
+        chat_id: Any = None,
+        message_id: Any = None,
+        thread_id: Any = None,
+    ) -> Optional[str]:
+        if not isinstance(snapshot, dict):
+            return None
+        trace_id = str(snapshot.get("trace_id") or "").strip()
+        if not trace_id:
+            return None
+        state = self._tool_progress_states()
+        previous = state.get(trace_id) if isinstance(state.get(trace_id), dict) else {}
+        stored = dict(snapshot)
+        for key, value in (
+            ("telegram_chat_id", chat_id),
+            ("telegram_message_id", message_id),
+            ("telegram_thread_id", thread_id),
+        ):
+            if value is not None:
+                stored[key] = str(value)
+            elif previous and previous.get(key) is not None:
+                stored[key] = previous.get(key)
+        state[trace_id] = stored
+        state.move_to_end(trace_id)
+        while len(state) > 128:
+            state.popitem(last=False)
+        return trace_id
+
+    def _build_tool_progress_keyboard(
+        self,
+        snapshot: Optional[dict],
+        *,
+        view: str = "summary",
+        call_index: Optional[int] = None,
+    ):
+        if not TELEGRAM_AVAILABLE or InlineKeyboardButton is Any:
+            return None
+        trace_id = str((snapshot or {}).get("trace_id") or "").strip()
+        if not trace_id:
+            return None
+        calls = list((snapshot or {}).get("calls") or [])
+        rows = []
+        if view == "detail":
+            rows.append([InlineKeyboardButton("Сводка", callback_data=f"tp:{trace_id}:s")])
+        else:
+            rows.append([InlineKeyboardButton("Подробнее", callback_data=f"tp:{trace_id}:d")])
+
+        if view.startswith("call") and call_index is not None:
+            rows.append([
+                InlineKeyboardButton("Args", callback_data=f"tp:{trace_id}:a:{call_index}"),
+                InlineKeyboardButton("Output", callback_data=f"tp:{trace_id}:o:{call_index}"),
+                InlineKeyboardButton("Назад", callback_data=f"tp:{trace_id}:d"),
+            ])
+        elif calls:
+            row = []
+            for call in calls[:8]:
+                idx = call.get("index")
+                try:
+                    idx_int = int(idx)
+                except (TypeError, ValueError):
+                    continue
+                row.append(InlineKeyboardButton(f"#{idx_int}", callback_data=f"tp:{trace_id}:c:{idx_int}"))
+                if len(row) == 4:
+                    rows.append(row)
+                    row = []
+            if row:
+                rows.append(row)
+        return InlineKeyboardMarkup(rows) if rows else None
+
+    async def send_tool_progress_message(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tool_trace: Optional[dict] = None,
+    ) -> SendResult:
+        """Send a Telegram progress bubble with interactive tool trace buttons."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        if getattr(self, "_send_path_degraded", False):
+            return SendResult(success=False, error="send_path_degraded", retryable=True)
+        if not content or not content.strip():
+            return SendResult(success=True, message_id=None)
+        reply_to_id = self._reply_to_message_id_for_send(
+            reply_to, metadata, reply_to_mode=self._reply_to_mode
+        )
+        thread_id = self._metadata_thread_id(metadata)
+        formatted = self.format_message(content)
+        if utf16_len(formatted) > self.MAX_MESSAGE_LENGTH:
+            formatted = self._truncate_stream_overflow_preview(formatted)
+        kwargs = {
+            "chat_id": normalize_telegram_chat_id(chat_id),
+            "text": formatted,
+            "parse_mode": ParseMode.MARKDOWN_V2,
+            "reply_markup": self._build_tool_progress_keyboard(tool_trace, view="summary"),
+            **self._link_preview_kwargs(),
+            **self._notification_kwargs(metadata),
+        }
+        if reply_to_id is not None:
+            kwargs["reply_to_message_id"] = reply_to_id
+        kwargs.update(
+            self._thread_kwargs_for_send(
+                chat_id, thread_id, metadata, reply_to_id, reply_to_mode=self._reply_to_mode
+            )
+        )
+        try:
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            self._remember_tool_progress_trace(
+                tool_trace,
+                chat_id=kwargs.get("chat_id"),
+                message_id=getattr(msg, "message_id", None),
+                thread_id=thread_id,
+            )
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as exc:
+            if not self._is_markdown_parse_error(exc):
+                err_str = str(exc).lower()
+                error_kind = classify_send_error(exc)
+                retry_after = getattr(exc, "retry_after", None)
+                is_timeout = "timed out" in err_str or "timeout" in err_str
+                return SendResult(
+                    success=False,
+                    error=str(exc),
+                    retryable=(
+                        retry_after is not None
+                        or self._looks_like_connect_timeout(exc)
+                        or self._looks_like_pool_timeout(exc)
+                        or not is_timeout
+                    ),
+                    error_kind=error_kind,
+                )
+            try:
+                plain_text = _strip_mdv2(content) if content else content
+                if plain_text and utf16_len(plain_text) > self.MAX_MESSAGE_LENGTH:
+                    plain_text = self._truncate_stream_overflow_preview(plain_text)
+                kwargs["text"] = plain_text
+                kwargs.pop("parse_mode", None)
+                msg = await self._send_message_with_thread_fallback(**kwargs)
+                self._remember_tool_progress_trace(
+                    tool_trace,
+                    chat_id=kwargs.get("chat_id"),
+                    message_id=getattr(msg, "message_id", None),
+                    thread_id=thread_id,
+                )
+                return SendResult(success=True, message_id=str(msg.message_id))
+            except Exception as fallback_exc:
+                error_kind = classify_send_error(fallback_exc)
+                retry_after = getattr(fallback_exc, "retry_after", None)
+                return SendResult(
+                    success=False,
+                    error=str(fallback_exc),
+                    retryable=retry_after is not None or error_kind == "network",
+                    error_kind=error_kind,
+                )
+
+    async def edit_tool_progress_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        tool_trace: Optional[dict] = None,
+    ) -> SendResult:
+        """Edit a Telegram progress bubble and refresh its drill-down payload."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        chat_id_normalized = normalize_telegram_chat_id(chat_id)
+        self._remember_tool_progress_trace(
+            tool_trace,
+            chat_id=chat_id_normalized,
+            message_id=message_id,
+        )
+        reply_markup = self._build_tool_progress_keyboard(tool_trace, view="summary")
+        formatted = self.format_message(content)
+        if utf16_len(formatted) > self.MAX_MESSAGE_LENGTH:
+            formatted = self._truncate_stream_overflow_preview(formatted)
+        try:
+            await self._bot.edit_message_text(
+                chat_id=normalize_telegram_chat_id(chat_id),
+                message_id=int(message_id),
+                text=formatted,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=reply_markup,
+                **self._link_preview_kwargs(),
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as exc:
+            err_str = str(exc).lower()
+            if "not modified" in err_str:
+                return SendResult(success=True, message_id=message_id)
+            if not self._is_markdown_parse_error(exc):
+                error_kind = classify_send_error(exc)
+                retry_after = getattr(exc, "retry_after", None)
+                is_timeout = "timed out" in err_str or "timeout" in err_str
+                return SendResult(
+                    success=False,
+                    error=str(exc),
+                    retryable=(
+                        retry_after is not None
+                        or self._looks_like_connect_timeout(exc)
+                        or self._looks_like_pool_timeout(exc)
+                        or not is_timeout
+                    ),
+                    error_kind=error_kind,
+                )
+            try:
+                plain_text = _strip_mdv2(content) if content else content
+                if plain_text and utf16_len(plain_text) > self.MAX_MESSAGE_LENGTH:
+                    plain_text = self._truncate_stream_overflow_preview(plain_text)
+                await self._bot.edit_message_text(
+                    chat_id=normalize_telegram_chat_id(chat_id),
+                    message_id=int(message_id),
+                    text=plain_text,
+                    reply_markup=reply_markup,
+                    **self._link_preview_kwargs(),
+                )
+                return SendResult(success=True, message_id=message_id)
+            except Exception as fallback_exc:
+                error_kind = classify_send_error(fallback_exc)
+                retry_after = getattr(fallback_exc, "retry_after", None)
+                return SendResult(
+                    success=False,
+                    error=str(fallback_exc),
+                    retryable=retry_after is not None or error_kind == "network",
+                    error_kind=error_kind,
+                )
+
+    async def _handle_tool_progress_callback(self, query, data: str) -> None:
+        parts = data.split(":")
+        if len(parts) < 3:
+            await query.answer(text="Bad tool trace button.")
+            return
+        trace_id = parts[1]
+        action = parts[2]
+        snapshot = self._tool_progress_states().get(trace_id)
+        if not snapshot:
+            await query.answer(text="Tool details expired.")
+            return
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        query_message = getattr(query, "message", None)
+        query_chat = getattr(query_message, "chat", None)
+        query_chat_id = getattr(query_message, "chat_id", None)
+        query_message_id = getattr(query_message, "message_id", None)
+        query_chat_type = getattr(query_chat, "type", None)
+        query_thread_id = getattr(query_message, "message_thread_id", None)
+        query_user_name = getattr(query.from_user, "first_name", None)
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ Not authorized.")
+            return
+
+        expected_chat_id = snapshot.get("telegram_chat_id")
+        expected_message_id = snapshot.get("telegram_message_id")
+        expected_thread_id = snapshot.get("telegram_thread_id")
+        if (
+            expected_chat_id
+            and query_chat_id is not None
+            and str(query_chat_id) != str(expected_chat_id)
+        ):
+            await query.answer(text="Tool details expired.")
+            return
+        if (
+            expected_message_id
+            and query_message_id is not None
+            and str(query_message_id) != str(expected_message_id)
+        ):
+            await query.answer(text="Tool details expired.")
+            return
+        if (
+            expected_thread_id
+            and query_thread_id is not None
+            and str(query_thread_id) != str(expected_thread_id)
+        ):
+            await query.answer(text="Tool details expired.")
+            return
+
+        from gateway.tool_progress_trace import (
+            format_tool_progress_call,
+            format_tool_progress_detail,
+            format_tool_progress_summary,
+        )
+
+        view = "summary"
+        call_index: Optional[int] = None
+        if action == "d":
+            text = format_tool_progress_detail(snapshot, max_chars=3900)
+            view = "detail"
+        elif action in {"c", "a", "o"}:
+            try:
+                call_index = int(parts[3])
+            except (IndexError, TypeError, ValueError):
+                await query.answer(text="Tool call is missing.")
+                return
+            section = {"c": "call", "a": "args", "o": "output"}[action]
+            text = format_tool_progress_call(snapshot, call_index, section=section, max_chars=3900)
+            view = "call"
+        else:
+            try:
+                inline_limit = int(snapshot.get("inline_limit", 2))
+            except (TypeError, ValueError):
+                inline_limit = 2
+            text = format_tool_progress_summary(snapshot, inline_limit=inline_limit, max_chars=3900)
+
+        reply_markup = self._build_tool_progress_keyboard(snapshot, view=view, call_index=call_index)
+        try:
+            await query.edit_message_text(
+                text=self.format_message(text),
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=reply_markup,
+                **self._link_preview_kwargs(),
+            )
+        except Exception as exc:
+            if "not modified" not in str(exc).lower():
+                try:
+                    await query.edit_message_text(
+                        text=_strip_mdv2(text),
+                        reply_markup=reply_markup,
+                        **self._link_preview_kwargs(),
+                    )
+                except Exception:
+                    pass
+        await query.answer()
+
     async def edit_message(
         self,
         chat_id: str,
@@ -4906,6 +5269,11 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Tool-progress drill-down callbacks ---
+        if data.startswith("tp:"):
+            await self._handle_tool_progress_callback(query, data)
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mm:", "mc:", "mb", "mx", "mg:")):

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -115,6 +115,40 @@ class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
         return SendResult(success=True, message_id=message_id)
 
 
+class InteractiveProgressCaptureAdapter(ProgressCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.tool_progress_sends = []
+        self.tool_progress_edits = []
+
+    async def send_tool_progress_message(
+        self, chat_id, content, *, reply_to=None, metadata=None, tool_trace=None
+    ) -> SendResult:
+        self.tool_progress_sends.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+                "tool_trace": tool_trace,
+            }
+        )
+        return await self.send(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+    async def edit_tool_progress_message(
+        self, chat_id, message_id, content, *, tool_trace=None
+    ) -> SendResult:
+        self.tool_progress_edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "tool_trace": tool_trace,
+            }
+        )
+        return await self.edit_message(chat_id, message_id, content)
+
+
 class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
     SUPPORTS_MESSAGE_EDITING = False
 
@@ -143,6 +177,38 @@ class FakeAgent:
             "messages": [],
             "api_calls": 1,
         }
+
+
+class AdaptiveTraceAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            for name, preview, args, result in [
+                ("read_file", "adapter.py", {"path": "adapter.py"}, {"content": "hello"}),
+                ("terminal", "pytest", {"command": "pytest -q"}, "passed"),
+                ("web_search", "Hermes docs", {"query": "Hermes Agent docs"}, "docs"),
+            ]:
+                cb("tool.started", name, preview, args)
+                cb("tool.completed", name, duration=0.1, result=result)
+                time.sleep(0.30)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class AdaptiveThinkingTraceAgent(AdaptiveTraceAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("_thinking", "checking the obvious path first")
+            time.sleep(0.30)
+        return super().run_conversation(message, conversation_history, task_id)
 
 
 class ThinkingAgent:
@@ -793,6 +859,85 @@ async def _run_with_agent(
         session_key=session_key,
     )
     return adapter, result
+
+
+@pytest.mark.asyncio
+async def test_run_agent_adaptive_tool_progress_uses_trace_payload(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        AdaptiveTraceAgent,
+        session_id="sess-adaptive-tool-progress",
+        config_data={
+            "display": {
+                "tool_progress": "adaptive",
+                "tool_progress_update_interval": 0.25,
+                "tool_progress_interactive_inline_limit": 2,
+                "interim_assistant_messages": False,
+            }
+        },
+        adapter_cls=InteractiveProgressCaptureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    interactive_updates = adapter.tool_progress_sends + adapter.tool_progress_edits
+    assert interactive_updates, "adaptive mode should use the interactive adapter path"
+    latest = interactive_updates[-1]
+    assert latest["tool_trace"]["total"] == 3
+    assert latest["tool_trace"]["completed"] == 3
+    assert "Tools: 3 calls" in latest["content"]
+    assert "Sequence: read_file → terminal → web_search" in latest["content"]
+    assert "pytest -q" not in latest["content"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_adaptive_progress_keeps_thinking_line(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        AdaptiveThinkingTraceAgent,
+        session_id="sess-adaptive-thinking-progress",
+        config_data={
+            "display": {
+                "tool_progress": "adaptive",
+                "thinking_progress": True,
+                "tool_progress_update_interval": 0.25,
+                "tool_progress_interactive_inline_limit": 2,
+                "interim_assistant_messages": False,
+            }
+        },
+        adapter_cls=InteractiveProgressCaptureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    latest = (adapter.tool_progress_sends + adapter.tool_progress_edits)[-1]
+    assert "💬 checking the obvious path first" in latest["content"]
+    assert "Tools: 3 calls" in latest["content"]
+
+
+@pytest.mark.asyncio
+async def test_webhook_adaptive_with_thinking_does_not_emit_tool_trace(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        AdaptiveThinkingTraceAgent,
+        session_id="sess-webhook-adaptive-thinking",
+        config_data={
+            "display": {
+                "tool_progress": "adaptive",
+                "thinking_progress": True,
+                "tool_progress_update_interval": 0.25,
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.WEBHOOK,
+        adapter_cls=InteractiveProgressCaptureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.tool_progress_sends == []
+    assert adapter.tool_progress_edits == []
+    assert any("checking the obvious path" in call["content"] for call in adapter.sent)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_tool_progress_trace.py
+++ b/tests/gateway/test_tool_progress_trace.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.tool_progress_trace import (
+    ToolProgressTrace,
+    format_tool_progress_call,
+    format_tool_progress_detail,
+    format_tool_progress_summary,
+)
+
+
+class FakeButton:
+    def __init__(self, text, callback_data=None):
+        self.text = text
+        self.callback_data = callback_data
+
+
+class FakeMarkup:
+    def __init__(self, rows):
+        self.inline_keyboard = rows
+
+
+def _snapshot_with_three_calls():
+    trace = ToolProgressTrace("trace1", max_args_chars=200, max_result_chars=200)
+    trace.started("read_file", "adapter.py", {"path": "adapter.py"})
+    trace.completed("read_file", duration=0.05, result={"content": "hello"})
+    trace.started("terminal", "pytest", {"command": "pytest tests/foo.py"})
+    trace.completed("terminal", duration=2.2, result="passed")
+    trace.started("web_search", "Hermes docs", {"query": "Hermes Agent docs"})
+    return trace.snapshot()
+
+
+def test_tool_progress_summary_is_inline_for_one_call():
+    trace = ToolProgressTrace("trace1")
+    trace.started("read_file", "adapter.py", {"path": "adapter.py"})
+    snapshot = trace.snapshot()
+
+    summary = format_tool_progress_summary(snapshot, inline_limit=2)
+
+    assert "Tools: 1 call" in summary
+    assert "#1" in summary
+    assert "read_file" in summary
+    assert "adapter.py" in summary
+
+
+def test_tool_progress_summary_collapses_after_inline_limit():
+    snapshot = _snapshot_with_three_calls()
+
+    summary = format_tool_progress_summary(snapshot, inline_limit=2)
+
+    assert "Tools: 3 calls" in summary
+    assert "Counts:" in summary
+    assert "Sequence: read_file → terminal → web_search" in summary
+    assert "Tap Details" in summary
+    assert "pytest tests/foo.py" not in summary
+
+
+def test_tool_progress_detail_and_call_views_include_drilldown_data():
+    snapshot = _snapshot_with_three_calls()
+
+    detail = format_tool_progress_detail(snapshot)
+    terminal_output = format_tool_progress_call(snapshot, 2, section="output")
+
+    assert "Tool details: 3 calls" in detail
+    assert "pytest tests/foo.py" in detail
+    assert "Output preview:" in terminal_output
+    assert "passed" in terminal_output
+
+
+def test_tool_progress_zero_detail_budget_suppresses_args_and_output():
+    trace = ToolProgressTrace("trace1", max_args_chars=0, max_result_chars=0)
+    trace.started("terminal", "run secret command", {"command": "echo SECRET"})
+    trace.completed("terminal", duration=0.1, result="SECRET output", call_id=None)
+    snapshot = trace.snapshot()
+    call = snapshot["calls"][0]
+
+    assert call["args_preview"] == ""
+    assert call["result_preview"] == ""
+    assert "SECRET" not in format_tool_progress_call(snapshot, 1)
+
+
+def test_tool_progress_completion_uses_call_id_for_same_named_tools():
+    trace = ToolProgressTrace("trace1")
+    trace.started("terminal", args={"command": "first"}, call_id="call-1")
+    trace.started("terminal", args={"command": "second"}, call_id="call-2")
+    trace.completed("terminal", result="second result", call_id="call-2")
+    trace.completed("terminal", result="first result", call_id="call-1")
+    snapshot = trace.snapshot()
+
+    assert snapshot["calls"][0]["args_preview"].find("first") >= 0
+    assert "first result" in snapshot["calls"][0]["result_preview"]
+    assert snapshot["calls"][1]["args_preview"].find("second") >= 0
+    assert "second result" in snapshot["calls"][1]["result_preview"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_tool_progress_send_registers_keyboard(monkeypatch):
+    from gateway.config import PlatformConfig
+    import plugins.platforms.telegram.adapter as telegram_adapter_mod
+
+    monkeypatch.setattr(telegram_adapter_mod, "InlineKeyboardButton", FakeButton)
+    monkeypatch.setattr(telegram_adapter_mod, "InlineKeyboardMarkup", FakeMarkup)
+    monkeypatch.setattr(telegram_adapter_mod, "ParseMode", SimpleNamespace(MARKDOWN_V2="MarkdownV2"))
+    monkeypatch.setattr(telegram_adapter_mod, "TELEGRAM_AVAILABLE", True)
+
+    adapter = telegram_adapter_mod.TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._bot = MagicMock()
+    adapter._send_message_with_thread_fallback = AsyncMock(
+        return_value=SimpleNamespace(message_id=123)
+    )
+    snapshot = _snapshot_with_three_calls()
+    content = format_tool_progress_summary(snapshot, inline_limit=2)
+
+    result = await adapter.send_tool_progress_message("42", content, tool_trace=snapshot)
+
+    assert result.success is True
+    assert result.message_id == "123"
+    kwargs = adapter._send_message_with_thread_fallback.await_args.kwargs
+    markup = kwargs["reply_markup"]
+    assert markup.inline_keyboard[0][0].text == "Подробнее"
+    assert markup.inline_keyboard[0][0].callback_data == "tp:trace1:d"
+    assert kwargs["disable_notification"] is True
+    assert [button.callback_data for button in markup.inline_keyboard[1]] == [
+        "tp:trace1:c:1",
+        "tp:trace1:c:2",
+        "tp:trace1:c:3",
+    ]
+    assert adapter._tool_progress_state["trace1"]["total"] == snapshot["total"]
+    assert adapter._tool_progress_state["trace1"]["telegram_chat_id"] == "42"
+    assert adapter._tool_progress_state["trace1"]["telegram_message_id"] == "123"
+
+
+@pytest.mark.asyncio
+async def test_telegram_tool_progress_callback_expands_details(monkeypatch):
+    from gateway.config import PlatformConfig
+    import plugins.platforms.telegram.adapter as telegram_adapter_mod
+
+    monkeypatch.setattr(telegram_adapter_mod, "InlineKeyboardButton", FakeButton)
+    monkeypatch.setattr(telegram_adapter_mod, "InlineKeyboardMarkup", FakeMarkup)
+    monkeypatch.setattr(telegram_adapter_mod, "ParseMode", SimpleNamespace(MARKDOWN_V2="MarkdownV2"))
+    monkeypatch.setattr(telegram_adapter_mod, "TELEGRAM_AVAILABLE", True)
+
+    adapter = telegram_adapter_mod.TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._tool_progress_state["trace1"] = _snapshot_with_three_calls()
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+
+    query = SimpleNamespace(
+        from_user=SimpleNamespace(id=7, first_name="Mikhail"),
+        message=SimpleNamespace(
+            chat_id=42,
+            message_thread_id=99,
+            chat=SimpleNamespace(type="supergroup"),
+        ),
+        edit_message_text=AsyncMock(),
+        answer=AsyncMock(),
+    )
+
+    await adapter._handle_tool_progress_callback(query, "tp:trace1:d")
+
+    query.edit_message_text.assert_awaited_once()
+    kwargs = query.edit_message_text.await_args.kwargs
+    assert "Tool details" in kwargs["text"]
+    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "tp:trace1:s"
+    query.answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_telegram_tool_progress_callback_rejects_wrong_message(monkeypatch):
+    from gateway.config import PlatformConfig
+    import plugins.platforms.telegram.adapter as telegram_adapter_mod
+
+    monkeypatch.setattr(telegram_adapter_mod, "InlineKeyboardButton", FakeButton)
+    monkeypatch.setattr(telegram_adapter_mod, "InlineKeyboardMarkup", FakeMarkup)
+    monkeypatch.setattr(telegram_adapter_mod, "ParseMode", SimpleNamespace(MARKDOWN_V2="MarkdownV2"))
+    monkeypatch.setattr(telegram_adapter_mod, "TELEGRAM_AVAILABLE", True)
+
+    adapter = telegram_adapter_mod.TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    snapshot = _snapshot_with_three_calls()
+    snapshot["telegram_chat_id"] = "42"
+    snapshot["telegram_message_id"] = "123"
+    adapter._tool_progress_state["trace1"] = snapshot
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+
+    query = SimpleNamespace(
+        from_user=SimpleNamespace(id=7, first_name="Mikhail"),
+        message=SimpleNamespace(
+            chat_id=42,
+            message_id=999,
+            message_thread_id=99,
+            chat=SimpleNamespace(type="supergroup"),
+        ),
+        edit_message_text=AsyncMock(),
+        answer=AsyncMock(),
+    )
+
+    await adapter._handle_tool_progress_callback(query, "tp:trace1:d")
+
+    query.edit_message_text.assert_not_awaited()
+    query.answer.assert_awaited_once_with(text="Tool details expired.")
+
+
+@pytest.mark.asyncio
+async def test_telegram_tool_progress_send_does_not_plain_retry_timeout(monkeypatch):
+    from gateway.config import PlatformConfig
+    import plugins.platforms.telegram.adapter as telegram_adapter_mod
+
+    class TimedOut(Exception):
+        pass
+
+    monkeypatch.setattr(telegram_adapter_mod, "InlineKeyboardButton", FakeButton)
+    monkeypatch.setattr(telegram_adapter_mod, "InlineKeyboardMarkup", FakeMarkup)
+    monkeypatch.setattr(telegram_adapter_mod, "ParseMode", SimpleNamespace(MARKDOWN_V2="MarkdownV2"))
+    monkeypatch.setattr(telegram_adapter_mod, "TELEGRAM_AVAILABLE", True)
+
+    adapter = telegram_adapter_mod.TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._bot = MagicMock()
+    adapter._send_message_with_thread_fallback = AsyncMock(side_effect=TimedOut("timed out"))
+    snapshot = _snapshot_with_three_calls()
+    content = format_tool_progress_summary(snapshot, inline_limit=2)
+
+    result = await adapter.send_tool_progress_message("42", content, tool_trace=snapshot)
+
+    assert result.success is False
+    assert result.retryable is False
+    assert adapter._send_message_with_thread_fallback.await_count == 1

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -194,6 +194,31 @@ hermes gateway
 
 The bot should come online within seconds. Send it a message on Telegram to verify.
 
+### Optional: adaptive interactive tool progress
+
+Telegram supports an adaptive tool-progress bubble with inline buttons. It starts
+as one message; one or two calls show inline details, then longer tool sequences
+collapse into counts plus call order. Tap **Подробнее** to inspect all calls, or
+`#1`, `#2`, … to drill into arguments and output previews.
+
+```yaml
+display:
+  platforms:
+    telegram:
+      # off | new | all | verbose | adaptive
+      tool_progress: adaptive
+      # Minimum seconds between visible progress edits/sends.
+      tool_progress_update_interval: 1.5
+      # Show full inline details until this many calls, then collapse.
+      tool_progress_interactive_inline_limit: 2
+      # Per-call argument/output preview budget stored for button drill-down.
+      tool_progress_interactive_detail_chars: 1200
+```
+
+The drill-down payload is in-memory gateway presentation state only. It is not
+added to model context and disappears after gateway restart or when the bounded
+cache evicts old progress messages.
+
 ## Sending Generated Files from Docker-backed Terminals
 
 If your terminal backend is `docker`, keep in mind that Telegram attachments are


### PR DESCRIPTION
## Summary
- add an adaptive Telegram tool-progress mode that keeps one editable progress bubble by default
- show inline details for small tool batches, then collapse larger batches into counts and sequence
- add Telegram inline buttons for summary/detail/per-call args/output drill-down
- make progress edit throttling configurable via display.tool_progress_update_interval
- cap/redact presentation-only tool args/results and keep drill-down state in-memory only

## Testing
- uv run --extra dev ruff check gateway/tool_progress_trace.py gateway/run.py plugins/platforms/telegram/adapter.py agent/tool_executor.py gateway/display_config.py tests/gateway/test_tool_progress_trace.py tests/gateway/test_run_progress_topics.py
- pytest -q tests/gateway/test_tool_progress_trace.py tests/gateway/test_run_progress_topics.py::test_run_agent_adaptive_tool_progress_uses_trace_payload tests/gateway/test_run_progress_topics.py::test_run_agent_adaptive_progress_keeps_thinking_line tests/gateway/test_run_progress_topics.py::test_webhook_adaptive_with_thinking_does_not_emit_tool_trace tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_sequential_browser_type_callbacks_redact_api_key tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_concurrent_browser_type_callbacks_redact_api_key
- pytest -q tests/gateway/test_run_progress_topics.py tests/gateway/test_tool_progress_trace.py tests/gateway/test_display_config.py tests/gateway/test_telegram_status_update.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_telegram_slash_confirm.py tests/gateway/test_telegram_model_picker.py tests/gateway/test_telegram_format.py
- python -m py_compile gateway/tool_progress_trace.py gateway/run.py plugins/platforms/telegram/adapter.py agent/tool_executor.py gateway/display_config.py tests/gateway/test_tool_progress_trace.py tests/gateway/test_run_progress_topics.py
- git diff --check