### PR TITLE
fix(x_search): bound upstream response reads

### DIFF
--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -19,6 +19,8 @@ class _FakeResponse:
         self._payload = payload
         self.status_code = status_code
         self.text = text if text is not None else json.dumps(payload)
+        self.content = self.text.encode("utf-8")
+        self.closed = False
 
     def raise_for_status(self):
         if self.status_code >= 400:
@@ -28,6 +30,13 @@ class _FakeResponse:
 
     def json(self):
         return self._payload
+
+    def iter_content(self, chunk_size=1):
+        for idx in range(0, len(self.content), chunk_size):
+            yield self.content[idx : idx + chunk_size]
+
+    def close(self):
+        self.closed = True
 
 
 # ---------------------------------------------------------------------------
@@ -42,11 +51,12 @@ def test_x_search_posts_responses_request(monkeypatch):
 
     captured = {}
 
-    def _fake_post(url, headers=None, json=None, timeout=None):
+    def _fake_post(url, headers=None, json=None, timeout=None, stream=None):
         captured["url"] = url
         captured["headers"] = headers
         captured["json"] = json
         captured["timeout"] = timeout
+        captured["stream"] = stream
         return _FakeResponse(
             {
                 "output_text": "People on X are discussing xAI's latest launch.",
@@ -70,6 +80,7 @@ def test_x_search_posts_responses_request(monkeypatch):
     tool_def = captured["json"]["tools"][0]
     assert captured["url"] == "https://api.x.ai/v1/responses"
     assert captured["headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
+    assert captured["stream"] is True
     assert captured["json"]["model"] == "grok-4.20-reasoning"
     assert captured["json"]["store"] is False
     assert tool_def["type"] == "x_search"
@@ -100,7 +111,7 @@ def test_x_search_rejects_conflicting_handle_filters(monkeypatch):
 def test_x_search_extracts_inline_url_citations(monkeypatch):
     from tools.x_search_tool import x_search_tool
 
-    def _fake_post(url, headers=None, json=None, timeout=None):
+    def _fake_post(url, headers=None, json=None, timeout=None, stream=None):
         return _FakeResponse(
             {
                 "output": [
@@ -173,12 +184,78 @@ def test_x_search_returns_structured_http_error(monkeypatch):
     assert result["error"] == "forbidden: x_search is not enabled for this model"
 
 
+def test_x_search_caps_success_response_body(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    class _LargeResponse:
+        status_code = 200
+
+        def __init__(self):
+            self.closed = False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size=1):
+            yield b"{"
+            yield b'"output_text":"' + (b"x" * (9 * 1024 * 1024))
+
+        def close(self):
+            self.closed = True
+
+    response = _LargeResponse()
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", lambda *a, **k: response)
+
+    result = json.loads(x_search_tool(query="latest xai discussion"))
+
+    assert result["success"] is False
+    assert result["error_type"] == "_XSearchResponseTooLarge"
+    assert "x_search response exceeded" in result["error"]
+    assert response.closed is True
+
+
+def test_x_search_caps_http_error_body(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    class _LargeErrorResponse:
+        status_code = 403
+
+        def __init__(self):
+            self.closed = False
+
+        def raise_for_status(self):
+            err = requests.HTTPError("403 Client Error: Forbidden")
+            err.response = self
+            raise err
+
+        def iter_content(self, chunk_size=1):
+            yield b"{"
+            yield b'"error":"' + (b"x" * (128 * 1024))
+
+        def close(self):
+            self.closed = True
+
+    response = _LargeErrorResponse()
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", lambda *a, **k: response)
+
+    result = json.loads(x_search_tool(query="latest xai discussion"))
+
+    assert result["success"] is False
+    assert result["error_type"] == "HTTPError"
+    assert "x_search error response exceeded" in result["error"]
+    assert response.closed is True
+
+
 def test_x_search_retries_read_timeout_then_succeeds(monkeypatch):
     from tools.x_search_tool import x_search_tool
 
     calls = {"count": 0}
 
-    def _fake_post(url, headers=None, json=None, timeout=None):
+    def _fake_post(url, headers=None, json=None, timeout=None, stream=None):
         calls["count"] += 1
         if calls["count"] == 1:
             raise requests.ReadTimeout("timed out")
@@ -205,7 +282,7 @@ def test_x_search_retries_5xx_then_succeeds(monkeypatch):
 
     calls = {"count": 0}
 
-    def _fake_post(url, headers=None, json=None, timeout=None):
+    def _fake_post(url, headers=None, json=None, timeout=None, stream=None):
         calls["count"] += 1
         if calls["count"] == 1:
             return _FakeResponse(
@@ -258,7 +335,7 @@ def test_x_search_uses_xai_oauth_when_only_oauth_available(monkeypatch):
 
     captured = {}
 
-    def _fake_post(url, headers=None, json=None, timeout=None):
+    def _fake_post(url, headers=None, json=None, timeout=None, stream=None):
         captured["headers"] = headers
         return _FakeResponse({"output_text": "Found posts via OAuth."})
 
@@ -296,7 +373,7 @@ def test_x_search_uses_api_key_when_only_xai_api_key_set(monkeypatch):
 
     captured = {}
 
-    def _fake_post(url, headers=None, json=None, timeout=None):
+    def _fake_post(url, headers=None, json=None, timeout=None, stream=None):
         captured["headers"] = headers
         return _FakeResponse({"output_text": "Found posts via API key."})
 
@@ -338,7 +415,7 @@ def test_x_search_prefers_oauth_when_both_available(monkeypatch):
 
     captured = {}
 
-    def _fake_post(url, headers=None, json=None, timeout=None):
+    def _fake_post(url, headers=None, json=None, timeout=None, stream=None):
         captured["headers"] = headers
         return _FakeResponse({"output_text": "OAuth preferred."})
 
@@ -410,7 +487,7 @@ def test_x_search_honors_config_model_and_timeout(monkeypatch, tmp_path):
 
     captured = {}
 
-    def _fake_post(url, headers=None, json=None, timeout=None):
+    def _fake_post(url, headers=None, json=None, timeout=None, stream=None):
         captured["model"] = json["model"]
         captured["timeout"] = timeout
         return _FakeResponse({"output_text": "Custom model OK."})
@@ -528,7 +605,7 @@ def test_x_search_allows_future_to_date(monkeypatch):
 
     monkeypatch.setattr("tools.x_search_tool.datetime", _FrozenDateTime)
 
-    def _fake_post(url, headers=None, json=None, timeout=None):
+    def _fake_post(url, headers=None, json=None, timeout=None, stream=None):
         return _FakeResponse(
             {"output_text": "future to_date is allowed", "citations": []}
         )

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -60,6 +60,13 @@ DEFAULT_X_SEARCH_MODEL = "grok-4.20-reasoning"
 DEFAULT_X_SEARCH_TIMEOUT_SECONDS = 180
 DEFAULT_X_SEARCH_RETRIES = 2
 MAX_HANDLES = 10
+X_SEARCH_RESPONSE_MAX_BYTES = 8 * 1024 * 1024
+X_SEARCH_ERROR_RESPONSE_MAX_BYTES = 64 * 1024
+X_SEARCH_RESPONSE_CHUNK_BYTES = 64 * 1024
+
+
+class _XSearchResponseTooLarge(ValueError):
+    pass
 
 
 # ---------------------------------------------------------------------------
@@ -243,14 +250,83 @@ def _extract_inline_citations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
     return citations
 
 
+def _close_response(response: requests.Response) -> None:
+    close = getattr(response, "close", None)
+    if callable(close):
+        close()
+
+
+def _response_chunks(response: requests.Response):
+    iter_content = getattr(response, "iter_content", None)
+    if callable(iter_content):
+        yield from iter_content(chunk_size=X_SEARCH_RESPONSE_CHUNK_BYTES)
+        return
+
+    content = getattr(response, "content", None)
+    if content is not None:
+        yield content.encode("utf-8") if isinstance(content, str) else bytes(content)
+        return
+
+    text = getattr(response, "text", "") or ""
+    yield str(text).encode("utf-8", errors="replace")
+
+
+def _read_response_body(
+    response: requests.Response,
+    *,
+    max_bytes: int,
+    label: str,
+) -> bytes:
+    chunks: List[bytes] = []
+    total = 0
+    try:
+        for chunk in _response_chunks(response):
+            if not chunk:
+                continue
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+            total += len(chunk)
+            if total > max_bytes:
+                raise _XSearchResponseTooLarge(f"{label} exceeded {max_bytes} bytes")
+            chunks.append(chunk)
+        return b"".join(chunks)
+    finally:
+        _close_response(response)
+
+
+def _read_response_json(
+    response: requests.Response,
+    *,
+    max_bytes: int = X_SEARCH_RESPONSE_MAX_BYTES,
+    label: str = "x_search response",
+) -> Dict[str, Any]:
+    raw = _read_response_body(response, max_bytes=max_bytes, label=label)
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} returned invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} returned non-object JSON")
+    return payload
+
+
 def _http_error_message(exc: requests.HTTPError) -> str:
     response = getattr(exc, "response", None)
     if response is None:
         return str(exc)
 
     try:
-        payload = response.json()
-    except Exception:
+        raw = _read_response_body(
+            response,
+            max_bytes=X_SEARCH_ERROR_RESPONSE_MAX_BYTES,
+            label="x_search error response",
+        )
+    except _XSearchResponseTooLarge as too_large:
+        return str(too_large)
+
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
         payload = None
 
     if isinstance(payload, dict):
@@ -261,7 +337,7 @@ def _http_error_message(exc: requests.HTTPError) -> str:
             message = f"{code}: {message}"
         return message or str(exc)
 
-    text = str(getattr(response, "text", "") or "").strip()
+    text = raw.decode("utf-8", errors="replace").strip()
     if text:
         return text[:500]
     return str(exc)
@@ -339,6 +415,7 @@ def x_search_tool(
                     },
                     json=payload,
                     timeout=timeout_seconds,
+                    stream=True,
                 )
                 response.raise_for_status()
                 break
@@ -367,7 +444,7 @@ def x_search_tool(
         if response is None:
             raise RuntimeError("x_search request did not return a response")
 
-        data = response.json()
+        data = _read_response_json(response)
 
         answer = _extract_response_text(data)
         citations = list(data.get("citations") or [])


### PR DESCRIPTION
﻿## What does this PR do?

- Streams xAI `/responses` calls from `tools.x_search_tool` instead of letting Requests eagerly expose unbounded bodies.
- Adds byte-limited response readers before JSON parsing: 8 MiB for successful x_search payloads and 64 KiB for HTTP error body previews.
- Closes streamed responses after bounded reads, including oversized bodies.
- Adds regression coverage for oversized success and HTTP error bodies.

Fixes #56527.

## Why?

`x_search_tool()` previously parsed successful upstream responses with `response.json()`, while `_http_error_message()` tried `response.json()` and then `response.text`. Those paths do not enforce a Hermes-specific body limit before materializing upstream data.

## Proof

- `python -m py_compile tools\x_search_tool.py tests\tools\test_x_search_tool.py`
- Direct focused proof script passed: oversized success responses return a controlled `_XSearchResponseTooLarge` error, oversized HTTP error bodies return a capped HTTPError message, `stream=True` is set, and both fake responses are closed.
- `python -m pytest tests\tools\test_x_search_tool.py -q` could not run in this checkout because the local Hermes venv is missing `pytest` (`No module named pytest`).

## Duplicate check

Before opening, I searched PRs/issues for `x_search response cap`, `x_search body limit`, `x_search response size`, `x_search upstream response reads`, `xAI web search`, and `tools/x_search_tool.py`. Existing results were x_search feature/docs work or xAI auth issues, not this bounded response-read fix.
