### PR TITLE
fix(tools): detect squashed multi-entry blobs as memory drift (#56464)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -457,6 +457,71 @@ class TestExternalDriftGuard:
         assert result["success"] is False
         assert path.stat().st_size == original_size
 
+    def test_replace_refuses_on_squashed_entry_under_char_limit(self, store):
+        """A delimiter-free legacy/hand-edited file parses as ONE entry.
+
+        Issue #56464: such a file can stay well under the char limit, so
+        the size-based signal doesn't fire — but replace() matching a
+        substring anywhere in it would previously overwrite the WHOLE blob,
+        destroying every other statement it absorbed.
+        """
+        path = store._path_for("memory")
+        lines = [f"Rule {i}: some short operational note." for i in range(10)]
+        raw = "\n".join(lines)
+        path.write_text(raw, encoding="utf-8")
+        assert len(raw) < store.memory_char_limit  # well under budget
+
+        result = store.replace("memory", "Rule 3:", "Rule 3: updated note.")
+
+        assert result["success"] is False
+        assert "drift_backup" in result
+        # Every original line survives on disk — nothing was overwritten.
+        assert path.read_text(encoding="utf-8") == raw
+
+    def test_remove_refuses_on_squashed_entry_under_char_limit(self, store):
+        path = store._path_for("memory")
+        lines = [f"Rule {i}: some short operational note." for i in range(10)]
+        raw = "\n".join(lines)
+        path.write_text(raw, encoding="utf-8")
+
+        result = store.remove("memory", "Rule 3:")
+
+        assert result["success"] is False
+        assert "drift_backup" in result
+        assert path.read_text(encoding="utf-8") == raw
+
+    def test_short_multiline_entry_is_not_flagged_as_squashed(self, store):
+        """A genuinely small multiline entry (few lines) is still allowed —
+        the docstring explicitly supports multiline entries; only blobs with
+        many internal newlines should be treated as drift."""
+        store.add("memory", "Line one.\nLine two.\nLine three.")
+
+        result = store.replace("memory", "Line two", "Line 2 edited.")
+        assert result["success"] is True
+
+    def test_drift_backup_filename_is_unique_per_invocation(self, store):
+        """Two drift refusals close together must not collide on bak.<ts>.
+
+        If two refusals share the same epoch second, the second call would
+        overwrite the first .bak. The current implementation accepts that
+        — both files describe the same on-disk state — but pin the path
+        format here so any future change has to think about it.
+
+        Note: add() no longer triggers drift detection (issue #42874) —
+        only replace/remove do.  Both r1 and r2 use replace/remove.
+        """
+        store.add("memory", "Initial.")
+        store.add("memory", "Second entry.")
+        self._plant_drift(store)
+
+        r1 = store.replace("memory", "Initial", "Replacement.")
+        r2 = store.remove("memory", "Second entry")
+        assert r1.get("drift_backup")
+        assert r2.get("drift_backup")
+        # Same epoch second is the expected collision case — both point
+        # at the same snapshot. Different second is also fine.
+        assert ".bak." in r1["drift_backup"]
+        assert ".bak." in r2["drift_backup"]
 
 class TestUnreadableFileDoesNotWipeMemory:
     """A file that exists but can't be read must NOT be treated as empty.

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -499,6 +499,49 @@ class TestExternalDriftGuard:
         assert result["success"] is False
         assert path.stat().st_size == original_size
 
+    def test_replace_refuses_on_squashed_entry_under_char_limit(self, store):
+        """A delimiter-free legacy/hand-edited file parses as ONE entry.
+
+        Issue #56464: such a file can stay well under the char limit, so the
+        size-based signal doesn't fire — but replace() matching a substring
+        anywhere in it would previously overwrite the WHOLE blob, destroying
+        every other statement it absorbed.
+        """
+        path = store._path_for("memory")
+        lines = [f"Rule {i}: some short operational note." for i in range(10)]
+        raw = "\n".join(lines)
+        path.write_text(raw, encoding="utf-8")
+        assert len(raw) < store.memory_char_limit  # well under budget
+
+        result = store.replace("memory", "Rule 3:", "Rule 3: updated note.")
+
+        assert result["success"] is False
+        assert "drift_backup" in result
+        # Every original line survives on disk — nothing was overwritten.
+        assert path.read_text(encoding="utf-8") == raw
+
+    def test_remove_refuses_on_squashed_entry_under_char_limit(self, store):
+        path = store._path_for("memory")
+        lines = [f"Rule {i}: some short operational note." for i in range(10)]
+        raw = "\n".join(lines)
+        path.write_text(raw, encoding="utf-8")
+
+        result = store.remove("memory", "Rule 3:")
+
+        assert result["success"] is False
+        assert "drift_backup" in result
+        assert path.read_text(encoding="utf-8") == raw
+
+    def test_short_multiline_entry_is_not_flagged_as_squashed(self, store):
+        """A genuinely small multiline entry (few lines) is still allowed — the
+        tool supports multiline entries; only blobs with many internal newlines
+        (>= _SQUASHED_ENTRY_NEWLINES) should be treated as drift."""
+        store.add("memory", "Line one.\nLine two.\nLine three.")
+
+        result = store.replace("memory", "Line two", "Line 2 edited.")
+        assert result["success"] is True
+        assert "drift_backup" not in result
+
 
 class TestUnreadableFileDoesNotWipeMemory:
     """A file that exists but can't be read must NOT be treated as empty.

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -804,6 +804,11 @@ class MemoryStore:
         """
         return MemoryStore._read_entries_checked(path)[0]
 
+    # A parsed entry with this many internal newlines reads as several
+    # undelimited statements squashed together rather than one legitimate
+    # multiline entry — see signal 3 in _detect_external_drift.
+    _SQUASHED_ENTRY_NEWLINES = 4
+
     def _detect_external_drift(self, target: str, raw: str) -> Optional[str]:
         """Return a backup-path string if on-disk content shows external drift.
 
@@ -815,7 +820,7 @@ class MemoryStore:
         between the two reads.
 
         The memory file is supposed to be a list of small entries the tool
-        wrote, joined by §. Detect drift via two signals:
+        wrote, joined by §. Detect drift via three signals:
 
         1. Round-trip mismatch — re-parsing and re-serializing the file
            doesn't produce identical bytes (rare; would catch oddly-encoded
@@ -828,6 +833,15 @@ class MemoryStore:
            free-form content into what the tool will treat as one entry.
            Flushing would then truncate that entry to the model's new
            content, discarding the appended bytes — issue #26045.
+        3. Squashed-entry blob — a parsed entry with many internal newlines
+           and no § inside it. Signal 2 only catches this when the blob
+           exceeds the whole-store limit, but a file that predates the §
+           delimiter (or was hand-edited outside the tool) can easily stay
+           UNDER the limit while still being dozens of statements with no
+           delimiter between them. Because replace()/remove() match by
+           substring, such a blob can be matched by ANY one of the
+           statements it absorbed and then overwritten/removed as a whole —
+           destroying every other statement in one call — issue #56464.
 
         Returns the absolute path of the .bak file when drift was found and
         backed up; returns None when the file looks tool-shaped.
@@ -844,8 +858,15 @@ class MemoryStore:
 
         char_limit = self._char_limit(target)
         max_entry_len = max((len(e) for e in parsed), default=0)
+        has_squashed_entry = any(
+            e.count("\n") >= self._SQUASHED_ENTRY_NEWLINES for e in parsed
+        )
 
-        drift_detected = (raw.strip() != roundtrip) or (max_entry_len > char_limit)
+        drift_detected = (
+            (raw.strip() != roundtrip)
+            or (max_entry_len > char_limit)
+            or has_squashed_entry
+        )
         if not drift_detected:
             return None
 

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -400,13 +400,26 @@ class MemoryStore:
         except OSError as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
+    # A parsed entry with this many internal newlines reads as several
+    # undelimited statements squashed together, not one legitimate multiline
+    # entry — see the squashed-entry signal in _detect_external_drift (#56464).
+    _SQUASHED_ENTRY_NEWLINES = 4
+
     def _detect_external_drift(self, target: str, raw: str) -> Optional[str]:
         """``.bak.<ts>`` snapshot path if *raw* shows external drift, else None. Signals:
-        round-trip mismatch, or one entry over the whole-file limit (no tool-written
-        entry can be — an external writer appended free-form text)."""
+        round-trip mismatch; one entry over the whole-file limit (no tool-written entry
+        can be — an external writer appended free-form text); or a squashed-entry blob —
+        a single parsed entry carrying many internal newlines and no ``§`` delimiter. A
+        file that predates the ``§`` delimiter (or was hand-edited outside the tool) can
+        stay UNDER the char limit while still being dozens of undelimited statements;
+        because replace()/remove() match by substring, any one absorbed statement would
+        match and overwrite/remove the WHOLE blob, destroying the rest in one call
+        (#56464)."""
         parsed = self._parse_entries(raw)
+        has_squashed_entry = any(e.count("\n") >= self._SQUASHED_ENTRY_NEWLINES for e in parsed)
         if not raw.strip() or (raw.strip() == ENTRY_DELIMITER.join(parsed)
-                               and max(map(len, parsed), default=0) <= self._char_limit(target)):
+                               and max(map(len, parsed), default=0) <= self._char_limit(target)
+                               and not has_squashed_entry):
             return None
         path = self._path_for(target)
         bak_path = path.with_suffix(path.suffix + f".bak.{int(time.time())}")


### PR DESCRIPTION
## What does this PR do?

Fixes a data-loss bug in the memory tool's `replace`/`remove` actions. `MEMORY.md`/`USER.md` files use `\n§\n` between entries. If a file has **zero** `§` delimiters (e.g. it predates the delimiter scheme, or was hand-edited/migrated from an older format), `_read_file` parses the entire file as **one giant entry**. The existing external-drift guard (from #26045) is supposed to catch un-roundtrippable content like this, but its two signals both miss this case as long as the blob stays under the store's whole-file char limit:

1. Round-trip check: a zero-delimiter file trivially round-trips through split/join as itself, so it always looks "clean."
2. Size check: only fires if the single entry exceeds the *whole store's* char limit — a delimiter-free file that's simply under budget slips through.

Because `replace()`/`remove()` match by substring across parsed entries, a call that matches any one statement inside that giant blob then overwrites (or deletes) the **entire blob** — silently destroying every other statement it had absorbed, in a single tool call. This matches the exact symptom in #56464 (28 entries → 5 entries after one `replace` call). The `add` truncation reported in the same issue is very likely the same root cause observed one step later: `add` (which skips the drift guard by design, since it's append-only — #42874) just builds on top of whatever's already on disk, so once an earlier `replace`/`remove` has collapsed the file, subsequent `add` calls look like they're "also truncating" when they're really just operating on an already-collapsed store.

I verified the premise before fixing: `add`'s drift-skip itself is fine (it's genuinely append-only), so I didn't touch it. The actual gap is that the guard's existing heuristics can't distinguish "one legitimate multiline entry" from "many undelimited statements squashed into one." I added a third signal reusing the *same* backup-and-refuse mechanism already established by #26045, rather than inventing a new code path.

