### PR TITLE
fix(photon): persist sidecar token for standalone sends

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12809,6 +12809,23 @@ def main():
                 seen_plugin_commands.add(cmd_info["name"])
 
             discover_plugins()
+            # Bundled platform plugins are normally deferred so plain `hermes`
+            # startup doesn't import every platform SDK. If the unknown
+            # positional token is itself a platform plugin's CLI command (for
+            # example `hermes photon status`), resolve just that platform now;
+            # its register() call can then contribute the CLI subparser.
+            plugin_candidate = _first_positional_argv()
+            if plugin_candidate:
+                try:
+                    from gateway.platform_registry import platform_registry
+
+                    platform_registry.get(plugin_candidate)
+                except Exception:
+                    logging.getLogger(__name__).debug(
+                        "Deferred platform CLI discovery failed for %s",
+                        plugin_candidate,
+                        exc_info=True,
+                    )
             for cmd_info in get_plugin_manager()._cli_commands.values():
                 if cmd_info["name"] in seen_plugin_commands:
                     continue

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -39,6 +39,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from hermes_constants import get_hermes_home
+
 if TYPE_CHECKING:
     # Type checkers see ``httpx`` as the always-imported module, so every use
     # site type-checks cleanly. The runtime fallback below keeps the optional
@@ -84,6 +86,53 @@ _DEDUP_MAX_SIZE = 4000
 _DEDUP_WINDOW_SECONDS = 48 * 3600
 
 _SIDECAR_DIR = Path(__file__).parent / "sidecar"
+
+
+def _sidecar_token_file(port: int) -> Path:
+    """Runtime handoff file for out-of-process senders."""
+    return get_hermes_home() / "runtime" / f"photon-sidecar-{port}.json"
+
+
+def _write_sidecar_token_file(port: int, token: str, pid: int) -> None:
+    """Persist the live sidecar control token with user-only permissions."""
+    path = _sidecar_token_file(port)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+    tmp.write_text(
+        json.dumps({"port": port, "token": token, "pid": pid}),
+        encoding="utf-8",
+    )
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    tmp.replace(path)
+
+
+def _read_sidecar_token_file(port: int) -> Optional[str]:
+    """Read the live gateway sidecar token for `hermes send`/cron fallback."""
+    try:
+        data = json.loads(_sidecar_token_file(port).read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if int(data.get("port") or 0) != port:
+        return None
+    token = data.get("token")
+    return token if isinstance(token, str) and token else None
+
+
+def _remove_sidecar_token_file(port: int, token: str) -> None:
+    """Remove our token file without clobbering a newer sidecar's token."""
+    path = _sidecar_token_file(port)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if data.get("token") == token:
+            path.unlink()
+    except FileNotFoundError:
+        return
+    except Exception:
+        logger.debug("[photon] failed to remove sidecar token file", exc_info=True)
+
 
 # Photon / Envoy / spectrum-ts error substrings that indicate a transient
 # upstream overload rather than a permanent failure.  These are not in the
@@ -884,6 +933,11 @@ class PhotonAdapter(BasePlatformAdapter):
             env=env,
             start_new_session=(sys.platform != "win32"),
         )
+        _write_sidecar_token_file(
+            self._sidecar_port,
+            self._sidecar_token,
+            int(self._sidecar_proc.pid),
+        )
 
         # Pump sidecar stderr/stdout into our logger so users see crashes.
         loop = asyncio.get_event_loop()
@@ -983,6 +1037,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 except subprocess.TimeoutExpired:
                     proc.kill()
         finally:
+            _remove_sidecar_token_file(self._sidecar_port, self._sidecar_token)
             self._sidecar_proc = None
             if self._sidecar_supervisor_task is not None:
                 self._sidecar_supervisor_task.cancel()
@@ -1584,13 +1639,13 @@ async def _standalone_send(
         (pconfig.extra or {}).get("sidecar_port") or os.getenv("PHOTON_SIDECAR_PORT"),
         _DEFAULT_SIDECAR_PORT,
     )
