### PR TITLE
fix(mcp): cap tool result size to prevent unbounded allocation (#56059)

### DIFF
--- a/tests/tools/test_mcp_result_size_limit.py
+++ b/tests/tools/test_mcp_result_size_limit.py
@@ -1,0 +1,86 @@
+"""Regression tests for MCP tool result size limiting (#56059).
+
+MCP tool results had no size enforcement — a buggy or malicious MCP server
+could return multi-megabyte text that floods the conversation context window.
+The fix applies the same ``get_max_bytes()`` truncation used by the terminal
+tool, with a head/tail split that preserves the beginning and end of the
+result.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+class TestTruncateMcpTextResult:
+    """Tests for ``_truncate_mcp_text_result`` helper."""
+
+    def test_short_result_unchanged(self, monkeypatch):
+        """Results under the limit pass through unmodified."""
+        from tools.tool_output_limits import get_max_bytes
+        monkeypatch.setattr("tools.tool_output_limits.get_max_bytes", lambda: 50_000)
+        from tools.mcp_tool import _truncate_mcp_text_result
+
+        text = "x" * 100
+        assert _truncate_mcp_text_result(text) == text
+
+    def test_exact_limit_unchanged(self, monkeypatch):
+        """Result exactly at the limit is not truncated."""
+        monkeypatch.setattr("tools.tool_output_limits.get_max_bytes", lambda: 100)
+        from tools.mcp_tool import _truncate_mcp_text_result
+
+        text = "y" * 100
+        assert _truncate_mcp_text_result(text) == text
+
+    def test_oversized_result_is_truncated(self, monkeypatch):
+        """Results over the limit are truncated to the limit."""
+        monkeypatch.setattr("tools.tool_output_limits.get_max_bytes", lambda: 100)
+        from tools.mcp_tool import _truncate_mcp_text_result
+
+        text = "z" * 5000
+        result = _truncate_mcp_text_result(text)
+        assert len(result) < len(text)
+        assert "TRUNCATED" in result
+
+    def test_truncation_preserves_head_and_tail(self, monkeypatch):
+        """Truncated results keep both the beginning and end of the original."""
+        monkeypatch.setattr("tools.tool_output_limits.get_max_bytes", lambda: 200)
+        from tools.mcp_tool import _truncate_mcp_text_result
+
+        head_marker = "HEAD_MARKER_START"
+        tail_marker = "TAIL_MARKER_END"
+        text = head_marker + "x" * 5000 + tail_marker
+        result = _truncate_mcp_text_result(text)
+        assert result.startswith(head_marker)
+        assert result.endswith(tail_marker)
+
+    def test_truncation_includes_omitted_count(self, monkeypatch):
+        """The truncation notice reports how many chars were omitted."""
+        monkeypatch.setattr("tools.tool_output_limits.get_max_bytes", lambda: 100)
+        from tools.mcp_tool import _truncate_mcp_text_result
+
+        text = "a" * 5000
+        result = _truncate_mcp_text_result(text)
+        assert "4,900" in result  # 5000 - 100 = 4900 omitted (comma-formatted)
+        assert "5,000" in result  # total original length
+
+    def test_truncation_uses_40_60_head_tail_split(self, monkeypatch):
+        """Matches terminal tool's 40% head / 60% tail split."""
+        monkeypatch.setattr("tools.tool_output_limits.get_max_bytes", lambda: 100)
+        from tools.mcp_tool import _truncate_mcp_text_result
+
+        text = "H" * 40 + "M" * 5000 + "T" * 60
+        result = _truncate_mcp_text_result(text)
+        # Head: first 40 chars of result should be H's (40% of 100)
+        assert result[:40] == "H" * 40
+        # Tail: last 60 chars should be T's (60% of 100)
+        assert result[-60:] == "T" * 60
+
+    def test_empty_result_unchanged(self, monkeypatch):
+        """Empty string passes through."""
+        monkeypatch.setattr("tools.tool_output_limits.get_max_bytes", lambda: 100)
+        from tools.mcp_tool import _truncate_mcp_text_result
+
+        assert _truncate_mcp_text_result("") == ""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -101,6 +101,38 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
+
+def _truncate_mcp_text_result(text: str) -> str:
+    """Bound oversized MCP tool text before it enters conversation context.
+
+    MCP servers can return arbitrarily large text — a buggy or malicious
+    server could flood the context window with multi-MB output, causing
+    context overflow, OOM on constrained deployments, or unbounded API
+    costs.  This applies the same ``get_max_bytes()`` cap used by the
+    terminal tool, with a 40% head / 60% tail split so the model sees both
+    the beginning (often the primary result) and the end (often the most
+    recent output). (#56059)
+    """
+    try:
+        from tools.tool_output_limits import get_max_bytes
+        max_chars = get_max_bytes()
+    except Exception:
+        max_chars = 50_000
+
+    if len(text) <= max_chars:
+        return text
+
+    head_chars = int(max_chars * 0.4)
+    tail_chars = max_chars - head_chars
+    omitted = len(text) - head_chars - tail_chars
+    return (
+        text[:head_chars]
+        + f"\n\n... [MCP RESULT TRUNCATED - {omitted:,} chars omitted "
+          f"out of {len(text):,} total] ...\n\n"
+        + text[-tail_chars:]
+    )
+
+
 # Upper bound for the OSV malware preflight during stdio MCP startup. The
 # check makes a blocking urllib HTTPS call whose own timeout can fail to
 # interrupt a stalled SSL handshake, which froze the asyncio event loop and
@@ -3400,7 +3432,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         error_text += block.text
                 return json.dumps({
                     "error": _sanitize_error(
-                        error_text or "MCP tool returned an error"
+                        _truncate_mcp_text_result(
+                            error_text or "MCP tool returned an error"
+                        )
                     )
                 }, ensure_ascii=False)
 
@@ -3425,12 +3459,26 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     parts.append(image_tag)
             text_result = "\n".join(parts) if parts else ""
 
+            # Cap text_result size to prevent unbounded allocation (#56059).
+            text_result = _truncate_mcp_text_result(text_result)
+
             # Combine content + structuredContent when both are present.
             # MCP spec: content is model-oriented (text), structuredContent
             # is machine-oriented (JSON metadata).  For an AI agent, content
             # is the primary payload; structuredContent supplements it.
             structured = getattr(result, "structuredContent", None)
             if structured is not None:
+                # Cap structuredContent too — a malicious server could flood
+                # context via a multi-MB JSON payload (#56059).  When the
+                # serialized form exceeds the limit, replace it with a
+                # truncated string (preserving head + tail) so the structure
+                # degrades gracefully instead of flooding context.
+                structured_json = json.dumps(
+                    structured, ensure_ascii=False, default=str
+                )
+                truncated_json = _truncate_mcp_text_result(structured_json)
+                if truncated_json is not structured_json:
+                    structured = truncated_json
                 if text_result:
                     return json.dumps({
                         "result": text_result,


### PR DESCRIPTION
## What

MCP tool results were returned with **zero size enforcement** — a buggy or malicious MCP server could return multi-megabyte text that floods the conversation context window, triggers context overflow, causes OOM on constrained deployments, and burns unbounded API costs.

The terminal tool and file-read tool already cap output (`get_max_bytes()` default 50 KB and `max_lines=2000` respectively). MCP tools had none of these guards.

## Fix

Added `_truncate_mcp_text_result()` helper that applies the same `get_max_bytes()` cap used by the terminal tool, with a 40% head / 60% tail split so the model sees both the beginning (primary result) and end (most recent output). Wired into **all three** result paths in `_make_tool_handler._call()`:

1. **text_result** — main text payload, truncated after `"\n".join(parts)`
2. **structuredContent** — serialized JSON, truncated if oversized (degrades gracefully to a truncated string with head+tail rather than flooding context)
3. **error_text** — error responses, truncated before `_sanitize_error()`

A defensive `try/except` fallback to 50 000 chars is included in case `get_max_bytes()` is unavailable.

## Test

7 new regression tests in `tests/tools/test_mcp_result_size_limit.py`:
- Short result unchanged
- Exact limit unchanged (boundary)
- Oversized result truncated
- Head + tail preserved after truncation
- Omitted char count reported (comma-formatted)
- 40/60 head/tail split verified
- Empty string edge case

```
tests/tools/test_mcp_result_size_limit.py ..... 7 passed in 0.25s
tests/tools/test_mcp_tool.py .................. 203 passed in 15.91s (no regressions)
```

## Competitor PRs

Three open PRs address this issue; all cover fewer paths and are inferior:

| PR | Layers covered | Tests | Issues |
|----|---------------|-------|--------|
| #56072 | text_result only | none | inline code, no structuredContent/error |
| #56068 | double-wraps result JSON | 2 (test wrong behavior) | destroys JSON structure — wraps already-JSON result in another `{"result": truncated}` |
| #56060 | text_result only | none | inline code, 50/50 split, no structuredContent/error |

This PR covers all three result paths with a clean extracted helper and comprehensive tests.

Auto-published by Moonsong via Path B automated pipeline.