### PR TITLE
fix(gateway): detect systemd start-limit counters

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -956,6 +956,8 @@ def _read_systemd_unit_properties(
         "ActiveState",
         "SubState",
         "Result",
+        "NRestarts",
+        "StartLimitBurst",
         "ExecMainStatus",
         "MainPID",
     ),
@@ -1096,7 +1098,25 @@ def _wait_for_systemd_service_restart(
 def _systemd_unit_is_start_limited(props: dict[str, str]) -> bool:
     result = props.get("Result", "").lower()
     sub_state = props.get("SubState", "").lower()
-    return result == "start-limit-hit" or sub_state == "start-limit-hit"
+    if result == "start-limit-hit" or sub_state == "start-limit-hit":
+        return True
+
+    active_state = props.get("ActiveState", "").lower()
+    if active_state != "failed":
+        return False
+
+    # Planned gateway restarts exit with 75 and are handled by
+    # _recover_pending_systemd_restart(); a stale restart counter should not
+    # turn that controlled handoff into crash-loop guidance.
+    if props.get("ExecMainStatus", "") == str(GATEWAY_SERVICE_RESTART_EXIT_CODE):
+        return False
+
+    try:
+        n_restarts = int(props.get("NRestarts", "") or "")
+        start_limit_burst = int(props.get("StartLimitBurst", "") or "")
+    except ValueError:
+        return False
+    return start_limit_burst > 0 and n_restarts >= start_limit_burst
 
 
 def _systemd_error_indicates_start_limit(exc: subprocess.CalledProcessError) -> bool:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -112,7 +112,7 @@ class TestSystemdServiceRefresh:
         assert unit_path.read_text(encoding="utf-8") == "new unit\n"
         assert calls[:5] == [
             ["systemctl", "--user", "daemon-reload"],
-            ["systemctl", "--user", "show", gateway_cli.get_service_name(), "--no-pager", "--property", "ActiveState,SubState,Result,ExecMainStatus,MainPID"],
+            ["systemctl", "--user", "show", gateway_cli.get_service_name(), "--no-pager", "--property", "ActiveState,SubState,Result,NRestarts,StartLimitBurst,ExecMainStatus,MainPID"],
             ["systemctl", "--user", "reset-failed", gateway_cli.get_service_name()],
             ["systemctl", "--user", "restart", gateway_cli.get_service_name()],
             ("wait", False, None),
@@ -1658,6 +1658,42 @@ class TestGatewaySystemServiceRouting:
         out = capsys.readouterr().out.lower()
         assert "rate-limited by systemd" in out
         assert "reset-failed" in out
+
+    def test_systemd_unit_start_limited_detects_restart_counter_burst(self):
+        assert gateway_cli._systemd_unit_is_start_limited(
+            {
+                "ActiveState": "failed",
+                "SubState": "failed",
+                "Result": "exit-code",
+                "NRestarts": "5",
+                "StartLimitBurst": "5",
+                "ExecMainStatus": "1",
+            }
+        )
+
+    def test_systemd_unit_start_limited_ignores_planned_restart_counter(self):
+        assert not gateway_cli._systemd_unit_is_start_limited(
+            {
+                "ActiveState": "failed",
+                "SubState": "failed",
+                "Result": "exit-code",
+                "NRestarts": "5",
+                "StartLimitBurst": "5",
+                "ExecMainStatus": str(GATEWAY_SERVICE_RESTART_EXIT_CODE),
+            }
+        )
+
+    def test_systemd_unit_start_limited_ignores_running_counter(self):
+        assert not gateway_cli._systemd_unit_is_start_limited(
+            {
+                "ActiveState": "active",
+                "SubState": "running",
+                "Result": "success",
+                "NRestarts": "9",
+                "StartLimitBurst": "5",
+                "ExecMainStatus": "0",
+            }
+        )
 
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)


### PR DESCRIPTION
﻿## What does this PR do?

- Reads `NRestarts` and `StartLimitBurst` from `systemctl show` for the gateway unit.
- Treats a failed unit as start-limit exhausted when the restart counter has reached the configured burst, even if `Result` is still `exit-code`.
- Keeps planned restart exit `75` out of that counter fallback so controlled restart handoffs still use the existing recovery path.

Related to #14051.

## Why?

On systemd, a crash loop can stop after `StartLimitBurst` while the unit still reports `Result=exit-code`. The existing Hermes check only catches `Result=start-limit-hit` or `SubState=start-limit-hit`, so `hermes gateway status` / restart handling can miss the real recovery hint and show the generic stopped/failed path.

## Proof

Focused behavior proof:

```text
systemd start-limit counter proof ok
```

Commands run:

```text
python -m py_compile hermes_cli\gateway.py tests\hermes_cli\test_gateway_service.py
```

```text
python - <<PY
# Imported hermes_cli.gateway, asserted:
# - failed + Result=exit-code + NRestarts >= StartLimitBurst => True
# - same counter shape with planned restart exit 75 => False
# - active/running with high lifetime restart counter => False
PY
```

`python -m pytest tests\hermes_cli\test_gateway_service.py -k "systemd_unit_start_limited or systemd_restart_reports_start_limit_hit or systemd_restart_refreshes_outdated_unit" -q` could not run locally because this checkout's Python environment has no `pytest` module installed.

## Duplicate check

- `gh pr list --search "systemd NRestarts StartLimitBurst in:title,body"` returned no matches.
- `gh pr list --search "gateway systemd restart counter StartLimitBurst"` only found older restart/root-cause work, not this status/restart classification gap.
- `gh issue list --search "NRestarts StartLimitBurst"` returned no open duplicate.

Autoreview: repo-local autoreview helper was not present in this checkout.
