### PR TITLE
fix(anthropic): bound oauth token responses

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -55,6 +55,24 @@ def _get_anthropic_sdk():
 
 logger = logging.getLogger(__name__)
 
+_MAX_OAUTH_RESPONSE_BYTES = 1024 * 1024
+
+
+def _read_oauth_json_response(resp: Any, *, limit: int = _MAX_OAUTH_RESPONSE_BYTES) -> Dict[str, Any]:
+    headers = getattr(resp, "headers", None)
+    raw_length = headers.get("Content-Length") if hasattr(headers, "get") else None
+    if isinstance(raw_length, (str, bytes, int)) and int(raw_length) > limit:
+        raise ValueError("Anthropic OAuth response body is too large")
+
+    body = resp.read(limit + 1)
+    if len(body) > limit:
+        raise ValueError("Anthropic OAuth response body is too large")
+    data = json.loads(body.decode())
+    if not isinstance(data, dict):
+        raise ValueError("Anthropic OAuth response was not a JSON object")
+    return data
+
+
 THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
 # Hermes effort → Anthropic adaptive-thinking effort (output_config.effort).
 # Anthropic exposes 5 levels on 4.7+: low, medium, high, xhigh, max.
@@ -1051,7 +1069,7 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
         )
         try:
             with urllib.request.urlopen(req, timeout=10) as resp:
-                result = json.loads(resp.read().decode())
+                result = _read_oauth_json_response(resp)
         except Exception as exc:
             last_error = exc
             logger.debug("Anthropic token refresh failed at %s: %s", endpoint, exc)
@@ -1494,7 +1512,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             )
             try:
                 with urllib.request.urlopen(req, timeout=15) as resp:
-                    result = json.loads(resp.read().decode())
+                    result = _read_oauth_json_response(resp)
                 break
             except Exception as exc:
                 last_error = exc

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -10,6 +10,7 @@ import pytest
 
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
+    _MAX_OAUTH_RESPONSE_BYTES,
     _is_azure_anthropic_endpoint,
     _is_oauth_token,
     _refresh_oauth_token,
@@ -23,6 +24,7 @@ from agent.anthropic_adapter import (
     is_claude_code_token_valid,
     normalize_model_name,
     read_claude_code_credentials,
+    refresh_anthropic_oauth_pure,
     resolve_anthropic_token,
     run_oauth_setup_token,
 )
@@ -553,6 +555,56 @@ class TestRefreshOauthToken:
 
         with patch("urllib.request.urlopen", side_effect=Exception("network error")):
             assert _refresh_oauth_token(creds) is None
+
+    def test_refresh_rejects_oversized_response_without_reading_body(self):
+        class _FakeResponse:
+            headers = {"Content-Length": str(_MAX_OAUTH_RESPONSE_BYTES + 1)}
+            read_called = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self, *_args):
+                self.read_called = True
+                return b"{}"
+
+        response = _FakeResponse()
+
+        with patch("urllib.request.urlopen", return_value=response):
+            with pytest.raises(ValueError, match="too large"):
+                refresh_anthropic_oauth_pure("refresh-123")
+
+        assert response.read_called is False
+
+    def test_refresh_reads_missing_content_length_with_cap(self):
+        class _FakeResponse:
+            headers = {}
+            read_sizes = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self, size=-1):
+                self.read_sizes.append(size)
+                return json.dumps({
+                    "access_token": "new-token",
+                    "refresh_token": "new-refresh",
+                    "expires_in": 3600,
+                }).encode()
+
+        response = _FakeResponse()
+
+        with patch("urllib.request.urlopen", return_value=response):
+            result = refresh_anthropic_oauth_pure("refresh-123")
+
+        assert result["access_token"] == "new-token"
+        assert response.read_sizes == [_MAX_OAUTH_RESPONSE_BYTES + 1]
 
 
 class TestWriteClaudeCodeCredentials:


### PR DESCRIPTION
## What does this PR do?

Bounds Anthropic OAuth token response reads on both refresh and PKCE exchange paths. Token endpoints should return small JSON objects; if a proxy/provider returns an oversized body, Hermes now fails the OAuth attempt instead of buffering the whole response.

## Related Issue

Fixes #54797

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✅ New feature (non-breaking change that adds functionality)
- [ ] 🔐 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py`: add a bounded OAuth JSON response reader with a 1 MiB cap.
- `agent/anthropic_adapter.py`: route refresh-token and login token-exchange responses through the bounded reader.
- `tests/agent/test_anthropic_adapter.py`: cover oversized `Content-Length` rejection and capped reads when `Content-Length` is absent.

## How to Test

1. `python -m py_compile agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py`
2. Focused proof script against `refresh_anthropic_oauth_pure()`:
   - oversized `Content-Length` raises `ValueError` without calling `read()`
   - missing `Content-Length` calls `read(_MAX_OAUTH_RESPONSE_BYTES + 1)` and parses a normal token response
3. Full pytest was not available in this local clone: `.venv\Scripts\python.exe` has no `pytest` or `pip`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — stdlib urllib/json only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
anthropic oauth cap proof ok
```

```text
python -m py_compile agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py
# exit 0
```