-    token = os.getenv("PHOTON_SIDECAR_TOKEN")
+    token = os.getenv("PHOTON_SIDECAR_TOKEN") or _read_sidecar_token_file(port)
     if not token:
         return {
             "error": (
                 "Photon standalone send requires a running sidecar with "
-                "PHOTON_SIDECAR_TOKEN set in the environment. Cron processes "
-                "cannot spawn the sidecar themselves."
+                "a readable runtime token. Start/restart the Hermes gateway "
+                "so it can launch the Photon sidecar."
             )
         }
     base = f"http://{_DEFAULT_SIDECAR_BIND}:{port}"

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -8,12 +8,16 @@ spawning Node or binding ports.
 """
 from __future__ import annotations
 
+import json
+import stat
 import subprocess
+from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import pytest
 
 from gateway.config import PlatformConfig
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from plugins.platforms.photon import adapter as photon_adapter
 from plugins.platforms.photon.adapter import PhotonAdapter
 
@@ -57,6 +61,61 @@ def _capture_kills(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[int, int]]:
 
     monkeypatch.setattr(photon_adapter.os, "kill", _fake_kill)
     return kills
+
+
+@pytest.fixture()
+def isolated_hermes_home(tmp_path: Path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        reset_hermes_home_override(token)
+
+
+class TestSidecarTokenFile:
+    def test_write_then_read_round_trip(self, isolated_hermes_home: Path) -> None:
+        photon_adapter._write_sidecar_token_file(9001, "secret-token", 12345)
+
+        path = isolated_hermes_home / "runtime" / "photon-sidecar-9001.json"
+        assert path.exists()
+        assert photon_adapter._read_sidecar_token_file(9001) == "secret-token"
+        assert json.loads(path.read_text(encoding="utf-8")) == {
+            "port": 9001,
+            "token": "secret-token",
+            "pid": 12345,
+        }
+        if hasattr(stat, "S_IMODE"):
+            assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    def test_read_ignores_wrong_port(self, isolated_hermes_home: Path) -> None:
+        path = isolated_hermes_home / "runtime" / "photon-sidecar-9002.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps({"port": 9003, "token": "wrong-port", "pid": 1}),
+            encoding="utf-8",
+        )
+
+        assert photon_adapter._read_sidecar_token_file(9002) is None
+
+    def test_read_missing_or_corrupt_file_returns_none(self, isolated_hermes_home: Path) -> None:
+        assert photon_adapter._read_sidecar_token_file(9004) is None
+
+        path = isolated_hermes_home / "runtime" / "photon-sidecar-9004.json"
+        path.parent.mkdir(parents=True)
+        path.write_text("not json", encoding="utf-8")
+
+        assert photon_adapter._read_sidecar_token_file(9004) is None
+
+    def test_remove_only_deletes_matching_token(self, isolated_hermes_home: Path) -> None:
+        photon_adapter._write_sidecar_token_file(9005, "newer-token", 222)
+        path = isolated_hermes_home / "runtime" / "photon-sidecar-9005.json"
+
+        photon_adapter._remove_sidecar_token_file(9005, "older-token")
+        assert path.exists()
+        assert photon_adapter._read_sidecar_token_file(9005) == "newer-token"
+
+        photon_adapter._remove_sidecar_token_file(9005, "newer-token")
+        assert not path.exists()
 
 
 @pytest.mark.asyncio
@@ -125,7 +184,7 @@ async def test_reap_raises_for_foreign_listener(
 
 @pytest.mark.asyncio
 async def test_start_sidecar_spawns_with_stdin_pipe(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_hermes_home: Path
 ) -> None:
     """The spawn must hold a stdin pipe and enable the sidecar's EOF watch."""
     adapter = _make_adapter(monkeypatch)
@@ -169,3 +228,4 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
     kwargs = spawned["kwargs"]
     assert kwargs["stdin"] is subprocess.PIPE
     assert kwargs["env"]["PHOTON_SIDECAR_WATCH_STDIN"] == "1"
+    assert photon_adapter._read_sidecar_token_file(adapter._sidecar_port) == adapter._sidecar_token


### PR DESCRIPTION
## Summary
- persist the Photon sidecar control token under Hermes runtime state so standalone sends / cron jobs can authenticate without inheriting gateway env
- lazily load bundled platform CLI commands so `hermes photon ...` resolves before plugin CLI iteration

## Tests
- `python -m pytest tests/plugins/platforms/photon tests/hermes_cli/test_startup_plugin_gating.py -q` (149 passed)

## Note
- Removed the unrelated Codex Telegram noise-filter change from this PR so it stays scoped to Photon/CLI startup.
