### PR TITLE
fix(mcp-oauth): gate browser-open on interactive TTY to prevent headless tab-flood

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -250,7 +250,25 @@ class TestUtilities:
         monkeypatch.delenv("SSH_TTY", raising=False)
         monkeypatch.setenv("DISPLAY", ":0")
         monkeypatch.setattr(os, "name", "posix")
+        # An interactive TTY is now a precondition for opening a browser
+        # (daemon/gateway contexts must never spawn tabs — see
+        # _can_open_browser). Simulate the interactive desktop case.
+        monkeypatch.setattr("tools.mcp_oauth._is_interactive", lambda: True)
         assert _can_open_browser() is True
+
+    def test_can_open_browser_false_without_tty(self, monkeypatch):
+        # Regression guard for the OAuth tab-flood failure mode: even on a
+        # macOS desktop with a display, a non-interactive process (launchd/
+        # systemd daemon, gateway service, piped stdin) must NOT open a
+        # browser — otherwise an OAuth reconnect loop can spawn unbounded
+        # login tabs and exhaust host memory.
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.setenv("DISPLAY", ":0")
+        monkeypatch.setattr(os, "name", "posix")
+        monkeypatch.setattr(os, "uname", lambda: type("", (), {"sysname": "Darwin"})())
+        monkeypatch.setattr("tools.mcp_oauth._is_interactive", lambda: False)
+        assert _can_open_browser() is False
 
 
 class TestRedirectHandlerSshHint:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -174,6 +174,16 @@ def suppress_interactive_oauth():
 
 def _can_open_browser() -> bool:
     """Return True if opening a browser is likely to work."""
+    # No interactive user present (launchd/systemd daemon, gateway service,
+    # piped stdin) → nobody can complete a browser-based login, so opening a
+    # browser is not just useless but actively harmful: a background service
+    # stuck in an OAuth reconnect loop calls webbrowser.open() on every retry,
+    # with no throttle and no dedup. With no user to finish the login, this can
+    # spawn an unbounded number of browser tabs pointing at the same provider
+    # login page until the host runs out of memory. Gate the whole decision on
+    # having an interactive TTY first.
+    if not _is_interactive():
+        return False
     # Explicit SSH session → no local display
     if os.environ.get("SSH_CLIENT") or os.environ.get("SSH_TTY"):
         return False


### PR DESCRIPTION
**What**

`_can_open_browser()` in `tools/mcp_oauth.py` returns `True` on macOS/Windows *before* checking whether anyone can actually complete a login. In a non-interactive process (launchd/systemd daemon, gateway service, piped stdin) an OAuth flow triggered by a stale cached token can therefore call `webbrowser.open()` on every unthrottled reconnect retry. With no user to finish the login, this opens an unbounded number of browser tabs at the same provider login page until the host OOMs.

**Repro on current `main`**

On macOS, `_can_open_browser()` hits `if os.uname().sysname == "Darwin": return True` before any TTY/interactivity check. So a headless/daemon context with no controlling terminal still reports "browser OK" and an OAuth reconnect loop will spawn tabs without bound.

**Relationship to #35927 (complementary, not a duplicate)**

#35927 addresses the **background-discovery** path: it runs discovery inside `suppress_interactive_oauth()`, a `ContextVar` that makes `_is_interactive()` return `False`, so discovery soft-skips OAuth instead of prompting. That correctly closes the discovery entry point.

This PR guards the **browser-open decision at its source**, so it also covers non-discovery call paths (reconnect / token-refresh) that reach `_can_open_browser()` without passing through the suppression context. On macOS there is otherwise no gate at all, because the function short-circuits to `True` before the SSH/display checks. The two changes stack: discovery is suppressed *and* browser-open is TTY-gated regardless of entry point.

**Fix**

Add an `_is_interactive()` gate at the top of `_can_open_browser()`: if there's no interactive TTY, return `False` before the platform-specific display checks. This composes with #35927 — `_is_interactive()` already accounts for the suppression `ContextVar`, so a suppressed context is treated as non-interactive here too. A real `hermes mcp login` on an interactive terminal keeps working (stdin is a TTY).

**Tests**

- `test_can_open_browser_true_with_display` — updated: an interactive TTY is now a precondition, so the desktop-with-display case is asserted with a TTY present.
- `test_can_open_browser_false_without_tty` — new regression guard: macOS + `DISPLAY` set but no TTY must return `False` (the headless tab-flood mode).
