### PR TITLE
fix(moa): normalize aggregator stream contract for completed responses

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 from typing import Any
 
 from agent.auxiliary_client import call_llm
@@ -466,6 +467,199 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 
+def _tool_call_arguments_str(args: Any) -> str:
+    """Coerce a tool call's ``arguments`` to the JSON *string* the streaming
+    consumer requires.
+
+    The consumer concatenates argument fragments (``entry["arguments"] +=
+    tc.function.arguments``), so a non-string value (an already-parsed dict/list
+    from some adapters) would raise ``TypeError`` there. Serialize non-strings
+    the same way ``_render_tool_calls`` does; a real ``None`` becomes ``""``.
+    """
+    if args is None:
+        return ""
+    if isinstance(args, str):
+        return args
+    try:
+        import json
+
+        return json.dumps(args, ensure_ascii=False)
+    except Exception:
+        return str(args)
+
+
+def _delta_tool_calls(tool_calls: Any) -> list[Any]:
+    """Reshape a completed message's ``tool_calls`` into streaming ``delta``
+    tool-call chunks the outer consumer can reassemble.
+
+    The completed Codex response carries ``tool_calls`` as
+    ``SimpleNamespace(id, type, function=SimpleNamespace(name, arguments))``
+    with NO stream ``.index`` — but the streaming consumer reads ``tc.index``,
+    ``tc.id``, ``tc.function.name/.arguments``, and ``tc.extra_content``. We add
+    a positional ``index`` (each completed tool call is already whole, so one
+    delta per call), coerce arguments to a JSON string (the consumer
+    concatenates them), and preserve ``extra_content`` metadata. Handles
+    dict-shaped tool calls too, mirroring ``_render_tool_calls``.
+    """
+    out: list[Any] = []
+    for idx, tc in enumerate(tool_calls or []):
+        if isinstance(tc, dict):
+            tc_id = tc.get("id") or ""
+            tc_type = tc.get("type") or "function"
+            fn = tc.get("function") or {}
+            name = (fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", None)) or ""
+            args = fn.get("arguments") if isinstance(fn, dict) else getattr(fn, "arguments", None)
+            extra_content = tc.get("extra_content")
+        else:
+            tc_id = getattr(tc, "id", "") or ""
+            tc_type = getattr(tc, "type", "function") or "function"
+            fn = getattr(tc, "function", None)
+            name = getattr(fn, "name", None) or ""
+            args = getattr(fn, "arguments", None)
+            extra_content = getattr(tc, "extra_content", None)
+        out.append(
+            SimpleNamespace(
+                index=idx,
+                id=tc_id,
+                type=tc_type,
+                function=SimpleNamespace(name=name, arguments=_tool_call_arguments_str(args)),
+                extra_content=extra_content,
+            )
+        )
+    return out
+
+
+def _stream_chunk(
+    *,
+    content: Any = None,
+    tool_calls: Any = None,
+    finish_reason: Any = None,
+    model: Any = None,
+    usage: Any = None,
+    reasoning_content: Any = None,
+    reasoning: Any = None,
+) -> Any:
+    """One OpenAI-chat-stream-shaped chunk built to the exact fields the shared
+    streaming consumer reads: ``choices[0].delta.role/.content/.tool_calls/
+    .reasoning_content/.reasoning``, ``choices[0].finish_reason``, ``model``,
+    and ``usage``.
+
+    Mirrors the delta shape produced by the sibling completed→stream shims
+    (``copilot_acp_client._completion_to_stream_chunks``,
+    ``gemini_native_adapter._make_stream_chunk``) — notably ``role="assistant"``
+    — so the Codex one-shot path is not a silent divergence from every other
+    provider's stream deltas. We keep a separate getattr-based builder here
+    (rather than importing those) because the Codex message shape lacks
+    ``reasoning_content``/``reasoning`` attributes those shims access directly,
+    and the plan scopes the fix to ``agent/moa_loop.py``.
+    """
+    delta = SimpleNamespace(
+        role="assistant",
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=reasoning_content,
+        reasoning=reasoning,
+    )
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model=model, usage=usage)
+
+
+def _one_shot_stream_from_response(response: Any) -> Any:
+    """Yield stream chunks reconstructed from a COMPLETED chat response.
+
+    Emits one content+tool-call chunk carrying the aggregator's text, any
+    tool-call deltas, and the terminal ``finish_reason``; then a final
+    usage-only chunk (empty ``choices``) mirroring the SDK's ``include_usage``
+    frame so session accounting still sees usage. A finish_reason is always
+    set (``tool_calls`` when tools are present, else ``stop``) so the
+    consumer's zero-chunk guard never mistakes a legitimate empty completion
+    for a dropped stream.
+    """
+    choices = getattr(response, "choices", None) or []
+    model = getattr(response, "model", None)
+    usage = getattr(response, "usage", None)
+
+    content: Any = None
+    tool_calls: Any = None
+    finish_reason: Any = None
+    reasoning_content: Any = None
+    reasoning: Any = None
+    if choices:
+        choice = choices[0]
+        finish_reason = getattr(choice, "finish_reason", None)
+        message = getattr(choice, "message", None)
+        if message is not None:
+            raw_content = getattr(message, "content", None)
+            if isinstance(raw_content, str) and raw_content:
+                content = raw_content
+            raw_tool_calls = getattr(message, "tool_calls", None)
+            if raw_tool_calls:
+                tool_calls = _delta_tool_calls(raw_tool_calls)
+            # Carry reasoning through when a reasoning-model aggregator returns
+            # a completed response; the pre-fix inline consumer guard surfaced
+            # these, and dropping them here would regress reasoning display.
+            reasoning_content = getattr(message, "reasoning_content", None)
+            reasoning = getattr(message, "reasoning", None)
+
+    if finish_reason is None:
+        finish_reason = "tool_calls" if tool_calls else "stop"
+
+    yield _stream_chunk(
+        content=content,
+        tool_calls=tool_calls,
+        finish_reason=finish_reason,
+        model=model,
+        usage=None,
+        reasoning_content=reasoning_content,
+        reasoning=reasoning,
+    )
+    if usage is not None:
+        # Final SDK-style frame: usage arrives with empty choices.
+        yield SimpleNamespace(choices=[], model=model, usage=usage)
+
+
+def _one_shot_stream_from_text(text: Any) -> Any:
+    """Wrap a bare string/bytes payload as a single content chunk.
+
+    Some code paths could hand back raw text on ``stream=True``. Text is
+    technically iterable but is NOT a provider chunk stream — iterating it in
+    the consumer would yield characters and crash on ``chunk.choices``. Expose
+    it as one content chunk instead so the text survives and the consumer stays
+    on its normal reassembly path (KTD4).
+    """
+    if isinstance(text, (bytes, bytearray)):
+        text = text.decode("utf-8", "replace")
+    yield _stream_chunk(content=text or None, finish_reason="stop")
+
+
+def _normalize_aggregator_stream(result: Any) -> Any:
+    """Normalize a ``stream=True`` aggregator return into something the outer
+    streaming consumer can always iterate.
+
+    - Completed chat response (has a ``choices`` attribute): reconstruct a
+      one-shot chunk iterator (KTD3). This is the Codex auxiliary-adapter case
+      that crashed the live turn with ``'types.SimpleNamespace' object is not
+      iterable`` — the adapter consumes Codex Responses events internally and
+      returns a completed response despite ``stream=True``.
+    - Raw provider stream (iterable, no ``choices``): return it unchanged so
+      the upstream MoA streaming feature keeps its latency benefit (KTD2).
+    - String/bytes: not a provider chunk stream — wrap as a single content
+      chunk rather than hand it over for character iteration (KTD4).
+    """
+    # A completed chat response is the mismatch we must repair. Discriminate on
+    # the mere PRESENCE of a ``choices`` attribute, not on it being a non-empty
+    # list: an adapter may hand back a completed response whose ``choices`` is
+    # None, empty, or a tuple, and every such shape is still a whole response
+    # (not a token stream) that would crash ``for chunk in stream``. Raw
+    # provider streams (SDK Stream objects, generators) expose no ``choices``.
+    if hasattr(result, "choices"):
+        return _one_shot_stream_from_response(result)
+    if isinstance(result, (str, bytes, bytearray)):
+        return _one_shot_stream_from_text(result)
+    # Raw provider stream (or an opaque stream-like sentinel): pass through.
+    return result
+
+
 def _extract_text(response: Any) -> str:
     try:
         transport = get_transport("chat_completions")
