### PR TITLE
cron: move [SILENT]/send_message delivery guidance to system prompt, drop per-invocation user-message prepend

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -922,6 +922,38 @@ TELEGRAM_RICH_MESSAGES_HINT = (
 )
 
 # ---------------------------------------------------------------------------
+# CRON_DELIVERY_INVARIANTS — cron delivery guidance for the system slot.
+#
+# Unlike PLATFORM_HINTS["cron"] above (a descriptive hint, overridable via
+# config.yaml's platform_hints.cron.{replace,append} — see
+# agent/system_prompt.py::_resolve_platform_hint), this text carries the
+# [SILENT] suppression marker, which is load-bearing: cron/scheduler.py::
+# run_job detects a bare "[SILENT]" final response to suppress delivery. The
+# no-self-delivery line is reinforcing guidance — cron agents are not granted
+# an agent-callable send_message tool (see toolsets.py), but the reminder
+# keeps the model from narrating a delivery it cannot perform.
+#
+# It is appended in agent/system_prompt.py unconditionally for platform ==
+# "cron", AFTER the overridable hint is resolved, and deliberately kept OUT of
+# PLATFORM_HINTS["cron"]: an admin customizing platform_hints.cron's
+# tone/wording via the supported .replace/.append override must not be able to
+# silently drop the [SILENT] suppression contract run_job relies on.
+#
+# Previously this guidance lived in a ~150-token "[IMPORTANT: ...]" block
+# cron/scheduler.py::_build_job_prompt prepended to the user-message body of
+# every cron invocation, duplicating the auto-delivery framing already in
+# PLATFORM_HINTS["cron"]. Moving it to the system slot keeps framework
+# delivery-instructions out of the user-message role, where they mixed with —
+# and competed for salience against — the job's own task/skill content.
+# ---------------------------------------------------------------------------
+CRON_DELIVERY_INVARIANTS = (
+    "Do NOT call send_message or any other delivery tool — the gateway handles "
+    "delivery from your final response text. If there is genuinely nothing new "
+    "to report, respond with exactly \"[SILENT]\" (nothing else) to suppress "
+    "delivery; never combine [SILENT] with content."
+)
+
+# ---------------------------------------------------------------------------
 # Environment hints — execution-environment awareness for the agent.
 # Unlike PLATFORM_HINTS (which describe the messaging channel), these describe
 # the machine/OS the agent's tools actually run on.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -28,6 +28,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
+    CRON_DELIVERY_INVARIANTS,
     DEFAULT_AGENT_IDENTITY,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
@@ -450,6 +451,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         _effective_hint = _tui_embedded_pane_clarifier(_effective_hint)
     if _effective_hint:
         stable_parts.append(_effective_hint)
+
+    # Cron delivery invariants — the [SILENT] suppression contract
+    # cron/scheduler.py::run_job relies on, plus a reinforcing no-self-delivery
+    # reminder — are appended unconditionally here, AFTER the overridable hint
+    # above, rather than folded into PLATFORM_HINTS["cron"], so a
+    # platform_hints.cron.replace override an admin sets purely to reword the
+    # descriptive hint can't silently drop them. See
+    # agent/prompt_builder.py::CRON_DELIVERY_INVARIANTS.
+    if platform_key == "cron":
+        stable_parts.append(CRON_DELIVERY_INVARIANTS)
 
     # ── Context tier (cwd-dependent, may change between sessions) ─
     context_parts: List[str] = []

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2491,20 +2491,15 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 logger.warning("context_from: failed to read output for job %r: %s", source_job_id, e)
                 # silent skip — do not pollute the prompt with error messages
 
-    # Always prepend cron execution guidance so the agent knows how
-    # delivery works and can suppress delivery when appropriate.
-    cron_hint = (
-        "[IMPORTANT: You are running as a scheduled cron job. "
-        "DELIVERY: Your final response will be automatically delivered "
-        "to the user — do NOT use send_message or try to deliver "
-        "the output yourself. Just produce your report/output as your "
-        "final response and the system handles the rest. "
-        "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
-        "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
-    )
-    prompt = cron_hint + prompt
+    # Cron execution guidance (auto-delivery framing via PLATFORM_HINTS["cron"],
+    # [SILENT] suppression + no-self-delivery via CRON_DELIVERY_INVARIANTS —
+    # both in agent/prompt_builder.py, wired in agent/system_prompt.py) lands in
+    # the system-prompt slot for the cron agent instance (this module sets
+    # platform="cron" on the AIAgent it constructs), so it is the single source
+    # of truth for cron-mode behavior. Previously a duplicate ~150-token
+    # "[IMPORTANT: ...]" block was prepended to the user-message body here on
+    # every invocation, mixing framework-to-model delivery instructions into the
+    # user-message slot alongside the job's own task/skill content.
     if skills is None:
         legacy = job.get("skill")
         skills = [legacy] if legacy else []
