### PR TITLE
feat(wandb): dispatch reasoning controls per model family, not just GLM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ images/
 __pycache__/
 hermes_agent.egg-info/
 wandb/
+!plugins/model-providers/wandb/
 testlogs
 
 # CLI config (may contain sensitive SSH paths)

--- a/plugins/model-providers/wandb/__init__.py
+++ b/plugins/model-providers/wandb/__init__.py
@@ -1,0 +1,89 @@
+"""W&B (Weights & Biases) inference provider profile.
+
+W&B hosts GLM-5.2 on a vLLM backend at api.inference.wandb.ai. The endpoint
+accepts:
+  - reasoning_effort as a top-level param ("high" or "max")
+  - chat_template_kwargs.enable_thinking as extra_body (false = no thinking)
+  - A browser User-Agent is required (Cloudflare blocks urllib default)
+
+GLM-5.2 only recognises "high" and "max" for reasoning_effort; other values
+(minimal/low/medium) are silently ignored and the model defaults to Think Max.
+The z.ai "thinking" parameter is also ignored by vLLM.
+
+This profile overrides build_api_kwargs_extras to emit the correct params.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+def _effort_to_glm(effort: str) -> str | None:
+    """Map Hermes reasoning effort levels to GLM-5.2's accepted values.
+
+    GLM-5.2 only supports "high" and "max". Unrecognised values silently
+    fall back to Think Max (the model default), so we explicitly map:
+      xhigh → "max" (GLM-5.2's deepest thinking)
+      high  → "high" (lighter, ~3× faster)
+      *     → None  (omit param — let GLM-5.2 use its default Think Max)
+    """
+    e = (effort or "").strip().lower()
+    if e in {"xhigh", "max"}:
+        return "max"
+    if e == "high":
+        return "high"
+    return None
+
+
+class WandbProfile(ProviderProfile):
+    """W&B inference — GLM-5.2 on vLLM with reasoning_effort + enable_thinking."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **ctx: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if not isinstance(reasoning_config, dict):
+            return extra_body, top_level
+
+        _enabled = reasoning_config.get("enabled", True)
+        _effort = (reasoning_config.get("effort") or "").strip().lower()
+
+        # Thinking disabled → chat_template_kwargs.enable_thinking=false
+        # This is the ONLY way to disable thinking on GLM-5.2 vLLM.
+        if _effort == "none" or _enabled is False:
+            extra_body["chat_template_kwargs"] = {"enable_thinking": False}
+            return extra_body, top_level
+
+        # Thinking enabled → emit reasoning_effort as top-level param
+        glm_effort = _effort_to_glm(_effort)
+        if glm_effort:
+            top_level["reasoning_effort"] = glm_effort
+
+        return extra_body, top_level
+
+
+wandb = WandbProfile(
+    name="wandb",
+    aliases=("wandb-ai", "weights-and-biases"),
+    env_vars=("WANDB_API_KEY",),
+    display_name="W&B Inference",
+    description="Weights & Biases inference API — GLM-5.2 on vLLM",
+    signup_url="https://wandb.ai",
+    base_url="https://api.inference.wandb.ai/v1",
+    fallback_models=("zai-org/GLM-5.2",),
+    default_max_tokens=65536,
+    # Cloudflare blocks the default urllib User-Agent; the transport
+    # adds a browser UA via default_headers.
+    default_headers={"User-Agent": "Mozilla/5.0"},
+)
+
+register_provider(wandb)

--- a/plugins/model-providers/wandb/__init__.py
+++ b/plugins/model-providers/wandb/__init__.py
@@ -1,18 +1,52 @@
 """W&B (Weights & Biases) inference provider profile.
 
-W&B hosts GLM-5.2 on a vLLM backend at api.inference.wandb.ai. The endpoint
-accepts:
-  - reasoning_effort as a top-level param ("high" or "max")
-  - chat_template_kwargs.enable_thinking as extra_body (false = no thinking)
-  - A browser User-Agent is required (Cloudflare blocks urllib default)
+W&B fronts ~29 open-weight models on a shared vLLM backend at
+api.inference.wandb.ai. Reasoning control is NOT uniform across the catalog —
+vLLM's chat-template-kwargs mechanism is a per-model-family contract, and W&B
+inherits whichever dialect each upstream model's chat template defines. This
+profile dispatches on model family, mirroring the OpenCodeGoProfile pattern
+(plugins/model-providers/opencode-zen) for the same "one relay, several wire
+formats" shape.
 
-GLM-5.2 only recognises "high" and "max" for reasoning_effort; other values
-(minimal/low/medium) are silently ignored and the model defaults to Think Max,
-so this profile maps unsupported lower efforts to the lightest supported value
-("high") instead of omitting the parameter. The z.ai "thinking" parameter is
-also ignored by vLLM.
+Confirmed dialects (live-tested against api.inference.wandb.ai + cross-checked
+against docs.wandb.ai/inference/response-settings/reasoning and vLLM's
+reasoning_outputs docs):
 
-This profile overrides build_api_kwargs_extras to emit the correct params.
+  GLM (zai-org/GLM-*)
+    Toggle:  chat_template_kwargs.enable_thinking (false to disable)
+    Effort:  top-level reasoning_effort — ONLY "high"/"max" recognised.
+             minimal/low/medium are silently ignored and fall back to
+             Think Max, so they're mapped up to "high" instead of omitted.
+
+  Granular-effort toggle family (Qwen3.5-*, Qwen3.6-*, Gemma-4, Nemotron-3)
+    Toggle:  chat_template_kwargs.enable_thinking (false to disable)
+    Effort:  top-level reasoning_effort passed through verbatim
+             (low/medium/high honoured — confirmed distinct reasoning-token
+             counts per level on Qwen3.6-35B-A3B); xhigh/max -> "max".
+
+  DeepSeek reasoning family (deepseek-ai/DeepSeek-V3.1, DeepSeek-V4-*)
+    Toggle:  chat_template_kwargs.thinking (note: "thinking", NOT
+             "enable_thinking" — a different key entirely; enable_thinking
+             produced weak/inconsistent output in testing). Matches vLLM's
+             dedicated deepseek_v3 reasoning parser contract.
+    Effort:  no granular effort observed — omitted entirely for this family.
+
+  Always-on reasoning family (openai/gpt-oss-20b, openai/gpt-oss-120b,
+  MiniMaxAI/MiniMax-M2.5, moonshotai/Kimi-K2.5, moonshotai/Kimi-K2.6,
+  moonshotai/Kimi-K2.7-Code, Qwen/Qwen3-235B-A22B-Thinking-2507)
+    Toggle:  none — reasoning cannot be disabled (W&B docs: "Always on").
+    Effort:  top-level reasoning_effort still modulates depth (confirmed on
+             gpt-oss-20b: reasoning_len 127 default vs 20 at effort=low), so
+             it's passed through verbatim when the user requests a level.
+
+  Everything else (Llama, Phi, plain Qwen3-Instruct non-thinking variants,
+  IBM Granite, JetBrains Mellum2, etc.) — no reasoning support; no-op.
+
+Unset/unrecognised model defaults to the GLM dialect, since GLM-5.2 is this
+profile's fallback_models entry and Hermes' bundled config.yaml default.
+
+Also handles the Cloudflare-blocks-default-urllib-UA quirk via default_headers
+(applies to every model on the endpoint, not just GLM).
 """
 
 from __future__ import annotations
@@ -21,6 +55,49 @@ from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
+
+
+def _model_lower(model: str | None) -> str:
+    return (model or "").strip().lower()
+
+
+def _is_glm_model(model: str | None) -> bool:
+    m = _model_lower(model)
+    return m.startswith("zai-org/glm") or m.startswith("glm-")
+
+
+def _is_deepseek_thinking_model(model: str | None) -> bool:
+    """DeepSeek reasoning family — V3.1 and the V4 generation.
+
+    Every DeepSeek model currently on W&B (V3.1, V4-Flash, V4-Pro) is
+    reasoning-capable, unlike the direct DeepSeek API where deepseek-chat
+    (V3) has no thinking mode — so a broad prefix match is safe here.
+    """
+    m = _model_lower(model)
+    return m.startswith("deepseek-ai/deepseek-v")
+
+
+def _is_granular_toggle_model(model: str | None) -> bool:
+    """Qwen3.5/3.6, Gemma-4, Nemotron-3 — enable_thinking + granular effort."""
+    m = _model_lower(model)
+    return (
+        m.startswith("qwen/qwen3.5")
+        or m.startswith("qwen/qwen3.6")
+        or m.startswith("google/gemma-4")
+        or m.startswith("nvidia/nvidia-nemotron-3")
+    )
+
+
+def _is_always_on_reasoning_model(model: str | None) -> bool:
+    """Models W&B docs list as 'Always on' — no disable switch, but effort
+    still modulates depth (confirmed on gpt-oss-20b)."""
+    m = _model_lower(model)
+    return (
+        m.startswith("openai/gpt-oss-")
+        or m.startswith("minimaxai/minimax-m2")
+        or m.startswith("moonshotai/kimi-k2")
+        or m == "qwen/qwen3-235b-a22b-thinking-2507"
+    )
 
 
 def _effort_to_glm(effort: str) -> str | None:
@@ -41,8 +118,23 @@ def _effort_to_glm(effort: str) -> str | None:
     return None
 
 
+def _effort_passthrough(effort: str) -> str | None:
+    """Pass Hermes effort through verbatim for models with real granularity.
+
+    low/medium/high map 1:1 (all three produce distinct reasoning-token
+    counts, confirmed on Qwen3.6-35B-A3B and gpt-oss-20b); xhigh/max
+    collapse to vLLM's "max".
+    """
+    e = (effort or "").strip().lower()
+    if e in {"xhigh", "max"}:
+        return "max"
+    if e in {"low", "medium", "high"}:
+        return e
+    return None
+
+
 class WandbProfile(ProviderProfile):
-    """W&B inference — GLM-5.2 on vLLM with reasoning_effort + enable_thinking."""
+    """W&B inference — per-model-family reasoning dispatch on a shared vLLM backend."""
 
     def build_api_kwargs_extras(
         self,
@@ -57,20 +149,48 @@ class WandbProfile(ProviderProfile):
         if not isinstance(reasoning_config, dict):
             return extra_body, top_level
 
-        _enabled = reasoning_config.get("enabled", True)
-        _effort = (reasoning_config.get("effort") or "").strip().lower()
+        enabled = reasoning_config.get("enabled", True)
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+        disabled = effort == "none" or enabled is False
 
-        # Thinking disabled → chat_template_kwargs.enable_thinking=false
-        # This is the ONLY way to disable thinking on GLM-5.2 vLLM.
-        if _effort == "none" or _enabled is False:
-            extra_body["chat_template_kwargs"] = {"enable_thinking": False}
+        # Unset/unrecognised model → default to the GLM dialect (this
+        # profile's fallback_models entry and Hermes' bundled config default).
+        if not model or _is_glm_model(model):
+            if disabled:
+                extra_body["chat_template_kwargs"] = {"enable_thinking": False}
+                return extra_body, top_level
+            glm_effort = _effort_to_glm(effort)
+            if glm_effort:
+                top_level["reasoning_effort"] = glm_effort
             return extra_body, top_level
 
-        # Thinking enabled → emit reasoning_effort as top-level param
-        glm_effort = _effort_to_glm(_effort)
-        if glm_effort:
-            top_level["reasoning_effort"] = glm_effort
+        if _is_deepseek_thinking_model(model):
+            # Distinct wire key: "thinking", not "enable_thinking" — matches
+            # vLLM's dedicated deepseek_v3 reasoning parser. No granular
+            # effort observed for this family, so it's never emitted.
+            extra_body["chat_template_kwargs"] = {"thinking": not disabled}
+            return extra_body, top_level
 
+        if _is_always_on_reasoning_model(model):
+            # No disable switch exists (W&B docs: "Always on") — a disable
+            # request is a no-op. Effort still passes through when set.
+            if not disabled:
+                passthrough_effort = _effort_passthrough(effort)
+                if passthrough_effort:
+                    top_level["reasoning_effort"] = passthrough_effort
+            return extra_body, top_level
+
+        if _is_granular_toggle_model(model):
+            if disabled:
+                extra_body["chat_template_kwargs"] = {"enable_thinking": False}
+                return extra_body, top_level
+            passthrough_effort = _effort_passthrough(effort)
+            if passthrough_effort:
+                top_level["reasoning_effort"] = passthrough_effort
+            return extra_body, top_level
+
+        # Everything else (Llama, Phi, non-thinking Qwen3-Instruct variants,
+        # IBM Granite, JetBrains Mellum2, etc.) has no reasoning support.
         return extra_body, top_level
 
 
@@ -79,13 +199,22 @@ wandb = WandbProfile(
     aliases=("wandb-ai", "weights-and-biases"),
     env_vars=("WANDB_API_KEY",),
     display_name="W&B Inference",
-    description="Weights & Biases inference API — GLM-5.2 on vLLM",
+    description="Weights & Biases inference API — 29 models on a shared vLLM backend",
     signup_url="https://wandb.ai",
     base_url="https://api.inference.wandb.ai/v1",
-    fallback_models=("zai-org/GLM-5.2",),
+    fallback_models=(
+        "zai-org/GLM-5.2",
+        "zai-org/GLM-5.1",
+        "deepseek-ai/DeepSeek-V4-Pro",
+        "deepseek-ai/DeepSeek-V4-Flash",
+        "Qwen/Qwen3.6-35B-A3B",
+        "moonshotai/Kimi-K2.7-Code",
+        "openai/gpt-oss-120b",
+    ),
     default_max_tokens=65536,
     # Cloudflare blocks the default urllib User-Agent; the transport
-    # adds a browser UA via default_headers.
+    # adds a browser UA via default_headers. Applies to every model on
+    # the endpoint, not just GLM.
     default_headers={"User-Agent": "Mozilla/5.0"},
 )
 

--- a/plugins/model-providers/wandb/__init__.py
+++ b/plugins/model-providers/wandb/__init__.py
@@ -7,8 +7,10 @@ accepts:
   - A browser User-Agent is required (Cloudflare blocks urllib default)
 
 GLM-5.2 only recognises "high" and "max" for reasoning_effort; other values
-(minimal/low/medium) are silently ignored and the model defaults to Think Max.
-The z.ai "thinking" parameter is also ignored by vLLM.
+(minimal/low/medium) are silently ignored and the model defaults to Think Max,
+so this profile maps unsupported lower efforts to the lightest supported value
+("high") instead of omitting the parameter. The z.ai "thinking" parameter is
+also ignored by vLLM.
 
 This profile overrides build_api_kwargs_extras to emit the correct params.
 """
@@ -26,14 +28,15 @@ def _effort_to_glm(effort: str) -> str | None:
 
     GLM-5.2 only supports "high" and "max". Unrecognised values silently
     fall back to Think Max (the model default), so we explicitly map:
-      xhigh → "max" (GLM-5.2's deepest thinking)
+      xhigh → "max"  (GLM-5.2's deepest thinking)
       high  → "high" (lighter, ~3× faster)
-      *     → None  (omit param — let GLM-5.2 use its default Think Max)
+      low/minimal/medium → "high" (lightest supported thinking)
+      unset/unknown → None (omit param — let GLM-5.2 use its default)
     """
     e = (effort or "").strip().lower()
     if e in {"xhigh", "max"}:
         return "max"
-    if e == "high":
+    if e in {"minimal", "low", "medium", "high"}:
         return "high"
     return None
 

--- a/plugins/model-providers/wandb/plugin.yaml
+++ b/plugins/model-providers/wandb/plugin.yaml
@@ -1,0 +1,5 @@
+name: wandb-provider
+kind: model-provider
+version: 1.0.0
+description: W&B Inference / GLM-5.2
+author: Nous Research

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -10,6 +10,13 @@ class TestRegistry:
         assert p is not None
         assert p.name == "nvidia"
 
+    def test_wandb_provider_discovered(self):
+        p = get_provider_profile("wandb")
+        assert p is not None
+        assert p.name == "wandb"
+        assert p.base_url == "https://api.inference.wandb.ai/v1"
+        assert p.default_headers["User-Agent"] == "Mozilla/5.0"
+
     def test_alias_lookup(self):
         assert get_provider_profile("kimi").name == "kimi-coding"
         assert get_provider_profile("moonshot").name == "kimi-coding"
@@ -44,6 +51,51 @@ class TestNvidiaProfile:
     def test_billing_header_not_profile_wide(self):
         p = get_provider_profile("nvidia")
         assert p.default_headers == {}
+
+
+class TestWandbProfile:
+    def test_none_disables_thinking_with_chat_template_kwargs(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "none"}
+        )
+        assert eb == {"chat_template_kwargs": {"enable_thinking": False}}
+        assert tl == {}
+
+    def test_high_maps_to_top_level_high(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}
+        )
+        assert eb == {}
+        assert tl["reasoning_effort"] == "high"
+
+    def test_xhigh_maps_to_top_level_max(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"}
+        )
+        assert eb == {}
+        assert tl["reasoning_effort"] == "max"
+
+    def test_lower_supported_efforts_map_to_lightest_glm_effort(self):
+        # W&B GLM-5.2 accepts only "high" and "max". Omitting the field for
+        # minimal/low/medium would silently select GLM's default Think Max,
+        # inverting the user's request for lighter reasoning.
+        p = get_provider_profile("wandb")
+        for effort in ("minimal", "low", "medium"):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort}
+            )
+            assert eb == {}
+            assert tl["reasoning_effort"] == "high"
+
+    def test_unset_or_unknown_effort_uses_provider_default(self):
+        p = get_provider_profile("wandb")
+        for cfg in ({"enabled": True}, {"enabled": True, "effort": "bogus"}):
+            eb, tl = p.build_api_kwargs_extras(reasoning_config=cfg)
+            assert eb == {}
+            assert tl == {}
 
 
 class TestKimiProfile:

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -97,6 +97,180 @@ class TestWandbProfile:
             assert eb == {}
             assert tl == {}
 
