### PR TITLE
security(gateway): re-resolve hooks directory per call to fix profile isolation

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -39,6 +39,7 @@ and ``thread_id`` is non-empty.
 import asyncio
 import importlib.util
 import sys
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import yaml
@@ -47,6 +48,35 @@ from hermes_cli.config import get_hermes_home
 
 
 HOOKS_DIR = get_hermes_home() / "hooks"
+# Import-time default, used by ``_resolve_hooks_dir`` below to detect a test
+# monkeypatch of the constant (test seam, see tests/gateway/test_hooks.py) vs.
+# an unmodified import-time value (in which case it re-resolves through the
+# active profile override).
+_HOOKS_DIR_IMPORT_DEFAULT = HOOKS_DIR
+
+
+def _resolve_hooks_dir() -> Path:
+    """Resolve the hooks directory, honoring the active profile.
+
+    ``HOOKS_DIR`` is frozen at import time, which pins every later hook
+    discovery to whichever profile's ``HERMES_HOME`` was active when this
+    module was first imported — a cross-profile leak under the multiplexed
+    gateway, where each profile's own ``Gateway``/``HookRegistry`` instance
+    shares one process. Without this, a later-starting profile's
+    ``discover_and_load()`` silently loads and executes the FIRST profile's
+    hook handlers (arbitrary Python) against its own live event context
+    (session_id, message, response text) instead of its own hooks directory.
+    Re-resolve through ``get_hermes_home()`` on every call so the
+    context-local profile override (``set_hermes_home_override``) is
+    honored, mirroring the cache-dir profile-isolation fix.
+
+    A test that monkeypatches the module constant away from its import-time
+    default is respected (test seam preserved).
+    """
+    current = HOOKS_DIR
+    if current != _HOOKS_DIR_IMPORT_DEFAULT:
+        return current
+    return get_hermes_home() / "hooks"
 
 
 class HookRegistry:
@@ -90,10 +120,11 @@ class HookRegistry:
         """
         self._register_builtin_hooks()
 
-        if not HOOKS_DIR.exists():
+        hooks_dir = _resolve_hooks_dir()
+        if not hooks_dir.exists():
             return
 
-        for hook_dir in sorted(HOOKS_DIR.iterdir()):
+        for hook_dir in sorted(hooks_dir.iterdir()):
             if not hook_dir.is_dir():
                 continue
 

--- a/tests/test_profile_isolation_runtime.py
+++ b/tests/test_profile_isolation_runtime.py
@@ -143,6 +143,62 @@ class TestRichSentStorePathResolution:
         assert b_seen.endswith("state/rich_sent_index.json")
 
 
+class TestGatewayHooksDirResolution:
+    """gateway/hooks.py's HookRegistry must discover hooks from the active
+    profile's directory — otherwise one profile's HookRegistry loads and
+    executes a DIFFERENT profile's hook handlers (arbitrary Python) against
+    its own live event context under the multiplexed gateway."""
+
+    def test_hooks_dir_follows_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import gateway.hooks as gh
+
+        a_seen = _under_override(prof_a, lambda: gh._resolve_hooks_dir())
+        b_seen = _under_override(prof_b, lambda: gh._resolve_hooks_dir())
+
+        assert a_seen == prof_a / "hooks"
+        assert b_seen == prof_b / "hooks"
+        assert a_seen != b_seen
+
+    def test_discover_and_load_uses_active_profile_hooks_dir(self, two_profiles):
+        """End-to-end: a hook that only exists under profile B's hooks dir
+        must not be discovered when profile A's override is active, and vice
+        versa — proving the registry doesn't fall back to a frozen profile."""
+        prof_a, prof_b = two_profiles
+        import gateway.hooks as gh
+
+        b_hook_dir = prof_b / "hooks" / "only-in-b"
+        b_hook_dir.mkdir(parents=True)
+        (b_hook_dir / "HOOK.yaml").write_text(
+            "name: only-in-b\nevents: [\"agent:start\"]\n", encoding="utf-8",
+        )
+        (b_hook_dir / "handler.py").write_text(
+            "async def handle(event_type, context):\n    pass\n", encoding="utf-8",
+        )
+
+        def _load_and_names():
+            reg = gh.HookRegistry()
+            reg.discover_and_load()
+            return [h["name"] for h in reg.loaded_hooks]
+
+        a_hooks = _under_override(prof_a, _load_and_names)
+        b_hooks = _under_override(prof_b, _load_and_names)
+
+        assert "only-in-b" not in a_hooks
+        assert "only-in-b" in b_hooks
+
+    def test_monkeypatched_constant_still_wins(self, two_profiles, monkeypatch, tmp_path):
+        """The existing test seam (monkeypatch the module constant, see
+        tests/gateway/test_hooks.py) is preserved."""
+        _prof_a, prof_b = two_profiles
+        import gateway.hooks as gh
+
+        forced = tmp_path / "forced_hooks"
+        monkeypatch.setattr("gateway.hooks.HOOKS_DIR", forced)
+        seen = _under_override(prof_b, lambda: gh._resolve_hooks_dir())
+        assert seen == forced
+
+
 # ---------------------------------------------------------------------------
 # M2 — thread / executor context propagation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`gateway/hooks.py::HOOKS_DIR` is resolved once at import time via `get_hermes_home()`, which reads a context-local `ContextVar` (`_HERMES_HOME_OVERRIDE`) set per-request under the multiplexed gateway (multiple profiles served from one process, e.g. the desktop `tui_gateway`). Freezing the resolved path at **import time** pins every later `HookRegistry.discover_and_load()` call to whichever profile's `HERMES_HOME` happened to be active the first time this module was imported in the process.

