### PR TITLE
Add native HKI source inventory workflow

### DIFF
--- a/hermes_cli/hki_cmd.py
+++ b/hermes_cli/hki_cmd.py
@@ -1,0 +1,136 @@
+"""``hermes hki`` CLI for project-scoped knowledge artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from hki.inventory import build_inventory, load_inventory, write_inventory
+from hki.manifest import build_manifest, load_manifest, write_manifest
+from hki.paths import resolve_scope
+from hki.report import write_sources_report
+
+
+def build_parser(
+    parent_subparsers: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    """Attach the ``hki`` subcommand tree. Returns the top parser."""
+
+    parser = parent_subparsers.add_parser(
+        "hki",
+        help="Manage project-scoped Human Knowledge Infrastructure artifacts",
+        description=(
+            "Create project-scoped HKI workspace artifacts under .hermes/hki/. "
+            "This first slice inventories sources, builds a stable manifest, "
+            "and writes a basic source report."
+        ),
+    )
+    sub = parser.add_subparsers(dest="hki_action")
+
+    inventory = sub.add_parser("inventory", help="Scan the workspace and write inventory.json")
+    _add_cwd_arg(inventory)
+
+    manifest = sub.add_parser("manifest", help="Build manifest.json from inventory.json")
+    _add_cwd_arg(manifest)
+
+    report = sub.add_parser("report", help="Write HKI reports")
+    report_sub = report.add_subparsers(dest="hki_report_action")
+    sources = report_sub.add_parser("sources", help="Write reports/sources.md")
+    _add_cwd_arg(sources)
+
+    parser.set_defaults(_hki_parser=parser)
+    report.set_defaults(_hki_report_parser=report)
+    return parser
+
+
+def hki_command(args: argparse.Namespace) -> int:
+    """Entry point from ``hermes hki ...`` argparse dispatch."""
+
+    action = getattr(args, "hki_action", None)
+    if not action:
+        parser = getattr(args, "_hki_parser", None)
+        if parser is not None:
+            parser.print_help()
+        else:
+            print("usage: hermes hki <action> [options]", file=sys.stderr)
+        return 0
+
+    try:
+        if action == "inventory":
+            return _cmd_inventory(args)
+        if action == "manifest":
+            return _cmd_manifest(args)
+        if action == "report":
+            report_action = getattr(args, "hki_report_action", None)
+            if report_action == "sources":
+                return _cmd_report_sources(args)
+            parser = getattr(args, "_hki_report_parser", None)
+            if parser is not None:
+                parser.print_help()
+                return 0
+            print("usage: hermes hki report <report> [options]", file=sys.stderr)
+            return 1
+    except (OSError, ValueError) as exc:
+        print(f"hki: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Unknown hki action: {action}", file=sys.stderr)
+    return 1
+
+
+def _add_cwd_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--cwd",
+        default=".",
+        metavar="PATH",
+        help="Workspace root to inspect (default: current directory)",
+    )
+
+
+def _cmd_inventory(args: argparse.Namespace) -> int:
+    scope = resolve_scope(args.cwd)
+    inventory = build_inventory(scope)
+    path = write_inventory(inventory, scope)
+    print(f"Wrote HKI inventory: {path}")
+    print(f"  workspace: {scope.root}")
+    print(f"  files:     {len(inventory.files)}")
+    print(f"  skipped:   {inventory.skipped_count}")
+    return 0
+
+
+def _cmd_manifest(args: argparse.Namespace) -> int:
+    scope = resolve_scope(args.cwd)
+    inventory = _load_or_create_inventory(scope)
+    manifest = build_manifest(inventory, inventory_path=scope.inventory_path)
+    path = write_manifest(manifest, scope)
+    print(f"Wrote HKI manifest: {path}")
+    print(f"  workspace: {scope.root}")
+    print(f"  sources:   {len(manifest.sources)}")
+    return 0
+
+
+def _cmd_report_sources(args: argparse.Namespace) -> int:
+    scope = resolve_scope(args.cwd)
+    manifest = _load_or_create_manifest(scope)
+    path = write_sources_report(manifest, scope)
+    print(f"Wrote HKI source report: {path}")
+    print(f"  workspace: {scope.root}")
+    print(f"  manifest:  {scope.manifest_path}")
+    return 0
+
+
+def _load_or_create_inventory(scope):
+    if scope.inventory_path.exists():
+        return load_inventory(scope.inventory_path)
+    inventory = build_inventory(scope)
+    write_inventory(inventory, scope)
+    return inventory
+
+
+def _load_or_create_manifest(scope):
+    if scope.manifest_path.exists():
+        return load_manifest(scope.manifest_path)
+    inventory = _load_or_create_inventory(scope)
+    manifest = build_manifest(inventory, inventory_path=scope.inventory_path)
+    write_manifest(manifest, scope)
+    return manifest

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4266,6 +4266,13 @@ def cmd_project(args):
     return projects_command(args)
 
 
+def cmd_hki(args):
+    """Manage project-scoped Human Knowledge Infrastructure artifacts."""
+    from hermes_cli.hki_cmd import hki_command
+
+    return hki_command(args)
+
+
 def cmd_hooks(args):
     """Shell-hook inspection and management."""
     from hermes_cli.hooks import hooks_command
@@ -11923,7 +11930,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "acp", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
         "config", "cron", "curator", "dashboard", "serve", "debug", "doctor",
-        "dump", "fallback", "gateway", "hooks", "import", "insights",
+        "dump", "fallback", "gateway", "hki", "hooks", "import", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "model", "pairing", "pets", "plugins", "portal", "postinstall", "profile",
         "project", "proxy",
@@ -12685,6 +12692,14 @@ def main():
 
     project_parser = _build_project_parser(subparsers)
     project_parser.set_defaults(func=cmd_project)
+
+    # =========================================================================
+    # hki command — project-scoped Human Knowledge Infrastructure artifacts
+    # =========================================================================
+    from hermes_cli.hki_cmd import build_parser as _build_hki_parser
+
+    hki_parser = _build_hki_parser(subparsers)
+    hki_parser.set_defaults(func=cmd_hki)
 
     # =========================================================================
     # hooks command — shell-hook inspection and management

--- a/hki/__init__.py
+++ b/hki/__init__.py
@@ -1,0 +1,9 @@
+"""Human Knowledge Infrastructure workspace helpers."""
+
+from __future__ import annotations
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/hki/inventory.py
+++ b/hki/inventory.py
@@ -1,0 +1,261 @@
+"""Workspace inventory generation for HKI."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hki.paths import HkiScope, ensure_output_dir
+
+
+SCHEMA_VERSION = 1
+DEFAULT_HASH_LIMIT_BYTES = 1024 * 1024
+SAMPLE_BYTES = 8192
+
+EXCLUDED_DIR_NAMES = frozenset(
+    {
+        ".git",
+        "node_modules",
+        ".venv",
+        "venv",
+        "__pycache__",
+        ".pytest_cache",
+        "dist",
+        "build",
+        ".mypy_cache",
+        ".ruff_cache",
+    }
+)
+
+
+@dataclass(frozen=True)
+class InventoryFile:
+    relative_path: str
+    size: int
+    mtime: int
+    suffix: str
+    is_text: bool
+    classification: str
+    sha256: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "relative_path": self.relative_path,
+            "size": self.size,
+            "mtime": self.mtime,
+            "suffix": self.suffix,
+            "is_text": self.is_text,
+            "classification": self.classification,
+        }
+        if self.sha256:
+            data["sha256"] = self.sha256
+        return data
+
+
+@dataclass(frozen=True)
+class Inventory:
+    root: str
+    generated_at: str
+    files: tuple[InventoryFile, ...]
+    skipped_count: int = 0
+    skipped_by_reason: dict[str, int] = field(default_factory=dict)
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "generated_at": self.generated_at,
+            "root": self.root,
+            "included_count": len(self.files),
+            "skipped_count": self.skipped_count,
+            "skipped_by_reason": dict(sorted(self.skipped_by_reason.items())),
+            "files": [item.to_dict() for item in self.files],
+        }
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def build_inventory(
+    scope: HkiScope,
+    *,
+    hash_limit_bytes: int = DEFAULT_HASH_LIMIT_BYTES,
+) -> Inventory:
+    """Scan ``scope.root`` and return an HKI inventory."""
+
+    root = scope.root.resolve()
+    files: list[InventoryFile] = []
+    skipped: Counter[str] = Counter()
+
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+        current = Path(dirpath)
+        kept_dirs: list[str] = []
+        for dirname in sorted(dirnames):
+            full_dir = current / dirname
+            reason = _excluded_dir_reason(full_dir, root)
+            if reason:
+                skipped[reason] += 1
+                continue
+            kept_dirs.append(dirname)
+        dirnames[:] = kept_dirs
+
+        for filename in sorted(filenames):
+            path = current / filename
+            reason = _excluded_file_reason(path, root)
+            if reason:
+                skipped[reason] += 1
+                continue
+            try:
+                item = _inventory_file(path, root, hash_limit_bytes=hash_limit_bytes)
+            except OSError:
+                skipped["read_error"] += 1
+                continue
+            if item is None:
+                skipped["outside_root"] += 1
+                continue
+            files.append(item)
+
+    files.sort(key=lambda item: item.relative_path)
+    return Inventory(
+        root=str(root),
+        generated_at=utc_now_iso(),
+        files=tuple(files),
+        skipped_count=sum(skipped.values()),
+        skipped_by_reason=dict(skipped),
+    )
+
+
+def write_inventory(inventory: Inventory, scope: HkiScope) -> Path:
+    """Write ``inventory`` to ``.hermes/hki/inventory.json``."""
+
+    ensure_output_dir(scope)
+    path = scope.inventory_path
+    path.write_text(
+        json.dumps(inventory.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def load_inventory(path: Path) -> Inventory:
+    """Load an inventory JSON file."""
+
+    return inventory_from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def inventory_from_dict(data: dict[str, Any]) -> Inventory:
+    files = tuple(
+        InventoryFile(
+            relative_path=str(item["relative_path"]),
+            size=int(item.get("size", 0)),
+            mtime=int(item.get("mtime", 0)),
+            suffix=str(item.get("suffix", "")),
+            is_text=bool(item.get("is_text", False)),
+            classification=str(item.get("classification") or ("text" if item.get("is_text") else "binary")),
+            sha256=item.get("sha256"),
+        )
+        for item in data.get("files", [])
+    )
+    return Inventory(
+        root=str(data.get("root", "")),
+        generated_at=str(data.get("generated_at", "")),
+        files=files,
+        skipped_count=int(data.get("skipped_count", 0)),
+        skipped_by_reason={str(k): int(v) for k, v in dict(data.get("skipped_by_reason", {})).items()},
+        schema_version=int(data.get("schema_version", SCHEMA_VERSION)),
+    )
+
+
+def _excluded_dir_reason(path: Path, root: Path) -> str | None:
+    name = path.name
+    if name in EXCLUDED_DIR_NAMES:
+        return "excluded_directory"
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        return "outside_root"
+    if _is_hki_output_path(rel):
+        return "hki_output"
+    if path.is_symlink():
+        return "symlink_directory"
+    return None
+
+
+def _excluded_file_reason(path: Path, root: Path) -> str | None:
+    name = path.name
+    if name == ".env" or name.startswith(".env."):
+        return "secret_env_file"
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        return "outside_root"
+    if _is_hki_output_path(rel):
+        return "hki_output"
+    return None
+
+
+def _is_hki_output_path(rel: Path) -> bool:
+    parts = rel.parts
+    return len(parts) >= 2 and parts[0] == ".hermes" and parts[1] == "hki"
+
+
+def _inventory_file(
+    path: Path,
+    root: Path,
+    *,
+    hash_limit_bytes: int,
+) -> InventoryFile | None:
+    if path.is_symlink():
+        resolved = path.resolve(strict=True)
+        if not resolved.is_relative_to(root):
+            return None
+
+    if not path.is_file():
+        raise OSError(f"not a regular file: {path}")
+
+    stat = path.stat()
+    is_text = _looks_text(path)
+    sha256 = _hash_file(path) if stat.st_size <= hash_limit_bytes else None
+    rel = path.relative_to(root).as_posix()
+    suffix = path.suffix.lower()
+    return InventoryFile(
+        relative_path=rel,
+        size=int(stat.st_size),
+        mtime=int(stat.st_mtime),
+        suffix=suffix,
+        is_text=is_text,
+        classification="text" if is_text else "binary",
+        sha256=sha256,
+    )
+
+
+def _looks_text(path: Path) -> bool:
+    try:
+        with path.open("rb") as handle:
+            sample = handle.read(SAMPLE_BYTES)
+    except OSError:
+        return False
+    if not sample:
+        return True
+    if b"\x00" in sample:
+        return False
+    try:
+        sample.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/hki/manifest.py
+++ b/hki/manifest.py
@@ -1,0 +1,199 @@
+"""Stable HKI source manifest generation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hki.inventory import Inventory, InventoryFile, load_inventory, utc_now_iso
+from hki.paths import HkiScope, as_workspace_relative, ensure_output_dir
+
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class SourceRecord:
+    source_id: str
+    relative_path: str
+    kind: str
+    size: int
+    mtime: int
+    is_text: bool
+    sha256: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "source_id": self.source_id,
+            "relative_path": self.relative_path,
+            "kind": self.kind,
+            "size": self.size,
+            "mtime": self.mtime,
+            "is_text": self.is_text,
+        }
+        if self.sha256:
+            data["sha256"] = self.sha256
+        return data
+
+
+@dataclass(frozen=True)
+class Manifest:
+    root: str
+    generated_at: str
+    sources: tuple[SourceRecord, ...]
+    inventory_path: str | None = None
+    inventory_skipped_count: int = 0
+    inventory_skipped_by_reason: dict[str, int] | None = None
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "schema_version": self.schema_version,
+            "generated_at": self.generated_at,
+            "root": self.root,
+            "source_count": len(self.sources),
+            "inventory_skipped_count": self.inventory_skipped_count,
+            "sources": [source.to_dict() for source in self.sources],
+        }
+        if self.inventory_skipped_by_reason:
+            data["inventory_skipped_by_reason"] = dict(
+                sorted(self.inventory_skipped_by_reason.items())
+            )
+        if self.inventory_path:
+            data["inventory_path"] = self.inventory_path
+        return data
+
+
+def build_manifest(inventory: Inventory, *, inventory_path: Path | None = None) -> Manifest:
+    """Create a stable source manifest from ``inventory``."""
+
+    inventory_ref = None
+    if inventory_path is not None:
+        inventory_ref = as_workspace_relative(inventory_path, Path(inventory.root))
+
+    records = tuple(
+        SourceRecord(
+            source_id=source_id_for(item.relative_path),
+            relative_path=item.relative_path,
+            kind=kind_for_inventory_file(item),
+            size=item.size,
+            mtime=item.mtime,
+            is_text=item.is_text,
+            sha256=item.sha256,
+        )
+        for item in sorted(inventory.files, key=lambda entry: entry.relative_path)
+    )
+    return Manifest(
+        root=inventory.root,
+        generated_at=utc_now_iso(),
+        sources=records,
+        inventory_path=inventory_ref,
+        inventory_skipped_count=inventory.skipped_count,
+        inventory_skipped_by_reason=dict(inventory.skipped_by_reason),
+    )
+
+
+def write_manifest(manifest: Manifest, scope: HkiScope) -> Path:
+    """Write ``manifest`` to ``.hermes/hki/manifest.json``."""
+
+    ensure_output_dir(scope)
+    path = scope.manifest_path
+    path.write_text(
+        json.dumps(manifest.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def load_manifest(path: Path) -> Manifest:
+    return manifest_from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def load_inventory_for_scope(scope: HkiScope) -> Inventory:
+    return load_inventory(scope.inventory_path)
+
+
+def manifest_from_dict(data: dict[str, Any]) -> Manifest:
+    sources = tuple(
+        SourceRecord(
+            source_id=str(item["source_id"]),
+            relative_path=str(item["relative_path"]),
+            kind=str(item.get("kind", "unknown")),
+            size=int(item.get("size", 0)),
+            mtime=int(item.get("mtime", 0)),
+            is_text=bool(item.get("is_text", False)),
+            sha256=item.get("sha256"),
+        )
+        for item in data.get("sources", [])
+    )
+    return Manifest(
+        root=str(data.get("root", "")),
+        generated_at=str(data.get("generated_at", "")),
+        sources=sources,
+        inventory_path=data.get("inventory_path"),
+        inventory_skipped_count=int(data.get("inventory_skipped_count", 0)),
+        inventory_skipped_by_reason={
+            str(k): int(v)
+            for k, v in dict(data.get("inventory_skipped_by_reason", {})).items()
+        },
+        schema_version=int(data.get("schema_version", SCHEMA_VERSION)),
+    )
+
+
+def source_id_for(relative_path: str) -> str:
+    digest = hashlib.sha1(relative_path.encode("utf-8")).hexdigest()[:20]
+    return f"src_{digest}"
+
+
+def kind_for_inventory_file(item: InventoryFile) -> str:
+    rel_name = Path(item.relative_path).name.lower()
+    suffix = item.suffix.lower()
+
+    special_names = {
+        "dockerfile": "dockerfile",
+        "makefile": "makefile",
+        "readme": "documentation",
+        "license": "license",
+    }
+    if rel_name in special_names:
+        return special_names[rel_name]
+
+    by_suffix = {
+        ".py": "python",
+        ".pyi": "python",
+        ".js": "javascript",
+        ".jsx": "javascript",
+        ".ts": "typescript",
+        ".tsx": "typescript",
+        ".md": "markdown",
+        ".mdx": "markdown",
+        ".rst": "documentation",
+        ".txt": "text",
+        ".json": "json",
+        ".jsonl": "jsonl",
+        ".yaml": "yaml",
+        ".yml": "yaml",
+        ".toml": "toml",
+        ".ini": "config",
+        ".cfg": "config",
+        ".csv": "csv",
+        ".html": "html",
+        ".css": "css",
+        ".scss": "css",
+        ".sh": "shell",
+        ".bash": "shell",
+        ".zsh": "shell",
+        ".sql": "sql",
+        ".png": "image",
+        ".jpg": "image",
+        ".jpeg": "image",
+        ".gif": "image",
+        ".webp": "image",
+        ".pdf": "pdf",
+    }
+    if suffix in by_suffix:
+        return by_suffix[suffix]
+    return "text" if item.is_text else "binary"

--- a/hki/paths.py
+++ b/hki/paths.py
@@ -37,8 +37,9 @@ class HkiScope:
 def resolve_scope(cwd: str | Path | None = None) -> HkiScope:
     """Resolve the HKI workspace root from ``cwd``.
 
-    The first slice is intentionally cwd-rooted. Project DB aware resolution can
-    be added here later without changing the CLI or the HKI domain modules.
+    Prefer the containing Git worktree root when it can be detected with a
+    filesystem-only parent walk. Project DB aware resolution can be added here
+    later without changing the CLI or the HKI domain modules.
     """
 
     raw = Path.cwd() if cwd is None else Path(cwd).expanduser()
@@ -50,8 +51,35 @@ def resolve_scope(cwd: str | Path | None = None) -> HkiScope:
     if not resolved.is_dir():
         raise ValueError(f"cwd is not a directory: {resolved}")
 
-    root = resolved
+    root = find_git_worktree_root(resolved) or resolved
     return HkiScope(cwd=resolved, root=root, output_dir=root / HKI_RELATIVE_DIR)
+
+
+def find_git_worktree_root(path: Path) -> Path | None:
+    """Return the nearest ancestor that looks like a Git worktree root.
+
+    Git worktrees and submodules often use a ``.git`` file rather than a
+    directory. For HKI's purpose, either marker is enough: the marker's parent is
+    the stable workspace root where artifacts should live.
+    """
+
+    current = path.resolve()
+    for candidate in (current, *current.parents):
+        git_marker = candidate / ".git"
+        if _is_git_marker(git_marker):
+            return candidate
+    return None
+
+
+def _is_git_marker(path: Path) -> bool:
+    if path.is_dir():
+        return (path / "HEAD").is_file()
+    if not path.is_file():
+        return False
+    try:
+        return path.read_text(encoding="utf-8", errors="replace").lstrip().startswith("gitdir:")
+    except OSError:
+        return False
 
 
 def ensure_output_dir(scope: HkiScope) -> Path:

--- a/hki/paths.py
+++ b/hki/paths.py
@@ -1,0 +1,70 @@
+"""Path resolution for project-scoped HKI artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+HKI_RELATIVE_DIR = Path(".hermes") / "hki"
+
+
+@dataclass(frozen=True)
+class HkiScope:
+    """Resolved workspace scope for HKI commands."""
+
+    cwd: Path
+    root: Path
+    output_dir: Path
+
+    @property
+    def inventory_path(self) -> Path:
+        return self.output_dir / "inventory.json"
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.output_dir / "manifest.json"
+
+    @property
+    def reports_dir(self) -> Path:
+        return self.output_dir / "reports"
+
+    @property
+    def sources_report_path(self) -> Path:
+        return self.reports_dir / "sources.md"
+
+
+def resolve_scope(cwd: str | Path | None = None) -> HkiScope:
+    """Resolve the HKI workspace root from ``cwd``.
+
+    The first slice is intentionally cwd-rooted. Project DB aware resolution can
+    be added here later without changing the CLI or the HKI domain modules.
+    """
+
+    raw = Path.cwd() if cwd is None else Path(cwd).expanduser()
+    try:
+        resolved = raw.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ValueError(f"cwd does not exist: {raw}") from exc
+
+    if not resolved.is_dir():
+        raise ValueError(f"cwd is not a directory: {resolved}")
+
+    root = resolved
+    return HkiScope(cwd=resolved, root=root, output_dir=root / HKI_RELATIVE_DIR)
+
+
+def ensure_output_dir(scope: HkiScope) -> Path:
+    """Create and return the HKI output directory for ``scope``."""
+
+    scope.output_dir.mkdir(parents=True, exist_ok=True)
+    return scope.output_dir
+
+
+def as_workspace_relative(path: Path, root: Path) -> str:
+    """Return ``path`` relative to ``root`` when possible."""
+
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return str(path)

--- a/hki/report.py
+++ b/hki/report.py
@@ -1,0 +1,103 @@
+"""Markdown HKI reports."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+from hki.inventory import utc_now_iso
+from hki.manifest import Manifest, load_manifest
+from hki.paths import HkiScope, as_workspace_relative
+
+
+def build_sources_report(manifest: Manifest, *, manifest_path: Path) -> str:
+    """Return a concise Markdown report for a source manifest."""
+
+    root = Path(manifest.root)
+    kind_counts = Counter(source.kind for source in manifest.sources)
+    suffix_counts = Counter(Path(source.relative_path).suffix.lower() or "(none)" for source in manifest.sources)
+    dir_counts = Counter(_top_level_dir(source.relative_path) for source in manifest.sources)
+    largest = sorted(manifest.sources, key=lambda source: (-source.size, source.relative_path))[:10]
+    total_size = sum(source.size for source in manifest.sources)
+    manifest_ref = as_workspace_relative(manifest_path, root)
+
+    lines = [
+        "# HKI Source Inventory Report",
+        "",
+        f"Generated: {utc_now_iso()}",
+        f"Workspace root: `{manifest.root}`",
+        f"Manifest: `{manifest_ref}`",
+        "",
+        "This is an HKI source inventory report, not a semantic dossier yet.",
+        "",
+        "## Summary",
+        "",
+        f"- Total included files: {len(manifest.sources)}",
+        f"- Total skipped/excluded entries: {manifest.inventory_skipped_count}",
+        f"- Total included bytes: {total_size}",
+        "",
+        "## Counts by Kind",
+        "",
+    ]
+    lines.extend(_count_lines(kind_counts))
+    lines.extend(
+        [
+            "",
+            "## Largest Files",
+            "",
+        ]
+    )
+    if largest:
+        for source in largest:
+            lines.append(f"- `{source.relative_path}` ({source.size} bytes, {source.kind})")
+    else:
+        lines.append("- None")
+
+    lines.extend(
+        [
+            "",
+            "## Notable Source Groups",
+            "",
+            "### By Directory",
+            "",
+        ]
+    )
+    lines.extend(_count_lines(dir_counts, limit=10))
+    lines.extend(
+        [
+            "",
+            "### By Extension",
+            "",
+        ]
+    )
+    lines.extend(_count_lines(suffix_counts, limit=10))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_sources_report(manifest: Manifest, scope: HkiScope) -> Path:
+    """Write the source report to ``.hermes/hki/reports/sources.md``."""
+
+    scope.reports_dir.mkdir(parents=True, exist_ok=True)
+    content = build_sources_report(manifest, manifest_path=scope.manifest_path)
+    path = scope.sources_report_path
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def load_manifest_for_scope(scope: HkiScope) -> Manifest:
+    return load_manifest(scope.manifest_path)
+
+
+def _count_lines(counter: Counter[str], *, limit: int | None = None) -> list[str]:
+    if not counter:
+        return ["- None"]
+    items = sorted(counter.items(), key=lambda item: (-item[1], item[0]))
+    if limit is not None:
+        items = items[:limit]
+    return [f"- `{name}`: {count}" for name, count in items]
+
+
+def _top_level_dir(relative_path: str) -> str:
+    parts = Path(relative_path).parts
+    return parts[0] if len(parts) > 1 else "."

--- a/skills/hki/SKILL.md
+++ b/skills/hki/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: hki
+description: "Use native HKI commands to inventory workspace sources, build a manifest, and write a source report."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [HKI, source inventory, workspace, manifest, report]
+    category: productivity
+    requires_toolsets: [terminal, files]
+---
+
+# HKI Source Inventory
+
+HKI — Human Knowledge Infrastructure — is a native project/workspace knowledge subsystem. The current slice inventories workspace sources, creates a stable source manifest, and writes a basic source report.
+
+This is not semantic search, entity indexing, dossier generation, vault/wiki publication, cron refresh, or frontend/UI work yet.
+
+## When To Use
+
+Use this skill when the user asks to:
+
+- assess a repo, project, source corpus, or workspace
+- build or update a source inventory
+- prepare evidence for later HKI work
+- understand what files or sources exist in a workspace
+- create a basic source report
+
+## When Not To Use
+
+Do not use this skill for:
+
+- ordinary code edits or simple file reads
+- semantic search across conversations
+- entity extraction
+- dossier generation
+- vault/wiki publication
+- background cron refresh
+- frontend/UI work
+
+## Commands
+
+Run these from any shell, choosing the intended workspace as `--cwd`:
+
+```bash
+hermes hki inventory --cwd <path>
+hermes hki manifest --cwd <path>
+hermes hki report sources --cwd <path>
+```
+
+Expected outputs:
+
+```text
+<cwd>/.hermes/hki/inventory.json
+<cwd>/.hermes/hki/manifest.json
+<cwd>/.hermes/hki/reports/sources.md
+```
+
+## Recommended Workflow
+
+1. Resolve the intended workspace/cwd with the user or from the active task context.
+2. Run `hermes hki inventory --cwd <path>`.
+3. Run `hermes hki manifest --cwd <path>`.
+4. Run `hermes hki report sources --cwd <path>`.
+5. Read the generated report first; read the manifest only as needed.
+6. Cite generated paths, `source_id` values, and report sections when summarizing.
+7. Avoid loading large manifests or inventories wholesale into prompt context unless the user explicitly needs that detail.
+
+## Safety And Limitations
+
+- Scope is currently cwd-rooted; pass the workspace root explicitly when in doubt.
+- Generated files live under `.hermes/hki/`.
+- Source IDs are deterministic but path-based, so renames change IDs.
+- Reports may be stale if files changed after manifest generation.
+- Secret exclusion is currently minimal: `.env` and `.env.*` are excluded, but this is not a full secret scanner.
+- Treat HKI output as a source inventory/report, not as a semantic dossier.

--- a/tests/hki/test_hki_slice.py
+++ b/tests/hki/test_hki_slice.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import hki_cmd
+from hki.inventory import build_inventory, write_inventory
+from hki.manifest import build_manifest, source_id_for, write_manifest
+from hki.paths import resolve_scope
+from hki.report import write_sources_report
+
+
+def _by_path(inventory):
+    return {item.relative_path: item for item in inventory.files}
+
+
+def _run_cli(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    hki_parser = hki_cmd.build_parser(sub)
+    hki_parser.set_defaults(func=hki_cmd.hki_command)
+    args = parser.parse_args(["hki", *argv])
+    return hki_cmd.hki_command(args)
+
+
+def test_basic_inventory_creation_records_text_binary_and_hash(tmp_path):
+    (tmp_path / "README.md").write_text("# Hello\n", encoding="utf-8")
+    (tmp_path / "blob.bin").write_bytes(b"abc\x00def")
+
+    scope = resolve_scope(tmp_path)
+    inventory = build_inventory(scope)
+    path = write_inventory(inventory, scope)
+
+    assert path == tmp_path / ".hermes" / "hki" / "inventory.json"
+    assert path.exists()
+
+    by_path = _by_path(inventory)
+    assert by_path["README.md"].is_text is True
+    assert by_path["README.md"].classification == "text"
+    assert by_path["README.md"].suffix == ".md"
+    assert by_path["README.md"].sha256
+
+    assert by_path["blob.bin"].is_text is False
+    assert by_path["blob.bin"].classification == "binary"
+    assert by_path["blob.bin"].sha256
+
+
+def test_inventory_excludes_common_generated_and_secret_paths(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / ".env").write_text("TOKEN=secret\n", encoding="utf-8")
+    (tmp_path / ".env.local").write_text("TOKEN=secret\n", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "config").write_text("[core]\n", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "pkg.js").write_text("module.exports = 1\n", encoding="utf-8")
+    (tmp_path / ".hermes" / "hki" / "cache").mkdir(parents=True)
+    (tmp_path / ".hermes" / "hki" / "cache" / "x").write_text("cached\n", encoding="utf-8")
+
+    inventory = build_inventory(resolve_scope(tmp_path))
+    paths = {item.relative_path for item in inventory.files}
+
+    assert paths == {"src/app.py"}
+    assert inventory.skipped_by_reason["secret_env_file"] == 2
+    assert inventory.skipped_by_reason["excluded_directory"] >= 2
+    assert inventory.skipped_by_reason["hki_output"] == 1
+    assert inventory.skipped_count >= 5
+
+
+def test_manifest_ordering_and_source_ids_are_deterministic(tmp_path):
+    (tmp_path / "b.txt").write_text("b\n", encoding="utf-8")
+    (tmp_path / "a.txt").write_text("a\n", encoding="utf-8")
+
+    inventory = build_inventory(resolve_scope(tmp_path))
+    manifest_one = build_manifest(inventory)
+    manifest_two = build_manifest(inventory)
+
+    paths = [source.relative_path for source in manifest_one.sources]
+    assert paths == ["a.txt", "b.txt"]
+    assert [source.source_id for source in manifest_one.sources] == [
+        source.source_id for source in manifest_two.sources
+    ]
+    assert manifest_one.sources[0].source_id == source_id_for("a.txt")
+    assert len(manifest_one.sources[0].source_id) == len("src_") + 20
+    assert len({source.source_id for source in manifest_one.sources}) == 2
+
+
+def test_sources_report_file_creation(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    (tmp_path / "docs" / "README.md").write_text("# Docs\n", encoding="utf-8")
+
+    scope = resolve_scope(tmp_path)
+    inventory = build_inventory(scope)
+    write_inventory(inventory, scope)
+    manifest = build_manifest(inventory, inventory_path=scope.inventory_path)
+    write_manifest(manifest, scope)
+    report_path = write_sources_report(manifest, scope)
+
+    content = report_path.read_text(encoding="utf-8")
+    assert report_path == tmp_path / ".hermes" / "hki" / "reports" / "sources.md"
+    assert "# HKI Source Inventory Report" in content
+    assert "not a semantic dossier yet" in content
+    assert "Manifest: `.hermes/hki/manifest.json`" in content
+    assert "Total skipped/excluded entries: 0" in content
+    assert "`python`: 1" in content
+    assert "`markdown`: 1" in content
+
+
+def test_symlink_outside_root_is_skipped(tmp_path):
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    (outside / "secret.txt").write_text("outside\n", encoding="utf-8")
+
+    link = root / "outside-link.txt"
+    try:
+        os.symlink(outside / "secret.txt", link)
+    except (AttributeError, NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    inventory = build_inventory(resolve_scope(root))
+
+    assert "outside-link.txt" not in {item.relative_path for item in inventory.files}
+    assert inventory.skipped_by_reason["outside_root"] == 1
+
+
+def test_cli_commands_write_expected_files(tmp_path, capsys):
+    (tmp_path / "note.txt").write_text("hello\n", encoding="utf-8")
+
+    assert _run_cli(["inventory", "--cwd", str(tmp_path)]) == 0
+    assert "Wrote HKI inventory" in capsys.readouterr().out
+    assert (tmp_path / ".hermes" / "hki" / "inventory.json").exists()
+
+    assert _run_cli(["manifest", "--cwd", str(tmp_path)]) == 0
+    manifest_path = tmp_path / ".hermes" / "hki" / "manifest.json"
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["inventory_path"] == ".hermes/hki/inventory.json"
+    assert [source["relative_path"] for source in manifest["sources"]] == ["note.txt"]
+
+    assert _run_cli(["report", "sources", "--cwd", str(tmp_path)]) == 0
+    assert (tmp_path / ".hermes" / "hki" / "reports" / "sources.md").exists()
+
+
+def test_resolve_scope_rejects_file_cwd(tmp_path):
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("x\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="cwd is not a directory"):
+        resolve_scope(Path(file_path))

--- a/tests/hki/test_hki_slice.py
+++ b/tests/hki/test_hki_slice.py
@@ -10,7 +10,7 @@ import pytest
 from hermes_cli import hki_cmd
 from hki.inventory import build_inventory, write_inventory
 from hki.manifest import build_manifest, source_id_for, write_manifest
-from hki.paths import resolve_scope
+from hki.paths import find_git_worktree_root, resolve_scope
 from hki.report import write_sources_report
 
 
@@ -47,6 +47,60 @@ def test_basic_inventory_creation_records_text_binary_and_hash(tmp_path):
     assert by_path["blob.bin"].is_text is False
     assert by_path["blob.bin"].classification == "binary"
     assert by_path["blob.bin"].sha256
+
+
+def test_resolve_scope_uses_git_root_when_cwd_is_repo_root(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    scope = resolve_scope(tmp_path)
+
+    assert scope.cwd == tmp_path.resolve()
+    assert scope.root == tmp_path.resolve()
+    assert scope.inventory_path == tmp_path / ".hermes" / "hki" / "inventory.json"
+
+
+def test_cli_from_nested_git_directory_writes_to_repo_root(tmp_path, capsys):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    nested = tmp_path / "src" / "pkg"
+    nested.mkdir(parents=True)
+    (nested / "module.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# Repo\n", encoding="utf-8")
+
+    assert _run_cli(["inventory", "--cwd", str(nested)]) == 0
+    assert "Wrote HKI inventory" in capsys.readouterr().out
+
+    root_inventory_path = tmp_path / ".hermes" / "hki" / "inventory.json"
+    nested_inventory_path = nested / ".hermes" / "hki" / "inventory.json"
+    assert root_inventory_path.exists()
+    assert not nested_inventory_path.exists()
+
+    inventory = json.loads(root_inventory_path.read_text(encoding="utf-8"))
+    assert inventory["root"] == str(tmp_path.resolve())
+    assert [item["relative_path"] for item in inventory["files"]] == [
+        "README.md",
+        "src/pkg/module.py",
+    ]
+
+
+def test_resolve_scope_outside_repo_falls_back_to_cwd(tmp_path):
+    nested = tmp_path / "notes"
+    nested.mkdir()
+
+    scope = resolve_scope(nested)
+
+    assert scope.cwd == nested.resolve()
+    assert scope.root == nested.resolve()
+    assert scope.inventory_path == nested / ".hermes" / "hki" / "inventory.json"
+
+
+def test_find_git_worktree_root_accepts_git_file_marker(tmp_path):
+    (tmp_path / ".git").write_text("gitdir: /tmp/example/worktrees/repo\n", encoding="utf-8")
+    nested = tmp_path / "src"
+    nested.mkdir()
+
+    assert find_git_worktree_root(nested) == tmp_path.resolve()
 
 
 def test_inventory_excludes_common_generated_and_secret_paths(tmp_path):
@@ -155,3 +209,8 @@ def test_resolve_scope_rejects_file_cwd(tmp_path):
 
     with pytest.raises(ValueError, match="cwd is not a directory"):
         resolve_scope(Path(file_path))
+
+
+def test_resolve_scope_rejects_missing_cwd(tmp_path):
+    with pytest.raises(ValueError, match="cwd does not exist"):
+        resolve_scope(tmp_path / "missing")


### PR DESCRIPTION
## Summary

* Add native `hki/` package for workspace inventory, manifest generation, and source reporting.
* Add `hermes hki` CLI commands for `inventory`, `manifest`, and `report sources`.
* Add HKI skill guidance for agent/operator use.
* Resolve HKI output root to the containing Git workspace where available.
* Store HKI artifacts under `.hermes/hki/` as ordinary workspace files.

## Tests

* `scripts/run_tests.sh tests/hki`
* `scripts/run_tests.sh tests/hermes_cli/test_startup_plugin_gating.py`
* `scripts/run_tests.sh tests/tools/test_skills_tool.py -q`
* `scripts/run_tests.sh tests/agent/test_skill_utils.py -q -k iter_skill_index`

## Manual validation

* Ran the HKI workflow from a Reuben session against `/home/josh/codex/reuben-agent`.
* Generated `.hermes/hki/inventory.json`, `.hermes/hki/manifest.json`, and `.hermes/hki/reports/sources.md`.
* Reuben summarized the generated source report successfully.

## Notes / intentionally deferred

* No semantic search yet.
* No entity indexing yet.
* No cron refresh.
* No JSON-RPC, REST, MCP, or frontend UI.
* No changes to core agent loop, toolsets, state DB, dashboard, or desktop UI.
* Current source IDs are deterministic and path-based.
* Current secret exclusion is minimal: `.env` / `.env.*`.