+    def test_no_model_defaults_to_glm_dialect(self):
+        """Unset model falls back to the GLM dialect (this profile's
+        fallback_models entry and Hermes' bundled config.yaml default)."""
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"}, model=None
+        )
+        assert eb == {}
+        assert tl["reasoning_effort"] == "high"
+
+    def test_glm_5_1_uses_same_dialect_as_5_2(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="zai-org/GLM-5.1",
+        )
+        assert eb == {}
+        assert tl["reasoning_effort"] == "high"
+
+
+class TestWandbDeepSeekDialect:
+    """DeepSeek reasoning family (V3.1, V4-*) — distinct toggle key from GLM.
+
+    Confirmed live: chat_template_kwargs.thinking (not enable_thinking) is
+    the only key that reliably turns reasoning on for this family; no
+    granular effort is observed so reasoning_effort is never emitted.
+    """
+
+    def test_disabled_sends_thinking_false(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="deepseek-ai/DeepSeek-V3.1",
+        )
+        assert eb == {"chat_template_kwargs": {"thinking": False}}
+        assert tl == {}
+
+    def test_enabled_sends_thinking_true_no_effort(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="deepseek-ai/DeepSeek-V3.1",
+        )
+        assert eb == {"chat_template_kwargs": {"thinking": True}}
+        assert tl == {}
+
+    def test_v4_flash_and_pro_use_same_dialect(self):
+        p = get_provider_profile("wandb")
+        for model in ("deepseek-ai/DeepSeek-V4-Flash", "deepseek-ai/DeepSeek-V4-Pro"):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True}, model=model
+            )
+            assert eb == {"chat_template_kwargs": {"thinking": True}}, model
+            assert tl == {}, model
+
+    def test_none_effort_disables(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"effort": "none"},
+            model="deepseek-ai/DeepSeek-V3.1",
+        )
+        assert eb == {"chat_template_kwargs": {"thinking": False}}
+
+
+class TestWandbGranularToggleDialect:
+    """Qwen3.5/3.6, Gemma-4, Nemotron-3 — enable_thinking + granular effort.
+
+    Unlike GLM, these models honour low/medium/high distinctly (confirmed:
+    distinct reasoning-token counts per level on Qwen3.6-35B-A3B).
+    """
+
+    def test_disabled_sends_enable_thinking_false(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="Qwen/Qwen3.6-35B-A3B",
+        )
+        assert eb == {"chat_template_kwargs": {"enable_thinking": False}}
+        assert tl == {}
+
+    def test_medium_passes_through_verbatim(self):
+        """Unlike GLM (which collapses medium->high), this family honours
+        medium as its own distinct level."""
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model="Qwen/Qwen3.6-35B-A3B",
+        )
+        assert eb == {}
+        assert tl["reasoning_effort"] == "medium"
+
+    def test_xhigh_maps_to_max(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            model="Qwen/Qwen3.6-27B",
+        )
+        assert tl["reasoning_effort"] == "max"
+
+    def test_gemma_and_nemotron_use_same_dialect(self):
+        p = get_provider_profile("wandb")
+        for model in (
+            "google/gemma-4-31B-it",
+            "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
+            "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+        ):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": "low"}, model=model
+            )
+            assert eb == {}, model
+            assert tl["reasoning_effort"] == "low", model
+
+
+class TestWandbAlwaysOnDialect:
+    """gpt-oss, MiniMax-M2.5, Kimi-K2.x, Qwen3-235B-Thinking — cannot be
+    disabled (W&B docs: "Always on"), but effort still modulates depth
+    (confirmed: gpt-oss-20b reasoning_len 127 default vs 20 at effort=low).
+    """
+
+    def test_disable_request_is_a_noop(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="openai/gpt-oss-20b",
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_effort_still_passes_through(self):
+        p = get_provider_profile("wandb")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "low"},
+            model="openai/gpt-oss-20b",
+        )
+        assert eb == {}
+        assert tl["reasoning_effort"] == "low"
+
+    def test_kimi_and_minimax_and_thinking_qwen_share_dialect(self):
+        p = get_provider_profile("wandb")
+        for model in (
+            "moonshotai/Kimi-K2.5",
+            "moonshotai/Kimi-K2.6",
+            "moonshotai/Kimi-K2.7-Code",
+            "MiniMaxAI/MiniMax-M2.5",
+            "Qwen/Qwen3-235B-A22B-Thinking-2507",
+            "openai/gpt-oss-120b",
+        ):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": "high"}, model=model
+            )
+            assert eb == {}, model
+            assert tl["reasoning_effort"] == "high", model
+
+
+class TestWandbNoReasoningDialect:
+    """Llama, Phi, non-thinking Qwen3-Instruct, IBM Granite, Mellum2 — no
+    reasoning support at all; every dispatch branch must no-op."""
+
+    def test_no_reasoning_models_are_noop(self):
+        p = get_provider_profile("wandb")
+        for model in (
+            "meta-llama/Llama-3.3-70B-Instruct",
+            "meta-llama/Llama-3.1-8B-Instruct",
+            "microsoft/Phi-4-mini-instruct",
+            "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "ibm-granite/granite-4.1-8b",
+            "JetBrains/Mellum2-12B-A2.5B-Instruct",
+        ):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": "high"}, model=model
+            )
+            assert eb == {}, model
+            assert tl == {}, model
+
 
 class TestKimiProfile:
     def test_temperature_omit(self):

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -156,6 +156,32 @@ def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():
     )
 
 
