### PR TITLE
fix(desktop): force UTF-8 for backend subprocess on non-UTF-8 locales

### DIFF
--- a/apps/desktop/electron/backend-env.cjs
+++ b/apps/desktop/electron/backend-env.cjs
@@ -87,6 +87,7 @@ function buildDesktopBackendEnv({
   const key = pathEnvKey(currentEnv, platform)
 
   return {
+    PYTHONUTF8: '1',
     PYTHONPATH: appendUniquePathEntries([...pythonPathEntries, currentPythonPath], { delimiter }),
     [key]: buildDesktopBackendPath({
       hermesHome,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -297,7 +297,7 @@ class _SlashWorker:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             bufsize=1,
             cwd=os.getcwd(),
             # slash_worker runs the Hermes agent → needs provider credentials.


### PR DESCRIPTION
## Problem

On Windows with a non-UTF-8 system locale (e.g. `cp936`/GBK, the default for Chinese Windows), the Desktop Electron app spawns the Python backend **without** `PYTHONUTF8=1` in the environment. The `tui_gateway` slash worker `Popen` uses `text=True` without an explicit `encoding`, so Python falls back to `locale.getpreferredencoding()` → `cp936`.

When the slash worker's stderr contains non-GBK bytes (e.g. UTF-8 output from git, LSP servers, or agent subprocesses), the `_drain_stderr` thread raises:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xaa in position 39: illegal multibyte sequence
```

This is logged as `[gateway-crash] thread Thread-27 (_drain_stderr) raised UnicodeDecodeError` in `desktop.log` and can crash the backend process, triggering the "Hermes 无法启动 / 后台网关没有启动" error dialog.

## Root Cause

1. `buildDesktopBackendEnv()` in `backend-env.cjs` only sets `PYTHONPATH` and `PATH` — it does not set `PYTHONUTF8`.
2. `stdio.py` does `os.environ.setdefault("PYTHONUTF8", "1")` at import time, but this runs **after** the interpreter has already started — `locale.getpreferredencoding()` is already cached as `cp936`.
3. `subprocess.Popen(text=True)` without `encoding=` uses `locale.getpreferredencoding()`, which is `cp936` on Chinese Windows without `PYTHONUTF8`.

## Fix

Two-layer fix:

### 1. `backend-env.cjs` — root cause fix
Add `PYTHONUTF8: '1'` to the backend spawn environment. This makes the entire Python backend process run in UTF-8 mode, so `locale.getpreferredencoding()` returns `utf-8` for all subprocess spawns.

### 2. `tui_gateway/server.py` — defense-in-depth
Explicitly set `encoding="utf-8", errors="replace"` on the slash worker `Popen`. This survives even if `PYTHONUTF8` is stripped from the environment, and `errors="replace"` ensures the `_drain_stderr` thread never crashes on malformed bytes.

## Test Plan

- [x] Verified `locale.getpreferredencoding()` returns `cp936` without `PYTHONUTF8=1` on Chinese Windows
- [x] Verified `locale.getpreferredencoding()` returns `utf-8` with `PYTHONUTF8=1`
- [x] Verified the `_drain_stderr` `UnicodeDecodeError` appears in production `desktop.log`
- [ ] CI passes

## Environment

- Windows 10 with Chinese locale (system codepage cp936)
- Hermes Agent v0.17.0 (9be292f1)
- Python 3.11.15 (cpython-3.11-windows-x86_64-none via uv)