### PR TITLE
fix(providers): bound live model catalog reads

### DIFF
--- a/providers/base.py
+++ b/providers/base.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 # Sentinel for "omit temperature entirely" (Kimi: server manages it)
 OMIT_TEMPERATURE = object()
 
+# Live provider catalogs are advisory: callers fall back to static models when
+# fetching fails. Keep the response bounded so a broken or hostile endpoint
+# cannot force the model picker/doctor path to buffer an unbounded body.
+_MAX_MODELS_RESPONSE_BYTES = 8 * 1024 * 1024
+
 
 def _profile_user_agent() -> str:
     """Return a ``hermes-cli/<version>`` UA string, with a stable fallback.
@@ -33,6 +38,21 @@ def _profile_user_agent() -> str:
         return f"hermes-cli/{_ver}"
     except Exception:
         return "hermes-cli"
+
+
+def _read_bounded_response(resp: Any, *, limit: int = _MAX_MODELS_RESPONSE_BYTES) -> bytes:
+    raw_length = resp.headers.get("Content-Length") if getattr(resp, "headers", None) is not None else None
+    if raw_length:
+        try:
+            if int(raw_length) > limit:
+                raise ValueError("provider model catalog response is too large")
+        except ValueError:
+            raise
+
+    body = resp.read(limit + 1)
+    if len(body) > limit:
+        raise ValueError("provider model catalog response is too large")
+    return body
 
 
 @dataclass
@@ -209,7 +229,7 @@ class ProviderProfile:
 
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                data = json.loads(resp.read().decode())
+                data = json.loads(_read_bounded_response(resp).decode())
             items = data if isinstance(data, list) else data.get("data", [])
             return [m["id"] for m in items if isinstance(m, dict) and "id" in m]
         except Exception as exc:

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -5,7 +5,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from threading import Thread
 from unittest.mock import patch, MagicMock
 
-from providers.base import ProviderProfile
+from providers.base import ProviderProfile, _MAX_MODELS_RESPONSE_BYTES
 
 
 class _FakeModelHandler(BaseHTTPRequestHandler):
@@ -57,6 +57,56 @@ class TestFetchModelsBaseUrlOverride:
             assert result == ["proxy-model-a"]
         finally:
             server.shutdown()
+
+    def test_oversized_content_length_returns_none_without_reading_body(self):
+        """Oversized live catalogs should fail closed before buffering the body."""
+
+        class _FakeResponse:
+            headers = {"Content-Length": str(_MAX_MODELS_RESPONSE_BYTES + 1)}
+            read_called = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self, *_args):
+                self.read_called = True
+                return b"{}"
+
+        response = _FakeResponse()
+        profile = ProviderProfile(name="test", base_url="https://example.invalid/v1")
+
+        with patch("urllib.request.urlopen", return_value=response):
+            assert profile.fetch_models(api_key="test-key") is None
+
+        assert response.read_called is False
+
+    def test_body_without_content_length_is_read_with_cap(self):
+        """Responses without Content-Length are still read with a hard cap."""
+
+        class _FakeResponse:
+            headers = {}
+            read_sizes = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self, size=-1):
+                self.read_sizes.append(size)
+                return b'{"data":[{"id":"small"}]}'
+
+        response = _FakeResponse()
+        profile = ProviderProfile(name="test", base_url="https://example.invalid/v1")
+
+        with patch("urllib.request.urlopen", return_value=response):
+            assert profile.fetch_models(api_key="test-key") == ["small"]
+
+        assert response.read_sizes == [_MAX_MODELS_RESPONSE_BYTES + 1]
 
     def test_fallback_to_self_base_url(self):
         """When base_url is None, falls back to self.base_url."""


### PR DESCRIPTION
## What does this PR do?

Bounds `ProviderProfile.fetch_models()` live model catalog reads so provider/model picker paths cannot buffer an unbounded `/models` response before falling back to static models.

## Related Issue

Fixes #56494

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✅ New feature (non-breaking change that adds functionality)
- [ ] 🔐 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `providers/base.py`: add a bounded catalog response reader with an 8 MiB cap and wire `fetch_models()` through it.
- `tests/providers/test_fetch_models_base_url.py`: cover oversized `Content-Length` rejection and capped reads when `Content-Length` is absent.

## How to Test

1. `python -m py_compile providers/base.py tests/providers/test_fetch_models_base_url.py`
2. Focused proof script against `ProviderProfile.fetch_models()`:
   - oversized `Content-Length` returns `None` without reading the body
   - missing `Content-Length` calls `read(_MAX_MODELS_RESPONSE_BYTES + 1)` and still parses a small catalog
3. Attempted: `uv run pytest tests/providers/test_fetch_models_base_url.py -q` timed out while preparing the environment; `.venv\Scripts\python.exe -m pytest ...` was unavailable because this clone's venv has no `pytest` or `pip`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — stdlib urllib/json only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
provider fetch_models cap proof ok
```

```text
python -m py_compile providers/base.py tests/providers/test_fetch_models_base_url.py
# exit 0
```