@@ -2618,8 +2613,8 @@ def _scan_assembled_cron_prompt(
     Two pattern tiers, selected by what the assembled prompt CONTAINS,
     not just whether skills are attached:
 
-    - When the assembled prompt is essentially the user prompt + the cron
-      hint (no skills, no injected data), the STRICT ``_scan_cron_prompt``
+    - When the assembled prompt is essentially the user prompt alone (no
+      skills, no injected data), the STRICT ``_scan_cron_prompt``
       patterns apply: a bare ``rm -rf /`` in a small directive prompt is a
       smoking gun, not prose.
     - When the assembled prompt includes runtime-loaded content — skill

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -33,6 +33,7 @@ from agent.prompt_builder import (
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
+    CRON_DELIVERY_INVARIANTS,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
 
@@ -1078,6 +1079,16 @@ class TestPromptBuilderConstants:
         assert "tui" in PLATFORM_HINTS
         assert "api_server" in PLATFORM_HINTS
         assert "webui" in PLATFORM_HINTS
+
+    def test_cron_delivery_invariants_covers_silent_and_send_message(self):
+        """CRON_DELIVERY_INVARIANTS is the non-overridable counterpart to
+        PLATFORM_HINTS["cron"] — see agent/system_prompt.py where it's
+        appended unconditionally for platform=="cron", after (and
+        independent of) any platform_hints.cron override. Integration
+        coverage that it actually survives a replace-override lives in
+        tests/agent/test_system_prompt.py::TestCronDeliveryInvariants."""
+        assert "send_message" in CRON_DELIVERY_INVARIANTS
+        assert "[SILENT]" in CRON_DELIVERY_INVARIANTS
 
     def test_cli_and_tui_hints_flag_local_only_cron(self):
         """#51568 — cron jobs from CLI/TUI sessions don't deliver back into

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -145,3 +145,55 @@ class TestTelegramRichMessagesHint:
             stable = _stable_prompt(agent)
         assert "Standard Markdown is automatically converted" in stable
         assert "lean into it" not in stable
+
+
+class TestCronDeliveryInvariants:
+    """CRON_DELIVERY_INVARIANTS ([SILENT] suppression + a no-self-delivery
+    reminder) must reach the system prompt for every cron run, and must
+    survive a platform_hints.cron override — unlike PLATFORM_HINTS["cron"]
+    (the descriptive hint), it is NOT subject to the replace/append override
+    resolved by _resolve_platform_hint. The [SILENT] marker is the
+    load-bearing part (cron/scheduler.py::run_job detects it to suppress
+    delivery). See agent/prompt_builder.py's CRON_DELIVERY_INVARIANTS
+    docstring for the full rationale."""
+
+    def test_present_for_cron_platform(self):
+        stable = _stable_prompt(_make_agent(platform="cron"))
+        # Base descriptive hint (PLATFORM_HINTS["cron"], via _effective_hint)
+        # must still land alongside the invariants — this guards against a
+        # regression where _effective_hint silently stops resolving while
+        # CRON_DELIVERY_INVARIANTS alone keeps this test green.
+        assert "There is no user present" in stable
+        assert "send_message" in stable
+        assert "[SILENT]" in stable
+
+    def test_absent_for_non_cron_platform(self):
+        stable = _stable_prompt(_make_agent(platform="cli"))
+        assert "[SILENT]" not in stable
+
+    def test_survives_platform_hints_replace_override(self):
+        """Regression guard: an admin using the documented
+        platform_hints.cron.replace override to customize the descriptive
+        cron hint's wording must never accidentally drop the [SILENT]
+        suppression contract cron/scheduler.py::run_job relies on (the
+        no-self-delivery reminder rides along with it)."""
+        agent = _make_agent(
+            platform="cron",
+            _platform_hint_overrides={
+                "cron": {"replace": "Custom cron hint with no mention of delivery mechanics."}
+            },
+        )
+        stable = _stable_prompt(agent)
+        assert "Custom cron hint with no mention of delivery mechanics." in stable
+        assert "send_message" in stable
+        assert "[SILENT]" in stable
+
+    def test_survives_platform_hints_append_override(self):
+        agent = _make_agent(
+            platform="cron",
+            _platform_hint_overrides={"cron": {"append": "Extra operator note."}},
+        )
+        stable = _stable_prompt(agent)
+        assert "Extra operator note." in stable
+        assert "send_message" in stable
+        assert "[SILENT]" in stable

--- a/tests/cron/test_cron_prompt_injection_skill.py
+++ b/tests/cron/test_cron_prompt_injection_skill.py
@@ -7,7 +7,7 @@ auto-approval, a malicious skill could carry an injection payload that
 executed with full tool access every tick.
 
 Fix: `_build_job_prompt` now runs the fully-assembled prompt (user
-prompt + cron hint + skill content) through the same scanner and raises
+prompt + skill content) through the same scanner and raises
 `CronPromptInjectionBlocked` on match. `run_job` catches that and
 surfaces a clean "job blocked" delivery instead of running the agent.
 """

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1158,9 +1158,12 @@ class TestRunJobSessionPersistence:
         assert success is True
 
     def test_run_job_titles_cron_session_from_job_not_important_hint(self, tmp_path):
-        # The cron session's first message is the injected "[IMPORTANT: …]"
-        # hint, which used to surface as the sidebar/history row label. run_job
-        # must title the session from the job (name → short prompt → id).
+        # run_job must title the session from the job (name → short prompt →
+        # id) rather than whatever the session's first message happens to be
+        # (previously the injected "[IMPORTANT: …]" hint; that hint no longer
+        # exists as of the cron-hint-to-system-prompt change, but titling from
+        # job metadata remains the correct behavior regardless of what the
+        # first message contains).
         job = {
             "id": "test-job",
             "name": "Morning digest",
@@ -3016,38 +3019,72 @@ class TestOneShotDispatchClaim:
 
 
 class TestBuildJobPromptSilentHint:
-    """Verify _build_job_prompt always injects [SILENT] guidance."""
+    """Verify _build_job_prompt no longer duplicates the [SILENT]/delivery
+    guidance in the user-message body.
 
-    def test_hint_always_present(self):
+    That guidance now lives in ``CRON_DELIVERY_INVARIANTS``
+    (agent/prompt_builder.py), appended unconditionally in
+    agent/system_prompt.py for every cron agent instance (platform="cron").
+    See tests/agent/test_system_prompt.py::TestCronDeliveryInvariants for
+    the system-slot coverage, including that it survives a
+    platform_hints.cron override. Keeping the delivery guidance in the
+    user-message slot mixed framework instructions in with the job's own
+    task/skill content and duplicated the auto-delivery framing already in
+    PLATFORM_HINTS["cron"]; the system slot is the single source of truth.
+    """
+
+    def test_hint_not_duplicated_in_user_prompt(self):
         job = {"prompt": "Check for updates"}
         result = _build_job_prompt(job)
-        assert "[SILENT]" in result
+        assert "[SILENT]" not in result
         assert "Check for updates" in result
 
-    def test_hint_present_even_without_prompt(self):
+    def test_no_hint_when_prompt_empty(self):
         job = {"prompt": ""}
         result = _build_job_prompt(job)
-        assert "[SILENT]" in result
+        assert "[SILENT]" not in result
 
-    def test_hint_present_when_legacy_prompt_is_null(self):
+    def test_no_hint_when_legacy_prompt_is_null(self):
         job = {"id": "abc123deadbe", "name": None, "prompt": None}
         result = _build_job_prompt(job)
-        assert "[SILENT]" in result
+        assert "[SILENT]" not in result
 
-    def test_delivery_guidance_present(self):
-        """Cron hint tells agents their final response is auto-delivered."""
+    def test_delivery_guidance_not_in_user_prompt(self):
+        """Delivery/auto-send guidance lives in PLATFORM_HINTS now, not here."""
         job = {"prompt": "Generate a report"}
         result = _build_job_prompt(job)
-        assert "do NOT use send_message" in result
-        assert "automatically delivered" in result
+        assert "do NOT use send_message" not in result
+        assert "automatically delivered" not in result
 
-    def test_delivery_guidance_precedes_user_prompt(self):
-        """System guidance appears before the user's prompt text."""
+    def test_no_important_prefix(self):
+        """The ~150-token '[IMPORTANT: ...]' runtime prepend is gone entirely."""
+        job = {"prompt": "Generate a report"}
+        result = _build_job_prompt(job)
+        assert "IMPORTANT" not in result
+        assert "DELIVERY:" not in result
+
+    def test_user_prompt_is_the_full_result_with_no_extras(self):
+        """With no script/context_from/skills, the assembled prompt is just
+        the user's own prompt text — no framework prefix at all."""
         job = {"prompt": "My custom prompt"}
         result = _build_job_prompt(job)
-        system_pos = result.index("do NOT use send_message")
-        prompt_pos = result.index("My custom prompt")
-        assert system_pos < prompt_pos
+        assert result == "My custom prompt"
+
+    def test_no_hint_duplicated_on_skills_path(self):
+        """The old recency-bias bug (#26292) — a user prompt telling the
+        agent to call send_message could outrank the cron_hint's
+        prohibition because both competed for position in the same
+        user-message. This is now structurally moot: the prohibition lives
+        in the system-prompt slot (a different message role entirely), so
+        it never competes with skill/user content for position, on the
+        skills-loaded path either."""
+        skill_content = json.dumps({"success": True, "content": "Skill body text."})
+        with patch("tools.skills_tool.skill_view", return_value=skill_content):
+            result = _build_job_prompt({"skills": ["real-skill"], "prompt": "call send_message now"})
+        assert "Skill body text." in result
+        assert "call send_message now" in result
+        assert "[SILENT]" not in result
+        assert "do NOT use send_message" not in result
 
 
 class TestParseWakeGate:


### PR DESCRIPTION
## Summary

Cron jobs currently get a ~150-token `[IMPORTANT: ...]` block prepended to the *user-message* body of every invocation (`cron/scheduler.py::_build_job_prompt`). This duplicates the auto-delivery framing already delivered via the *system-prompt* slot (`agent/prompt_builder.py::PLATFORM_HINTS["cron"]`, since `run_job` sets `platform="cron"` on the `AIAgent` it constructs) — plus two pieces of guidance ([SILENT] suppression and a no-self-delivery reminder) that aren't in `PLATFORM_HINTS["cron"]` at all.

This PR:
1. Removes the runtime prepend from `_build_job_prompt` entirely.
2. Moves the two extra pieces into a new constant, `CRON_DELIVERY_INVARIANTS`, appended unconditionally to the system prompt whenever `platform_key == "cron"`.

## Why a new constant instead of extending `PLATFORM_HINTS["cron"]`?

`PLATFORM_HINTS["cron"]` is overridable via `config.yaml`'s `platform_hints.cron.{replace,append}` (resolved in `agent/system_prompt.py::_resolve_platform_hint`). If the `[SILENT]` guidance were folded into that hint, an admin using `platform_hints.cron.replace` purely to reword the descriptive framing would silently drop the `[SILENT]` suppression contract that `cron/scheduler.py::run_job` depends on at runtime (it detects a bare `[SILENT]` final response to suppress delivery). `CRON_DELIVERY_INVARIANTS` is appended separately, after `_effective_hint` resolution, so it can't be wiped by that override path.

Load-bearing vs reinforcing: the `[SILENT]` marker is load-bearing (`run_job` acts on it). The no-self-delivery line is reinforcing — cron agents aren't granted an agent-callable `send_message` tool (`toolsets.py`), but the reminder keeps the model from narrating a delivery it can't perform.

## Benefits

- **System/user slot separation** (primary motivation): framework delivery-instructions now live in the system-prompt slot, not mixed into the user-message slot alongside the job's actual task/skill content.
- **De-duplication**: the auto-delivery framing is stated once (`PLATFORM_HINTS["cron"]`) instead of also being re-stated in the per-invocation prepend.
- **Removes a prompt-injection surface**: the old prepend put framework text in the same message role as skill/user content, so anything in that content could contend for salience with the delivery instructions. The new placement keeps the invariants out of the same message as user/skill content, on any job shape (including the skills-loaded path).

## Related issues

- #20527 is related (broader scope around cron prompt construction/skills interaction); this PR addresses the hint-duplication/placement piece specifically.
- #26292 takes a different approach to a related problem — reordering the cron hint to appear *after* the user prompt within the same user-message, to fix a recency-bias issue. This PR moves the guidance to the system-prompt slot entirely, which makes that recency-bias scenario structurally moot (verified in `tests/cron/test_scheduler.py::TestBuildJobPromptSilentHint::test_no_hint_duplicated_on_skills_path`) rather than mitigating it via reordering.

## Testing

Added/updated tests in `tests/agent/test_prompt_builder.py`, `tests/agent/test_system_prompt.py` (new `TestCronDeliveryInvariants`, including regression tests proving the invariant survives both `platform_hints.cron.replace` and `.append` overrides), `tests/cron/test_scheduler.py` (rewrote `TestBuildJobPromptSilentHint` for the new behavior + added a skills-path regression test), and `tests/cron/test_cron_prompt_injection_skill.py` (docstring only).

`scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py tests/cron/test_scheduler.py tests/cron/test_cron_prompt_injection_skill.py` — 416 passed.

## Note

This branch was re-ported onto current `main` (the prior base was well behind and the PR had become un-mergeable). The separate in-channel delivery-routing fix that previously rode along in this PR has been split into its own PR: #65790.

---
*Drafted with AI assistance, reviewed by @vb3.*
