### PR TITLE
fix(cli): bound enrollment response reads

### DIFF
--- a/hermes_cli/dashboard_register.py
+++ b/hermes_cli/dashboard_register.py
@@ -56,6 +56,21 @@ _NAME_NOUNS = (
     "kepler", "tesla", "curie", "hopper", "turing", "lovelace",
 )
 
+_MAX_PORTAL_RESPONSE_BYTES = 1024 * 1024
+
+
+def _read_json_response(resp, *, limit: int = _MAX_PORTAL_RESPONSE_BYTES) -> dict:
+    headers = getattr(resp, "headers", None)
+    raw_length = headers.get("Content-Length") if hasattr(headers, "get") else None
+    if isinstance(raw_length, (str, bytes, int)) and int(raw_length) > limit:
+        raise ValueError("Portal JSON response body is too large")
+
+    body = resp.read(limit + 1)
+    if len(body) > limit:
+        raise ValueError("Portal JSON response body is too large")
+    payload = json.loads(body.decode())
+    return payload if isinstance(payload, dict) else {}
+
 
 def _generate_dashboard_name() -> str:
     """Return a human-readable ``adjective_noun`` name (Docker-style)."""
@@ -139,12 +154,12 @@ def _register_self_hosted_client(
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
+            payload = _read_json_response(resp)
     except urllib.error.HTTPError as exc:
         # The endpoint returns structured JSON errors ({error, error_description}).
         detail = ""
         try:
-            err_body = json.loads(exc.read().decode())
+            err_body = _read_json_response(exc)
             detail = (
                 err_body.get("error_description")
                 or err_body.get("error")
@@ -170,6 +185,8 @@ def _register_self_hosted_client(
         raise RuntimeError(
             f"Could not reach Nous Portal at {portal_base_url}: {exc.reason}"
         ) from exc
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise RuntimeError(f"Portal returned an invalid JSON response: {exc}") from exc
 
     if not isinstance(payload, dict) or not payload.get("client_id"):
         raise RuntimeError("Portal returned an unexpected response (no client_id).")

--- a/hermes_cli/gateway_enroll.py
+++ b/hermes_cli/gateway_enroll.py
@@ -38,6 +38,21 @@ import urllib.error
 import urllib.request
 from typing import Optional
 
+_MAX_ENROLL_RESPONSE_BYTES = 1024 * 1024
+
+
+def _read_json_response(resp, *, limit: int = _MAX_ENROLL_RESPONSE_BYTES) -> dict:
+    headers = getattr(resp, "headers", None)
+    raw_length = headers.get("Content-Length") if hasattr(headers, "get") else None
+    if isinstance(raw_length, (str, bytes, int)) and int(raw_length) > limit:
+        raise ValueError("Connector JSON response body is too large")
+
+    body = resp.read(limit + 1)
+    if len(body) > limit:
+        raise ValueError("Connector JSON response body is too large")
+    payload = json.loads(body.decode())
+    return payload if isinstance(payload, dict) else {}
+
 
 def _default_gateway_id() -> str:
     """A stable-ish default gateway instance id: ``<hostname>-<pid-free slug>``.
@@ -113,11 +128,11 @@ def _post_enroll(
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
+            payload = _read_json_response(resp)
     except urllib.error.HTTPError as exc:
         detail = ""
         try:
-            detail = (json.loads(exc.read().decode()) or {}).get("error", "")
+            detail = (_read_json_response(exc) or {}).get("error", "")
         except Exception:
             pass
         if exc.code == 401:
@@ -137,6 +152,8 @@ def _post_enroll(
         raise RuntimeError(
             f"Could not reach the connector at {connector_base_url}: {exc.reason}"
         ) from exc
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise RuntimeError(f"Connector returned an invalid JSON response: {exc}") from exc
 
     if not isinstance(payload, dict) or not payload.get("secret"):
         raise RuntimeError("Connector returned an unexpected response (no secret).")

--- a/tests/hermes_cli/test_dashboard_register.py
+++ b/tests/hermes_cli/test_dashboard_register.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import hermes_cli.dashboard_register as dr
+import hermes_cli.gateway_enroll as ge
 
 
 def _ns(**kw):
@@ -72,6 +73,96 @@ def _fake_http_ok(payload: dict):
     cm = MagicMock()
     cm.__enter__.return_value.read.return_value = json.dumps(payload).encode()
     return cm
+
+
+class _BoundedFakeResponse:
+    def __init__(self, payload: dict, *, content_length=None):
+        self.headers = {}
+        if content_length is not None:
+            self.headers["Content-Length"] = str(content_length)
+        self.read_sizes = []
+        self.read_called = False
+        self._body = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, size=-1):
+        self.read_called = True
+        self.read_sizes.append(size)
+        return self._body
+
+
+class TestBoundedEnrollmentResponses:
+    def test_dashboard_register_rejects_oversized_response_before_reading(self):
+        response = _BoundedFakeResponse(
+            {"client_id": "agent:selfhost-1"},
+            content_length=dr._MAX_PORTAL_RESPONSE_BYTES + 1,
+        )
+
+        with patch.object(dr.urllib.request, "urlopen", return_value=response):
+            with pytest.raises(RuntimeError, match="too large"):
+                dr._register_self_hosted_client(
+                    access_token="tok",
+                    portal_base_url="https://portal.example",
+                    name="box",
+                    custom_redirect_uri=None,
+                )
+
+        assert response.read_called is False
+
+    def test_dashboard_register_reads_missing_content_length_with_cap(self):
+        response = _BoundedFakeResponse({"client_id": "agent:selfhost-1"})
+
+        with patch.object(dr.urllib.request, "urlopen", return_value=response):
+            payload = dr._register_self_hosted_client(
+                access_token="tok",
+                portal_base_url="https://portal.example",
+                name="box",
+                custom_redirect_uri=None,
+            )
+
+        assert payload["client_id"] == "agent:selfhost-1"
+        assert response.read_sizes == [dr._MAX_PORTAL_RESPONSE_BYTES + 1]
+
+    def test_gateway_enroll_rejects_oversized_response_before_reading(self):
+        response = _BoundedFakeResponse(
+            {"secret": "secret"},
+            content_length=ge._MAX_ENROLL_RESPONSE_BYTES + 1,
+        )
+
+        with patch.object(ge.urllib.request, "urlopen", return_value=response):
+            with pytest.raises(RuntimeError, match="too large"):
+                ge._post_enroll(
+                    connector_base_url="https://connector.example",
+                    access_token="tok",
+                    enrollment_token="enroll",
+                    gateway_id="gw",
+                )
+
+        assert response.read_called is False
+
+    def test_gateway_enroll_reads_missing_content_length_with_cap(self):
+        response = _BoundedFakeResponse({
+            "secret": "secret",
+            "deliveryKey": "delivery",
+            "tenant": "tenant",
+            "gatewayId": "gw",
+        })
+
+        with patch.object(ge.urllib.request, "urlopen", return_value=response):
+            payload = ge._post_enroll(
+                connector_base_url="https://connector.example",
+                access_token="tok",
+                enrollment_token="enroll",
+                gateway_id="gw",
+            )
+
+        assert payload["secret"] == "secret"
+        assert response.read_sizes == [ge._MAX_ENROLL_RESPONSE_BYTES + 1]
 
 
 class TestHappyPath:


### PR DESCRIPTION
## What does this PR do?

Bounds JSON response reads in the self-hosted enrollment CLI helpers:

- `hermes dashboard register` portal registration response/error detail
- `hermes gateway enroll` connector enrollment response/error detail

Both responses are expected to be small JSON objects. Oversized success responses now fail with a user-facing `RuntimeError`; oversized HTTP-error bodies are ignored as details while preserving the existing 401/403/status mapping.

## Related Issue

Fixes #54757

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✅ New feature (non-breaking change that adds functionality)
- [ ] 🔐 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/dashboard_register.py`: add bounded portal JSON response reads.
- `hermes_cli/gateway_enroll.py`: add bounded connector JSON response reads.
- `tests/hermes_cli/test_dashboard_register.py`: cover oversized `Content-Length` rejection and capped reads for both enrollment helpers.

## How to Test

1. `python -m py_compile hermes_cli/dashboard_register.py hermes_cli/gateway_enroll.py tests/hermes_cli/test_dashboard_register.py`
2. Focused proof script against `_register_self_hosted_client()` and `_post_enroll()`:
   - oversized `Content-Length` raises before `read()` for both helpers
   - missing `Content-Length` calls `read(limit + 1)` for both helpers and parses normal JSON
3. Full pytest was not available in this local clone: `.venv\Scripts\python.exe` has no `pytest` or `pip`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — stdlib urllib/json only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
enrollment response cap proof ok
```

```text
python -m py_compile hermes_cli/dashboard_register.py hermes_cli/gateway_enroll.py tests/hermes_cli/test_dashboard_register.py
# exit 0
```