@@ -896,6 +1090,17 @@ class MoAChatCompletions:
                     self._pending_trace["aggregator_output"] = _extract_text(_agg_response)
                 except Exception:  # pragma: no cover - defensive
                     self._pending_trace["aggregator_output"] = None
+        if stream:
+            # Provider-contract guard. call_llm(stream=True) normally yields a
+            # raw provider token stream, but Hermes' Codex auxiliary adapter
+            # consumes Codex Responses events internally and returns a COMPLETED
+            # chat response even under stream=True. Handing that non-iterable
+            # object straight to the outer streaming consumer crashes it with
+            # "'types.SimpleNamespace' object is not iterable". Normalize here,
+            # at the seam that knows it requested a stream, so raw streams pass
+            # through untouched while completed responses become a one-shot
+            # chunk iterator the existing consumer can reassemble.
+            _agg_response = _normalize_aggregator_stream(_agg_response)
         return _agg_response
 
 

--- a/tests/run_agent/test_moa_streaming.py
+++ b/tests/run_agent/test_moa_streaming.py
@@ -16,6 +16,101 @@ def _response(content="done", *, tool_calls=None):
     return SimpleNamespace(choices=[choice], usage=None, model="fake-model")
 
 
+def _codex_completed_response(
+    content="codex acted",
+    *,
+    tool_calls=None,
+    usage=None,
+    model="gpt-5.5",
+):
+    """A completed chat response shaped exactly like Hermes' Codex auxiliary
+    adapter returns from ``_CodexCompletionsAdapter.create()`` — a bare
+    ``SimpleNamespace`` with ``choices[0].message`` and NO ``__iter__``.
+
+    This is the object that crashed the live MoA streaming turn with
+    ``'types.SimpleNamespace' object is not iterable`` when handed straight to
+    the outer streaming consumer. Mirrors agent/auxiliary_client.py: tool_calls
+    are ``SimpleNamespace(id, type='function', function=SimpleNamespace(name,
+    arguments))`` WITHOUT a stream ``.index`` field, and finish_reason is
+    ``"tool_calls"`` when tools are present, else ``"stop"``.
+    """
+    message = SimpleNamespace(
+        role="assistant",
+        content=content,
+        tool_calls=tool_calls or None,
+    )
+    choice = SimpleNamespace(
+        index=0,
+        message=message,
+        finish_reason="stop" if not tool_calls else "tool_calls",
+    )
+    return SimpleNamespace(choices=[choice], model=model, usage=usage)
+
+
+def _codex_tool_call(name="do_thing", arguments='{"x": 1}', call_id="call_abc"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _drain(stream):
+    """Consume ``stream`` exactly the way the real streaming consumer does
+    (agent/chat_completion_helpers.py) and return the reassembled result.
+
+    Reads only the chunk fields the production consumer reads: ``chunk.model``,
+    ``chunk.usage``, ``chunk.choices[0].delta.content``, ``.delta.tool_calls``
+    (with ``.index``/``.id``/``.function.name``/``.function.arguments``), and
+    ``chunk.choices[0].finish_reason``. If ``stream`` is not iterable this
+    raises the same ``TypeError`` the live turn hit.
+    """
+    content = ""
+    reasoning = ""
+    tool_calls: dict = {}
+    finish_reason = None
+    model = None
+    usage = None
+    roles: list = []
+    for chunk in stream:  # TypeError here == the historical crash
+        if getattr(chunk, "model", None):
+            model = chunk.model
+        if not chunk.choices:
+            if getattr(chunk, "usage", None):
+                usage = chunk.usage
+            continue
+        delta = chunk.choices[0].delta
+        if getattr(delta, "role", None):
+            roles.append(delta.role)
+        reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+        if reasoning_text:
+            reasoning += reasoning_text
+        if getattr(delta, "content", None):
+            content += delta.content
+        for tc in getattr(delta, "tool_calls", None) or []:
+            idx = tc.index if tc.index is not None else 0
+            entry = tool_calls.setdefault(idx, {"id": "", "name": "", "arguments": ""})
+            if tc.id:
+                entry["id"] = tc.id
+            if tc.function and tc.function.name:
+                entry["name"] = tc.function.name
+            if tc.function and tc.function.arguments:
+                entry["arguments"] += tc.function.arguments  # TypeError if args not a str
+        if chunk.choices[0].finish_reason:
+            finish_reason = chunk.choices[0].finish_reason
+        if getattr(chunk, "usage", None):
+            usage = chunk.usage
+    return SimpleNamespace(
+        content=content,
+        reasoning=reasoning,
+        tool_calls=tool_calls,
+        finish_reason=finish_reason,
+        model=model,
+        usage=usage,
+        roles=roles,
+    )
+
+
 def _write_cfg(home):
     home.mkdir()
     (home / "config.yaml").write_text(
@@ -219,3 +314,258 @@ def test_call_llm_non_stream_still_validates(monkeypatch):
         messages=[{"role": "user", "content": "hi"}],
     )
     assert validated["called"] is True
+
+
+# --------------------------------------------------------------------------
+# U1: stream-contract normalization at the MoA boundary
+#
+# When the aggregator adapter returns a COMPLETED chat response despite
+# stream=True (Hermes' Codex auxiliary shim does exactly this), create() must
+# hand the outer streaming consumer something iterable — never the raw
+# non-iterable response. Raw provider streams still pass through untouched.
+# --------------------------------------------------------------------------
+
+def test_stream_wraps_completed_text_response_into_iterator(monkeypatch, tmp_path):
+    """A completed text response from the aggregator (stream=True) is wrapped
+    into a one-shot iterator whose single content delta is the message text."""
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return _codex_completed_response("hello from codex")
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(messages=[{"role": "user", "content": "q"}], stream=True)
+
+    # Must be iterable (not the raw completed response) and reassemble the text.
+    result = _drain(out)
+    assert result.content == "hello from codex"
+    assert result.finish_reason == "stop"
+
+
+def test_stream_wraps_completed_tool_call_response(monkeypatch, tmp_path):
+    """A completed tool-call response is wrapped so the consumer can still
+    reassemble tool calls from delta.tool_calls (with a stream .index)."""
+    tc = _codex_tool_call(name="search", arguments='{"q": "cats"}', call_id="c1")
+
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return _codex_completed_response(content=None, tool_calls=[tc])
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(
+        messages=[{"role": "user", "content": "q"}],
+        tools=[{"type": "function"}],
+        stream=True,
+    )
+
+    result = _drain(out)
+    assert result.finish_reason == "tool_calls"
+    assert list(result.tool_calls.values()) == [
+        {"id": "c1", "name": "search", "arguments": '{"q": "cats"}'}
+    ]
+
+
+def test_stream_raw_iterable_passthrough_unchanged(monkeypatch, tmp_path):
+    """A genuine raw stream iterable is returned verbatim — not wrapped or
+    consumed early — preserving the upstream streaming feature."""
+    raw_stream = iter(["real", "provider", "chunks"])
+
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return raw_stream
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(messages=[{"role": "user", "content": "q"}], stream=True)
+    assert out is raw_stream
+
+
+def test_stream_string_like_not_treated_as_char_stream(monkeypatch, tmp_path):
+    """A plain string return is technically iterable but is NOT a provider
+    chunk stream — the facade must not hand it over for character iteration."""
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return "a bare string that must not char-iterate"
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(messages=[{"role": "user", "content": "q"}], stream=True)
+
+    # Not returned as the raw string (which would char-iterate in the consumer).
+    assert out != "a bare string that must not char-iterate"
+    # Draining yields chunk objects, never single characters.
+    result = _drain(out)
+    assert result.content == "a bare string that must not char-iterate"
+
+
+def test_stream_empty_completed_response_yields_terminal_chunk(monkeypatch, tmp_path):
+    """A completed response with no choices yields a terminal chunk rather than
+    crashing the consumer's zero-chunk guard."""
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return SimpleNamespace(choices=[], model="gpt-5.5", usage=None)
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(messages=[{"role": "user", "content": "q"}], stream=True)
+
+    result = _drain(out)
+    assert result.content == ""
+    assert result.tool_calls == {}
+    # A non-None finish_reason so the consumer's empty-stream guard does not fire.
+    assert result.finish_reason is not None
+
+
+# --------------------------------------------------------------------------
+# U3: integration-shaped regression around the historical live failure
+# --------------------------------------------------------------------------
+
+def test_stream_simplenamespace_not_iterable_regression(monkeypatch, tmp_path):
+    """Historical crash repro: iterating the MoA stream return value no longer
+    raises ``'types.SimpleNamespace' object is not iterable``.
+
+    Before the fix, create(stream=True) returned the Codex adapter's completed
+    SimpleNamespace directly; the outer consumer's ``for chunk in stream`` then
+    raised TypeError. The wrapper makes the return iterable.
+    """
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return _codex_completed_response("recovered")
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(messages=[{"role": "user", "content": "q"}], stream=True)
+
+    # The exact operation that crashed live — must not raise TypeError.
+    result = _drain(out)
+    assert result.content == "recovered"
+
+
+def test_stream_wrapped_response_preserves_usage(monkeypatch, tmp_path):
+    """When the completed response carries usage, the wrapped stream preserves
+    it in the shape session accounting reads (final chunk's ``usage``)."""
+    usage = SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18)
+
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return _codex_completed_response("with usage", usage=usage)
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(messages=[{"role": "user", "content": "q"}], stream=True)
+
+    result = _drain(out)
+    assert result.usage is usage
+
+
+def test_stream_wrapped_tool_calls_finish_reason_distinguishable(monkeypatch, tmp_path):
+    """A completed tool_calls finish_reason stays distinguishable from a normal
+    stop completion after wrapping."""
+    tc = _codex_tool_call()
+
+    def on_call(kwargs):
+        task = kwargs["task"]
+        if task == "moa_aggregator":
+            # First aggregator call returns tools, distinct facade instances
+            # would be needed for two turns; here we assert a single tool turn.
+            return _codex_completed_response(content=None, tool_calls=[tc])
+        return None
+
+    tool_dir = tmp_path / "tool_turn"
+    tool_dir.mkdir()
+    facade, _calls = _facade(monkeypatch, tool_dir, on_call=on_call)
+    out = facade.create(
+        messages=[{"role": "user", "content": "q"}],
+        tools=[{"type": "function"}],
+        stream=True,
+    )
+    assert _drain(out).finish_reason == "tool_calls"
+
+    # A plain stop completion (separate facade/turn) stays "stop".
+    def on_call_stop(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return _codex_completed_response("just text")
+        return None
+
+    stop_dir = tmp_path / "stop_turn"
+    stop_dir.mkdir()
+    facade2, _calls2 = _facade(monkeypatch, stop_dir, on_call=on_call_stop)
+    out2 = facade2.create(messages=[{"role": "user", "content": "q2"}], stream=True)
+    assert _drain(out2).finish_reason == "stop"
+
+
+# --------------------------------------------------------------------------
+# Hardening (from code review): contract fidelity of the wrapped chunks
+# --------------------------------------------------------------------------
+
+def test_stream_wrapped_delta_sets_assistant_role(monkeypatch, tmp_path):
+    """The wrapped delta sets role="assistant", matching every other provider's
+    stream delta (copilot/gemini shims) so the consumer's message reassembly
+    is not a silent divergence for the Codex one-shot path."""
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return _codex_completed_response("hi")
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(messages=[{"role": "user", "content": "q"}], stream=True)
+    assert _drain(out).roles == ["assistant"]
+
+
+def test_stream_wrapped_carries_reasoning(monkeypatch, tmp_path):
+    """A completed response carrying reasoning_content is not dropped — the
+    wrapped delta exposes it so reasoning display/accumulation survives."""
+    resp = _codex_completed_response("answer")
+    resp.choices[0].message.reasoning_content = "thinking step"
+
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return resp
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(messages=[{"role": "user", "content": "q"}], stream=True)
+    result = _drain(out)
+    assert result.reasoning == "thinking step"
+    assert result.content == "answer"
+
+
+def test_stream_tool_call_dict_arguments_are_json_stringified(monkeypatch, tmp_path):
+    """A tool call whose arguments arrive already-parsed (dict) is serialized to
+    a JSON string so the consumer's ``arguments +=`` concatenation cannot raise
+    TypeError."""
+    tc = _codex_tool_call(name="search", arguments={"q": "cats"}, call_id="c1")
+
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return _codex_completed_response(content=None, tool_calls=[tc])
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(
+        messages=[{"role": "user", "content": "q"}],
+        tools=[{"type": "function"}],
+        stream=True,
+    )
+    # _drain concatenates arguments as strings; a dict would have raised.
+    reassembled = _drain(out).tool_calls[0]["arguments"]
+    import json
+
+    assert json.loads(reassembled) == {"q": "cats"}
+
+
+def test_stream_completed_response_with_none_choices_is_wrapped(monkeypatch, tmp_path):
+    """A completed response whose ``choices`` is None (error/content-filter
+    frame) is still recognized as a whole response and wrapped, not passed
+    through to crash ``for chunk in stream``."""
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return SimpleNamespace(choices=None, model="gpt-5.5", usage=None)
+        return None
+
+    facade, _calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    out = facade.create(messages=[{"role": "user", "content": "q"}], stream=True)
+    # Must not raise 'SimpleNamespace object is not iterable'.
+    result = _drain(out)
+    assert result.finish_reason is not None


### PR DESCRIPTION
## What does this PR do?

Fixes a crash where a MoA turn using an `openai-codex` aggregator dies under streaming with `'types.SimpleNamespace' object is not iterable`.

MoA forwards `stream=True` to the aggregator so its output can stream to the user live. That is correct for SDK clients that return a raw token stream, but Hermes' Codex auxiliary adapter (`_CodexCompletionsAdapter.create`) consumes Codex Responses events internally and returns a **completed** chat-completions-shaped `SimpleNamespace` even under `stream=True`. `MoAChatCompletions.create()` hands that completed, non-iterable object straight to the outer streaming consumer, whose `for chunk in stream` then raises.

The fix guards at the MoA boundary — the seam that knows it requested a stream. When `stream=True`, `create()` normalizes its return:

- raw provider streams pass through unchanged (latency preserved);
- a completed chat response is reconstructed into a **one-shot chunk iterator** shaped to the exact fields the shared streaming consumer reads (`delta.role/.content/.tool_calls` with a stream `index`, `finish_reason`, `model`, and a trailing `include_usage`-style usage frame), so text + tool-call reassembly continue on the normal path;
- string/bytes payloads are wrapped as one content chunk instead of being handed over for character iteration.

The non-streaming path (`stream=False`) is byte-for-byte unchanged. Teaching the Codex adapter to emit native stream chunks is a cleaner long-term fix but touches the provider-adapter surface; this boundary guard stops the live crash for Codex — and any future adapter with the same contract mismatch — without that risk.

## Related Issue

No existing issue or PR found (searched open + merged for "MoA stream", "SimpleNamespace iterable", "aggregator streaming"). Happy to file one if preferred.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moa_loop.py` — add `_normalize_aggregator_stream` (+ helpers `_delta_tool_calls`, `_tool_call_arguments_str`, `_stream_chunk`, `_one_shot_stream_from_response`, `_one_shot_stream_from_text`); call it on the `stream=True` return of `MoAChatCompletions.create()`.
- `tests/run_agent/test_moa_streaming.py` — regression + contract-fidelity coverage.

## How to Test

1. Configure a MoA preset with an `openai-codex` aggregator and stream a turn (Telegram/gateway) — previously crashed with `'types.SimpleNamespace' object is not iterable`; now streams normally.
2. Automated: `scripts/run_tests.sh tests/run_agent/test_moa_streaming.py` (19 tests). Covers the historical crash repro, raw-stream passthrough, tool-call reassembly with a stream index, usage preservation, `tool_calls` vs `stop` finish_reason, `role="assistant"`, reasoning carry-through, JSON-stringified dict tool-call arguments, and `choices=None`/empty terminal-chunk handling.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(moa): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass (`tests/run_agent/test_moa_streaming.py`: 19 passed; broader MoA + streaming subset: 188 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — code-level only; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python object reshaping, no OS/path/process calls)