+def test_bundled_model_provider_plugins_have_manifests():
+    """Bundled model-provider plugin dirs must be visible to PluginManager.
+
+    ``providers`` can import a provider profile directly from ``__init__.py``,
+    but the general plugin-management surface discovers directories by
+    manifest. Keep bundled model providers consistent with the rest of the
+    plugin tree so install/list/enable flows can see them.
+    """
+    missing = []
+    for provider_dir in sorted((REPO_ROOT / "plugins" / "model-providers").iterdir()):
+        if not provider_dir.is_dir():
+            continue
+        if not (provider_dir / "__init__.py").exists():
+            continue
+        if not (
+            (provider_dir / "plugin.yaml").exists()
+            or (provider_dir / "plugin.yml").exists()
+        ):
+            missing.append(provider_dir.relative_to(REPO_ROOT).as_posix())
+
+    assert not missing, (
+        "Bundled model-provider plugins with __init__.py must include "
+        f"plugin.yaml/plugin.yml manifests for PluginManager discovery: {missing}"
+    )
+
+
 # Minimum non-vulnerable Starlette: CVE-2026-48710 ("BadHost") was fixed in
 # 1.0.1. Anything below that lets a malformed Host header desync
 # ``request.url.path`` from the dispatched ASGI path, bypassing path-based


