### PR TITLE
fix: strip anthropic_content_blocks in chat_completions transport

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -160,6 +160,13 @@ class ChatCompletionsTransport(ProviderTransport):
           gateways (e.g. opencode-go, codex.nekos.me) reject with
           ``Extra inputs are not permitted, field: 'messages[N]._empty_recovery_synthetic'``,
           which then poisons every subsequent request in the session.
+        - ``anthropic_content_blocks`` on assistant messages — written by the
+          ``anthropic_messages`` transport to preserve thinking-block ordering
+          for replay. When a session switches from an anthropic_messages-routed
+          model (e.g. MiniMax on opencode-go) to a chat_completions-routed
+          model (e.g. GLM-5.2, DeepSeek), the field leaks into the outgoing
+          payload. Strict providers (opencode-go, Fireworks) reject it with
+          ``Extra inputs are not permitted, field: 'messages[N].anthropic_content_blocks'``.
         """
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
@@ -173,6 +180,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "codex_message_items" in msg
                 or "tool_name" in msg
                 or "timestamp" in msg  # #47868 — strict providers reject this
+                or "anthropic_content_blocks" in msg  # model-switch leak (→ GH-XXXX)
             ):
                 needs_sanitize = True
                 break
@@ -203,6 +211,7 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
             msg.pop("timestamp", None)  # #47868 — leak into strict providers
+            msg.pop("anthropic_content_blocks", None)  # model-switch leak
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.

--- a/tests/agent/test_anthropic_output_field_leak.py
+++ b/tests/agent/test_anthropic_output_field_leak.py
@@ -11,7 +11,7 @@ normalize_response capture, _sanitize_replay_block (ordered-blocks replay), and
 _convert_content_part_to_anthropic (content-list replay).
 """
 import sys, os
