### PR TITLE
fix(ci): classify .hadolint.yaml changes into the docker lane

### DIFF
--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -38,7 +38,7 @@ import sys
 
 _FRONTEND = ("ui-tui/", "web/", "apps/")  # TS typecheck-matrix packages
 _ROOT_NPM = {"package.json", "package-lock.json"}  # shifts every package's tree
-_DOCKER_META = ("docker/", ".hadolint.yml", "Dockerfile") # docker setup
+_DOCKER_META = ("docker/", ".hadolint.yaml", "Dockerfile") # docker setup
 _SITE = ("website/", "skills/", "optional-skills/")  # docs site + skill pages
 # Prose/frontend trees that can't touch Python. skills/ is excluded on purpose.
 _PY_SKIP = ("docs/", "website/") + _FRONTEND

--- a/tests/ci/test_classify_changes.py
+++ b/tests/ci/test_classify_changes.py
@@ -63,6 +63,9 @@ CASES = {
     # skill edit must still run Python.
     "skill md → python + site": (["skills/github/SKILL.md"], _lanes(python=True, site=True)),
     "dockerfile → docker meta": (["Dockerfile"], _lanes(docker_meta=True)),
+    # The hadolint config lives at .hadolint.yaml (see docker-lint.yml); editing
+    # it must re-run the docker lint lane, or a rule change ships unchecked.
+    "hadolint config → docker meta": ([".hadolint.yaml"], _lanes(docker_meta=True)),
     # Unknown top-level file keeps Python on rather than risk a silent skip.
     "unknown toplevel → python": (["Makefile"], _lanes(python=True)),
     "mixed docs+python → python": (["README.md", "agent/x.py"], _lanes(python=True, scan=True)),


### PR DESCRIPTION
## What does this PR do?

`scripts/ci/classify_changes.py` maps a PR's changed files to CI work lanes. Its `_DOCKER_META` tuple matched the hadolint config as `.hadolint.yml`, but the actual file is `.hadolint.yaml` — see `.hadolint.yaml` at the repo root and the `config: .hadolint.yaml` passed to hadolint in `.github/workflows/docker-lint.yml`.

Because `.hadolint.yaml` never `startswith(".hadolint.yml")`, the typo'd entry matched nothing. A PR that **only** edits the hadolint config therefore resolved `docker_meta=false` and skipped the Docker lint lane, so a hadolint rule change could ship without hadolint ever re-running. That violates the classifier's documented contract:

> Contract — *fail open, never closed*. We may run a lane we didn't need, but must never skip one a change could break.

## Related Issue

No existing issue — found while auditing the CI lane classifier. N/A.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/ci/classify_changes.py`: `_DOCKER_META` now matches `.hadolint.yaml` (was `.hadolint.yml`), so editing the hadolint config triggers the `docker_meta` lane — consistent with how `Dockerfile` / `docker/` changes are already handled.
- `tests/ci/test_classify_changes.py`: added a regression case asserting `.hadolint.yaml` → `docker_meta=true`.

## How to Test

Before the fix, a hadolint-only change skipped the docker lane:

```
$ printf '.hadolint.yaml\n' | python scripts/ci/classify_changes.py
python=true
docker_meta=false      # <- lane skipped; hadolint never re-runs
...
```

After the fix (matches Dockerfile behavior):

```
$ printf '.hadolint.yaml\n' | python scripts/ci/classify_changes.py
python=false
docker_meta=true
...
```

Targeted test:

```
$ python -m pytest tests/ci/test_classify_changes.py -q
22 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(ci): ...`)
- [x] I searched existing PRs/issues to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests (`pytest tests/ci/test_classify_changes.py -q` → 22 passed); the full suite runs in CI
- [x] I've added a regression test for this fix
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (CI path classifier, platform-independent)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

See **How to Test** above — before/after output of the classifier plus the passing targeted test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
