### PR TITLE
fix(desktop): restore styled tooltips on right sidebar file tree buttons and rows

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -4,6 +4,7 @@ import { type NodeApi, type NodeRendererProps, type RowRendererProps, Tree, type
 
 import { TreeSkeleton } from '@/components/chat/skeletons'
 import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { cn } from '@/lib/utils'
 import { $repoChangeByPath, type RepoChangeKind } from '@/store/coding-status'
@@ -271,85 +272,86 @@ function ProjectTreeRow({
   const editing = !isPlaceholder && renamingPath === node.data.id
 
   const row = (
-    <div
-      aria-expanded={isFolder ? node.isOpen : undefined}
-      aria-selected={node.isSelected}
-      className={cn(
-        'group/row flex h-full cursor-pointer select-none items-center gap-1 border border-transparent px-3 text-xs font-normal leading-(--file-tree-row-height) text-(--ui-text-secondary) transition-colors duration-100 ease-out hover:bg-(--ui-row-hover-background) hover:text-foreground hover:transition-none',
-        node.isSelected && 'bg-(--ui-row-active-background) text-foreground',
-        isPlaceholder && 'pointer-events-none italic text-muted-foreground/70'
-      )}
-      draggable={!isPlaceholder && !editing}
-      onClick={event => {
-        event.stopPropagation()
-
-        // Read the rename atom LIVE (not the render closure): the fall-through
-        // click from a context-menu close can fire before the editing re-render
-        // commits, so a stale closure would still select/activate and yank focus.
-        if (isPlaceholder || $renamingPath.get() === node.data.id) {
-          return
-        }
-
-        if (event.shiftKey) {
-          ;(isFolder ? onAttachFolder : onAttachFile)(node.data.id)
-
-          return
-        }
-
-        if (isFolder) {
-          node.toggle()
-        } else {
-          node.select()
-        }
-      }}
-      onDoubleClick={event => {
-        event.stopPropagation()
-
-        if (!isFolder && !isPlaceholder && $renamingPath.get() !== node.data.id) {
-          onPreviewFile?.(node.data.id)
-        }
-      }}
-      onDragStart={event => {
-        if (isPlaceholder || $renamingPath.get() === node.data.id) {
-          event.preventDefault()
-
-          return
-        }
-
-        const payload = JSON.stringify([{ isDirectory: isFolder, path: node.data.id }])
-
-        event.dataTransfer.effectAllowed = 'copy'
-        event.dataTransfer.setData('application/x-hermes-paths', payload)
-        event.dataTransfer.setData('text/plain', node.data.id)
-      }}
-      ref={dragHandle}
-      style={{
-        ...style,
-        paddingLeft: withTreeInset(style.paddingLeft)
-      }}
-      title={node.data.id}
-    >
-      {/* No chevron column — the folder icon (open/closed) already carries the
-          expand state, so the extra glyph was pure noise. */}
-      <span aria-hidden className="flex w-3.5 items-center justify-center text-(--ui-text-tertiary)">
-        {isPlaceholder && !isErrorPlaceholder ? (
-          <Codicon name="loading" size="0.75rem" spinning />
-        ) : isErrorPlaceholder ? (
-          <Codicon name="warning" size="0.75rem" />
-        ) : isFolder ? (
-          <Codicon name={node.isOpen ? 'folder-opened' : 'folder'} size="0.875rem" />
-        ) : (
-          <Codicon name="file" size="0.875rem" />
+    <Tip label={node.data.id} side="left">
+      <div
+        aria-expanded={isFolder ? node.isOpen : undefined}
+        aria-selected={node.isSelected}
+        className={cn(
+          'group/row flex h-full cursor-pointer select-none items-center gap-1 border border-transparent px-3 text-xs font-normal leading-(--file-tree-row-height) text-(--ui-text-secondary) transition-colors duration-100 ease-out hover:bg-(--ui-row-hover-background) hover:text-foreground hover:transition-none',
+          node.isSelected && 'bg-(--ui-row-active-background) text-foreground',
+          isPlaceholder && 'pointer-events-none italic text-muted-foreground/70'
         )}
-      </span>
-      {editing ? (
-        <InlineRenameInput name={node.data.name} path={node.data.id} />
-      ) : (
-        // Git decoration (VS Code-style): tint changed files; the explicit color
-        // wins over the row's hover/selected text color, so it persists.
-        <span className={cn('min-w-0 flex-1 truncate', changeKind && CHANGE_TINT[changeKind])}>{node.data.name}</span>
-      )}
-    </div>
+        draggable={!isPlaceholder && !editing}
+        onClick={event => {
+          event.stopPropagation()
+
+          // Read the rename atom LIVE (not the render closure): the fall-through
+          // click from a context-menu close can fire before the editing re-render
+          // commits, so a stale closure would still select/activate and yank focus.
+          if (isPlaceholder || $renamingPath.get() === node.data.id) {
+            return
+          }
+
+          if (event.shiftKey) {
+            ;(isFolder ? onAttachFolder : onAttachFile)(node.data.id)
+
+            return
+          }
+
+          if (isFolder) {
+            node.toggle()
+          } else {
+            node.select()
+          }
+        }}
+        onDoubleClick={event => {
+          event.stopPropagation()
+
+          if (!isFolder && !isPlaceholder && $renamingPath.get() !== node.data.id) {
+            onPreviewFile?.(node.data.id)
+          }
+        }}
+        onDragStart={event => {
+          if (isPlaceholder || $renamingPath.get() === node.data.id) {
+            event.preventDefault()
+
+            return
+          }
+
+          const payload = JSON.stringify([{ isDirectory: isFolder, path: node.data.id }])
+
+          event.dataTransfer.effectAllowed = 'copy'
+          event.dataTransfer.setData('application/x-hermes-paths', payload)
+          event.dataTransfer.setData('text/plain', node.data.id)
+        }}
+        ref={dragHandle}
+        style={{
+          ...style,
+          paddingLeft: withTreeInset(style.paddingLeft)
+        }}
+      >
+        {/* No chevron column — the folder icon (open/closed) already carries the
+            expand state, so the extra glyph was pure noise. */}
+        <span aria-hidden className="flex w-3.5 items-center justify-center text-(--ui-text-tertiary)">
+          {isPlaceholder && !isErrorPlaceholder ? (
+            <Codicon name="loading" size="0.75rem" spinning />
+          ) : isErrorPlaceholder ? (
+            <Codicon name="warning" size="0.75rem" />
+          ) : isFolder ? (
+            <Codicon name={node.isOpen ? 'folder-opened' : 'folder'} size="0.875rem" />
+          ) : (
+            <Codicon name="file" size="0.875rem" />
+          )}
+        </span>
+        {editing ? (
+          <InlineRenameInput name={node.data.name} path={node.data.id} />
+        ) : (
+          // Git decoration (VS Code-style): tint changed files; the explicit color
+          // wins over the row's hover/selected text color, so it persists.
+          <span className={cn('min-w-0 flex-1 truncate', changeKind && CHANGE_TINT[changeKind])}>{node.data.name}</span>
+        )}
+      </div>
+    </Tip>
   )
 
   if (isPlaceholder) {

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -5,6 +5,7 @@ import { TreeSkeleton } from '@/components/chat/skeletons'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
 import { useDelayedTrue } from '@/hooks/use-delayed-true'
 import { useI18n } from '@/i18n'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
@@ -151,28 +152,30 @@ function FilesystemTab({
         <div className="flex min-w-0 flex-1">
           <SidebarPanelLabel>{cwdName}</SidebarPanelLabel>
         </div>
-        <Button
-          aria-label={r.refreshTree}
-          className={HEADER_ACTION_LABEL_REVEAL}
-          disabled={loading}
-          onClick={onRefresh}
-          size="icon-xs"
-          title={r.refreshTree}
-          variant="ghost"
-        >
-          <Codicon name="refresh" size="0.8125rem" spinning={loading} />
-        </Button>
-        <Button
-          aria-label={r.collapseAll}
-          className={cn(HEADER_ACTION_CLASS, !canCollapse && 'pointer-events-none opacity-0')}
-          disabled={!canCollapse}
-          onClick={onCollapseAll}
-          size="icon-xs"
-          title={r.collapseAll}
-          variant="ghost"
-        >
-          <Codicon name="collapse-all" size="0.8125rem" />
-        </Button>
+        <Tip label={r.refreshTree} side="left">
+          <Button
+            aria-label={r.refreshTree}
+            className={HEADER_ACTION_LABEL_REVEAL}
+            disabled={loading}
+            onClick={onRefresh}
+            size="icon-xs"
+            variant="ghost"
+          >
+            <Codicon name="refresh" size="0.8125rem" spinning={loading} />
+          </Button>
+        </Tip>
+        <Tip label={r.collapseAll} side="left">
+          <Button
+            aria-label={r.collapseAll}
+            className={cn(HEADER_ACTION_CLASS, !canCollapse && 'pointer-events-none opacity-0')}
+            disabled={!canCollapse}
+            onClick={onCollapseAll}
+            size="icon-xs"
+            variant="ghost"
+          >
+            <Codicon name="collapse-all" size="0.8125rem" />
+          </Button>
+        </Tip>
       </RightSidebarSectionHeader>
       <FileTreeBody
         collapseNonce={collapseNonce}


### PR DESCRIPTION

## What does this PR do?
Fixes the Refresh and Collapse All buttons in the right sidebar's file tree header, and each file/folder row in the file tree itself, showing plain browser-native tooltips instead of the app's styled dark tooltip.

This restores work from #51315 ("replace native title tooltips with styled Tip component"), which wrapped these buttons in `<Tip>`. #49037 rewrote `FilesystemTab` as part of the Projects feature, and its merge reintroduced the native `title=` attributes, reverting the tooltip fix from #51315. #49037 also removed the Open Folder button from that same file — its PR description states the freeform folder picker was retired in favor of project/worktree-based workspace switching, so that change is intentional and out of scope here. Only the two remaining buttons need the tooltip restored.

Additionally, `ProjectTree` (`./files/tree.tsx`) rendered each file/folder row with a native `title={node.data.id}` showing the full path, which had the same plain-tooltip regression. This wasn't touched by #51315 originally, so it's addressed here with the same fix.

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `apps/desktop/src/app/right-sidebar/index.tsx` — replaced native `title=` with `<Tip label={...} side="left">` on the Refresh and Collapse All buttons in `FilesystemTab` (regressed by #49037; Open Folder was intentionally removed by that PR and is not restored here)
- `apps/desktop/src/app/right-sidebar/files/tree.tsx` — replaced native `title={node.data.id}` with `<Tip label={node.data.id} side="left">` on each file tree row in `ProjectTreeRow`

## How to Test
1. Launch the desktop app with a workspace/project open (so the file tree renders)
2. Open the right sidebar and hover over the Refresh button — verify a styled dark tooltip appears
3. Hover over the Collapse All button — verify a styled dark tooltip appears
4. Hover over any file or folder row in the tree — verify a styled dark tooltip with the full path appears (instead of the native browser tooltip), positioned to the left so it doesn't overflow the sidebar
5. Verify drag-and-drop of a file row still works (e.g. dragging a file into the chat attach zone)
6. Verify the tree still scrolls/renders correctly with the tooltip wrapper (no row height/layout regressions from virtualization)

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills
N/A

## Screenshots / Logs

<img width="598" height="448" alt="right_sidebar" src="https://github.com/user-attachments/assets/ffa424dd-25a4-48d2-9a33-c1adadfa8d95" />

<img width="682" height="394" alt="right_sidebar 2" src="https://github.com/user-attachments/assets/270b9f39-6424-4bc4-8b16-97ed0c4d39f1" />
