### PR TITLE
fix(cron): catch RuntimeError from Path.expanduser() in lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -100,12 +100,20 @@ def _read_script_for_scanning(script_path: str) -> str:
     ``UnicodeDecodeError`` on such files, and swallowing that error would let
     an attacker hide the command in binary noise.  Returns an empty string
     only when the file cannot be read at all.
+
+    ``_resolve_script_path``'s ``Path.expanduser()`` raises ``RuntimeError``
+    (not ``OSError``) for a ``~user``-shaped path with no matching system
+    user — e.g. an LLM-authored ``script`` value that happens to start with
+    ``~someuser/...``.  Catch it alongside ``OSError`` so a malformed script
+    path degrades to "can't scan it" instead of crashing job creation with an
+    unhandled exception (same bug class as agent/subdirectory_hints.py's
+    tilde-expansion crash).
     """
     try:
         return _resolve_script_path(script_path).read_bytes().decode(
             "utf-8", errors="replace"
         )
-    except OSError:
+    except (OSError, RuntimeError):
         return ""
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -428,6 +428,23 @@ class TestLifecycleGuardModule:
         from cron.lifecycle_guard import check_gateway_lifecycle
         check_gateway_lifecycle("clean prompt", str(tmp_path / "nonexistent.sh"))
 
+    def test_tilde_unknown_user_script_does_not_crash(self):
+        """A ``~user``-shaped script path with no matching system user must
+        degrade to "can't scan it" instead of raising RuntimeError.
+
+        ``Path.expanduser()`` raises ``RuntimeError`` (not ``OSError``) for
+        an unresolvable ``~user`` prefix — same bug class as
+        agent/subdirectory_hints.py's tilde-expansion crash (an LLM-authored
+        script value like ``~nonexistent_user_xyzzy_12345/restart.sh`` must
+        not crash cron job creation).
+        """
+        from cron.lifecycle_guard import check_gateway_lifecycle
+        # Must not raise RuntimeError — the guard treats an unscannable
+        # script as absent and only judges the (clean) prompt.
+        check_gateway_lifecycle(
+            "clean prompt", "~nonexistent_user_xyzzy_12345/restart.sh",
+        )
+
     def test_relative_script_resolved_under_scripts_dir(self, tmp_path, monkeypatch):
         """A bare/relative script name resolves under HERMES_HOME/scripts (the
         same place the scheduler runs it from) — otherwise the guard would read


### PR DESCRIPTION
## Summary

`cron/lifecycle_guard.py::_resolve_script_path` calls `Path(script_path).expanduser()` to resolve a cron job's `script` path before scanning it for gateway-lifecycle commands (`check_gateway_lifecycle`, enforced in `cron.jobs.create_job` — reachable via both `hermes cron create` and the agent's `cronjob` model tool directly).

`Path.expanduser()` raises `RuntimeError` (not `OSError`) for a `~user`-shaped path with no matching system user:

```pycon
>>> from pathlib import Path
>>> Path('~nonexistentuser12345/foo').expanduser()
RuntimeError: Can't determine home directory for 'nonexistentuser12345'
```

`_read_script_for_scanning`'s `except OSError:` doesn't catch this, so an LLM-authored `script` value that happens to start with `~someuser/...` (a plausible thing for an agent to produce — the same trigger shape already fixed for `agent/subdirectory_hints.py` in #c126a99fc, "LLMs use `~` for 'approximately'" or a guessed/malformed path) crashes cron job creation with an unhandled `RuntimeError` instead of the intended graceful `GatewayLifecycleBlocked`/pass-through behavior the module is designed around.

## Fix

Add `RuntimeError` to the caught exceptions in `_read_script_for_scanning`, mirroring the exact fix already applied to `agent/subdirectory_hints.py`'s three `Path.expanduser()`/`Path.home()` call sites in #c126a99fc.

## Test plan

- [x] New regression test `test_tilde_unknown_user_script_does_not_crash` — confirmed it fails with an uncaught `RuntimeError` on the pre-fix code (via `git stash`) and passes after the fix
- [x] `pytest tests/hermes_cli/test_gateway_restart_loop.py -q` — 66 passed
- [x] `ruff check` on all changed files — clean
- [x] Checked for competitors: PR #41881 ("sweep remaining bare expanduser() to safe_expanduser()") is a 2-file refactor (`cron/jobs.py`, `cron/scheduler.py`) that does **not** include `cron/lifecycle_guard.py` — confirmed via `gh pr view --json files`. No overlap.