### PR DESCRIPTION
## What

Expands `WandbProfile.build_api_kwargs_extras` from a GLM-5.2-only reasoning
implementation to a per-model-family dispatch table covering the rest of
W&B's ~29-model catalog. Builds on #56054 (merge that first, or this can be
rebased once it lands — currently includes those two commits so it's
self-contained and testable standalone).

## Why

W&B fronts many open-weight models on a shared vLLM backend
(`api.inference.wandb.ai`). Reasoning control is **not** a W&B-wide
convention — it's whatever chat-template contract each upstream model
defines, and vLLM just passes it through. The current `WandbProfile`
hardcodes GLM-5.2's dialect (`enable_thinking` toggle + `reasoning_effort`
top-level, high/max only) for every model on the endpoint, which is wrong
for most of the catalog.

This mirrors the `OpenCodeGoProfile` pattern already in this repo
(`plugins/model-providers/opencode-zen`) for the same "one relay, several
wire formats" shape — dispatch by model family via small predicate
functions, not a single hardcoded contract. Per AGENTS.md's "extend, don't
duplicate" guidance, this felt like the right shared-interface move rather
than shipping a second GLM-only-shaped PR.

## How — four dialects, live-tested against `api.inference.wandb.ai`

Cross-checked against `docs.wandb.ai/inference/response-settings/reasoning`
(which documents *which* models default on/off/always-on, but not the wire
format) and vLLM's own `reasoning_outputs` docs (which documents the wire
formats per parser, but not which W&B-hosted model uses which). Neither
source alone was sufficient; behavior was empirically confirmed with live
API calls before writing the dispatch logic.