## Related Issue

Fixes #56464

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py`: `MemoryStore._detect_external_drift` gains a third drift signal — a parsed entry with `>= 4` internal newlines and no `§` inside it is treated as a squashed multi-entry blob and refused (with the same `.bak.<ts>` snapshot + remediation message as the existing round-trip/size signals). Only affects `replace`/`remove`; `add` is unchanged (still append-only, still skips the guard per #42874).
- `tests/tools/test_memory_tool.py`: regression tests reproducing the exact bug — a delimiter-free 10-line file well under the char limit is refused (not silently collapsed) on both `replace` and `remove`, with the original file verified byte-for-byte unchanged on disk. Added a companion test confirming a genuinely short multiline entry (below the newline threshold) is still allowed through unaffected.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_memory_tool.py -q` → 86 passed (0 failed).
2. Manual repro of the original bug (before the fix, this silently collapsed 28 lines down to 1 replaced entry; after the fix, it's refused and the file is untouched):
   ```python
   store = MemoryStore(memory_char_limit=2200, user_char_limit=1375)
   store.load_from_disk()
   path = store._path_for("memory")
   path.write_text("\n".join(f"- Rule {i}: note." for i in range(28)))
   store2 = MemoryStore(memory_char_limit=2200, user_char_limit=1375)
   store2.load_from_disk()
   store2.replace("memory", "Rule 5:", "Rule 5: updated.")
   # before: file on disk becomes just "Rule 5: updated." (27 lines lost)
   # after:  refused with drift_backup; file on disk unchanged
   ```
3. Ran the full suite (`scripts/run_tests.sh -q`); the 34 failures observed are all pre-existing and unrelated to this change (ACP/gateway/WSL modules and a macOS `/tmp` → `/private/tmp` symlink-resolution issue in `test_file_tools.py`), reproduced identically with this commit stashed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/tools/test_memory_tool.py -q` and all tests pass (see note above re: full-suite pre-existing unrelated failures)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the `_detect_external_drift` docstring to describe the new signal
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure string/logic change, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, the `memory` tool's schema/behavior contract is unchanged; this only tightens an internal safety guard