### PR TITLE
fix(model): keep bare MiMo on authenticated aggregator

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -31,6 +31,7 @@ from hermes_cli.providers import (
     determine_api_mode,
     get_label,
     is_aggregator,
+    is_routing_aggregator,
     resolve_provider_full,
 )
 from hermes_cli.model_normalize import (
@@ -802,6 +803,7 @@ def switch_model(
         ModelSwitchResult with all information the caller needs.
     """
     from hermes_cli.models import (
+        _AGGREGATOR_PROVIDERS as _MODEL_AGGREGATOR_PROVIDERS,
         copilot_model_api_mode,
         detect_provider_for_model,
         validate_requested_model,
@@ -1104,7 +1106,37 @@ def switch_model(
         ):
             detected = detect_provider_for_model(new_model, current_provider)
             if detected:
-                target_provider, new_model = detected
+                detected_provider, detected_model = detected
+                current_routes_vendor_slugs = (
+                    current_provider in _MODEL_AGGREGATOR_PROVIDERS
+                    or is_routing_aggregator(current_provider)
+                )
+                detected_routes_vendor_slugs = (
+                    detected_provider in _MODEL_AGGREGATOR_PROVIDERS
+                    or is_aggregator(detected_provider)
+                )
+                if (
+                    detected_provider != current_provider
+                    and current_routes_vendor_slugs
+                    and not detected_routes_vendor_slugs
+                ):
+                    try:
+                        resolve_runtime_provider(
+                            requested=detected_provider,
+                            target_model=detected_model,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Detected provider %s for model %s has no usable "
+                            "credentials; keeping current provider %s",
+                            detected_provider,
+                            detected_model,
+                            current_provider,
+                        )
+                    else:
+                        target_provider, new_model = detected_provider, detected_model
+                else:
+                    target_provider, new_model = detected_provider, detected_model
 
     # =================================================================
     # COMMON PATH: Resolve credentials, normalize, get metadata

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1132,6 +1132,7 @@ def switch_model(
                             detected_provider,
                             detected_model,
                             current_provider,
+                            exc_info=True,
                         )
                     else:
                         target_provider, new_model = detected_provider, detected_model

--- a/tests/hermes_cli/test_model_switch_vendor_credentials.py
+++ b/tests/hermes_cli/test_model_switch_vendor_credentials.py
@@ -1,0 +1,118 @@
+"""Regression tests for bare vendor model selection with aggregators.
+
+Issue #56465: ``/model mimo-v2.5`` should not switch from an authenticated
+aggregator to direct Xiaomi when Xiaomi credentials are missing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_ACCEPTED = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def _runtime_resolver_without_xiaomi(**kwargs):
+    requested = kwargs.get("requested")
+    if requested == "xiaomi":
+        raise RuntimeError("XIAOMI_API_KEY is not configured")
+    return {
+        "api_key": f"{requested}-token",
+        "base_url": f"https://{requested}.example/v1",
+        "api_mode": "chat_completions",
+    }
+
+
+def _runtime_resolver_with_xiaomi(**kwargs):
+    requested = kwargs.get("requested")
+    return {
+        "api_key": f"{requested}-token",
+        "base_url": f"https://{requested}.example/v1",
+        "api_mode": "chat_completions",
+    }
+
+
+def _run_switch(
+    *,
+    raw_input: str,
+    current_provider: str,
+    explicit_provider: str = "",
+    runtime_resolver=_runtime_resolver_without_xiaomi,
+    catalog: list[str] | None = None,
+):
+    with patch("hermes_cli.model_switch.list_provider_models", return_value=catalog or []), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=runtime_resolver), \
+         patch("hermes_cli.models.validate_requested_model", return_value=_ACCEPTED), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider=current_provider,
+            current_model="old-model",
+            current_api_key=f"{current_provider}-token",
+            explicit_provider=explicit_provider,
+        )
+
+
+def test_bare_mimo_stays_on_nous_when_xiaomi_credentials_missing():
+    result = _run_switch(raw_input="mimo-v2.5", current_provider="nous")
+
+    assert result.success is True, result.error_message
+    assert result.target_provider == "nous"
+    assert result.new_model == "xiaomi/mimo-v2.5"
+    assert result.api_key == "nous-token"
+
+
+def test_bare_mimo_stays_on_openrouter_when_xiaomi_credentials_missing():
+    result = _run_switch(raw_input="mimo-v2.5", current_provider="openrouter")
+
+    assert result.success is True, result.error_message
+    assert result.target_provider == "openrouter"
+    assert result.new_model == "xiaomi/mimo-v2.5"
+    assert result.api_key == "openrouter-token"
+
+
+def test_explicit_xiaomi_still_reports_missing_credentials():
+    result = _run_switch(
+        raw_input="mimo-v2.5",
+        current_provider="nous",
+        explicit_provider="xiaomi",
+    )
+
+    assert result.success is False
+    assert result.target_provider == "xiaomi"
+    assert "Could not resolve credentials for provider 'Xiaomi MiMo'" in result.error_message
+    assert "XIAOMI_API_KEY is not configured" in result.error_message
+
+
+def test_bare_mimo_uses_xiaomi_when_credentials_available():
+    result = _run_switch(
+        raw_input="mimo-v2.5",
+        current_provider="nous",
+        runtime_resolver=_runtime_resolver_with_xiaomi,
+    )
+
+    assert result.success is True, result.error_message
+    assert result.target_provider == "xiaomi"
+    assert result.new_model == "mimo-v2.5"
+    assert result.api_key == "xiaomi-token"
+
+
+def test_mimo_alias_still_uses_aggregator_catalog_match():
+    result = _run_switch(
+        raw_input="mimo",
+        current_provider="openrouter",
+        catalog=["xiaomi/mimo-v2.5-pro"],
+    )
+
+    assert result.success is True, result.error_message
+    assert result.target_provider == "openrouter"
+    assert result.new_model == "xiaomi/mimo-v2.5-pro"
+    assert result.resolved_via_alias == "mimo"


### PR DESCRIPTION
## What does this PR do?

Fixes a `/model` routing case from #56465.

A bare MiMo model should not switch Hermes to the direct Xiaomi provider when the user only has Nous/OpenRouter credentials. This keeps the model on the authenticated aggregator unless the user explicitly asks for Xiaomi.

## Related Issue

Fixes #56465

## Changes Made

- In the no-provider `/model` path, only switch to a detected direct provider when its credentials resolve.
- If direct Xiaomi credentials are missing and the current provider is a routing aggregator, keep the current provider and normalize the bare MiMo name to `xiaomi/...`.
- Added focused tests for Nous/OpenRouter fallback, explicit Xiaomi, direct Xiaomi with credentials, and the existing `mimo` alias path.

## How to Test

```bash
/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_model_switch_vendor_credentials.py -q
/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_model_switch_*.py -q
git diff --check
```

## Checklist

- [x] I searched for existing PRs to avoid a duplicate.
- [x] I added regression tests for the bug.
- [x] I ran focused model-switch tests.