| Family | Toggle | Effort |
|---|---|---|
| GLM (`zai-org/GLM-5.1`, `GLM-5.2`) | `chat_template_kwargs.enable_thinking` | top-level `reasoning_effort`, only `high`/`max` recognized — unchanged from #56054, still the default dialect for unset/unknown models |
| Granular (`Qwen3.5-*`, `Qwen3.6-*`, `Gemma-4`, `Nemotron-3`) | same toggle | `low`/`medium`/`high` honored **distinctly** — confirmed differing reasoning-token counts per level on `Qwen3.6-35B-A3B`, unlike GLM which collapses everything below `high` |
| DeepSeek (`DeepSeek-V3.1`, `V4-Flash`, `V4-Pro`) | **different key**: `chat_template_kwargs.thinking` (not `enable_thinking`) | none observed |
| Always-on (`gpt-oss-20b/120b`, `MiniMax-M2.5`, `Kimi-K2.5/2.6/2.7-Code`, `Qwen3-235B-Thinking`) | none — cannot be disabled | `reasoning_effort` still modulates depth even though it can't be turned off (confirmed: `gpt-oss-20b` reasoning_len 127 default vs 20 at `effort=low`) |
| Everything else (Llama, Phi, non-thinking Qwen3-Instruct, IBM Granite, Mellum2) | — | no-op, unchanged |

The DeepSeek finding is the one most likely to surprise a reviewer: I tested
`enable_thinking: true` on `DeepSeek-V3.1` first (since that's the GLM/Qwen
key) and got weak/inconsistent reasoning output (184 chars). Switching to
`thinking: true` (matching vLLM's dedicated `deepseek_v3` parser and Hermes'
own direct-DeepSeek `DeepSeekProfile`) produced consistent, substantial
reasoning (950 chars) every time.

## Testing

```bash
python3 -m pytest tests/providers/test_provider_profiles.py tests/test_packaging_metadata.py -o "addopts=" -q
# 85 passed (71 existing + 14 new)

python3 -m pytest tests/providers/ tests/plugins/model_providers/ tests/hermes_cli/test_setup_model_provider.py -o "addopts=" -q
# 247 passed — no regressions in the wider provider/model-picker surface
```

All existing GLM-only tests pass unmodified — unset-model calls fall
through to the GLM dialect, matching Hermes' bundled `config.yaml` default
(`zai-org/GLM-5.2`) and this profile's `fallback_models[0]`.

14 new tests, one class per dialect, each asserting against the live-tested
behavior described above (not guessed defaults).
