### PR TITLE
fix(codex-app-server): honor approvals.mode/yolo for gateway-context approval routing (salvage of #26533 by @simpolism, closes #26530)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -269,32 +269,22 @@ def run_codex_app_server_turn(
         # requests through, so codex app-server exec / apply_patch requests
         # fail closed (silently decline) by default. When the user has
         # explicitly opted out of Hermes approvals — via `approvals.mode: off`
-        # in config, the /yolo session toggle, or HERMES_YOLO_MODE=1 — honor
-        # that and let codex's own sandbox permission profile
+        # in config, the /yolo session toggle, or --yolo / HERMES_YOLO_MODE —
+        # honor that and let codex's own sandbox permission profile
         # (~/.codex/config.toml) be the policy gate instead of double-gating
         # with a missing Hermes UI. Defaults (manual/smart/unset) preserve the
         # current fail-closed behavior — this is a no-op for those users.
         auto_approve_requests = False
         try:
-            from tools.approval import (
-                _get_approval_mode,
-                is_current_session_yolo_enabled,
-            )
+            from tools.approval import is_approval_bypass_active
 
-            auto_approve_requests = (
-                _get_approval_mode() == "off"
-                or is_current_session_yolo_enabled()
-            )
+            auto_approve_requests = is_approval_bypass_active()
         except Exception:
             logger.debug(
-                "codex app-server: approval-mode lookup failed; "
+                "codex app-server: approval-bypass lookup failed; "
                 "keeping fail-closed default",
                 exc_info=True,
             )
-        if not auto_approve_requests:
-            auto_approve_requests = os.getenv(
-                "HERMES_YOLO_MODE", ""
-            ).strip().lower() in {"1", "true", "yes", "on"}
 
         def _on_codex_event(note: dict) -> None:
             # Bridge Codex app-server item/started notifications to Hermes

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -244,7 +244,10 @@ def run_codex_app_server_turn(
     Called from run_conversation() when agent.api_mode == "codex_app_server".
     Returns the same dict shape as the chat_completions path.
     """
-    from agent.transports.codex_app_server_session import CodexAppServerSession
+    from agent.transports.codex_app_server_session import (
+        CodexAppServerSession,
+        _ServerRequestRouting,
+    )
 
     # Lazy session: one CodexAppServerSession per AIAgent instance.
     # Spawned on first turn, reused across turns, closed at AIAgent
@@ -261,6 +264,37 @@ def run_codex_app_server_turn(
             approval_callback = _get_approval_callback()
         except Exception:
             approval_callback = None
+
+        # Gateway / cron contexts have no UI to surface codex's approval
+        # requests through, so codex app-server exec / apply_patch requests
+        # fail closed (silently decline) by default. When the user has
+        # explicitly opted out of Hermes approvals — via `approvals.mode: off`
+        # in config, the /yolo session toggle, or HERMES_YOLO_MODE=1 — honor
+        # that and let codex's own sandbox permission profile
+        # (~/.codex/config.toml) be the policy gate instead of double-gating
+        # with a missing Hermes UI. Defaults (manual/smart/unset) preserve the
+        # current fail-closed behavior — this is a no-op for those users.
+        auto_approve_requests = False
+        try:
+            from tools.approval import (
+                _get_approval_mode,
+                is_current_session_yolo_enabled,
+            )
+
+            auto_approve_requests = (
+                _get_approval_mode() == "off"
+                or is_current_session_yolo_enabled()
+            )
+        except Exception:
+            logger.debug(
+                "codex app-server: approval-mode lookup failed; "
+                "keeping fail-closed default",
+                exc_info=True,
+            )
+        if not auto_approve_requests:
+            auto_approve_requests = os.getenv(
+                "HERMES_YOLO_MODE", ""
+            ).strip().lower() in {"1", "true", "yes", "on"}
 
         def _on_codex_event(note: dict) -> None:
             # Bridge Codex app-server item/started notifications to Hermes
@@ -281,6 +315,10 @@ def run_codex_app_server_turn(
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            request_routing=_ServerRequestRouting(
+                auto_approve_exec=auto_approve_requests,
+                auto_approve_apply_patch=auto_approve_requests,
+            ),
             on_event=_on_codex_event,
         )
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -326,6 +326,133 @@ class TestRunConversationCodexPath:
 
         assert captured["cwd"] == str(tmp_path)
 
+    def _capture_routing_agent(self, monkeypatch):
+        """Build a codex agent with a CodexAppServerSession stub that captures
+        the request_routing passed at construction time, so we can assert how
+        the gateway-context approval routing was resolved."""
+        captured: dict = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+            self._thread_id = "thread-stub-1"
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="ok",
+                projected_messages=[{"role": "assistant", "content": "ok"}],
+                turn_id="turn-stub-1",
+                thread_id="thread-stub-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-stub-1"
+        )
+        return captured
+
+    def test_approvals_mode_off_auto_approves_codex_server_requests(
+        self, monkeypatch
+    ):
+        """When the user disables Hermes approvals, codex app-server approval
+        requests should not fail closed just because no interactive callback is
+        wired (the typical gateway path). Codex's own sandbox permission
+        profile remains the filesystem boundary."""
+        captured = self._capture_routing_agent(monkeypatch)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"mode": "off"}},
+        ):
+            agent = _make_codex_agent()
+            with patch.object(
+                agent, "_spawn_background_review", return_value=None
+            ):
+                agent.run_conversation("write something")
+        routing = captured["request_routing"]
+        assert routing.auto_approve_exec is True
+        assert routing.auto_approve_apply_patch is True
+
+    def test_yaml_boolean_false_approval_mode_also_auto_approves(
+        self, monkeypatch
+    ):
+        """YAML 1.1 parses unquoted `off` as False; match the normal approval
+        subsystem's compatibility behavior for codex app-server routing too."""
+        captured = self._capture_routing_agent(monkeypatch)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"mode": False}},
+        ):
+            agent = _make_codex_agent()
+            with patch.object(
+                agent, "_spawn_background_review", return_value=None
+            ):
+                agent.run_conversation("write something")
+        routing = captured["request_routing"]
+        assert routing.auto_approve_exec is True
+        assert routing.auto_approve_apply_patch is True
+
+    def test_manual_approvals_keep_codex_server_requests_fail_closed(
+        self, monkeypatch
+    ):
+        """Default (manual) approvals must preserve the fail-closed behavior —
+        this fix is a no-op for users who haven't opted out."""
+        captured = self._capture_routing_agent(monkeypatch)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"mode": "manual"}},
+        ):
+            agent = _make_codex_agent()
+            with patch.object(
+                agent, "_spawn_background_review", return_value=None
+            ):
+                agent.run_conversation("write something")
+        routing = captured["request_routing"]
+        assert routing.auto_approve_exec is False
+        assert routing.auto_approve_apply_patch is False
+
+    def test_hermes_yolo_env_auto_approves_codex_server_requests(
+        self, monkeypatch
+    ):
+        """HERMES_YOLO_MODE should flow through to codex app-server routing so
+        gateway/cron contexts do not fail closed when the user explicitly
+        enabled yolo mode outside the CLI slash-command path."""
+        captured = self._capture_routing_agent(monkeypatch)
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"mode": "manual"}},
+        ):
+            agent = _make_codex_agent()
+            with patch.object(
+                agent, "_spawn_background_review", return_value=None
+            ):
+                agent.run_conversation("write something")
+        routing = captured["request_routing"]
+        assert routing.auto_approve_exec is True
+        assert routing.auto_approve_apply_patch is True
+
+    def test_session_yolo_auto_approves_codex_server_requests(
+        self, monkeypatch
+    ):
+        """The /yolo session toggle should be honored at Codex session creation
+        time, independent of the startup-time approvals config."""
+        captured = self._capture_routing_agent(monkeypatch)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"mode": "manual"}},
+        ):
+            agent = _make_codex_agent()
+            with patch(
+                "tools.approval.is_current_session_yolo_enabled",
+                return_value=True,
+            ), patch.object(
+                agent, "_spawn_background_review", return_value=None
+            ):
+                agent.run_conversation("write something")
+        routing = captured["request_routing"]
+        assert routing.auto_approve_exec is True
+        assert routing.auto_approve_apply_patch is True
+
 
 class TestReviewForkApiModeDowngrade:
     """When the parent agent runs on codex_app_server, the background

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -410,14 +410,17 @@ class TestRunConversationCodexPath:
         assert routing.auto_approve_exec is False
         assert routing.auto_approve_apply_patch is False
 
-    def test_hermes_yolo_env_auto_approves_codex_server_requests(
+    def test_frozen_yolo_env_auto_approves_codex_server_requests(
         self, monkeypatch
     ):
-        """HERMES_YOLO_MODE should flow through to codex app-server routing so
-        gateway/cron contexts do not fail closed when the user explicitly
-        enabled yolo mode outside the CLI slash-command path."""
+        """--yolo / HERMES_YOLO_MODE (frozen into _YOLO_MODE_FROZEN at import
+        time — a prompt-injection-safe process-scoped bypass) should flow
+        through to codex app-server routing so gateway/cron contexts do not
+        fail closed when the user launched with yolo mode."""
+        import tools.approval as _approval
+
         captured = self._capture_routing_agent(monkeypatch)
-        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        monkeypatch.setattr(_approval, "_YOLO_MODE_FROZEN", True)
         with patch(
             "hermes_cli.config.load_config",
             return_value={"approvals": {"mode": "manual"}},

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1770,6 +1770,27 @@ def _get_approval_mode() -> str:
     return _normalize_approval_mode(mode)
 
 
+def is_approval_bypass_active() -> bool:
+    """Return True when the user has opted out of Hermes approval prompts.
+
+    Collapses the canonical three-source bypass check used across the codebase
+    into one place:
+      - process-scoped ``--yolo`` / ``HERMES_YOLO_MODE`` (frozen at import time
+        so a mid-process skill can't flip it — a prompt-injection escalation
+        path; see ``_YOLO_MODE_FROZEN`` above),
+      - the session-scoped gateway ``/yolo`` toggle,
+      - ``approvals.mode: off`` in config.
+
+    This is the pure-bypass sub-expression only. Callers that also honor a
+    hardline blocklist / permanent allowlist must check those separately.
+    """
+    return (
+        _YOLO_MODE_FROZEN
+        or is_current_session_yolo_enabled()
+        or _get_approval_mode() == "off"
+    )
+
+
 def _get_approval_timeout() -> int:
     """Read the approval timeout from config. Defaults to 60 seconds."""
     try:


### PR DESCRIPTION
## Summary
Codex app-server exec/apply_patch requests on gateway/cron contexts now honor `approvals.mode: off` / `/yolo` / `HERMES_YOLO_MODE=1` instead of silently failing closed.

**Root cause:** On non-CLI contexts no approval-UI callback is wired, so `CodexAppServerSession._decide_exec_approval` / `_decide_apply_patch_approval` hit their fail-closed `return "decline"` path. Codex sees a synthetic "user denied" and drops to read-only — the bot appears responsive but can't write files, and no prompt surfaces anywhere.

**Fix:** When the user has explicitly opted out of Hermes approvals, build the session with `_ServerRequestRouting(auto_approve_exec=True, auto_approve_apply_patch=True)` so codex's own sandbox permission profile (`~/.codex/config.toml`) becomes the boundary. Defaults (`manual`/`smart`/unset) keep the current fail-closed behavior — a no-op for anyone who hasn't opted out.

Salvage of #26533 by @simpolism (also the reporter of #26530). Re-authored onto current `main`: the construction site the original PR targeted (`run_agent.py`) has since moved into `agent/codex_runtime.py::run_codex_app_server_turn()`. Authorship preserved.

## Changes
- `agent/codex_runtime.py`: resolve opt-out at session-build time via the canonical `tools.approval._get_approval_mode()` (which already normalizes the YAML-1.1 bare-`off`→`False` case) + `is_current_session_yolo_enabled()` + `HERMES_YOLO_MODE`; pass `request_routing`. Reading at build time means a mid-session `/yolo` toggle is honored too.
- `tests/run_agent/test_codex_app_server_integration.py`: 5 tests — config `off`, YAML `False`, `HERMES_YOLO_MODE`, session `/yolo`, plus the default `manual` fail-closed regression guard.

## Validation
| approvals state | auto_approve | real exec decision |
|---|---|---|
| `off` | True | `accept` |
| `manual` / `smart` (default) | False | `decline` |
| `HERMES_YOLO_MODE=1` | True | `accept` |
| `/yolo` session toggle | True | `accept` |

- 28/28 integration tests pass (23 existing + 5 new); 58/58 session tests pass.
- E2E with real imports + temp `HERMES_HOME` config: the gateway-context exec decision flips `decline`→`accept` only when opted out; fail-closed preserved otherwise.

## Notes
- The bigger "surface codex approvals in gateway channels" feature (async per-tool-call correlation) is out of scope — tracked by the #25889 / #27636 / #43217 cluster. This fix unblocks the immediate silent-read-only case.
- Not addressed here: the MCP `mcpServer/elicitation/request` fail-closed path for non-`hermes-tools` servers (reported on #26530 by @TAE58). That path declines by hard-coded server-name gating (arguably intentional) rather than `_routing` — a separate design question.

Closes #26530

---
### Follow-up commit (self-review, `hermes-pr-review` Phase 2)
`refactor(approval): extract is_approval_bypass_active(); use frozen-env bypass in codex routing`

Phase-2 review flagged that the initial adaptation re-read `os.getenv("HERMES_YOLO_MODE")` at runtime, which diverges from the repo's security invariant — `HERMES_YOLO_MODE` is frozen into `_YOLO_MODE_FROZEN` at import time precisely so a mid-process skill can't set the env var and flip the approval bypass (prompt-injection escalation path). Fixed architecturally: extracted the canonical three-source bypass check into `tools.approval.is_approval_bypass_active()` (this was the 4th inline copy of that OR-chain; `codex_runtime.py` now calls the shared helper). Env-yolo test updated to patch `_YOLO_MODE_FROZEN` (canonical pattern) instead of `setenv`. 28 integration + 77 session/yolo tests pass; E2E re-confirmed.
