### PR TITLE
fix(model): keep bare vendor models on aggregators

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -34,6 +34,7 @@ from hermes_cli.providers import (
     resolve_provider_full,
 )
 from hermes_cli.model_normalize import (
+    detect_vendor,
     normalize_model_for_provider,
 )
 from agent.models_dev import (
@@ -1034,6 +1035,26 @@ def switch_model(
                                 new_model = mid
                                 resolved_in_current_catalog = True
                                 break
+
+        # --- Step d.25: aggregator vendor-prefix normalization (#56465) ---
+        # A bare vendor model selected while already on an aggregator should stay
+        # on that authenticated aggregator.  Otherwise step e sees the bare name
+        # in a native provider's static catalog (e.g. ``mimo-v2.5`` -> Xiaomi),
+        # rewrites ``model.provider`` to that direct API, and the next gateway
+        # turn fails before credentials can fall back to the user's aggregator
+        # auth.  Normalize to the aggregator slug now and mark it resolved so the
+        # native-provider detector cannot second-guess the current route.
+        if (
+            is_aggregator(target_provider)
+            and not resolved_alias
+            and not resolved_in_current_catalog
+            and "/" not in new_model
+        ):
+            if detect_vendor(new_model):
+                normalized = normalize_model_for_provider(new_model, target_provider)
+                if normalized and normalized != new_model:
+                    new_model = normalized
+                    resolved_in_current_catalog = True
 
         # --- Step d.5: configured-provider exact-match detection (#45006) ---
         # If the typed model is declared in user/custom provider config, route

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -57,6 +57,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "nous": HermesOverlay(
         transport="openai_chat",
         auth_type="oauth_device_code",
+        is_aggregator=True,
         base_url_override="https://inference-api.nousresearch.com/v1",
     ),
     "openai-codex": HermesOverlay(

--- a/tests/hermes_cli/test_model_switch_aggregator_vendor.py
+++ b/tests/hermes_cli/test_model_switch_aggregator_vendor.py
@@ -1,0 +1,35 @@
+"""Regression tests for aggregator model switching with bare vendor models."""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+def test_bare_vendor_model_stays_on_current_aggregator():
+    """Bare MiMo IDs on Nous should become aggregator slugs, not direct Xiaomi.
+
+    Regression for #56465: a static native-catalog match for ``mimo-v2.5`` used
+    to rewrite ``model.provider`` to ``xiaomi`` before any credential check, so
+    users authenticated through Nous OAuth got wedged on the next gateway turn.
+    """
+    with (
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.models.validate_requested_model",
+            return_value={"accepted": True, "persist": True, "recognized": True, "message": ""},
+        ),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+    ):
+        result = switch_model(
+            "mimo-v2.5",
+            current_provider="nous",
+            current_model="openai/gpt-5.4",
+            current_api_key="oauth-token",
+            current_base_url="https://inference-api.nousresearch.com/v1",
+        )
+
+    assert result.success
+    assert result.target_provider == "nous"
+    assert result.provider_changed is False
+    assert result.new_model == "xiaomi/mimo-v2.5"


### PR DESCRIPTION
Fixes #56465.\n\nWhen a bare vendor model such as `mimo-v2.5` is selected while already using an aggregator like Nous, keep the selection on the authenticated aggregator and normalize it to the vendor/model slug instead of switching `model.provider` to the direct Xiaomi API before credentials are checked.\n\nTests: `scripts/run_tests.sh tests/hermes_cli/test_model_switch_aggregator_vendor.py tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_models.py::TestDetectProviderForModel`