This is more serious than the typical instance of this bug class (already fixed for cache dirs, `skills_hub.py`, `rich_sent_store.py`, and — from this same audit — the Anthropic OAuth file, Nous auth.json, sessions.json index, checkpoint store, and sticker cache): the hooks system loads and executes **arbitrary Python** (`handler.py`, dynamically imported via `importlib.util`) in response to live agent events. Under the multiplexed gateway, each profile owns its own `Gateway`/`HookRegistry` instance, but they all read the same frozen module constant — so a later-starting profile's `HookRegistry` discovers and executes the FIRST profile's hook handlers against its own live event context (`session_id`, `chat_id`, `message`, `response` text truncated to 500 chars, per the module's own docstring), not the profile's own hooks. This is both a cross-profile data leak and an isolation-boundary violation (profile B's process runs profile A's hook code).

## Changes

- `gateway/hooks.py`: added `_resolve_hooks_dir()`, called from `discover_and_load()` instead of reading `HOOKS_DIR` directly. Keeps the module constant for backward compat and to preserve the existing test seam (`tests/gateway/test_hooks.py` has many call sites that `patch("gateway.hooks.HOOKS_DIR", tmp_path)`) — the resolver honors a monkeypatched value away from its import-time default, otherwise re-resolves fresh, mirroring `gateway/platforms/base.py::_resolve_cache_dir`'s established pattern.
- `tests/test_profile_isolation_runtime.py` (the existing profile-isolation regression suite): added `TestGatewayHooksDirResolution` with three tests — the resolved path actually differs between two distinct profile overrides, an end-to-end test proving a hook that only exists under profile B's hooks dir is NOT discovered when profile A's override is active (and vice versa), and a "monkeypatched constant still wins" regression test for the test-seam-preserving resolver.

## Test plan

- [x] `pytest tests/gateway/test_hooks.py tests/gateway/test_background_command.py -q` — 42 passed, 1 pre-existing unrelated failure (confirmed via `git stash`: a macOS `/private/var` vs `/var` symlink path-comparison quirk in `test_media_files_routed_by_type`, present identically before this change)
- [x] `pytest tests/test_profile_isolation_runtime.py -q` — 13 passed (10 pre-existing + 3 new)
- [x] `ruff check` on all changed files — clean