-sys.path.insert(0, os.path.expanduser("~/.hermes/hermes-agent"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 import pytest
 from agent.anthropic_adapter import (

--- a/tests/agent/test_chat_completions_strips_anthropic_blocks.py
+++ b/tests/agent/test_chat_completions_strips_anthropic_blocks.py
@@ -1,0 +1,160 @@
+"""Regression: anthropic_content_blocks must not leak into chat_completions payloads.
+
+Reproduces HTTP 400:
+``Extra inputs are not permitted, field: 'messages[N].anthropic_content_blocks'``
+
+When a session switches from an anthropic_messages-routed model (e.g. MiniMax
+on opencode-go) to a chat_completions-routed model (e.g. GLM-5.2, DeepSeek V4 Pro),
+assistant messages carry ``anthropic_content_blocks`` — a provider-data field the
+``anthropic_messages`` transport writes for thinking-block replay. The
+``chat_completions`` transport must strip this field before the message hits the
+wire because strict providers reject unknown top-level message keys.
+
+Fix: ``ChatCompletionsTransport.convert_messages()`` now pops
+``anthropic_content_blocks`` alongside the other provider-specific fields
+(codex_reasoning_items, codex_message_items, tool_name, timestamp, extra_content).
+"""
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+import pytest
+from agent.transports.chat_completions import ChatCompletionsTransport
+
+
+@pytest.fixture
+def transport():
+    return ChatCompletionsTransport()
+
+
+class TestAnthropicContentBlocksStrip:
+    """Verify convert_messages strips anthropic_content_blocks."""
+
+    def test_strips_from_assistant_message(self, transport):
+        """anthropic_content_blocks should be removed from assistant messages."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Let me think about this...",
+                "anthropic_content_blocks": [
+                    {"type": "thinking", "thinking": "planning...", "signature": "s1"},
+                    {"type": "text", "text": "Let me think..."},
+                ],
+            }
+        ]
+        clean = transport.convert_messages(messages)
+        assert "anthropic_content_blocks" not in clean[0], (
+            f"anthropic_content_blocks leaked: {clean[0]}"
+        )
+        assert clean[0]["role"] == "assistant"
+        assert clean[0]["content"] == "Let me think about this..."
+
+    def test_strips_from_multiple_messages(self, transport):
+        """All messages should be cleaned, not just the first."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "hi",
+                "anthropic_content_blocks": [{"type": "thinking", "thinking": "x", "signature": "s"}],
+            },
+            {"role": "user", "content": "what?"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "anthropic_content_blocks": [{"type": "text", "text": "ok"}],
+            },
+        ]
+        clean = transport.convert_messages(messages)
+        assert len(clean) == 4
+        assert "anthropic_content_blocks" not in clean[1]
+        assert "anthropic_content_blocks" not in clean[3]
+        # user messages should be untouched
+        assert clean[0] == {"role": "user", "content": "hello"}
+
+    def test_noop_when_field_absent(self, transport):
+        """Messages without the field should pass through unchanged."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        clean = transport.convert_messages(messages)
+        assert clean == messages
+        # Should return the same list (no deep-copy when no sanitization needed)
+        assert clean is messages
+
+    def test_deepcopy_isolates_original(self, transport):
+        """Original messages should not be mutated (deep copy)."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "hi",
+                "anthropic_content_blocks": [{"type": "text", "text": "ok"}],
+            }
+        ]
+        original_block = messages[0]["anthropic_content_blocks"]
+        clean = transport.convert_messages(messages)
+        # Original should be untouched
+        assert "anthropic_content_blocks" in messages[0], "original was mutated!"
+        assert messages[0]["anthropic_content_blocks"] is original_block
+        # Copy should be clean
+        assert "anthropic_content_blocks" not in clean[0]
+
+    def test_real_world_leak_scenario(self, transport):
+        """Simulate a MiniMax → GLM-5.2 session switch leaking anthropic_content_blocks."""
+        # Messages 0-144 are earlier history (abbreviated for the test)
+        messages = [{"role": m["role"], "content": m["content"]} for m in [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "fix the bug"},
+        ]]
+        # Message 145 is a MiniMax response (anthropic_messages) with thinking blocks
+        messages.append({
+            "role": "assistant",
+            "content": "I'll check the logs.",
+            "anthropic_content_blocks": [
+                {"type": "thinking", "thinking": "Let me analyze the error...", "signature": "sig-abc"},
+                {"type": "tool_use", "id": "toolu_1", "name": "read_file",
+                 "input": {"path": "/tmp/log.txt"}},
+            ],
+            # Also contains _anthropic_content_blocks (the stashed variant)
+            "_anthropic_content_blocks": [
+                {"type": "thinking", "thinking": "Let me analyze...", "signature": "sig-abc"},
+            ],
+        })
+        # Message 146 is a tool result
+        messages.append({"role": "tool", "content": "error: 404 Not Found"})
+
+        # Now the model switches to GLM-5.2 (chat_completions)
+        # convert_messages should strip the Anthropic-specific fields
+        clean = transport.convert_messages(messages)
+
+        # The assistant message (index 2, 0-based) should be stripped
+        stripped_msg = clean[2]
+        assert "anthropic_content_blocks" not in stripped_msg, (
+            f"anthropic_content_blocks leaked into chat_completions payload"
+        )
+        assert "_anthropic_content_blocks" not in stripped_msg, (
+            f"_anthropic_content_blocks leaked into chat_completions payload"
+        )
+        assert stripped_msg.get("content") == "I'll check the logs."
+        assert stripped_msg.get("role") == "assistant"
+
+    def test_also_strips_underscore_variant(self, transport):
+        """_anthropic_content_blocks (stashed variant) should also be stripped.
+
+        model_metadata.py stashes thinking blocks as _anthropic_content_blocks
+        for image counting. This is already handled by the ``_``-prefixed key
+        stripping, but verify explicitly.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "hi",
+                "_anthropic_content_blocks": [{"type": "image", "source": {}}],
+            }
+        ]
+        clean = transport.convert_messages(messages)
+        assert "_anthropic_content_blocks" not in clean[0]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Fixes HTTP 400 `Extra inputs are not permitted: messages[N].anthropic_content_blocks` when switching from an `anthropic_messages`-routed model (e.g. MiniMax on opencode-go) to a `chat_completions`-routed model (e.g. GLM-5.2, DeepSeek V4 Pro) mid-session.

## Problem

```bash
# Start with minimax-m3 (anthropic_messages)
$ hermes model
# → minimax-m3 works fine, generates thinking blocks as anthropic_content_blocks

# Switch to GLM-5.2-med (chat_completions) mid-session
$ /model glm-5.2-med

# Next API call fails:
API call failed after 3 retries: HTTP 400:
Extra inputs are not permitted, field: 'messages[146].anthropic_content_blocks'
```

The `anthropic_messages` transport writes `anthropic_content_blocks` into assistant messages to preserve thinking-block ordering for replay. When the model switches to `chat_completions`, these fields leak into the outgoing payload. Strict providers (opencode-go, Fireworks) reject unknown top-level message keys.

## Root Cause

`agent/transports/chat_completions.py` — `convert_messages()` already strips several provider-specific fields (`codex_reasoning_items`, `codex_message_items`, `tool_name`, `timestamp`) but did not handle `anthropic_content_blocks`.

The existing `test_anthropic_output_field_leak.py` only covers block-level field sanitization (`parsed_output`, `caller`), not the transport-level message key stripping.

## Fix

`agent/transports/chat_completions.py` — added `anthropic_content_blocks` to both the detection check and the stripping loop in `convert_messages()` (+4 lines):

```python
# Detection (line 183)
or "anthropic_content_blocks" in msg  # model-switch leak

# Stripping (line 214)
msg.pop("anthropic_content_blocks", None)  # model-switch leak
```

The `_anthropic_content_blocks` variant (stashed by `model_metadata.py` for image counting) is already handled by the existing `_`-prefixed key stripping logic (line 209).

## Related

- **PR #56216** — fixes OpenCode base_url `/v1` missing bug. Both bugs surface when switching models on opencode-go, but have different root causes and disjoint fix locations.

## Testing

13 tests across 2 files, all passing:

```
test_anthropic_output_field_leak.py (existing, 7 tests):
  ✓ test_text_block_strips_parsed_output_and_null_citations
  ✓ test_tool_use_strips_caller
  ✓ test_thinking_preserves_signature
  ✓ test_text_keeps_real_citations
  ✓ test_unknown_type_dropped
  ✓ test_stored_text_block_with_parsed_output_cleaned
  ✓ test_interleaved_blocks_replayed_clean_and_ordered

test_chat_completions_strips_anthropic_blocks.py (new, 6 tests):
  ✓ test_strips_from_assistant_message
  ✓ test_strips_from_multiple_messages
  ✓ test_noop_when_field_absent
  ✓ test_deepcopy_isolates_original
  ✓ test_real_world_leak_scenario
  ✓ test_also_strips_underscore_variant
```

## Impact

- **Fixes**: model switching from MiniMax → GLM, DeepSeek, Kimi, Gemini (any anthropic_messages → chat_completions)
- **No regression**: existing field stripping (codex, tool_name, timestamp, `_`-prefixed) untouched
- **No regression**: anthropic_messages replay keeps `anthropic_content_blocks` (only stripped in chat_completions transport)

## Files Changed

- `agent/transports/chat_completions.py` — add anthropic_content_blocks to convert_messages stripping (+14 lines)
- `tests/agent/test_chat_completions_strips_anthropic_blocks.py` — 6 new tests (new, 136 lines)
- `tests/agent/test_anthropic_output_field_leak.py` — fix import path to relative (../../) (+1/-1 lines)